### PR TITLE
Update git to 2.35.2 in docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- Updated minimum required veresion of `git` to 2.35.2 in `gitserver` and `server` Docker image. This addresses a few vulnerabilities disclosed in https://github.blog/2022-04-12-git-security-vulnerability-announced/.
 
 ### Fixed
 

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -37,8 +37,8 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # We require git 2.34.1 because we use git-repack with flag
-    # --write-midx.  We require git 2.35.2 to fix this vulnerability:
+    # We require git 2.34.1 because we use git-repack with flag --write-midx.
+    # We require git 2.35.2 to fix this vulnerability:
     # https://github.blog/2022-04-12-git-security-vulnerability-announced/
     'git>=2.35.2' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -37,8 +37,10 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    # We require git 2.34.1 because we use git-repack with flag
+    # --write-midx.  We require git 2.35.2 to fix this vulnerability:
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    'git>=2.35.2' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -7,9 +7,9 @@
 FROM sourcegraph/alpine-3.14:154143_2022-06-13_1eababf8817e@sha256:f1c4ac9ca1a36257c1eb699d0acf489d83dd86e067b1fc3ea4a563231a047e05 AS p4cli
 
 # hadolint ignore=DL3003
-RUN wget http://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/p4 && \
-    mv p4 /usr/local/bin/p4 && \
-    chmod +x /usr/local/bin/p4
+RUN wget http://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/p4
+RUN mv p4 /usr/local/bin/p4
+RUN chmod +x /usr/local/bin/p4
 
 FROM sourcegraph/alpine-3.14:154143_2022-06-13_1eababf8817e@sha256:f1c4ac9ca1a36257c1eb699d0acf489d83dd86e067b1fc3ea4a563231a047e05 AS p4-fusion
 
@@ -40,9 +40,10 @@ RUN apk add --no-cache \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
     # We require git 2.35.2 to fix this vulnerability:
     # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    'git>=2.35.2' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
-    git-p4 \
-    && apk add --no-cache  \
+    'git>=2.35.2' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main \
+    git-p4
+
+RUN apk add --no-cache  \
     openssh-client \
     # We require libstdc++ for p4-fusion
     libstdc++ \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -42,7 +42,9 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' \
+    # We require git 2.35.2 to fix this vulnerability:
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    'git>=2.35.2' \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -2,9 +2,9 @@
 FROM sourcegraph/alpine-3.14:154143_2022-06-13_1eababf8817e@sha256:f1c4ac9ca1a36257c1eb699d0acf489d83dd86e067b1fc3ea4a563231a047e05 AS p4cli
 
 # hadolint ignore=DL3003
-RUN wget http://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/p4 && \
-    mv p4 /usr/local/bin/p4 && \
-    chmod +x /usr/local/bin/p4
+RUN wget http://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/p4
+RUN mv p4 /usr/local/bin/p4
+RUN chmod +x /usr/local/bin/p4
 
 # Install p4-fusion (keep this up to date with cmd/gitserver/Dockerfile)
 FROM sourcegraph/alpine-3.14:154143_2022-06-13_1eababf8817e@sha256:f1c4ac9ca1a36257c1eb699d0acf489d83dd86e067b1fc3ea4a563231a047e05 AS p4-fusion
@@ -46,18 +46,21 @@ RUN apk add --no-cache --verbose \
     # https://github.blog/2022-04-12-git-security-vulnerability-announced/
     'git>=2.35.2' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main  \
+
+RUN apk add --no-cache --verbose \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     # You can't just bump the major version since that requires pgupgrade
     # between Sourcegraph releases.
-    && apk add --no-cache --verbose \
     postgresql=~12 \
     postgresql-contrib=~12 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main  \
-    && apk add --no-cache --verbose \
+
+
+RUN apk add --no-cache --verbose \
     'bash>=5.0.17' \
     'redis>=5.0' \
     python2 \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -46,7 +46,7 @@ RUN apk add --no-cache --verbose \
     # https://github.blog/2022-04-12-git-security-vulnerability-announced/
     'git>=2.35.2' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main  \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main
 
 RUN apk add --no-cache --verbose \
     # NOTE that the Postgres version we run is different

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -57,8 +57,7 @@ RUN apk add --no-cache --verbose \
     # between Sourcegraph releases.
     postgresql=~12 \
     postgresql-contrib=~12 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main  \
-
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main
 
 RUN apk add --no-cache --verbose \
     'bash>=5.0.17' \


### PR DESCRIPTION
Second attempt for #37547 since we had to revert it because of a broken build in main.

This addresses the vulnerabilities disclosed in https://github.blog/2022-04-12-git-security-vulnerability-announced/

This was originally brought to our attention on Slack [here](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1655822423268479) this week.

## Test plan

Verified that this works now with a `main-dry-run` build here: https://buildkite.com/sourcegraph/sourcegraph/builds/156522


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
