### PR TITLE
Structural search: Stream from comby for zip file search

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -393,7 +393,7 @@ func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatt
 	}()
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
-	numWorkers := 4
+	numWorkers := 0
 
 	matcher := toMatcher(languages, extensionHint)
 
@@ -415,59 +415,18 @@ func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatt
 
 	switch combyInput := inputType.(type) {
 	case comby.Tar:
-		return runCombyWithStreaming(ctx, args, combyInput, sender)
+		return runCombyAgainstTar(ctx, args, combyInput, sender)
 	case comby.ZipPath:
-		cmd, stdin, stdout, err := comby.SetupCmdWithPipes(ctx, args)
-		if err != nil {
-			return err
-		}
-		stdin.Close()
-
-		zipReader, err := zip.OpenReader(string(combyInput))
-		if err != nil {
-			return err
-		}
-		defer zipReader.Close()
-
-		wg := sync.WaitGroup{}
-		defer wg.Wait()
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer stdout.Close()
-
-			scanner := bufio.NewScanner(stdout)
-			// increase the scanner buffer size for potentially long lines
-			scanner.Buffer(make([]byte, 100), 10*bufio.MaxScanTokenSize)
-
-			for scanner.Scan() {
-				b := scanner.Bytes()
-				if err := scanner.Err(); err != nil {
-					// warn on scanner errors and skip
-					log.NamedError("comby error: skipping scanner error line", err)
-					break
-				}
-
-				fm, err := toFileMatch(&zipReader.Reader, comby.ToFileMatch(b).(*comby.FileMatch))
-				if err != nil {
-					log.NamedError("error converting comby match to FileMatch, skipping", err)
-					continue
-				}
-				sender.Send(fm)
-			}
-		}()
-
-		return comby.StartAndWaitForCompletion(cmd)
+		return runCombyAgainstZip(ctx, args, combyInput, sender)
 	}
 
 	return errors.New("comby input must be either -tar or -zip for structural search")
 }
 
-// runCombyWithStreaming runs comby with the flags `-tar` and `-chunk-matches 0`. `-chunk-matches 0` instructs comby to return
+// runCombyAgainstTar runs comby with the flags `-tar` and `-chunk-matches 0`. `-chunk-matches 0` instructs comby to return
 // chunks as part of matches that it finds. Data is streamed into stdin from the channel on tarInput and out from stdout
 // to the result stream.
-func runCombyWithStreaming(ctx context.Context, args comby.Args, tarInput comby.Tar, sender matchSender) (err error) {
+func runCombyAgainstTar(ctx context.Context, args comby.Args, tarInput comby.Tar, sender matchSender) (err error) {
 	cmd, stdin, stdout, err := comby.SetupCmdWithPipes(ctx, args)
 	if err != nil {
 		return err
@@ -520,13 +479,14 @@ func runCombyWithStreaming(ctx context.Context, args comby.Args, tarInput comby.
 	return comby.StartAndWaitForCompletion(cmd)
 }
 
-// runCombyWithCollection runs comby with the flag `-zip`. It collects all matches that comby finds in the zip file, then
-// attempts to convert each of those to a protocol.FileMatch, sending it to the result stream if successful.
-func runCombyWithCollection(ctx context.Context, args comby.Args, zipPath comby.ZipPath, sender matchSender) (err error) {
-	combyMatches, err := comby.Matches(ctx, args)
+// runCombyAgainstZip runs comby with the flag `-zip`. It reads matches from comby's stdout as they are returned and
+// attempts to convert each to a protocol.FileMatch, sending it to the result stream if successful.
+func runCombyAgainstZip(ctx context.Context, args comby.Args, zipPath comby.ZipPath, sender matchSender) (err error) {
+	cmd, stdin, stdout, err := comby.SetupCmdWithPipes(ctx, args)
 	if err != nil {
 		return err
 	}
+	stdin.Close() // don't need to write to stdin when using `-zip`
 
 	zipReader, err := zip.OpenReader(string(zipPath))
 	if err != nil {
@@ -534,16 +494,36 @@ func runCombyWithCollection(ctx context.Context, args comby.Args, zipPath comby.
 	}
 	defer zipReader.Close()
 
-	for _, combyMatch := range combyMatches {
-		fm, err := toFileMatch(&zipReader.Reader, combyMatch)
-		if err != nil {
-			log.NamedError("error converting comby match to FileMatch, skipping", err)
-			continue
-		}
-		sender.Send(fm)
-	}
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
 
-	return nil
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer stdout.Close()
+
+		scanner := bufio.NewScanner(stdout)
+		// increase the scanner buffer size for potentially long lines
+		scanner.Buffer(make([]byte, 100), 10*bufio.MaxScanTokenSize)
+
+		for scanner.Scan() {
+			b := scanner.Bytes()
+			if err := scanner.Err(); err != nil {
+				// warn on scanner errors and skip
+				log.NamedError("comby error: skipping scanner error line", err)
+				break
+			}
+
+			fm, err := toFileMatch(&zipReader.Reader, comby.ToFileMatch(b).(*comby.FileMatch))
+			if err != nil {
+				log.NamedError("error converting comby match to FileMatch, skipping", err)
+				continue
+			}
+			sender.Send(fm)
+		}
+	}()
+
+	return comby.StartAndWaitForCompletion(cmd)
 }
 
 var metricRequestTotalStructuralSearch = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -393,7 +393,7 @@ func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatt
 	}()
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
-	numWorkers := 0
+	numWorkers := 4
 
 	matcher := toMatcher(languages, extensionHint)
 

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -514,12 +514,15 @@ func runCombyAgainstZip(ctx context.Context, args comby.Args, zipPath comby.ZipP
 				break
 			}
 
-			fm, err := toFileMatch(&zipReader.Reader, comby.ToFileMatch(b).(*comby.FileMatch))
-			if err != nil {
-				log.NamedError("error converting comby match to FileMatch, skipping", err)
-				continue
+			cfm := comby.ToFileMatch(b)
+			if cfm != nil {
+				fm, err := toFileMatch(&zipReader.Reader, cfm.(*comby.FileMatch))
+				if err != nil {
+					log.NamedError("error converting comby match to FileMatch, skipping", err)
+					continue
+				}
+				sender.Send(fm)
 			}
-			sender.Send(fm)
 		}
 	}()
 

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -87,7 +87,7 @@ func ToCombyFileMatchWithChunks(b []byte) Result {
 	return m
 }
 
-func toFileMatch(b []byte) Result {
+func ToFileMatch(b []byte) Result {
 	var m *FileMatch
 	if err := json.Unmarshal(b, &m); err != nil {
 		log15.Warn("toFileMatch() comby error: skipping unmarshaling error", "err", err.Error())
@@ -225,7 +225,7 @@ func Matches(ctx context.Context, args Args) ([]*FileMatch, error) {
 	defer span.Finish()
 
 	args.ResultKind = MatchOnly
-	results, err := Run(ctx, args, toFileMatch)
+	results, err := Run(ctx, args, ToFileMatch)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With [flushing output per match implemented in comby v1.8.1](https://github.com/comby-tools/comby/pull/343), we can confidently implement streaming results from comby for searches over zip files. 

## Test plan
Run existing unit tests. Run backend integration tests. Manually verify un-indexed structural search results are now streamed back.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
