### PR TITLE
frontend: add health check

### DIFF
--- a/cmd/frontend/internal/cli/checks.go
+++ b/cmd/frontend/internal/cli/checks.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/check"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+)
+
+var checkCanReachGitserver = check.Check{
+	Name:     "check_can_reach_gitserver",
+	Interval: time.Minute,
+	Run: func() any {
+
+		type resp struct {
+			Addr string `json:"addr"`
+			Ok   bool   `json:"ok"`
+			Msg  string `json:"msg"`
+		}
+
+		addrs := conf.Get().ServiceConnections().GitServers
+		resps := make([]resp, 0, len(addrs))
+
+		checkAddr := func(addr string) ([]byte, error) {
+			req, err := http.NewRequest("GET", "http://"+addr+"/ping", nil)
+			if err != nil {
+				return nil, err
+			}
+
+			r, err := httpcli.InternalDoer.Do(req)
+			if err != nil {
+				return nil, err
+			}
+
+			if r.StatusCode != 200 {
+				return nil, errors.New(r.Status)
+			}
+
+			b, err := io.ReadAll(r.Body)
+			if err != nil {
+				return nil, err
+			}
+			return b, nil
+		}
+
+		for _, addr := range addrs {
+			b, err := checkAddr(addr)
+			if err != nil {
+				resps = append(resps, resp{
+					Addr: addr,
+					Ok:   false,
+					Msg:  err.Error(),
+				})
+			} else {
+				resps = append(resps, resp{
+					Addr: addr,
+					Ok:   true,
+					Msg:  string(b),
+				})
+			}
+		}
+
+		return resps
+	},
+}

--- a/cmd/frontend/internal/cli/checks.go
+++ b/cmd/frontend/internal/cli/checks.go
@@ -29,7 +29,7 @@ var checkCanReachGitserver = check.Check{
 
 var checkCanReachSearcher = check.Check{
 	Name:     "check_can_reach_searcher",
-	Interval: time.Second,
+	Interval: time.Minute,
 	Run: func(ctx context.Context) (any, error) {
 		addrs, err := search.SearcherURLs().Endpoints()
 		if err != nil {

--- a/cmd/frontend/internal/cli/checks.go
+++ b/cmd/frontend/internal/cli/checks.go
@@ -26,7 +26,7 @@ var checkCanReachGitserver = check.Check{
 		resps := make([]resp, 0, len(addrs))
 
 		checkAddr := func(addr string) ([]byte, error) {
-			req, err := http.NewRequest("GET", "http://"+addr+"/ping", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "http://"+addr+"/ping", nil)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/frontend/internal/cli/checks.go
+++ b/cmd/frontend/internal/cli/checks.go
@@ -10,75 +10,90 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/check"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/search"
 )
 
 var checkCanReachGitserver = check.Check{
 	Name:     "check_can_reach_gitserver",
 	Interval: time.Minute,
 	Run: func(ctx context.Context) (any, error) {
-
-		type resp struct {
-			Addr string `json:"addr"`
-			Out  string `json:"out"`
-		}
-
 		addrs := conf.Get().ServiceConnections().GitServers
-		resps := make([]resp, 0, len(addrs))
 
-		checkAddr := func(addr string) ([]byte, error) {
-			req, err := http.NewRequestWithContext(ctx, "GET", "http://"+addr+"/ping", nil)
-			if err != nil {
-				return nil, err
-			}
-
-			r, err := httpcli.InternalDoer.Do(req)
-			if err != nil {
-				return nil, err
-			}
-
-			if r.StatusCode != 200 {
-				return nil, errors.New(r.Status)
-			}
-
-			b, err := io.ReadAll(r.Body)
-			if err != nil {
-				return nil, err
-			}
-			return b, nil
-		}
-
-		fail := false
+		var addrs2 []string
 		for _, addr := range addrs {
-			b, err := checkAddr(addr)
-			if err != nil {
-				fail = true
-				resps = append(resps, resp{
-					Addr: addr,
-					Out:  err.Error(),
-				})
-			} else {
-				resps = append(resps, resp{
-					Addr: addr,
-					Out:  string(b),
-				})
-			}
+			addrs2 = append(addrs2, "http://"+addr+"/ping")
 		}
-
-		var err error
-		if fail {
-			err = errors.New("could not reach one or more gitservers")
-		}
-		return resps, err
+		return checkCanReachHTTP(ctx, addrs2)
 	},
 }
 
-var checkDummy = check.Check{
-	Name:     "check_dummy",
-	Interval: time.Second * 10,
+var checkCanReachSearcher = check.Check{
+	Name:     "check_can_reach_searcher",
+	Interval: time.Second,
 	Run: func(ctx context.Context) (any, error) {
-		return struct {
-			Time time.Time
-			Msg  string
-		}{Time: time.Now(), Msg: "hello"}, nil
+		addrs, err := search.SearcherURLs().Endpoints()
+		if err != nil {
+			return "", err
+		}
+		var addrs2 []string
+		for _, addr := range addrs {
+			addrs2 = append(addrs2, addr+"/healthz")
+		}
+		return checkCanReachHTTP(ctx, addrs2)
 	},
+}
+
+func checkCanReachHTTP(ctx context.Context, addrs []string) (any, error) {
+	type resp struct {
+		Addr string `json:"addr"`
+		Out  string `json:"out"`
+	}
+
+	resps := make([]resp, 0, len(addrs))
+
+	checkAddr := func(addr string) ([]byte, error) {
+		req, err := http.NewRequestWithContext(ctx, "GET", addr, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		r, err := httpcli.InternalDoer.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if r.StatusCode != 200 {
+			return nil, errors.New(r.Status)
+		}
+
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	}
+
+	fail := false
+	for _, addr := range addrs {
+		b, err := checkAddr(addr)
+		if err != nil {
+			fail = true
+			resps = append(resps, resp{
+				Addr: addr,
+				Out:  err.Error(),
+			})
+		} else {
+			resps = append(resps, resp{
+				Addr: addr,
+				Out:  string(b),
+			})
+		}
+	}
+
+	// Aggregate error.
+	var err error
+	if fail {
+		err = errors.New("could not reach one or more servers")
+	}
+	return resps, err
 }

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -127,7 +127,7 @@ func healthCheckMiddleware(next http.Handler) http.Handler {
 
 // newInternalHTTPHandler creates and returns the HTTP handler for the internal API (accessible to
 // other internal services).
-func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newComputeStreamHandler enterprise.NewComputeStreamHandler, rateLimitWatcher graphqlbackend.LimitWatcher, newHealthCheckHandler http.Handler) http.Handler {
+func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newComputeStreamHandler enterprise.NewComputeStreamHandler, rateLimitWatcher graphqlbackend.LimitWatcher, healthCheckHandler http.Handler) http.Handler {
 	internalMux := http.NewServeMux()
 	internalMux.Handle("/.internal/", gziphandler.GzipHandler(
 		actor.HTTPMiddleware(
@@ -139,7 +139,7 @@ func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntel
 					newCodeIntelUploadHandler,
 					newComputeStreamHandler,
 					rateLimitWatcher,
-					newHealthCheckHandler,
+					healthCheckHandler,
 				),
 			),
 		),

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -127,7 +127,7 @@ func healthCheckMiddleware(next http.Handler) http.Handler {
 
 // newInternalHTTPHandler creates and returns the HTTP handler for the internal API (accessible to
 // other internal services).
-func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newComputeStreamHandler enterprise.NewComputeStreamHandler, rateLimitWatcher graphqlbackend.LimitWatcher) http.Handler {
+func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newComputeStreamHandler enterprise.NewComputeStreamHandler, rateLimitWatcher graphqlbackend.LimitWatcher, newHealthCheckHandler http.Handler) http.Handler {
 	internalMux := http.NewServeMux()
 	internalMux.Handle("/.internal/", gziphandler.GzipHandler(
 		actor.HTTPMiddleware(
@@ -139,6 +139,7 @@ func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntel
 					newCodeIntelUploadHandler,
 					newComputeStreamHandler,
 					rateLimitWatcher,
+					newHealthCheckHandler,
 				),
 			),
 		),
@@ -165,7 +166,7 @@ const (
 	// crossOriginPolicyAPI describes that the middleware should handle cross origin requests as a
 	// public API. That is, cross-origin requests are allowed from any domain but
 	// cookie/session-based authentication is only allowed if the origin is in the configured
-	/// allow-list of origins. Otherwise, only access token authentication is permitted.
+	// allow-list of origins. Otherwise, only access token authentication is permitted.
 	//
 	// This is to be used for all /.api routes, such as our GraphQL and search streaming APIs as we
 	// want third-party websites (such as e.g. github1s.com, or internal tools for on-prem

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -147,7 +147,7 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 	logger := sglog.Scoped("server", "the frontend server program")
 	ready := make(chan struct{})
 	go debugserver.NewServerRoutine(ready, debugserver.Endpoint{
-		Name:    "aggregate checks",
+		Name:    "Health Checks",
 		Path:    "/aggregate-checks",
 		Handler: check.NewAggregateHealthCheckHandler(check.DefaultEndpointProvider),
 	}).Start()

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -147,8 +147,8 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 	logger := sglog.Scoped("server", "the frontend server program")
 	ready := make(chan struct{})
 	go debugserver.NewServerRoutine(ready, debugserver.Endpoint{
-		Name:    "checks",
-		Path:    "/checks",
+		Name:    "aggregate checks",
+		Path:    "/aggregate-checks",
 		Handler: check.NewAggregateHealthCheckHandler(),
 	}).Start()
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -140,7 +140,7 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 
 	hc := &check.HealthChecker{Checks: []check.Check{
 		checkCanReachGitserver,
-		checkDummy,
+		checkCanReachSearcher,
 	}}
 	hc.Init()
 
@@ -149,7 +149,7 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 	go debugserver.NewServerRoutine(ready, debugserver.Endpoint{
 		Name:    "aggregate checks",
 		Path:    "/aggregate-checks",
-		Handler: check.NewAggregateHealthCheckHandler(),
+		Handler: check.NewAggregateHealthCheckHandler(check.DefaultEndpointProvider),
 	}).Start()
 
 	sqlDB, err := InitDB(logger)

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -298,7 +298,7 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 		return err
 	}
 
-	internalAPI, err := makeInternalAPI(schema, db, enterprise, rateLimitWatcher, hc.NewHealthCheckHandler())
+	internalAPI, err := makeInternalAPI(schema, db, enterprise, rateLimitWatcher, hc)
 	if err != nil {
 		return err
 	}
@@ -352,7 +352,7 @@ func makeExternalAPI(db database.DB, schema *graphql.Schema, enterprise enterpri
 	return server, nil
 }
 
-func makeInternalAPI(schema *graphql.Schema, db database.DB, enterprise enterprise.Services, rateLimiter graphqlbackend.LimitWatcher, newHealthCheckHandler http.Handler) (goroutine.BackgroundRoutine, error) {
+func makeInternalAPI(schema *graphql.Schema, db database.DB, enterprise enterprise.Services, rateLimiter graphqlbackend.LimitWatcher, healthCheckHandler http.Handler) (goroutine.BackgroundRoutine, error) {
 	if httpAddrInternal == "" {
 		return nil, nil
 	}
@@ -369,7 +369,7 @@ func makeInternalAPI(schema *graphql.Schema, db database.DB, enterprise enterpri
 		enterprise.NewCodeIntelUploadHandler,
 		enterprise.NewComputeStreamHandler,
 		rateLimiter,
-		newHealthCheckHandler,
+		healthCheckHandler,
 	)
 	httpServer := &http.Server{
 		Handler:     internalHandler,

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -37,6 +37,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/vfsutil"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/check"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
@@ -140,6 +141,11 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 	logger := sglog.Scoped("server", "the frontend server program")
 	ready := make(chan struct{})
 	go debugserver.NewServerRoutine(ready).Start()
+
+	hc := &check.HealthChecker{Checks: []check.Check{
+		checkCanReachGitserver,
+	}}
+	hc.Init()
 
 	sqlDB, err := InitDB(logger)
 	if err != nil {

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -124,7 +124,7 @@ func NewHandler(
 // 🚨 SECURITY: This handler should not be served on a publicly exposed port. 🚨
 // This handler is not guaranteed to provide the same authorization checks as
 // public API handlers.
-func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newComputeStreamHandler enterprise.NewComputeStreamHandler, rateLimitWatcher graphqlbackend.LimitWatcher, newHealthCheckHandler http.Handler) http.Handler {
+func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newComputeStreamHandler enterprise.NewComputeStreamHandler, rateLimitWatcher graphqlbackend.LimitWatcher, healthCheckHandler http.Handler) http.Handler {
 	logger := sglog.Scoped("InternalHandler", "")
 	if m == nil {
 		m = apirouter.New(nil)
@@ -179,7 +179,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 
 	m.Get(apirouter.LSIFUpload).Handler(trace.Route(newCodeIntelUploadHandler(true)))
 
-	m.Get(apirouter.Checks).Handler(trace.Route(newHealthCheckHandler))
+	m.Get(apirouter.Checks).Handler(trace.Route(healthCheckHandler))
 
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("API no route: %s %s from %s", r.Method, r.URL, r.Referer())

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -124,7 +124,7 @@ func NewHandler(
 // 🚨 SECURITY: This handler should not be served on a publicly exposed port. 🚨
 // This handler is not guaranteed to provide the same authorization checks as
 // public API handlers.
-func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newComputeStreamHandler enterprise.NewComputeStreamHandler, rateLimitWatcher graphqlbackend.LimitWatcher) http.Handler {
+func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, newComputeStreamHandler enterprise.NewComputeStreamHandler, rateLimitWatcher graphqlbackend.LimitWatcher, newHealthCheckHandler http.Handler) http.Handler {
 	logger := sglog.Scoped("InternalHandler", "")
 	if m == nil {
 		m = apirouter.New(nil)
@@ -177,7 +177,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.StreamingSearch).Handler(trace.Route(frontendsearch.StreamHandler(sglog.Scoped("Router", "StreamingSearch"), db)))
 	m.Get(apirouter.ComputeStream).Handler(trace.Route(newComputeStreamHandler()))
 
-	m.Get(apirouter.LSIFUpload).Handler(trace.Route(newCodeIntelUploadHandler(true)))
+	m.Get(apirouter.Checks).Handler(trace.Route(newHealthCheckHandler))
 
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("API no route: %s %s from %s", r.Method, r.URL, r.Referer())

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -177,6 +177,8 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.StreamingSearch).Handler(trace.Route(frontendsearch.StreamHandler(sglog.Scoped("Router", "StreamingSearch"), db)))
 	m.Get(apirouter.ComputeStream).Handler(trace.Route(newComputeStreamHandler()))
 
+	m.Get(apirouter.LSIFUpload).Handler(trace.Route(newCodeIntelUploadHandler(true)))
+
 	m.Get(apirouter.Checks).Handler(trace.Route(newHealthCheckHandler))
 
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -50,6 +50,7 @@ const (
 	ExternalServiceConfigs = "internal.external-services.configs"
 	ExternalServicesList   = "internal.external-services.list"
 	StreamingSearch        = "internal.stream-search"
+	Checks                 = "internal.checks"
 )
 
 // New creates a new API router with route URL pattern definitions but
@@ -118,6 +119,7 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/lsif/upload").Methods("POST").Name(LSIFUpload)
 	base.Path("/search/stream").Methods("GET").Name(StreamingSearch)
 	base.Path("/compute/stream").Methods("GET", "POST").Name(ComputeStream)
+	base.Path("/checks").Methods("GET").Name(Checks)
 	addRegistryRoute(base)
 	addGraphQLRoute(base)
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -163,8 +163,13 @@ func NewAggregateHealthCheckHandler() http.Handler {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
-
 				defer res.Body.Close()
+
+				if res.StatusCode != 200 {
+					fmt.Fprintf(w, "%q: %q\n", endpoint.Host, "unreachable")
+					continue
+				}
+
 				b, err := io.ReadAll(res.Body)
 				if err != nil {
 					w.WriteHeader(http.StatusInternalServerError)

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -98,25 +98,23 @@ func errString(err error) string {
 	return err.Error()
 }
 
-// NewHealthCheckHandler returns a handler that serves a page just like /vars
-// but filtered for health checks. Each service should expose a /checks
-// endpoint. All /checks endpoints are aggregated by ServeHealthCheckAggregate
-func (hc *HealthChecker) NewHealthCheckHandler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		fmt.Fprintf(w, "{\n")
-		first := true
-		for _, check := range hc.Checks {
-			if !first {
-				fmt.Fprintf(w, ",\n")
-			}
-			first = false
-
-			v := expvar.Get(check.Name)
-			fmt.Fprintf(w, "%q: %s", check.Name, v.String())
+// ServeHTTP serves a page just like /vars but filtered for health checks. Each
+// service should expose a /checks endpoint. All /checks endpoints are
+// aggregated by ServeHealthCheckAggregate
+func (hc *HealthChecker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	fmt.Fprintf(w, "{\n")
+	first := true
+	for _, check := range hc.Checks {
+		if !first {
+			fmt.Fprintf(w, ",\n")
 		}
-		fmt.Fprintf(w, "\n}\n")
-	})
+		first = false
+
+		v := expvar.Get(check.Name)
+		fmt.Fprintf(w, "%q: %s", check.Name, v.String())
+	}
+	fmt.Fprintf(w, "\n}\n")
 }
 
 // TODO: How can we reach ALL frontends?

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1,0 +1,174 @@
+package check
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strconv"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"golang.org/x/sync/semaphore"
+)
+
+type RunFunc func(ctx context.Context) (string, error)
+
+type Check struct {
+	Name        string
+	Description string
+
+	Run RunFunc
+
+	LastRun           time.Time
+	CachedCheckErr    error
+	CachedCheckOutput string
+}
+
+func (c *Check) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Name              string    `json:"name"`
+		Description       string    `json:"description"`
+		LastRun           time.Time `json:"last_run"`
+		CachedCheckErr    string    `json:"cached_check_err"`
+		CachedCheckOutput string    `json:"cached_check_output"`
+	}{
+		Name:              c.Name,
+		Description:       c.Description,
+		LastRun:           c.LastRun,
+		CachedCheckErr:    errString(c.CachedCheckErr),
+		CachedCheckOutput: c.CachedCheckOutput,
+	})
+}
+
+type HealthChecker struct {
+	mu     sync.Mutex
+	Checks []Check
+}
+
+func (c *HealthChecker) MarshalJSON() ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return json.Marshal(c.Checks)
+}
+
+func (c *HealthChecker) Run() {
+	for {
+		time.Sleep(60 * time.Second)
+		c.doRun()
+	}
+}
+
+func (c *HealthChecker) doRun() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	sem := semaphore.NewWeighted(int64(runtime.GOMAXPROCS(0)))
+	wg := sync.WaitGroup{}
+
+	for i, check := range c.Checks {
+		err := sem.Acquire(ctx, 1)
+		if err != nil {
+			return
+		}
+		wg.Add(1)
+		go func(i int, check Check) {
+			defer sem.Release(1)
+			defer wg.Done()
+
+			check.CachedCheckOutput, check.CachedCheckErr = check.Run(ctx)
+			check.LastRun = time.Now().UTC()
+
+			c.mu.Lock()
+			c.Checks[i] = check
+			c.mu.Unlock()
+		}(i, check)
+	}
+	wg.Wait()
+}
+
+func (c *HealthChecker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Header.Get("Accept") {
+	case "application/json":
+		out, err := json.Marshal(c)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to marshal: %s", err), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(out)))
+
+		w.Write(out)
+
+	default:
+		out, err := c.RenderTable()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to render plain text table: %s", err), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", strconv.Itoa(len(out)))
+
+		w.Write(out)
+	}
+}
+
+func (c *HealthChecker) RenderTable() ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	bw := bytes.Buffer{}
+	tw := tabwriter.NewWriter(&bw, 16, 8, 4, ' ', 0)
+
+	_, err := fmt.Fprintf(tw, "status\tname\tdescription\toutput\terr\tlast_run\n")
+	if err != nil {
+		return nil, errors.Wrap(err, "writing column headers")
+	}
+
+	for _, check := range c.Checks {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			func() string {
+				if check.LastRun.IsZero() {
+					return "PENDING"
+				}
+				if check.CachedCheckErr == nil {
+					return "OK"
+				}
+				return "FAIL"
+			}(),
+			check.Name,
+			check.Description,
+			check.CachedCheckOutput,
+			errString(check.CachedCheckErr),
+			timestampString(check.LastRun),
+		)
+	}
+
+	err = tw.Flush()
+	if err != nil {
+		return nil, errors.Wrap(err, "flushing tabwriter")
+	}
+
+	return bw.Bytes(), nil
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func timestampString(t time.Time) string {
+	if t.IsZero() {
+		return "never"
+	}
+	return t.Format(time.RFC3339)
+}

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1,14 +1,22 @@
 package check
 
 import (
+	"context"
 	"encoding/json"
 	"expvar"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
-// RunFunc returns a valid JSON. The HealthChecker will call json.Marshal on the
-// return value.
-type RunFunc func() any
+// RunFunc returns a valid JSON and an error. The HealthChecker will call
+// json.Marshal on any.
+type RunFunc func(ctx context.Context) (any, error)
 
 type Check struct {
 	// Name should have the prefix "check_".
@@ -24,15 +32,149 @@ type HealthChecker struct {
 	Checks []Check
 }
 
+const timeout = time.Second * 60
+
 func (hc *HealthChecker) Init() {
 	for _, check := range hc.Checks {
 		go func(c Check) {
-			ev := expvar.NewString(c.Name)
+
+			// Each check is represented by an expvar.Map with the fields
+			// - status OK|FAIL|PENDING
+			// - out JSON
+			// - error STRING
+			// - last_run RFC3339 formatted timestamp
+			m := expvar.NewMap(c.Name)
+
+			status := new(expvar.String)
+			status.Set("PENDING")
+			m.Set("status", status)
+
+			out := new(expvar.String)
+			m.Set("out", out)
+
+			checkErr := new(expvar.String)
+			m.Set("error", checkErr)
+
+			lastRun := new(expvar.String)
+			// set to 0 to make it easier for the client to parse.
+			lastRun.Set(time.Time{}.Format(time.RFC3339))
+			m.Set("last_run", lastRun)
+
 			for {
 				time.Sleep(c.Interval)
-				b, _ := json.Marshal(c.Run())
-				ev.Set(string(b))
+
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+
+				res, err := c.Run(ctx)
+				if err != nil {
+					status.Set("FAIL")
+				} else {
+					status.Set("OK")
+				}
+
+				lastRun.Set(time.Now().Format(time.RFC3339))
+
+				checkErr.Set(errString(err))
+
+				b, _ := json.Marshal(res)
+				out.Set(string(b))
 			}
 		}(check)
 	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+type NewHealthChecksHandler func() http.Handler
+
+// NewHealthCheckHandler returns a handler that serves a page just like /vars
+// but filtered for health checks. Each service should expose a /checks
+// endpoint. All /checks endpoints are aggregates by ServeHealthCheckAggregate
+func (hc *HealthChecker) NewHealthCheckHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		fmt.Fprintf(w, "{\n")
+		first := true
+		for _, check := range hc.Checks {
+			if !first {
+				fmt.Fprintf(w, ",\n")
+			}
+			first = false
+
+			v := expvar.Get(check.Name)
+			fmt.Fprintf(w, "%q: %s", check.Name, v.String())
+		}
+		fmt.Fprintf(w, "\n}\n")
+	})
+}
+
+// NewAggregateHealthCheckHandler should only be called in frontend.
+func NewAggregateHealthCheckHandler() http.Handler {
+	services := []string{"frontend"}
+
+	endpoints := func(service string) []*url.URL {
+		switch service {
+		case "frontend":
+			u, err := url.Parse(internalapi.Client.URL)
+			if err != nil {
+				return nil
+			}
+			return []*url.URL{u.ResolveReference(&url.URL{Path: "/.internal/checks"})}
+		default:
+			return nil
+		}
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		fmt.Fprintf(w, "{\n")
+		defer fmt.Fprintf(w, "\n}\n")
+
+		firstService := true
+		for _, service := range services {
+			if !firstService {
+				fmt.Fprintf(w, ",\n")
+			}
+			firstService = false
+
+			fmt.Fprintf(w, "%q: {\n", service)
+
+			firstEndpoint := true
+			for _, endpoint := range endpoints(service) {
+				if !firstEndpoint {
+					fmt.Fprintf(w, ",\n")
+				}
+				firstEndpoint = false
+				req, err := http.NewRequest("GET", endpoint.String(), nil)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+
+				res, err := httpcli.InternalDoer.Do(req)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+
+				defer res.Body.Close()
+				b, err := io.ReadAll(res.Body)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+
+				fmt.Fprintf(w, "%q: %s\n", endpoint.Host, b)
+			}
+
+			fmt.Fprintf(w, "\n}\n")
+		}
+	})
 }

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -149,7 +149,7 @@ func DefaultEndpointProvider(service string) []*url.URL {
 // While it is not necessary to add newlines to the JSON output, it is really
 // convenient for grepping from the command line.
 func NewAggregateHealthCheckHandler(endpointProvider func(service string) []*url.URL) http.Handler {
-	services := []string{"frontend", "searcher"}
+	services := []string{"frontend"}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -99,8 +99,7 @@ func errString(err error) string {
 }
 
 // ServeHTTP serves a page just like /vars but filtered for health checks. Each
-// service should expose a /checks endpoint. All /checks endpoints are
-// aggregated by ServeHealthCheckAggregate
+// service should expose a /checks endpoint.
 func (hc *HealthChecker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	fmt.Fprintf(w, "{\n")

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -118,6 +118,7 @@ func (hc *HealthChecker) NewHealthCheckHandler() http.Handler {
 func NewAggregateHealthCheckHandler() http.Handler {
 	services := []string{"frontend"}
 
+	// TODO: How can we reach ALL frontends?
 	endpoints := func(service string) []*url.URL {
 		switch service {
 		case "frontend":

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1,174 +1,38 @@
 package check
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"runtime"
-	"strconv"
-	"sync"
-	"text/tabwriter"
+	"expvar"
 	"time"
-
-	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"golang.org/x/sync/semaphore"
 )
 
-type RunFunc func(ctx context.Context) (string, error)
+// RunFunc returns a valid JSON. The HealthChecker will call json.Marshal on the
+// return value.
+type RunFunc func() any
 
 type Check struct {
-	Name        string
-	Description string
+	// Name should have the prefix "check_".
+	Name string
+
+	// How often the check runs.
+	Interval time.Duration
 
 	Run RunFunc
-
-	LastRun           time.Time
-	CachedCheckErr    error
-	CachedCheckOutput string
-}
-
-func (c *Check) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		Name              string    `json:"name"`
-		Description       string    `json:"description"`
-		LastRun           time.Time `json:"last_run"`
-		CachedCheckErr    string    `json:"cached_check_err"`
-		CachedCheckOutput string    `json:"cached_check_output"`
-	}{
-		Name:              c.Name,
-		Description:       c.Description,
-		LastRun:           c.LastRun,
-		CachedCheckErr:    errString(c.CachedCheckErr),
-		CachedCheckOutput: c.CachedCheckOutput,
-	})
 }
 
 type HealthChecker struct {
-	mu     sync.Mutex
 	Checks []Check
 }
 
-func (c *HealthChecker) MarshalJSON() ([]byte, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return json.Marshal(c.Checks)
-}
-
-func (c *HealthChecker) Run() {
-	for {
-		time.Sleep(60 * time.Second)
-		c.doRun()
+func (hc *HealthChecker) Init() {
+	for _, check := range hc.Checks {
+		go func(c Check) {
+			ev := expvar.NewString(c.Name)
+			for {
+				time.Sleep(c.Interval)
+				b, _ := json.Marshal(c.Run())
+				ev.Set(string(b))
+			}
+		}(check)
 	}
-}
-
-func (c *HealthChecker) doRun() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-
-	sem := semaphore.NewWeighted(int64(runtime.GOMAXPROCS(0)))
-	wg := sync.WaitGroup{}
-
-	for i, check := range c.Checks {
-		err := sem.Acquire(ctx, 1)
-		if err != nil {
-			return
-		}
-		wg.Add(1)
-		go func(i int, check Check) {
-			defer sem.Release(1)
-			defer wg.Done()
-
-			check.CachedCheckOutput, check.CachedCheckErr = check.Run(ctx)
-			check.LastRun = time.Now().UTC()
-
-			c.mu.Lock()
-			c.Checks[i] = check
-			c.mu.Unlock()
-		}(i, check)
-	}
-	wg.Wait()
-}
-
-func (c *HealthChecker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch r.Header.Get("Accept") {
-	case "application/json":
-		out, err := json.Marshal(c)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("failed to marshal: %s", err), http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Content-Length", strconv.Itoa(len(out)))
-
-		w.Write(out)
-
-	default:
-		out, err := c.RenderTable()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("failed to render plain text table: %s", err), http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Type", "text/plain")
-		w.Header().Set("Content-Length", strconv.Itoa(len(out)))
-
-		w.Write(out)
-	}
-}
-
-func (c *HealthChecker) RenderTable() ([]byte, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	bw := bytes.Buffer{}
-	tw := tabwriter.NewWriter(&bw, 16, 8, 4, ' ', 0)
-
-	_, err := fmt.Fprintf(tw, "status\tname\tdescription\toutput\terr\tlast_run\n")
-	if err != nil {
-		return nil, errors.Wrap(err, "writing column headers")
-	}
-
-	for _, check := range c.Checks {
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			func() string {
-				if check.LastRun.IsZero() {
-					return "PENDING"
-				}
-				if check.CachedCheckErr == nil {
-					return "OK"
-				}
-				return "FAIL"
-			}(),
-			check.Name,
-			check.Description,
-			check.CachedCheckOutput,
-			errString(check.CachedCheckErr),
-			timestampString(check.LastRun),
-		)
-	}
-
-	err = tw.Flush()
-	if err != nil {
-		return nil, errors.Wrap(err, "flushing tabwriter")
-	}
-
-	return bw.Bytes(), nil
-}
-
-func errString(err error) string {
-	if err == nil {
-		return ""
-	}
-	return err.Error()
-}
-
-func timestampString(t time.Time) string {
-	if t.IsZero() {
-		return "never"
-	}
-	return t.Format(time.RFC3339)
 }

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -147,6 +147,9 @@ func DefaultEndpointProvider(service string) []*url.URL {
 // }
 //
 // The handler should only be used in frontend.
+//
+// While it is not necessary to add newlines to the JSON output, it is really
+// convenient for grepping from the command line.
 func NewAggregateHealthCheckHandler(endpointProvider func(service string) []*url.URL) http.Handler {
 	services := []string{"frontend", "searcher"}
 


### PR DESCRIPTION
This PR introduces the package `checks`. The package provides a comon framework for defining and consuming health checks across services.

### Overview
- Each service defines its own checks. Checks have the format `func(ctx context.Context) (any, error)`
- Checks are run in the background. The frequency is configurable.
- Each service exposes a /checks endpoint on its default port. The endpoint returns a JSON with a fixed format. This is an example of how a reponse from `GET <frontend>/.internal/checks` looks like:
```shell
# /checks
{
  "check_can_reach_gitserver": {
    "error": "",
    "last_run": "2022-06-30T13:01:45Z",
    "out": "[{\"addr\":\"127.0.0.1:3178\",\"out\":\"\"}]",
    "status": "OK"
  },
  "check_dummy": {
    "error": "",
    "last_run": "2022-06-30T13:02:05Z",
    "out": "{\"Time\":\"2022-06-30T13:02:05.815109Z\",\"Msg\":\"hello\"}",
    "status": "OK"
  }
}

```

- Frontend plays a special role. It exposes a second endpoint that aggregates checks from all services, including frontend itself. The checks are grouped by service > address > check:
```shell
# /aggregate-checks
{
  "frontend": {
    "localhost:3090": {
      "check_can_reach_gitserver": {
        "error": "",
        "last_run": "0001-01-01T00:00:00Z",
        "out": "",
        "status": "PENDING"
      },
      "check_dummy": {
        "error": "",
        "last_run": "2022-06-30T13:01:25Z",
        "out": "{\"Time\":\"2022-06-30T13:01:25.811925Z\",\"Msg\":\"hello\"}",
        "status": "OK"
      }
    }
  }
}
```

- frontend serves the aggregate endpoint under /debug/aggregate-checks. This way it is reachable under port :6060 within the container
- We avoid the debug port :6060 for other services because we cannot guarantee that it is reachable from frontend in every environment. 
- /checks enpoints
  - frontend: /.internal/checks
  - gitserver: /checks  
  - zoekt-webserver: /checks
  - searcher: /checks
  - TBD

### How can an admin access the health checks?
In the first version, admins can access the frontend container and curl the aggregate endpoint on the debug port :6060. In the future we might want to expose the data via the GraphQL API and make it consumable from the site admin interface.

### Test Plan
```shell
sg start
curl http://localhost:3090/.internal/checks -sS | jq
curl http://localhost:6063/aggregate-checks -sS | jq 
```


