### PR TITLE
codemirror: Consider focus state for filter highlighting on every update

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -518,20 +518,22 @@ const highlightFocusedFilter = ViewPlugin.define(
     () => ({
         decorations: Decoration.none,
         update(update) {
-            if (update.focusChanged && !update.view.hasFocus) {
-                this.decorations = Decoration.none
-            } else if (update.docChanged || update.selectionSet || update.focusChanged) {
-                const query = update.state.facet(parsedQuery)
-                const position = update.state.selection.main.head
-                const focusedFilter = query.tokens.find(
-                    (token): token is Filter =>
-                        // Inclusive end so that the filter is highlighed when
-                        // the cursor is positioned directly after the value
-                        token.type === 'filter' && token.range.start <= position && token.range.end >= position
-                )
-                this.decorations = focusedFilter
-                    ? Decoration.set(focusedFilterDeco.range(focusedFilter.range.start, focusedFilter.range.end))
-                    : Decoration.none
+            if (update.docChanged || update.selectionSet || update.focusChanged) {
+                if (update.view.hasFocus) {
+                    const query = update.state.facet(parsedQuery)
+                    const position = update.state.selection.main.head
+                    const focusedFilter = query.tokens.find(
+                        (token): token is Filter =>
+                            // Inclusive end so that the filter is highlighed when
+                            // the cursor is positioned directly after the value
+                            token.type === 'filter' && token.range.start <= position && token.range.end >= position
+                    )
+                    this.decorations = focusedFilter
+                        ? Decoration.set(focusedFilterDeco.range(focusedFilter.range.start, focusedFilter.range.end))
+                        : Decoration.none
+                } else {
+                    this.decorations = Decoration.none
+                }
             }
         },
     }),


### PR DESCRIPTION
**Note:** Best reviewed with white space changes turned off.

Currently when navigating e.g. from search results to a file, we will
update the content of the search query input but not focus it. Because
the content changes the logic for recomputing the current filter
highlight gets triggered and highlights the last filter in the input,
which is not desirable:

<img width="955" alt="2022-06-28_08-07" src="https://user-images.githubusercontent.com/179026/176128702-a9401106-b195-4aa7-b189-70db93d27c33.png">


This commit updates the logic to take the focus state into account on
every update.

<img width="958" alt="2022-06-28_08-08" src="https://user-images.githubusercontent.com/179026/176128730-d92af5fc-3694-4e92-844a-762617db102a.png">




## Test plan

- Go to https://sourcegraph.test:3443/search and perform a (file) search
- Select any search result
- Observe that on the file page the search query input is not focused and none of the filters is highlighted.

## App preview:

- [Web](https://sg-web-fkling-fix-filter-highlight.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yvhetdlspq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
