### PR TITLE
add missing generated references

### DIFF
--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -146,6 +146,8 @@ sg ci build --help
 				Aliases: []string{"v"},
 				Usage:   "Open build page in browser",
 			},
+			&ciBuildFlag,
+			&ciBranchFlag,
 		},
 		Action: func(ctx *cli.Context) error {
 			client, err := bk.NewClient(ctx.Context, std.Out.Output)
@@ -382,6 +384,7 @@ From there, you can start exploring logs with the Grafana explore panel.
 `,
 		Flags: []cli.Flag{
 			&ciBuildFlag,
+			&ciBranchFlag,
 			&cli.StringFlag{
 				Name:    "job",
 				Aliases: []string{"j"},

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -196,6 +196,8 @@ Get the status of the CI run associated with the currently checked out branch.
 
 Flags:
 
+* `--branch, -b="<value>"`: Branch `name` of build to target (defaults to current branch)
+* `--build="<value>"`: Override branch detection with a specific build `number`
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 * `--view, -v`: Open build page in browser
 * `--wait, -w`: Wait by blocking until the build is finished
@@ -247,6 +249,7 @@ From there, you can start exploring logs with the Grafana explore panel.
 
 Flags:
 
+* `--branch, -b="<value>"`: Branch `name` of build to target (defaults to current branch)
 * `--build="<value>"`: Override branch detection with a specific build `number`
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 * `--job, -j="<value>"`: ID or name of the job to export logs for


### PR DESCRIPTION
While working on printing annotations for `sg ci status` I saw that these  flags were missing. So I added them back.

@mrnugget also noticed it and posted about it here https://github.com/sourcegraph/sourcegraph/discussions/37621
## Test plan
Tested manually
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
