### PR TITLE
batches: move fake source into a testing package

### DIFF
--- a/enterprise/internal/batches/processor/bulk_processor_test.go
+++ b/enterprise/internal/batches/processor/bulk_processor_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/global"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
+	stesting "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/testing"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
@@ -52,10 +52,10 @@ func TestBulkProcessor(t *testing.T) {
 	})
 
 	t.Run("Unknown job type", func(t *testing.T) {
-		fake := &sources.FakeChangesetSource{}
+		fake := &stesting.FakeChangesetSource{}
 		bp := &bulkProcessor{
 			tx:      bstore,
-			sourcer: sources.NewFakeSourcer(nil, fake),
+			sourcer: stesting.NewFakeSourcer(nil, fake),
 		}
 		job := &types.ChangesetJob{JobType: types.ChangesetJobType("UNKNOWN")}
 		err := bp.Process(ctx, job)
@@ -92,10 +92,10 @@ func TestBulkProcessor(t *testing.T) {
 	})
 
 	t.Run("Comment job", func(t *testing.T) {
-		fake := &sources.FakeChangesetSource{}
+		fake := &stesting.FakeChangesetSource{}
 		bp := &bulkProcessor{
 			tx:      bstore,
-			sourcer: sources.NewFakeSourcer(nil, fake),
+			sourcer: stesting.NewFakeSourcer(nil, fake),
 		}
 		job := &types.ChangesetJob{
 			JobType:     types.ChangesetJobTypeComment,
@@ -116,10 +116,10 @@ func TestBulkProcessor(t *testing.T) {
 	})
 
 	t.Run("Detach job", func(t *testing.T) {
-		fake := &sources.FakeChangesetSource{}
+		fake := &stesting.FakeChangesetSource{}
 		bp := &bulkProcessor{
 			tx:      bstore,
-			sourcer: sources.NewFakeSourcer(nil, fake),
+			sourcer: stesting.NewFakeSourcer(nil, fake),
 		}
 		job := &types.ChangesetJob{
 			JobType:       types.ChangesetJobTypeDetach,
@@ -149,10 +149,10 @@ func TestBulkProcessor(t *testing.T) {
 	})
 
 	t.Run("Reenqueue job", func(t *testing.T) {
-		fake := &sources.FakeChangesetSource{}
+		fake := &stesting.FakeChangesetSource{}
 		bp := &bulkProcessor{
 			tx:      bstore,
-			sourcer: sources.NewFakeSourcer(nil, fake),
+			sourcer: stesting.NewFakeSourcer(nil, fake),
 		}
 		job := &types.ChangesetJob{
 			JobType:     types.ChangesetJobTypeReenqueue,
@@ -178,10 +178,10 @@ func TestBulkProcessor(t *testing.T) {
 	})
 
 	t.Run("Merge job", func(t *testing.T) {
-		fake := &sources.FakeChangesetSource{}
+		fake := &stesting.FakeChangesetSource{}
 		bp := &bulkProcessor{
 			tx:      bstore,
-			sourcer: sources.NewFakeSourcer(nil, fake),
+			sourcer: stesting.NewFakeSourcer(nil, fake),
 		}
 		job := &types.ChangesetJob{
 			JobType:     types.ChangesetJobTypeMerge,
@@ -199,10 +199,10 @@ func TestBulkProcessor(t *testing.T) {
 	})
 
 	t.Run("Close job", func(t *testing.T) {
-		fake := &sources.FakeChangesetSource{FakeMetadata: &github.PullRequest{}}
+		fake := &stesting.FakeChangesetSource{FakeMetadata: &github.PullRequest{}}
 		bp := &bulkProcessor{
 			tx:      bstore,
-			sourcer: sources.NewFakeSourcer(nil, fake),
+			sourcer: stesting.NewFakeSourcer(nil, fake),
 		}
 		job := &types.ChangesetJob{
 			JobType:     types.ChangesetJobTypeClose,
@@ -220,10 +220,10 @@ func TestBulkProcessor(t *testing.T) {
 	})
 
 	t.Run("Publish job", func(t *testing.T) {
-		fake := &sources.FakeChangesetSource{FakeMetadata: &github.PullRequest{}}
+		fake := &stesting.FakeChangesetSource{FakeMetadata: &github.PullRequest{}}
 		bp := &bulkProcessor{
 			tx:      bstore,
-			sourcer: sources.NewFakeSourcer(nil, fake),
+			sourcer: stesting.NewFakeSourcer(nil, fake),
 		}
 
 		t.Run("errors", func(t *testing.T) {

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
+	stesting "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/testing"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
@@ -133,13 +133,13 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 
 			// Setup the sourcer that's used to create a Source with which
 			// to create/update a changeset.
-			fakeSource := &sources.FakeChangesetSource{Svc: extSvc, FakeMetadata: githubPR}
+			fakeSource := &stesting.FakeChangesetSource{Svc: extSvc, FakeMetadata: githubPR}
 			if changesetSpec != nil {
 				fakeSource.WantHeadRef = changesetSpec.Spec.HeadRef
 				fakeSource.WantBaseRef = changesetSpec.Spec.BaseRef
 			}
 
-			sourcer := sources.NewFakeSourcer(nil, fakeSource)
+			sourcer := stesting.NewFakeSourcer(nil, fakeSource)
 
 			// Run the reconciler
 			rec := Reconciler{

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
+	stesting "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/testing"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
@@ -213,8 +213,8 @@ func TestService(t *testing.T) {
 	s := store.NewWithClock(db, &observation.TestContext, nil, clock)
 	rs, _ := ct.CreateTestRepos(t, ctx, db, 4)
 
-	fakeSource := &sources.FakeChangesetSource{}
-	sourcer := sources.NewFakeSourcer(nil, fakeSource)
+	fakeSource := &stesting.FakeChangesetSource{}
+	sourcer := stesting.NewFakeSourcer(nil, fakeSource)
 
 	svc := New(s)
 	svc.sourcer = sourcer
@@ -814,8 +814,8 @@ func TestService(t *testing.T) {
 	})
 
 	t.Run("FetchUsernameForBitbucketServerToken", func(t *testing.T) {
-		fakeSource := &sources.FakeChangesetSource{Username: "my-bbs-username"}
-		sourcer := sources.NewFakeSourcer(nil, fakeSource)
+		fakeSource := &stesting.FakeChangesetSource{Username: "my-bbs-username"}
+		sourcer := stesting.NewFakeSourcer(nil, fakeSource)
 
 		// Create a fresh service for this test as to not mess with state
 		// possibly used by other tests.

--- a/enterprise/internal/batches/sources/bitbucketcloud.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud.go
@@ -54,7 +54,7 @@ func NewBitbucketCloudSource(svc *types.ExternalService, cf *httpcli.Factory) (*
 // GitserverPushConfig returns an authenticated push config used for pushing
 // commits to the code host.
 func (s BitbucketCloudSource) GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
-	return gitserverPushConfig(ctx, store, repo, s.client.Authenticator())
+	return GitserverPushConfig(ctx, store, repo, s.client.Authenticator())
 }
 
 // WithAuthenticator returns a copy of the original Source configured to use the

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -55,7 +55,7 @@ func NewBitbucketServerSource(svc *types.ExternalService, cf *httpcli.Factory) (
 }
 
 func (s BitbucketServerSource) GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
-	return gitserverPushConfig(ctx, store, repo, s.au)
+	return GitserverPushConfig(ctx, store, repo, s.au)
 }
 
 func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -70,7 +70,7 @@ func newGithubSource(urn string, c *schema.GitHubConnection, cf *httpcli.Factory
 }
 
 func (s GithubSource) GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
-	return gitserverPushConfig(ctx, store, repo, s.au)
+	return GitserverPushConfig(ctx, store, repo, s.au)
 }
 
 func (s GithubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -73,7 +73,7 @@ func newGitLabSource(urn string, c *schema.GitLabConnection, cf *httpcli.Factory
 }
 
 func (s GitLabSource) GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
-	return gitserverPushConfig(ctx, store, repo, s.au)
+	return GitserverPushConfig(ctx, store, repo, s.au)
 }
 
 func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/sources.go
+++ b/enterprise/internal/batches/sources/sources.go
@@ -69,14 +69,6 @@ func NewSourcer(cf *httpcli.Factory) Sourcer {
 	}
 }
 
-// NewFakeSourcer returns a new faked Sourcer to be used for testing Batch Changes.
-func NewFakeSourcer(err error, source ChangesetSource) Sourcer {
-	return &fakeSourcer{
-		err,
-		source,
-	}
-}
-
 // ForChangeset returns a ChangesetSource for the given changeset. The changeset.RepoID
 // is used to find the matching code host.
 func (s *sourcer) ForChangeset(ctx context.Context, tx SourcerStore, ch *btypes.Changeset) (ChangesetSource, error) {
@@ -125,7 +117,10 @@ func (s *sourcer) loadBatchesSource(ctx context.Context, tx SourcerStore, extern
 	return css, nil
 }
 
-func gitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo, au auth.Authenticator) (*protocol.PushConfig, error) {
+// GitserverPushConfig creates a push configuration given a repo and an
+// authenticator. This function is only public for testing purposes, and should
+// not be used otherwise.
+func GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo, au auth.Authenticator) (*protocol.PushConfig, error) {
 	// Empty authenticators are not allowed.
 	if au == nil {
 		return nil, ErrNoPushCredentials{}

--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -528,7 +528,7 @@ func TestGitserverPushConfig(t *testing.T) {
 				return services, nil
 			})
 
-			havePushConfig, haveErr := gitserverPushConfig(context.Background(), ess, repo, tt.authenticator)
+			havePushConfig, haveErr := GitserverPushConfig(context.Background(), ess, repo, tt.authenticator)
 			if haveErr != tt.wantErr {
 				t.Fatalf("invalid error returned, want=%v have=%v", tt.wantErr, haveErr)
 			}


### PR DESCRIPTION
This reduces the amount of testing code that we have in a normal release build. It's not really doing us any harm to have the fake changeset source and friends in the main `sources` package, but with this change it never gets compiled in except in tests.

As ever, I only wish Go would let you depend on things in `+test` files in other packages.

I also just realised the actual testing change in #37649 got accidentally moved into this PR when I split them, so we should probably get that in, even if we don't want the rest of the refactor. 😬 

## Test plan

Mostly a testing change only, and the handful of mechanical changes caused by exporting `GitserverPushConfig` are trivially verified by (a) the code building, and (b) the existing tests continuing to pass.