### PR TITLE
search: Add integration test for query input line break handling

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -91,7 +91,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
     // placeholder text properly. CodeMirror has built-in support for
     // placeholders.
 }) => {
-    const value = preventNewLine ? queryState.query.replace(replacePattern, '') : queryState.query
+    const value = preventNewLine ? queryState.query.replace(replacePattern, ' ') : queryState.query
     // We use both, state and a ref, for the editor instance because we need to
     // re-run some hooks when the editor changes but we also need a stable
     // reference that doesn't change across renders (and some hooks should only

--- a/client/search-ui/src/input/MonacoQueryInput.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.tsx
@@ -341,11 +341,11 @@ export const MonacoQueryInput: React.FunctionComponent<React.PropsWithChildren<M
         if (!editor) {
             return
         }
-        const replacePattern = /[\n\r↵]/g
+        const replacePattern = /[\n\r↵]+/g
         const disposable = editor.onDidChangeModelContent(() => {
             const value = editor.getValue()
             onChange({
-                query: preventNewLine ? value.replace(replacePattern, '') : value,
+                query: preventNewLine ? value.replace(replacePattern, ' ') : value,
                 changeSource: QueryChangeSource.userInput,
             })
         })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -217,36 +217,47 @@ describe('Search', () => {
 
     describe('Search field value', () => {
         withSearchQueryInput((editorName, editorSelector) => {
-            test(`Is set from the URL query parameter when loading a search-related page ${editorName}`, async () => {
-                const editor = createEditorAPI(driver, editorName, editorSelector)
+            describe(editorName, () => {
+                let editor: EditorAPI
 
-                testContext.overrideGraphQL({
-                    ...commonSearchGraphQLResults,
-                    ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
-                    RegistryExtensions: () => ({
-                        extensionRegistry: {
-                            __typename: 'ExtensionRegistry',
-                            extensions: { error: null, nodes: [] },
-                            featuredExtensions: null,
-                        },
-                    }),
+                beforeEach(() => {
+                    editor = createEditorAPI(driver, editorName, editorSelector)
+
+                    testContext.overrideGraphQL({
+                        ...commonSearchGraphQLResults,
+                        ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
+                        RegistryExtensions: () => ({
+                            extensionRegistry: {
+                                __typename: 'ExtensionRegistry',
+                                extensions: { error: null, nodes: [] },
+                                featuredExtensions: null,
+                            },
+                        }),
+                    })
                 })
 
-                await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=foo')
-                await editor.waitForIt()
-                expect(await editor.getValue()).toStrictEqual('foo')
-                // Field value is cleared when navigating to a non search-related page
-                await driver.page.waitForSelector('a[href="/extensions"]')
-                await driver.page.click('a[href="/extensions"]')
-                // Search box is gone when in a non-search page
-                expect(await editor.getValue()).toStrictEqual(undefined)
-                // Field value is restored when the back button is pressed
-                await driver.page.goBack()
-                expect(await editor.getValue()).toStrictEqual('foo')
+                test('Is set from the URL query parameter when loading a search-related page', async () => {
+                    await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=foo')
+                    await editor.waitForIt()
+                    expect(await editor.getValue()).toStrictEqual('foo')
+                    // Field value is cleared when navigating to a non search-related page
+                    await driver.page.waitForSelector('a[href="/extensions"]')
+                    await driver.page.click('a[href="/extensions"]')
+                    // Search box is gone when in a non-search page
+                    expect(await editor.getValue()).toStrictEqual(undefined)
+                    // Field value is restored when the back button is pressed
+                    await driver.page.goBack()
+                    expect(await editor.getValue()).toStrictEqual('foo')
+                })
+
+                test.only('Normalizes input with line breaks', async () => {
+                    await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                    await editor.focus()
+                    await driver.paste('foo\n\n\n\n\nbar')
+                    expect(await editor.getValue()).toBe('foo bar')
+                })
             })
         })
-
-        // TODO: Add test for line break handling (https://github.com/sourcegraph/sourcegraph/issues/36725)
     })
 
     describe('Case sensitivity toggle', () => {


### PR DESCRIPTION
Closes #36725

This commit also changes how line breaks are treated in Monaco. Instead of stripping them (consecutive) line breaks are replaced with a single space.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
