### PR TITLE
dev/ci: build images on any dockerfile change

### DIFF
--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -103,9 +103,14 @@ func ParseDiff(files []string) (diff Diff) {
 			diff |= Docs
 		}
 
-		// Affects Dockerfiles
+		// Affects Dockerfiles (which assumes images are being changed as well)
 		if strings.HasPrefix(p, "Dockerfile") || strings.HasSuffix(p, "Dockerfile") {
-			diff |= Dockerfiles
+			diff |= (Dockerfiles | DockerImages)
+		}
+		// Affects anything in docker-images directories (which implies image build
+		// scripts and/or resources are affected)
+		if strings.HasPrefix(p, "docker-images/") || strings.HasPrefix(p, "docker-images/") {
+			diff |= DockerImages
 		}
 
 		// Affects executor docker registry mirror
@@ -131,11 +136,6 @@ func ParseDiff(files []string) (diff Diff) {
 		// Affects scripts
 		if strings.HasSuffix(p, ".sh") {
 			diff |= Shell
-		}
-
-		// Affects docker-images directories
-		if strings.HasPrefix(p, "docker-images/") {
-			diff |= DockerImages
 		}
 	}
 	return

--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -109,7 +109,7 @@ func ParseDiff(files []string) (diff Diff) {
 		}
 		// Affects anything in docker-images directories (which implies image build
 		// scripts and/or resources are affected)
-		if strings.HasPrefix(p, "docker-images/") || strings.HasPrefix(p, "docker-images/") {
+		if strings.HasPrefix(p, "docker-images/") {
 			diff |= DockerImages
 		}
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -110,6 +110,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			}
 		}
 		if c.Diff.Has(changed.DockerImages) {
+			// Build and scan docker images
 			testBuilds := operations.NewNamedSet("Test builds")
 			scanBuilds := operations.NewNamedSet("Scan test builds")
 			for _, image := range images.SourcegraphDockerImages {


### PR DESCRIPTION
Expands on https://github.com/sourcegraph/sourcegraph/pull/36425 with the liberal building of all docker images if any Dockerfiles have changed, to catch issues like https://github.com/sourcegraph/sourcegraph/pull/37547 causing build failures in `main` that should have been caught in PR.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a