### PR TITLE
[SG-35114]: Accessibility: Global nav bar: Extensions item unexpectedly steals focus

### DIFF
--- a/client/web/src/extensions/ExtensionRegistry.tsx
+++ b/client/web/src/extensions/ExtensionRegistry.tsx
@@ -349,7 +349,7 @@ export const ExtensionRegistry: React.FunctionComponent<React.PropsWithChildren<
                                     name="query"
                                     value={query}
                                     onChange={onQueryChangeEvent}
-                                    autoFocus={true}
+                                    autoFocus={false}
                                     autoComplete="off"
                                     autoCorrect="off"
                                     autoCapitalize="off"


### PR DESCRIPTION
## Audit type
Keyboard navigation

## Problem description
- Navigate through the navigation bar
- Select "Extensions"
- See that focus has been unexpectedly removed.

## Expected behavior
 We should remove autofocus from this page.
## Refs
- [Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/35114).
- [Gitstart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35114)


## App preview:

- [Web](https://sg-web-contractors-sg-35114-1.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sbmbuejhiq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

## Test Plan
1. Using keyboard navigate to `Extensions` navbar item,
2. Click to trigger
3. Verify that the navbar item does not loose focus
