### PR TITLE
search: make better parser test output

### DIFF
--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -168,7 +168,7 @@ func nodeToJSON(node Node) any {
 	return struct{}{}
 }
 
-func allNodesToJSON(q Q) []any {
+func nodesToJSON(q Q) []any {
 	var jsons []any
 	for _, node := range q {
 		jsons = append(jsons, nodeToJSON(node))
@@ -177,7 +177,7 @@ func allNodesToJSON(q Q) []any {
 }
 
 func ToJSON(q Q) (string, error) {
-	json, err := json.Marshal(allNodesToJSON(q))
+	json, err := json.Marshal(nodesToJSON(q))
 	if err != nil {
 		return "", err
 	}
@@ -185,7 +185,7 @@ func ToJSON(q Q) (string, error) {
 }
 
 func PrettyJSON(q Q) (string, error) {
-	json, err := json.MarshalIndent(allNodesToJSON(q), "", "  ")
+	json, err := json.MarshalIndent(nodesToJSON(q), "", "  ")
 	if err != nil {
 		return "", err
 	}

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/hexops/autogold"
@@ -16,18 +15,6 @@ func TestPipelineStructural(t *testing.T) {
 	autogold.Want("contains(...) spans newlines", `"repo:contains.file(\nfoo\n)"`).Equal(t, test("repo:contains.file(\nfoo\n)"))
 }
 
-func jsonFormatted(nodes []Node) string {
-	var jsons []any
-	for _, node := range nodes {
-		jsons = append(jsons, toJSON(node))
-	}
-	json, err := json.MarshalIndent(jsons, "", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(json)
-}
-
 func TestSubstituteSearchContexts(t *testing.T) {
 	test := func(input string, verbose bool) string {
 		lookup := func(string) (string, error) {
@@ -39,59 +26,21 @@ func TestSubstituteSearchContexts(t *testing.T) {
 		}
 
 		if verbose {
-			return jsonFormatted(plan.ToQ())
+			json, _ := PrettyJSON(plan.ToQ())
+			return json
 		}
 		return plan.ToQ().String()
 	}
 
-	autogold.Want("failing", `(or (and "repo:primary" "repo:protobuf" "select:repo") (and "repo:secondary" "repo:protobuf" "select:repo") (and "repo:primary" "repo:PROTOBUF" "select:repo") (and "repo:secondary" "repo:PROTOBUF" "select:repo"))`).Equal(t, test("context:go-deps (r:protobuf OR r:PROTOBUF) select:repo", false))
-	autogold.Want("basic", `(or (and "repo:primary" "scamaz") (and "repo:secondary" "scamaz"))`).Equal(t, test("context:gordo scamaz", false))
+	t.Run("failing case", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test("context:go-deps (r:protobuf OR r:PROTOBUF) select:repo", false)))
+	})
 
-	autogold.Want("preserve predicate label", `[
-  {
-    "or": [
-      {
-        "and": [
-          {
-            "field": "repo",
-            "value": "primary",
-            "negated": false,
-            "labels": [
-              "None"
-            ]
-          },
-          {
-            "field": "repo",
-            "value": "contains.file(gordo)",
-            "negated": false,
-            "labels": [
-              "IsPredicate"
-            ]
-          }
-        ]
-      },
-      {
-        "and": [
-          {
-            "field": "repo",
-            "value": "secondary",
-            "negated": false,
-            "labels": [
-              "None"
-            ]
-          },
-          {
-            "field": "repo",
-            "value": "contains.file(gordo)",
-            "negated": false,
-            "labels": [
-              "IsPredicate"
-            ]
-          }
-        ]
-      }
-    ]
-  }
-]`).
-		Equal(t, test("context:gordo repo:contains.file(gordo)", true))
+	t.Run("basic case", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test("context:gordo scamaz", false)))
+	})
+
+	t.Run("preserve predicate label", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test("context:gordo repo:contains.file(gordo)", true)))
+	})
 }

--- a/internal/search/query/testdata/TestSubstituteSearchContexts/basic_case.golden
+++ b/internal/search/query/testdata/TestSubstituteSearchContexts/basic_case.golden
@@ -1,0 +1,1 @@
+(or (and "repo:primary" "scamaz") (and "repo:secondary" "scamaz"))

--- a/internal/search/query/testdata/TestSubstituteSearchContexts/failing_case.golden
+++ b/internal/search/query/testdata/TestSubstituteSearchContexts/failing_case.golden
@@ -1,0 +1,1 @@
+(or (and "repo:primary" "repo:protobuf" "select:repo") (and "repo:secondary" "repo:protobuf" "select:repo") (and "repo:primary" "repo:PROTOBUF" "select:repo") (and "repo:secondary" "repo:PROTOBUF" "select:repo"))

--- a/internal/search/query/testdata/TestSubstituteSearchContexts/preserve_predicate_label.golden
+++ b/internal/search/query/testdata/TestSubstituteSearchContexts/preserve_predicate_label.golden
@@ -1,0 +1,86 @@
+[
+  {
+    "or": [
+      {
+        "and": [
+          {
+            "field": "repo",
+            "value": "primary",
+            "negated": false,
+            "labels": [
+              "None"
+            ],
+            "range": {
+              "start": {
+                "line": 0,
+                "column": 0
+              },
+              "end": {
+                "line": 0,
+                "column": 12
+              }
+            }
+          },
+          {
+            "field": "repo",
+            "value": "contains.file(gordo)",
+            "negated": false,
+            "labels": [
+              "IsPredicate"
+            ],
+            "range": {
+              "start": {
+                "line": 0,
+                "column": 14
+              },
+              "end": {
+                "line": 0,
+                "column": 39
+              }
+            }
+          }
+        ]
+      },
+      {
+        "and": [
+          {
+            "field": "repo",
+            "value": "secondary",
+            "negated": false,
+            "labels": [
+              "None"
+            ],
+            "range": {
+              "start": {
+                "line": 0,
+                "column": 16
+              },
+              "end": {
+                "line": 0,
+                "column": 30
+              }
+            }
+          },
+          {
+            "field": "repo",
+            "value": "contains.file(gordo)",
+            "negated": false,
+            "labels": [
+              "IsPredicate"
+            ],
+            "range": {
+              "start": {
+                "line": 0,
+                "column": 14
+              },
+              "end": {
+                "line": 0,
+                "column": 39
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/37656

deduplicates JSON print functions and puts verbose test output in `testdata` files

## Test plan
Semantics-preserving
