### PR TITLE
Structural search: use non-capturing regex groups for comby translation

### DIFF
--- a/internal/comby/translate.go
+++ b/internal/comby/translate.go
@@ -181,12 +181,12 @@ func StructuralPatToRegexpQuery(pattern string, shortcircuit bool) string {
 
 	if len(pieces) == 0 {
 		// Match anything.
-		return "(.|\\s)*?"
+		return "(?:.|\\s)*?"
 	}
 
 	if shortcircuit {
 		// As a shortcircuit, do not match across newlines of structural search pieces.
-		return "(" + strings.Join(pieces, ").*?(") + ")"
+		return "(?:" + strings.Join(pieces, ").*?(?:") + ")"
 	}
-	return "(" + strings.Join(pieces, ")(.|\\s)*?(") + ")"
+	return "(?:" + strings.Join(pieces, ")(?:.|\\s)*?(?:") + ")"
 }

--- a/internal/comby/translate_test.go
+++ b/internal/comby/translate_test.go
@@ -15,99 +15,99 @@ func TestStructuralPatToRegexpQuery(t *testing.T) {
 		{
 			Name:    "Just a hole",
 			Pattern: ":[1]",
-			Want:    `(.|\s)*?`,
+			Want:    `(?:.|\s)*?`,
 		},
 		{
 			Name:    "Adjacent holes",
 			Pattern: ":[1]:[2]:[3]",
-			Want:    `(.|\s)*?`,
+			Want:    `(?:.|\s)*?`,
 		},
 		{
 			Name:    "Substring between holes",
 			Pattern: ":[1] substring :[2]",
-			Want:    `([\s]+substring[\s]+)`,
+			Want:    `(?:[\s]+substring[\s]+)`,
 		},
 		{
 			Name:    "Substring before and after different hole kinds",
 			Pattern: "prefix :[[1]] :[2.] suffix",
-			Want:    `(prefix[\s]+)(.|\s)*?([\s]+)(.|\s)*?([\s]+suffix)`,
+			Want:    `(?:prefix[\s]+)(?:.|\s)*?(?:[\s]+)(?:.|\s)*?(?:[\s]+suffix)`,
 		},
 		{
 			Name:    "Substrings covering all hole kinds.",
 			Pattern: `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.`,
-			Want:    `(1\.[\s]+)(.|\s)*?([\s]+2\.[\s]+)(.|\s)*?([\s]+3\.[\s]+)(.|\s)*?([\s]+4\.[\s]+)(.|\s)*?([\s]+5\.[\s]+)(.|\s)*?([\s]+6\.[\s]+)(.|\s)*?([\s]+done\.)`,
+			Want:    `(?:1\.[\s]+)(?:.|\s)*?(?:[\s]+2\.[\s]+)(?:.|\s)*?(?:[\s]+3\.[\s]+)(?:.|\s)*?(?:[\s]+4\.[\s]+)(?:.|\s)*?(?:[\s]+5\.[\s]+)(?:.|\s)*?(?:[\s]+6\.[\s]+)(?:.|\s)*?(?:[\s]+done\.)`,
 		},
 		{
 			Name:    "Allow alphanumeric identifiers in holes",
 			Pattern: "sub :[alphanum_ident_123] string",
-			Want:    `(sub[\s]+)(.|\s)*?([\s]+string)`,
+			Want:    `(?:sub[\s]+)(?:.|\s)*?(?:[\s]+string)`,
 		},
 
 		{
 			Name:    "Whitespace separated holes",
 			Pattern: ":[1] :[2]",
-			Want:    `([\s]+)`,
+			Want:    `(?:[\s]+)`,
 		},
 		{
 			Name:    "Expect newline separated pattern",
 			Pattern: "ParseInt(:[stuff], :[x]) if err ",
-			Want:    `(ParseInt\()(.|\s)*?(,[\s]+)(.|\s)*?(\)[\s]+if[\s]+err[\s]+)`,
+			Want:    `(?:ParseInt\()(?:.|\s)*?(?:,[\s]+)(?:.|\s)*?(?:\)[\s]+if[\s]+err[\s]+)`,
 		},
 		{
 			Name: "Contiguous whitespace is replaced by regex",
 			Pattern: `ParseInt(:[stuff],    :[x])
              if err `,
-			Want: `(ParseInt\()(.|\s)*?(,[\s]+)(.|\s)*?(\)[\s]+if[\s]+err[\s]+)`,
+			Want: `(?:ParseInt\()(?:.|\s)*?(?:,[\s]+)(?:.|\s)*?(?:\)[\s]+if[\s]+err[\s]+)`,
 		},
 		{
 			Name:    "Regex holes extracts regex",
 			Pattern: `:[x~[yo]]`,
-			Want:    `([yo])`,
+			Want:    `(?:[yo])`,
 		},
 		{
 			Name:    "Regex holes with escaped space",
 			Pattern: `:[x~\ ]`,
-			Want:    `(\ )`,
+			Want:    `(?:\ )`,
 		},
 		{
 			Name:    "Shorthand",
 			Pattern: ":[[1]]",
-			Want:    `(.|\s)*?`,
+			Want:    `(?:.|\s)*?`,
 		},
 		{
 			Name:    "Array-like preserved",
 			Pattern: `[:[x]]`,
-			Want:    `(\[)(.|\s)*?(\])`,
+			Want:    `(?:\[)(?:.|\s)*?(?:\])`,
 		},
 		{
 			Name:    "Shorthand",
 			Pattern: ":[[1]]",
-			Want:    `(.|\s)*?`,
+			Want:    `(?:.|\s)*?`,
 		},
 		{
 			Name:    "Not well-formed is undefined",
 			Pattern: ":[[",
-			Want:    `(:\[\[)`,
+			Want:    `(?::\[\[)`,
 		},
 		{
 			Name:    "Complex regex with character class",
 			Pattern: `:[chain~[^(){}\[\],]+\n( +\..*\n)+]`,
-			Want:    `([^(){}\[\],]+\n( +\..*\n)+)`,
+			Want:    `(?:[^(){}\[\],]+\n( +\..*\n)+)`,
 		},
 		{
 			Name:    "Colon regex",
 			Pattern: `:[~:]`,
-			Want:    `(:)`,
+			Want:    `(?::)`,
 		},
 		{
 			Name:    "Colon prefix",
 			Pattern: `::[version]bar`,
-			Want:    `(:)(.|\s)*?(bar)`,
+			Want:    `(?::)(?:.|\s)*?(?:bar)`,
 		},
 		{
 			Name:    "Colon prefix",
 			Pattern: `::::[version]bar`,
-			Want:    `(:::)(.|\s)*?(bar)`,
+			Want:    `(?::::)(?:.|\s)*?(?:bar)`,
 		},
 	}
 	for _, tt := range cases {


### PR DESCRIPTION
This updates the translation of comby patterns to regex so that they are
constructed with non-capturing groups rather than capturing groups. This
is just a minor performance optimization.

## Test plan

Unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
