### PR TITLE
JetBrains: Ignore bin files that are generated by VS Code extension

### DIFF
--- a/client/jetbrains/.gitignore
+++ b/client/jetbrains/.gitignore
@@ -35,3 +35,6 @@ fabric.properties
 
 # JavaScript resources
 src/main/resources/dist/*
+
+# VSCode langserver artifacts
+/bin/


### PR DESCRIPTION
I've been setting up Java support in VS Code and it seems that the extension caches some artifacts in `client/jetbrains/bin`. I don't want to commit these mistakenly so adding it to the gitignore.

It seems like the setup already works in VS Code so that's cool 😎 
![Screenshot 2022-06-27 at 14 17 38](https://user-images.githubusercontent.com/458591/175939722-a1372535-6388-4310-ba4d-854afad04505.png)


## Test plan

Ensured that bin/ files are no longer added by `git add .` 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-vscode-langserver.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-svuowrttdp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
