### PR TITLE
gitserver: mark repository as corrupted if commit-graph is malformed

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -1002,7 +1002,7 @@ func makeFakeRepo(d string, sizeBytes int) error {
 	return nil
 }
 
-func TestMaybeCorruptStderrRe(t *testing.T) {
+func TestStdErrIndicatesCorruption(t *testing.T) {
 	bad := []string{
 		"error: packfile .git/objects/pack/pack-a.pack does not match index",
 		"error: Could not read d24d09b8bc5d1ea2c3aa24455f4578db6aa3afda\n",
@@ -1011,6 +1011,8 @@ error: Could not read d24d09b8bc5d1ea2c3aa24455f4578db6aa3afda`,
 		`unrelated
 error: Could not read d24d09b8bc5d1ea2c3aa24455f4578db6aa3afda`,
 		"\n\nerror: Could not read d24d09b8bc5d1ea2c3aa24455f4578db6aa3afda",
+		"fatal: commit-graph requires overflow generation data but has none\n",
+		"\rResolving deltas: 100% (21750/21750), completed with 565 local objects.\nfatal: commit-graph requires overflow generation data but has none\nerror: https://github.com/sgtest/megarepo did not send all necessary objects\n\n\": exit status 1",
 	}
 	good := []string{
 		"",
@@ -1019,12 +1021,12 @@ error: Could not read d24d09b8bc5d1ea2c3aa24455f4578db6aa3afda`,
 		"error: object 45043b3ff0440f4d7937f8c68f8fb2881759edef is a tree, not a commit",
 	}
 	for _, stderr := range bad {
-		if !maybeCorruptStderrRe.MatchString(stderr) {
+		if !stdErrIndicatesCorruption(stderr) {
 			t.Errorf("should contain corrupt line:\n%s", stderr)
 		}
 	}
 	for _, stderr := range good {
-		if maybeCorruptStderrRe.MatchString(stderr) {
+		if stdErrIndicatesCorruption(stderr) {
 			t.Errorf("should not contain corrupt line:\n%s", stderr)
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/37872

On dogfood, git operations against the megarepo are currently failing with error messages that look like the following:

```
...
fatal: commit-graph requires overflow generation data but has none
error: <repo> did not send all necessary objects
...
```

It looks like this was a bug that was introduced in git `2.36.1`: https://lore.kernel.org/git/581c7ef2-3de4-eb8a-bfbb-d4bca3522a2d@github.com/T/. This bug is unresolved as of this time of writing. 

We upgraded to git 2.36.1 in all of our docker images in https://github.com/sourcegraph/sourcegraph/commit/04c98ab493e0889394e2e60fb85e1a53225e5a35.


---


This PR works around this issue by having gitserver mark a repository as corrupted if the `fatal: commit-graph requires overflow generation data but has none` message occurs in the standard error output. 

The mailing list threads suggest that a cheaper solution is just to `rm objects/info/commit-graph && git gc` (which avoids a re-clone). However, I think it's easier operationally if we are consistent with just re-cloning whenever we encounter these (hopefully infrequent) kinds of corruption errors. 


## Test plan

Unit tests. 

We'll also see in dogfood's logs if the error is resolved once this image is deployed.
