### PR TITLE
JetBrains: set 'codemirror6' as monaco query input editor component

### DIFF
--- a/client/jetbrains/webview/src/index.scss
+++ b/client/jetbrains/webview/src/index.scss
@@ -1,15 +1,1 @@
 @import '../../../branded/src/global-styles/index.scss';
-
-.monaco-mouse-cursor-text {
-    /* Hack: remove focus ring around Monaco editor cursor */
-    &:focus-within,
-    &:focus-visible {
-        box-shadow: none !important;
-    }
-}
-
-.monaco-editor,
-.monaco-editor-background,
-.monaco-editor .inputarea.ime-input {
-    background-color: transparent !important;
-}

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
@@ -142,28 +142,4 @@
             float: right;
         }
     }
-
-    /* 
-        As we use the default `suggestLineHeight` value for the Monaco editor rendered by
-        the JetBrains SearchBox, override styles defined by MonacoQueryInput to ensure that
-        suggestion item content fits the container.
-    */
-    :global(.monaco-editor) {
-        width: 0 !important;
-
-        :global(.suggest-widget)
-            :global(.monaco-list)
-            :global(.monaco-list-row):global(.focused):global(.string-label)
-            > :global(.contents)
-            > :global(.main) {
-            max-height: 100%;
-
-            > :global(.right) {
-                &::after {
-                    height: 100%;
-                    margin-top: 0;
-                }
-            }
-        }
-    }
 }

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
@@ -4,10 +4,8 @@
 import React, { useCallback, useState } from 'react'
 
 import classNames from 'classnames'
-import * as Monaco from 'monaco-editor'
 
-import { QueryState, SearchContextInputProps, SubmitSearchProps } from '@sourcegraph/search'
-import { DEFAULT_MONACO_OPTIONS } from '@sourcegraph/search-ui'
+import { SearchContextInputProps, QueryState, SubmitSearchProps } from '@sourcegraph/search'
 import {
     IEditor,
     LazyMonacoQueryInput,
@@ -70,14 +68,6 @@ export interface JetBrainsSearchBoxProps
     onEditorCreated?: (editor: IEditor) => void
 }
 
-const MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
-    ...DEFAULT_MONACO_OPTIONS,
-
-    // Reset to default value to avoid suggestion box shrinking.
-    // Related issue: https://github.com/microsoft/monaco-editor/issues/3147
-    suggestLineHeight: undefined,
-}
-
 export const JetBrainsSearchBox: React.FunctionComponent<React.PropsWithChildren<JetBrainsSearchBoxProps>> = props => {
     const { queryState, onEditorCreated: onEditorCreatedCallback, onChange } = props
 
@@ -135,7 +125,6 @@ export const JetBrainsSearchBox: React.FunctionComponent<React.PropsWithChildren
                         className={styles.searchBoxInput}
                         onEditorCreated={onEditorCreated}
                         placeholder="Enter search query..."
-                        editorOptions={MONACO_OPTIONS}
                         editorComponent="codemirror6"
                     />
                     <JetBrainsToggles

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
@@ -136,6 +136,7 @@ export const JetBrainsSearchBox: React.FunctionComponent<React.PropsWithChildren
                         onEditorCreated={onEditorCreated}
                         placeholder="Enter search query..."
                         editorOptions={MONACO_OPTIONS}
+                        editorComponent="codemirror6"
                     />
                     <JetBrainsToggles
                         patternType={props.patternType}

--- a/client/jetbrains/webview/src/search/results/SearchResultList.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.tsx
@@ -118,7 +118,6 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
             }
 
             if (event.key === 'ArrowDown') {
-                console.log('UP')
                 const nextElement = getSiblingResultElement(currentElement, 'next')
                 if (nextElement) {
                     selectResult(nextElement.id.replace('search-result-list-item-', ''))
@@ -129,7 +128,6 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
             }
 
             if (event.key === 'ArrowUp') {
-                console.log('DOWN')
                 const previousElement = getSiblingResultElement(currentElement, 'previous')
                 if (previousElement) {
                     selectResult(previousElement.id.replace('search-result-list-item-', ''))

--- a/client/jetbrains/webview/src/search/results/SearchResultList.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.tsx
@@ -82,15 +82,12 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
             const target = event.target as HTMLElement
 
             // We only want to handle keydown events on the search box
-            if (
-                (target.nodeName !== 'TEXTAREA' || !target.className.includes('inputarea')) &&
-                target.nodeName !== 'BODY'
-            ) {
+            if (!target.className.includes('cm-content') && target.nodeName !== 'BODY') {
                 return
             }
 
             // Ignore events when the autocomplete dropdown is open
-            const isAutocompleteOpen = document.querySelector('.monaco-list.element-focused') !== null
+            const isAutocompleteOpen = document.querySelector('.cm-tooltip-autocomplete') !== null
             if (isAutocompleteOpen) {
                 return
             }
@@ -121,6 +118,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
             }
 
             if (event.key === 'ArrowDown') {
+                console.log('UP')
                 const nextElement = getSiblingResultElement(currentElement, 'next')
                 if (nextElement) {
                     selectResult(nextElement.id.replace('search-result-list-item-', ''))
@@ -131,6 +129,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
             }
 
             if (event.key === 'ArrowUp') {
+                console.log('DOWN')
                 const previousElement = getSiblingResultElement(currentElement, 'previous')
                 if (previousElement) {
                     selectResult(previousElement.id.replace('search-result-list-item-', ''))

--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -100,6 +100,7 @@
                     height: 1.25rem;
 
                     svg {
+                        fill: var(--search-query-text-color);
                         flex-shrink: 0;
                     }
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/37722

Sets 'codemirror6' as editor component for the monaco query input.
By default ([settings](https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph.git&branch=HEAD&file=doc%2Fadmin%2Fconfig%2Fsettings.schema.json&editor=VSCode&version=2.2.4&start_row=305&start_col=30&end_row=305&end_col=30&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands), [usages](https://sourcegraph.com/search?q=context:global+repo:sourcegraph/sourcegraph+%3F%3F+%27monaco%27&patternType=literal)) `monaco` is the editor component used in [`LazyMonacoQueryInput` component](https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph.git&branch=HEAD&file=client%2Fsearch-ui%2Fsrc%2Finput%2FLazyMonacoQueryInput.tsx&editor=VSCode&version=2.2.4&start_row=61&start_col=3&end_row=61&end_col=3&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands).

Although, mouse selection works well for both editor components on sourcegraph.com, for yet unknow reason `monaco` editor component doesn't allow mouse selection while `codemirror6` allows.
This PR suggests to ignore `editor` experimental feature value until we figure out why `monaco` editor component doesn't wotk for the JetBRains plugin.

[Loom](https://www.loom.com/share/0d0b8aeae4fb477f8de4b7fad78c5297)

## Test plan
Run JetBrains plugin in standalone mode and ensure that query input can be selected both with keyboard and mouse/touchpad.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-jetbrains-fix-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ezisbwufui.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
