### PR TITLE
batches: make current execution "clickable" when using VoiceOver

### DIFF
--- a/client/web/src/enterprise/batches/BatchSpecNode.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.tsx
@@ -56,18 +56,18 @@ export const BatchSpecNode: React.FunctionComponent<React.PropsWithChildren<Batc
             </div>
             <div className="px-2 pb-1">
                 <H3 className="pr-2">
-                    {currentSpecID === node.id && (
-                        <>
-                            <Icon
-                                className="text-warning"
-                                data-tooltip="Currently applied spec"
-                                aria-label="Currently applied spec"
-                                as={StarIcon}
-                            />{' '}
-                        </>
-                    )}
                     {currentSpecID && (
                         <Link to={`${node.namespace.url}/batch-changes/${node.description.name}/executions/${node.id}`}>
+                            {currentSpecID === node.id && (
+                                <>
+                                    <Icon
+                                        className="text-warning"
+                                        data-tooltip="Currently applied spec"
+                                        aria-label="Currently applied spec"
+                                        as={StarIcon}
+                                    />{' '}
+                                </>
+                            )}
                             Executed by <strong>{node.creator?.username}</strong>{' '}
                             <Timestamp date={node.createdAt} now={now} />
                         </Link>


### PR DESCRIPTION
Executions that aren't current operate as expected, but the tree for current specs looks something like this, and VoiceOver doesn't make it activatable:

```
H3
|
+-- Icon
+-- Link
```

Because the element is a heading and not a group, the user can't navigate into the child elements. We also can't ignore the icon entirely because it includes important semantic information (namely, that this is the current spec).

There's no real reason we can't flip this so the icon is inside the link, so that's what I've done. There's a very slight visual regression on hover where the link underline now extends into the space between the icon and text, but I think that's fine, and the icon being clickable really feels right anyway, so it's visually part of the label anyway.

Related to #34084.

## Test plan

Tested with VoiceOver to ensure the element is now clickable, and normally to ensure there are no other behavioural quirks other than the noted underline issue.

## App preview:

- [Web](https://sg-web-aharvey-a11y-fix-for-current-spec.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sylxtklfoh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
