### PR TITLE
NPS Survey: Update question wording

### DIFF
--- a/client/web/src/marketing/components/SurveyUseCaseForm.tsx
+++ b/client/web/src/marketing/components/SurveyUseCaseForm.tsx
@@ -102,7 +102,7 @@ export const SurveyUseCaseForm: React.FunctionComponent<SurveyUseCaseFormProps> 
                     containerClassName="mt-3"
                     label={
                         <Text size="small" className={formLabelClassName}>
-                            What else are you using Sourcegraph to do?
+                            What else do you use Sourcegraph to do?
                         </Text>
                     }
                     onChange={event => onChangeOtherUseCase(event.target.value)}
@@ -113,7 +113,7 @@ export const SurveyUseCaseForm: React.FunctionComponent<SurveyUseCaseFormProps> 
                 containerClassName="mt-3"
                 label={
                     <Text size="small" className={formLabelClassName}>
-                        What can Sourcegraph do to provide a better product?
+                        What would make Sourcegraph better?
                     </Text>
                 }
                 onChange={event => onChangeBetter(event.target.value)}

--- a/client/web/src/marketing/page/SurveyForm.tsx
+++ b/client/web/src/marketing/page/SurveyForm.tsx
@@ -105,7 +105,7 @@ export const SurveyForm: React.FunctionComponent<React.PropsWithChildren<SurveyF
                 className="my-2"
                 authenticatedUser={authenticatedUser}
                 formLabelClassName={styles.label}
-                title="You are using Sourcegraph to..."
+                title="You use Sourcegraph to..."
                 useCases={useCases}
                 onChangeUseCases={setUseCases}
                 otherUseCase={otherUseCase}

--- a/client/web/src/marketing/page/SurveyPage.test.tsx
+++ b/client/web/src/marketing/page/SurveyPage.test.tsx
@@ -52,7 +52,7 @@ describe('SurveyPage', () => {
             const score10 = within(recommendRadioGroup).getByLabelText(mockVariables.score)
             fireEvent.click(score10)
 
-            const reasonInput = renderResult.getByLabelText('What can Sourcegraph do to provide a better product?')
+            const reasonInput = renderResult.getByLabelText('What would make Sourcegraph better?')
             expect(reasonInput).toBeVisible()
             fireEvent.change(reasonInput, { target: { value: mockVariables.better } })
 
@@ -63,7 +63,7 @@ describe('SurveyPage', () => {
             const otherUseCaseCheckbox = renderResult.getByLabelText('Other')
             fireEvent.click(otherUseCaseCheckbox)
 
-            const otherUseCaseInput = renderResult.getByLabelText('What else are you using Sourcegraph to do?')
+            const otherUseCaseInput = renderResult.getByLabelText('What else do you use Sourcegraph to do?')
             expect(otherUseCaseInput).toBeVisible()
 
             fireEvent.change(otherUseCaseInput, { target: { value: mockVariables.otherUseCase } })

--- a/client/web/src/marketing/toast/SurveyToast.test.tsx
+++ b/client/web/src/marketing/toast/SurveyToast.test.tsx
@@ -112,7 +112,7 @@ describe('SurveyToast', () => {
                 const continueButton = renderResult.getByRole('button', { name: 'Continue' })
                 expect(continueButton).toBeVisible()
                 fireEvent.click(continueButton)
-                expect(renderResult.getByText('You are using Sourcegraph to...')).toBeVisible()
+                expect(renderResult.getByText('You use Sourcegraph to...')).toBeVisible()
             })
         })
 
@@ -207,7 +207,7 @@ describe('SurveyToast', () => {
 
             const continueButton = renderResult.getByRole('button', { name: 'Continue' })
             fireEvent.click(continueButton)
-            expect(renderResult.getByText('You are using Sourcegraph to...')).toBeVisible()
+            expect(renderResult.getByText('You use Sourcegraph to...')).toBeVisible()
         }
 
         beforeEach(() => moveToUseCaseForm())
@@ -218,18 +218,18 @@ describe('SurveyToast', () => {
                     expect(renderResult.getByLabelText(labelValue)).toBeVisible()
                 })
             }
-            expect(renderResult.getByLabelText('What can Sourcegraph do to provide a better product?')).toBeVisible()
+            expect(renderResult.getByLabelText('What would make Sourcegraph better?')).toBeVisible()
         })
 
         it('Should allow user to provide arbitrary use case', () => {
             const otherUseCaseElement = renderResult.getByLabelText('Other')
             fireEvent.click(otherUseCaseElement)
 
-            expect(renderResult.getByLabelText('What else are you using Sourcegraph to do?')).toBeVisible()
+            expect(renderResult.getByLabelText('What else do you use Sourcegraph to do?')).toBeVisible()
         })
 
         it('Should show some gratitude after usecase submission', async () => {
-            const reasonInput = renderResult.getByLabelText('What can Sourcegraph do to provide a better product?')
+            const reasonInput = renderResult.getByLabelText('What would make Sourcegraph better?')
             expect(reasonInput).toBeVisible()
             fireEvent.change(reasonInput, { target: { value: mockVariables.better } })
 
@@ -240,7 +240,7 @@ describe('SurveyToast', () => {
             const otherUseCaseCheckbox = renderResult.getByLabelText('Other')
             fireEvent.click(otherUseCaseCheckbox)
 
-            const otherUseCaseInput = renderResult.getByLabelText('What else are you using Sourcegraph to do?')
+            const otherUseCaseInput = renderResult.getByLabelText('What else do you use Sourcegraph to do?')
             expect(otherUseCaseInput).toBeVisible()
 
             fireEvent.change(otherUseCaseInput, { target: { value: mockVariables.otherUseCase } })

--- a/client/web/src/marketing/toast/SurveyUseCaseToast.tsx
+++ b/client/web/src/marketing/toast/SurveyUseCaseToast.tsx
@@ -46,7 +46,7 @@ export const SurveyUseCaseToast: React.FunctionComponent<SurveyUseCaseFormToastP
         toastContentClassName="mt-0"
         cta={
             <SurveyUseCaseForm
-                title="You are using Sourcegraph to..."
+                title="You use Sourcegraph to..."
                 authenticatedUser={authenticatedUser}
                 useCases={useCases}
                 onChangeUseCases={onChangeUseCases}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1058,7 +1058,7 @@ type RandomizeUserPasswordResult {
 }
 
 """
-Possible answers to "You are using Sourcegraph to..." in the NPS Survey.
+Possible answers to "You use Sourcegraph to..." in the NPS Survey.
 """
 enum SurveyUseCase {
     UNDERSTAND_NEW_CODE
@@ -1082,15 +1082,15 @@ input SurveySubmissionInput {
     """
     score: Int!
     """
-    The answer to "You are using Sourcegraph to...".
+    The answer to "You use Sourcegraph to...".
     """
     useCases: [SurveyUseCase!]
     """
-    The answer to "What else are you using Sourcegraph to do?".
+    The answer to "What else do you use Sourcegraph to do?".
     """
     otherUseCase: String
     """
-    The answer to "What can Sourcegraph do to provide a better product?"
+    The answer to "What would make Sourcegraph better?"
     """
     better: String
 }
@@ -5990,11 +5990,11 @@ type SurveyResponse {
     """
     better: String
     """
-    The answer to "You are using Sourcegraph to...".
+    The answer to "You use Sourcegraph to...".
     """
     useCases: [SurveyUseCase!]
     """
-    The answer to "What else are you using Sourcegraph to do?".
+    The answer to "What else do you use Sourcegraph to do?".
     """
     otherUseCase: String
     """

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -79,9 +79,9 @@ type SurveySubmissionInput struct {
 	Email *string
 	// Score is the user's likelihood of recommending Sourcegraph to a friend, from 0-10.
 	Score int32
-	// UseCases is the answer to "You are using Sourcegraph to...".
+	// UseCases is the answer to "You use Sourcegraph to...".
 	UseCases *[]string
-	// OtherUseCase is the answer to "What else are you using Sourcegraph to do?".
+	// OtherUseCase is the answer to "What else do you use Sourcegraph to do?".
 	OtherUseCase *string
 	// Better is the answer to "What can Sourcegraph do to provide a better product"
 	Better *string


### PR DESCRIPTION
## Description

Updates wording:

**Focusing on general usage rather than immediate usage**:
`You are using Sourcegraph to...` -> `You use Sourcegraph to...`
`What else are you using Sourcegraph to do?` -> `What else do you use Sourcegraph to do?`

**Simpler request for improvement feedback**
`What can Sourcegraph do to provide a better product?` -> `What would make Sourcegraph better?`

## Test plan

Checked locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
