### PR TITLE
Update estimator build version

### DIFF
--- a/doc/admin/deploy/resource_estimator.md
+++ b/doc/admin/deploy/resource_estimator.md
@@ -40,7 +40,7 @@
 </style>
 
 <script src="https://storage.googleapis.com/sourcegraph-resource-estimator/go_1_18_wasm_exec.js"></script>
-<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="0249096"></script>
+<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="dbc14f6"></script>
 
 # Sourcegraph resource estimator
 


### PR DESCRIPTION
Update version number to the latest build from https://github.com/sourcegraph/resource-estimator/pull/16

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
File is built and deployed to google storage