### PR TITLE
search: standard query interprets literal and regexp patterns

### DIFF
--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -18,6 +18,7 @@ const (
 	// IsAlias flags whether the original syntax referred to an alias rather
 	// than canonical form (r: instead of repo:)
 	IsAlias
+	Standard
 )
 
 var allLabels = map[labels]string{

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -748,3 +748,18 @@ func Test_newOperator(t *testing.T) {
 		})
 	}
 }
+
+func TestParseStandard(t *testing.T) {
+	test := func(input string) string {
+		result, err := Parse(input, SearchTypeStandard)
+		if err != nil {
+			return err.Error()
+		}
+		json, _ := PrettyJSON(result)
+		return json
+	}
+
+	t.Run("patterns are literal and slash-delimited patterns /.../ are regexp", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test("anjou /saumur/")))
+	})
+}

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -168,12 +168,24 @@ func nodeToJSON(node Node) any {
 	return struct{}{}
 }
 
-func ToJSON(q Q) (string, error) {
+func allNodesToJSON(q Q) []any {
 	var jsons []any
 	for _, node := range q {
 		jsons = append(jsons, nodeToJSON(node))
 	}
-	json, err := json.Marshal(jsons)
+	return jsons
+}
+
+func ToJSON(q Q) (string, error) {
+	json, err := json.Marshal(allNodesToJSON(q))
+	if err != nil {
+		return "", err
+	}
+	return string(json), nil
+}
+
+func PrettyJSON(q Q) (string, error) {
+	json, err := json.MarshalIndent(allNodesToJSON(q), "", "  ")
 	if err != nil {
 		return "", err
 	}

--- a/internal/search/query/testdata/TestParseStandard/patterns_are_literal_and_slash-delimited_patterns_/.../_are_regexp.golden
+++ b/internal/search/query/testdata/TestParseStandard/patterns_are_literal_and_slash-delimited_patterns_/.../_are_regexp.golden
@@ -1,0 +1,40 @@
+[
+  {
+    "concat": [
+      {
+        "value": "anjou",
+        "negated": false,
+        "labels": [
+          "Literal"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 0
+          },
+          "end": {
+            "line": 0,
+            "column": 5
+          }
+        }
+      },
+      {
+        "value": "saumur",
+        "negated": false,
+        "labels": [
+          "Regexp"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 6
+          },
+          "end": {
+            "line": 0,
+            "column": 14
+          }
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/37655.

This lets `standard` queries interpret `/<regex>/` as regex and literal otherwise. The parser stuff probably needs a bit of tidying at some point, but even better would be if we just remove regex and literal parsers 🙊 

## Test plan
Adds tests. Still unused.
