### PR TITLE
authz: Persist group cache information on 403 response

### DIFF
--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -280,14 +281,16 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 			} else {
 				repos, hasNextPage, _, err = client.ListTeamRepositories(ctx, group.Org, group.Team, page)
 			}
-			if github.IsNotFound(err) {
-				// If we get a 404 here, something funky is going on and this is very
-				// unexpected. Since this is likely not transient, instead of bailing out
-				// and potentially causing unbounded retries later, we let this result
-				// proceed to cache. This is safe because the cache will eventually get
-				// invalidated, at which point we can retry this group, or a sync can be
-				// triggered that marks the cached group as invalidated.
-				log15.Debug("list repos for group: unexpected 404, persisting to cache",
+			if github.IsNotFound(err) || github.HTTPErrorCode(err) == http.StatusForbidden {
+				// If we get a 403/404 here, something funky is going on and this is very
+				// unexpected. Since this is likely not transient, instead of bailing out and
+				// potentially causing unbounded retries later, we let this result proceed to
+				// cache. This is safe because the cache will eventually get invalidated, at
+				// which point we can retry this group, or a sync can be triggered that marks the
+				// cached group as invalidated. GitHub sometimes returns 403 when requesting team
+				// or org information when the token is not allowed to see it, so we treat it the
+				// same as 404.
+				log15.Debug("list repos for group: unexpected 403/404, persisting to cache",
 					"error", err)
 			} else if err != nil {
 				// Add and return what we've found on this page but don't persist group


### PR DESCRIPTION
This is similar to a previous change for 404 errors since github can
sometimes also return a 403 error during team or org repo listing.

Similar to https://github.com/sourcegraph/sourcegraph/pull/32357

Part of https://github.com/sourcegraph/customer/issues/993

## Test plan

Unit tests added