### PR TITLE
search: make query concat transformer return []Node not Pattern

### DIFF
--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -201,7 +201,7 @@ func TestSubstituteOrForRegexp(t *testing.T) {
 func TestSubstituteConcat(t *testing.T) {
 	cases := []struct {
 		input  string
-		concat func([]Pattern) Pattern
+		concat func([]Pattern) []Node
 		want   string
 	}{
 		{


### PR DESCRIPTION
Setup for RFC 675 and pattern interpretation.

Optional context from [comment](https://github.com/sourcegraph/sourcegraph/pull/37658#discussion_r906441195)

> need to implement a different Concat processor for standard. Concat nodes always contain patterns (they can be regexp or literal, doesn't matter).

> Currently, literal patterns are concatted with space. regexp patterns are concatted with .*. Now, with standard, it's possible to have literal and regexp patterns alternate in the input string for the first time, so the Concat behavior will be different (we don't want to always use space, but right now it does, and consequently, it just means that the regexp pattern is reduced to a literal string). Instead, the end state will work like this:

> Any sequence of regexp patterns like /foo/ /bar/ /baz/ will be AND-ed
Alternation of regexp and literal patterns like /foo/ bar /baz/ will be ANDed
Any sequence of literal patterns like foo bar baz will be concatenated with space (preserving literal search behavior as before).
Essentially, everything will be ANDed except for contiguous literal patterns, which will be space, as before. My intuition is that the AND meaning is more intuitive outside of the literal pattern behavior, because unlike literal patterns, regex patterns are explicitly delineated with /.../. For example, it would be a little silly to say /foo/ /bar/ if you prefer to concat those patterns--you would probably (should) prefer to just write /foo bar/.

## Test plan
Semantics-preserving. Runs against existing tests.
