### PR TITLE
[dotcom] Change getting started link to point to self-hosted instances

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -572,7 +572,7 @@ export function buildSearchURLQuery(
 }
 
 export function buildGetStartedURL(source: string, returnTo?: string): string {
-    const url = new URL('https://about.sourcegraph.com/get-started')
+    const url = new URL('https://about.sourcegraph.com/get-started/self-hosted')
     url.searchParams.set('utm_medium', 'inproduct')
     url.searchParams.set('utm_source', source)
     url.searchParams.set('utm_campaign', 'inproduct-cta')

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -241,7 +241,7 @@ exports[`GlobalNavbar default 1`] = `
           </a>
           <a
             class="anchorLink btn btnSm signUp"
-            href="https://about.sourcegraph.com/get-started?utm_medium=inproduct&utm_source=nav&utm_campaign=inproduct-cta"
+            href="https://about.sourcegraph.com/get-started/self-hosted?utm_medium=inproduct&utm_source=nav&utm_campaign=inproduct-cta"
             tabindex="0"
           >
             Get started
@@ -515,7 +515,7 @@ exports[`GlobalNavbar low-profile 1`] = `
           </a>
           <a
             class="anchorLink btn btnSm signUp"
-            href="https://about.sourcegraph.com/get-started?utm_medium=inproduct&utm_source=nav&utm_campaign=inproduct-cta"
+            href="https://about.sourcegraph.com/get-started/self-hosted?utm_medium=inproduct&utm_source=nav&utm_campaign=inproduct-cta"
             tabindex="0"
           >
             Get started


### PR DESCRIPTION
# Merging
⚠️ **SHOULD ONLY BE MERGED ON 30th June** ⚠️

# Related
resolves #37805 

## Test plan

1-line change in the link. Tested manually.
To test the change yourself:
1. run sourcegraph in dotcom mode
2. Open the webpage, on the top there's a button named `Get Started`
3. Once clicked, it should navigate to self-hosted getting started page

## App preview:

- [Web](https://sg-web-milan-change-get-started-link.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dneguataca.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
