### PR TITLE
doc/dev: remove mention that teammates don't need the CLA bot

### DIFF
--- a/doc/dev/contributing/accepting_contribution.md
+++ b/doc/dev/contributing/accepting_contribution.md
@@ -4,11 +4,10 @@ This page outlines how to accept a contribution to the [Sourcegraph repository](
 
 ## CLA-bot
 
-1. For external contributors only: ensure that that contributor signed the [CLA](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing). All fields should be filled with valid data to proceed with the pull request. (This does not apply for Sourcegraph teammates.)
-2. Wait up to 30 minutes for the form response to be synchronized to the [contributors list](https://github.com/sourcegraph/clabot-config).
+1. If the `cla-bot` check fails, ensure that that contributor signed the [CLA](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing). You may have to wait up to 30 minutes for the form response to be synchronized to the [contributors list](https://github.com/sourcegraph/clabot-config).
    1. A sync can also be manually triggered from [the `sync` workflow](https://github.com/sourcegraph/clabot-config/actions/workflows/sync.yml).
-3. Comment on the pull request: `@cla-bot check`.
-4. The `verification/cla-signed` workflow should become green. 🎉
+2. Comment on the pull request: `@cla-bot check`.
+3. The `verification/cla-signed` workflow should become green. 🎉
 
 ## Buildkite
 


### PR DESCRIPTION
This is misleading, teammates need to be in the CLA bot regardless. IMO they should just sign the form and leave minimal details, and the sync will work automatically

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a