### PR TITLE
web: document known client flakes and tips to fix them

### DIFF
--- a/doc/dev/background-information/ci/index.md
+++ b/doc/dev/background-information/ci/index.md
@@ -148,6 +148,42 @@ An example use of `Skip`:
  }
 ```
 
+##### Assessing flaky client steps
+
+The breakdown of known client flakes by type with resolution tips:
+
+###### Visual regression flakes
+
+_Problem:_ Percy’s pixel sensitivity is too high, and we cannot relax it further which means that SVG rendering can be flaky.
+_Solution:_ Snapshot these pages in Chromatic or hide flaky elements from Percy using the `.percy-hide` class name.
+
+_Problem:_ UI depends on the date and time, which are not appropriately mocked.
+_Solution:_ Mock the date and time properly in your integration test or Storybook story.
+
+_Problem:_ Mocks are not configured correctly, resulting in flaky error messages in UI.
+_Solution:_ Double-check mocks required for rendering the snapshotted UI.
+
+_Problem:_ The screenshot is taken without waiting for the UI to settle down. E.g., a snapshot taken after clicking an input element doesn’t wait for the focus state on it.
+_Solution:_ Wait for the UI to settle using tools provided by Puppeteer.
+
+###### Visual regression flakes caused by test logic
+
+_Problem examples:_
+
+1. `Navigation timeout of 30000 ms exceeded.`
+2. `Error: GraphQL query "XXX" has no configured mock response. Make sure the call to overrideGraphQL() includes a result for the "XXX" query.`
+
+_Solution:_ These should be disabled immediately and fixed later by owning teams.
+
+###### Percy outages
+
+_Problem:_ Percy API outages result into
+
+1. HTTP requests to upload screenshots fail with internal server errors.
+2. HTTP requests to upload screenshots fail with errors about duplicated snapshot names. `[percy] Error: The name of each snapshot must be unique, and this name already exists in the build`
+
+_Solution:_ Wait for the Percy infrastructure to come back to life and restart the build. 🥲
+
 ##### Flaky infrastructure
 
 If the [build or test infrastructure itself is flaky](https://handbook.sourcegraph.com/departments/product-engineering/engineering/enablement/dev-experience#build-pipeline-support), then [open an issue with the `team/devx` label](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/devx) and notify the [Developer Experience team](https://handbook.sourcegraph.com/departments/product-engineering/engineering/enablement/dev-experience#contact).

--- a/doc/dev/background-information/ci/index.md
+++ b/doc/dev/background-information/ci/index.md
@@ -150,39 +150,7 @@ An example use of `Skip`:
 
 ##### Assessing flaky client steps
 
-The breakdown of known client flakes by type with resolution tips:
-
-###### Visual regression flakes
-
-_Problem:_ Percy’s pixel sensitivity is too high, and we cannot relax it further which means that SVG rendering can be flaky.
-_Solution:_ Snapshot these pages in Chromatic or hide flaky elements from Percy using the `.percy-hide` class name.
-
-_Problem:_ UI depends on the date and time, which are not appropriately mocked.
-_Solution:_ Mock the date and time properly in your integration test or Storybook story.
-
-_Problem:_ Mocks are not configured correctly, resulting in flaky error messages in UI.
-_Solution:_ Double-check mocks required for rendering the snapshotted UI.
-
-_Problem:_ The screenshot is taken without waiting for the UI to settle down. E.g., a snapshot taken after clicking an input element doesn’t wait for the focus state on it.
-_Solution:_ Wait for the UI to settle using tools provided by Puppeteer.
-
-###### Visual regression flakes caused by test logic
-
-_Problem examples:_
-
-1. `Navigation timeout of 30000 ms exceeded.`
-2. `Error: GraphQL query "XXX" has no configured mock response. Make sure the call to overrideGraphQL() includes a result for the "XXX" query.`
-
-_Solution:_ These should be disabled immediately and fixed later by owning teams.
-
-###### Percy outages
-
-_Problem:_ Percy API outages result into
-
-1. HTTP requests to upload screenshots fail with internal server errors.
-2. HTTP requests to upload screenshots fail with errors about duplicated snapshot names. `[percy] Error: The name of each snapshot must be unique, and this name already exists in the build`
-
-_Solution:_ Wait for the Percy infrastructure to come back to life and restart the build. 🥲
+See more information on how to assess flaky client steps [here](../../how-to/testing.md#assessing-flaky-client-steps).
 
 ##### Flaky infrastructure
 

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -421,14 +421,14 @@ If, for whatever reason, we have to ignore some elements from an accessibility a
 
 We run Lighthouse performance tests through [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci). These tests are relatively hands-off and run a series of Lighthouse audits against a deployed server. The flow for running these tests is:
 
-
 #### Running the tests locally
+
 1. Create a production bundle that can be served locally. `NODE_ENV=production WEBPACK_SERVE_INDEX=true yarn workspace @sourcegraph/web build`
 2. Run the Lighthouse CI tests. `yarn test-lighthouse`. This will automatically serve the production bundle and start running audits through Puppeteer. Note: It's possible to provide different URLs or config through editing `lighthouserc.js` or by providing CLI flags to this command.
 
 #### Running the tests in CI
-The CI flow is quite similar to the local flow, the main difference is that we provide some additional flags to Lighthouse. We provide a specific URL for each parallel step, and we add some additional config to support reporting results back to GitHub PRs as status checks.
 
+The CI flow is quite similar to the local flow, the main difference is that we provide some additional flags to Lighthouse. We provide a specific URL for each parallel step, and we add some additional config to support reporting results back to GitHub PRs as status checks.
 
 ### Bundlesize
 
@@ -442,3 +442,39 @@ If `Bundlesize` fails, it is likely because one of the generated bundles has gon
 2. That you are not using dependencies that are potentially too large to be suitable for our application. Tip: Use [Bundlephobia](https://bundlephobia.com) to help find the size of an npm dependency.
 
 If none of the above is applicable, we might need to consider adjusting our limits. Please start a discussion with @sourcegraph/frontend-devs before doing this!
+
+### Assessing flaky client steps
+
+The breakdown of known client flakes by type with resolution tips:
+
+#### Visual regression flakes
+
+_Problem:_ Percy’s pixel sensitivity is too high, and we cannot relax it further which means that SVG rendering can be flaky.
+_Solution:_ Snapshot these pages in Chromatic or hide flaky elements from Percy using the `.percy-hide` class name.
+
+_Problem:_ UI depends on the date and time, which are not appropriately mocked.
+_Solution:_ Mock the date and time properly in your integration test or Storybook story.
+
+_Problem:_ Mocks are not configured correctly, resulting in flaky error messages in UI.
+_Solution:_ Double-check mocks required for rendering the snapshotted UI.
+
+_Problem:_ The screenshot is taken without waiting for the UI to settle down. E.g., a snapshot taken after clicking an input element doesn’t wait for the focus state on it.
+_Solution:_ Wait for the UI to settle using tools provided by Puppeteer.
+
+#### Visual regression flakes caused by test logic
+
+_Problem examples:_
+
+1. `Navigation timeout of 30000 ms exceeded.`
+2. `Error: GraphQL query "XXX" has no configured mock response. Make sure the call to overrideGraphQL() includes a result for the "XXX" query.`
+
+_Solution:_ These should be disabled immediately and fixed later by owning teams.
+
+#### Percy outages
+
+_Problem:_ Percy API outages result into
+
+1. HTTP requests to upload screenshots fail with internal server errors.
+2. HTTP requests to upload screenshots fail with errors about duplicated snapshot names. `[percy] Error: The name of each snapshot must be unique, and this name already exists in the build`
+
+_Solution:_ Wait for the Percy infrastructure to come back to life and restart the build. 🥲


### PR DESCRIPTION
## Context

It's tricky to find the root causes of CI client flakes. This PR documents the most frequent scenarios, along with tips on how to fix them. We can add the flaky-tests documentation link to the Builkite failure Slack messages to keep it on engineers' radar when they bump into flakes on the `main` branch.

Closes https://github.com/sourcegraph/sourcegraph/issues/37665

## Test plan

N/A — documentation update.
