### PR TITLE
Re-enable dependency search integration tests

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1478,8 +1478,9 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 		// indexed the repositories above.
 		// We wait longer than usual because there's a lag between setting up a
 		// policy and it being matched against repositories (up to 1 minute).
+		timeout := 200 * time.Second // 3min20s to be sure we have 1min for lockfile indexing to start and then some.
 		err = client.WaitForReposToBeClonedWithin(
-			5*time.Minute,
+			timeout,
 			"npm/urql/core",
 			"npm/wonka",
 			"python/atomicwrites",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -109,6 +109,8 @@ type searchClient interface {
 	SearchFiles(query string) (*gqltestutil.SearchFileResults, error)
 	SearchAll(query string) ([]*gqltestutil.AnyResult, error)
 
+	CreatePolicy(input gqltestutil.CreatePolicyInput) (string, error)
+
 	UpdateSiteConfiguration(config *schema.SiteConfiguration) error
 	SiteConfiguration() (*schema.SiteConfiguration, error)
 
@@ -1333,96 +1335,108 @@ func testSearchClient(t *testing.T, client searchClient) {
 	})
 }
 
+func enableGlobalLockfileIndexing(t *testing.T) {
+	t.Helper()
+
+	siteConfig, err := client.SiteConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldSiteConfig := new(schema.SiteConfiguration)
+	*oldSiteConfig = *siteConfig
+	t.Cleanup(func() {
+		err = client.UpdateSiteConfiguration(oldSiteConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	value := true
+	siteConfig.CodeIntelAutoIndexingAllowGlobalPolicies = &value
+	siteConfig.CodeIntelLockfileIndexingEnabled = &value
+
+	err = client.UpdateSiteConfiguration(siteConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 
-		t.Skip("TODO: Re-enable with lockfile indexing added")
+		// Setup global lockfile indexing
+		enableGlobalLockfileIndexing(t)
 
-		// We are adding another GitHub external service here to make sure we don't
+		// We are adding other external service here to make sure we don't
 		// pollute the other integration tests running earlier.
-		_, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
-			Kind:        extsvc.KindGitHub,
-			DisplayName: "gqltest-dependency-search",
-			Config: mustMarshalJSONString(struct {
-				URL                   string   `json:"url"`
-				Token                 string   `json:"token"`
-				Repos                 []string `json:"repos"`
-				RepositoryPathPattern string   `json:"repositoryPathPattern"`
-			}{
-				URL:   "https://ghe.sgdev.org/",
-				Token: *githubToken,
-				Repos: []string{
-					"sgtest/pipenv-hw",
-					"sgtest/poetry-hw",
-					"sgtest/empty",
-				},
-				RepositoryPathPattern: "github.com/{nameWithOwner}",
-			}),
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = client.AddExternalService(gqltestutil.AddExternalServiceInput{
-			Kind:        extsvc.KindNpmPackages,
-			DisplayName: "gqltest-npm-search",
-			Config: mustMarshalJSONString(&schema.NpmPackagesConnection{
-				Registry: "https://registry.npmjs.org",
-				Dependencies: []string{
-					"urql@2.2.0", // We're searching the dependencies of this repo.
-				},
-			}),
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = client.AddExternalService(gqltestutil.AddExternalServiceInput{
-			Kind:        extsvc.KindGoModules,
-			DisplayName: "gqltest-go-search",
-			Config: mustMarshalJSONString(&schema.GoModulesConnection{
-				Urls: []string{"https://proxy.golang.org"},
-				Dependencies: []string{
-					"github.com/oklog/ulid/v2@v2.0.2",
-				},
-			}),
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = client.AddExternalService(gqltestutil.AddExternalServiceInput{
-			Kind:        extsvc.KindPythonPackages,
-			DisplayName: "gqltest-python-search",
-			Config: mustMarshalJSONString(&schema.PythonPackagesConnection{
-				Urls: []string{"https://pypi.org/simple"},
-				Dependencies: []string{
-					"rich == 12.3.0",
-				},
-			}),
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = client.AddExternalService(gqltestutil.AddExternalServiceInput{
-			Kind:        extsvc.KindJVMPackages,
-			DisplayName: "gqltest-jvm-search",
-			Config: mustMarshalJSONString(&schema.JVMPackagesConnection{
-				Maven: &schema.Maven{
-					Dependencies: []string{
-						"com.google.guava:guava:19.0",
-						"com.google.guava:guava:21.0",
+		configs := []gqltestutil.AddExternalServiceInput{
+			{
+				Kind:        extsvc.KindGitHub,
+				DisplayName: "gqltest-dependency-search",
+				Config: mustMarshalJSONString(&schema.GitHubConnection{
+					Url:   "https://ghe.sgdev.org/",
+					Token: *githubToken,
+					Repos: []string{
+						"sgtest/pipenv-hw",
+						"sgtest/poetry-hw",
+						"sgtest/empty",
 					},
-				},
-			}),
-		})
-		if err != nil {
-			t.Fatal(err)
+					RepositoryPathPattern: "github.com/{nameWithOwner}",
+				}),
+			},
+			{
+				Kind:        extsvc.KindNpmPackages,
+				DisplayName: "gqltest-npm-search",
+				Config: mustMarshalJSONString(&schema.NpmPackagesConnection{
+					Registry: "https://registry.npmjs.org",
+					Dependencies: []string{
+						"urql@2.2.0", // We're searching the dependencies of this repo.
+					},
+				}),
+			},
+			{
+				Kind:        extsvc.KindGoModules,
+				DisplayName: "gqltest-go-search",
+				Config: mustMarshalJSONString(&schema.GoModulesConnection{
+					Urls: []string{"https://proxy.golang.org"},
+					Dependencies: []string{
+						"github.com/oklog/ulid/v2@v2.0.2",
+					},
+				}),
+			},
+			{
+				Kind:        extsvc.KindPythonPackages,
+				DisplayName: "gqltest-python-search",
+				Config: mustMarshalJSONString(&schema.PythonPackagesConnection{
+					Urls: []string{"https://pypi.org/simple"},
+					Dependencies: []string{
+						"rich == 12.3.0",
+					},
+				}),
+			},
+			{
+				Kind:        extsvc.KindJVMPackages,
+				DisplayName: "gqltest-jvm-search",
+				Config: mustMarshalJSONString(&schema.JVMPackagesConnection{
+					Maven: &schema.Maven{
+						Dependencies: []string{
+							"com.google.guava:guava:19.0",
+							"com.google.guava:guava:21.0",
+						},
+					},
+				}),
+			},
 		}
 
-		err = client.WaitForReposToBeCloned(
+		for _, config := range configs {
+			_, err := client.AddExternalService(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		err := client.WaitForReposToBeCloned(
 			"npm/urql",
 			"go/github.com/oklog/ulid/v2",
 			"maven/com.google.guava/guava",
@@ -1430,6 +1444,53 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 			"github.com/sgtest/pipenv-hw",
 			"github.com/sgtest/poetry-hw",
 			"github.com/sgtest/empty",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create policy to index the lockfiles in these repositories
+		_, err = client.CreatePolicy(gqltestutil.CreatePolicyInput{
+			Name: "Lockfile indexing",
+			RepositoryPatterns: []string{
+				"github.com/sgtest/pipenv-hw",
+				"github.com/sgtest/poetry-hw",
+				"github.com/sgtest/empty",
+				"npm/urql",
+				"go/github.com/oklog/ulid/v2",
+				"python/rich",
+				"maven/com.google.guava/guava",
+			},
+			Type:    "GIT_COMMIT",
+			Pattern: "HEAD",
+
+			// Enable lockfile indexing
+			LockfileIndexingEnabled: true,
+		})
+		if err != nil {
+			t.Fatalf("creating lockfile indexing policy failed: %s", err)
+		}
+
+		// Wait for dependencies to be cloned, which means we've successfully indexed the repositories above
+		err = client.WaitForReposToBeCloned(
+			"npm/urql/core",
+			"npm/wonka",
+			"python/atomicwrites",
+			"python/attrs",
+			"python/colorama",
+			"python/more-itertools",
+			"python/packaging",
+			"python/pluggy",
+			"python/py",
+			"python/pyparsing",
+			"python/pytest",
+			"python/tqdm",
+			"python/wcwidth",
+			"python/certifi",
+			"python/charset-normalizer",
+			"python/idna",
+			"python/requests",
+			"python/urllib3",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1500,7 +1500,7 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 			"python/urllib3",
 		)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("lockfile indexing failed to clone dependency repos: %s", err)
 		}
 
 		for _, tc := range []struct {

--- a/internal/gqltestutil/policies.go
+++ b/internal/gqltestutil/policies.go
@@ -20,8 +20,8 @@ type CreatePolicyInput struct {
 	LockfileIndexingEnabled bool `json:"lockfileIndexingEnabled"`
 }
 
-// CreateSearchContext creates a new search context with the given input and repository revisions to be searched.
-// It returns the GraphQL node ID of the newly created search context.
+// CreatePolicy creates a new code intelligence policy with the given input.
+// It returns the GraphQL node ID of the newly created policy.
 //
 // This method requires the authenticated user to be a site admin.
 func (c *Client) CreatePolicy(input CreatePolicyInput) (string, error) {

--- a/internal/gqltestutil/policies.go
+++ b/internal/gqltestutil/policies.go
@@ -1,0 +1,80 @@
+package gqltestutil
+
+import "github.com/sourcegraph/sourcegraph/lib/errors"
+
+type CreatePolicyInput struct {
+	Name               string   `json:"name"`
+	RepositoryPatterns []string `json:"repositoryPatterns"`
+
+	Type    string `json:"type"`
+	Pattern string `json:"pattern"`
+
+	RetentionEnabled          bool `json:"retentionEnabled"`
+	RetentionDurationHours    *int `json:"retentionDurationHours"`
+	RetainIntermediateCommits bool `json:"retainIntermediateCommits"`
+
+	IndexingEnabled          bool `json:"indexingEnabled"`
+	IndexCommitMaxAgeHours   *int `json:"indexCommitMaxAgeHours"`
+	IndexIntermediateCommits bool `json:"indexIntermediateCommits"`
+
+	LockfileIndexingEnabled bool `json:"lockfileIndexingEnabled"`
+}
+
+// CreateSearchContext creates a new search context with the given input and repository revisions to be searched.
+// It returns the GraphQL node ID of the newly created search context.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) CreatePolicy(input CreatePolicyInput) (string, error) {
+	const query = `
+mutation CreateCodeIntelligenceConfigurationPolicy($repositoryId: ID, $repositoryPatterns: [String!], $name: String!, $type: GitObjectType!, $pattern: String!, $retentionEnabled: Boolean!, $retentionDurationHours: Int, $retainIntermediateCommits: Boolean!, $indexingEnabled: Boolean!, $indexCommitMaxAgeHours: Int, $indexIntermediateCommits: Boolean!, $lockfileIndexingEnabled: Boolean!) {
+  createCodeIntelligenceConfigurationPolicy(
+    repository: $repositoryId
+    repositoryPatterns: $repositoryPatterns
+    name: $name
+    type: $type
+    pattern: $pattern
+    retentionEnabled: $retentionEnabled
+    retentionDurationHours: $retentionDurationHours
+    retainIntermediateCommits: $retainIntermediateCommits
+    indexingEnabled: $indexingEnabled
+    indexCommitMaxAgeHours: $indexCommitMaxAgeHours
+    indexIntermediateCommits: $indexIntermediateCommits
+    lockfileIndexingEnabled: $lockfileIndexingEnabled
+  ) {
+    id
+    __typename
+  }
+}
+`
+	variables := map[string]any{
+		"name":               input.Name,
+		"repositoryPatterns": input.RepositoryPatterns,
+
+		"type":    input.Type,
+		"pattern": input.Pattern,
+
+		"retentionEnabled":          input.RetentionEnabled,
+		"retentionDurationHours":    input.RetentionDurationHours,
+		"retainIntermediateCommits": input.RetainIntermediateCommits,
+
+		"indexingEnabled":          input.IndexingEnabled,
+		"indexCommitMaxAgeHours":   input.IndexCommitMaxAgeHours,
+		"indexIntermediateCommits": input.IndexIntermediateCommits,
+
+		"lockfileIndexingEnabled": input.LockfileIndexingEnabled,
+	}
+
+	var resp struct {
+		Data struct {
+			CreateCodeIntelligenceConfigurationPolicy struct {
+				ID string `json:"id"`
+			} `json:"createCodeIntelligenceConfigurationPolicy"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return "", errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.CreateCodeIntelligenceConfigurationPolicy.ID, nil
+}

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -7,12 +7,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// WaitForReposToBeCloned waits (up to two minutes) for all repositories
+// WaitForReposToBeCloned waits up to two minutes for all repositories
 // in the list to be cloned.
 //
 // This method requires the authenticated user to be a site admin.
 func (c *Client) WaitForReposToBeCloned(repos ...string) error {
 	timeout := 120 * time.Second
+	return c.WaitForReposToBeClonedWithin(timeout, repos...)
+}
+
+// WaitForReposToBeClonedWithin waits up to specified duration for all
+// repositories in the list to be cloned.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) WaitForReposToBeClonedWithin(timeout time.Duration, repos ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
This re-enables the dependency search integration tests that are now
dependent on lockfile indexing.

The tests now configure site-config to allow global lockfile indexing
and then add a policy to index lockfiles of the repositories for which
we want to run dependency searches.

Ideally we'd have something like #37619 for them to run faster.

## Test plan

- This is an integration test
