### PR TITLE
fix: do not panic on partial, multi-line highlight

### DIFF
--- a/cmd/frontend/internal/highlight/html.go
+++ b/cmd/frontend/internal/highlight/html.go
@@ -135,8 +135,9 @@ func lsifToHTML(
 
 	occurrences := document.Occurrences
 
+	rowCount := int32(len(splitLines))
 	row, occIndex := int32(0), 0
-	for row < int32(len(splitLines)) {
+	for row < rowCount {
 		// skip invalid lines, when passed
 		if validLines != nil && !validLines[row] {
 			row += 1
@@ -154,6 +155,12 @@ func lsifToHTML(
 
 			startRow, startCharacter, endRow, endCharacter := normalizeSCIPRange(occ.Range)
 
+			// We may not have handled all the occurrences up until now
+			// so skip the ones where the ranges do not overlap.
+			if endRow < row {
+				continue
+			}
+
 			addText(occ.SyntaxKind, safeSlice(line, lineCharacter, startCharacter))
 
 			if startRow != endRow {
@@ -167,6 +174,11 @@ func lsifToHTML(
 					addText(occ.SyntaxKind, string(line))
 
 					row += 1
+				}
+
+				// Do not allow access past end of rows
+				if row >= rowCount {
+					return
 				}
 
 				line = splitLines[row]

--- a/cmd/frontend/internal/highlight/html.go
+++ b/cmd/frontend/internal/highlight/html.go
@@ -168,6 +168,11 @@ func lsifToHTML(
 
 				row += 1
 				for row < endRow {
+					// We've reached the end of the lines, so we can return now
+					if row >= rowCount {
+						return
+					}
+
 					line = splitLines[row]
 
 					addRow(row)
@@ -176,7 +181,7 @@ func lsifToHTML(
 					row += 1
 				}
 
-				// Do not allow access past end of rows
+				// We've reached the end of the lines, so we can return now
 				if row >= rowCount {
 					return
 				}

--- a/cmd/frontend/internal/highlight/html_test.go
+++ b/cmd/frontend/internal/highlight/html_test.go
@@ -1,0 +1,88 @@
+package highlight
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+)
+
+func TestMultilineOccurrence(t *testing.T) {
+	code := `namespace MyCompanyName.MyProjectName;
+
+[DependsOn(
+    // ABP Framework packages
+    typeof(AbpAspNetCoreMvcModule)
+)]`
+
+	document := &scip.Document{
+		Occurrences: []*scip.Occurrence{
+			// Past end range occurrence
+			{
+				Range:      []int32{7, 0, 1},
+				SyntaxKind: scip.SyntaxKind_BooleanLiteral,
+			},
+		},
+	}
+
+	rows := map[int32]bool{}
+	lsifToHTML(code, document, func(row int32) {
+		rows[row] = true
+	}, func(kind scip.SyntaxKind, line string) {}, nil)
+
+	if len(rows) != 6 {
+		t.Error("Should only add once per row, and should skip the 7th row (since it doesn't exist)")
+	}
+}
+
+func TestMultilineOccurrence2(t *testing.T) {
+	code := `namespace MyCompanyName.MyProjectName;
+
+[DependsOn(
+    // ABP Framework packages
+    typeof(AbpAspNetCoreMvcModule)
+)]`
+
+	document := &scip.Document{
+		Occurrences: []*scip.Occurrence{
+			// Valid range at the beginning, should be skipped.
+			{
+				Range:      []int32{0, 0, 8},
+				SyntaxKind: scip.SyntaxKind_IdentifierModule,
+			},
+
+			// Past end range occurrence, should not cause panic
+			{
+				Range:      []int32{2, 0, 30, 4},
+				SyntaxKind: scip.SyntaxKind_BooleanLiteral,
+			},
+		},
+	}
+
+	// Should stay false, because we should skip this identifier
+	// due to the valid lines that is passed to lsifToHTML
+	sawModuleIdentifier := false
+
+	rowsSeen := map[int32]bool{}
+	lsifToHTML(code, document, func(row int32) {
+		rowsSeen[row] = true
+	}, func(kind scip.SyntaxKind, line string) {
+		if kind == scip.SyntaxKind_IdentifierModule {
+			sawModuleIdentifier = true
+		}
+
+	}, map[int32]bool{
+		0: false,
+		1: false,
+		2: true,
+		3: false,
+		4: false,
+	})
+
+	if len(rowsSeen) != 4 {
+		t.Error("Should only add the rows from 2 until the end (due to weird multiline occurrence)")
+	}
+
+	if sawModuleIdentifier {
+		t.Error("Should not have seen identifier for module, because line was skipped")
+	}
+}


### PR DESCRIPTION
There were two main problems hidden behind `enableFastResultLoading`.

The first problem was that if we had occurrences from lines that we skipped (due to only passing certain line ranges), then we didn't discard them in our loop to iterate over the lines.

The second problem was that if we had multi-line occurrences (and we didn't skip certain lines) then we would could access past the last row (this is primarily fixed by part 1, but I added a safeguard to make sure that even if we get malformed scip data that we just return early to avoid a panic).

## Test plan

- [ ] Test that `repo:^github\.com/abpframework/abp$ core` no longer panics with `enableFastResultLoading`
