### PR TITLE
search: move query JSON printer to internal pkg

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -2,72 +2,9 @@ package graphqlbackend
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )
-
-func toJSON(node query.Node) any {
-	switch n := node.(type) {
-	case query.Operator:
-		var jsons []any
-		for _, o := range n.Operands {
-			jsons = append(jsons, toJSON(o))
-		}
-
-		switch n.Kind {
-		case query.And:
-			return struct {
-				And []any `json:"and"`
-			}{
-				And: jsons,
-			}
-		case query.Or:
-			return struct {
-				Or []any `json:"or"`
-			}{
-				Or: jsons,
-			}
-		case query.Concat:
-			// Concat should already be processed at this point, or
-			// the original query expresses something that is not
-			// supported. We just return the parse tree anyway.
-			return struct {
-				Concat []any `json:"concat"`
-			}{
-				Concat: jsons,
-			}
-		}
-	case query.Parameter:
-		return struct {
-			Field   string      `json:"field"`
-			Value   string      `json:"value"`
-			Negated bool        `json:"negated"`
-			Labels  []string    `json:"labels"`
-			Range   query.Range `json:"range"`
-		}{
-			Field:   n.Field,
-			Value:   n.Value,
-			Negated: n.Negated,
-			Labels:  n.Annotation.Labels.String(),
-			Range:   n.Annotation.Range,
-		}
-	case query.Pattern:
-		return struct {
-			Value   string      `json:"value"`
-			Negated bool        `json:"negated"`
-			Labels  []string    `json:"labels"`
-			Range   query.Range `json:"range"`
-		}{
-			Value:   n.Value,
-			Negated: n.Negated,
-			Labels:  n.Annotation.Labels.String(),
-			Range:   n.Annotation.Range,
-		}
-	}
-	// unreachable.
-	return struct{}{}
-}
 
 func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 	Query       string
@@ -90,13 +27,9 @@ func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	var jsons []any
-	for _, node := range plan.ToQ() {
-		jsons = append(jsons, toJSON(node))
-	}
-	json, err := json.Marshal(jsons)
+	jsonString, err := query.ToJSON(plan.ToQ())
 	if err != nil {
 		return nil, err
 	}
-	return &JSONValue{Value: string(json)}, nil
+	return &JSONValue{Value: jsonString}, nil
 }

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -103,4 +104,78 @@ func toString(nodes []Node) string {
 		result = append(result, node.String())
 	}
 	return strings.Join(result, " ")
+}
+
+func nodeToJSON(node Node) any {
+	switch n := node.(type) {
+	case Operator:
+		var jsons []any
+		for _, o := range n.Operands {
+			jsons = append(jsons, nodeToJSON(o))
+		}
+
+		switch n.Kind {
+		case And:
+			return struct {
+				And []any `json:"and"`
+			}{
+				And: jsons,
+			}
+		case Or:
+			return struct {
+				Or []any `json:"or"`
+			}{
+				Or: jsons,
+			}
+		case Concat:
+			// Concat should already be processed at this point, or
+			// the original query expresses something that is not
+			// supported. We just return the parse tree anyway.
+			return struct {
+				Concat []any `json:"concat"`
+			}{
+				Concat: jsons,
+			}
+		}
+	case Parameter:
+		return struct {
+			Field   string   `json:"field"`
+			Value   string   `json:"value"`
+			Negated bool     `json:"negated"`
+			Labels  []string `json:"labels"`
+			Range   Range    `json:"range"`
+		}{
+			Field:   n.Field,
+			Value:   n.Value,
+			Negated: n.Negated,
+			Labels:  n.Annotation.Labels.String(),
+			Range:   n.Annotation.Range,
+		}
+	case Pattern:
+		return struct {
+			Value   string   `json:"value"`
+			Negated bool     `json:"negated"`
+			Labels  []string `json:"labels"`
+			Range   Range    `json:"range"`
+		}{
+			Value:   n.Value,
+			Negated: n.Negated,
+			Labels:  n.Annotation.Labels.String(),
+			Range:   n.Annotation.Range,
+		}
+	}
+	// unreachable.
+	return struct{}{}
+}
+
+func ToJSON(q Q) (string, error) {
+	var jsons []any
+	for _, node := range q {
+		jsons = append(jsons, nodeToJSON(node))
+	}
+	json, err := json.Marshal(jsons)
+	if err != nil {
+		return "", err
+	}
+	return string(json), nil
 }


### PR DESCRIPTION
this is a better output format to test `standard` query interpretation because it prints labels for each pattern, so moving it into the query pkg

## Test plan
Semantics-preserving
