### PR TITLE
search: add concat behavior for Standard search

### DIFF
--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -93,7 +93,9 @@ func SubstituteSearchContexts(lookupQueryString func(contextValue string) (strin
 func For(searchType SearchType) step {
 	var processType step
 	switch searchType {
-	case SearchTypeStandard, SearchTypeLucky, SearchTypeLiteral:
+	case SearchTypeStandard, SearchTypeLucky:
+		processType = succeeds(substituteConcat(standard))
+	case SearchTypeLiteral:
 		processType = succeeds(substituteConcat(space))
 	case SearchTypeRegex:
 		processType = succeeds(escapeParensHeuristic, substituteConcat(fuzzyRegexp))

--- a/internal/search/query/testdata/TestConcat/#06.golden
+++ b/internal/search/query/testdata/TestConcat/#06.golden
@@ -1,0 +1,53 @@
+[
+  {
+    "value": "alsace",
+    "negated": false,
+    "labels": [
+      "Regexp"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 8
+      }
+    }
+  },
+  {
+    "value": "bourgogne bordeaux",
+    "negated": false,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 9
+      },
+      "end": {
+        "line": 0,
+        "column": 18
+      }
+    }
+  },
+  {
+    "value": "champagne",
+    "negated": false,
+    "labels": [
+      "Regexp"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 28
+      },
+      "end": {
+        "line": 0,
+        "column": 39
+      }
+    }
+  }
+]

--- a/internal/search/query/testdata/TestConcat/#07.golden
+++ b/internal/search/query/testdata/TestConcat/#07.golden
@@ -1,0 +1,53 @@
+[
+  {
+    "value": "alsace",
+    "negated": false,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 6
+      }
+    }
+  },
+  {
+    "value": "bourgogne",
+    "negated": false,
+    "labels": [
+      "Regexp"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 7
+      },
+      "end": {
+        "line": 0,
+        "column": 18
+      }
+    }
+  },
+  {
+    "value": "bordeaux",
+    "negated": false,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 19
+      },
+      "end": {
+        "line": 0,
+        "column": 27
+      }
+    }
+  }
+]

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -228,6 +228,15 @@ func TestConcat(t *testing.T) {
 	t.Run("", func(t *testing.T) {
 		autogold.Equal(t, autogold.Raw(test("a b (c and d) e f (g or h) (i j k)", SearchTypeRegex)))
 	})
+
+	t.Run("", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`/alsace/ bourgogne bordeaux /champagne/`, SearchTypeStandard)))
+	})
+
+	t.Run("", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`alsace /bourgogne/ bordeaux`, SearchTypeStandard)))
+	})
+
 }
 
 func TestEllipsesForHoles(t *testing.T) {


### PR DESCRIPTION
This makes `patterntype:standard` "work" (RFC 675). Now you can write `/.../` for regexp pattern, or alternatively literal patterns (they keep working the same way), or you can alternate them. Just going to copy the docstring to explain the behavior:

>  standard reduces a sequence of Patterns such that:
>
> - adjacent literal patterns are concattenated with space. I.e., contiguous
 literal patterns are joined on space to create one literal pattern.
>
> - any patterns adjacent to regular expression patterns are AND-ed.
>
> Here are concrete examples of input strings and equivalent transformation.
 I'm using the `content` field for literal patterns to explicitly delineate
 how those are processed.
>
> `/foo/ /bar/ baz` -> `(/foo/ AND /bar/ AND content:"baz")`
 `/foo/ bar baz` -> `(/foo/ AND content:"bar baz")`
 `/foo/ bar /baz/` -> `(/foo/ AND content:"bar" AND /baz/)`


Next: 

- the frontend doesn't understand any of this new `patterntype:standard` business, but once that's hooked up this behavior will kick in. 

- remaining backend changes is to bump the query version to V3 and use this interpretation by default going forward


## Test plan
Added tests. At some point I will look into make these less verbose but right now the verbosity is OK.
