### PR TITLE
doc/adr: fix ADR templates

### DIFF
--- a/doc/dev/adr/1653383629-use-tech-radar.md
+++ b/doc/dev/adr/1653383629-use-tech-radar.md
@@ -2,17 +2,17 @@
 
 Date: 2022-05-24
 
-### Context
+## Context
 
 We want a quick visual overview of our tech stack: what's the established norms are, what has been explored, what has been rejected, and so on. We think this will improve developer onboarding as it will be easy to digest our stack for the new hires quickly.
 
 Proposed & discussed on May 12 during the [Backend Crew meeting](https://docs.google.com/document/d/1Y51d863Nuqr9BzbTbwwSF9jes0ro71vB724oc2p8qsQ/edit#heading=h.1cbmcls3l8u). Tech Radar is not unique for the back-end, and our ambition is to include both front-end and back-end tools, practices, libraries, etc.
 
-### Decision
+## Decision
 
 Build Sourcegraph Tech Radar. The initial version uses the [Build your Own Radar](https://www.thoughtworks.com/radar/byor) version hosted at Thoughtworks.com
 
-### Consequences
+## Consequences
 
 - Improve understanding of our current tech stack.
 - Improve onboarding.

--- a/doc/dev/adr/how-to.md
+++ b/doc/dev/adr/how-to.md
@@ -12,9 +12,14 @@ Great! You've decided to write an ADR. This process will likely improve in the f
 ### ADR template
 
 ```
-{{date}}
+# {{index}}. {{title}}
+
+Date: {{YYYY-MM-DD}}
 
 ### Context
+
 ### Decision
+
 ### Consequences
+
 ```


### PR DESCRIPTION
The existing template didn't really reflect the actual ADRs already published, this PR fixes them

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a