### PR TITLE
Revert "Search backend: use efficient implementation for repo:contains.file()"

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -527,7 +527,7 @@ func toTextPatternInfo(b query.Basic, resultTypes result.Types, p search.Protoco
 	langInclude, langExclude := b.IncludeExcludeValues(query.FieldLang)
 	filesInclude = append(filesInclude, mapSlice(langInclude, query.LangToFileRegexp)...)
 	filesExclude = append(filesExclude, mapSlice(langExclude, query.LangToFileRegexp)...)
-	filesReposMustInclude, filesReposMustExclude := b.RepoContainsFile()
+	filesReposMustInclude, filesReposMustExclude := b.IncludeExcludeValues(query.FieldRepoHasFile)
 	selector, _ := filter.SelectPathFromString(b.FindValue(query.FieldSelect)) // Invariant: select is validated
 	count := count(b, p)
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -509,12 +509,6 @@ func TestToTextPatternInfo(t *testing.T) {
 	}, {
 		input:  `patterntype:regexp // literal slash`,
 		output: autogold.Want("107", `{"Pattern":"(?://).*?(?:literal).*?(?:slash)","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","FilePatternsReposMustInclude":null,"FilePatternsReposMustExclude":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
-	}, {
-		input:  `repo:contains.file(Dockerfile)`,
-		output: autogold.Want("108", `{"Pattern":"","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","FilePatternsReposMustInclude":["Dockerfile"],"FilePatternsReposMustExclude":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
-	}, {
-		input:  `repohasfile:Dockerfile`,
-		output: autogold.Want("109", `{"Pattern":"","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","FilePatternsReposMustInclude":["Dockerfile"],"FilePatternsReposMustExclude":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
 	}}
 
 	test := func(input string) string {

--- a/internal/search/predicate/substitute_test.go
+++ b/internal/search/predicate/substitute_test.go
@@ -110,9 +110,9 @@ func TestSubstitute(t *testing.T) {
 
 	autogold.Want("predicate that generates a plan is replaced by values",
 		"repo:^contains-foo$").
-		Equal(t, test("repo:contains.content(foo)"))
+		Equal(t, test("repo:contains.file(foo)"))
 
 	autogold.Want("value that does not generate plan passes through",
 		"repo:^contains-foo$ repo:dependencies(bar)").
-		Equal(t, test("repo:contains.content(foo) repo:dependencies(bar)"))
+		Equal(t, test("repo:contains.file(foo) repo:dependencies(bar)"))
 }

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -237,8 +237,8 @@ func (f *RepoContainsFilePredicate) ParseParams(params string) error {
 func (f *RepoContainsFilePredicate) Field() string { return FieldRepo }
 func (f *RepoContainsFilePredicate) Name() string  { return "contains.file" }
 func (f *RepoContainsFilePredicate) Plan(parent Basic) (Plan, error) {
-	// Handled by repo search
-	return nil, nil
+	contains := RepoContainsPredicate{File: f.Pattern, Content: ""}
+	return contains.Plan(parent)
 }
 
 /* repo:contains.commit.after(...) */

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -330,41 +330,6 @@ func (p Parameters) IncludeExcludeValues(field string) (include, exclude []strin
 	return include, exclude
 }
 
-func (p Parameters) RepoContainsFile() (include, exclude []string) {
-	nodes := toNodes(p)
-	VisitField(nodes, FieldRepoHasFile, func(v string, negated bool, _ Annotation) {
-		if negated {
-			exclude = append(exclude, v)
-		} else {
-			include = append(include, v)
-		}
-	})
-
-	VisitField(nodes, FieldRepo, func(v string, negated bool, ann Annotation) {
-		if !ann.Labels.IsSet(IsPredicate) {
-			return
-		}
-
-		name, params := ParseAsPredicate(v)
-		if name != "contains.file" {
-			return
-		}
-
-		var p RepoContainsFilePredicate
-		if err := p.ParseParams(params); err != nil {
-			return
-		}
-
-		if negated {
-			exclude = append(exclude, p.Pattern)
-		} else {
-			include = append(include, p.Pattern)
-		}
-	})
-
-	return include, exclude
-}
-
 // Exists returns whether a parameter exists in the query (whether negated or not).
 func (p Parameters) Exists(field string) bool {
 	found := false


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#37629

It's breaking integration tests with what appears to be an actual bug. 