### PR TITLE
a11y: fix search context create/edit pages for narrow screens

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -73,7 +73,7 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<
     )
 
     return (
-        <div className="container col-8">
+        <div className="container col-sm-8">
             <PageTitle title="Create new code monitor" />
             <PageHeader
                 path={[

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -107,7 +107,7 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
     )
 
     return (
-        <div className="container col-8">
+        <div className="container col-sm-8">
             <PageTitle title="Manage code monitor" />
             <PageHeader
                 path={[{ icon: CodeMonitoringLogo, to: '/code-monitoring' }, { text: 'Manage code monitor' }]}

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.module.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.module.scss
@@ -49,3 +49,9 @@
 .test-action-error {
     color: var(--danger);
 }
+
+.action-button-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.module.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.module.scss
@@ -1,6 +1,13 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .query-input {
     display: flex;
     align-items: stretch;
+
+    @media (--xs-breakpoint-down) {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 
     &-preview-link {
         white-space: nowrap;
@@ -16,6 +23,14 @@
         &-icon {
             max-height: 1rem;
             max-width: 1rem;
+        }
+
+        @media (--xs-breakpoint-down) {
+            height: 2rem;
+            width: 100%;
+            border-top: none;
+            border-top-right-radius: 0;
+            border-bottom-left-radius: 2px;
         }
     }
 
@@ -34,6 +49,12 @@
         &:focus-within {
             border: 1px solid var(--input-focus-border-color);
             box-shadow: 0 0 0 2px rgba(28, 126, 214, 0.25);
+        }
+
+        @media (--xs-breakpoint-down) {
+            border-right: 1px solid var(--input-border-color);
+            border-top-right-radius: 2px;
+            border-bottom-left-radius: 0;
         }
     }
 }

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -324,7 +324,7 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                     aria-label="Edit trigger: When there are new search results"
                     onClick={toggleQueryForm}
                 >
-                    <div className="d-flex justify-content-between align-items-center w-100">
+                    <div className="d-flex flex-wrap justify-content-between align-items-center w-100">
                         <div>
                             <div
                                 className={classNames(
@@ -350,7 +350,7 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                             )}
                         </div>
                         {triggerCompleted && (
-                            <Button variant="link" as="div">
+                            <Button variant="link" as="div" className="p-0">
                                 Edit
                             </Button>
                         )}

--- a/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.tsx
@@ -181,35 +181,36 @@ export const ActionEditor: React.FunctionComponent<React.PropsWithChildren<Actio
                             {actionEnabled ? 'Enabled' : 'Disabled'}
                         </span>
                     </div>
-                    <div className="d-flex justify-content-between">
-                        <div>
-                            <Button
-                                data-testid={`submit-action-${idName}`}
-                                className={`mr-1 test-submit-action-${idName}`}
-                                onClick={submitHandler}
-                                disabled={!canSubmit}
-                                variant="secondary"
-                            >
-                                Continue
-                            </Button>
-                            <Button
-                                onClick={cancelHandler}
-                                outline={true}
-                                variant="secondary"
-                                data-testid={`cancel-action-${idName}`}
-                            >
-                                Cancel
-                            </Button>
-                        </div>
+                    <div className={styles.actionButtonRow}>
+                        <Button
+                            data-testid={`submit-action-${idName}`}
+                            className={`test-submit-action-${idName}`}
+                            onClick={submitHandler}
+                            disabled={!canSubmit}
+                            variant="secondary"
+                        >
+                            Continue
+                        </Button>
+                        <Button
+                            onClick={cancelHandler}
+                            outline={true}
+                            variant="secondary"
+                            data-testid={`cancel-action-${idName}`}
+                        >
+                            Cancel
+                        </Button>
                         {canDelete && (
-                            <Button
-                                onClick={deleteHandler}
-                                outline={true}
-                                variant="danger"
-                                data-testid={`delete-action-${idName}`}
-                            >
-                                Delete
-                            </Button>
+                            <>
+                                <div className="flex-grow-1" />
+                                <Button
+                                    onClick={deleteHandler}
+                                    outline={true}
+                                    variant="danger"
+                                    data-testid={`delete-action-${idName}`}
+                                >
+                                    Delete
+                                </Button>
+                            </>
                         )}
                     </div>
                 </Card>

--- a/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.tsx
@@ -230,7 +230,7 @@ export const ActionEditor: React.FunctionComponent<React.PropsWithChildren<Actio
                     aria-label={`Edit action: ${label}`}
                     onClick={toggleExpanded}
                 >
-                    <div className="d-flex justify-content-between align-items-center w-100">
+                    <div className="d-flex flex-wrap justify-content-between align-items-center w-100">
                         <div>
                             <div className={classNames('font-weight-bold', !completed && styles.cardLink)}>{title}</div>
                             {completed ? (

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
@@ -102,8 +102,8 @@ export const SlackWebhookAction: React.FunctionComponent<React.PropsWithChildren
     return (
         <ActionEditor
             title={
-                <div className="d-flex align-items-center">
-                    Send Slack message to channel <ProductStatusBadge className="ml-1" status="beta" />{' '}
+                <div>
+                    Send Slack message to channel <ProductStatusBadge className="ml-1 mb-1" status="beta" />{' '}
                 </div>
             }
             label="Send Slack message to channel"

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.tsx
@@ -101,8 +101,8 @@ export const WebhookAction: React.FunctionComponent<React.PropsWithChildren<Acti
     return (
         <ActionEditor
             title={
-                <div className="d-flex align-items-center">
-                    Call a webhook <ProductStatusBadge className="ml-1" status="beta" />{' '}
+                <div>
+                    Call a webhook <ProductStatusBadge className="ml-1 mb-1" status="beta" />{' '}
                 </div>
             }
             label="Call a webhook"


### PR DESCRIPTION
Closes #35733

Another low-cost, best-effort approach of making pages usable at narrow screen sizes.

- Pages are now full-width at the XS size
- In the expanded trigger card, query input and preview links are now vertically placed at the XS size
- In the expanded trigger card, validation checkboxes no longer shrink
- In the collapsed trigger and actions cards, the content now wraps so the edit button is now below the title at smaller sizes
- In the action card titles for Slack and Webhooks, the "Beta" badges now wrap with the content
- In the expanded action cards, buttons at the bottom now wrap at smaller sizes instead of having an odd placement

![image](https://user-images.githubusercontent.com/206864/175404926-d092e677-d840-4794-a40e-2948a535dc5a.png)

![image](https://user-images.githubusercontent.com/206864/175405533-6890e97e-3327-4085-8a98-e2a460b6b809.png)

![image](https://user-images.githubusercontent.com/206864/175405027-953cedbc-bace-4b75-aa6d-9c0c98517320.png)


## Test plan

Verify create and edit code monitor pages at 320px width
