### PR TITLE
dev/sg: fix dev-private cloning

### DIFF
--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -94,7 +94,18 @@ NOTE: You can ignore this if you're not a Sourcegraph teammate.`,
 					}
 					return errors.New("could not find dev-private repository either in current directory or one above")
 				},
-				Fix: cmdFix(`git clone git@github.com:sourcegraph/dev-private.git`),
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					rootDir, err := root.RepositoryRoot()
+					if err != nil {
+						return errors.Wrap(err, "sourcegraph/sourcegraph should be cloned first")
+					}
+
+					return run.Cmd(ctx, `git clone git@github.com:sourcegraph/dev-private.git`).
+						// Clone to parent
+						Dir(filepath.Join(rootDir, "..")).
+						Run().
+						StreamLines(cio.Verbose)
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Remove `dev-private`, and:

`go run ./dev/sg setup -f`