### PR TITLE
Web: Increase bundlesize perf limit temporarily

### DIFF
--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -5,7 +5,12 @@ const config = {
      */
     {
       path: '../../ui/assets/scripts/*.bundle.js.br',
-      maxSize: '400kb',
+      /**
+       * Note: Temporary increase from 400kb.
+       * Primary cause is due to multiple ongoing migrations that mean we are duplicating similar dependencies.
+       * Issue to track: https://github.com/sourcegraph/sourcegraph/issues/37845
+       */
+      maxSize: '425kb',
       compression: 'none',
     },
     /**


### PR DESCRIPTION
## Description

CI builds are currently blocked because our perf has gone above the limit. This wasn't caught in a PR build as it has been a steady increase, and `main` wasn't pulled in on PRs that finally pushed us over the edge, so the main pipeline failed.

cc: @sourcegraph/frontend-devs 

I know temporary can be a famous last word here, but quite confident we can reduce this down in future. We have 3 large migrations going on that have added extra dependencies and contributed to this. Once those are done, we can remove the redundant deps and enjoy a bundle size decrease. https://github.com/sourcegraph/sourcegraph/issues/37845

## Test plan

N/A - CI only

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-increase-perf-limit.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fkpdbwmmgl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
