### PR TITLE
JetBrains: Log URL and access token change events

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/SourcegraphJBCefBrowser.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/SourcegraphJBCefBrowser.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.browser;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.jcef.JBCefBrowser;
 import com.sourcegraph.config.SettingsChangeListener;
@@ -11,9 +10,6 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 
 public class SourcegraphJBCefBrowser extends JBCefBrowser {
-
-    private final SettingsChangeListener settingsChangeListener;
-
     public SourcegraphJBCefBrowser(@NotNull JSToJavaBridgeRequestHandler requestHandler) {
         super("http://sourcegraph/html/index.html");
         // Create and set up JCEF browser
@@ -26,8 +22,7 @@ public class SourcegraphJBCefBrowser extends JBCefBrowser {
         Disposer.register(this, jsToJavaBridge);
         JavaToJSBridge javaToJSBridge = new JavaToJSBridge(this);
 
-        Project project = requestHandler.getProject();
-        settingsChangeListener = new SettingsChangeListener(project, javaToJSBridge);
+        requestHandler.getProject().getService(SettingsChangeListener.class).setJavaToJSBridge(javaToJSBridge);
 
         UIManager.addPropertyChangeListener(propertyChangeEvent -> {
             if (propertyChangeEvent.getPropertyName().equals("lookAndFeel")) {
@@ -38,12 +33,5 @@ public class SourcegraphJBCefBrowser extends JBCefBrowser {
 
     public void focus() {
         this.getCefBrowser().setFocus(true);
-    }
-
-    @Override
-    public void dispose() {
-        super.dispose();
-
-        settingsChangeListener.dispose();
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -65,7 +65,7 @@ public class ConfigUtil {
     }
 
     public static void setInstallEventLogged(boolean value) {
-        SourcegraphApplicationService.getInstance().installEventLogged = value;
+        SourcegraphApplicationService.getInstance().isInstallEventLogged = value;
     }
 
     @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -60,6 +60,14 @@ public class ConfigUtil {
         SourcegraphApplicationService.getInstance().anonymousUserId = anonymousUserId;
     }
 
+    public static boolean isInstallEventLogged() {
+        return SourcegraphApplicationService.getInstance().isInstallEventLogged();
+    }
+
+    public static void setInstallEventLogged(boolean value) {
+        SourcegraphApplicationService.getInstance().installEventLogged = value;
+    }
+
     @Nullable
     public static Search getLastSearch(@NotNull Project project) {
         return getProjectLevelConfig(project).getLastSearch();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
@@ -1,12 +1,13 @@
 package com.sourcegraph.config;
 
 import com.intellij.util.messages.Topic;
+import org.jetbrains.annotations.Nullable;
 
 public interface PluginSettingChangeActionNotifier {
 
     Topic<PluginSettingChangeActionNotifier> TOPIC = Topic.create("Sourcegraph plugin settings have changed", PluginSettingChangeActionNotifier.class);
 
-    void beforeAction();
+    void beforeAction(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken);
 
-    void afterAction();
+    void afterAction(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken);
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
@@ -1,13 +1,13 @@
 package com.sourcegraph.config;
 
 import com.intellij.util.messages.Topic;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 public interface PluginSettingChangeActionNotifier {
 
     Topic<PluginSettingChangeActionNotifier> TOPIC = Topic.create("Sourcegraph plugin settings have changed", PluginSettingChangeActionNotifier.class);
 
-    void beforeAction(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken);
+    void beforeAction(@NotNull PluginSettingChangeContext context);
 
-    void afterAction(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken);
+    void afterAction(@NotNull PluginSettingChangeContext context);
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -1,0 +1,24 @@
+package com.sourcegraph.config;
+
+import org.jetbrains.annotations.Nullable;
+
+public class PluginSettingChangeContext {
+    @Nullable
+    public String oldUrl;
+
+    @Nullable
+    public String oldAccessToken;
+
+    @Nullable
+    public String newUrl;
+
+    @Nullable
+    public String newAccessToken;
+
+    public PluginSettingChangeContext(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken) {
+        this.oldUrl = oldUrl;
+        this.oldAccessToken = oldAccessToken;
+        this.newUrl = newUrl;
+        this.newAccessToken = newAccessToken;
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -16,12 +16,12 @@ public class SettingsChangeListener implements Disposable {
         connection = bus.connect();
         connection.subscribe(PluginSettingChangeActionNotifier.TOPIC, new PluginSettingChangeActionNotifier() {
             @Override
-            public void beforeAction() {
+            public void beforeAction(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken) {
                 // Do nothing
             }
 
             @Override
-            public void afterAction() {
+            public void afterAction(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken) {
                 javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
             }
         });

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -5,7 +5,11 @@ import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.MessageBusConnection;
 import com.sourcegraph.browser.JavaToJSBridge;
+import com.sourcegraph.telemetry.GraphQlLogger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 public class SettingsChangeListener implements Disposable {
     private final MessageBusConnection connection;
@@ -17,12 +21,29 @@ public class SettingsChangeListener implements Disposable {
         connection.subscribe(PluginSettingChangeActionNotifier.TOPIC, new PluginSettingChangeActionNotifier() {
             @Override
             public void beforeAction(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken) {
-                // Do nothing
+                if (!Objects.equals(oldUrl, newUrl)) {
+                    GraphQlLogger.logUninstallEvent(project);
+                    ConfigUtil.setInstallEventLogged(false);
+                }
             }
 
             @Override
             public void afterAction(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken) {
                 javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
+
+                if (!Objects.equals(oldUrl, newUrl)) {
+                    GraphQlLogger.logInstallEvent(project, (wasSuccessful) -> {
+                        if (wasSuccessful) {
+                            ConfigUtil.setInstallEventLogged(true);
+                        }
+                    });
+                } else if (!Objects.equals(oldAccessToken, newAccessToken) && !ConfigUtil.isInstallEventLogged()) {
+                    GraphQlLogger.logInstallEvent(project, (wasSuccessful) -> {
+                        if (wasSuccessful) {
+                            ConfigUtil.setInstallEventLogged(true);
+                        }
+                    });
+                }
             }
         });
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -29,11 +29,9 @@ public class SettingsChangeListener implements Disposable {
 
             @Override
             public void afterAction(@NotNull PluginSettingChangeContext context) {
-                if (javaToJSBridge == null) {
-                    return;
+                if (javaToJSBridge != null) {
+                    javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
                 }
-
-                javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
 
                 if (!Objects.equals(context.oldUrl, context.newUrl)) {
                     GraphQlLogger.logInstallEvent(project, (wasSuccessful) -> {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -12,8 +12,9 @@ import java.util.Objects;
 
 public class SettingsChangeListener implements Disposable {
     private final MessageBusConnection connection;
+    private JavaToJSBridge javaToJSBridge;
 
-    public SettingsChangeListener(@NotNull Project project, @NotNull JavaToJSBridge javaToJSBridge) {
+    public SettingsChangeListener(@NotNull Project project) {
         MessageBus bus = project.getMessageBus();
 
         connection = bus.connect();
@@ -28,6 +29,10 @@ public class SettingsChangeListener implements Disposable {
 
             @Override
             public void afterAction(@NotNull PluginSettingChangeContext context) {
+                if (javaToJSBridge == null) {
+                    return;
+                }
+
                 javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
 
                 if (!Objects.equals(context.oldUrl, context.newUrl)) {
@@ -45,6 +50,10 @@ public class SettingsChangeListener implements Disposable {
                 }
             }
         });
+    }
+
+    public void setJavaToJSBridge(JavaToJSBridge javaToJSBridge) {
+        this.javaToJSBridge = javaToJSBridge;
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -34,17 +34,9 @@ public class SettingsChangeListener implements Disposable {
                 }
 
                 if (!Objects.equals(context.oldUrl, context.newUrl)) {
-                    GraphQlLogger.logInstallEvent(project, (wasSuccessful) -> {
-                        if (wasSuccessful) {
-                            ConfigUtil.setInstallEventLogged(true);
-                        }
-                    });
+                    GraphQlLogger.logInstallEvent(project, ConfigUtil::setInstallEventLogged);
                 } else if (!Objects.equals(context.oldAccessToken, context.newAccessToken) && !ConfigUtil.isInstallEventLogged()) {
-                    GraphQlLogger.logInstallEvent(project, (wasSuccessful) -> {
-                        if (wasSuccessful) {
-                            ConfigUtil.setInstallEventLogged(true);
-                        }
-                    });
+                    GraphQlLogger.logInstallEvent(project, ConfigUtil::setInstallEventLogged);
                 }
             }
         });

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -51,13 +51,16 @@ public class SettingsConfigurable implements Configurable {
     public void apply() {
         MessageBus bus = project.getMessageBus();
         PluginSettingChangeActionNotifier publisher = bus.syncPublisher(PluginSettingChangeActionNotifier.TOPIC);
+
         SourcegraphProjectService settings = SourcegraphProjectService.getInstance(project);
+
         String oldUrl = settings.url;
         String oldAccessToken = settings.accessToken;
         String newUrl = mySettingsComponent.getSourcegraphUrl();
         String newAccessToken = mySettingsComponent.getAccessToken();
+        PluginSettingChangeContext context = new PluginSettingChangeContext(oldUrl, oldAccessToken, newUrl, newAccessToken);
 
-        publisher.beforeAction(oldUrl, oldAccessToken, newUrl, newAccessToken);
+        publisher.beforeAction(context);
 
         settings.url = newUrl;
         settings.accessToken = newAccessToken;
@@ -65,7 +68,7 @@ public class SettingsConfigurable implements Configurable {
         settings.remoteUrlReplacements = mySettingsComponent.getRemoteUrlReplacements();
         settings.isGlobbingEnabled = mySettingsComponent.isGlobbingEnabled();
 
-        publisher.afterAction(oldUrl, oldAccessToken, newUrl, newAccessToken);
+        publisher.afterAction(context);
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -51,16 +51,19 @@ public class SettingsConfigurable implements Configurable {
     public void apply() {
         MessageBus bus = project.getMessageBus();
         PluginSettingChangeActionNotifier publisher = bus.syncPublisher(PluginSettingChangeActionNotifier.TOPIC);
-        publisher.beforeAction();
-
         SourcegraphProjectService settings = SourcegraphProjectService.getInstance(project);
+        String oldUrl = settings.url;
+        String oldAccessToken = settings.accessToken;
+
+        publisher.beforeAction(oldUrl, oldAccessToken, mySettingsComponent.getSourcegraphUrl(), mySettingsComponent.getAccessToken());
+
         settings.url = mySettingsComponent.getSourcegraphUrl();
         settings.accessToken = mySettingsComponent.getAccessToken();
         settings.defaultBranch = mySettingsComponent.getDefaultBranchName();
         settings.remoteUrlReplacements = mySettingsComponent.getRemoteUrlReplacements();
         settings.isGlobbingEnabled = mySettingsComponent.isGlobbingEnabled();
 
-        publisher.afterAction();
+        publisher.afterAction(oldUrl, oldAccessToken, settings.url, settings.accessToken);
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -54,16 +54,18 @@ public class SettingsConfigurable implements Configurable {
         SourcegraphProjectService settings = SourcegraphProjectService.getInstance(project);
         String oldUrl = settings.url;
         String oldAccessToken = settings.accessToken;
+        String newUrl = mySettingsComponent.getSourcegraphUrl();
+        String newAccessToken = mySettingsComponent.getAccessToken();
 
-        publisher.beforeAction(oldUrl, oldAccessToken, mySettingsComponent.getSourcegraphUrl(), mySettingsComponent.getAccessToken());
+        publisher.beforeAction(oldUrl, oldAccessToken, newUrl, newAccessToken);
 
-        settings.url = mySettingsComponent.getSourcegraphUrl();
-        settings.accessToken = mySettingsComponent.getAccessToken();
+        settings.url = newUrl;
+        settings.accessToken = newAccessToken;
         settings.defaultBranch = mySettingsComponent.getDefaultBranchName();
         settings.remoteUrlReplacements = mySettingsComponent.getRemoteUrlReplacements();
         settings.isGlobbingEnabled = mySettingsComponent.isGlobbingEnabled();
 
-        publisher.afterAction(oldUrl, oldAccessToken, settings.url, settings.accessToken);
+        publisher.afterAction(oldUrl, oldAccessToken, newUrl, newAccessToken);
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 public class SourcegraphApplicationService implements PersistentStateComponent<SourcegraphApplicationService> {
     @Nullable
     public String anonymousUserId;
+    public boolean installEventLogged;
 
     @NotNull
     public static SourcegraphApplicationService getInstance() {
@@ -23,6 +24,10 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     @Nullable
     public String getAnonymousUserId() {
         return anonymousUserId;
+    }
+
+    public boolean isInstallEventLogged() {
+        return installEventLogged;
     }
 
     @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 public class SourcegraphApplicationService implements PersistentStateComponent<SourcegraphApplicationService> {
     @Nullable
     public String anonymousUserId;
-    public boolean installEventLogged;
+    public boolean isInstallEventLogged;
 
     @NotNull
     public static SourcegraphApplicationService getInstance() {
@@ -27,7 +27,7 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     }
 
     public boolean isInstallEventLogged() {
-        return installEventLogged;
+        return isInstallEventLogged;
     }
 
     @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -19,15 +19,16 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
 
 public class GraphQlLogger {
     private static final Logger logger = Logger.getInstance(GraphQlLogger.class);
 
-    public static void logInstallEvent(Project project) {
+    public static void logInstallEvent(Project project, Consumer<Boolean> callback) {
         String anonymousUserId = ConfigUtil.getAnonymousUserId();
         if (anonymousUserId != null) {
             Event event = new Event("IDEInstalled", anonymousUserId, ConfigUtil.getSourcegraphUrl(project), null, null);
-            logEvent(project, event);
+            logEvent(project, event, (responseStatusCode) -> callback.accept(responseStatusCode == 200));
         }
     }
 
@@ -35,12 +36,12 @@ public class GraphQlLogger {
         String anonymousUserId = ConfigUtil.getAnonymousUserId();
         if (anonymousUserId != null) {
             Event event = new Event("IDEUninstalled", anonymousUserId, ConfigUtil.getSourcegraphUrl(project), null, null);
-            logEvent(project, event);
+            logEvent(project, event, null);
         }
     }
 
     // This could be exposed later as public, but currently, we don't use it externally.
-    private static void logEvent(Project project, @NotNull Event event) {
+    private static void logEvent(Project project, @NotNull Event event, @Nullable Consumer<Integer> callback) {
         String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
         String accessToken = ConfigUtil.getAccessToken(project);
         new Thread(() -> {
@@ -57,18 +58,22 @@ public class GraphQlLogger {
             variables.add("events", events);
 
             try {
-                callGraphQLService(instanceUrl, accessToken, query, variables);
+                int responseStatusCode = callGraphQLService(instanceUrl, accessToken, query, variables);
+                if (callback != null) {
+                    callback.accept(responseStatusCode);
+                }
             } catch (IOException e) {
                 logger.info(e);
             }
         }).start();
     }
 
-    private static void callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws IOException {
+    private static int callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws IOException {
         HttpPost request = createRequest(instanceUrl, accessToken, query, variables);
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             CloseableHttpResponse response = client.execute(request);
             response.close();
+            return response.getStatusLine().getStatusCode();
         }
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -41,11 +41,9 @@ public class GraphQlLogger {
 
     // This could be exposed later as public, but currently, we don't use it externally.
     private static void logEvent(Project project, @NotNull Event event) {
+        String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
+        String accessToken = ConfigUtil.getAccessToken(project);
         new Thread(() -> {
-            String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
-
-            String accessToken = ConfigUtil.getAccessToken(project);
-
             String query = "" +
                 "mutation LogEvents($events: [Event!]) {" +
                 "    logEvents(events: $events) { " +

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
@@ -26,7 +26,9 @@ public class PostStartupActivity implements StartupActivity {
         PluginInstaller.addStateListener(new PluginStateListener() {
             public void install(@NotNull IdeaPluginDescriptor ideaPluginDescriptor) {
                 GraphQlLogger.logInstallEvent(project, (wasSuccessful) -> {
-                    // TODO
+                    if (wasSuccessful) {
+                        ConfigUtil.setInstallEventLogged(true);
+                    }
                 });
             }
 
@@ -37,6 +39,8 @@ public class PostStartupActivity implements StartupActivity {
 
                     // Clearing this so that we can detect a new installation if the user re-enables the extension.
                     ConfigUtil.setAnonymousUserId(null);
+
+                    ConfigUtil.setInstallEventLogged(false);
                 }
             }
         });

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
@@ -25,7 +25,9 @@ public class PostStartupActivity implements StartupActivity {
 
         PluginInstaller.addStateListener(new PluginStateListener() {
             public void install(@NotNull IdeaPluginDescriptor ideaPluginDescriptor) {
-                GraphQlLogger.logInstallEvent(project);
+                GraphQlLogger.logInstallEvent(project, (wasSuccessful) -> {
+                    // TODO
+                });
             }
 
             @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
-public class PostStartupActivity implements StartupActivity {
+public class PostStartupActivity implements StartupActivity.DumbAware {
     private static String generateAnonymousUserId() {
         return UUID.randomUUID().toString();
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
@@ -6,6 +6,7 @@ import com.intellij.ide.plugins.PluginStateListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.SettingsChangeListener;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -17,6 +18,9 @@ public class PostStartupActivity implements StartupActivity {
 
     @Override
     public void runActivity(@NotNull Project project) {
+        // Make sure that SettingsChangeListener is loaded
+        project.getService(SettingsChangeListener.class);
+
         // When no anonymous user ID is set yet, we create a new one and treat this as an installation event.
         // This likely means that the user has never started IntelliJ with our extension before
         if (ConfigUtil.getAnonymousUserId() == null) {

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -11,8 +11,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="com.sourcegraph.config.SourcegraphProjectService"/>
         <projectService serviceImplementation="com.sourcegraph.config.SettingsChangeListener"/>
-        <applicationService serviceImplementation="com.sourcegraph.config.SourcegraphApplicationService"
-                            preload="true"/>
+        <applicationService serviceImplementation="com.sourcegraph.config.SourcegraphApplicationService"/>
         <projectConfigurable
             parentId="tools"
             instance="com.sourcegraph.config.SettingsConfigurable"

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="com.sourcegraph.config.SourcegraphProjectService"/>
+        <projectService serviceImplementation="com.sourcegraph.config.SettingsChangeListener"/>
         <applicationService serviceImplementation="com.sourcegraph.config.SourcegraphApplicationService"
                             preload="true"/>
         <projectConfigurable


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/35178

The requirements were these:

- Log install/uninstall events when access token and/or URL changes.
  - If only the **access token** changes: see if we've successfully sent the "install" event, and try to send it again if not.
  - If only the **URL** changes, or **both** change: send the "uninstall" event before applying the change and the "install" event after.

Handling multiple projects is tricky. No avoid over-engineering this, I've decided to save the "has the install event been logged" flag at the **application** level.
There is one edge case that we don't handle this way. If the user does this:
1. Install the plugin (no access token is set, URL is sourcegraph.com by default → we log the event to sourcegraph.com)
2. Changes the URL to ValidSourcegraphServer1 with an _invalid_ access token in Project1
3. Changes the URL to ValidSourcegraphServer2 with a valid access token in Project2
4. Opens Project1 and sets the access token to a **valid** one, without changing the URL

**Then** we won't log the install event for ValidSourcegraphServer1.
I think this is a caveat that we can live with.

## Test plan

- [8-min Loom](https://www.loom.com/share/3cf468fd8b5147b8b15358ff03e25dad)
- I used small commits with comments to make it easy to understand my train of thought.

## App preview:

- [Web](https://sg-web-dv-jetbrains-log-url-and-token.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yetveblnik.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

