### PR TITLE
search: show skipped files for archived and forks

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/google/zoekt/stream"
+	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -239,5 +240,5 @@ func (r *skippedIndexedResolver) Query() string {
 	// match. This is important because the indexed content (NOT-INDEXED: <reason>)
 	// is different from the on-disk content served by gitserver which leads to
 	// broken highlighting and problems with rendering content of binary files.
-	return fmt.Sprintf("r:^%s$@%s type:file select:file index:only patternType:regexp archived:yes fork:yes ^NOT-INDEXED:", r.repo.Name(), r.branch)
+	return fmt.Sprintf("r:^%s$@%s type:file select:file index:only patternType:regexp ^NOT-INDEXED:", regexp.QuoteMeta(r.repo.Name()), r.branch)
 }

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -239,5 +239,5 @@ func (r *skippedIndexedResolver) Query() string {
 	// match. This is important because the indexed content (NOT-INDEXED: <reason>)
 	// is different from the on-disk content served by gitserver which leads to
 	// broken highlighting and problems with rendering content of binary files.
-	return fmt.Sprintf("r:^%s$@%s type:file select:file index:only patternType:regexp ^NOT-INDEXED:", r.repo.Name(), r.branch)
+	return fmt.Sprintf("r:^%s$@%s type:file select:file index:only patternType:regexp archived:yes fork:yes ^NOT-INDEXED:", r.repo.Name(), r.branch)
 }


### PR DESCRIPTION
This fixes a bug where we wouldn't show skipped files for archived repos or forks.

## Test plan
- I tested this manually for a couple of archived repos and forks on Cloud 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
