### PR TITLE
search frontend: highlight regex-delimited patterns

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1486,8 +1486,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('highlight repo:dependencies predicate', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:dependencies(.*)')))).toMatchInlineSnapshot(
-            `
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:dependencies(.*)')))).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -1518,7 +1517,42 @@ describe('getMonacoTokens()', () => {
                 "scopes": "metaPredicateParenthesis"
               }
             ]
-        `
-        )
+        `)
+    })
+
+    test('highlight regex delimited pattern for standard search', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('/f.*/ x', false, SearchPatternType.standard))))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "metaRegexpDelimited"
+              },
+              {
+                "startIndex": 1,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "metaRegexpRangeQuantifier"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaRegexpDelimited"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "identifier"
+              }
+            ]
+        `)
     })
 })

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -235,9 +235,26 @@ const coalescePatterns = (tokens: DecoratedToken[]): DecoratedToken[] => {
 
 const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] | undefined => {
     const tokens: DecoratedToken[] = []
+
+    if (pattern.delimited) {
+        tokens.push({
+            type: 'metaRegexp',
+            range: { start: pattern.range.start, end: pattern.range.start + 1 },
+            value: '/',
+            kind: MetaRegexpKind.Delimited,
+        })
+        tokens.push({
+            type: 'metaRegexp',
+            range: { start: pattern.range.end - 1, end: pattern.range.end },
+            value: '/',
+            kind: MetaRegexpKind.Delimited,
+        })
+    }
+
+    const offset = pattern.delimited ? pattern.range.start + 1 : pattern.range.start
+
     try {
         const ast = new RegExpParser().parsePattern(pattern.value)
-        const offset = pattern.range.start
         visitRegExpAST(ast, {
             onAlternativeEnter(node: Alternative) {
                 // regexpp doesn't tell us where a '|' operator is. We infer it by visiting any

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -186,7 +186,7 @@ describe('getHoverResult()', () => {
             {
               "contents": [
                 {
-                  "value": "**Group**. Groups together multiple expressions to match."
+                  "value": "**Delimiter**. Delimits regular expressions to match."
                 }
               ],
               "range": {

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -60,7 +60,7 @@ const toRegexpHover = (token: MetaRegexp): string => {
         case MetaRegexpKind.CharacterClassMember:
             return `**Character**. This character class matches the character \`${token.value}\`.`
         case MetaRegexpKind.Delimited:
-            return '**Group**. Groups together multiple expressions to match.'
+            return '**Delimiter**. Delimits regular expressions to match.'
         case MetaRegexpKind.EscapedCharacter: {
             const escapable = '~`!@#$%^&*()[]{}<>,.?/\\|=+-_'
             let description = escapable.includes(token.value[1])


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/37912.

Now that the tokens carry extra state, it's easy to case out when the syntax allows a regex pattern like this:

![Screen Shot 2022-06-28 at 10 05 47 PM](https://user-images.githubusercontent.com/888624/176356549-801874bf-dfb3-4789-9792-f424fd86c40e.png)

Along with this change I'm making the decision to classify the slashes in `/.../` to be the same as parens in regex capture groups `(...)` since for the most part they "mean" the same from a search perspective. This makes it easier to just reuse existing Token definition and hovers with a slight rephrase. I'm treating this as soft intermediate step, and will follow up with separating `(...)` and `/.../` as a lower-priority issue.

## Test plan


## App preview:

- [Web](https://sg-web-rvt-highlight-regex-3.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ldlhxnotxz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

