### PR TITLE
database: don't ignore unknown sub expressions in alternate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- A bug where some complex `repo:` regexes only returned a subset of repository results. [#37925](https://github.com/sourcegraph/sourcegraph/pull/37925)
 
 ### Removed
 

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1676,9 +1676,13 @@ func allMatchingStrings(re *regexpsyntax.Regexp) (exact, contains, prefix, suffi
 			if isDotStar(sub) && i == len(re.Sub)-1 {
 				subcontains = []string{""}
 			} else {
-				subexact, subcontains, _, _, err = allMatchingStrings(sub)
+				var subprefix, subsuffix []string
+				subexact, subcontains, subprefix, subsuffix, err = allMatchingStrings(sub)
 				if err != nil {
 					return nil, nil, nil, nil, err
+				}
+				if subprefix != nil || subsuffix != nil {
+					return nil, nil, nil, nil, nil
 				}
 			}
 			if subexact == nil && subcontains == nil {
@@ -1729,6 +1733,10 @@ func allMatchingStrings(re *regexpsyntax.Regexp) (exact, contains, prefix, suffi
 			subexact, subcontains, subprefix, subsuffix, err := allMatchingStrings(sub)
 			if err != nil {
 				return nil, nil, nil, nil, err
+			}
+			// If we don't understand one sub expression, we give up.
+			if subexact == nil && subcontains == nil && subprefix == nil && subsuffix == nil {
+				return nil, nil, nil, nil, nil
 			}
 			exact = append(exact, subexact...)
 			contains = append(contains, subcontains...)

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -79,6 +79,12 @@ func TestParseIncludePattern(t *testing.T) {
 			exact: []string{"github.com/sourcegraph/sourcegraph", "github.com/sourcegraph/sourcegraph-atom"},
 		},
 
+		// Ensure we don't lose foo/.*. In the past we returned exact for bar only.
+		`(^foo/.+$|^bar$)`:     {regexp: `(^foo/.+$|^bar$)`},
+		`^foo/.+$|^bar$`:       {regexp: `^foo/.+$|^bar$`},
+		`((^foo/.+$)|(^bar$))`: {regexp: `((^foo/.+$)|(^bar$))`},
+		`((^foo/.+)|(^bar$))`:  {regexp: `((^foo/.+)|(^bar$))`},
+
 		`(^github\.com/Microsoft/vscode$)|(^github\.com/sourcegraph/go-langserver$)`: {
 			exact: []string{"github.com/Microsoft/vscode", "github.com/sourcegraph/go-langserver"},
 		},


### PR DESCRIPTION
A customer was running into an issue where we didn't search all
repositories. They were using a more complicated regexp query for the
repo clause. The root cause was we ignored parts of the sub expression.
This commit makes us fallback to just using postgres's regex engine in
those cases.

This code really does need a rewrite, I can think up many cases where it
breaks. However, it has been running without much reports for a long
time so I just fixed this for now.

Test Plan: unit test added

plz-review-url: https://plz.review/review/6591