### PR TITLE
Release resource estimator 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Updated minimum required veresion of `git` to 2.35.2 in `gitserver` and `server` Docker image. This addresses a few vulnerabilities disclosed in https://github.blog/2022-04-12-git-security-vulnerability-announced/.
 - Search: Pasting a query with line breaks into the main search query input will now replace them with spaces instead of removing them. [#37674](https://github.com/sourcegraph/sourcegraph/pull/37674)
+- Rewrite resource estimator using the latest metrics [#37869](https://github.com/sourcegraph/sourcegraph/pull/37869)
 
 ### Fixed
 

--- a/doc/admin/deploy/resource_estimator.md
+++ b/doc/admin/deploy/resource_estimator.md
@@ -54,56 +54,30 @@ The output is estimated based on existing data we collected from current running
 
 #### How to apply these changes to your deployment?
 
-In a docker-compose deployment, edit your docker-compose.yml file and set cpus and mem_limit to the limits shown above.
-
-In Kubernetes deployments, edit the respective yaml file and update, limits, requests, and replicas according to the above.
+- For docker-compose deployments, edit your [docker-compose.yml file](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) and set cpus and mem_limit to the limits shown above.
+- For Helm deployments, create an [override file](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/examples/common-modifications/override.yaml) (or update your existing override file) with the new values shown above.
+- For non-Helm Kubernetes deployments, we recommend using Kustomize to generate manifests with the values shown above. Please refer to our [Kustomize docs](https://docs.sourcegraph.com/admin/deploy/kubernetes/kustomize#kustomize) on how to use Kustomize.
 
 #### What is the default deployment size?
 
-Our default deployment should support up to ~1000 users and about 1500 repositories with one monorepo that is less than 5GB.
+- Our default deployment should support ~1000 users and ~1000 repositories with one monorepo that is less than 5GB.
 
 #### What is engagement rate?
 
-Engagement rate refers to the percentage of users who use Sourcegraph regularly. It is generally used for existing deployments to estimate resources.
-
+- Engagement rate refers to the percentage of users who use Sourcegraph regularly. It is generally used for existing deployments to estimate resources.
 
 #### What is the recommended deployment type?
 
-We recommend Kubernetes for any deployments requiring > 1 service replica, but docker-compose does support service replicas and can scale up with multiple replicas as long as you can provision a sufficiently large single machine.
+- We recommend Kubernetes for any deployments requiring > 1 service replica, but docker-compose does support service replicas and can scale up with multiple replicas as long as you can provision a sufficiently large single machine.
 
 #### If you plan to enforce repository permissions on Sourcegraph
 
-Repository permissions on Sourcegraph can have a noticeable impact on search performance if you have a large number of users and/or repositories on your code host.
+- Repository permissions on Sourcegraph can have a noticeable impact on search performance if you have a large number of users and/or repositories on your code host. We suggest setting your authorization ttl values as high as you are comfortable setting it in order to reduce the chance of this (e.g. to 72h) in the repository permission configuration.
 
-We suggest setting your authorization ttl values as high as you are comfortable setting it in order to reduce the chance of this (e.g. to 72h) in the repository permission configuration.
+#### What kind of data can be regenerated without backup?
+
+- See our docs on [Persistent data backup in Kubernetes](https://docs.sourcegraph.com/admin/deploy/migrate-backup#persistent-data-backup-in-kubernetes) for more detail.
 
 #### How does Sourcegraph scale?
 
-[Click here to learn more about how Sourcegraph scales.](https://docs.sourcegraph.com/admin/install/kubernetes/scale)
-
-
-## Service overview
-
-| Service | Description |
-|---------|------|
-| cadvisor | A cAdvisor instance that exports container monitoring metrics scraped by Prometheus and visualized in Grafana |
-| codeinsights-db | A PostgreSQL instance for storing code insights data |
-| codeintel-db | A PostgreSQL instance for storing large-volume precise code intelligence data |
-| frontend | Serves the web application, extensions, and graphQL services. Almost every service has a link back to the frontend, from which it gathers configuration updates. |
-| github-proxy | Proxies all requests to github.com to keep track of rate limits and prevent triggering abuse mechanisms	|
-| gitserver | Mirrors repositories from their code host. All other Sourcegraph services talk to gitserver when they need data from git  |
-| grafana | A Grafana instance that displays data from Prometheus and Jaeger. It is shipped with customized dashboards for Sourcegraph services |
-| jaeger | A Jaeger instance for end-to-end distributed tracing |
-| minio | A MinIO instance that serves as a local S3-compatible object storage to hold user uploads for code-intel before they can be processed |
-| pgsql | The main database. It is a PostgreSQL instance where things like repo lists, user data, site config files are stored (anything not related to code-intel and code-insights) |
-| precise-code-intel | Converts LSIF upload file into Postgres data. The entire index must be read into memory to be correlated |
-| prometheus | Collecting high-level, and low-cardinality, metrics across services. |
-| redis-cache | A Redis instance for storing cache data. |
-| redis-store  | A Redis instance for storing short-term information such as user sessions. |
-| repo-updater | Repo-updater tracks the state of repositories, and is responsible for automatically scheduling updates using gitserver. Other apps which desire updates or fetches should be telling repo-updater, rather than using gitserver directly, so repo-updater can take their changes into account. |
-| searcher | Provides on-demand unindexed search for repositories. It fetches archives from gitserver and searches them with regexp	|
-| symbols | Indexes symbols in repositories using Ctags. By default, the symbols service saves SQLite DBs as files on disk, and copies an old one to a new file when a user visits a new commit. If Rockskip is enabled, the symbols are stored in the codeintel-db instead while the cache is stored on disk |
-| syntect-server | An HTTP server that exposes the Rust Syntect syntax highlighting library for use by other services |
-| worker |  Runs a collection of background jobs (for both Code-Intel and Code-Insight) periodically or in response to an external event. It is currently janitorial and commit based. |
-| zoekt-indexserver | Indexes all enabled repositories on Sourcegraph, as well as keeping the indexes up to date |
-| zoekt-webserver | Runs searches from in-memory indexes, but persists these indexes to disk to avoid re-indexing everything on startup |
+- [Click here to learn more about how Sourcegraph scales.](https://docs.sourcegraph.com/admin/install/kubernetes/scale)

--- a/doc/admin/deploy/resource_estimator.md
+++ b/doc/admin/deploy/resource_estimator.md
@@ -46,6 +46,8 @@
 
 Updating the form below will recalculate an estimate for the resources you can use to configure your Sourcegraph deployment.
 
+The output is estimated based on existing data we collected from current running deployments.
+
 <form id="root"></form>
 
 ## Additional information

--- a/doc/admin/deploy/resource_estimator.md
+++ b/doc/admin/deploy/resource_estimator.md
@@ -24,7 +24,7 @@
 }
 
 .estimator .copy-as-markdown {
-    width: 40rem;
+    width: 100%;
     height: 8rem;
 }
 
@@ -36,9 +36,72 @@
   top: 16px;
   left: 0;
 }
+
 </style>
 
 <script src="https://storage.googleapis.com/sourcegraph-resource-estimator/go_1_18_wasm_exec.js"></script>
-<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="08f379a"></script>
+<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="0249096"></script>
+
+# Sourcegraph resource estimator
+
+Updating the form below will recalculate an estimate for the resources you can use to configure your Sourcegraph deployment.
 
 <form id="root"></form>
+
+## Additional information
+
+#### How to apply these changes to your deployment?
+
+In a docker-compose deployment, edit your docker-compose.yml file and set cpus and mem_limit to the limits shown above.
+
+In Kubernetes deployments, edit the respective yaml file and update, limits, requests, and replicas according to the above.
+
+#### What is the default deployment size?
+
+Our default deployment should support up to ~1000 users and about 1500 repositories with one monorepo that is less than 5GB.
+
+#### What is engagement rate?
+
+Engagement rate refers to the percentage of users who use Sourcegraph regularly. It is generally used for existing deployments to estimate resources.
+
+
+#### What is the recommended deployment type?
+
+We recommend Kubernetes for any deployments requiring > 1 service replica, but docker-compose does support service replicas and can scale up with multiple replicas as long as you can provision a sufficiently large single machine.
+
+#### If you plan to enforce repository permissions on Sourcegraph
+
+Repository permissions on Sourcegraph can have a noticeable impact on search performance if you have a large number of users and/or repositories on your code host.
+
+We suggest setting your authorization ttl values as high as you are comfortable setting it in order to reduce the chance of this (e.g. to 72h) in the repository permission configuration.
+
+#### How does Sourcegraph scale?
+
+[Click here to learn more about how Sourcegraph scales.](https://docs.sourcegraph.com/admin/install/kubernetes/scale)
+
+
+## Service overview
+
+| Service | Description |
+|---------|------|
+| cadvisor | A cAdvisor instance that exports container monitoring metrics scraped by Prometheus and visualized in Grafana |
+| codeinsights-db | A PostgreSQL instance for storing code insights data |
+| codeintel-db | A PostgreSQL instance for storing large-volume precise code intelligence data |
+| frontend | Serves the web application, extensions, and graphQL services. Almost every service has a link back to the frontend, from which it gathers configuration updates. |
+| github-proxy | Proxies all requests to github.com to keep track of rate limits and prevent triggering abuse mechanisms	|
+| gitserver | Mirrors repositories from their code host. All other Sourcegraph services talk to gitserver when they need data from git  |
+| grafana | A Grafana instance that displays data from Prometheus and Jaeger. It is shipped with customized dashboards for Sourcegraph services |
+| jaeger | A Jaeger instance for end-to-end distributed tracing |
+| minio | A MinIO instance that serves as a local S3-compatible object storage to hold user uploads for code-intel before they can be processed |
+| pgsql | The main database. It is a PostgreSQL instance where things like repo lists, user data, site config files are stored (anything not related to code-intel and code-insights) |
+| precise-code-intel | Converts LSIF upload file into Postgres data. The entire index must be read into memory to be correlated |
+| prometheus | Collecting high-level, and low-cardinality, metrics across services. |
+| redis-cache | A Redis instance for storing cache data. |
+| redis-store  | A Redis instance for storing short-term information such as user sessions. |
+| repo-updater | Repo-updater tracks the state of repositories, and is responsible for automatically scheduling updates using gitserver. Other apps which desire updates or fetches should be telling repo-updater, rather than using gitserver directly, so repo-updater can take their changes into account. |
+| searcher | Provides on-demand unindexed search for repositories. It fetches archives from gitserver and searches them with regexp	|
+| symbols | Indexes symbols in repositories using Ctags. By default, the symbols service saves SQLite DBs as files on disk, and copies an old one to a new file when a user visits a new commit. If Rockskip is enabled, the symbols are stored in the codeintel-db instead while the cache is stored on disk |
+| syntect-server | An HTTP server that exposes the Rust Syntect syntax highlighting library for use by other services |
+| worker |  Runs a collection of background jobs (for both Code-Intel and Code-Insight) periodically or in response to an external event. It is currently janitorial and commit based. |
+| zoekt-indexserver | Indexes all enabled repositories on Sourcegraph, as well as keeping the indexes up to date |
+| zoekt-webserver | Runs searches from in-memory indexes, but persists these indexes to disk to avoid re-indexing everything on startup |


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/resource-estimator/pull/13

This PR updates the resource estimator version number to the build number from https://github.com/sourcegraph/resource-estimator/pull/13

The additional information section has been removed from the actual resource estimator and added to the resource_estimator.md file instead so that if we would like to update the additional information section, we won't need to create another build. It also makes link-sharing easier using url fragment 

I have also moved the `Service overview` section to this md file due to the aforementioned reason.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Docs update. Tested manually please see screenshots below:
![image](https://user-images.githubusercontent.com/68532117/176249005-4c6fa75c-6269-4f47-8bd3-93d436edaf97.png)
![image](https://user-images.githubusercontent.com/68532117/176249071-291d9a3d-68cb-4958-abdf-11678c352450.png)
![image](https://user-images.githubusercontent.com/68532117/176249103-b387182d-4294-4da7-aad2-8c8e1f72ff4e.png)
