### PR TITLE
Code Insights: Fix insights line chart ticks rendering

### DIFF
--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -30,35 +30,27 @@ import {
 import styles from './LineChart.module.scss'
 
 interface GetLineGroupStyleOptions {
-    // Whether this series contains the active point
+    /** Whether this series contains the active point */
     id: string
 
-    // The id of the series
+    /** The id of the series */
     hasActivePoint: boolean
 
-    // Whether the chart has some active point
+    /** Whether the chart has some active point */
     isActive: boolean
 }
 
 export interface LineChartProps<Datum> extends SeriesLikeChart<Datum>, SVGProps<SVGSVGElement> {
-    /**
-     * The width of the chart
-     */
+    /** The width of the chart */
     width: number
 
-    /**
-     * The height of the chart
-     */
+    /** The height of the chart */
     height: number
 
-    /**
-     * Whether to start Y axis at zero
-     */
+    /** Whether to start Y axis at zero */
     zeroYAxisMin?: boolean
 
-    /**
-     * Function to style a given line group
-     */
+    /** Function to style a given line group */
     getLineGroupStyle?: (options: GetLineGroupStyleOptions) => CSSProperties
 
     /**

--- a/client/web/src/charts/core/components/axis/Axis.tsx
+++ b/client/web/src/charts/core/components/axis/Axis.tsx
@@ -23,6 +23,7 @@ interface AxisLeftProps {
 export const AxisLeft = memo(
     forwardRef<SVGGElement, AxisLeftProps>((props, reference) => {
         const { scale, left, top, width, height } = props
+        const ticksValues = getYScaleTicks({ scale, space: height })
 
         return (
             <>
@@ -36,10 +37,10 @@ export const AxisLeft = memo(
                     className={styles.gridLine}
                 />
 
-                <Group innerRef={reference} top={top} left={left}>
+                <Group key={ticksValues.reduce((store, tick) => `${store}-${tick}`, '')} innerRef={reference} top={top} left={left}>
                     <VisxAxisLeft
                         scale={scale}
-                        tickValues={getYScaleTicks({ scale, space: height })}
+                        tickValues={ticksValues}
                         tickFormat={formatYTick}
                         tickLabelProps={getTickYProps}
                         tickComponent={Tick}

--- a/client/web/src/charts/core/components/axis/Axis.tsx
+++ b/client/web/src/charts/core/components/axis/Axis.tsx
@@ -37,7 +37,12 @@ export const AxisLeft = memo(
                     className={styles.gridLine}
                 />
 
-                <Group key={ticksValues.reduce((store, tick) => `${store}-${tick}`, '')} innerRef={reference} top={top} left={left}>
+                <Group
+                    key={ticksValues.reduce((store, tick) => `${store}-${tick}`, '')}
+                    innerRef={reference}
+                    top={top}
+                    left={left}
+                >
                     <VisxAxisLeft
                         scale={scale}
                         tickValues={ticksValues}

--- a/client/web/src/charts/core/components/axis/Axis.tsx
+++ b/client/web/src/charts/core/components/axis/Axis.tsx
@@ -33,7 +33,7 @@ export const AxisLeft = memo(
                     width={width}
                     height={height}
                     scale={scale}
-                    tickValues={getYScaleTicks({ scale, space: height })}
+                    tickValues={ticksValues}
                     className={styles.gridLine}
                 />
 


### PR DESCRIPTION
Сloses https://github.com/sourcegraph/sourcegraph/issues/36749

| Before  | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/18492575/175564825-66cfe0b4-bcdc-4990-81dd-0e3f9cc87ed3.mov" /> | <video src="https://user-images.githubusercontent.com/18492575/175564870-8c5f660a-1df9-4a52-b4d8-618e971f35d1.mov" />  |







## Test plan
- Enable feature flag `insight-polling-enabled`
- Create an insight 
- See that when new data is pulled from the backend and was rendered on the chart Line chart ticks look good (don't have overflowed problem) 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-line-chart-ticks-updating.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kpfjpzkata.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
