### PR TITLE
dev/sg: add 'sg adr [list|view|search|create]'

### DIFF
--- a/dev/adr-docs/index.md.tmpl
+++ b/dev/adr-docs/index.md.tmpl
@@ -8,6 +8,6 @@ Are you considering adding an ADR? Check out the [How-to page](how-to.md)!
 
 To preserve order, individual documents are prefixed by the **current epoch Unix timestamp**.
 {{""}}
-{{- range .Adrs }}
-{{ .Number }}. _{{ .Date }}_ [{{ .Title }}]({{ .Path }})
+{{- range .ADRs }}
+{{ .Number }}. _{{ .Date.Format "2006-01-02" }}_ [{{ .Title }}]({{ .BasePath }})
 {{- end }}

--- a/dev/adr-docs/main.go
+++ b/dev/adr-docs/main.go
@@ -1,27 +1,16 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"text/template"
-	"time"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/adr"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 )
 
-type adr struct {
-	Number int
-	Title  string
-	Path   string
-	Date   string
-}
-
 type templateData struct {
-	Adrs []adr
+	ADRs []adr.ArchitectureDecisionRecord
 }
 
 //go:generate go run .
@@ -30,50 +19,19 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
 	tmpl, err := template.ParseFiles(filepath.Join(repoRoot, "dev", "adr-docs", "index.md.tmpl"))
 	if err != nil {
 		panic(err)
 	}
-	entries, err := os.ReadDir(filepath.Join(repoRoot, "doc", "dev", "adr"))
+
+	adrs, err := adr.List(filepath.Join(repoRoot, "doc", "dev", "adr"))
 	if err != nil {
-		panic(err)
-	}
-
-	var adrs []adr
-	re := regexp.MustCompile(`^(\d+)-.+\.md`)
-	for _, entry := range entries {
-		if !re.MatchString(entry.Name()) {
-			continue
-		}
-		b, err := os.ReadFile(filepath.Join(repoRoot, "doc", "dev", "adr", entry.Name()))
-		if err != nil {
-			panic(err)
-		}
-		m := re.FindAllStringSubmatch(entry.Name(), 1)
-		ts, _ := strconv.Atoi(m[0][1]) // We can ignore the err because we know from the regexp it's only digits.
-
-		reHeader := regexp.MustCompile(`#\s+(\d+)\.\s+(.*)$`)
-		s := bufio.NewScanner(bytes.NewReader(b))
-		var title string
-		var number int
-		for s.Scan() {
-			matches := reHeader.FindAllStringSubmatch(s.Text(), 1)
-			if len(matches) > 0 {
-				number, _ = strconv.Atoi(matches[0][1]) // We can ignore the err because we know from the regexp it's only digits.
-				title = matches[0][2]
-				adrs = append(adrs, adr{
-					Title:  title,
-					Number: number,
-					Path:   entry.Name(),
-					Date:   time.Unix(int64(ts), 0).Format("2006-01-02"),
-				})
-				break
-			}
-		}
+		return
 	}
 
 	presenter := templateData{
-		Adrs: adrs,
+		ADRs: adrs,
 	}
 
 	f, err := os.Create(filepath.Join(repoRoot, "doc", "dev", "adr", "index.md"))

--- a/dev/sg/adr/adr.go
+++ b/dev/sg/adr/adr.go
@@ -2,14 +2,12 @@ package adr
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -29,11 +27,7 @@ func (r ArchitectureDecisionRecord) DocsiteURL() string {
 	return fmt.Sprintf("https://docs.sourcegraph.com/dev/adr/" + cleanedName)
 }
 
-var (
-	adrFileRegexp        = regexp.MustCompile(`^(\d+)-.+\.md`)
-	markdownHeaderRegexp = regexp.MustCompile(`#\s+(\d+)\.\s+(.*)$`)
-)
-
+// List parses all ADRs and returns them in read order.
 func List(adrDir string) ([]ArchitectureDecisionRecord, error) {
 	var adrs []ArchitectureDecisionRecord
 	return adrs, VisitAll(adrDir, func(adr ArchitectureDecisionRecord) error {
@@ -41,6 +35,13 @@ func List(adrDir string) ([]ArchitectureDecisionRecord, error) {
 		return nil
 	})
 }
+
+var (
+	// Matches for ADRs with filename format ${timestamp}-${name}.md
+	adrFilenameRegexp = regexp.MustCompile(`^(\d+)-.+\.md`)
+	// Matches for Markdown headers
+	markdownHeaderRegexp = regexp.MustCompile(`#\s+(\d+)\.\s+(.*)$`)
+)
 
 // VisitAll applies visit on all ADRs.
 //
@@ -51,29 +52,39 @@ func VisitAll(adrDir string, visit func(adr ArchitectureDecisionRecord) error) e
 			return nil
 		}
 
-		if !adrFileRegexp.MatchString(entry.Name()) {
+		// Ensure this file matches the ADR format
+		filenameMatch := adrFilenameRegexp.FindAllStringSubmatch(entry.Name(), 1)
+		if filenameMatch == nil {
 			return nil
 		}
-		b, err := os.ReadFile(path)
+
+		// Parse the timestamp - we can ignore the err because we know from the regexp
+		// it's only digits.
+		ts, _ := strconv.Atoi(filenameMatch[0][1])
+		date := time.Unix(int64(ts), 0)
+
+		// Look for more details in the file contents
+		file, err := os.Open(path)
 		if err != nil {
 			return err
 		}
-
-		m := adrFileRegexp.FindAllStringSubmatch(entry.Name(), 1)
-		ts, _ := strconv.Atoi(m[0][1]) // We can ignore the err because we know from the regexp it's only digits.
-
-		s := bufio.NewScanner(bytes.NewReader(b))
-		var title string
-		var number int
+		defer file.Close()
+		s := bufio.NewScanner(file)
 		for s.Scan() {
-			matches := markdownHeaderRegexp.FindAllStringSubmatch(s.Text(), 1)
-			if len(matches) > 0 {
-				number, _ = strconv.Atoi(matches[0][1]) // We can ignore the err because we know from the regexp it's only digits.
-				title = matches[0][2]
+			headerMatches := markdownHeaderRegexp.FindAllStringSubmatch(s.Text(), 1)
+			// We only care about the first header match, so process it to get ADR details
+			// and exit.
+			if len(headerMatches) > 0 {
+				// We can ignore the err because we know from the regexp it's only digits.
+				number, _ := strconv.Atoi(headerMatches[0][1])
+				// Title is after the number
+				title := headerMatches[0][2]
+
+				// Pass to visit
 				if err := visit(ArchitectureDecisionRecord{
 					Title:  title,
 					Number: number,
-					Date:   time.Unix(int64(ts), 0),
+					Date:   date,
 
 					Path:     path,
 					BasePath: entry.Name(),
@@ -86,14 +97,6 @@ func VisitAll(adrDir string, visit func(adr ArchitectureDecisionRecord) error) e
 
 		return nil
 	})
-}
-
-var nonAlphaNumericOrDash = regexp.MustCompile("[^a-z0-9-]+")
-
-func sanitizeADRName(name string) string {
-	return nonAlphaNumericOrDash.ReplaceAllString(
-		strings.ReplaceAll(strings.ToLower(name), " ", "-"), "",
-	)
 }
 
 // Create generates an ADR template file.

--- a/dev/sg/adr/adr.go
+++ b/dev/sg/adr/adr.go
@@ -1,0 +1,124 @@
+package adr
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type ArchitectureDecisionRecord struct {
+	Number int
+	Title  string
+	Date   time.Time
+
+	// The following are set if ADR is read or created
+	Path     string
+	BasePath string
+}
+
+// DocsiteURL returns a link to this ADR in docs.sourcegraph.com
+func (r ArchitectureDecisionRecord) DocsiteURL() string {
+	cleanedName := r.BasePath[:len(r.BasePath)-len(filepath.Ext(r.BasePath))]
+	return fmt.Sprintf("https://docs.sourcegraph.com/dev/adr/" + cleanedName)
+}
+
+var (
+	adrFileRegexp        = regexp.MustCompile(`^(\d+)-.+\.md`)
+	markdownHeaderRegexp = regexp.MustCompile(`#\s+(\d+)\.\s+(.*)$`)
+)
+
+func List(adrDir string) ([]ArchitectureDecisionRecord, error) {
+	var adrs []ArchitectureDecisionRecord
+	return adrs, VisitAll(adrDir, func(adr ArchitectureDecisionRecord) error {
+		adrs = append(adrs, adr)
+		return nil
+	})
+}
+
+// VisitAll applies visit on all ADRs.
+//
+// Must be kept in sync with the generator in Create.
+func VisitAll(adrDir string, visit func(adr ArchitectureDecisionRecord) error) error {
+	return filepath.WalkDir(adrDir, func(path string, entry fs.DirEntry, err error) error {
+		if entry.IsDir() {
+			return nil
+		}
+
+		if !adrFileRegexp.MatchString(entry.Name()) {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		m := adrFileRegexp.FindAllStringSubmatch(entry.Name(), 1)
+		ts, _ := strconv.Atoi(m[0][1]) // We can ignore the err because we know from the regexp it's only digits.
+
+		s := bufio.NewScanner(bytes.NewReader(b))
+		var title string
+		var number int
+		for s.Scan() {
+			matches := markdownHeaderRegexp.FindAllStringSubmatch(s.Text(), 1)
+			if len(matches) > 0 {
+				number, _ = strconv.Atoi(matches[0][1]) // We can ignore the err because we know from the regexp it's only digits.
+				title = matches[0][2]
+				if err := visit(ArchitectureDecisionRecord{
+					Title:  title,
+					Number: number,
+					Date:   time.Unix(int64(ts), 0),
+
+					Path:     path,
+					BasePath: entry.Name(),
+				}); err != nil {
+					return err
+				}
+				break
+			}
+		}
+
+		return nil
+	})
+}
+
+var nonAlphaNumericOrDash = regexp.MustCompile("[^a-z0-9-]+")
+
+func sanitizeADRName(name string) string {
+	return nonAlphaNumericOrDash.ReplaceAllString(
+		strings.ReplaceAll(strings.ToLower(name), " ", "-"), "",
+	)
+}
+
+// Create generates an ADR template file.
+//
+// Must be kept in sync with the parser in VisitAll.
+func Create(adrDir string, adr *ArchitectureDecisionRecord) error {
+	fileName := fmt.Sprintf("%d-%s.md", adr.Date.Unix(), sanitizeADRName(adr.Title))
+	f, err := os.Create(filepath.Join(adrDir, fileName))
+	if err != nil {
+		return err
+	}
+
+	// Update the ADR
+	adr.Path = f.Name()
+	adr.BasePath = filepath.Base(adr.Path)
+
+	// Write header
+	fmt.Fprintf(f, "# %d. %s\n\n", adr.Number, adr.Title)
+	fmt.Fprintf(f, "Date: %s\n\n", adr.Date.Format("2006-01-02"))
+
+	// Create sections
+	fmt.Fprint(f, "## Context\n\nTODO\n\n")
+	fmt.Fprint(f, "## Decision\n\nTODO\n\n")
+	fmt.Fprint(f, "## Consequences\n\nTODO\n")
+
+	// Save file
+	return f.Sync()
+}

--- a/dev/sg/adr/sanitize.go
+++ b/dev/sg/adr/sanitize.go
@@ -1,0 +1,14 @@
+package adr
+
+import (
+	"regexp"
+	"strings"
+)
+
+var nonAlphaNumericOrDash = regexp.MustCompile("[^a-z0-9-]+")
+
+func sanitizeADRName(name string) string {
+	return nonAlphaNumericOrDash.ReplaceAllString(
+		strings.ReplaceAll(strings.ToLower(name), " ", "-"), "",
+	)
+}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -246,6 +246,7 @@ var sg = &cli.App{
 		// Company
 		teammateCommand,
 		rfcCommand,
+		adrCommand,
 		liveCommand,
 		opsCommand,
 		auditCommand,

--- a/dev/sg/sg_adr.go
+++ b/dev/sg/sg_adr.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/adr"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+var adrCommand = &cli.Command{
+	Name:  "adr",
+	Usage: `List, search, view, and create Sourcegraph Architecture Decision Records (ADRs)`,
+	Description: `We use Architecture Decision Records (ADRs) only for logging decisions that have notable
+architectural impact on our codebase. Since we're a high-agency company, we encourage any
+contributor to commit an ADR if they've made an architecturally significant decision.
+
+ADRs are not meant to replace our current RFC process but to complement it by capturing
+decisions made in RFCs. However, ADRs do not need to come out of RFCs only. GitHub issues
+or pull requests, PoCs, team-wide discussions, and similar processes may result in an ADR
+as well.
+
+Learn more about ADRs here: https://docs.sourcegraph.com/dev/adr`,
+	UsageText: `
+# List all ADRs
+sg adr list
+
+# Search for an ADR
+sg adr search "search terms"
+
+# Open a specific index
+sg adr view 420
+
+# Create a new ADR!
+sg adr create my ADR title
+`,
+	Category: CategoryCompany,
+	Subcommands: []*cli.Command{
+		{
+			Name:  "list",
+			Usage: "List all ADRs",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "asc",
+					Usage: "List oldest ADRs first",
+				},
+			},
+			Action: func(cmd *cli.Context) error {
+				repoRoot, err := root.RepositoryRoot()
+				if err != nil {
+					return err
+				}
+
+				adrs, err := adr.List(filepath.Join(repoRoot, "doc", "dev", "adr"))
+				if err != nil {
+					return err
+				}
+				if !cmd.Bool("asc") {
+					sort.Slice(adrs, func(i, j int) bool {
+						return adrs[i].Date.After(adrs[j].Date)
+					})
+				}
+				for _, r := range adrs {
+					printADR(r)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "search",
+			ArgsUsage: "[terms...]",
+			Usage:     "Search ADR titles and content",
+			Action: func(cmd *cli.Context) error {
+				if cmd.NArg() == 0 {
+					return errors.New("search arguments are required")
+				}
+
+				// Build a regexp out of terms
+				var terms []string
+				for _, arg := range cmd.Args().Slice() {
+					terms = append(terms, fmt.Sprintf("(%s)", regexp.QuoteMeta(arg)))
+				}
+				// Case-insensitive, with implicit wildcard
+				searchRegexp, err := regexp.Compile("(?i)" + strings.Join(terms, "((.|\n|\r)*)"))
+				if err != nil {
+					return errors.Wrap(err, "invalid search")
+				}
+
+				repoRoot, err := root.RepositoryRoot()
+				if err != nil {
+					return err
+				}
+
+				var found bool
+				if err := adr.VisitAll(filepath.Join(repoRoot, "doc", "dev", "adr"), func(r adr.ArchitectureDecisionRecord) error {
+					if searchRegexp.MatchString(r.Title) {
+						printADR(r)
+						found = true
+						return nil
+					}
+
+					content, err := os.ReadFile(r.Path)
+					if err != nil {
+						return err
+					}
+					if searchRegexp.Match(content) {
+						printADR(r)
+						found = true
+						return nil
+					}
+
+					return nil
+				}); err != nil {
+					return err
+				}
+
+				if !found {
+					return errors.New("no ADRs found matching the given terms")
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "view",
+			ArgsUsage: "[number]",
+			Usage:     "View an ADR",
+			Action: func(cmd *cli.Context) error {
+				arg := cmd.Args().First()
+				index, err := strconv.Atoi(arg)
+				if err != nil {
+					return errors.Wrap(err, "invalid ADR index")
+				}
+
+				repoRoot, err := root.RepositoryRoot()
+				if err != nil {
+					return err
+				}
+
+				var found bool
+				if err := adr.VisitAll(filepath.Join(repoRoot, "doc", "dev", "adr"), func(r adr.ArchitectureDecisionRecord) error {
+					if r.Number != index {
+						return nil
+					}
+
+					found = true
+					content, err := os.ReadFile(r.Path)
+					if err != nil {
+						return err
+					}
+
+					if err := std.Out.WriteMarkdown(string(content)); err != nil {
+						return err
+					}
+					std.Out.WriteSuggestionf("If published, you can also see and share this ADR at %s%s",
+						output.StyleUnderline, r.DocsiteURL())
+					return nil
+				}); err != nil {
+					return err
+				}
+
+				if !found {
+					return errors.New("ADR not found - use 'sg adr list' or 'sg adr search' to find an ADR")
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "create",
+			ArgsUsage: "<title>",
+			Usage:     "Create an ADR!",
+			Action: func(cmd *cli.Context) error {
+				repoRoot, err := root.RepositoryRoot()
+				if err != nil {
+					return err
+				}
+
+				adrs, err := adr.List(filepath.Join(repoRoot, "doc", "dev", "adr"))
+				if err != nil {
+					return err
+				}
+
+				newADR := &adr.ArchitectureDecisionRecord{
+					Number: len(adrs) + 1,
+					Title:  strings.Join(cmd.Args().Slice(), " "),
+					Date:   time.Now().UTC(),
+				}
+				if err := adr.Create(filepath.Join(repoRoot, "doc", "dev", "adr"), newADR); err != nil {
+					return err
+				}
+
+				std.Out.WriteSuccessf("Created template at for 'ADR %d %s' at %s",
+					newADR.Number, newADR.Title, newADR.Path)
+				return nil
+			},
+		},
+	},
+}
+
+func printADR(r adr.ArchitectureDecisionRecord) {
+	std.Out.Writef("ADR %d %s%s%s %s%s%s",
+		r.Number, output.CombineStyles(output.StyleBold, output.StyleSuccess), r.Title, output.StyleReset, output.StyleSuggestion, r.Date.Format("2006-01-02"), output.StyleReset)
+}

--- a/dev/sg/sg_adr.go
+++ b/dev/sg/sg_adr.go
@@ -104,12 +104,14 @@ sg adr create my ADR title
 
 				var found bool
 				if err := adr.VisitAll(filepath.Join(repoRoot, "doc", "dev", "adr"), func(r adr.ArchitectureDecisionRecord) error {
+					// Try to match the title
 					if searchRegexp.MatchString(r.Title) {
 						printADR(r)
 						found = true
 						return nil
 					}
 
+					// Otherwise, try to match the file contents
 					content, err := os.ReadFile(r.Path)
 					if err != nil {
 						return err
@@ -199,7 +201,7 @@ sg adr create my ADR title
 					return err
 				}
 
-				std.Out.WriteSuccessf("Created template at for 'ADR %d %s' at %s",
+				std.Out.WriteSuccessf("Created template for 'ADR %d %s' at %s",
 					newADR.Number, newADR.Title, newADR.Path)
 				return nil
 			},

--- a/doc/dev/adr/how-to.md
+++ b/doc/dev/adr/how-to.md
@@ -1,17 +1,20 @@
-# How to write an ADR?
+# Writing an ADR
 
-Great! You've decided to write an ADR. This process will likely improve in the future, but here are the recommended steps for now:
+Great! You've decided to write an ADR. To get started:
+
+1. Create an ADR with `sg adr create [title]`, or [create one manually](#manual-creation)
+2. Keep it short and sweet; ADRs are meant to be brief and easy to digest. Check out the other ADRs for inspiration!
+3. Open a PR and ask for feedback. Tag the people familiar with the specific area to verify that your decision record correctly captures the decision made.
+
+## Manual creation
 
 1. Add a new ADR file to this folder (`.md` format)
-2. Use the following name: `{{timestamp}}-short-decision-summary.md`
-  1. Grab the `timestamp` from [this page](https://www.unixtimestamp.com)
+2. Use the following name: `{{timestamp}}-short-decision-summary.md` (grab the `timestamp` from [this page](https://www.unixtimestamp.com))
 3. Use the template below for writing an ADR
-4. Keep it short and sweet; ADRs are meant to be brief and easy to digest. Check out the other ADRs for inspiration!
-5. Open a PR and ask for feedback. Tag the people familiar with the specific area to verify that your decision record correctly captures the decision made.
 
 ### ADR template
 
-```
+```md
 # {{index}}. {{title}}
 
 Date: {{YYYY-MM-DD}}

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -896,6 +896,79 @@ Flags:
 
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 
+## sg adr
+
+List, search, view, and create Sourcegraph Architecture Decision Records (ADRs).
+
+We use Architecture Decision Records (ADRs) only for logging decisions that have notable
+architectural impact on our codebase. Since we're a high-agency company, we encourage any
+contributor to commit an ADR if they've made an architecturally significant decision.
+
+ADRs are not meant to replace our current RFC process but to complement it by capturing
+decisions made in RFCs. However, ADRs do not need to come out of RFCs only. GitHub issues
+or pull requests, PoCs, team-wide discussions, and similar processes may result in an ADR
+as well.
+
+Learn more about ADRs here: https://docs.sourcegraph.com/dev/adr
+
+```sh
+# List all ADRs
+$ sg adr list
+
+# Search for an ADR
+$ sg adr search "search terms"
+
+# Open a specific index
+$ sg adr view 420
+
+# Create a new ADR!
+$ sg adr create my ADR title
+```
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a Github discussion
+
+### sg adr list
+
+List all ADRs.
+
+
+Flags:
+
+* `--asc`: List oldest ADRs first
+* `--feedback`: provide feedback about this command by opening up a Github discussion
+
+### sg adr search
+
+Search ADR titles and content.
+
+Arguments: `[terms...]`
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a Github discussion
+
+### sg adr view
+
+View an ADR.
+
+Arguments: `[number]`
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a Github discussion
+
+### sg adr create
+
+Create an ADR!.
+
+Arguments: `<title>`
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a Github discussion
+
 ## sg live
 
 Reports which version of Sourcegraph is currently live in the given environment.


### PR DESCRIPTION
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```sh
go run ./dev/sg adr list
go run ./dev/sg adr search go scripting
go run ./dev/sg adr view 1
go run ./dev/sg adr create hello world
go generate ./dev/adr-docs # no diff as expected
```

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/23356519/175833791-97db6821-e61c-451f-bdb0-fcdfd5148a19.png">
