### PR TITLE
Code Insights: Use "save changes" instead of "save insight" copy for the edit insight UI

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
@@ -230,7 +230,7 @@ export const CaptureGroupCreationForm: React.FunctionComponent<
                     type="submit"
                     alwaysShowLabel={true}
                     loading={submitting}
-                    label={submitting ? 'Submitting' : isEditMode ? 'Save insight' : 'Create code insight'}
+                    label={submitting ? 'Submitting' : isEditMode ? 'Save changes' : 'Create code insight'}
                     disabled={submitting || !creationPermission?.available}
                     data-testid="insight-save-button"
                     className="mr-2 mb-2"

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
@@ -79,7 +79,7 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<
             onSubmit={handleSubmit}
             onReset={onFormReset}
         >
-            {/* 
+            {/*
                 a11y-ignore
                 Rule: aria-allowed-role ARIA - role should be appropriate for the element
                 Error occurs as a result of using `role=combobox` on `textarea` element.
@@ -138,7 +138,7 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<
                     alwaysShowLabel={true}
                     data-testid="insight-save-button"
                     loading={submitting}
-                    label={submitting ? 'Submitting' : isEditMode ? 'Save insight' : 'Create code insight'}
+                    label={submitting ? 'Submitting' : isEditMode ? 'Save changes' : 'Create code insight'}
                     type="submit"
                     disabled={submitting || !creationPermission?.available}
                     className="mr-2 mb-2"

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
@@ -210,7 +210,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<
                 <LoaderButton
                     alwaysShowLabel={true}
                     loading={submitting}
-                    label={submitting ? 'Submitting' : isEditMode ? 'Save insight' : 'Create code insight'}
+                    label={submitting ? 'Submitting' : isEditMode ? 'Save changes' : 'Create code insight'}
                     type="submit"
                     disabled={submitting || !creationPermission?.available}
                     data-testid="insight-save-button"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36697

## Test plan
- Go to the edit insight UI and make sure that the edit button says "Save changes"

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-edit-ui-insight-copy.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-blurfavvsm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
