### PR TITLE
Aa/fix output variables

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -496,6 +496,27 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
         return outputLines
     }, [step.exitCode, step.outputLines])
 
+    const renderOutputVariable = (outputVariable: {
+        __typename?: 'BatchSpecWorkspaceOutputVariable'
+        name: string
+        value: unknown
+    }): JSX.Element => {
+        if (typeof outputVariable.value === 'string') {
+            return <li key={outputVariable.name}>{outputVariable.name}: outputVariable.value</li>
+        }
+
+        return (
+            <li key={outputVariable.name}>
+                {outputVariable.name}:
+                <ul>
+                    {Object.keys(outputVariable.value).map(value => {
+                        ;<li key={value}>{value}</li>
+                    })}
+                </ul>
+            </li>
+        )
+    }
+
     return (
         <Collapse isOpen={isExpanded} onOpenChange={setIsExpanded}>
             <CollapseHeader
@@ -562,11 +583,7 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                                             <Text className="text-muted mb-0">No output variables specified</Text>
                                         )}
                                         <ul className="mb-0">
-                                            {step.outputVariables?.map(variable => (
-                                                <li key={variable.name}>
-                                                    {variable.name}: {variable.value}
-                                                </li>
-                                            ))}
+                                            {step.outputVariables?.map(variable => renderOutputVariable(variable))}
                                         </ul>
                                     </TabPanel>
                                     <TabPanel className="pt-2" key="diff">

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -496,27 +496,6 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
         return outputLines
     }, [step.exitCode, step.outputLines])
 
-    const renderOutputVariable = (outputVariable: {
-        __typename?: 'BatchSpecWorkspaceOutputVariable'
-        name: string
-        value: unknown
-    }): JSX.Element => {
-        if (typeof outputVariable.value === 'string') {
-            return <li key={outputVariable.name}>{outputVariable.name}: outputVariable.value</li>
-        }
-
-        return (
-            <li key={outputVariable.name}>
-                {outputVariable.name}:
-                <ul>
-                    {Object.keys(outputVariable.value).map(value => {
-                        ;<li key={value}>{value}</li>
-                    })}
-                </ul>
-            </li>
-        )
-    }
-
     return (
         <Collapse isOpen={isExpanded} onOpenChange={setIsExpanded}>
             <CollapseHeader
@@ -583,7 +562,11 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                                             <Text className="text-muted mb-0">No output variables specified</Text>
                                         )}
                                         <ul className="mb-0">
-                                            {step.outputVariables?.map(variable => renderOutputVariable(variable))}
+                                            {step.outputVariables?.map(variable => (
+                                                <li key={variable.name}>
+                                                    {variable.name}: {JSON.stringify(variable.value)}
+                                                </li>
+                                            ))}
                                         </ul>
                                     </TabPanel>
                                     <TabPanel className="pt-2" key="diff">


### PR DESCRIPTION
When executing a batch spec that contains `non-string` output variables, the UI runs into an error. [Context](https://sourcegraph.slack.com/archives/C01LJ9DK8ES/p1655988892511759).

This happens because the [batch spec output variable](https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph.git&branch=main&file=cmd%2Ffrontend%2Fgraphqlbackend%2Fbatches.graphql&editor=VSCode&version=2.2.4&start_row=2466&start_col=0&end_row=2478&end_col=1&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands) has a field value that is of type JSONValue!in the batches.graphql, however when the graphql-operations.ts file is generated, the concept of JSONValue! isn't known, so the compiler interprets it as unknown  and this is why ESLINT / TS doesn't catch that issue.

![image](https://user-images.githubusercontent.com/25608335/175358086-8fd85a35-6678-4065-906c-98b36de9a0e2.png)

When the value of the output variable is wrapped in a valid HTML tag, it returns an error and that's because React doesn't know how to handle children that are of type `unknown`.
![image](https://user-images.githubusercontent.com/25608335/175358242-04d33e42-afb2-4f2b-8848-242d28aabe9b.png)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Create a batch change using a spec that contains output that are not in `string` format
```yaml
name: hello
description: Run `eslint --fix` in repositories with `eslintrc[.js]` files.

on:
  - repositoriesMatchingQuery: file:^.eslintrc[\.js|\.json]? -repo:^github\.com/sourcegraph/sourcegraph$ -repo:^github\.com/BolajiOlajide/*

steps:
  # Dynamically print a YAML object on standard out with information about
  # which package manager is used.
  # We can use this to execute different steps.
  - run: |
      echo "usesYarn: $(test -f yarn.lock && echo true || echo false)" &&
      echo "usesNPM: $(test -f package-lock.json && echo true || echo false)"
    container: alpine:3
    outputs:
      packageManagers:
        value: ${{ step.stdout }}
        format: yaml
  # Use yarn to run eslint --fix if we detected yarn before.
  # exit 0 in any case, because we want the fixes, even though there might
  # still be warnings/errors.
  - run: yarn && yarn run eslint --fix --ext .js,.jsx,.ts,.tsx . || exit 0
    if: ${{ outputs.packageManagers.usesYarn }}
    container: node:14.0
  # Use npm if we detected npm.
  - run: |
      npm config set package-lock false \
        && npm install \
        && npm run eslint --fix --ext .js,.jsx,.ts,.tsx . || exit 0
    if: ${{ outputs.packageManagers.usesNPM }}
    container: node:14.0
changesetTemplate:
  title: Run eslint --fix
  body: The changes here were produced by running `eslint --fix`
  commit:
    message: Run `eslint --fix` in the directories
  branch: batch-changes/eslint-fix
  published: false
```
* Execute the batch spec and confirm the output variables are displayed correctly
![image](https://user-images.githubusercontent.com/25608335/175357253-34bf2b68-228f-446f-9953-74e68a12d242.png)
