### PR TITLE
[SG-34973]Accessibility: Commits page - Copy SHA button does not inform screen readers of status

### DIFF
--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -7,7 +7,15 @@ import DotsHorizontalIcon from 'mdi-react/DotsHorizontalIcon'
 import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
 
 import { pluralize } from '@sourcegraph/common'
-import { Button, ButtonGroup, DeprecatedTooltipController, Link, Icon, Code } from '@sourcegraph/wildcard'
+import {
+    Button,
+    ButtonGroup,
+    DeprecatedTooltipController,
+    Link,
+    Icon,
+    Code,
+    screenReaderAnnounce,
+} from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../components/time/Timestamp'
 import { GitCommitFields } from '../../graphql-operations'
@@ -96,6 +104,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
         eventLogger.log('CommitSHACopiedToClipboard')
         copy(oid)
         setFlashCopiedToClipboardMessage(true)
+        screenReaderAnnounce('Copied!')
 
         setTimeout(() => {
             setFlashCopiedToClipboardMessage(false)


### PR DESCRIPTION
### Audit type
Screen reader navigation

### User journey audit issue[
[#34423](https://github.com/sourcegraph/sourcegraph/issues/34423)

### Description
Currently, the `screen reader ` doesn't announce when the `git commit` is copied to the clipboard.

Button State 1:
<img width="195" alt="buttonstate1" src="https://user-images.githubusercontent.com/7220167/175471915-50cfb57d-fbff-4da7-9434-7afdf9bbba67.png">

Button State 2:
<img width="182" alt="buttonstate2" src="https://user-images.githubusercontent.com/7220167/175471921-8bd896d1-478a-496e-aa57-d2b0542883af.png">

### Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/34973)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34973)

### Expected behavior
We should use screenReaderAnnounce to quickly inform users when this state changes.

### Test Plan
- [ ] Navigate to [Git Commits](https://client-sourcegraph-frontend.onrender.com/github.com/hellokaton/java-bible/-/commits)
- [ ] Use the `screen reader` and on the copy icon, it should announce the label `Copy full SHA`.
- [ ] Clicking on the copy icon should announce `Copied!`

### Test Loom Video
https://www.loom.com/share/18b8593c06ae43cbb28c2868341e2c88

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-contractors-sg-34973.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tjsgifrsjn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
