### PR TITLE
perms_syncer: fix logged counts and move up docstring

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -972,6 +972,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	if err = txs.SetRepoPermissions(ctx, p); err != nil {
 		return errors.Wrap(err, "set repository permissions")
 	}
+	regularCount := len(p.UserIDs)
 
 	// If there is no provider, there would be no pending permissions that need to be generated.
 	if provider != nil {
@@ -984,9 +985,11 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 			return errors.Wrap(err, "set repository pending permissions")
 		}
 	}
+	pendingCount := len(p.UserIDs)
 
 	logger.Debug("synced",
-		log.Int("count", len(p.UserIDs)),
+		log.Int("regularCount", regularCount),
+		log.Int("pendingCount", pendingCount),
 		log.Object("fetchOpts", log.Bool("invalidateCaches", fetchOpts.InvalidateCaches)),
 	)
 	return nil


### PR DESCRIPTION
The call of `SetRepoPendingPermissions` would reset `p.UserIDs` in place, so we were only logging the count of pending users.

Also move up docstring of `GrantPendingPermissions` to its interface, I think it was overlooked.

_Discovered while working on https://github.com/sourcegraph/customer/issues/993._

## Test plan

Manual testing and unit tests.