### PR TITLE
dev docs: add ping debugging information

### DIFF
--- a/doc/dev/background-information/adding_ping_data.md
+++ b/doc/dev/background-information/adding_ping_data.md
@@ -66,11 +66,10 @@ To update the schema:
 Options for debugging ping abnormalities. Refer to [life of a ping](https://docs.sourcegraph.com/dev/background-information/architecture/life-of-a-ping) for the steps in the ping process.
 
 1. BigQuery: Query the [update_checks error records](https://console.cloud.google.com/bigquery?sq=839055276916:62219ea9d95d4a49880e661318f419ba) and/or [check the latest pings received](https://console.cloud.google.com/bigquery?sq=839055276916:3c6a5282e66a4f0fac1b958305d7b197) based on installer email admin. 
-1. Dataflow: Review [Dataflow](https://console.cloud.google.com/dataflow/jobs/us-central1/2020-02-05_10_31_47-13247700157778222556?project=telligentsourcegraph&organizationId=1006954638239): WriteSuccessfulRecords should be full of throughputs and the Failed/Error jobs should be empty of throughputs. 
-1. Stackdriver (log viewer): [Check the frontend logs](https://console.cloud.google.com/logs/viewer?project=sourcegraph-dev&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fdot-com%2Fnamespace_name%2Fprod%2Fcontainer_name%2Ffrontend), which contain all pings that come through Sourcegraph.com. Use the following the advanced filters to find the pings you're interested in.
-1. Grafana: Run `src_updatecheck_client_duration_seconds_sum` on [Grafana](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Prometheus%22,%7B%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D) to understand how long each method is taking. Request this information from an instance admin, if necessary.
-1. Test on a Sourcegraph dev instance to make sure the pings are being sent properly
-
+2. Dataflow: Review [Dataflow](https://console.cloud.google.com/dataflow/jobs/us-central1/2020-02-05_10_31_47-13247700157778222556?project=telligentsourcegraph&organizationId=1006954638239): WriteSuccessfulRecords should be full of throughputs and the Failed/Error jobs should be empty of throughputs. 
+3. Stackdriver (log viewer): [Check the frontend logs](https://console.cloud.google.com/logs/viewer?project=sourcegraph-dev&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fdot-com%2Fnamespace_name%2Fprod%2Fcontainer_name%2Ffrontend), which contain all pings that come through Sourcegraph.com. Use the following the advanced filters to find the pings you're interested in.
+4. Grafana: Run `src_updatecheck_client_duration_seconds_sum` on [Grafana](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Prometheus%22,%7B%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D) to understand how long each method is taking. Request this information from an instance admin, if necessary.
+5. Test on a Sourcegraph dev instance to make sure the pings are being sent properly
 ```
 resource.type="k8s_container"
 resource.labels="dot-com"
@@ -78,3 +77,4 @@ resource.labels.cluster_name="prod"
 resource.labels.container_name="frontend"
 "[COMPANY]" AND "updatecheck"
 ```
+6. Locally: To see non-critical pings locally, you will need to update your site configuration such that `disableNonCriticalTelemetry` is set to false. It is set to `true` by default. For Sourcegraph employees you should change this in your `dev-private` repo under `enterprise/dev/site-config.json`. 


### PR DESCRIPTION
This updates our dev docs so that it's clearer how to debug pings on local dev instances. 

## Test plan
This is a docs change only.