### PR TITLE
search: Fix invalid DOM nesting error on search page

### DIFF
--- a/client/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/client/web/src/search/panels/SavedSearchesPanel.tsx
@@ -103,12 +103,14 @@ export const SavedSearchesPanel: React.FunctionComponent<React.PropsWithChildren
         <div className="d-flex flex-column h-100 justify-content-between">
             <table className="w-100 mt-2">
                 <thead className="pb-1">
-                    <th>
-                        <small>Search</small>
-                    </th>
-                    <th className="text-right">
-                        <small>Edit</small>
-                    </th>
+                    <tr>
+                        <th>
+                            <small>Search</small>
+                        </th>
+                        <th className="text-right">
+                            <small>Edit</small>
+                        </th>
+                    </tr>
                 </thead>
                 <tbody>
                     {savedSearches


### PR DESCRIPTION
In development mode, React throws the following error (only relevant
stack trace):

```
Warning: validateDOMNesting(...): <th> cannot appear as a child of <thead>.
th
thead
table
div
div
div
PanelContainer@webpack-internal:///./src/search/panels/PanelContainer.tsx:22:24
SavedSearchesPanel@webpack-internal:///./src/search/panels/SavedSearchesPanel.tsx:65:28
[...]
```



## Test plan

Going to https://sourcegraph.test:3443/search doesn't throw that error anymore.

## App preview:

- [Web](https://sg-web-fkling-fix-dom-nesting.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ahrkptblte.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
