### PR TITLE
JetBrains: Pass version and anonymous user ID to JS

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridge.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridge.java
@@ -2,7 +2,6 @@ package com.sourcegraph.browser;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.google.gson.JsonSyntaxException;
 import com.intellij.openapi.Disposable;
 import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefJSQuery;

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -34,11 +34,7 @@ public class JSToJavaBridgeRequestHandler {
         try {
             switch (action) {
                 case "getConfig":
-                    JsonObject configAsJson = new JsonObject();
-                    configAsJson.addProperty("instanceURL", ConfigUtil.getSourcegraphUrl(this.project));
-                    configAsJson.addProperty("isGlobbingEnabled", ConfigUtil.isGlobbingEnabled(this.project));
-                    configAsJson.addProperty("accessToken", ConfigUtil.getAccessToken(this.project));
-                    return createSuccessResponse(configAsJson);
+                    return createSuccessResponse(ConfigUtil.getConfigAsJson(project));
                 case "getTheme":
                     JsonObject currentThemeAsJson = ThemeUtil.getCurrentThemeAsJson();
                     return createSuccessResponse(currentThemeAsJson);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -19,6 +19,8 @@ public class ConfigUtil {
         configAsJson.addProperty("instanceURL", ConfigUtil.getSourcegraphUrl(project));
         configAsJson.addProperty("isGlobbingEnabled", ConfigUtil.isGlobbingEnabled(project));
         configAsJson.addProperty("accessToken", ConfigUtil.getAccessToken(project));
+        configAsJson.addProperty("anonymousUserId", ConfigUtil.getAnonymousUserId());
+        configAsJson.addProperty("pluginVersion", ConfigUtil.getPluginVersion());
         return configAsJson;
     }
 

--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -52,6 +52,8 @@ function handleRequest(
                     instanceURL,
                     isGlobbingEnabled: true,
                     accessToken: null,
+                    anonymousUserId: 'test',
+                    pluginVersion: '1.2.3',
                 })
             )
             break

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -102,7 +102,7 @@ export function applyTheme(theme: Theme): void {
     root.style.setProperty('--jb-border-color', intelliJTheme['Component.borderColor'])
     root.style.setProperty('--jb-icon-color', intelliJTheme['Component.iconColor'] || '#7f8b91')
 
-    // There is no color for this in the serialized theme so I have picked this option from the
+    // There is no color for this in the serialized theme, so I have picked this option from the
     // Dracula theme
     root.style.setProperty('--code-bg', theme.isDarkTheme ? '#2b2b2b' : '#ffffff')
     root.style.setProperty('--body-bg', theme.isDarkTheme ? '#2b2b2b' : '#ffffff')

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -26,6 +26,8 @@ let isDarkTheme = false
 let instanceURL = 'https://sourcegraph.com'
 let isGlobbingEnabled = false
 let accessToken: string | null = null
+let anonymousUserId: string
+let pluginVersion: string
 let initialSearch: Search | null = null
 let initialAuthenticatedUser: AuthenticatedUser | null
 let telemetryService: EventLogger
@@ -46,7 +48,7 @@ window.initializeSourcegraph = async () => {
         console.warn(`No initial authenticated user with access token “${accessToken}”`)
     }
 
-    telemetryService = new EventLogger('anonid', { editor: 'jetbrains', version: '1.4.5' })
+    telemetryService = new EventLogger(anonymousUserId, { editor: 'jetbrains', version: pluginVersion })
 
     renderReactApp()
 
@@ -78,6 +80,8 @@ export function applyConfig(config: PluginConfig): void {
     instanceURL = config.instanceURL
     isGlobbingEnabled = config.isGlobbingEnabled || false
     accessToken = config.accessToken || null
+    anonymousUserId = config.anonymousUserId || 'no-user-id'
+    pluginVersion = config.pluginVersion || '0.0.0'
     polyfillEventSource(accessToken ? { Authorization: `token ${accessToken}` } : {})
 }
 

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -81,7 +81,7 @@ export function applyConfig(config: PluginConfig): void {
     isGlobbingEnabled = config.isGlobbingEnabled || false
     accessToken = config.accessToken || null
     anonymousUserId = config.anonymousUserId || 'no-user-id'
-    pluginVersion = config.pluginVersion || '0.0.0'
+    pluginVersion = config.pluginVersion
     polyfillEventSource(accessToken ? { Authorization: `token ${accessToken}` } : {})
 }
 

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -91,6 +91,8 @@ export async function getConfigAlwaysFulfill(): Promise<PluginConfig> {
             instanceURL: 'https://sourcegraph.com',
             isGlobbingEnabled: false,
             accessToken: null,
+            anonymousUserId: 'no-user-id',
+            pluginVersion: '0.0.0',
         }
     }
 }

--- a/client/jetbrains/webview/src/search/types.d.ts
+++ b/client/jetbrains/webview/src/search/types.d.ts
@@ -21,6 +21,8 @@ export interface PluginConfig {
     instanceURL: string
     isGlobbingEnabled: boolean
     accessToken: string | null
+    anonymousUserId: string
+    pluginVersion: string
 }
 
 export interface Search {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/35178

## Test plan

Tested it with the in-IDE and  standalone versions: [1-min Loom](https://www.loom.com/share/4d78ed59f8574747ae6c2382cfe05b4b)

## App preview:

- [Web](https://sg-web-dv-jetbrains-pass-version-and.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-luswkqopfw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
