### PR TITLE
Search backend: fix repo contains file for zoekt

### DIFF
--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -34,7 +34,7 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 	langInclude, langExclude := b.IncludeExcludeValues(query.FieldLang)
 	filesInclude = append(filesInclude, mapSlice(langInclude, query.LangToFileRegexp)...)
 	filesExclude = append(filesExclude, mapSlice(langExclude, query.LangToFileRegexp)...)
-	filesReposMustInclude, filesReposMustExclude := b.IncludeExcludeValues(query.FieldRepoHasFile)
+	filesReposMustInclude, filesReposMustExclude := b.RepoContainsFile()
 
 	var and []zoekt.Q
 	if q != nil {


### PR DESCRIPTION
I missed a spot. I honestly had no idea that Zoekt does this natively. That's cool. 

Replaces #37641 


## Test plan

Ran integration tests locally and they passed.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
