### PR TITLE
Add query to retrieve individual flag

### DIFF
--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -184,6 +184,21 @@ func (r *schemaResolver) OrganizationFeatureFlagOverrides(ctx context.Context) (
 	return overridesToResolvers(r.db, flags), nil
 }
 
+func (r *schemaResolver) FeatureFlag(ctx context.Context, args struct {
+	Name string
+}) (*FeatureFlagResolver, error) {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	ff, err := r.db.FeatureFlags().GetFeatureFlag(ctx, args.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FeatureFlagResolver{r.db, ff}, nil
+}
+
 func (r *schemaResolver) FeatureFlags(ctx context.Context) ([]*FeatureFlagResolver, error) {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1422,6 +1422,11 @@ type Query {
     featureFlags: [FeatureFlag!]!
 
     """
+    Retrieve a feature flag
+    """
+    featureFlag(name: String!): FeatureFlag!
+
+    """
     Evaluates a feature flag for the current user
     Returns null if feature flag does not exist
     """


### PR DESCRIPTION
As part of the MI automation work, we would like to be able to retrieve individual feature flag. The existing `Query.featureFlags` doesn't provide any filtering but return all flags at once.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```sh
sg start
```

go to admin console and create a new flag named `michael-flag` with boolean type

then go to API console and run the following query, you should see the flag

```gql
query FeatureFlags {
    featureFlag(name: "michael-flag") {
        ...FeatureFlagFields
    }
}

fragment FeatureFlagFields on FeatureFlag {
    __typename
    ... on FeatureFlagBoolean {
        name
        value
        overrides {
            ...OverrideFields
        }
    }
    ... on FeatureFlagRollout {
        name
        rolloutBasisPoints
        overrides {
            ...OverrideFields
        }
    }
}

fragment OverrideFields on FeatureFlagOverride {
    id
    value
}
```