### PR TITLE
Revert "Update git to 2.35.2 in docker images"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- Updated minimum required veresion of `git` to 2.35.2 in `gitserver` and `server` Docker image. This addresses a few vulnerabilities disclosed in https://github.blog/2022-04-12-git-security-vulnerability-announced/.
+-
 
 ### Fixed
 

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -38,9 +38,7 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 RUN apk add --no-cache \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    # We require git 2.35.2 to fix this vulnerability:
-    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    'git>=2.35.2' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -42,9 +42,7 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    # We require git 2.35.2 to fix this vulnerability:
-    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    'git>=2.35.2' \
+    'git>=2.34.1' \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#37547

Alpine 3.15 does not contain 2.35.2 which is making the image build fail.

# Test plan

Not applicable. Reverting a broken build.