### PR TITLE
JetBrains: Remove usage of APIs added after 2021.1

### DIFF
--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -6,8 +6,11 @@ pluginName=Sourcegraph
 pluginVersion=1.2.4
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-# 2020.2 was the first version to have JCEF enabled by default -> https://plugins.jetbrains.com/docs/intellij/jcef.html
-pluginSinceBuild=202.0
+#  - 2020.2 was the first version to have JCEF enabled by default
+#    -> https://plugins.jetbrains.com/docs/intellij/jcef.html
+#  - Version 2020.2 and 2020.3 have issues with adding custsom HTTP headers to requests from within the JCEF view
+#    -> https://github.com/sourcegraph/sourcegraph/issues/37475#issuecomment-1171355831
+pluginSinceBuild=211.0
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
 platformVersion=2022.1

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/BrowserAndLoadingPanel.java
@@ -10,6 +10,7 @@ import java.awt.*;
  * Inspired by <a href="https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java">FindPopupPanel.java</a>
  */
 public class BrowserAndLoadingPanel extends JLayeredPane {
+    private final JBPanelWithEmptyText overlayPanel;
     private boolean isBrowserVisible = false;
     private final JBPanelWithEmptyText jcefPanel;
 
@@ -17,12 +18,14 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
         jcefPanel = new JBPanelWithEmptyText(new BorderLayout()).withEmptyText(
             "Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
 
-        JBPanelWithEmptyText overlayPanel = new JBPanelWithEmptyText();
+        overlayPanel = new JBPanelWithEmptyText();
         //noinspection DialogTitleCapitalization
         overlayPanel.getEmptyText().setText("Loading Sourcegraph...");
 
-        add(overlayPanel, 0);
-        add(jcefPanel, 1);
+        // We need to use the add(Component, Object) overload of the add method to ensure that the constraints are
+        // properly set.
+        add(overlayPanel, Integer.valueOf(1));
+        add(jcefPanel, Integer.valueOf(2));
     }
 
     public void setBrowser(@NotNull SourcegraphJBCefBrowser browser) {
@@ -31,14 +34,12 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
 
     @Override
     public void doLayout() {
-        Component overlay = getComponent(0);
-        Component browser = getComponent(1);
         if (isBrowserVisible) {
-            browser.setBounds(0, 0, getWidth(), getHeight());
+            jcefPanel.setBounds(0, 0, getWidth(), getHeight());
         } else {
-            browser.setBounds(0, 0, 1, 1);
+            jcefPanel.setBounds(0, 0, 1, 1);
         }
-        overlay.setBounds(0, 0, getWidth(), getHeight());
+        overlayPanel.setBounds(0, 0, getWidth(), getHeight());
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridge.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridge.java
@@ -3,7 +3,7 @@ package com.sourcegraph.browser;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.Disposable;
-import com.intellij.ui.jcef.JBCefBrowserBase;
+import com.intellij.ui.jcef.JBCefBrowser;
 import com.intellij.ui.jcef.JBCefJSQuery;
 import org.cef.browser.CefBrowser;
 import org.cef.browser.CefFrame;
@@ -13,9 +13,10 @@ import org.cef.network.CefRequest;
 public class JSToJavaBridge implements Disposable {
     JBCefJSQuery query;
 
-    public JSToJavaBridge(JBCefBrowserBase browser,
+    public JSToJavaBridge(JBCefBrowser browser,
                           JSToJavaBridgeRequestHandler requestHandler,
                           String jsCodeToRunAfterBridgeInit) {
+        // Using a deprecated method because JBCefBrowserBase is not present in older JetBrains versions
         query = JBCefJSQuery.create(browser);
         query.addHandler((String requestAsString) -> {
             try {

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.ui.jcef.JBCefBrowserBase;
+import com.intellij.ui.jcef.JBCefBrowser;
 import com.intellij.ui.jcef.JBCefJSQuery;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,13 +17,14 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 public class JavaToJSBridge {
-    private final JBCefBrowserBase browser;
+    private final JBCefBrowser browser;
     private final JBCefJSQuery query;
     private final Lock lock;
     private Function<String, JBCefJSQuery.Response> handler = null;
 
-    public JavaToJSBridge(JBCefBrowserBase browser) {
+    public JavaToJSBridge(JBCefBrowser browser) {
         this.browser = browser;
+        // Using a deprecated method because JBCefBrowserBase is not present in older JetBrains versions
         this.query = JBCefJSQuery.create(browser);
         this.lock = new ReentrantLock();
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/SourcegraphJBCefBrowser.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/SourcegraphJBCefBrowser.java
@@ -14,7 +14,6 @@ public class SourcegraphJBCefBrowser extends JBCefBrowser {
         super("http://sourcegraph/html/index.html");
         // Create and set up JCEF browser
         CefApp.getInstance().registerSchemeHandlerFactory("http", "sourcegraph", new HttpSchemeHandlerFactory());
-        this.setPageBackgroundColor(ThemeUtil.getPanelBackgroundColorHexString());
 
         // Create bridges, set up handlers, then run init function
         String initJSCode = "window.initializeSourcegraph();";

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
@@ -1,12 +1,10 @@
 package com.sourcegraph.find;
 
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.KeyboardShortcut;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.keymap.KeymapUtil;
-import com.intellij.openapi.project.DumbAwareAction;
-import com.intellij.ui.components.AnActionLink;
+import com.intellij.ui.components.labels.LinkLabel;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -16,7 +14,7 @@ import java.awt.event.KeyEvent;
 import java.util.Objects;
 
 public class SelectionMetadataPanel extends JPanel {
-    private final AnActionLink selectionMetadataLabel;
+    private LinkLabel selectionMetadataLabel = null;
     private final JLabel externalLinkLabel;
     private final JLabel openShortcutLabel;
     private PreviewContent previewContent;
@@ -24,19 +22,17 @@ public class SelectionMetadataPanel extends JPanel {
     public SelectionMetadataPanel() {
         super(new FlowLayout(FlowLayout.LEFT, 0, 8));
 
-        selectionMetadataLabel = new AnActionLink("", new DumbAwareAction() {
-            @Override
-            public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-                if (previewContent != null) {
-                    try {
-                        previewContent.openInEditorOrBrowser();
-                    } catch (Exception e) {
-                        Logger logger = Logger.getInstance(SelectionMetadataPanel.class);
-                        logger.error("Error opening file in editor: \"" + selectionMetadataLabel.getText() + "\"", e);
-                    }
+        selectionMetadataLabel = new LinkLabel("", null, (aSource, aLinkData) -> {
+            if (previewContent != null) {
+                try {
+                    previewContent.openInEditorOrBrowser();
+                } catch (Exception e) {
+                    Logger logger = Logger.getInstance(SelectionMetadataPanel.class);
+                    logger.error("Error opening file in editor: \"" + selectionMetadataLabel.getText() + "\"", e);
                 }
             }
         });
+
         selectionMetadataLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 0));
         externalLinkLabel = new JLabel("", AllIcons.Ide.External_link_arrow, SwingConstants.LEFT);
         externalLinkLabel.setVisible(false);


### PR DESCRIPTION
Closes #37475 

This still needs testing. I was not able to run on macOS versions prior to 2022.1 because of the JCEF bundling issue we were seeing at the very beginning of our trial. Will verify on Windows instead.

## The changes:

- JBCefBrowserBase → JBCefBrowser
- AnActionLink → LinkLabel
- SourcegraphJBCefBrowser#setPageBackgroundColor → removed

## Current support

With these changes, I was able to verify support for these versions:

```
IC-2022.1.3 ✅
IC-2021.3.3 ✅
IC-2021.2.4 ✅
IC-2021.1.3 ✅ 
IC-2020.3.4 ❌
IC-2020.2.4 ❌
```

`2020.2` and `2020.3` are limited by [this issue](https://github.com/sourcegraph/sourcegraph/issues/37475#issuecomment-1171355831).

## Decision:

We decided to drop support for 2020.2 and 2020.3

## Test plan

I ran all of these versions on our Debian test machine. Here's an example of a working version (2021.1):

![Screenshot 2022-06-30 at 17 27 09](https://user-images.githubusercontent.com/458591/176716397-2eabcf6a-f430-4e3b-bd82-cd9473f7ad35.png)
![Screenshot 2022-06-30 at 17 26 49](https://user-images.githubusercontent.com/458591/176716686-722e0966-430d-4e0a-bcd9-93d38ad22dc6.png)

```
α jetbrains (ps/jetbrains-2020.2-support) ./gradlew listProductsReleases
Starting a Gradle Daemon (subsequent builds will be faster)

> Task :listProductsReleases
IC-2022.1.3
IC-2021.3.3
IC-2021.2.4
IC-2021.1.3
BUILD SUCCESSFUL in 6s
1 actionable task: 1 executed
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-2020-2-support.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bwyugxljxa.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

