### PR TITLE
JetBrains: Add Java side telemetry

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.UUID;
 
 public class ConfigUtil {
     @NotNull
@@ -52,6 +53,18 @@ public class ConfigUtil {
     @Nullable
     public static String getAnonymousUserId() {
         return SourcegraphApplicationService.getInstance().getAnonymousUserId();
+    }
+
+    public static void clearAnonymousUserId() {
+        SourcegraphApplicationService.getInstance().anonymousUserId = null;
+    }
+
+    public static void generateAndSetAnonymousUserId() {
+        SourcegraphApplicationService.getInstance().anonymousUserId = generateAnonymousUserId();
+    }
+
+    private static String generateAnonymousUserId() {
+        return UUID.randomUUID().toString();
     }
 
     @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -50,6 +50,11 @@ public class ConfigUtil {
     }
 
     @Nullable
+    public static String getAnonymousUserId() {
+        return SourcegraphApplicationService.getInstance().getAnonymousUserId();
+    }
+
+    @Nullable
     public static Search getLastSearch(@NotNull Project project) {
         return getProjectLevelConfig(project).getLastSearch();
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
-import java.util.UUID;
 
 public class ConfigUtil {
     @NotNull
@@ -55,16 +54,8 @@ public class ConfigUtil {
         return SourcegraphApplicationService.getInstance().getAnonymousUserId();
     }
 
-    public static void clearAnonymousUserId() {
-        SourcegraphApplicationService.getInstance().anonymousUserId = null;
-    }
-
-    public static void generateAndSetAnonymousUserId() {
-        SourcegraphApplicationService.getInstance().anonymousUserId = generateAnonymousUserId();
-    }
-
-    private static String generateAnonymousUserId() {
-        return UUID.randomUUID().toString();
+    public static void setAnonymousUserId(@Nullable String anonymousUserId) {
+        SourcegraphApplicationService.getInstance().anonymousUserId = anonymousUserId;
     }
 
     @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/Event.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/Event.java
@@ -1,0 +1,46 @@
+package com.sourcegraph.telemetry;
+
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class Event {
+    String eventName;
+    String anonymousUserId;
+    String url;
+    JsonObject eventProperties;
+    /**
+     * PRIVACY: Do NOT include any potentially private information, such as search queries or repository names.
+     */
+    JsonObject publicArgument;
+    int eventId;
+
+    public Event(@NotNull String eventName,
+                 @NotNull String anonymousUserId,
+                 @NotNull String url,
+                 @Nullable JsonObject eventProperties,
+                 @Nullable JsonObject publicArgument) {
+        this.eventName = eventName;
+        this.anonymousUserId = anonymousUserId;
+        this.url = url;
+        this.eventProperties = eventProperties;
+        this.publicArgument = publicArgument;
+    }
+
+    public JsonObject toJson() {
+        JsonObject returnValue = new JsonObject();
+        returnValue.addProperty("event", this.eventName);
+        returnValue.addProperty("userCookieID", this.anonymousUserId);
+        returnValue.addProperty("url", this.url);
+        returnValue.addProperty("source", "IDEEXTENSION");
+        returnValue.addProperty("referrer", "JETBRAINS");
+        if (eventProperties != null) {
+            returnValue.add("argument", eventProperties);
+        }
+        if (publicArgument != null) {
+            returnValue.add("publicArgument", publicArgument);
+        }
+        returnValue.addProperty("deviceID", this.anonymousUserId);
+        return returnValue;
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -1,0 +1,97 @@
+package com.sourcegraph.telemetry;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.config.ConfigUtil;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class GraphQlLogger {
+    private static final Logger logger = Logger.getInstance(GraphQlLogger.class);
+
+    public static void logInstallEvent(Project project) {
+        String anonymousUserId = ConfigUtil.getAnonymousUserId();
+        if (anonymousUserId != null) {
+            Event event = new Event("IDEInstalled", anonymousUserId, ConfigUtil.getSourcegraphUrl(project), null, null);
+            logEvent(project, event);
+        }
+    }
+
+    public static void logUninstallEvent(Project project) {
+        String anonymousUserId = ConfigUtil.getAnonymousUserId();
+        if (anonymousUserId != null) {
+            Event event = new Event("IDEUninstalled", anonymousUserId, ConfigUtil.getSourcegraphUrl(project), null, null);
+            logEvent(project, event);
+        }
+    }
+
+    public static void logEvent(Project project, @NotNull Event event) {
+        String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
+
+        String accessToken = ConfigUtil.getAccessToken(project);
+
+        String query = "" +
+            "mutation LogEvents($events: [Event!]) {" +
+            "    logEvents(events: $events) { " +
+            "        alwaysNil" +
+            "    }" +
+            "}";
+
+        JsonArray events = new JsonArray();
+        events.add(event.toJson());
+        JsonObject variables = new JsonObject();
+        variables.add("events", events);
+
+        try {
+
+            callGraphQLService(instanceUrl, accessToken, query, variables);
+        } catch (IOException e) {
+            logger.info(e);
+        }
+    }
+
+    private static void callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws IOException {
+        HttpPost request = createRequest(instanceUrl, accessToken, query, variables);
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            CloseableHttpResponse response = client.execute(request);
+            response.close();
+        }
+    }
+
+    @NotNull
+    private static HttpPost createRequest(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws UnsupportedEncodingException {
+        HttpPost request = new HttpPost(getGraphQLApiURI(instanceUrl));
+        request.setHeader("Content-Type", "application/json");
+        request.setHeader("X-Sourcegraph-Should-Trace", "false");
+        if (accessToken != null) {
+            request.setHeader("Authorization", "token " + accessToken);
+        }
+        JsonObject body = new JsonObject();
+        body.addProperty("query", query);
+        body.add("variables", variables);
+        request.setEntity(new StringEntity(body.toString()));
+        return request;
+    }
+
+    @NotNull
+    private static URI getGraphQLApiURI(String instanceUrl) {
+        try {
+            return new URIBuilder(instanceUrl + "/.api/graphql").build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -94,7 +94,6 @@ public class GraphQlLogger {
         entity.setContentEncoding(StandardCharsets.UTF_8.toString());
 
         request.setEntity(entity);
-        //request.setProtocolVersion(HttpVersion.HTTP_1_1);
         return request;
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -39,7 +39,8 @@ public class GraphQlLogger {
         }
     }
 
-    public static void logEvent(Project project, @NotNull Event event) {
+    // This could be exposed later as public, but currently, we don't use it externally.
+    private static void logEvent(Project project, @NotNull Event event) {
         String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
 
         String accessToken = ConfigUtil.getAccessToken(project);

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -41,27 +41,29 @@ public class GraphQlLogger {
 
     // This could be exposed later as public, but currently, we don't use it externally.
     private static void logEvent(Project project, @NotNull Event event) {
-        String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
+        new Thread(() -> {
+            String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
 
-        String accessToken = ConfigUtil.getAccessToken(project);
+            String accessToken = ConfigUtil.getAccessToken(project);
 
-        String query = "" +
-            "mutation LogEvents($events: [Event!]) {" +
-            "    logEvents(events: $events) { " +
-            "        alwaysNil" +
-            "    }" +
-            "}";
+            String query = "" +
+                "mutation LogEvents($events: [Event!]) {" +
+                "    logEvents(events: $events) { " +
+                "        alwaysNil" +
+                "    }" +
+                "}";
 
-        JsonArray events = new JsonArray();
-        events.add(event.toJson());
-        JsonObject variables = new JsonObject();
-        variables.add("events", events);
+            JsonArray events = new JsonArray();
+            events.add(event.toJson());
+            JsonObject variables = new JsonObject();
+            variables.add("events", events);
 
-        try {
-            callGraphQLService(instanceUrl, accessToken, query, variables);
-        } catch (IOException e) {
-            logger.info(e);
-        }
+            try {
+                callGraphQLService(instanceUrl, accessToken, query, variables);
+            } catch (IOException e) {
+                logger.info(e);
+            }
+        }).start();
     }
 
     private static void callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws IOException {

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
@@ -8,13 +8,19 @@ import com.intellij.openapi.startup.StartupActivity;
 import com.sourcegraph.config.ConfigUtil;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.UUID;
+
 public class PostStartupActivity implements StartupActivity {
+    private static String generateAnonymousUserId() {
+        return UUID.randomUUID().toString();
+    }
+
     @Override
     public void runActivity(@NotNull Project project) {
         // When no anonymous user ID is set yet, we create a new one and treat this as an installation event.
         // This likely means that the user has never started IntelliJ with our extension before
         if (ConfigUtil.getAnonymousUserId() == null) {
-            ConfigUtil.generateAndSetAnonymousUserId();
+            ConfigUtil.setAnonymousUserId(generateAnonymousUserId());
         }
 
         PluginInstaller.addStateListener(new PluginStateListener() {
@@ -28,7 +34,7 @@ public class PostStartupActivity implements StartupActivity {
                     GraphQlLogger.logUninstallEvent(project);
 
                     // Clearing this so that we can detect a new installation if the user re-enables the extension.
-                    ConfigUtil.clearAnonymousUserId();
+                    ConfigUtil.setAnonymousUserId(null);
                 }
             }
         });

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
@@ -26,11 +26,14 @@ public class PostStartupActivity implements StartupActivity {
 
         PluginInstaller.addStateListener(new PluginStateListener() {
             public void install(@NotNull IdeaPluginDescriptor ideaPluginDescriptor) {
+                GraphQlLogger.logInstallEvent(project);
             }
 
             @Override
             public void uninstall(@NotNull IdeaPluginDescriptor ideaPluginDescriptor) {
                 if (ideaPluginDescriptor.getPluginId().getIdString().equals("com.sourcegraph.jetbrains")) {
+                    GraphQlLogger.logUninstallEvent(project);
+
                     // Clear the anonymous user ID so that we can detect a new installation if the user re-enables the
                     // extension.
                     applicationConfig.anonymousUserId = null;

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
@@ -3,25 +3,18 @@ package com.sourcegraph.telemetry;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginInstaller;
 import com.intellij.ide.plugins.PluginStateListener;
-import com.intellij.openapi.application.Application;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
-import com.sourcegraph.config.SourcegraphApplicationService;
+import com.sourcegraph.config.ConfigUtil;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.UUID;
 
 public class PostStartupActivity implements StartupActivity {
     @Override
     public void runActivity(@NotNull Project project) {
-        Application app = ApplicationManager.getApplication();
-        SourcegraphApplicationService applicationConfig = app.getService(SourcegraphApplicationService.class);
-
-        // When no anonymous user ID is set yet, we create a new one and treat this as an installation event. This
-        // likely means that the user has never started IntelliJ with our extension before
-        if (applicationConfig.getAnonymousUserId() == null) {
-            applicationConfig.anonymousUserId = generateAnonymousUserId();
+        // When no anonymous user ID is set yet, we create a new one and treat this as an installation event.
+        // This likely means that the user has never started IntelliJ with our extension before
+        if (ConfigUtil.getAnonymousUserId() == null) {
+            ConfigUtil.generateAndSetAnonymousUserId();
         }
 
         PluginInstaller.addStateListener(new PluginStateListener() {
@@ -34,15 +27,10 @@ public class PostStartupActivity implements StartupActivity {
                 if (ideaPluginDescriptor.getPluginId().getIdString().equals("com.sourcegraph.jetbrains")) {
                     GraphQlLogger.logUninstallEvent(project);
 
-                    // Clear the anonymous user ID so that we can detect a new installation if the user re-enables the
-                    // extension.
-                    applicationConfig.anonymousUserId = null;
+                    // Clearing this so that we can detect a new installation if the user re-enables the extension.
+                    ConfigUtil.clearAnonymousUserId();
                 }
             }
         });
-    }
-
-    private static String generateAnonymousUserId() {
-        return UUID.randomUUID().toString();
     }
 }

--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -1,12 +1,12 @@
-import { Subject, EMPTY } from 'rxjs'
+import { EMPTY, Subject } from 'rxjs'
 import { bufferTime, catchError, concatMap } from 'rxjs/operators'
 
 import { gql } from '@sourcegraph/http-client'
+import { EventSource } from '@sourcegraph/shared/src/graphql-operations'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import {
     Event,
-    EventSource,
     LogEventsResult,
     LogEventsVariables,
     LogLegacySearchUserEventResult,
@@ -78,9 +78,9 @@ let eventId = 1
 
 // Event Logger for the JetBrains Extension
 export class EventLogger implements TelemetryService {
-    private anonymousUserId: string
+    private readonly anonymousUserId: string
     private listeners: Set<(eventName: string) => void> = new Set()
-    private editorInfo: { editor: string; version: string }
+    private readonly editorInfo: { editor: string; version: string }
 
     constructor(anonymousUserId: string, editorInfo: { editor: string; version: string }) {
         this.anonymousUserId = anonymousUserId
@@ -104,14 +104,15 @@ export class EventLogger implements TelemetryService {
      * Log a user action or event.
      * Event names should be specific and follow a ${noun}${verb} structure in pascal case, e.g. "ButtonClicked" or "SignInInitiated"
      *
-     * @param eventName: the event name.
-     * @param eventProperties: event properties. These get logged to our database, but do not get
+     * @param eventName -
+     * @param eventProperties event properties. These get logged to our database, but do not get
      * sent to our analytics systems. This may contain private info such as repository names or search queries.
-     * @param publicArgument: event properties that include only public information. Do NOT
+     * @param publicArgument event properties that include only public information. Do NOT
      * include any private information, such as full URLs that may contain private repo names or
      * search queries. The contents of this parameter are sent to our analytics systems.
+     * @param uri -
      */
-    public log(eventName: string, eventProperties?: any, publicArgument?: any, uri?: string): void {
+    public log(eventName: string, eventProperties?: Record<string, unknown>, publicArgument?: Record<string, unknown>, uri?: string): void {
         this.tracker(
             eventName,
             { ...eventProperties, ...this.editorInfo },

--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -112,7 +112,12 @@ export class EventLogger implements TelemetryService {
      * search queries. The contents of this parameter are sent to our analytics systems.
      * @param uri -
      */
-    public log(eventName: string, eventProperties?: Record<string, unknown>, publicArgument?: Record<string, unknown>, uri?: string): void {
+    public log(
+        eventName: string,
+        eventProperties?: Record<string, unknown>,
+        publicArgument?: Record<string, unknown>,
+        uri?: string
+    ): void {
         this.tracker(
             eventName,
             { ...eventProperties, ...this.editorInfo },


### PR DESCRIPTION
Resolves task no. 3 of https://github.com/sourcegraph/sourcegraph/issues/35178

Added GraphQL client and hooked it up with installs and uninstalls.

## Test plan

[3-min demo](https://www.loom.com/share/f9f314887b504c468b7774132cf969b1) of the code and the feature.
After the demo, I moved the logging logic and remote call to a separate thread to make sure we're not blocking the main thread; I think this might've been the cause of the hanging, and it's more prudent to do stuff like this away from the EDT.

## App preview:

- [Web](https://sg-web-dv-jetbrains-add-java-side.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dsbbafrdgh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
