### PR TITLE
Revert "Code Insights: Add pings for the standalone insight page"

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -62,8 +62,6 @@ interface DrillDownInsightFilters {
     /** Fires whenever the user changes filter value in any form input. */
     onFiltersChange: (filters: FormChangeEvent<DrillDownFiltersFormValues>) => void
 
-    onFilterValuesChange?: (values: DrillDownFiltersFormValues) => void
-
     /** Fires whenever the user clicks the save/update filter button. */
     onFilterSave: (filters: DrillDownFiltersFormValues, displayOptions: SeriesDisplayOptionsInput) => SubmissionResult
 
@@ -89,7 +87,6 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
         originalSeriesDisplayOptions,
         onSeriesDisplayOptionsChange,
         onVisualModeChange = noop,
-        onFilterValuesChange = noop,
     } = props
 
     const [activeSection, setActiveSection] = useState<FilterSection | null>(FilterSection.RegularExpressions)
@@ -98,7 +95,6 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
     const { ref, formAPI, handleSubmit, values } = useForm<DrillDownFiltersFormValues>({
         initialValues,
         onChange: onFiltersChange,
-        onPureValueChange: onFilterValuesChange,
         onSubmit: values => onFilterSave(values, seriesDisplayOptions),
     })
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useContext, useEffect, useMemo } from 'react'
+import { FunctionComponent, useContext, useMemo } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, useObservable } from '@sourcegraph/wildcard'
@@ -25,10 +25,6 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
 
     const insight = useObservable(useMemo(() => getInsightById(insightId), [getInsightById, insightId]))
 
-    useEffect(() => {
-        telemetryService.logPageView('StandaloneInsightPage')
-    }, [telemetryService])
-
     if (insight === undefined) {
         return <LoadingSpinner inline={false} />
     }
@@ -42,11 +38,10 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
             <PageTitle title={`${insight.title} - Code Insights`} />
             <PageHeader
                 path={[{ to: '/insights/dashboards/all', icon: CodeInsightsIcon }, { text: insight.title }]}
-                actions={<CodeInsightIndependentPageActions insight={insight} telemetryService={telemetryService} />}
+                actions={<CodeInsightIndependentPageActions insight={insight} />}
             />
 
             <StandaloneInsightDashboardPills
-                telemetryService={telemetryService}
                 dashboards={insight.dashboards}
                 insightId={insight.id}
                 className={styles.dashboards}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -3,7 +3,6 @@ import { FunctionComponent, useRef, useState } from 'react'
 import LinkVariantIcon from 'mdi-react/LinkVariantIcon'
 import { useHistory } from 'react-router'
 
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Icon } from '@sourcegraph/wildcard'
 
 import { ConfirmDeleteModal } from '../../../../../components/modals/ConfirmDeleteModal'
@@ -12,12 +11,12 @@ import { useCopyURLHandler } from '../../../../../hooks/use-copy-url-handler'
 
 import styles from './CodeInsightIndependentPageActions.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props {
     insight: Pick<Insight, 'title' | 'id' | 'type'>
 }
 
 export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props => {
-    const { insight, telemetryService } = props
+    const { insight } = props
 
     const history = useHistory()
 
@@ -40,10 +39,6 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
         setShowDeleteConfirm(true)
     }
 
-    const handleEditClick = (): void => {
-        telemetryService.log('StandaloneInsightPageEditClick')
-    }
-
     return (
         <div className={styles.container}>
             <Button
@@ -57,12 +52,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
             <Button variant="danger" onClick={handleDeleteClick}>
                 Delete
             </Button>
-            <Button
-                variant="primary"
-                as={Link}
-                to={`/insights/edit/${insight.id}?insight=${insight.id}`}
-                onClick={handleEditClick}
-            >
+            <Button variant="primary" as={Link} to={`/insights/edit/${insight.id}?insight=${insight.id}`}>
                 Edit
             </Button>
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
@@ -3,24 +3,19 @@ import { FunctionComponent, HTMLAttributes } from 'react'
 import classNames from 'classnames'
 import ViewDashboardIcon from 'mdi-react/ViewDashboardIcon'
 
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
 
 import { ALL_INSIGHTS_DASHBOARD, InsightDashboardReference } from '../../../../../core'
 
 import styles from './StandaloneInsightDashboardPills.module.scss'
 
-interface StandaloneInsightDashboardPillsProps extends HTMLAttributes<HTMLDivElement>, TelemetryProps {
+interface StandaloneInsightDashboardPillsProps extends HTMLAttributes<HTMLDivElement> {
     dashboards: InsightDashboardReference[]
     insightId: string
 }
 
 export const StandaloneInsightDashboardPills: FunctionComponent<StandaloneInsightDashboardPillsProps> = props => {
-    const { dashboards, insightId, className, telemetryService, ...attributes } = props
-
-    const handleDashboardClick = (): void => {
-        telemetryService.log('StandaloneInsightDashboardClick')
-    }
+    const { dashboards, insightId, className, ...attributes } = props
 
     return (
         <div {...attributes} className={classNames(className, styles.list)}>
@@ -39,7 +34,6 @@ export const StandaloneInsightDashboardPills: FunctionComponent<StandaloneInsigh
                     target="_blank"
                     rel="noopener"
                     className={styles.pill}
-                    onClick={handleDashboardClick}
                 >
                     <Icon as={ViewDashboardIcon} aria-hidden={true} />
                     {dashboard.title}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -54,7 +54,6 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
     const { telemetryService, insight, className } = props
     const history = useHistory()
     const { createInsight, updateInsight } = useContext(CodeInsightsBackendContext)
-
     const seriesToggleState = useSeriesToggle()
     const [insightData, setInsightData] = useState<BackendInsightData | undefined>()
     const [enablePolling] = useFeatureFlag('insight-polling-enabled', true)
@@ -105,7 +104,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         }
     )
 
-    const { trackMouseLeave, trackMouseEnter, trackDatumClicks, trackFilterChanges } = useCodeInsightViewPings({
+    const { trackMouseLeave, trackMouseEnter, trackDatumClicks } = useCodeInsightViewPings({
         telemetryService,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
@@ -161,7 +160,6 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
                         visualMode={filterVisualMode}
                         onVisualModeChange={setFilterVisualMode}
                         onFiltersChange={handleFilterChange}
-                        onFilterValuesChange={trackFilterChanges}
                         onFilterSave={handleFilterSave}
                         onCreateInsightRequest={() => setStep(DrillDownFiltersStep.ViewCreation)}
                         originalSeriesDisplayOptions={DEFAULT_SERIES_DISPLAY_OPTIONS}

--- a/client/web/src/enterprise/insights/pings/use-code-insight-view-pings.ts
+++ b/client/web/src/enterprise/insights/pings/use-code-insight-view-pings.ts
@@ -1,7 +1,5 @@
 import { useCallback, useRef } from 'react'
 
-import { useDebouncedCallback } from 'use-debounce'
-
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { CodeInsightTrackType } from './types'
@@ -18,7 +16,6 @@ interface PingHandlers {
     trackMouseEnter: () => void
     trackMouseLeave: () => void
     trackDatumClicks: () => void
-    trackFilterChanges: () => void
 }
 
 /**
@@ -45,14 +42,9 @@ export function useCodeInsightViewPings(props: UseCodeInsightViewPingsInput): Pi
         telemetryService.log('InsightDataPointClick', { insightType }, { insightType })
     }, [insightType, telemetryService])
 
-    const trackFilterChanges = useDebouncedCallback(() => {
-        telemetryService.log('InsightFiltersChange', { insightType }, { insightType })
-    }, 1000)
-
     return {
         trackDatumClicks,
         trackMouseEnter,
         trackMouseLeave,
-        trackFilterChanges,
     }
 }

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -27,6 +27,7 @@ We keep this docs page up to date because pings are a vital component of our pro
 - **Version Added:** 3.25
 - **Version(s) broken:**  3.31-3.35.0 (does not count backend insights) ([fix PR](https://github.com/sourcegraph/sourcegraph/pull/25317))
 
+
 ### Hovers count
 
 **Type:** FE event
@@ -87,7 +88,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 **Other considerations:** As we add new insights pages it's important to make sure we're adding pages to this counter. 
 
 - Aggregation: By week 
-- Event Code: [ViewInsights](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+ViewInsights&patternType=regexp), [StandaloneInsightPageViewed](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+StandaloneInsightPageViewed&patternType=regexp),
+- Event Code: [InsightsPageView](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+InsightsPageView&patternType=regexp) 
 - PRs: [#17805](https://github.com/sourcegraph/sourcegraph/pull/17805/files)
 - **Version Added:** 3.25
 - **Version(s) broken:** 3.25-3.26 (not weekly)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/20070/files)), 3.30 (broken when switching to dashboard pages, didn't track dashboard views)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/24129/files))
@@ -107,51 +108,6 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 - PRs: [#17805](https://github.com/sourcegraph/sourcegraph/pull/17805/files)
 - **Version Added:** 3.25
 - **Version(s) broken:** 3.25-3.26 (not weekly)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/20070/files)), 3.30 (broken when switching to dashboard pages, didn't track dashboard views)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/24129/files))
-
-### Standalone insights page filters edits count
-
-**Type:** FE event
-
-**Intended purpose:** To track how many users actively re-filter insights through the standalone insight page's filter panel.
-
-**Functional implementation:** This ping works by firing a telemetry event on the client when a user changes insights filters (include/exclude repository regexp, search context, etc).
-
-**Other considerations:** N/A
-
-- Aggregation: By week
-- Event Code: [InsightFiltersChange](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27InsightFiltersChange%27&patternType=literal)
-- PRs: [#37521](https://github.com/sourcegraph/sourcegraph/pull/37521)
-- **Version Added:** 3.41
-
-### Standalone insights page dashboard clicks count
-
-**Type:** FE event
-
-**Intended purpose:** To track how many users are discovering dashboards from this page.
-
-**Functional implementation:** This ping works by firing a telemetry event on the client when a user clicks any dashboard pills on the standalone insight page.
-
-**Other considerations:** N/A
-
-- Aggregation: By week
-- Event Code: [StandaloneInsightDashboardClick](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27StandaloneInsightDashboardClick%27&patternType=literal)
-- PRs: [#37521](https://github.com/sourcegraph/sourcegraph/pull/37521)
-- **Version Added:** 3.41
-
-### Standalone insights page edit button clicks count
-
-**Type:** FE event
-
-**Intended purpose:** To track how many users are going to the edit page through the standalone insight page.
-
-**Functional implementation:** This ping works by firing a telemetry event on the client when a user clicks on the edit button on the standalone insight page.
-
-**Other considerations:** N/A
-
-- Aggregation: By week
-- Event Code: [StandaloneInsightPageEditClick](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27StandaloneInsightPageEditClick%27&patternType=literal)
-- PRs: [#37521](https://github.com/sourcegraph/sourcegraph/pull/37521)
-- **Version Added:** 3.41
 
 ### In-product landing page events (hover, data points click, template section clicks)
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1336,31 +1336,25 @@ type ExtensionUsageStatistics struct {
 }
 
 type CodeInsightsUsageStatistics struct {
-	WeeklyUsageStatisticsByInsight               []*InsightUsageStatistics
-	WeeklyInsightsPageViews                      *int32
-	WeeklyStandaloneInsightPageViews             *int32
-	WeeklyStandaloneDashboardClicks              *int32
-	WeeklyStandaloneEditClicks                   *int32
-	WeeklyInsightsGetStartedPageViews            *int32
-	WeeklyInsightsUniquePageViews                *int32
-	WeeklyInsightsGetStartedUniquePageViews      *int32
-	WeeklyStandaloneInsightUniquePageViews       *int32
-	WeeklyStandaloneInsightUniqueDashboardClicks *int32
-	WeeklyStandaloneInsightUniqueEditClicks      *int32
-	WeeklyInsightConfigureClick                  *int32
-	WeeklyInsightAddMoreClick                    *int32
-	WeekStart                                    time.Time
-	WeeklyInsightCreators                        *int32
-	WeeklyFirstTimeInsightCreators               *int32
-	WeeklyAggregatedUsage                        []AggregatedPingStats
-	WeeklyGetStartedTabClickByTab                []InsightGetStartedTabClickPing
-	WeeklyGetStartedTabMoreClickByTab            []InsightGetStartedTabClickPing
-	InsightTimeIntervals                         []InsightTimeIntervalPing
-	InsightOrgVisible                            []OrgVisibleInsightPing
-	InsightTotalCounts                           InsightTotalCounts
-	TotalOrgsWithDashboard                       *int32
-	TotalDashboardCount                          *int32
-	InsightsPerDashboard                         InsightsPerDashboardPing
+	WeeklyUsageStatisticsByInsight          []*InsightUsageStatistics
+	WeeklyInsightsPageViews                 *int32
+	WeeklyInsightsGetStartedPageViews       *int32
+	WeeklyInsightsUniquePageViews           *int32
+	WeeklyInsightsGetStartedUniquePageViews *int32
+	WeeklyInsightConfigureClick             *int32
+	WeeklyInsightAddMoreClick               *int32
+	WeekStart                               time.Time
+	WeeklyInsightCreators                   *int32
+	WeeklyFirstTimeInsightCreators          *int32
+	WeeklyAggregatedUsage                   []AggregatedPingStats
+	WeeklyGetStartedTabClickByTab           []InsightGetStartedTabClickPing
+	WeeklyGetStartedTabMoreClickByTab       []InsightGetStartedTabClickPing
+	InsightTimeIntervals                    []InsightTimeIntervalPing
+	InsightOrgVisible                       []OrgVisibleInsightPing
+	InsightTotalCounts                      InsightTotalCounts
+	TotalOrgsWithDashboard                  *int32
+	TotalDashboardCount                     *int32
+	InsightsPerDashboard                    InsightsPerDashboardPing
 }
 
 type CodeInsightsCriticalTelemetry struct {
@@ -1376,7 +1370,6 @@ type InsightUsageStatistics struct {
 	Hovers           *int32
 	UICustomizations *int32
 	DataPointClicks  *int32
-	FiltersChange    *int32
 }
 
 type PingName string

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -19,35 +19,24 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 
 	const platformQuery = `
 	SELECT
-		COUNT(*) FILTER (WHERE name = 'ViewInsights')                       			AS weekly_insights_page_views,
-		COUNT(*) FILTER (WHERE name = 'ViewInsightsGetStartedPage')         			AS weekly_insights_get_started_page_views,
-		COUNT(*) FILTER (WHERE name = 'StandaloneInsightPageViewed')					AS weekly_standalone_insight_page_views,
-		COUNT(*) FILTER (WHERE name = 'StandaloneInsightDashboardClick') 				AS weekly_standalone_dashboard_clicks,
-        COUNT(*) FILTER (WHERE name = 'StandaloneInsightPageEditClick') 				AS weekly_standalone_edit_clicks,
-		COUNT(distinct user_id) FILTER (WHERE name = 'ViewInsights')        			AS weekly_insights_unique_page_views,
-		COUNT(distinct user_id) FILTER (WHERE name = 'ViewInsightsGetStartedPage')  	AS weekly_insights_get_started_unique_page_views,
-		COUNT(distinct user_id) FILTER (WHERE name = 'StandaloneInsightPageViewed') 	AS weekly_standalone_insight_unique_page_views,
-		COUNT(distinct user_id) FILTER (WHERE name = 'StandaloneInsightDashboardClick') AS weekly_standalone_insight_unique_dashboard_clicks,
-		COUNT(distinct user_id) FILTER (WHERE name = 'StandaloneInsightPageEditClick')  AS weekly_standalone_insight_unique_edit_clicks,
-		COUNT(distinct user_id) FILTER (WHERE name = 'InsightAddition')					AS weekly_insight_creators,
-		COUNT(*) FILTER (WHERE name = 'InsightConfigureClick') 							AS weekly_insight_configure_click,
-		COUNT(*) FILTER (WHERE name = 'InsightAddMoreClick') 							AS weekly_insight_add_more_click
+		COUNT(*) FILTER (WHERE name = 'ViewInsights')                       		AS weekly_insights_page_views,
+		COUNT(*) FILTER (WHERE name = 'ViewInsightsGetStartedPage')         		AS weekly_insights_get_started_page_views,
+		COUNT(distinct user_id) FILTER (WHERE name = 'ViewInsights')        		AS weekly_insights_unique_page_views,
+		COUNT(distinct user_id) FILTER (WHERE name = 'ViewInsightsGetStartedPage')  AS weekly_insights_get_started_unique_page_views,
+		COUNT(distinct user_id)
+			FILTER (WHERE name = 'InsightAddition')									AS weekly_insight_creators,
+		COUNT(*) FILTER (WHERE name = 'InsightConfigureClick') 						AS weekly_insight_configure_click,
+		COUNT(*) FILTER (WHERE name = 'InsightAddMoreClick') 						AS weekly_insight_add_more_click
 	FROM event_logs
-	WHERE name in ('ViewInsights', 'StandaloneInsightPageViewed', 'StandaloneInsightDashboardClick', 'StandaloneInsightPageEditClick', 'ViewInsightsGetStartedPage', 'InsightAddition', 'InsightConfigureClick', 'InsightAddMoreClick')
+	WHERE name in ('ViewInsights', 'ViewInsightsGetStartedPage', 'InsightAddition', 'InsightConfigureClick', 'InsightAddMoreClick')
 		AND timestamp > DATE_TRUNC('week', $1::timestamp);
 	`
 
 	if err := db.QueryRowContext(ctx, platformQuery, timeNow()).Scan(
 		&stats.WeeklyInsightsPageViews,
 		&stats.WeeklyInsightsGetStartedPageViews,
-		&stats.WeeklyStandaloneInsightPageViews,
-		&stats.WeeklyStandaloneDashboardClicks,
-		&stats.WeeklyStandaloneEditClicks,
 		&stats.WeeklyInsightsUniquePageViews,
 		&stats.WeeklyInsightsGetStartedUniquePageViews,
-		&stats.WeeklyStandaloneInsightUniquePageViews,
-		&stats.WeeklyStandaloneInsightUniqueDashboardClicks,
-		&stats.WeeklyStandaloneInsightUniqueEditClicks,
 		&stats.WeeklyInsightCreators,
 		&stats.WeeklyInsightConfigureClick,
 		&stats.WeeklyInsightAddMoreClick,
@@ -62,10 +51,9 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
         COUNT(*) FILTER (WHERE name = 'InsightRemoval') 		             		AS removals,
 		COUNT(*) FILTER (WHERE name = 'InsightHover') 			             		AS hovers,
 		COUNT(*) FILTER (WHERE name = 'InsightUICustomization') 			 		AS ui_customizations,
-		COUNT(*) FILTER (WHERE name = 'InsightDataPointClick') 				 		AS data_point_clicks,
-		COUNT(*) FILTER (WHERE name = 'InsightFiltersChange') 				 		AS filters_change
+		COUNT(*) FILTER (WHERE name = 'InsightDataPointClick') 				 		AS data_point_clicks
 	FROM event_logs
-	WHERE name in ('InsightAddition', 'InsightEdit', 'InsightRemoval', 'InsightHover', 'InsightUICustomization', 'InsightDataPointClick', 'InsightFiltersChange')
+	WHERE name in ('InsightAddition', 'InsightEdit', 'InsightRemoval', 'InsightHover', 'InsightUICustomization', 'InsightDataPointClick')
 		AND timestamp > DATE_TRUNC('week', $1::timestamp)
 	GROUP BY insight_type;
 	`
@@ -89,7 +77,6 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 			&weeklyInsightUsageStatistics.Hovers,
 			&weeklyInsightUsageStatistics.UICustomizations,
 			&weeklyInsightUsageStatistics.DataPointClicks,
-			&weeklyInsightUsageStatistics.FiltersChange,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -46,6 +46,7 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 			(6, 'InsightEdit', '{"insightType": "searchInsights"}', '', 2, '420657f0-d443-4d16-ac7d-003d8cdc19ac', 'WEB', '3.23.0', $1::timestamp - interval '2 days'),
 			(7, 'InsightAddition', '{"insightType": "codeStatsInsights"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', '3.23.0', $1::timestamp - interval '8 days'),
 			(8, 'CodeInsightsSearchBasedCreationPageSubmitClick', '{}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', '3.23.0', $1::timestamp - interval '1 day')
+
 	`, now)
 	if err != nil {
 		t.Fatal(err)
@@ -72,7 +73,6 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 			Hovers:           &zeroInt,
 			UICustomizations: &zeroInt,
 			DataPointClicks:  &zeroInt,
-			FiltersChange:    &zeroInt,
 		},
 		{
 			InsightType:      &searchInsightsType,
@@ -82,31 +82,24 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 			Hovers:           &zeroInt,
 			UICustomizations: &zeroInt,
 			DataPointClicks:  &zeroInt,
-			FiltersChange:    &zeroInt,
 		},
 	}
 
 	want := &types.CodeInsightsUsageStatistics{
-		WeeklyUsageStatisticsByInsight:               weeklyUsageStatisticsByInsight,
-		WeeklyInsightsPageViews:                      &twoInt,
-		WeeklyInsightsGetStartedPageViews:            &zeroInt,
-		WeeklyInsightsUniquePageViews:                &oneInt,
-		WeeklyInsightsGetStartedUniquePageViews:      &zeroInt,
-		WeeklyInsightConfigureClick:                  &zeroInt,
-		WeeklyInsightAddMoreClick:                    &zeroInt,
-		WeekStart:                                    weekStart,
-		WeeklyInsightCreators:                        &twoInt,
-		WeeklyFirstTimeInsightCreators:               &oneInt,
-		WeeklyGetStartedTabClickByTab:                []types.InsightGetStartedTabClickPing{},
-		WeeklyGetStartedTabMoreClickByTab:            []types.InsightGetStartedTabClickPing{},
-		TotalDashboardCount:                          &zeroInt,
-		TotalOrgsWithDashboard:                       &zeroInt,
-		WeeklyStandaloneDashboardClicks:              &zeroInt,
-		WeeklyStandaloneInsightUniqueEditClicks:      &zeroInt,
-		WeeklyStandaloneInsightUniquePageViews:       &zeroInt,
-		WeeklyStandaloneInsightUniqueDashboardClicks: &zeroInt,
-		WeeklyStandaloneInsightPageViews:             &zeroInt,
-		WeeklyStandaloneEditClicks:                   &zeroInt,
+		WeeklyUsageStatisticsByInsight:          weeklyUsageStatisticsByInsight,
+		WeeklyInsightsPageViews:                 &twoInt,
+		WeeklyInsightsGetStartedPageViews:       &zeroInt,
+		WeeklyInsightsUniquePageViews:           &oneInt,
+		WeeklyInsightsGetStartedUniquePageViews: &zeroInt,
+		WeeklyInsightConfigureClick:             &zeroInt,
+		WeeklyInsightAddMoreClick:               &zeroInt,
+		WeekStart:                               weekStart,
+		WeeklyInsightCreators:                   &twoInt,
+		WeeklyFirstTimeInsightCreators:          &oneInt,
+		WeeklyGetStartedTabClickByTab:           []types.InsightGetStartedTabClickPing{},
+		WeeklyGetStartedTabMoreClickByTab:       []types.InsightGetStartedTabClickPing{},
+		TotalDashboardCount:                     &zeroInt,
+		TotalOrgsWithDashboard:                  &zeroInt,
 	}
 
 	wantedWeeklyUsage := []types.AggregatedPingStats{

--- a/package.json
+++ b/package.json
@@ -471,7 +471,6 @@
     "ts-key-enum": "^2.0.7",
     "tslib": "^2.1.0",
     "use-callback-ref": "^1.2.5",
-    "use-debounce": "^8.0.1",
     "use-deep-compare-effect": "^1.6.1",
     "use-resize-observer": "^7.0.0",
     "utility-types": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24592,11 +24592,6 @@ use-callback-ref@^1.2.3, use-callback-ref@^1.2.5:
   resolved "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz#6115ed242cfbaed5915499c0a9842ca2912f38a5"
   integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
 
-use-debounce@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.npmjs.org/use-debounce/-/use-debounce-8.0.1.tgz#5f3e11b067bdf9f2c554a20b4764e38b48022664"
-  integrity sha512-6tGAFJKJ0qCalecaV7/gm/M6n238nmitNppvR89ff1yfwSFjwFKR7IQZzIZf1KZRQhqNireBzytzU6jgb29oVg==
-
 use-deep-compare-effect@^1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.6.1.tgz#061a0ac5400aa0461e33dddfaa2a98bca873182a"


### PR DESCRIPTION
This reverts commit 9611679cb95518b4d7990047b1fda2453ae66eb6.

Revert the standalone insight pings since data tables haven't been updated and [the ping RFC](https://docs.google.com/document/d/1wDZRxiWBVbLs5Xh13rarBOGZS2ZekppSOSFIdGlkp9Q/edit#heading=h.d62xpl4xzda) hasn't been approved yet. 

## Test plan
- Make sure that CI and (client and go builds) is green

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
