### PR TITLE
search: clean up Concat test output

### DIFF
--- a/internal/search/query/testdata/TestConcat/#00.golden
+++ b/internal/search/query/testdata/TestConcat/#00.golden
@@ -1,0 +1,19 @@
+[
+  {
+    "value": "a b c d e f",
+    "negated": false,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 1
+      }
+    }
+  }
+]

--- a/internal/search/query/testdata/TestConcat/#01.golden
+++ b/internal/search/query/testdata/TestConcat/#01.golden
@@ -1,0 +1,70 @@
+[
+  {
+    "value": "a",
+    "negated": false,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 1
+      },
+      "end": {
+        "line": 0,
+        "column": 2
+      }
+    }
+  },
+  {
+    "value": "b",
+    "negated": true,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 3
+      },
+      "end": {
+        "line": 0,
+        "column": 8
+      }
+    }
+  },
+  {
+    "value": "c",
+    "negated": true,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 9
+      },
+      "end": {
+        "line": 0,
+        "column": 14
+      }
+    }
+  },
+  {
+    "value": "d",
+    "negated": false,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 15
+      },
+      "end": {
+        "line": 0,
+        "column": 16
+      }
+    }
+  }
+]

--- a/internal/search/query/testdata/TestConcat/#02.golden
+++ b/internal/search/query/testdata/TestConcat/#02.golden
@@ -1,0 +1,41 @@
+[
+  {
+    "and": [
+      {
+        "value": "(((a b c)))",
+        "negated": false,
+        "labels": [
+          "HeuristicParensAsPatterns",
+          "Literal"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 0
+          },
+          "end": {
+            "line": 0,
+            "column": 11
+          }
+        }
+      },
+      {
+        "value": "d",
+        "negated": false,
+        "labels": [
+          "Literal"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 16
+          },
+          "end": {
+            "line": 0,
+            "column": 17
+          }
+        }
+      }
+    ]
+  }
+]

--- a/internal/search/query/testdata/TestConcat/#03.golden
+++ b/internal/search/query/testdata/TestConcat/#03.golden
@@ -1,0 +1,19 @@
+[
+  {
+    "value": "(?:foo\\d).*?(?:bar\\*)",
+    "negated": false,
+    "labels": [
+      "Regexp"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 0
+      }
+    }
+  }
+]

--- a/internal/search/query/testdata/TestConcat/#04.golden
+++ b/internal/search/query/testdata/TestConcat/#04.golden
@@ -1,0 +1,19 @@
+[
+  {
+    "value": "(?:bar\\*).*?(?:foo\\d).*?(?:bar\\*).*?(?:foo\\d)",
+    "negated": false,
+    "labels": [
+      "Regexp"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 0
+      }
+    }
+  }
+]

--- a/internal/search/query/testdata/TestConcat/#05.golden
+++ b/internal/search/query/testdata/TestConcat/#05.golden
@@ -1,0 +1,129 @@
+[
+  {
+    "value": "(?:a).*?(?:b)",
+    "negated": false,
+    "labels": [
+      "Regexp"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 0
+      }
+    }
+  },
+  {
+    "and": [
+      {
+        "value": "c",
+        "negated": false,
+        "labels": [
+          "Regexp"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 5
+          },
+          "end": {
+            "line": 0,
+            "column": 6
+          }
+        }
+      },
+      {
+        "value": "d",
+        "negated": false,
+        "labels": [
+          "Regexp"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 11
+          },
+          "end": {
+            "line": 0,
+            "column": 12
+          }
+        }
+      }
+    ]
+  },
+  {
+    "value": "(?:e).*?(?:f)",
+    "negated": false,
+    "labels": [
+      "Regexp"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 0
+      }
+    }
+  },
+  {
+    "or": [
+      {
+        "value": "g",
+        "negated": false,
+        "labels": [
+          "Regexp"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 19
+          },
+          "end": {
+            "line": 0,
+            "column": 20
+          }
+        }
+      },
+      {
+        "value": "h",
+        "negated": false,
+        "labels": [
+          "Regexp"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 24
+          },
+          "end": {
+            "line": 0,
+            "column": 25
+          }
+        }
+      }
+    ]
+  },
+  {
+    "value": "(i j k)",
+    "negated": false,
+    "labels": [
+      "Regexp"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 27
+      },
+      "end": {
+        "line": 0,
+        "column": 34
+      }
+    }
+  }
+]

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -198,62 +198,36 @@ func TestSubstituteOrForRegexp(t *testing.T) {
 	}
 }
 
-func TestSubstituteConcat(t *testing.T) {
-	cases := []struct {
-		input  string
-		concat func([]Pattern) []Node
-		want   string
-	}{
-		{
-			input:  "a b c d e f",
-			concat: space,
-			want:   `"a b c d e f"`,
-		},
-		{
-			input:  "a (b and c) d",
-			concat: space,
-			want:   `"a" (and "b" "c") "d"`,
-		},
-		{
-			input:  "a b (c and d) e f (g or h) (i j k)",
-			concat: space,
-			want:   `"a b" (and "c" "d") "e f" (or "g" "h") "(i j k)"`,
-		},
-		{
-			input:  "(((a b c))) and d",
-			concat: space,
-			want:   `(and "(((a b c)))" "d")`,
-		},
-		{
-			input:  `foo\d "bar*"`,
-			concat: fuzzyRegexp,
-			want:   `"(?:foo\\d).*?(?:bar\\*)"`,
-		},
-		{
-			input:  `"bar*" foo\d "bar*" foo\d`,
-			concat: fuzzyRegexp,
-			want:   `"(?:bar\\*).*?(?:foo\\d).*?(?:bar\\*).*?(?:foo\\d)"`,
-		},
-		{
-			input:  "a b (c and d) e f (g or h) (i j k)",
-			concat: fuzzyRegexp,
-			want:   `"(?:a).*?(?:b)" (and "c" "d") "(?:e).*?(?:f)" (or "g" "h") "(i j k)"`,
-		},
-		{
-			input:  "(a not b not c d)",
-			concat: space,
-			want:   `"a" (not "b") (not "c") "d"`,
-		},
+func TestConcat(t *testing.T) {
+	test := func(input string, searchType SearchType) string {
+		query, _ := ParseSearchType(input, searchType)
+		json, _ := PrettyJSON(query)
+		return json
 	}
-	for _, c := range cases {
-		t.Run("Map query", func(t *testing.T) {
-			query, _ := Parse(c.input, SearchTypeRegex)
-			got := toString(Map(query, substituteConcat(c.concat)))
-			if diff := cmp.Diff(c.want, got); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
+
+	t.Run("", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test("a b c d e f", SearchTypeLiteral)))
+	})
+
+	t.Run("", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test("(a not b not c d)", SearchTypeLiteral)))
+	})
+
+	t.Run("", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test("(((a b c))) and d", SearchTypeLiteral)))
+	})
+
+	t.Run("", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`foo\d "bar*"`, SearchTypeRegex)))
+	})
+
+	t.Run("", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`"bar*" foo\d "bar*" foo\d`, SearchTypeRegex)))
+	})
+
+	t.Run("", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test("a b (c and d) e f (g or h) (i j k)", SearchTypeRegex)))
+	})
 }
 
 func TestEllipsesForHoles(t *testing.T) {


### PR DESCRIPTION
Just changing test output to prep for new changes (want verbose output with labels). Deleted two test cases that are technically invalid queries that should never get to the concat pipeline, and they're cluttering/bloating the output for functionality under test.

## Test plan
Just changing test output.