### PR TITLE
Webapp [Charts]: Fix line chart focus management

### DIFF
--- a/client/web/src/charts/components/bar-chart/BarChart.tsx
+++ b/client/web/src/charts/components/bar-chart/BarChart.tsx
@@ -159,7 +159,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
                 />
             )}
 
-            {activeSegment && rootRef.current &&  (
+            {activeSegment && rootRef.current && (
                 <Tooltip containerElement={rootRef.current}>
                     <BarTooltipContent
                         category={activeSegment.category}

--- a/client/web/src/charts/components/bar-chart/BarChart.tsx
+++ b/client/web/src/charts/components/bar-chart/BarChart.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, SVGProps, useMemo, useState } from 'react'
+import { ReactElement, SVGProps, useMemo, useRef, useState } from 'react'
 
 import { scaleBand, scaleLinear } from '@visx/scale'
 import classNames from 'classnames'
@@ -44,6 +44,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         ...attributes
     } = props
 
+    const rootRef = useRef(null)
     const [yAxisElement, setYAxisElement] = useState<SVGGElement | null>(null)
     const [xAxisReference, setXAxisElement] = useState<SVGGElement | null>(null)
     const [activeSegment, setActiveSegment] = useState<ActiveSegment<Datum> | null>(null)
@@ -101,6 +102,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
 
     return (
         <svg
+            ref={rootRef}
             width={outerWidth}
             height={outerHeight}
             {...attributes}
@@ -157,8 +159,8 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
                 />
             )}
 
-            {activeSegment && (
-                <Tooltip>
+            {activeSegment && rootRef.current &&  (
+                <Tooltip containerElement={rootRef.current}>
                     <BarTooltipContent
                         category={activeSegment.category}
                         activeBar={activeSegment.datum}

--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useMemo, useState, SVGProps, CSSProperties } from 'react'
+import { ReactElement, useMemo, useState, SVGProps, CSSProperties, useRef } from 'react'
 
 import { AxisScale, TickFormatter } from '@visx/axis/lib/types'
 import { Group } from '@visx/group'
@@ -85,6 +85,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
         ...attributes
     } = props
 
+    const rootReference = useRef<SVGSVGElement>(null)
     const [activePoint, setActivePoint] = useState<Point<D> & { element?: Element }>()
     const [yAxisElement, setYAxisElement] = useState<SVGGElement | null>(null)
     const [xAxisReference, setXAxisElement] = useState<SVGGElement | null>(null)
@@ -164,14 +165,14 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                 setActivePoint(closestPoint.data)
             }
         },
-        onPointerLeave: () => setActivePoint(undefined),
-        onFocusOut: () => setActivePoint(undefined),
         onClick: event => {
             if (activePoint?.linkUrl) {
                 onDatumClick(event)
                 window.open(activePoint.linkUrl)
             }
         },
+        onPointerLeave: () => setActivePoint(undefined),
+        onFocusOut: () => setActivePoint(undefined),
     })
 
     const activeSeriesId = activePoint?.seriesId ?? ''
@@ -188,6 +189,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
 
     return (
         <svg
+            ref={rootReference}
             width={outerWidth}
             height={outerHeight}
             className={classNames(styles.root, className, { [styles.rootWithHoveredLinkPoint]: activePoint?.linkUrl })}
@@ -265,8 +267,8 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                 )}
             </Group>
 
-            {activePoint && (
-                <Tooltip>
+            {activePoint && rootReference.current && (
+                <Tooltip containerElement={rootReference.current} activeElement={activePoint.element as HTMLElement}>
                     <TooltipContent series={activeSeries} activePoint={activePoint} stacked={stacked} />
                 </Tooltip>
             )}

--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -165,6 +165,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
             }
         },
         onPointerLeave: () => setActivePoint(undefined),
+        onFocusOut: () => setActivePoint(undefined),
         onClick: event => {
             if (activePoint?.linkUrl) {
                 onDatumClick(event)
@@ -173,6 +174,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
         },
     })
 
+    const activeSeriesId = activePoint?.seriesId ?? ''
     const sortedSeries = useMemo(
         () =>
             [...activeSeries]
@@ -180,8 +182,8 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                 // this is to make sure the hovered series is always rendered on top
                 // since SVGs do not support z-index, we have to render the hovered
                 // series last
-                .sort(series => sortByDataKey(series.id, activePoint?.seriesId || '')),
-        [activeSeries, activePoint]
+                .sort(series => sortByDataKey(series.id, activeSeriesId)),
+        [activeSeries, activeSeriesId]
     )
 
     return (
@@ -214,6 +216,19 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                 {stacked && <StackedArea dataSeries={activeSeries} xScale={xScale} yScale={yScale} />}
 
                 {sortedSeries.map(line => (
+                    <LinePath
+                        key={line.id}
+                        data={line.data as SeriesDatum<D>[]}
+                        defined={isDatumWithValidNumber}
+                        x={data => xScale(data.x)}
+                        y={data => yScale(getDatumValue(data))}
+                        stroke={line.color}
+                        strokeLinecap="round"
+                        strokeWidth={2}
+                    />
+                ))}
+
+                {activeSeries.map(line => (
                     <Group
                         key={line.id}
                         style={getLineGroupStyle?.({
@@ -222,30 +237,32 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                             isActive: activePoint?.seriesId === line.id,
                         })}
                     >
-                        <LinePath
-                            data={line.data as SeriesDatum<D>[]}
-                            defined={isDatumWithValidNumber}
-                            x={data => xScale(data.x)}
-                            y={data => yScale(getDatumValue(data))}
-                            stroke={line.color}
-                            strokeLinecap="round"
-                            strokeWidth={2}
-                        />
                         {points[line.id].map(point => (
                             <PointGlyph
                                 key={point.id}
                                 left={point.x}
                                 top={point.y}
-                                active={activePoint?.id === point.id}
+                                active={false}
                                 color={point.color}
                                 linkURL={point.linkUrl}
                                 onClick={onDatumClick}
                                 onFocus={event => setActivePoint({ ...point, element: event.target })}
-                                onBlur={() => setActivePoint(undefined)}
                             />
                         ))}
                     </Group>
                 ))}
+
+                {activePoint && (
+                    <PointGlyph
+                        left={activePoint.x}
+                        top={activePoint.y}
+                        active={true}
+                        color={activePoint.color}
+                        linkURL={activePoint.linkUrl}
+                        onClick={onDatumClick}
+                        tabIndex={-1}
+                    />
+                )}
             </Group>
 
             {activePoint && (

--- a/client/web/src/charts/components/line-chart/components/PointGlyph.tsx
+++ b/client/web/src/charts/components/line-chart/components/PointGlyph.tsx
@@ -10,13 +10,14 @@ interface PointGlyphProps {
     color: string
     active: boolean
     linkURL?: string
+    tabIndex?: number
     onClick: MouseEventHandler<Element>
-    onFocus: FocusEventHandler<Element>
-    onBlur: FocusEventHandler<Element>
+    onFocus?: FocusEventHandler<Element>
+    onBlur?: FocusEventHandler<Element>
 }
 
 export const PointGlyph: React.FunctionComponent<React.PropsWithChildren<PointGlyphProps>> = props => {
-    const { top, left, color, active, linkURL, onFocus, onBlur, onClick } = props
+    const { top, left, color, active, linkURL, tabIndex = 0, onFocus, onBlur, onClick } = props
 
     return (
         <MaybeLink
@@ -26,11 +27,12 @@ export const PointGlyph: React.FunctionComponent<React.PropsWithChildren<PointGl
             onClick={onClick}
             onFocus={onFocus}
             onBlur={onBlur}
+            tabIndex={tabIndex}
             role={linkURL ? 'link' : 'graphics-dataunit'}
             aria-label={linkURL ? 'Click to view data point detail' : 'Data point'}
         >
             <GlyphDot
-                tabIndex={linkURL ? -1 : 0}
+                tabIndex={linkURL ? -1 : tabIndex}
                 onFocus={onFocus}
                 onBlur={onBlur}
                 cx={left}

--- a/client/web/src/charts/components/line-chart/hooks/event-listeners.ts
+++ b/client/web/src/charts/components/line-chart/hooks/event-listeners.ts
@@ -1,4 +1,4 @@
-import { MouseEvent, MouseEventHandler, PointerEventHandler } from 'react'
+import { FocusEventHandler, MouseEvent, MouseEventHandler, PointerEventHandler } from 'react'
 
 import { localPoint } from '@visx/event'
 import { Point } from '@visx/point'
@@ -6,12 +6,14 @@ import { Point } from '@visx/point'
 interface UseChartEventHandlersProps {
     onPointerMove: (point: Point) => void
     onPointerLeave: () => void
+    onFocusOut: FocusEventHandler<SVGSVGElement>
     onClick: MouseEventHandler<SVGSVGElement>
 }
 
 interface ChartHandlers {
     onPointerMove: PointerEventHandler<SVGSVGElement>
     onPointerLeave: PointerEventHandler<SVGSVGElement>
+    onBlurCapture: FocusEventHandler<SVGSVGElement>
     onClick: MouseEventHandler<SVGSVGElement>
 }
 
@@ -19,7 +21,7 @@ interface ChartHandlers {
  * Provides special svg|chart-specific handlers for mouse/touch events.
  */
 export function useChartEventHandlers(props: UseChartEventHandlersProps): ChartHandlers {
-    const { onPointerMove, onPointerLeave, onClick } = props
+    const { onPointerMove, onPointerLeave, onFocusOut, onClick } = props
 
     const handleMouseMove: MouseEventHandler<SVGGElement> = event => {
         const point = localPoint(event.currentTarget, event)
@@ -47,9 +49,19 @@ export function useChartEventHandlers(props: UseChartEventHandlersProps): ChartH
         onPointerLeave()
     }
 
+    const handleBlurCapture: FocusEventHandler<SVGSVGElement> = event => {
+        const relatedTarget = event.relatedTarget as Element
+        const currentTarget = event.currentTarget as Element
+
+        if (!currentTarget.contains(relatedTarget)) {
+            onFocusOut(event)
+        }
+    }
+
     return {
         onPointerMove: handleMouseMove,
         onPointerLeave: handleMouseOut,
+        onBlurCapture: handleBlurCapture,
         onClick,
     }
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
@@ -8,7 +8,7 @@ import { InsightFilters } from '../../../../../../core'
 import { DrillDownFiltersPopover } from '../drill-down-filters-popover/DrillDownFiltersPopover'
 
 const defaultStory: Meta = {
-    title: 'DrillDownFilters',
+    title: 'web/insights/DrillDownInsightFilters',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
 }
 

--- a/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
+++ b/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
@@ -17,12 +17,14 @@ export interface PopoverContentProps extends Omit<FloatingPanelProps, 'target' |
     isOpen?: boolean
     focusLocked?: boolean
     autoFocus?: boolean
+    targetElement?: HTMLElement | null
 }
 
 export const PopoverContent = forwardRef((props, reference) => {
     const {
         isOpen,
         children,
+        targetElement: propertyTargetElement = null,
         focusLocked = true,
         autoFocus = true,
         as: Component = 'div',
@@ -31,11 +33,13 @@ export const PopoverContent = forwardRef((props, reference) => {
         ...otherProps
     } = props
 
-    const { isOpen: isOpenContext, targetElement, tailElement, anchor, setOpen } = useContext(PopoverContext)
+    const { isOpen: isOpenContext, targetElement: contextTargetElement, tailElement, anchor, setOpen } = useContext(
+        PopoverContext
+    )
     const { renderRoot } = useContext(PopoverRoot)
 
+    const targetElement = contextTargetElement ?? propertyTargetElement
     const [focusLock, setFocusLock] = useState(false)
-
     const [tooltipElement, setTooltipElement] = useState<HTMLDivElement | null>(null)
     const tooltipReferenceCallback = useCallbackRef<HTMLDivElement>(null, setTooltipElement)
     const mergeReference = useMergeRefs([tooltipReferenceCallback, reference])


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/37885
Fixes https://github.com/sourcegraph/sourcegraph/issues/38304
Fixes part of https://github.com/sourcegraph/sourcegraph/issues/38269

## Background
This PR fixes the focus flow for the line chart. Before this PR change, we had a completely broken focus management in the line/bar chart. 
Now you should be able 
- Go through all points with a link with the tab key
- Tooltip should stick with focused points, but it shouldn't deactivate the mouse-based position for the tooltip element if the user cursor is moving.

## Test plan
- Go to the line chart storybook stories
- Try to go through all points by keyboard tab-click
- You should see that all points on the chart are accessible through keyboard navigation
- You also should see that the line chart tooltip is rendered when one of the points is focused.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-line-chart-focus.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sqtlugfmku.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

