### PR TITLE
search: bump comby 1.8.1

### DIFF
--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache add pcre sqlite-libs libev
 # The comby/comby image is a small binary-only distribution. See the bin and src directories
 # here: https://github.com/comby-tools/comby/tree/master/dockerfiles/alpine
 # hadolint ignore=DL3022
-COPY --from=comby/comby:1.8.0@sha256:0d3e3e81ca93e013c96a89b6dd8d423b027e3638a1fdcff32d5bbda1786e7946 /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:alpine-3.14-1.8.1@sha256:a5e80d6bad6af008478679809dc8327ebde7aeff7b23505b11b20e36aa62a0b2 /usr/local/bin/comby /usr/local/bin/comby
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -72,7 +72,7 @@ RUN apk add --no-cache --verbose \
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)
 # have been appropriately set in cmd/server/shared/shared.go.
 # hadolint ignore=DL3022
-COPY --from=comby/comby:1.8.0@sha256:0d3e3e81ca93e013c96a89b6dd8d423b027e3638a1fdcff32d5bbda1786e7946 /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:alpine-3.14-1.8.1@sha256:a5e80d6bad6af008478679809dc8327ebde7aeff7b23505b11b20e36aa62a0b2 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=docker.io/sourcegraph/syntect_server:21-08-31_c330964@sha256:759f331a474d2a67b811a1b374b0b24a4661446a2d8e9b211f51ea8ae95e1130 /syntect_server /usr/local/bin/
 

--- a/dev/comby-install-or-upgrade.sh
+++ b/dev/comby-install-or-upgrade.sh
@@ -3,7 +3,7 @@
 # This function installs the comby dependency for cmd/searcher.
 # The CI pipeline calls this script to install or upgrade comby
 # for tests or development environments.
-REQUIRE_VERSION="1.8.0"
+REQUIRE_VERSION="1.8.1"
 
 RELEASE_VERSION=$REQUIRE_VERSION
 RELEASE_TAG=$REQUIRE_VERSION


### PR DESCRIPTION
Changelog:

> Matches are now flushed to stdout per result (previously comby would possibly buffer more than one result).

https://github.com/comby-tools/comby/releases/tag/1.8.1

## Test plan
Runs against tests