### PR TITLE
bext: fix command palette styles on GitLab

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
@@ -7,6 +7,10 @@
     z-index: 1001 !important;
 }
 
+:global(.show) > .command-list-popover {
+    display: block;
+}
+
 .command-palette-button > span {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33906

| Before | After |
| -- | -- |
|![image](https://user-images.githubusercontent.com/25318659/175555716-b03fa8d3-3bae-4a6f-9f47-817714ead670.png) | <img width="1456" alt="Screenshot 2022-06-24 at 17 22 13" src="https://user-images.githubusercontent.com/25318659/175555656-aa7e8153-9240-415e-a94b-d524d475dd3b.png"> |

## Test plan
Run browser extension locally, navigate to GitLab and interact with the command palette (see screenshots). 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fix-command-palette.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yvxchlulxl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
