### PR TITLE
JetBrains: Remove leftover reference to com.intellij.java

### DIFF
--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,6 @@
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.lang</depends>
-    <depends>com.intellij.java</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="com.sourcegraph.config.SourcegraphProjectService"/>


### PR DESCRIPTION
Follow up #37697 

I noticed this leftover to before I removed `com.intellij.java` dependencies. 😐 

## Test plan

Opening the `plugin.xml` file in IntelliJ no longer errors.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-remove-leftover.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kwgzsnfmlu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
