### PR TITLE
Fix checkBinary for oss development

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -121,7 +121,7 @@ commands:
         export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/oss-frontend github.com/sourcegraph/sourcegraph/cmd/frontend
-    checkBinary: .bin/frontend
+    checkBinary: .bin/oss-frontend
     env:
       CONFIGURATION_MODE: server
       USE_ENHANCED_LANGUAGE_DETECTION: false

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -257,7 +257,7 @@ commands:
 
       ./cmd/symbols/build-ctags.sh &&
       go build -gcflags="$GCFLAGS" -o .bin/oss-symbols github.com/sourcegraph/sourcegraph/cmd/symbols
-    checkBinary: .bin/symbols
+    checkBinary: .bin/oss-symbols
     env:
       CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
       CTAGS_PROCESSES: 2
@@ -335,7 +335,7 @@ commands:
 
   docsite:
     cmd: .bin/docsite_${DOCSITE_VERSION} -config doc/docsite.json serve -http=localhost:5080
-    install_func: "installDocsite"
+    install_func: 'installDocsite'
     env:
       DOCSITE_VERSION: v1.8.7 # Update DOCSITE_VERSION in all places (including outside this repo)
 
@@ -720,7 +720,7 @@ commandsets:
     env:
       # EXTSVC_CONFIG_FILE being set prevents the e2e test suite to add
       # additional connections.
-      EXTSVC_CONFIG_FILE: ""
+      EXTSVC_CONFIG_FILE: ''
 
   dotcom:
     <<: *enterprise_set
@@ -952,9 +952,9 @@ tests:
       BROWSER: chrome
     external_secrets:
       GH_TOKEN:
-        provider: "gcloud"
-        project: "sourcegraph-ci"
-        name: "BUILDKITE_GITHUBDOTCOM_TOKEN"
+        provider: 'gcloud'
+        project: 'sourcegraph-ci'
+        name: 'BUILDKITE_GITHUBDOTCOM_TOKEN'
 
   docsite:
     cmd: .bin/docsite_${DOCSITE_VERSION} check ./doc


### PR DESCRIPTION

## Test plan
`sg start oss` does not fail, as it did before 