### PR TITLE
Structural search: return early when prefiltering returns no results

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -333,6 +333,9 @@ func filteredStructuralSearch(ctx context.Context, zipPath string, zf *zipFile, 
 	if err != nil {
 		return err
 	}
+	if len(fileMatches) == 0 {
+		return nil
+	}
 
 	matchedPaths := make([]string, 0, len(fileMatches))
 	for _, fm := range fileMatches {


### PR DESCRIPTION
This adds an early return to `filteredStructuralSearch` when we return
no matches from `regexSearchBatch`. Before this, we would continue to do
a structural search on the repo with an empty string, which is
apparently interpreted by Comby as "search everything", which was
causing unindexed searches to take far more resources than they needed to.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
