### PR TITLE
search: Replicate Monaco suggestions look in CodeMirror (icons, match style,...)

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -126,13 +126,13 @@
                     }
 
                     .tabStyle {
-                        align-items: center;
                         border: 1px solid var(--text-muted);
                         border-radius: 0.25rem;
                         height: 1.25rem;
                         font-size: 0.65rem;
                         line-height: 1;
                         padding: 0.25rem 0.375rem;
+                        margin-left: auto;
                         color: var(--text-muted);
                         opacity: 0.75;
                         display: none;

--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -89,30 +89,67 @@
             color: var(--search-query-text-color);
             background-color: var(--color-bg-1);
 
-            > ul > li {
-                padding-top: 0.25rem;
-                padding-bottom: 0.25rem;
+            > ul {
+                font-family: var(--code-font-family);
 
-                &[aria-selected] {
-                    color: var(--search-query-text-color);
-                    background-color: var(--color-bg-2);
+                > li {
+                    box-sizing: content-box;
+                    padding-top: 0.25rem;
+                    padding-bottom: 0.25rem;
+                    display: flex;
+                    height: 1.25rem;
 
-                    :global(.theme-dark) & {
-                        background-color: var(--color-bg-3);
+                    svg {
+                        flex-shrink: 0;
                     }
-                }
 
-                :global(.cm-completionDetail) {
-                    padding-left: 0.25rem;
-                    color: var(--gray-06);
-                }
+                    :global(.cm-completionLabel) {
+                        flex-shrink: 0;
+                    }
 
-                :global(.cm-completionMatchedText) {
-                    // Reset
-                    text-decoration: none;
+                    :global(.cm-completionDetail) {
+                        padding-left: 0.25rem;
+                        color: var(--gray-06);
+                        flex: 1;
+                        min-width: 0;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                    }
 
-                    // Our style
-                    background-color: var(--mark-bg);
+                    :global(.cm-completionMatchedText) {
+                        // Reset
+                        text-decoration: none;
+
+                        // Our style
+                        color: var(--search-filter-keyword-color);
+                        font-weight: bold;
+                    }
+
+                    .tabStyle {
+                        align-items: center;
+                        border: 1px solid var(--text-muted);
+                        border-radius: 0.25rem;
+                        height: 1.25rem;
+                        font-size: 0.65rem;
+                        line-height: 1;
+                        padding: 0.25rem 0.375rem;
+                        color: var(--text-muted);
+                        opacity: 0.75;
+                        display: none;
+                    }
+
+                    &[aria-selected] {
+                        color: var(--search-query-text-color);
+                        background-color: var(--color-bg-2);
+
+                        :global(.theme-dark) & {
+                            background-color: var(--color-bg-3);
+                        }
+
+                        .tabStyle {
+                            display: inline-block;
+                        }
+                    }
                 }
             }
         }

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -127,6 +127,10 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
     const extensions = useMemo(() => {
         const extensions: Extension[] = [
             EditorView.contentAttributes.of({ 'aria-label': ariaLabel }),
+            EditorView.domEventHandlers({
+                blur: onBlur,
+                focus: onFocus,
+            }),
             EditorView.updateListener.of((update: ViewUpdate) => {
                 if (update.docChanged) {
                     onChange({
@@ -135,14 +139,6 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
                         query: update.state.doc.toString(),
                         changeSource: QueryChangeSource.userInput,
                     })
-                }
-                if (update.focusChanged) {
-                    if (onFocus && update.view.hasFocus) {
-                        onFocus()
-                    }
-                    if (onBlur && !update.view.hasFocus) {
-                        onBlur()
-                    }
                 }
                 // See https://codemirror.net/docs/ref/#state.Transaction^userEvent
                 if (


### PR DESCRIPTION
Fixes: #35485

This PR makes a couple of changes to make the suggestions look similar to Monaco's:

It adds icons to the search query suggestions in CodeMirror. Unlike originally intended, it doesn't use the same icons as Monaco (I couldn't find them). Instead I'm using the same icons that is used in the search result view, defined in [`SymbolIcon`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@610506d59acc961c1945c4b125d2fa1fabd2e457/-/blob/client/shared/src/symbols/SymbolIcon.tsx?L39-97):

<img width="743" alt="2022-06-23_13-00" src="https://user-images.githubusercontent.com/179026/175306274-7d261319-7295-434c-ab47-145469b2ad41.png">

For suggestion items that are missing from that list (filters, repositories) I picked icons from `@mdi/js` that look similar to the Monaco ones.

**NOTE:** We might want to update our icon set, but that should be done separately.

This PR also adds the "Tab" indicator after the selected suggestion. I wasn't able to make this work nicely with CSS only, so I used CodeMirror's API to insert an additional node.

It also changes the "match" style to be more similar to Monaco's style.

Before: 
<img width="841" alt="2022-06-23_12-56_1" src="https://user-images.githubusercontent.com/179026/175307347-da88dae8-1ac2-42b1-ba97-8cd537dcdfd0.png">



After: 
<img width="840" alt="2022-06-23_12-56" src="https://user-images.githubusercontent.com/179026/175307360-812b4178-399f-446e-b14f-262369dac6f7.png">


## Test plan

Open search page. Try "default" completion (filters, symbols), `repo:`, `file:` and `type:` completions.

## App preview:

- [Web](https://sg-web-fkling-35485-suggestion-symbols.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nbnziywrpf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
