### PR TITLE
Update go version for estimator

### DIFF
--- a/doc/admin/deploy/resource_estimator.md
+++ b/doc/admin/deploy/resource_estimator.md
@@ -38,7 +38,7 @@
 }
 </style>
 
-<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/go_1_14_wasm_exec.js"></script>
+<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/go_1_18_wasm_exec.js"></script>
 <script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="94ad774"></script>
 
 <form id="root"></form>


### PR DESCRIPTION
Detail in [slack](https://sourcegraph.slack.com/archives/C07KZF47K/p1656010650156479)

Currently, our resource estimator in our docs is not able to load a locally hosted resource estimator through the `?dev=true` URL Parama if it is built from the latest version of the [resource-estimator repo](https://github.com/sourcegraph/resource-estimator)

As mentioned in the thread by @slimsag :

> on that page the script from Go 1.14 is being used, while your local dev server is using Go 1.18 and the generated WASM code expects the Go 1.18 script to be in use.

Also updating the go version from 1.16 to 1.18 in the  [resource-estimator repo](https://github.com/sourcegraph/resource-estimator)


PR: https://github.com/sourcegraph/resource-estimator/pull/13/commits/d77befe579b44c09bb8c6577b616f0933240a9b7

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
This is a doc update
