### PR TITLE
Harden grafana against extraneous auth headers

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -114,6 +114,8 @@ func addGrafana(r *mux.Router, db database.DB) {
 			// 🚨 SECURITY: Only admins have access to Grafana dashboard
 			r.PathPrefix(prefix).Handler(adminOnly(&httputil.ReverseProxy{
 				Director: func(req *http.Request) {
+					// if set, grafana will fail with an authentication error, so don't allow passthrough
+					req.Header.Del("Authorization")
 					req.URL.Scheme = "http"
 					req.URL.Host = grafanaURL.Host
 					if i := strings.Index(req.URL.Path, prefix); i >= 0 {


### PR DESCRIPTION
grafana will fail with `{"message":"invalid API key"}` if an `authorization` header is set. Ideally, such a header would not be set, but it may be in the case of specific proxies sitting in front of SG. In our case, we stripped the authorization header to get around this issue, but that causes issues when using token auth (like with vscode extension)

## Test plan

1. Set `authentication` header to some dummy value (I use a chrome extension for modifying headers)
2. go to `https://sourcegraph.test:3443/-/debug/grafana/` and note the `{"message":"invalid API key"}`
3. Make the change present in this PR
4. go to `https://sourcegraph.test:3443/-/debug/grafana/` and note the grafana loads correctly