### PR TITLE
notebooks embed: add GlobalContributions

### DIFF
--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -1,13 +1,16 @@
-import React, { Suspense, useEffect } from 'react'
+import React, { Suspense, useEffect, useMemo } from 'react'
 
-import { BrowserRouter, Route, RouteComponentProps, Switch } from 'react-router-dom'
+import { BrowserRouter, Route, RouteComponentProps, Switch, useHistory } from 'react-router-dom'
 import { CompatRouter } from 'react-router-dom-v5-compat'
 
+import { createController as createExtensionsController } from '@sourcegraph/shared/src/extensions/controller'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Alert, LoadingSpinner, setLinkComponent, WildcardTheme, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import '../../SourcegraphWebApp.scss'
 
+import { GlobalContributions } from '../../contributions'
+import { createPlatformContext } from '../../platform/context'
 import { ThemePreference } from '../../stores/themeState'
 import { useTheme } from '../../theme'
 
@@ -48,6 +51,10 @@ export const EmbeddedWebApp: React.FunctionComponent<React.PropsWithChildren<unk
         document.documentElement.classList.toggle('theme-dark', !isLightTheme)
     }, [isLightTheme])
 
+    const platformContext = useMemo(() => createPlatformContext(), [])
+    const extensionsController = useMemo(() => createExtensionsController(platformContext), [platformContext])
+    const history = useHistory()
+
     // 🚨 SECURITY: The `EmbeddedWebApp` is intended to be embedded into 3rd party sites where we do not have total control.
     // That is why it is essential to be mindful when adding new routes that may be vulnerable to clickjacking or similar exploits.
     // It is crucial not to embed any components that an attacker could hijack and use to leak personal information (e.g., the sign-in page).
@@ -78,6 +85,8 @@ export const EmbeddedWebApp: React.FunctionComponent<React.PropsWithChildren<unk
                                             authenticatedUser={null}
                                             isLightTheme={isLightTheme}
                                             settingsCascade={EMPTY_SETTINGS_CASCADE}
+                                            platformContext={platformContext}
+                                            extensionsController={extensionsController}
                                         />
                                     )}
                                 />
@@ -91,6 +100,11 @@ export const EmbeddedWebApp: React.FunctionComponent<React.PropsWithChildren<unk
                                 />
                             </Switch>
                         </Suspense>
+                        <GlobalContributions
+                            extensionsController={extensionsController}
+                            platformContext={platformContext}
+                            history={history}
+                        />
                     </div>
                 </WildcardThemeContext.Provider>
             </CompatRouter>

--- a/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
@@ -7,11 +7,11 @@ import { catchError, startWith } from 'rxjs/operators'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { FetchFileParameters } from '@sourcegraph/search-ui'
 import { fetchHighlightedFileLineRanges as fetchHighlightedFileLineRangesShared } from '@sourcegraph/shared/src/backend/file'
-import { createController as createExtensionsController } from '@sourcegraph/shared/src/extensions/controller'
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
 import { Alert, LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
-import { createPlatformContext } from '../../platform/context'
 import { eventLogger } from '../../tracking/eventLogger'
 import { fetchNotebook } from '../backend'
 import { convertNotebookTitleToFileName } from '../serialize'
@@ -20,14 +20,16 @@ import { NotebookContent, NotebookContentProps } from './NotebookContent'
 
 interface EmbeddedNotebookPageProps
     extends Pick<
-        NotebookContentProps,
-        | 'isLightTheme'
-        | 'searchContextsEnabled'
-        | 'showSearchContext'
-        | 'isSourcegraphDotCom'
-        | 'authenticatedUser'
-        | 'settingsCascade'
-    > {
+            NotebookContentProps,
+            | 'isLightTheme'
+            | 'searchContextsEnabled'
+            | 'showSearchContext'
+            | 'isSourcegraphDotCom'
+            | 'authenticatedUser'
+            | 'settingsCascade'
+        >,
+        PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'>,
+        ExtensionsControllerProps<'extHostAPI' | 'executeCommand'> {
     notebookId: string
 }
 
@@ -35,12 +37,11 @@ const LOADING = 'loading' as const
 
 export const EmbeddedNotebookPage: React.FunctionComponent<React.PropsWithChildren<EmbeddedNotebookPageProps>> = ({
     notebookId,
+    platformContext,
+    extensionsController,
     ...props
 }) => {
     useEffect(() => eventLogger.logViewEvent('EmbeddedNotebookPage'), [])
-
-    const platformContext = useMemo(() => createPlatformContext(), [])
-    const extensionsController = useMemo(() => createExtensionsController(platformContext), [platformContext])
 
     const notebookOrError = useObservable(
         useMemo(


### PR DESCRIPTION
Fixes #37566

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
- Create a notebook with a syntax highlighted markdown code block
- Go to the embed page of the notebook
- Code block should be highlighted

## App preview:

- [Web](https://sg-web-rn-notebooks-embed-global.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qrdqogthbu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
