### PR TITLE
[a11y] search results: wrap headers on smaller screens

### DIFF
--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                 />
                 <svg
                   aria-label="github.com"
-                  class="iconInline text-muted flex-shrink-0"
+                  class="iconInline text-muted flex-shrink-0 mr-1"
                   data-state="closed"
                   fill="currentColor"
                   height="24"
@@ -89,7 +89,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                   data-testid="result-container-header"
                 >
                   <div
-                    class="ml-1 flex-shrink-past-contents text-truncate"
+                    class="titleInner"
                   >
                     <a
                       class="anchorLink"
@@ -114,9 +114,13 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                     class="ml-2 headerDescription"
                   />
                 </div>
-                <small>
-                  1 match
-                </small>
+                <span
+                  class="d-flex align-items-center"
+                >
+                  <small>
+                    1 match
+                  </small>
+                </span>
               </div>
               <div
                 class="fileMatchChildren"
@@ -333,7 +337,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                 />
                 <svg
                   aria-label="github.com"
-                  class="iconInline text-muted flex-shrink-0"
+                  class="iconInline text-muted flex-shrink-0 mr-1"
                   data-state="closed"
                   fill="currentColor"
                   height="24"
@@ -350,7 +354,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                   data-testid="result-container-header"
                 >
                   <div
-                    class="ml-1 flex-shrink-past-contents text-truncate"
+                    class="titleInner"
                   >
                     <a
                       class="anchorLink"
@@ -377,9 +381,13 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                     class="ml-2 headerDescription"
                   />
                 </div>
-                <small>
-                  2 matches
-                </small>
+                <span
+                  class="d-flex align-items-center"
+                >
+                  <small>
+                    2 matches
+                  </small>
+                </span>
               </div>
               <div
                 class="fileMatchChildren"
@@ -550,7 +558,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                 />
                 <svg
                   aria-label="github.com"
-                  class="iconInline text-muted flex-shrink-0"
+                  class="iconInline text-muted flex-shrink-0 mr-1"
                   data-state="closed"
                   fill="currentColor"
                   height="24"
@@ -567,7 +575,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                   data-testid="result-container-header"
                 >
                   <div
-                    class="ml-1 flex-shrink-past-contents text-truncate"
+                    class="titleInner"
                   >
                     <a
                       class="anchorLink"
@@ -592,9 +600,13 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                     class="ml-2 headerDescription"
                   />
                 </div>
-                <small>
-                  1 match
-                </small>
+                <span
+                  class="d-flex align-items-center"
+                >
+                  <small>
+                    1 match
+                  </small>
+                </span>
               </div>
               <div
                 class="fileMatchChildren"

--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import VisuallyHidden from '@reach/visually-hidden'
+import classNames from 'classnames'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
@@ -8,7 +9,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { CommitMatch, getCommitMatchUrl, getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
 // eslint-disable-next-line no-restricted-imports
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
-import { Link, Code, useIsTruncated } from '@sourcegraph/wildcard'
+import { Link, Code } from '@sourcegraph/wildcard'
 
 import { CommitSearchResultMatch } from './CommitSearchResultMatch'
 import { ResultContainer } from './ResultContainer'
@@ -34,32 +35,19 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
     as,
     index,
 }) => {
-    /**
-     * Use the custom hook useIsTruncated to check if overflow: ellipsis is activated for the element
-     * We want to do it on mouse enter as browser window size might change after the element has been
-     * loaded initially
-     */
-    const [titleReference, truncated, checkTruncation] = useIsTruncated()
-
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
-            <span
-                onMouseEnter={checkTruncation}
-                className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
-                ref={titleReference}
-                data-tooltip={(truncated && `${result.authorName}: ${result.message.split('\n', 1)[0]}`) || null}
-            >
+            <span className={classNames('test-search-result-label flex-grow-1', styles.titleInner)}>
                 <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
                 <span aria-hidden={true}> ›</span> <Link to={getCommitMatchUrl(result)}>{result.authorName}</Link>
                 <span aria-hidden={true}>{': '}</span>
                 <Link to={getCommitMatchUrl(result)}>{result.message.split('\n', 1)[0]}</Link>
             </span>
-            <span className={styles.spacer} />
             {/*
                 Relative positioning needed needed to avoid VisuallyHidden creating a scrollable overflow in Chrome.
                 Related bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1154640#c15
             */}
-            <Link to={getCommitMatchUrl(result)} className="position-relative">
+            <Link to={getCommitMatchUrl(result)} className={classNames('position-relative', styles.titleInner)}>
                 <Code className={styles.commitOid}>
                     <VisuallyHidden>Commit hash:</VisuallyHidden>
                     {result.oid.slice(0, 7)}

--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -30,6 +30,8 @@ import { FileMatchChildren } from './FileMatchChildren'
 import { RepoFileLink } from './RepoFileLink'
 import { ResultContainerProps, ResultContainer } from './ResultContainer'
 
+import styles from './SearchResult.module.scss'
+
 interface Props extends SettingsCascadeProps, TelemetryProps {
     location: H.Location
     /**
@@ -114,7 +116,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
                         ? `${props.repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
                         : undefined
                 }
-                className="ml-1 flex-shrink-past-contents text-truncate"
+                className={styles.titleInner}
             />
         </>
     )

--- a/client/search-ui/src/components/RepoFileLink.tsx
+++ b/client/search-ui/src/components/RepoFileLink.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 
 import { appendSubtreeQueryParameter } from '@sourcegraph/common'
 import { displayRepoName, splitPath } from '@sourcegraph/shared/src/components/RepoLink'
-import { useIsTruncated, Link } from '@sourcegraph/wildcard'
+import { Link } from '@sourcegraph/wildcard'
 
 interface Props {
     repoName: string
@@ -28,20 +28,9 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
     className,
 }) => {
     const [fileBase, fileName] = splitPath(filePath)
-    /**
-     * Use the custom hook useIsTruncated to check if overflow: ellipsis is activated for the element
-     * We want to do it on mouse enter as browser window size might change after the element has been
-     * loaded initially
-     */
-    const [titleReference, truncated, checkTruncation] = useIsTruncated()
 
     return (
-        <div
-            ref={titleReference}
-            onMouseEnter={checkTruncation}
-            className={classNames(className)}
-            data-tooltip={truncated ? (fileBase ? `${fileBase}/${fileName}` : fileName) : null}
-        >
+        <div className={classNames(className)}>
             <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link>
             <span aria-hidden={true}> ›</span>{' '}
             <Link to={appendSubtreeQueryParameter(fileURL)}>

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -6,7 +6,7 @@ import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
-import { Icon, Link, Tooltip, useIsTruncated } from '@sourcegraph/wildcard'
+import { Icon, Link } from '@sourcegraph/wildcard'
 
 import { LastSyncedIcon } from './LastSyncedIcon'
 import { ResultContainer } from './ResultContainer'
@@ -28,24 +28,11 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     as,
     index,
 }) => {
-    /**
-     * Use the custom hook useIsTruncated to check if overflow: ellipsis is activated for the element
-     * We want to do it on mouse enter as browser window size might change after the element has been
-     * loaded initially
-     */
-    const [titleReference, truncated, checkTruncation] = useIsTruncated()
-
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
-            <Tooltip content={(truncated && displayRepoName(getRepoMatchLabel(result))) || null} placement="bottom">
-                <span
-                    onMouseEnter={checkTruncation}
-                    className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
-                    ref={titleReference}
-                >
-                    <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
-                </span>
-            </Tooltip>
+            <span className={classNames('test-search-result-label', styles.titleInner)}>
+                <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
+            </span>
         </div>
     )
 

--- a/client/search-ui/src/components/ResultContainer.module.scss
+++ b/client/search-ui/src/components/ResultContainer.module.scss
@@ -15,12 +15,13 @@
     background-color: transparent;
     display: flex;
     align-items: center;
-    white-space: nowrap;
+    flex-wrap: wrap;
 
     &-title {
         flex: 1 1 auto;
         overflow: hidden;
         display: flex;
+        flex-wrap: wrap;
     }
 
     &-divider {

--- a/client/search-ui/src/components/ResultContainer.tsx
+++ b/client/search-ui/src/components/ResultContainer.tsx
@@ -175,7 +175,7 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
                               })}
                     />
                     <div className={classNames('mx-1', styles.headerDivider)} />
-                    <CodeHostIcon repoName={repoName} className="text-muted flex-shrink-0" />
+                    <CodeHostIcon repoName={repoName} className="text-muted flex-shrink-0 mr-1" />
                     <div
                         className={classNames(styles.headerTitle, titleClassName)}
                         data-testid="result-container-header"
@@ -186,10 +186,10 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
                         )}
                     </div>
                     {matchCountLabel && (
-                        <>
+                        <span className="d-flex align-items-center">
                             <small>{matchCountLabel}</small>
                             {collapsible && <div className={classNames('mx-2', styles.headerDivider)} />}
-                        </>
+                        </span>
                     )}
                     {collapsible && (
                         <Button
@@ -222,10 +222,10 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
                         <div className={classNames('mx-2', styles.headerDivider)} />
                     )}
                     {formattedRepositoryStarCount && (
-                        <>
+                        <span className="d-flex align-items-center">
                             <SearchResultStar aria-label={`${repoStars} stars`} />
                             <span aria-hidden={true}>{formattedRepositoryStarCount}</span>
-                        </>
+                        </span>
                     )}
                 </div>
                 {!expanded && collapsedChildren}

--- a/client/search-ui/src/components/SearchResult.module.scss
+++ b/client/search-ui/src/components/SearchResult.module.scss
@@ -82,6 +82,11 @@
     align-items: center;
     flex-grow: 1;
     min-width: 0;
+    flex-wrap: wrap;
+}
+
+.title-inner {
+    overflow-wrap: anywhere;
 }
 
 .commit-oid {


### PR DESCRIPTION
Closes #36322

This changes the headers of search results so that the paths/repos/commit titles wrap instead of being truncated.

<details>
<summary>Screenshots</summary>

### Repo result
![CleanShot 2022-06-28 at 15 10 08](https://user-images.githubusercontent.com/206864/176309627-f3ca6da5-bb66-4bb6-8f15-c14f63fca18f.png)

### File/path/symbol result
![image](https://user-images.githubusercontent.com/206864/176309795-097cfa53-304c-4f35-a5a5-9b83d9988c05.png)

### Commit/diff result
![image](https://user-images.githubusercontent.com/206864/176309968-a4e15b14-ee1b-406e-9555-2f7ffb8b4cca.png)
</details>


## Test plan

Test all result types at 320px width

## App preview:

- [Web](https://sg-web-jp-resultheaderwrapping.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ngmduvisue.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
