### PR TITLE
permissions: Add TouchUserPermissions and use during user permissions sync

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -199,6 +199,109 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}
 }
 
+func TestPermsSyncer_syncUserPerms_touchUserPermissions(t *testing.T) {
+	p := &mockProvider{
+		id:          1,
+		serviceType: extsvc.TypeGitLab,
+		serviceID:   "https://gitlab.com/",
+	}
+	authz.SetProviders(false, []authz.Provider{p})
+	defer authz.SetProviders(true, nil)
+
+	users := database.NewMockUserStore()
+	users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
+		return &types.User{ID: id}, nil
+	})
+
+	mockRepos := database.NewMockRepoStore()
+	mockRepos.ListMinimalReposFunc.SetDefaultHook(func(ctx context.Context, opt database.ReposListOptions) ([]types.MinimalRepo, error) {
+		if !opt.OnlyPrivate {
+			return nil, errors.New("OnlyPrivate want true but got false")
+		}
+
+		names := make([]types.MinimalRepo, 0, len(opt.ExternalRepos))
+		for _, r := range opt.ExternalRepos {
+			id, _ := strconv.Atoi(r.ID)
+			names = append(names, types.MinimalRepo{ID: api.RepoID(id)})
+		}
+		return names, nil
+	})
+
+	externalAccounts := database.NewMockUserExternalAccountsStore()
+	externalAccounts.ListFunc.SetDefaultHook(func(ctx context.Context, options database.ExternalAccountsListOptions) ([]*extsvc.Account, error) {
+		// Force an error here to bail out of fetchUserPermsViaExternalAccounts
+		return nil, errors.New("forced error")
+	})
+
+	userEmails := database.NewMockUserEmailsStore()
+	userEmails.ListByUserFunc.SetDefaultHook(func(ctx context.Context, options database.UserEmailsListOptions) ([]*database.UserEmail, error) {
+		return []*database.UserEmail{}, nil
+	})
+
+	db := database.NewMockDB()
+	db.UsersFunc.SetDefaultReturn(users)
+	db.ReposFunc.SetDefaultReturn(mockRepos)
+	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
+	db.UserEmailsFunc.SetDefaultReturn(userEmails)
+
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db))
+	reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{1}, nil)
+	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{2, 3, 4}, nil)
+	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
+
+	var touchUserPermsCalled bool
+	perms := edb.NewMockPermsStore()
+	perms.SetUserPermissionsFunc.SetDefaultHook(func(_ context.Context, p *authz.UserPermissions) error {
+		wantIDs := []int32{1, 2, 3, 4, 5}
+		assert.Equal(t, wantIDs, p.GenerateSortedIDsSlice())
+		return nil
+	})
+	perms.UserIsMemberOfOrgHasCodeHostConnectionFunc.SetDefaultReturn(true, nil)
+	perms.TouchUserPermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32) error {
+		touchUserPermsCalled = true
+		return nil
+	})
+
+	eauthz.MockProviderFromExternalService = func(siteConfig schema.SiteConfiguration, svc *types.ExternalService) (authz.Provider, error) {
+		return p, nil
+	}
+	defer func() {
+		eauthz.MockProviderFromExternalService = nil
+	}()
+
+	s := NewPermsSyncer(logtest.Scoped(t), db, reposStore, perms, timeutil.Now, nil)
+
+	t.Run("fetchUserPermsViaExternalAccounts", func(t *testing.T) {
+		err := s.syncUserPerms(context.Background(), 1, true, authz.FetchPermsOptions{})
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if !touchUserPermsCalled {
+			t.Fatal("TouchUserPermissions should have been called")
+		}
+	})
+
+	// Setup for fetchUserPermsViaExternalServices
+	touchUserPermsCalled = false
+	externalAccounts.ListFunc.SetDefaultHook(func(ctx context.Context, options database.ExternalAccountsListOptions) ([]*extsvc.Account, error) {
+		return []*extsvc.Account{}, nil
+	})
+	perms.UserIsMemberOfOrgHasCodeHostConnectionFunc.SetDefaultHook(func(ctx context.Context, i int32) (bool, error) {
+		// Force an error here to bail out of fetchUserPermsViaExternalServices
+		return false, errors.New("forced error")
+	})
+
+	t.Run("fetchUserPermsViaExternalServices", func(t *testing.T) {
+		err := s.syncUserPerms(context.Background(), 1, true, authz.FetchPermsOptions{})
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if !touchUserPermsCalled {
+			t.Fatal("TouchUserPermissions should have been called")
+		}
+	})
+}
+
 // If we hit a temporary error from the provider we should fetch existing
 // permissions from the database
 func TestPermsSyncer_syncUserPermsTemporaryProviderError(t *testing.T) {

--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -47,6 +47,7 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"SetRepoPermissions", testPermsStore_SetRepoPermissions(db)},
 		{"SetRepoPermissionsUnrestricted", testPermsStore_SetRepoPermissionsUnrestricted(db)},
 		{"TouchRepoPermissions", testPermsStore_TouchRepoPermissions(db)},
+		{"TouchUserPermissions", testPermsStore_TouchUserPermissions(db)},
 		{"LoadUserPendingPermissions", testPermsStore_LoadUserPendingPermissions(db)},
 		{"SetRepoPendingPermissions", testPermsStore_SetRepoPendingPermissions(db)},
 		{"ListPendingUsers", testPermsStore_ListPendingUsers(db)},

--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -11243,6 +11243,9 @@ type MockPermsStore struct {
 	// TouchRepoPermissionsFunc is an instance of a mock function object
 	// controlling the behavior of the method TouchRepoPermissions.
 	TouchRepoPermissionsFunc *PermsStoreTouchRepoPermissionsFunc
+	// TouchUserPermissionsFunc is an instance of a mock function object
+	// controlling the behavior of the method TouchUserPermissions.
+	TouchUserPermissionsFunc *PermsStoreTouchUserPermissionsFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *PermsStoreTransactFunc
@@ -11364,6 +11367,11 @@ func NewMockPermsStore() *MockPermsStore {
 			},
 		},
 		TouchRepoPermissionsFunc: &PermsStoreTouchRepoPermissionsFunc{
+			defaultHook: func(context.Context, int32) (r0 error) {
+				return
+			},
+		},
+		TouchUserPermissionsFunc: &PermsStoreTouchUserPermissionsFunc{
 			defaultHook: func(context.Context, int32) (r0 error) {
 				return
 			},
@@ -11505,6 +11513,11 @@ func NewStrictMockPermsStore() *MockPermsStore {
 				panic("unexpected invocation of MockPermsStore.TouchRepoPermissions")
 			},
 		},
+		TouchUserPermissionsFunc: &PermsStoreTouchUserPermissionsFunc{
+			defaultHook: func(context.Context, int32) error {
+				panic("unexpected invocation of MockPermsStore.TouchUserPermissions")
+			},
+		},
 		TransactFunc: &PermsStoreTransactFunc{
 			defaultHook: func(context.Context) (PermsStore, error) {
 				panic("unexpected invocation of MockPermsStore.Transact")
@@ -11601,6 +11614,9 @@ func NewMockPermsStoreFrom(i PermsStore) *MockPermsStore {
 		},
 		TouchRepoPermissionsFunc: &PermsStoreTouchRepoPermissionsFunc{
 			defaultHook: i.TouchRepoPermissions,
+		},
+		TouchUserPermissionsFunc: &PermsStoreTouchUserPermissionsFunc{
+			defaultHook: i.TouchUserPermissions,
 		},
 		TransactFunc: &PermsStoreTransactFunc{
 			defaultHook: i.Transact,
@@ -13792,6 +13808,113 @@ func (c PermsStoreTouchRepoPermissionsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c PermsStoreTouchRepoPermissionsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// PermsStoreTouchUserPermissionsFunc describes the behavior when the
+// TouchUserPermissions method of the parent MockPermsStore instance is
+// invoked.
+type PermsStoreTouchUserPermissionsFunc struct {
+	defaultHook func(context.Context, int32) error
+	hooks       []func(context.Context, int32) error
+	history     []PermsStoreTouchUserPermissionsFuncCall
+	mutex       sync.Mutex
+}
+
+// TouchUserPermissions delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockPermsStore) TouchUserPermissions(v0 context.Context, v1 int32) error {
+	r0 := m.TouchUserPermissionsFunc.nextHook()(v0, v1)
+	m.TouchUserPermissionsFunc.appendCall(PermsStoreTouchUserPermissionsFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the TouchUserPermissions
+// method of the parent MockPermsStore instance is invoked and the hook
+// queue is empty.
+func (f *PermsStoreTouchUserPermissionsFunc) SetDefaultHook(hook func(context.Context, int32) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// TouchUserPermissions method of the parent MockPermsStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *PermsStoreTouchUserPermissionsFunc) PushHook(hook func(context.Context, int32) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *PermsStoreTouchUserPermissionsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int32) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *PermsStoreTouchUserPermissionsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int32) error {
+		return r0
+	})
+}
+
+func (f *PermsStoreTouchUserPermissionsFunc) nextHook() func(context.Context, int32) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *PermsStoreTouchUserPermissionsFunc) appendCall(r0 PermsStoreTouchUserPermissionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of PermsStoreTouchUserPermissionsFuncCall
+// objects describing the invocations of this function.
+func (f *PermsStoreTouchUserPermissionsFunc) History() []PermsStoreTouchUserPermissionsFuncCall {
+	f.mutex.Lock()
+	history := make([]PermsStoreTouchUserPermissionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// PermsStoreTouchUserPermissionsFuncCall is an object that describes an
+// invocation of method TouchUserPermissions on an instance of
+// MockPermsStore.
+type PermsStoreTouchUserPermissionsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c PermsStoreTouchUserPermissionsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c PermsStoreTouchUserPermissionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 


### PR DESCRIPTION
Add TouchUserPermissions to PermsStore

Then, touch user permissions if we encounter error in syncUserPerms so that the failed user sync
is moved to the back of the sync queue.

Part of https://github.com/sourcegraph/customer/issues/993

## Test plan

Tests added