### PR TITLE
search: lucky search uses standard interpretation

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1071,12 +1071,12 @@ func (p *parser) parseAnd() ([]Node, error) {
 	switch p.leafParser {
 	case SearchTypeRegex:
 		left, err = p.parseLeaves(Regexp)
-	case SearchTypeLiteral:
+	case SearchTypeLiteral, SearchTypeStructural:
 		left, err = p.parseLeaves(Literal)
-	case SearchTypeStandard:
+	case SearchTypeStandard, SearchTypeLucky:
 		left, err = p.parseLeaves(Literal | Standard)
 	default:
-		left, err = p.parseLeaves(Literal)
+		left, err = p.parseLeaves(Literal | Standard)
 	}
 	if err != nil {
 		return nil, err

--- a/internal/search/query/testdata/TestConcat/#08.golden
+++ b/internal/search/query/testdata/TestConcat/#08.golden
@@ -1,0 +1,53 @@
+[
+  {
+    "value": "alsace",
+    "negated": false,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 6
+      }
+    }
+  },
+  {
+    "value": "bourgogne",
+    "negated": false,
+    "labels": [
+      "Regexp"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 7
+      },
+      "end": {
+        "line": 0,
+        "column": 18
+      }
+    }
+  },
+  {
+    "value": "bordeaux",
+    "negated": false,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 19
+      },
+      "end": {
+        "line": 0,
+        "column": 27
+      }
+    }
+  }
+]

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -237,6 +237,9 @@ func TestConcat(t *testing.T) {
 		autogold.Equal(t, autogold.Raw(test(`alsace /bourgogne/ bordeaux`, SearchTypeStandard)))
 	})
 
+	t.Run("", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`alsace /bourgogne/ bordeaux`, SearchTypeLucky)))
+	})
 }
 
 func TestEllipsesForHoles(t *testing.T) {


### PR DESCRIPTION
Makes lucky search use standard interpretation (allows regex and literal strings). I thought https://github.com/sourcegraph/sourcegraph/pull/37890 would do this automatically but nope, I needed to activate it in the parser still.

## Test plan
Added a test.