### PR TITLE
search query input: Better handle CodeMirror extensions derived from props

### DIFF
--- a/client/search-ui/src/input/extensions/index.ts
+++ b/client/search-ui/src/input/extensions/index.ts
@@ -1,4 +1,5 @@
-import { Extension } from '@codemirror/state'
+/* eslint-disable jsdoc/check-indentation */
+import { Extension, StateEffect, StateEffectType, StateField } from '@codemirror/state'
 import { EditorView, ViewUpdate } from '@codemirror/view'
 import { Observable } from 'rxjs'
 
@@ -40,3 +41,44 @@ export const createDefaultSuggestions = ({
             isSourcegraphDotCom,
         })
     )
+
+/**
+ * A helper function for creating an extension that operates on the value which
+ * can be updated via an effect.
+ * This is useful in React components where the extension depends on the value
+ * of a prop  but that prop is unstable, and especially useful for callbacks.
+ * Instead of reconfiguring the editor whenever the value changes (which is
+ * apparently not cheap), the extension can be updated via the returned update
+ * function or effect.
+ *
+ * Example:
+ *
+ * const {onChange} = props;
+ * const [onChangeField, setOnChange] = useMemo(() => createUpdateableField(...), [])
+ * ...
+ * useEffect(() => {
+ *   if (editor) {
+ *     setOnchange(editor, onChange)
+ *   }
+ * }, [editor, onChange])
+ */
+export function createUpdateableField<T>(
+    provider: (field: StateField<T>) => Extension,
+    defaultValue?: T
+): [StateField<T>, (editor: EditorView, newValue: typeof defaultValue) => void, StateEffectType<typeof defaultValue>] {
+    const fieldEffect = StateEffect.define<typeof defaultValue>()
+    const field = StateField.define<typeof defaultValue>({
+        create() {
+            return defaultValue
+        },
+        update(value, transaction) {
+            const effect = transaction.effects.find((effect): effect is StateEffect<typeof defaultValue> =>
+                effect.is(fieldEffect)
+            )
+            return effect ? effect.value : value
+        },
+        provide: provider,
+    })
+
+    return [field, (editor, newValue) => editor.dispatch({ effects: [fieldEffect.of(newValue)] }), fieldEffect]
+}

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
@@ -65,6 +65,10 @@
         border: none;
         box-shadow: none;
     }
+
+    :global(.cm-editor) {
+        flex: 1;
+    }
 }
 
 .editor {


### PR DESCRIPTION
Fixes #37721 

Please read [this comment](https://github.com/sourcegraph/sourcegraph/issues/37721#issuecomment-1166300433) from the issue for more information about what causes the problem.

**tl;dr**: `onChange` changed after `onBlur` was called, which caused a group of extensions to be re-created, including the `onBlur` DOM event handler, which caused it to fire as along as the editor wasn't focused (go back to the beginning).

This PR introduces a couple of changes to prevent unexpected issues with recreating CodeMirror extensions:

- At the Monaco facade level, all callbacks are "bound" via state fields. That means that extensions are not recreated (and the editor is not reconfigured) when any of the callback functions change. The downside is that extensions cannot be conditionally created depending on whether a callback was provided or not (e.g. there is always an event handler bound for `Mod+k` even if `onHandleFuzzyFinder` is not provided), but luckily CodeMirror provides ways to indicate that an event wasn't handled by the extension (e.g. returning `false` from the keybinding handler).
- `onFocus` and `onBlur` event handlers are now triggered from the state update handler (as it was before) instead of DOM event handlers, to prevent them from being accidentally triggered, which was the cause for the Code Insights creation form freeze up.
- The "core" CodeMirror query input also switches to using a compartment for the theme setting. With this any extension created by the component itself won't ever be re-created. All extensions derived from props are updated via transactions.

I'm also including a minor CSS fix. Without it the actual input doesn't expand to the whole width of the container and clicking inside what appears to be the input field doesn't focus to actual input.

## Test plan

Go to https://sourcegraph.test:3443/insights/create/search?dashboardId=all and create a new code insight. Go to the search query input. Type something, leave the input. The page does not freeze.

## App preview:

- [Web](https://sg-web-fkling-37721-query-input-freeze.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-flzvxufdpf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
