### PR TITLE
[SG-36772] Update Storybook stories to use Component Story Format: `client/web/enterprise/*` - `batches, insights, searchContexts...`

### DIFF
--- a/client/web/src/enterprise/batches/BatchSpecNode.story.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.story.tsx
@@ -20,7 +20,7 @@ const config: Meta = {
 
 export default config
 
-export const _BatchSpecNode: Story = () => (
+export const BatchSpecNodeStory: Story = () => (
     <WebStory>
         {props => (
             <>
@@ -32,4 +32,4 @@ export const _BatchSpecNode: Story = () => (
     </WebStory>
 )
 
-_BatchSpecNode.storyName = 'BatchSpecNode'
+BatchSpecNodeStory.storyName = 'BatchSpecNode'

--- a/client/web/src/enterprise/batches/BatchSpecsPage.story.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecsPage.story.tsx
@@ -8,6 +8,21 @@ import { queryBatchSpecs as _queryBatchSpecs } from './backend'
 import { BatchSpecsPage } from './BatchSpecsPage'
 import { NODES, successNode } from './testData'
 
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/batches/settings/specs/BatchSpecsPage',
+    decorators: [decorator],
+    parameters: {
+        chromatic: {
+            viewports: [320, 576, 978, 1440],
+            disableSnapshot: false,
+        },
+    },
+}
+
+export default config
+
 const NOW = () => addDays(new Date(), 1)
 
 const queryBatchSpecs: typeof _queryBatchSpecs = () =>
@@ -31,21 +46,6 @@ const queryNoBatchSpecs: typeof _queryBatchSpecs = () =>
         },
         nodes: [],
     })
-
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
-
-const config: Meta = {
-    title: 'web/batches/settings/specs/BatchSpecsPage',
-    decorators: [decorator],
-    parameters: {
-        chromatic: {
-            viewports: [320, 576, 978, 1440],
-            disableSnapshot: false,
-        },
-    },
-}
-
-export default config
 
 export const ListOfSpecs: Story = () => (
     <WebStory>{props => <BatchSpecsPage {...props} queryBatchSpecs={queryBatchSpecs} now={NOW} />}</WebStory>

--- a/client/web/src/enterprise/batches/Branch.story.tsx
+++ b/client/web/src/enterprise/batches/Branch.story.tsx
@@ -1,10 +1,10 @@
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
 import { BranchMerge } from './Branch'
 
-const config = {
+const config: Meta = {
     title: 'web/batches/Branch',
 }
 

--- a/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
@@ -14,6 +14,15 @@ import {
 import { USER_CODE_HOSTS } from './backend'
 import { BatchChangesSettingsArea } from './BatchChangesSettingsArea'
 
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/batches/settings/BatchChangesSettingsArea',
+    decorators: [decorator],
+}
+
+export default config
+
 const codeHostsResult = (...hosts: BatchChangesCodeHostFields[]): UserBatchChangesCodeHostsResult => ({
     node: {
         __typename: 'User',
@@ -31,15 +40,6 @@ const sshCredential = (isSiteCredential: boolean): BatchChangesCredentialFields 
     sshPublicKey:
         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
 })
-
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
-
-const config: Meta = {
-    title: 'web/batches/settings/BatchChangesSettingsArea',
-    decorators: [decorator],
-}
-
-export default config
 
 export const Overview: Story = () => (
     <WebStory>

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
@@ -14,6 +14,15 @@ import {
 import { GLOBAL_CODE_HOSTS } from './backend'
 import { BatchChangesSiteConfigSettingsArea } from './BatchChangesSiteConfigSettingsArea'
 
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/batches/settings/BatchChangesSiteConfigSettingsArea',
+    decorators: [decorator],
+}
+
+export default config
+
 const createMock = (...hosts: BatchChangesCodeHostFields[]): MockedResponse<GlobalBatchChangesCodeHostsResult>[] => [
     {
         request: {
@@ -34,15 +43,6 @@ const createMock = (...hosts: BatchChangesCodeHostFields[]): MockedResponse<Glob
         },
     },
 ]
-
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
-
-const config: Meta = {
-    title: 'web/batches/settings/BatchChangesSiteConfigSettingsArea',
-    decorators: [decorator],
-}
-
-export default config
 
 export const Overview: Story = () => (
     <WebStory>

--- a/client/web/src/enterprise/batches/settings/CheckButton.story.tsx
+++ b/client/web/src/enterprise/batches/settings/CheckButton.story.tsx
@@ -1,11 +1,11 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { CheckButton } from './CheckButton'
 
-const config = {
+const config: Meta = {
     title: 'web/batches/settings/CheckButton',
 }
 

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.story.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.story.tsx
@@ -13,6 +13,15 @@ import {
 import { CHECK_BATCH_CHANGES_CREDENTIAL } from './backend'
 import { CodeHostConnectionNode } from './CodeHostConnectionNode'
 
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/batches/settings/CodeHostConnectionNode',
+    decorators: [decorator],
+}
+
+export default config
+
 const checkCredResult = (): CheckBatchChangesCredentialResult => ({
     checkBatchChangesCredential: {
         alwaysNil: null,
@@ -25,15 +34,6 @@ const sshCredential = (isSiteCredential: boolean): BatchChangesCredentialFields 
     sshPublicKey:
         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
 })
-
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
-
-const config: Meta = {
-    title: 'web/batches/settings/CodeHostConnectionNode',
-    decorators: [decorator],
-}
-
-export default config
 
 export const Overview: Story = () => (
     <WebStory>

--- a/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
@@ -7,13 +7,6 @@ import { WebStory } from '../../../components/WebStory'
 
 import { RemoveCredentialModal } from './RemoveCredentialModal'
 
-const credential = {
-    id: '123',
-    isSiteCredential: false,
-    sshPublicKey:
-        'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-}
-
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
@@ -28,6 +21,13 @@ const config: Meta = {
 }
 
 export default config
+
+const credential = {
+    id: '123',
+    isSiteCredential: false,
+    sshPublicKey:
+        'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+}
 
 export const NoSsh: Story = () => (
     <WebStory>

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
@@ -6,13 +6,6 @@ import { BatchChangesCredentialFields, ExternalServiceKind } from '../../../grap
 
 import { ViewCredentialModal } from './ViewCredentialModal'
 
-const credential: BatchChangesCredentialFields = {
-    id: '123',
-    isSiteCredential: false,
-    sshPublicKey:
-        'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-}
-
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
@@ -21,6 +14,13 @@ const config: Meta = {
 }
 
 export default config
+
+const credential: BatchChangesCredentialFields = {
+    id: '123',
+    isSiteCredential: false,
+    sshPublicKey:
+        'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+}
 
 export const View: Story = () => (
     <WebStory>

--- a/client/web/src/enterprise/batches/workspaces-list/ListItem.story.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/ListItem.story.tsx
@@ -9,11 +9,6 @@ import { Descriptor } from './Descriptor'
 import { CachedIcon, ExcludeIcon } from './Icons'
 import { ListItem } from './ListItem'
 
-const STATUS_INDICATORS: [key: string, icon: React.FunctionComponent<React.PropsWithChildren<unknown>>][] = [
-    ['cached', CachedIcon],
-    ['exclude', ExcludeIcon],
-]
-
 const decorator: DecoratorFn = story => <div className="list-group w-100">{story()}</div>
 
 const config: Meta = {
@@ -22,6 +17,11 @@ const config: Meta = {
 }
 
 export default config
+
+const STATUS_INDICATORS: [key: string, icon: React.FunctionComponent<React.PropsWithChildren<unknown>>][] = [
+    ['cached', CachedIcon],
+    ['exclude', ExcludeIcon],
+]
 
 export const Basic: Story = () => (
     <WebStory>
@@ -50,8 +50,6 @@ export const Basic: Story = () => (
         )}
     </WebStory>
 )
-
-Basic.storyName = 'basic'
 
 export const NonRootPath: Story = () => (
     <WebStory>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.story.tsx
@@ -10,16 +10,6 @@ import { WebStory } from '../../components/WebStory'
 import { CodeMonitoringLogs, CODE_MONITOR_EVENTS } from './CodeMonitoringLogs'
 import { mockLogs } from './testing/util'
 
-const mockedResponse: MockedResponse[] = [
-    {
-        request: {
-            query: getDocumentNode(CODE_MONITOR_EVENTS),
-            variables: { first: 20, after: null, triggerEventsFirst: 20, triggerEventsAfter: null },
-        },
-        result: { data: mockLogs },
-    },
-]
-
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
@@ -31,6 +21,16 @@ const config: Meta = {
         },
     },
 }
+
+const mockedResponse: MockedResponse[] = [
+    {
+        request: {
+            query: getDocumentNode(CODE_MONITOR_EVENTS),
+            variables: { first: 20, after: null, triggerEventsFirst: 20, triggerEventsAfter: null },
+        },
+        result: { data: mockLogs },
+    },
+]
 
 export default config
 
@@ -44,8 +44,6 @@ export const Default: Story = () => (
     </WebStory>
 )
 
-Default.storyName = 'default'
-
 export const Open: Story = () => (
     <WebStory>
         {() => (
@@ -55,8 +53,6 @@ export const Open: Story = () => (
         )}
     </WebStory>
 )
-
-Open.storyName = 'open'
 
 export const Empty: Story = () => {
     const emptyMockedResponse: MockedResponse[] = [
@@ -85,5 +81,3 @@ export const Empty: Story = () => {
         </WebStory>
     )
 }
-
-Empty.storyName = 'empty'

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 
@@ -10,6 +10,19 @@ import { ListCodeMonitors, ListUserCodeMonitorsVariables } from '../../graphql-o
 
 import { CodeMonitoringPage } from './CodeMonitoringPage'
 import { mockCodeMonitorNodes } from './testing/util'
+
+const config: Meta = {
+    title: 'web/enterprise/code-monitoring/CodeMonitoringPage',
+    parameters: {
+        chromatic: {
+            // Delay screenshot taking, so <CodeMonitoringPage /> is ready to show content.
+            delay: 600,
+            disableSnapshot: false,
+        },
+    },
+}
+
+export default config
 
 const generateMockFetchMonitors = (count: number) => ({ id, first, after }: ListUserCodeMonitorsVariables) => {
     const result: ListCodeMonitors = {
@@ -34,26 +47,12 @@ const additionalPropsLongList = { ...additionalProps, fetchUserCodeMonitors: gen
 const additionalPropsEmptyList = { ...additionalProps, fetchUserCodeMonitors: generateMockFetchMonitors(0) }
 const additionalPropsAlwaysLoading = { ...additionalProps, fetchUserCodeMonitors: () => NEVER }
 
-const config = {
-    title: 'web/enterprise/code-monitoring/CodeMonitoringPage',
-    parameters: {
-        chromatic: {
-            // Delay screenshot taking, so <CodeMonitoringPage /> is ready to show content.
-            delay: 600,
-            disableSnapshot: false,
-        },
-    },
-}
-
-export default config
-
-export const CodeMonitoringListPageLessThan10Results: Story = () => (
+export const LessThan10Results: Story = () => (
     <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsShortList} />}</WebStory>
 )
 
-CodeMonitoringListPageLessThan10Results.storyName = 'Code monitoring list page - less than 10 results'
-
-CodeMonitoringListPageLessThan10Results.parameters = {
+LessThan10Results.storyName = 'Code monitoring list page - less than 10 results'
+LessThan10Results.parameters = {
     design: {
         type: 'figma',
         url:
@@ -61,13 +60,12 @@ CodeMonitoringListPageLessThan10Results.parameters = {
     },
 }
 
-export const CodeMonitoringListPageMoreThan10Results: Story = () => (
+export const MoreThan10Results: Story = () => (
     <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsLongList} />}</WebStory>
 )
 
-CodeMonitoringListPageMoreThan10Results.storyName = 'Code monitoring list page - more than 10 results'
-
-CodeMonitoringListPageMoreThan10Results.parameters = {
+MoreThan10Results.storyName = 'Code monitoring list page - more than 10 results'
+MoreThan10Results.parameters = {
     design: {
         type: 'figma',
         url:
@@ -75,13 +73,12 @@ CodeMonitoringListPageMoreThan10Results.parameters = {
     },
 }
 
-export const CodeMonitoringListPageLoading: Story = () => (
+export const PageLoading: Story = () => (
     <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsAlwaysLoading} />}</WebStory>
 )
 
-CodeMonitoringListPageLoading.storyName = 'Code monitoring list page - loading'
-
-CodeMonitoringListPageLoading.parameters = {
+PageLoading.storyName = 'Code monitoring list page - loading'
+PageLoading.parameters = {
     design: {
         type: 'figma',
         url:
@@ -89,13 +86,12 @@ CodeMonitoringListPageLoading.parameters = {
     },
 }
 
-export const CodeMonitoringListPageEmptyShowGettingStarted: Story = () => (
+export const ListPageEmptyShowGettingStarted: Story = () => (
     <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsEmptyList} />}</WebStory>
 )
 
-CodeMonitoringListPageEmptyShowGettingStarted.storyName = 'Code monitoring list page - empty, show getting started'
-
-CodeMonitoringListPageEmptyShowGettingStarted.parameters = {
+ListPageEmptyShowGettingStarted.storyName = 'Code monitoring list page - empty, show getting started'
+ListPageEmptyShowGettingStarted.parameters = {
     design: {
         type: 'figma',
         url:
@@ -103,31 +99,30 @@ CodeMonitoringListPageEmptyShowGettingStarted.parameters = {
     },
 }
 
-export const CodeMonitoringListPageUnauthenticatedShowGettingStarted: Story = () => (
+export const ListPageUnauthenticatedShowGettingStarted: Story = () => (
     <WebStory initialEntries={['/code-monitoring']}>
         {props => <CodeMonitoringPage {...props} {...additionalProps} authenticatedUser={null} />}
     </WebStory>
 )
 
-CodeMonitoringListPageUnauthenticatedShowGettingStarted.storyName =
+ListPageUnauthenticatedShowGettingStarted.storyName =
     'Code monitoring list page - unauthenticated, show getting started'
 
-export const CodeMonitoringEmptyListPage: Story = () => (
+export const EmptyListPage: Story = () => (
     <WebStory initialEntries={['/code-monitoring/getting-started']}>
         {props => <CodeMonitoringPage {...props} {...additionalPropsEmptyList} testForceTab="list" />}
     </WebStory>
 )
 
-CodeMonitoringEmptyListPage.storyName = 'Code monitoring empty list page'
-
-CodeMonitoringEmptyListPage.parameters = {
+EmptyListPage.storyName = 'Code monitoring empty list page'
+EmptyListPage.parameters = {
     design: {
         type: 'figma',
         url: 'https://www.figma.com/file/6WMfHdPt2ovTE1P527brwc/Code-monitor-getting-started-21161?node-id=87%3A277',
     },
 }
 
-export const CodeMonitoringEmptyListPageUnauthenticated: Story = () => (
+export const EmptyListPageUnauthenticated: Story = () => (
     <WebStory initialEntries={['/code-monitoring/getting-started']}>
         {props => (
             <CodeMonitoringPage {...props} {...additionalPropsEmptyList} authenticatedUser={null} testForceTab="list" />
@@ -135,9 +130,8 @@ export const CodeMonitoringEmptyListPageUnauthenticated: Story = () => (
     </WebStory>
 )
 
-CodeMonitoringEmptyListPageUnauthenticated.storyName = 'Code monitoring empty list page - unauthenticated'
-
-CodeMonitoringEmptyListPageUnauthenticated.parameters = {
+EmptyListPageUnauthenticated.storyName = 'Code monitoring empty list page - unauthenticated'
+EmptyListPageUnauthenticated.parameters = {
     design: {
         type: 'figma',
         url: 'https://www.figma.com/file/6WMfHdPt2ovTE1P527brwc/Code-monitor-getting-started-21161?node-id=1%3A1650',

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import sinon from 'sinon'
 
 import { AuthenticatedUser } from '../../auth'
@@ -6,7 +6,7 @@ import { WebStory } from '../../components/WebStory'
 
 import { CreateCodeMonitorPage } from './CreateCodeMonitorPage'
 
-const config = {
+const config: Meta = {
     title: 'web/enterprise/code-monitoring/CreateCodeMonitorPage',
     parameters: {
         chromatic: { disableSnapshot: false },
@@ -15,7 +15,7 @@ const config = {
 
 export default config
 
-export const _CreateCodeMonitorPage: Story = () => (
+export const CreateCodeMonitorPageStory: Story = () => (
     <WebStory>
         {props => (
             <CreateCodeMonitorPage
@@ -28,9 +28,8 @@ export const _CreateCodeMonitorPage: Story = () => (
     </WebStory>
 )
 
-_CreateCodeMonitorPage.storyName = 'CreateCodeMonitorPage'
-
-_CreateCodeMonitorPage.parameters = {
+CreateCodeMonitorPageStory.storyName = 'CreateCodeMonitorPage'
+CreateCodeMonitorPageStory.parameters = {
     design: {
         type: 'figma',
         url:

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 import { fake } from 'sinon'
 
@@ -7,13 +7,13 @@ import { WebStory } from '../../components/WebStory'
 import { ManageCodeMonitorPage } from './ManageCodeMonitorPage'
 import { mockCodeMonitor, mockUser } from './testing/util'
 
-const config = {
+const config: Meta = {
     title: 'web/enterprise/code-monitoring/ManageCodeMonitorPage',
 }
 
 export default config
 
-export const _ManageCodeMonitorPage: Story = () => (
+export const ManageCodeMonitorPageStory: Story = () => (
     <WebStory>
         {props => (
             <ManageCodeMonitorPage
@@ -28,9 +28,8 @@ export const _ManageCodeMonitorPage: Story = () => (
     </WebStory>
 )
 
-_ManageCodeMonitorPage.storyName = 'ManageCodeMonitorPage'
-
-_ManageCodeMonitorPage.parameters = {
+ManageCodeMonitorPageStory.storyName = 'ManageCodeMonitorPage'
+ManageCodeMonitorPageStory.parameters = {
     design: {
         type: 'figma',
         url:

--- a/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.story.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import { NEVER } from 'rxjs'
 import sinon from 'sinon'
 
@@ -8,7 +8,7 @@ import { mockCodeMonitor } from '../testing/util'
 
 import { DeleteMonitorModal } from './DeleteMonitorModal'
 
-const config = {
+const config: Meta = {
     title: 'web/enterprise/code-monitoring/DeleteMonitorModal',
     parameters: {
         chromatic: { disableSnapshot: false },
@@ -17,7 +17,7 @@ const config = {
 
 export default config
 
-export const _DeleteMonitorModal: Story = () => (
+export const DeleteMonitorModalStory: Story = () => (
     <WebStory>
         {props => (
             <DeleteMonitorModal
@@ -31,9 +31,8 @@ export const _DeleteMonitorModal: Story = () => (
     </WebStory>
 )
 
-_DeleteMonitorModal.storyName = 'DeleteMonitorModal'
-
-_DeleteMonitorModal.parameters = {
+DeleteMonitorModalStory.storyName = 'DeleteMonitorModal'
+DeleteMonitorModalStory.parameters = {
     design: {
         type: 'figma',
         url:

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import sinon from 'sinon'
 
 import { H2 } from '@sourcegraph/wildcard'
@@ -9,8 +9,20 @@ import { FormTriggerArea } from './FormTriggerArea'
 
 import codeMonitorFormStyles from './CodeMonitorForm.module.scss'
 
-const config = {
+const config: Meta = {
     title: 'web/enterprise/code-monitoring/FormTrigerArea',
+    parameters: {
+        design: {
+            type: 'Figma',
+            url:
+                'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=3891%3A41568',
+        },
+        chromatic: {
+            delay: 600, // Delay screenshot for input validation debouncing
+            viewports: [720],
+            disableSnapshot: false,
+        },
+    },
 }
 
 export default config
@@ -88,16 +100,3 @@ export const FormTrigerArea: Story = () => (
 )
 
 FormTrigerArea.storyName = 'FormTrigerArea'
-
-FormTrigerArea.parameters = {
-    design: {
-        type: 'Figma',
-        url:
-            'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=3891%3A41568',
-    },
-    chromatic: {
-        delay: 600, // Delay screenshot for input validation debouncing
-        viewports: [720],
-        disableSnapshot: false,
-    },
-}

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.story.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import sinon from 'sinon'
 
 import { H2 } from '@sourcegraph/wildcard'
@@ -8,6 +8,15 @@ import { mockAuthenticatedUser } from '../../testing/util'
 import { ActionProps } from '../FormActionArea'
 
 import { EmailAction } from './EmailAction'
+
+const config: Meta = {
+    title: 'web/enterprise/code-monitoring/actions/EmailAction',
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
+}
+
+export default config
 
 const defaultProps: ActionProps = {
     action: undefined,
@@ -25,13 +34,7 @@ const action: ActionProps['action'] = {
     includeResults: false,
 }
 
-const config = {
-    title: 'web/enterprise/code-monitoring/actions/EmailAction',
-}
-
-export default config
-
-export const _EmailAction: Story = () => (
+export const EmailActionStory: Story = () => (
     <WebStory>
         {() => (
             <>
@@ -60,10 +63,4 @@ export const _EmailAction: Story = () => (
     </WebStory>
 )
 
-_EmailAction.storyName = 'EmailAction'
-
-_EmailAction.parameters = {
-    parameters: {
-        chromatic: { disableSnapshot: false },
-    },
-}
+EmailActionStory.storyName = 'EmailAction'

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.story.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import sinon from 'sinon'
 
 import { H2 } from '@sourcegraph/wildcard'
@@ -8,6 +8,15 @@ import { mockAuthenticatedUser } from '../../testing/util'
 import { ActionProps } from '../FormActionArea'
 
 import { SlackWebhookAction } from './SlackWebhookAction'
+
+const config: Meta = {
+    title: 'web/enterprise/code-monitoring/actions/SlackWebhookAction',
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
+}
+
+export default config
 
 const defaultProps: ActionProps = {
     action: undefined,
@@ -25,13 +34,7 @@ const action: ActionProps['action'] = {
     includeResults: false,
 }
 
-const config = {
-    title: 'web/enterprise/code-monitoring/actions/SlackWebhookAction',
-}
-
-export default config
-
-export const _SlackWebhookAction: Story = () => (
+export const SlackWebhookActionStory: Story = () => (
     <WebStory>
         {() => (
             <>
@@ -67,10 +70,4 @@ export const _SlackWebhookAction: Story = () => (
     </WebStory>
 )
 
-_SlackWebhookAction.storyName = 'SlackWebhookAction'
-
-_SlackWebhookAction.parameters = {
-    parameters: {
-        chromatic: { disableSnapshot: false },
-    },
-}
+SlackWebhookActionStory.storyName = 'SlackWebhookAction'

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.story.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import sinon from 'sinon'
 
 import { H2 } from '@sourcegraph/wildcard'
@@ -8,6 +8,15 @@ import { mockAuthenticatedUser } from '../../testing/util'
 import { ActionProps } from '../FormActionArea'
 
 import { WebhookAction } from './WebhookAction'
+
+const config: Meta = {
+    title: 'web/enterprise/code-monitoring/actions/WebhookAction',
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
+}
+
+export default config
 
 const defaultProps: ActionProps = {
     action: undefined,
@@ -25,13 +34,7 @@ const action: ActionProps['action'] = {
     includeResults: false,
 }
 
-const config = {
-    title: 'web/enterprise/code-monitoring/actions/WebhookAction',
-}
-
-export default config
-
-export const _WebhookAction: Story = () => (
+export const WebhookActionStory: Story = () => (
     <WebStory>
         {() => (
             <>
@@ -63,8 +66,4 @@ export const _WebhookAction: Story = () => (
     </WebStory>
 )
 
-_WebhookAction.storyName = 'WebhookAction'
-
-_WebhookAction.parameters = {
-    chromatic: { disableSnapshot: false },
-}
+WebhookActionStory.storyName = 'WebhookAction'

--- a/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.story.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.story.tsx
@@ -15,6 +15,15 @@ import { UseCodeIntelStatusPayload, UseRequestLanguageSupportParameters } from '
 import { CodeIntelligenceBadgeContentProps } from './CodeIntelligenceBadgeContent'
 import { CodeIntelligenceBadgeMenu } from './CodeIntelligenceBadgeMenu'
 
+const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+
+const config: Meta = {
+    title: 'web/codeintel/enterprise/CodeIntelligenceBadgeMenu',
+    decorators: [decorator],
+}
+
+export default config
+
 const uploadPrototype: Omit<LsifUploadFields, 'id' | 'state' | 'uploadedAt'> = {
     __typename: 'LSIFUpload',
     inputCommit: '9ea5e9f0e0344f8197622df6b36faf48ccd02570',
@@ -254,15 +263,6 @@ const withPayload = (payload: Partial<UseCodeIntelStatusPayload>): typeof defaul
     ...defaultProps,
     useCodeIntelStatus: () => ({ data: { ...emptyPayload, ...payload }, loading: false }),
 })
-
-const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
-
-const config: Meta = {
-    title: 'web/codeintel/enterprise/CodeIntelligenceBadgeMenu',
-    decorators: [decorator],
-}
-
-export default config
 
 export const Unsupported: Story = () => <CodeIntelligenceBadgeMenu {...defaultProps} />
 export const Unavailable: Story = () => <CodeIntelligenceBadgeMenu {...withPayload({ searchBasedSupport })} />

--- a/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.story.tsx
+++ b/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.story.tsx
@@ -19,11 +19,14 @@ const decorator: DecoratorFn = story => <div className="p-3 container">{story()}
 const config: Meta = {
     title: 'web/enterprise/searchContexts/DeleteSearchContextModal',
     decorators: [decorator],
+    parameters: {
+        chromatic: { viewports: [1200], disableSnapshot: false },
+    },
 }
 
 export default config
 
-export const _DeleteSearchContextModal: Story = () => (
+export const DeleteSearchContextModalStory: Story = () => (
     <WebStory>
         {webProps => (
             <DeleteSearchContextModal
@@ -38,7 +41,4 @@ export const _DeleteSearchContextModal: Story = () => (
     </WebStory>
 )
 
-_DeleteSearchContextModal.storyName = 'DeleteSearchContextModal'
-_DeleteSearchContextModal.parameters = {
-    chromatic: { viewports: [1200], disableSnapshot: false },
-}
+DeleteSearchContextModalStory.storyName = 'DeleteSearchContextModal'

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -11,6 +11,18 @@ import { WebStory } from '../../components/WebStory'
 
 import { SearchContextForm } from './SearchContextForm'
 
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/enterprise/searchContexts/SearchContextForm',
+    decorators: [decorator],
+    parameters: {
+        chromatic: { viewports: [1200], disableSnapshot: false },
+    },
+}
+
+export default config
+
 const onSubmit = (): Observable<ISearchContext> =>
     of({
         __typename: 'SearchContext',
@@ -74,18 +86,6 @@ const authUser: AuthenticatedUser = {
 }
 
 const deleteSearchContext = sinon.fake(() => NEVER)
-
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
-
-const config: Meta = {
-    title: 'web/enterprise/searchContexts/SearchContextForm',
-    decorators: [decorator],
-    parameters: {
-        chromatic: { viewports: [1200], disableSnapshot: false },
-    },
-}
-
-export default config
 
 export const EmptyCreate: Story = () => (
     <WebStory>

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.story.tsx
@@ -9,6 +9,18 @@ import { WebStory } from '../../components/WebStory'
 
 import { SearchContextPage } from './SearchContextPage'
 
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/enterprise/searchContexts/SearchContextPage',
+    decorators: [decorator],
+    parameters: {
+        chromatic: { viewports: [1200], disableSnapshot: false },
+    },
+}
+
+export default config
+
 const repositories: ISearchContextRepositoryRevisions[] = [
     {
         __typename: 'SearchContextRepositoryRevisions',
@@ -59,18 +71,6 @@ const fetchAutoDefinedContext = (): Observable<ISearchContext> =>
         ...mockContext,
         autoDefined: true,
     })
-
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
-
-const config: Meta = {
-    title: 'web/enterprise/searchContexts/SearchContextPage',
-    decorators: [decorator],
-    parameters: {
-        chromatic: { viewports: [1200], disableSnapshot: false },
-    },
-}
-
-export default config
 
 export const PublicContext: Story = () => (
     <WebStory>
@@ -128,7 +128,7 @@ export const Loading: Story = () => (
 
 Loading.storyName = 'loading'
 
-export const _Error: Story = () => (
+export const ErrorStory: Story = () => (
     <WebStory>
         {webProps => (
             <SearchContextPage
@@ -140,4 +140,4 @@ export const _Error: Story = () => (
     </WebStory>
 )
 
-_Error.storyName = 'error'
+ErrorStory.storyName = 'error'

--- a/client/web/src/enterprise/searchContexts/SearchContextsListTab.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListTab.story.tsx
@@ -14,6 +14,22 @@ import { WebStory } from '../../components/WebStory'
 
 import { SearchContextsListTab, SearchContextsListTabProps } from './SearchContextsListTab'
 
+const decorator: DecoratorFn = story => (
+    <div className="p-3 container" style={{ position: 'static' }}>
+        {story()}
+    </div>
+)
+
+const config: Meta = {
+    title: 'web/enterprise/searchContexts/SearchContextsListTab',
+    decorators: [decorator],
+    parameters: {
+        chromatic: { viewports: [1200], disableSnapshot: false },
+    },
+}
+
+export default config
+
 const defaultProps: SearchContextsListTabProps = {
     authenticatedUser: null,
     isSourcegraphDotCom: true,
@@ -82,25 +98,7 @@ const propsWithContexts: SearchContextsListTabProps = {
         }),
 }
 
-const decorator: DecoratorFn = story => (
-    <div className="p-3 container" style={{ position: 'static' }}>
-        {story()}
-    </div>
-)
-
-const config: Meta = {
-    title: 'web/enterprise/searchContexts/SearchContextsListTab',
-    decorators: [decorator],
-    parameters: {
-        chromatic: { viewports: [1200], disableSnapshot: false },
-    },
-}
-
-export default config
-
 export const Default: Story = () => <WebStory>{() => <SearchContextsListTab {...defaultProps} />}</WebStory>
-
-Default.storyName = 'default'
 
 export const WithSourcegraphDotComDisabled: Story = () => (
     <WebStory>{() => <SearchContextsListTab {...propsWithContexts} isSourcegraphDotCom={false} />}</WebStory>


### PR DESCRIPTION
## Problem statement

The [Component Story Format](https://storybook.js.org/docs/react/api/csf) is the recommended way to write stories in Storybook. The new format is easier to understand and it is also important that we update our existing stories to ensure we stay up to date with new features, and are able to follow future documentation.

[Check out this Sourcegraph search result to view these stories.
](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+storiesOf%28&patternType=regexp)

## Success criteria

- All stories in the repo are using the Component Story Format
- All stories still usable when running `yarn storybook`

## Implementation details

[Please see this PR description](https://github.com/sourcegraph/sourcegraph/pull/25222) as an example of how this change can be implemented.

In summary, follow these implementation steps:
1. Modify existing `storiesOf` usage to ensure any `add`  or alternative function calls are chained onto the original `storiesOf` function call. See this diff for an example of this change: https://github.com/sourcegraph/sourcegraph/pull/25222/commits/e3a39cae40c69cb74de1d0461bd70fb31bdb281a
2. Run the [storiesof-to-csf Storybook codemod](https://github.com/storybookjs/storybook/blob/next/lib/codemod/README.md#storiesof-to-csf) with this command: `npx sb migrate storiesof-to-csf --glob="client/web/**/*.story.tsx"`. For an expected diff (on different files) see this commit: https://github.com/sourcegraph/sourcegraph/commit/5a5b716337da4a768b4b26157d06728035c57816
3. Run the [csf-hoist-story-annotations Storybook codemod](https://github.com/storybookjs/storybook/blob/next/lib/codemod/README.md#csf-hoist-story-annotations) with this command: `npx sb migrate csf-hoist-story-annotations --glob="client/web/**/*.story.tsx"`. For an expected diff (on different files) see this commit: https://github.com/sourcegraph/sourcegraph/commit/b228f5d5879b5164d23565c7d63480793e6004da
4. You will likely see TypeScript warnings on the newly-modified files. Update these by adding the Storybook types. See this commit for reference: https://github.com/sourcegraph/sourcegraph/commit/810e8e217d6a665f109ca2a0a92ba4125f6b27ea

## Ref
https://github.com/sourcegraph/sourcegraph/issues/25227

## Directories Migrated
- client/web/src/enterprise/batches/settings
- client/web/src/enterprise/batches/workspaces-list
- client/web/src/enterprise/batches/repo
- client/web/src/enterprise/insights
- client/web/src/enterprise/searchContexts
- client/web/src/enterprise/codeintel
- client/web/src/enterprise/code-monitoring
- client/web/src/enterprise/batches/DropdownButton.story.tsx
- client/web/src/enterprise/batches/BatchSpecsPage.story.tsx
- client/web/src/enterprise/batches/BatchSpecNode.story.tsx
- client/web/src/enterprise/batches/Branch.story.tsx
- client/web/src/enterprise/batches/Description.story.tsx

## Time estimate

- Pull requests with ~450 lines changed should take **3 hours** at maximum. Ping the reviewer in the spec pull request if time-consuming changes are required.
- Split the work into multiple pull requests if the total diff is bigger than 450 lines of code.
## Test plan
Run `yarn storybook`
Storybook should run without any error


## App preview:

- [Web](https://sg-web-contractors-sg-36772.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zrpzzfpqga.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
