### PR TITLE
codemirror: Fix suggestions icon color in dark mode

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -100,8 +100,11 @@
                     height: 1.25rem;
 
                     svg {
-                        fill: var(--search-query-text-color);
                         flex-shrink: 0;
+
+                        path {
+                            fill: var(--search-query-text-color);
+                        }
                     }
 
                     :global(.cm-completionLabel) {


### PR DESCRIPTION
Fixes #37752 

I cannot reproduce this problem locally but it looks like `fill` might
not be a valid CSS rule for `svg` and therefore it is somehow removed
in production builds.
Hopefully applying it to `path` will work.



## Test plan

Triggering suggestions in the main search query input shows icons with appropriate colors in dark and light mode (though as already mentioned, the issues itself doesn't reproduce in local dev builds).

## App preview:

- [Web](https://sg-web-fkling-37752-dark-mode-suggestion.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yijwzjwzpf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
