### PR TITLE
Results: Fix long scroll at end of results

### DIFF
--- a/client/search-ui/src/results/progress/StreamingProgressCount.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressCount.tsx
@@ -50,7 +50,9 @@ export const StreamingProgressCount: React.FunctionComponent<
                 )}
                 data-testid="streaming-progress-count"
             >
-                <VisuallyHidden aria-live="polite">{readingContent}</VisuallyHidden>
+                <span className="position-relative">
+                    <VisuallyHidden aria-live="polite">{readingContent}</VisuallyHidden>
+                </span>
                 <span aria-hidden={true}>{content}</span>
                 {progress.repositoriesCount !== undefined && (
                     <Tooltip

--- a/client/search-ui/src/results/progress/StreamingProgressCount.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressCount.tsx
@@ -50,6 +50,10 @@ export const StreamingProgressCount: React.FunctionComponent<
                 )}
                 data-testid="streaming-progress-count"
             >
+                {/*
+                    Span wrapper needed to avoid VisuallyHidden creating a scrollable overflow in Chrome.
+                    Related bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1154640#c15
+                 */}
                 <span className="position-relative">
                     <VisuallyHidden aria-live="polite">{readingContent}</VisuallyHidden>
                 </span>

--- a/client/search-ui/src/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/search-ui/src/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -13,10 +13,14 @@ exports[`StreamingProgressCount should not render a trace link when not opted in
     data-testid="streaming-progress-count"
   >
     <span
-      aria-live="polite"
-      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      class="position-relative"
     >
-      0 results in 0.00 seconds
+      <span
+        aria-live="polite"
+        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      >
+        0 results in 0.00 seconds
+      </span>
     </span>
     <span
       aria-hidden="true"
@@ -40,10 +44,14 @@ exports[`StreamingProgressCount should render correctly for 0 items in progress 
     data-testid="streaming-progress-count"
   >
     <span
-      aria-live="polite"
-      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      class="position-relative"
     >
-      0 results in 0.00 seconds
+      <span
+        aria-live="polite"
+        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      >
+        0 results in 0.00 seconds
+      </span>
     </span>
     <span
       aria-hidden="true"
@@ -67,10 +75,14 @@ exports[`StreamingProgressCount should render correctly for 0 repositories 1`] =
     data-testid="streaming-progress-count"
   >
     <span
-      aria-live="polite"
-      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      class="position-relative"
     >
-      0 results in 0.00 seconds
+      <span
+        aria-live="polite"
+        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      >
+        0 results in 0.00 seconds
+      </span>
     </span>
     <span
       aria-hidden="true"
@@ -103,10 +115,14 @@ exports[`StreamingProgressCount should render correctly for 1 item complete 1`] 
     data-testid="streaming-progress-count"
   >
     <span
-      aria-live="polite"
-      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      class="position-relative"
     >
-      1 result in 1.25 seconds
+      <span
+        aria-live="polite"
+        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      >
+        1 result in 1.25 seconds
+      </span>
     </span>
     <span
       aria-hidden="true"
@@ -139,10 +155,14 @@ exports[`StreamingProgressCount should render correctly for 123 items complete 1
     data-testid="streaming-progress-count"
   >
     <span
-      aria-live="polite"
-      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      class="position-relative"
     >
-      123 results in 1.25 seconds
+      <span
+        aria-live="polite"
+        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      >
+        123 results in 1.25 seconds
+      </span>
     </span>
     <span
       aria-hidden="true"
@@ -175,10 +195,14 @@ exports[`StreamingProgressCount should render correctly for big numbers complete
     data-testid="streaming-progress-count"
   >
     <span
-      aria-live="polite"
-      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      class="position-relative"
     >
-      1.2m results in 52.50 seconds
+      <span
+        aria-live="polite"
+        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      >
+        1.2m results in 52.50 seconds
+      </span>
     </span>
     <span
       aria-hidden="true"
@@ -211,10 +235,14 @@ exports[`StreamingProgressCount should render correctly for limithit 1`] = `
     data-testid="streaming-progress-count"
   >
     <span
-      aria-live="polite"
-      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      class="position-relative"
     >
-      123+ results in 1.25 seconds
+      <span
+        aria-live="polite"
+        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      >
+        123+ results in 1.25 seconds
+      </span>
     </span>
     <span
       aria-hidden="true"
@@ -253,10 +281,14 @@ exports[`StreamingProgressCount should render correctly when a trace url is prov
     data-testid="streaming-progress-count"
   >
     <span
-      aria-live="polite"
-      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      class="position-relative"
     >
-      0 results in 0.00 seconds
+      <span
+        aria-live="polite"
+        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      >
+        0 results in 0.00 seconds
+      </span>
     </span>
     <span
       aria-hidden="true"

--- a/doc/dev/background-information/web/accessibility/how-to-screen-reader.md
+++ b/doc/dev/background-information/web/accessibility/how-to-screen-reader.md
@@ -45,6 +45,7 @@ Depending on the platform, there are two widely used screen readers. Although th
 
 - Use [`aria-hidden`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) to hide decorative elements from screen readers.
 - Use ReachUI's [`<VisuallyHidden />`](https://reach.tech/visually-hidden/) to provide accessible text that is visually hidden from the UI. This is useful for communicating the semantic meaning of buttons or other elements which are visually represented with an icon or other purely graphical content.
+  - Note: `VisuallyHidden` and `sr-only` can sometimes cause visual bugs. See [this related Chromium bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=1154640). We should only use this approach where it is not possible to use an equivalent `aria-` attribute.
 - Provide a more specific `aria-label` to elements whose exact meaning requires context around it to understand.
   - For example, in a list of items where each item also has a button associated with it, the button should be `aria-label`ed to more clearly indicate which item the button is for.
 - Use `screenReaderAnnounce` to communicate messages about implied changing state (e.g. form submission, async resolutions, or changes to on-screen data from polling).


### PR DESCRIPTION
## Description

I was pretty suprised to find that `VisuallyHidden` is actually impacting the UI here. It's because it has a `1px` height (needed it's still included in the page for screen readers), and `position: absolute`. There's no `position: relative;` in the parent elements so it seems to be pushing the page all the way down - interested to hear if anyone can figure out exactly why that happens, but this immediate fix works here.

## Test plan

Visual tests and locally with a screen reader

## App preview:

- [Web](https://sg-web-tr-fix-search-long-scroll.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-aceaesgtld.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
