### PR TITLE
Contrast compliant syntax highlighting: V2

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -244,8 +244,8 @@ $theme-colors: (
 // Syntax highlighting changes for WCAG 2.1 contrast compliance (currently behind feature flag)
 // https://github.com/sourcegraph/sourcegraph/issues/36251
 .theme-light .theme-contrast-compliant-syntax-highlighting {
-    --line-number-color: #536da1;
+    --line-number-color: var(--gray-07);
 }
 .theme-dark .theme-contrast-compliant-syntax-highlighting {
-    --line-number-color: #bdc8df;
+    --line-number-color: var(--gray-06);
 }

--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -1027,7 +1027,7 @@
     --hl-comment: #767676;
     --hl-modifier: #1626b8;
 
-    // Semantic variable -> Color variable for backwards compatibility.
+    // Color variable = Semantic variable for backwards compatibility.
     // TODO: Use semantic variables directly in the code instead.
     --hl-pink: var(--hl-property);
     --hl-cyan: var(--hl-string);
@@ -1064,7 +1064,7 @@
     --hl-comment: #3ba04f;
     --hl-other: #d08770;
 
-    // Semantic variable -> Color variable for backwards compatibility.
+    // Color variable = Semantic variable for backwards compatibility.
     // TODO: Use semantic variables directly in the code instead.
     --hl-pink: var(--hl-property);
     --hl-yellow: var(--hl-function);

--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -1027,7 +1027,8 @@
     --hl-comment: #767676;
     --hl-modifier: #1626b8;
 
-    // Overrides. TODO: Replace these in the code instead
+    // Semantic variable -> Color variable for backwards compatibility.
+    // TODO: Use semantic variables directly in the code instead.
     --hl-pink: var(--hl-property);
     --hl-cyan: var(--hl-string);
     --hl-yellow: var(--hl-function);
@@ -1052,27 +1053,27 @@
 }
 .theme-dark .theme-contrast-compliant-syntax-highlighting {
     --hl-property: #eb519c;
-    --hl-string: #2aa198;
+    --hl-string: #fb90c4;
     --hl-function: #b58900;
     --hl-object: #859900;
     --hl-keyword: #329af0;
-    --hl-type: #78b8eb;
+    --hl-type: #329af0;
     --hl-const-num: #777dec;
     --hl-punctuation: #d66f6d;
     --hl-symbol: #bbbbbb;
     --hl-comment: #3ba04f;
     --hl-other: #d08770;
 
-    // Overrides. TODO: Replace these in the code instead
+    // Semantic variable -> Color variable for backwards compatibility.
+    // TODO: Use semantic variables directly in the code instead.
     --hl-pink: var(--hl-property);
-    --hl-cyan: var(--hl-string);
     --hl-yellow: var(--hl-function);
     --hl-dark-blue-3: var(--hl-keyword);
     --hl-dark-blue-1: var(--hl-type);
     --hl-purple: var(--hl-const-num);
     --hl-gray-3: var(--hl-symbol);
     --hl-dark-green: var(--hl-comment);
-    --hl-red: #fb90c4;
+    --hl-red: var(--hl-string);
 
     .hl-keyword.hl-other.hl-unit {
         color: var(--hl-other);

--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -1014,7 +1014,6 @@
 // Syntax highlighting changes for WCAG 2.1 contrast compliance (currently behind feature flag)
 // https://github.com/sourcegraph/sourcegraph/issues/36251
 .theme-light .theme-contrast-compliant-syntax-highlighting {
-    // New values
     --hl-property: #d33682;
     --hl-string: #058356;
     --hl-function: #886700;

--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -1014,27 +1014,68 @@
 // Syntax highlighting changes for WCAG 2.1 contrast compliance (currently behind feature flag)
 // https://github.com/sourcegraph/sourcegraph/issues/36251
 .theme-light .theme-contrast-compliant-syntax-highlighting {
-    --hl-yellow: #7f6102;
-    --hl-green: #226a00;
-    --hl-red: #ce0804;
-    --hl-orange: #af4001;
-    --hl-blue: #006bb7;
-    --hl-cyan: #545454;
-    --hl-eggshell: #c8c7c5;
-    --hl-purple: #555bc2;
-    --hl-pink: #c32974;
-    --hl-gray-0: #666666;
-    --hl-gray-1: #666666;
-    --hl-gray-2: ##666666;
-    --hl-gray-3: #606060;
+    // New values
+    --hl-property: #d33682;
+    --hl-string: #058356;
+    --hl-function: #886700;
+    --hl-object: #677700;
+    --hl-keyword: #c44e06;
+    --hl-type: #2178b6;
+    --hl-const-num: #5f66e0;
+    --hl-punctuation: #767676;
+    --hl-symbol: #6d6c6c;
+    --hl-comment: #767676;
+    --hl-modifier: #1626b8;
+
+    // Overrides. TODO: Replace these in the code instead
+    --hl-pink: var(--hl-property);
+    --hl-cyan: var(--hl-string);
+    --hl-yellow: var(--hl-function);
+    --hl-green: var(--hl-object);
+    --hl-orange: var(--hl-keyword);
+    --hl-blue: var(--hl-type);
+    --hl-purple: var(--hl-purple);
+    --hl-gray-0: var(--hl-comment);
+    --hl-gray-1: var(--hl-comment);
+    --hl-gray-2: var(--hl-comment);
+    --hl-gray-3: var(--hl-symbol);
+
+    // surrounding quotes
+    .hl-punctuation.hl-definition.hl-string {
+        color: var(--hl-punctuation);
+    }
+
+    // const, public, inline
+    .hl-storage.hl-modifier {
+        color: var(--hl-modifier);
+    }
 }
 .theme-dark .theme-contrast-compliant-syntax-highlighting {
-    --hl-dark-green: #90c29a;
-    --hl-dark-blue-1: #62b4f9;
-    --hl-dark-blue-3: #7ac3fe;
+    --hl-property: #eb519c;
+    --hl-string: #2aa198;
+    --hl-function: #b58900;
+    --hl-object: #859900;
+    --hl-keyword: #329af0;
+    --hl-type: #78b8eb;
+    --hl-const-num: #777dec;
+    --hl-punctuation: #d66f6d;
+    --hl-symbol: #bbbbbb;
+    --hl-comment: #3ba04f;
+    --hl-other: #d08770;
+
+    // Overrides. TODO: Replace these in the code instead
+    --hl-pink: var(--hl-property);
+    --hl-cyan: var(--hl-string);
+    --hl-yellow: var(--hl-function);
+    --hl-dark-blue-3: var(--hl-keyword);
+    --hl-dark-blue-1: var(--hl-type);
+    --hl-purple: var(--hl-const-num);
+    --hl-gray-3: var(--hl-symbol);
+    --hl-dark-green: var(--hl-comment);
+    --hl-red: #fb90c4;
 
     .hl-keyword.hl-other.hl-unit {
-        color: #dba291;
+        color: var(--hl-other);
     }
 
     .hl-punctuation.hl-section.hl-embedded,


### PR DESCRIPTION
## Description

Follow up to https://github.com/sourcegraph/sourcegraph/pull/37385 and feedback we have received.

This PR:
- Further updates contrast contrast. We have decided to prioritise the typical viewing experience (e.g. not `diff-added|remove` or `selected-line`). We will address those areas in a future high-contrast theme. This gives us the extra flexibility to make our code highlighting readable and compliant at the same time.
- Adds semantic colors. Right now, this is mainly so we can iterate on this fast and understand what we're changing. In the future we should aim to use the colors everywhere, instead of `hl-blue` etc, as that is not brittle to change.

**These changes are feature-flagged. See #37385 for more information**

### Example before
![image](https://user-images.githubusercontent.com/9516420/175582747-e8117019-764b-4859-9bda-acb235e1805f.png)

### Example after
![image](https://user-images.githubusercontent.com/9516420/175584030-f6168048-8050-48af-889a-b8f103423e0d.png)


## Test plan

Local testing and ARC Toolkit audits

## App preview:

- [Web](https://sg-web-tr-color-contrast-v2.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wwgeuqwffx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

