### PR TITLE
notebooks: fix sidebar wrapping

### DIFF
--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -291,7 +291,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
 
                 {selectedTab === 'notebooks' && (
                     <div className="row mb-5">
-                        <div className="d-flex flex-column col-sm-2 mr-2">
+                        <div className="d-flex flex-column col-sm-2">
                             {filters.map(filter => (
                                 <Button
                                     key={filter.id}
@@ -303,7 +303,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                                 </Button>
                             ))}
                         </div>
-                        <div className="d-flex flex-column w-100 col">
+                        <div className="d-flex flex-column col-sm-10">
                             {selectedFilter && (
                                 <NotebooksList
                                     key={selectedFilter.id}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/206864/175378066-1983a241-f207-4cb3-9048-46bf564820f0.png)

After:
![image](https://user-images.githubusercontent.com/206864/175378019-4b9aeac9-efde-473f-b831-d21e91b8f7ae.png)

## Test plan

Visually inspecting to make sure notebooks page looks correct at various screen sizes and sidebar doesn't wrap

## App preview:

- [Web](https://sg-web-jp-notebooksidebarwrapping.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-whvkkrrpor.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
