### PR TITLE
insights: clean up forgotten print statement

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -430,7 +430,6 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, definitions []ityp
 			return errors.Wrap(err, "RecordSeriesPoints Zero Value")
 		}
 		for _, job := range jobs {
-			j := *job
 			err := h.enqueueQueryRunnerJob(ctx, job)
 			if err != nil {
 				multi = errors.Append(multi, err)

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/time/rate"
 
 	sglog "github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -430,7 +431,6 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, definitions []ityp
 		}
 		for _, job := range jobs {
 			j := *job
-			fmt.Printf("job: %v", j)
 			err := h.enqueueQueryRunnerJob(ctx, job)
 			if err != nil {
 				multi = errors.Append(multi, err)

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"


### PR DESCRIPTION
removes a forgotten println that was creating loads of logs

## Test plan
n/a, just removes a println