### PR TITLE
codeintel: fix auto indexing scheduling metrics not being counted

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/indexing/observability.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/observability.go
@@ -33,10 +33,6 @@ func newOperations(observationContext *observation.Context) *dependencyReposOper
 			})
 		}
 
-		schedulerOps = &schedulerOperations{
-			HandleIndexScheduler: op("indexing", "HandleIndexSchedule"),
-		}
-
 		m = metrics.NewREDMetrics(
 			observationContext.Registerer,
 			"codeintel_dependency_repos",

--- a/enterprise/cmd/worker/internal/codeintel/indexing/observability.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/observability.go
@@ -8,27 +8,21 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-type schedulerOperations struct {
-	HandleIndexScheduler *observation.Operation
-}
-
 type dependencyReposOperations struct {
 	InsertCloneableDependencyRepo *observation.Operation
 }
 
 var (
-	schedulerOps       *schedulerOperations
-	dependencyReposOps *dependencyReposOperations
 	once               sync.Once
+	dependencyReposOps *dependencyReposOperations
 )
 
-func newOperations(observationContext *observation.Context) *schedulerOperations {
+func newOperations(observationContext *observation.Context) *dependencyReposOperations {
 	once.Do(func() {
 		m := metrics.NewREDMetrics(
 			observationContext.Registerer,
-			"codeintel_index_scheduler",
-			metrics.WithLabels("op"),
-			metrics.WithCountHelp("Total number of method invocations."),
+			"codeintel_dependency_repos",
+			metrics.WithLabels("op", "scheme", "new"),
 		)
 
 		op := func(prefix, name string) *observation.Operation {
@@ -53,5 +47,5 @@ func newOperations(observationContext *observation.Context) *schedulerOperations
 			InsertCloneableDependencyRepo: op("dependencyrepos", "InsertCloneableDependencyRepo"),
 		}
 	})
-	return schedulerOps
+	return dependencyReposOps
 }

--- a/internal/codeintel/autoindexing/background/scheduler/init.go
+++ b/internal/codeintel/autoindexing/background/scheduler/init.go
@@ -5,16 +5,32 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func NewScheduler(
 	autoindexingSvc *autoindexing.Service,
 	dbStore DBStore,
 	policyMatcher PolicyMatcher,
+	observationContext *observation.Context,
 ) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), ConfigInst.Interval, &scheduler{
+	m := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_index_scheduler",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	handleIndexScheduler := observationContext.Operation(observation.Op{
+		Name:              "codeintel.indexing.HandleIndexSchedule",
+		MetricLabelValues: []string{"HandleIndexSchedule"},
+		Metrics:           m,
+	})
+
+	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), ConfigInst.Interval, &scheduler{
 		autoindexingSvc: autoindexingSvc,
 		dbStore:         dbStore,
 		policyMatcher:   policyMatcher,
-	})
+	}, handleIndexScheduler)
 }


### PR DESCRIPTION
Updated moved periodic autoindexing scheduler to emit its original metrics again. Panels are being left where they are under the Worker group for now, until we decide otherwise once the whole deal is tidied up

## Test plan

N/A, metrics update
