### PR TITLE
docs: remove broken blockquote from helm tutorial

### DIFF
--- a/doc/admin/deploy/kubernetes/helm.md
+++ b/doc/admin/deploy/kubernetes/helm.md
@@ -483,9 +483,8 @@ Now the deployment is complete, more information on configuring the Sourcegraph 
 #### Prerequisites {#eks-prerequisites}
 
 1. You need to have a EKS cluster (>=1.19) with the following addons enabled:
-   - [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
+   - [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html). Alternatively, you may consider deploying your own Ingress Controller instead of the ALB Ingress Controller, [learn more](https://kubernetes.github.io/ingress-nginx/).
    - [AWS EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html)
-> You may consider deploying your own Ingress Controller instead of the ALB Ingress Controller, [learn more](https://kubernetes.github.io/ingress-nginx/)
 1. Your account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
 1. Connect to your cluster (via either the console or the command line using `eksctl`) and ensure the cluster is up and running using: `kubectl get nodes` (several `ready` nodes should be listed)
 1. Have the [Helm CLI](https://helm.sh/docs/intro/install/) installed and run the following command to link to the Sourcegraph helm repository (on the machine used to interact with your cluster):
@@ -568,9 +567,8 @@ Now the deployment is complete, more information on configuring the Sourcegraph 
 #### Prerequisites {#aks-prerequisites}
 
 1. You need to have a AKS cluster (>=1.19) with the following addons enabled:
-   - [Azure Application Gateway Ingress Controller](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-install-new)
+   - [Azure Application Gateway Ingress Controller](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-install-new). Alternatively, you may consider using your custom Ingress Controller instead of Application Gateway, [learn more](https://docs.microsoft.com/en-us/azure/aks/ingress-basic).
    - [Azure Disk CSI driver](https://docs.microsoft.com/en-us/azure/aks/csi-storage-drivers)
-> You may consider using your custom Ingress Controller instead of Application Gateway, [learn more](https://docs.microsoft.com/en-us/azure/aks/ingress-basic)
 1. Your account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
 1. Connect to your cluster (via either the console or the command line using the Azure CLI) and ensure the cluster is up and running using: `kubectl get nodes` (several `ready` nodes should be listed)
 1. Have the [Helm CLI](https://helm.sh/docs/intro/install/) installed and run the following command to link to the Sourcegraph helm repository (on the machine used to interact with your cluster):


### PR DESCRIPTION
markdown doesn't like having blockquotes in between ordered list items and it looks horrible, so we might as well remove the fancy blockquote

![CleanShot 2022-06-26 at 10 39 17](https://user-images.githubusercontent.com/8373004/175826955-c54949b5-cae9-4f80-ac81-c04593fe643e.png)

https://docs.sourcegraph.com/admin/deploy/kubernetes/helm#configure-sourcegraph-on-elastic-kubernetes-service-eks
https://docs.sourcegraph.com/admin/deploy/kubernetes/helm#configure-sourcegraph-on-azure-managed-kubernetes-service-aks

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


```sh
sg run docsite
```