### PR TITLE
insights: stop insight polling if api returns an error

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -111,6 +111,9 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                 seriesToggleState.setSelectedSeriesIds([])
                 setInsightData(parsedData)
             },
+            onError: () => {
+                stopPolling()
+            },
         }
     )
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -102,6 +102,9 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
                 }
                 setInsightData(parsedData)
             },
+            onError: () => {
+                stopPolling()
+            },
         }
     )
 


### PR DESCRIPTION
Stop insight polling if an error occurs

resolves https://github.com/sourcegraph/sourcegraph/issues/37862

## Test plan
Force an error and ensure `GetInsightView` is only called once
<img width="1122" alt="Screen Shot 2022-06-28 at 1 05 49 PM" src="https://user-images.githubusercontent.com/6098507/176241806-ec093dc2-179f-4bae-bd71-67d28361b2dd.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cw-disable-polling-on-error.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fvtjfrbqgt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
