### PR TITLE
Update build version for resource estimator

### DIFF
--- a/doc/admin/deploy/resource_estimator.md
+++ b/doc/admin/deploy/resource_estimator.md
@@ -39,6 +39,6 @@
 </style>
 
 <script src="https://storage.googleapis.com/sourcegraph-resource-estimator/go_1_18_wasm_exec.js"></script>
-<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="94ad774"></script>
+<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="08f379a"></script>
 
 <form id="root"></form>


### PR DESCRIPTION
A follow up on https://github.com/sourcegraph/sourcegraph/pull/37653

This PR updates build version number to the resource estimator version number built with Go 1.18

Latest build version number: 08f379a from https://github.com/sourcegraph/resource-estimator/pull/14

Uploaded to [Google Cloud Storage bucket](https://console.cloud.google.com/storage/browser/sourcegraph-resource-estimator?authuser=1&project=sourcegraph-dev).

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Tested locally