### PR TITLE
Update repository.name description

### DIFF
--- a/doc/batch_changes/references/batch_spec_templating.md
+++ b/doc/batch_changes/references/batch_spec_templating.md
@@ -85,7 +85,7 @@ They are evaluated before the execution of each entry in `steps`, except for the
 | `batch_change.description` | `string` | The `description` of the batch change, as set in the batch spec. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.26 or later</small></i>. 
 | `repository.search_result_paths` | `list of strings` | Unique list of file paths relative to the repository root directory in which the search results of the `repositoriesMatchingQuery`s have been found. |
 | `repository.branch` | `string` | The target branch of the repository in which the step is being executed. </br><i><small>Requires Sourcegraph 3.35 or later.</small></i> |
-| `repository.name` | `string` | Full path of the repository in which the step is being executed. Example: `org_foo/repo_bar`. |
+| `repository.name` | `string` | Full name of the repository in which the step is being executed. Example: `org_foo/repo_bar`. |
 | `previous_step.modified_files` | `list of strings` | List of files that have been modified by the previous step in `steps`. Empty list if no files have been modified. |
 | `previous_step.added_files` | `list of strings` | List of files that have been added by the previous step in `steps`. Empty list if no files have been added. |
 | `previous_step.deleted_files` | `list of strings` | List of files that have been deleted by the previous step in `steps`. Empty list if no files have been deleted. |
@@ -115,7 +115,7 @@ They are evaluated after the execution of all entries in `steps`.
 | `batch_change.description` | `string` | The `description` of the batch change, as set in the batch spec. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.26 or later</small></i>.  |
 | `repository.search_result_paths` | `list of strings` | Unique list of file paths relative to the repository root directory in which the search results of the `repositoriesMatchingQuery`s have been found. |
 | `repository.branch` | `string` | The target branch of the repository in which the step is being executed. </br><i><small>Requires Sourcegraph 3.35 or later.</small></i> |
-| `repository.name` | `string` | Full path of the repository in which the step is being executed. Example: `org_foo/repo_bar`. |
+| `repository.name` | `string` | Full name of the repository in which the step is being executed. Example: `org_foo/repo_bar`. |
 | `steps.modified_files` | `list of strings` | List of files that have been modified by the `steps`. Empty list if no files have been modified. |
 | `steps.added_files` | `list of strings` | List of files that have been added by the `steps`. Empty list if no files have been added. |
 | `steps.deleted_files` | `list of strings` | List of files that have been deleted by the `steps`. Empty list if no files have been deleted. |

--- a/doc/batch_changes/references/batch_spec_templating.md
+++ b/doc/batch_changes/references/batch_spec_templating.md
@@ -85,7 +85,7 @@ They are evaluated before the execution of each entry in `steps`, except for the
 | `batch_change.description` | `string` | The `description` of the batch change, as set in the batch spec. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.26 or later</small></i>. 
 | `repository.search_result_paths` | `list of strings` | Unique list of file paths relative to the repository root directory in which the search results of the `repositoriesMatchingQuery`s have been found. |
 | `repository.branch` | `string` | The target branch of the repository in which the step is being executed. </br><i><small>Requires Sourcegraph 3.35 or later.</small></i> |
-| `repository.name` | `string` | Full name of the repository in which the step is being executed. |
+| `repository.name` | `string` | Full path of the repository in which the step is being executed. Example: `org_foo/repo_bar`. |
 | `previous_step.modified_files` | `list of strings` | List of files that have been modified by the previous step in `steps`. Empty list if no files have been modified. |
 | `previous_step.added_files` | `list of strings` | List of files that have been added by the previous step in `steps`. Empty list if no files have been added. |
 | `previous_step.deleted_files` | `list of strings` | List of files that have been deleted by the previous step in `steps`. Empty list if no files have been deleted. |
@@ -115,7 +115,7 @@ They are evaluated after the execution of all entries in `steps`.
 | `batch_change.description` | `string` | The `description` of the batch change, as set in the batch spec. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.26 or later</small></i>.  |
 | `repository.search_result_paths` | `list of strings` | Unique list of file paths relative to the repository root directory in which the search results of the `repositoriesMatchingQuery`s have been found. |
 | `repository.branch` | `string` | The target branch of the repository in which the step is being executed. </br><i><small>Requires Sourcegraph 3.35 or later.</small></i> |
-| `repository.name` | `string` | Full name of the repository in which the step is being executed. |
+| `repository.name` | `string` | Full path of the repository in which the step is being executed. Example: `org_foo/repo_bar`. |
 | `steps.modified_files` | `list of strings` | List of files that have been modified by the `steps`. Empty list if no files have been modified. |
 | `steps.added_files` | `list of strings` | List of files that have been added by the `steps`. Empty list if no files have been added. |
 | `steps.deleted_files` | `list of strings` | List of files that have been deleted by the `steps`. Empty list if no files have been deleted. |


### PR DESCRIPTION
Received feedback from a user that the current description for the `repository.name`variable led them to believe they only needed the repo name when in reality they needed to include the full repo path. Updating the docs to clarify.



## Test plan

No review required; updating documentation. 
