### PR TITLE
Only redact URLs on Sourcegraph.com for paths that start with /github…

### DIFF
--- a/client/web/src/tracking/util.test.ts
+++ b/client/web/src/tracking/util.test.ts
@@ -4,7 +4,7 @@ describe('tracking/util', () => {
     describe(`${redactSensitiveInfoFromAppURL.name}()`, () => {
         it('removes search queries from URLs', () => {
             expect(redactSensitiveInfoFromAppURL('https://sourcegraph.com/search?q=test+query')).toEqual(
-                'https://sourcegraph.com/redacted?q=redacted'
+                'https://sourcegraph.com/search/redacted?q=redacted'
             )
         })
 
@@ -13,7 +13,7 @@ describe('tracking/util', () => {
                 redactSensitiveInfoFromAppURL(
                     'https://sourcegraph.com/search?q=test+query&utm_source=test&utm_campaign=test&utm_cid=test'
                 )
-            ).toEqual('https://sourcegraph.com/redacted?q=redacted&utm_source=test&utm_campaign=test&utm_cid=test')
+            ).toEqual('https://sourcegraph.com/search/redacted?q=redacted&utm_source=test&utm_campaign=test&utm_cid=test')
         })
 
         it('removes all query params from URLs but maintains marketing query params', () => {
@@ -22,7 +22,7 @@ describe('tracking/util', () => {
                     'https://sourcegraph.com/search?some_query_param=test+query&utm_source=test&utm_campaign=test&utm_content=test&utm_medium=test&utm_medium=test'
                 )
             ).toEqual(
-                'https://sourcegraph.com/redacted?some_query_param=redacted&utm_source=test&utm_campaign=test&utm_content=test&utm_medium=test&utm_medium=test'
+                'https://sourcegraph.com/search/redacted?some_query_param=redacted&utm_source=test&utm_campaign=test&utm_content=test&utm_medium=test&utm_medium=test'
             )
         })
 
@@ -31,7 +31,7 @@ describe('tracking/util', () => {
                 redactSensitiveInfoFromAppURL(
                     'https://sourcegraph.com/github.com/test/test?utm_source=test&utm_campaign=test'
                 )
-            ).toEqual('https://sourcegraph.com/redacted?utm_source=test&utm_campaign=test')
+            ).toEqual('https://sourcegraph.com/github.com/redacted?utm_source=test&utm_campaign=test')
         })
 
         it('removes repo and file information from URLs', () => {
@@ -39,7 +39,7 @@ describe('tracking/util', () => {
                 redactSensitiveInfoFromAppURL(
                     'https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/test?utm_source=test&utm_campaign=test'
                 )
-            ).toEqual('https://sourcegraph.com/redacted?utm_source=test&utm_campaign=test')
+            ).toEqual('https://sourcegraph.com/github.com/redacted?utm_source=test&utm_campaign=test')
         })
 
         it('does not redact pathnames from marketing site URLs', () => {
@@ -48,6 +48,14 @@ describe('tracking/util', () => {
                     'https://about.sourcegraph.com/case-studies?utm_source=test&utm_campaign=test'
                 )
             ).toEqual('https://about.sourcegraph.com/case-studies?utm_source=test&utm_campaign=test')
+        })
+
+        it('does not redact pathnames from all non-sensitive app URLs', () => {
+            expect(
+                redactSensitiveInfoFromAppURL(
+                    'https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTMwMA=='
+                )
+            ).toEqual('https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTMwMA==')
         })
     })
 

--- a/client/web/src/tracking/util.test.ts
+++ b/client/web/src/tracking/util.test.ts
@@ -13,7 +13,9 @@ describe('tracking/util', () => {
                 redactSensitiveInfoFromAppURL(
                     'https://sourcegraph.com/search?q=test+query&utm_source=test&utm_campaign=test&utm_cid=test'
                 )
-            ).toEqual('https://sourcegraph.com/search/redacted?q=redacted&utm_source=test&utm_campaign=test&utm_cid=test')
+            ).toEqual(
+                'https://sourcegraph.com/search/redacted?q=redacted&utm_source=test&utm_campaign=test&utm_cid=test'
+            )
         })
 
         it('removes all query params from URLs but maintains marketing query params', () => {

--- a/client/web/src/tracking/util.test.ts
+++ b/client/web/src/tracking/util.test.ts
@@ -51,11 +51,9 @@ describe('tracking/util', () => {
         })
 
         it('does not redact pathnames from all non-sensitive app URLs', () => {
-            expect(
-                redactSensitiveInfoFromAppURL(
-                    'https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTMwMA=='
-                )
-            ).toEqual('https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTMwMA==')
+            expect(redactSensitiveInfoFromAppURL('https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTMwMA==')).toEqual(
+                'https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTMwMA=='
+            )
         })
     })
 

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -18,6 +18,8 @@ export function stripURLParameters(url: string, parametersToRemove: string[] = [
  * leaking sensitive information from Sourcegraph Cloud, while maintaining
  * non-sensitive query parameters used for attribution tracking.
  *
+ * Note that URL redaction also happens in internal/usagestats/event_handlers.go.
+ *
  * @param url the original, full URL
  */
 export function redactSensitiveInfoFromAppURL(url: string): string {
@@ -27,8 +29,8 @@ export function redactSensitiveInfoFromAppURL(url: string): string {
         return url
     }
 
-    // Capture urls for notebook pages
-    if (sourceURL.pathname.startsWith('/notebooks')) {
+    // Only redact GitHub.com URLs. Currently, private code on Sourcegraph.com is only supported for GitHub.com.
+    if (!sourceURL.pathname.startsWith('/github.com') && !sourceURL.pathname.startsWith('/gitlab.com')) {
         return url
     }
     // Ensure we do not leak repo and file names in the URL

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -29,12 +29,16 @@ export function redactSensitiveInfoFromAppURL(url: string): string {
         return url
     }
 
-    // Only redact GitHub.com URLs. Currently, private code on Sourcegraph.com is only supported for GitHub.com.
-    if (!sourceURL.pathname.startsWith('/github.com') && !sourceURL.pathname.startsWith('/gitlab.com')) {
+    // Redact all GitHub.com code URLs, GitLab.com code URLs, and search URLs to ensure we do not leak sensitive information.
+    if (sourceURL.pathname.startsWith('/github.com')) {
+        sourceURL.pathname = '/github.com/redacted'
+    } else if (sourceURL.pathname.startsWith('/gitlab.com')) {
+        sourceURL.pathname = '/gitlab.com/redacted'
+    } else if (sourceURL.pathname.startsWith('/search')) {
+        sourceURL.pathname = '/search/redacted'
+    } else {
         return url
     }
-    // Ensure we do not leak repo and file names in the URL
-    sourceURL.pathname = '/redacted'
 
     const marketingQueryParameters = new Set([
         'utm_source',

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -234,6 +234,8 @@ func serializeLocalEvents(events []Event) ([]*database.Event, error) {
 // may contain sensitive info on Sourcegraph Cloud. We replace all paths,
 // and only maintain query parameters in a specified allowlist,
 // which are known to be essential for marketing analytics on Sourcegraph Cloud.
+//
+// Note that URL redaction also happens in web/src/tracking/util.ts.
 func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -241,6 +243,11 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 	}
 
 	if parsedURL.Host != "sourcegraph.com" {
+		return rawURL, nil
+	}
+
+	// Only redact GitHub.com URLs. Currently, private code on Sourcegraph.com is only supported for GitHub.com.
+	if !strings.HasPrefix(parsedURL.Path,"/github.com") && !strings.HasPrefix(parsedURL.Path, "/gitlab.com") {
 		return rawURL, nil
 	}
 

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"math/rand"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -247,7 +248,7 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 	}
 
 	// Only redact GitHub.com URLs. Currently, private code on Sourcegraph.com is only supported for GitHub.com.
-	if !strings.HasPrefix(parsedURL.Path,"/github.com") && !strings.HasPrefix(parsedURL.Path, "/gitlab.com") {
+	if !strings.HasPrefix(parsedURL.Path, "/github.com") && !strings.HasPrefix(parsedURL.Path, "/gitlab.com") {
 		return rawURL, nil
 	}
 

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -247,13 +247,19 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 		return rawURL, nil
 	}
 
-	// Only redact GitHub.com URLs. Currently, private code on Sourcegraph.com is only supported for GitHub.com.
-	if !strings.HasPrefix(parsedURL.Path, "/github.com") && !strings.HasPrefix(parsedURL.Path, "/gitlab.com") {
+	// Redact all GitHub.com code URLs, GitLab.com code URLs, and search URLs to ensure we do not leak sensitive information.
+	if strings.HasPrefix(parsedURL.Path, "/github.com") {
+		parsedURL.RawPath = "/github.com/redacted"
+		parsedURL.Path = "/github.com/redacted"
+	} else if strings.HasPrefix(parsedURL.Path, "/gitlab.com") {
+		parsedURL.RawPath = "/gitlab.com/redacted"
+		parsedURL.Path = "/gitlab.com/redacted"
+	} else if strings.HasPrefix(parsedURL.Path, "/search") {
+		parsedURL.RawPath = "/search/redacted"
+		parsedURL.Path = "/search/redacted"
+	} else {
 		return rawURL, nil
 	}
-
-	parsedURL.RawPath = "/redacted"
-	parsedURL.Path = "/redacted"
 
 	marketingQueryParameters := map[string]struct{}{
 		"utm_source":   {},

--- a/internal/usagestats/event_handlers_test.go
+++ b/internal/usagestats/event_handlers_test.go
@@ -16,17 +16,17 @@ func TestRedactSensitiveInfoFromCloudURL(t *testing.T) {
 		{
 			name: "path redacted",
 			url:  "https://sourcegraph.com/github.com/test/test",
-			want: "https://sourcegraph.com/redacted",
+			want: "https://sourcegraph.com/github.com/redacted",
 		},
 		{
 			name: "path and non-approved query param redacted",
 			url:  "https://sourcegraph.com/search?q=abcd",
-			want: "https://sourcegraph.com/redacted?q=redacted",
+			want: "https://sourcegraph.com/search/redacted?q=redacted",
 		},
 		{
 			name: "path and non-approved query param redacted, approved params retained",
 			url:  "https://sourcegraph.com/search?q=abcd&utm_source=test&utm_campaign=test&utm_medium=test&utm_content=test&utm_term=test&utm_cid=test",
-			want: "https://sourcegraph.com/redacted?q=redacted&utm_campaign=test&utm_cid=test&utm_content=test&utm_medium=test&utm_source=test&utm_term=test",
+			want: "https://sourcegraph.com/search/redacted?q=redacted&utm_campaign=test&utm_cid=test&utm_content=test&utm_medium=test&utm_source=test&utm_term=test",
 		},
 	}
 


### PR DESCRIPTION
….com, /gitlab.com, and /search, as we only provide private code browsing on Sourcegraph.com from GitHub.com and GitLab.com.

Related: https://github.com/sourcegraph/sourcegraph/pull/37581/files#commit-suggestions

## Test plan

All edited files are already covered by unit tests. There are no UI effects of this PR, so no storybook/e2e/integration tests should be required. 

My changes include updates to all relevant unit tests and an addition of a new test.

