### PR TITLE
policies: update matched repos right after policy is created

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -63,6 +63,7 @@ type DBStore interface {
 	RequestLanguageSupport(ctx context.Context, userID int, language string) error
 	LanguagesRequestedBy(ctx context.Context, userID int) ([]string, error)
 	GetAuditLogsForUpload(ctx context.Context, uploadID int) ([]dbstore.UploadLog, error)
+	UpdateReposMatchingPatterns(ctx context.Context, patterns []string, policyID int, repositoryMatchLimit *int) (err error)
 }
 
 type LSIFStore interface {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks_test.go
@@ -144,6 +144,10 @@ type MockDBStore struct {
 	// function object controlling the behavior of the method
 	// UpdateIndexConfigurationByRepositoryID.
 	UpdateIndexConfigurationByRepositoryIDFunc *DBStoreUpdateIndexConfigurationByRepositoryIDFunc
+	// UpdateReposMatchingPatternsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// UpdateReposMatchingPatterns.
+	UpdateReposMatchingPatternsFunc *DBStoreUpdateReposMatchingPatternsFunc
 }
 
 // NewMockDBStore creates a new mock of the DBStore interface. All methods
@@ -322,6 +326,11 @@ func NewMockDBStore() *MockDBStore {
 		},
 		UpdateIndexConfigurationByRepositoryIDFunc: &DBStoreUpdateIndexConfigurationByRepositoryIDFunc{
 			defaultHook: func(context.Context, int, []byte) (r0 error) {
+				return
+			},
+		},
+		UpdateReposMatchingPatternsFunc: &DBStoreUpdateReposMatchingPatternsFunc{
+			defaultHook: func(context.Context, []string, int, *int) (r0 error) {
 				return
 			},
 		},
@@ -507,6 +516,11 @@ func NewStrictMockDBStore() *MockDBStore {
 				panic("unexpected invocation of MockDBStore.UpdateIndexConfigurationByRepositoryID")
 			},
 		},
+		UpdateReposMatchingPatternsFunc: &DBStoreUpdateReposMatchingPatternsFunc{
+			defaultHook: func(context.Context, []string, int, *int) error {
+				panic("unexpected invocation of MockDBStore.UpdateReposMatchingPatterns")
+			},
+		},
 	}
 }
 
@@ -618,6 +632,9 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 		},
 		UpdateIndexConfigurationByRepositoryIDFunc: &DBStoreUpdateIndexConfigurationByRepositoryIDFunc{
 			defaultHook: i.UpdateIndexConfigurationByRepositoryID,
+		},
+		UpdateReposMatchingPatternsFunc: &DBStoreUpdateReposMatchingPatternsFunc{
+			defaultHook: i.UpdateReposMatchingPatterns,
 		},
 	}
 }
@@ -4541,6 +4558,120 @@ func (c DBStoreUpdateIndexConfigurationByRepositoryIDFuncCall) Args() []interfac
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBStoreUpdateIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBStoreUpdateReposMatchingPatternsFunc describes the behavior when the
+// UpdateReposMatchingPatterns method of the parent MockDBStore instance is
+// invoked.
+type DBStoreUpdateReposMatchingPatternsFunc struct {
+	defaultHook func(context.Context, []string, int, *int) error
+	hooks       []func(context.Context, []string, int, *int) error
+	history     []DBStoreUpdateReposMatchingPatternsFuncCall
+	mutex       sync.Mutex
+}
+
+// UpdateReposMatchingPatterns delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockDBStore) UpdateReposMatchingPatterns(v0 context.Context, v1 []string, v2 int, v3 *int) error {
+	r0 := m.UpdateReposMatchingPatternsFunc.nextHook()(v0, v1, v2, v3)
+	m.UpdateReposMatchingPatternsFunc.appendCall(DBStoreUpdateReposMatchingPatternsFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// UpdateReposMatchingPatterns method of the parent MockDBStore instance is
+// invoked and the hook queue is empty.
+func (f *DBStoreUpdateReposMatchingPatternsFunc) SetDefaultHook(hook func(context.Context, []string, int, *int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpdateReposMatchingPatterns method of the parent MockDBStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *DBStoreUpdateReposMatchingPatternsFunc) PushHook(hook func(context.Context, []string, int, *int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBStoreUpdateReposMatchingPatternsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, []string, int, *int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBStoreUpdateReposMatchingPatternsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, []string, int, *int) error {
+		return r0
+	})
+}
+
+func (f *DBStoreUpdateReposMatchingPatternsFunc) nextHook() func(context.Context, []string, int, *int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBStoreUpdateReposMatchingPatternsFunc) appendCall(r0 DBStoreUpdateReposMatchingPatternsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBStoreUpdateReposMatchingPatternsFuncCall
+// objects describing the invocations of this function.
+func (f *DBStoreUpdateReposMatchingPatternsFunc) History() []DBStoreUpdateReposMatchingPatternsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBStoreUpdateReposMatchingPatternsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBStoreUpdateReposMatchingPatternsFuncCall is an object that describes an
+// invocation of method UpdateReposMatchingPatterns on an instance of
+// MockDBStore.
+type DBStoreUpdateReposMatchingPatternsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 *int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBStoreUpdateReposMatchingPatternsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBStoreUpdateReposMatchingPatternsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 


### PR DESCRIPTION
This is a strawman proposal: probably not the best code to solve this
and maybe not performant, but something to start discussion.

Background is that I've been writing intergration tests for
lockfile-indexing-based dependency search and the tests have to wait for
the lockfile policy to take effect.

Without the change in this PR this takes ~1min, because the matcher
only runs every minute and checks whether repos match a new policy.

With this change, we match the repositories right after creating policy.
That's not ideal, it should be in the background, but it *feels great
man* when the policy matches immediately after creation.


## Test plan

- Existing tests & manual testing
