### PR TITLE
search frontend: update scanner to recognize standard interpretation

### DIFF
--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -202,6 +202,14 @@ describe('scanSearchQuery() for regexp', () => {
     })
 })
 
+describe('scanSearchQuery() for standard', () => {
+    test('scan literal and regexp patterns', () => {
+        expect(scanSearchQuery('pfalz /mosel/', false, SearchPatternType.standard)).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":5},"kind":1,"value":"pfalz"},{"type":"whitespace","range":{"start":5,"end":6}},{"type":"pattern","range":{"start":6,"end":13},"kind":2,"value":"mosel"}]}'
+        )
+    })
+})
+
 describe('scanSearchQuery() with comments', () => {
     test('interpret C-style comments', () => {
         const query = `// saucegraph is best graph


### PR DESCRIPTION
Implementing [RFC 675](https://docs.google.com/document/d/1KebTihO_jrPcLblgeT4X428kfgs42NkFz_3kCr8bT0M/edit) means that it's possible to have literal and regex patterns in the same string. When this happens, we want the frontend to know whether it scans a regex pattern `/xyz/` versus a literal pattern `abc`. This PR updates the scanner to tag `/xyz/` patterns as regex, and literals otherwise. This'll let us support contextual highlighting (will add in follow up PR). 

Another way to phrase this: If we don't add this distinction then we either have to give up highlighting regex metasyntax altogether (bad, since we are now explicitly introducing regex support with RFC 675, so could lead to confusion) or incorrectly highlight all syntax (including literals) as regex, which is also bad, because that's just wrong.


## Test plan
Added a test.

## App preview:

- [Web](https://sg-web-rvt-highlight-regex.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fmhftcjopx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
