### PR TITLE
JetBrains: Escape inside the web view with a dropdown open should not close the window

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -7,6 +7,7 @@ import com.intellij.ui.jcef.JBCefJSQuery;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.ThemeUtil;
 import com.sourcegraph.find.FindPopupPanel;
+import com.sourcegraph.find.FindService;
 import com.sourcegraph.find.PreviewContent;
 import com.sourcegraph.find.Search;
 import org.jetbrains.annotations.NotNull;
@@ -21,10 +22,12 @@ import java.util.Date;
 public class JSToJavaBridgeRequestHandler {
     private final Project project;
     private final FindPopupPanel findPopupPanel;
+    private final FindService findService;
 
-    public JSToJavaBridgeRequestHandler(@NotNull Project project, @NotNull FindPopupPanel findPopupPanel) {
+    public JSToJavaBridgeRequestHandler(@NotNull Project project, @NotNull FindPopupPanel findPopupPanel, @NotNull FindService findService) {
         this.project = project;
         this.findPopupPanel = findPopupPanel;
+        this.findService = findService;
     }
 
     public JBCefJSQuery.Response handle(@NotNull JsonObject request) {
@@ -97,6 +100,9 @@ public class JSToJavaBridgeRequestHandler {
                     return createSuccessResponse(null);
                 case "indicateFinishedLoading":
                     findPopupPanel.setBrowserVisible(true);
+                    return createSuccessResponse(null);
+                case "windowClose":
+                    ApplicationManager.getApplication().invokeLater(() -> findService.hidePopup());
                     return createSuccessResponse(null);
                 default:
                     return createErrorResponse("Unknown action: '" + action + "'.", "No stack trace");

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -28,7 +28,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
     private final SelectionMetadataPanel selectionMetadataPanel;
     private Date lastPreviewUpdate;
 
-    public FindPopupPanel(@NotNull Project project) {
+    public FindPopupPanel(@NotNull Project project, @NotNull FindService findService) {
         super(new BorderLayout());
 
         setPreferredSize(JBUI.size(1200, 800));
@@ -46,7 +46,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         bottomPanel.add(previewPanel, BorderLayout.CENTER);
 
         browserAndLoadingPanel = new BrowserAndLoadingPanel();
-        JSToJavaBridgeRequestHandler requestHandler = new JSToJavaBridgeRequestHandler(project, this);
+        JSToJavaBridgeRequestHandler requestHandler = new JSToJavaBridgeRequestHandler(project, this, findService);
         browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(requestHandler) : null;
         if (browser != null) {
             browserAndLoadingPanel.setBrowser(browser);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -8,9 +8,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ex.WindowManagerEx;
 import com.intellij.util.ui.UIUtil;
-import org.cef.browser.CefBrowser;
-import org.cef.handler.CefKeyboardHandler;
-import org.cef.misc.BoolRef;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
@@ -30,7 +27,7 @@ public class FindService implements Disposable {
         this.project = project;
 
         // Create main panel
-        mainPanel = new FindPopupPanel(project);
+        mainPanel = new FindPopupPanel(project, this);
     }
 
     synchronized public void showPopup() {
@@ -57,10 +54,9 @@ public class FindService implements Disposable {
         } else {
             popup = new FindPopupDialog(project, mainPanel);
 
-            // We add a manual listener to both the global key handler (since the editor component seems to work around
-            // the default swing event handler) and the browser panel which seems to handle events in a separate queue.
+            // We add a manual listener to the global key handler since the editor component seems to work around the
+            // default swing event handler.
             registerGlobalKeyListeners();
-            registerJBCefClientKeyListeners();
 
             // We also need to detect when the main IDE frame or another popup inside the project gets focus and close
             // the Sourcegraph window accordingly.
@@ -75,36 +71,17 @@ public class FindService implements Disposable {
                     return false;
                 }
 
-                return handleKeyPress(false, e.getKeyCode(), e.getModifiersEx());
+                return handleKeyPress(e.getKeyCode(), e.getModifiersEx());
             });
     }
 
-    private void registerJBCefClientKeyListeners() {
-        if (mainPanel.getBrowser() == null) {
-            logger.error("Browser panel is null");
-            return;
-        }
-
-        mainPanel.getBrowser().getJBCefClient().addKeyboardHandler(new CefKeyboardHandler() {
-            @Override
-            public boolean onPreKeyEvent(CefBrowser browser, CefKeyEvent event, BoolRef is_keyboard_shortcut) {
-                return false;
-            }
-
-            @Override
-            public boolean onKeyEvent(CefBrowser browser, CefKeyEvent event) {
-                return handleKeyPress(true, event.windows_key_code, event.modifiers);
-            }
-        }, mainPanel.getBrowser().getCefBrowser());
-    }
-
-    private boolean handleKeyPress(boolean isWebView, int keyCode, int modifiers) {
+    private boolean handleKeyPress(int keyCode, int modifiers) {
         if (keyCode == KeyEvent.VK_ESCAPE && modifiers == 0) {
             ApplicationManager.getApplication().invokeLater(this::hidePopup);
             return true;
         }
 
-        if (!isWebView && keyCode == KeyEvent.VK_ENTER && (modifiers & ALT_DOWN_MASK) == ALT_DOWN_MASK) {
+        if (keyCode == KeyEvent.VK_ENTER && (modifiers & ALT_DOWN_MASK) == ALT_DOWN_MASK) {
             if (mainPanel.getPreviewPanel() != null && mainPanel.getPreviewPanel().getPreviewContent() != null) {
                 ApplicationManager.getApplication().invokeLater(() -> {
                     try {

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -55,7 +55,7 @@ public class FindService implements Disposable {
             popup = new FindPopupDialog(project, mainPanel);
 
             // We add a manual listener to the global key handler since the editor component seems to work around the
-            // default swing event handler.
+            // default Swing event handler.
             registerGlobalKeyListeners();
 
             // We also need to detect when the main IDE frame or another popup inside the project gets focus and close

--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -137,6 +137,12 @@ function handleRequest(
             break
         }
 
+        case 'windowClose': {
+            console.log('Closing window')
+            onSuccessCallback('null')
+            break
+        }
+
         default: {
             const exhaustiveCheck: never = action
             onFailureCallback(2, `Unknown action: ${exhaustiveCheck as string}`)

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -27,6 +27,7 @@ import { getAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
 import { initializeSourcegraphSettings } from '../sourcegraphSettings'
 import { EventLogger } from '../telemetry/EventLogger'
 
+import { GlobalKeyboardListeners } from './GlobalKeyboardListeners'
 import { JetBrainsSearchBox } from './input/JetBrainsSearchBox'
 import { saveLastSearch } from './js-to-java-bridge'
 import { SearchResultList } from './results/SearchResultList'
@@ -222,6 +223,7 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
 
     return (
         <WildcardThemeContext.Provider value={{ isBranded: true }}>
+            <GlobalKeyboardListeners />
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
             <div className={styles.root} onMouseDown={preventAll}>
                 <div className={styles.searchBoxContainer}>

--- a/client/jetbrains/webview/src/search/GlobalKeyboardListeners.ts
+++ b/client/jetbrains/webview/src/search/GlobalKeyboardListeners.ts
@@ -7,7 +7,7 @@ const CAPTURE_PHASE = { capture: true }
 export const GlobalKeyboardListeners: React.FunctionComponent<{}> = () => {
     const handleKeyDown = useCallback((event: KeyboardEvent) => {
         if (event.key === 'Escape' && !event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey) {
-            if (isJetBrainsDropdownOpen()) {
+            if (isAnyDropdownOpen()) {
                 return
             }
 
@@ -18,7 +18,7 @@ export const GlobalKeyboardListeners: React.FunctionComponent<{}> = () => {
     }, [])
 
     useEffect(() => {
-        // We're adding listeners to the capture phase to be able to exermine the dropdown status before the event is
+        // We're adding listeners to the capture phase to be able to examine the dropdown status before the event is
         // propagated and the dropdown is closed.
         document.addEventListener('keydown', handleKeyDown, CAPTURE_PHASE)
         return () => document.removeEventListener('keydown', handleKeyDown, CAPTURE_PHASE)
@@ -27,8 +27,8 @@ export const GlobalKeyboardListeners: React.FunctionComponent<{}> = () => {
     return null
 }
 
-// CodeMirror does not prevent bubbeling of the escape keyboard event so we need to check if the dropdown are open.
-export function isJetBrainsDropdownOpen(): boolean {
+// CodeMirror does not prevent bubbling of the escape keyboard event so we need to check if any dropdown is open.
+export function isAnyDropdownOpen(): boolean {
     const isCodeMirrorDropdownOpen = document.querySelector('.cm-tooltip-autocomplete') !== null
     const isSearchContextDropdownOpen = document.querySelector('.jb-search-context-dropdown.show') !== null
     return isCodeMirrorDropdownOpen || isSearchContextDropdownOpen

--- a/client/jetbrains/webview/src/search/GlobalKeyboardListeners.ts
+++ b/client/jetbrains/webview/src/search/GlobalKeyboardListeners.ts
@@ -1,0 +1,35 @@
+import React, { useEffect, useCallback } from 'react'
+
+import { onWindowClose } from './js-to-java-bridge'
+
+const CAPTURE_PHASE = { capture: true }
+
+export const GlobalKeyboardListeners: React.FunctionComponent<{}> = () => {
+    const handleKeyDown = useCallback((event: KeyboardEvent) => {
+        if (event.key === 'Escape' && !event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey) {
+            if (isJetBrainsDropdownOpen()) {
+                return
+            }
+
+            onWindowClose()
+                .then(() => {})
+                .catch(() => {})
+        }
+    }, [])
+
+    useEffect(() => {
+        // We're adding listeners to the capture phase to be able to exermine the dropdown status before the event is
+        // propagated and the dropdown is closed.
+        document.addEventListener('keydown', handleKeyDown, CAPTURE_PHASE)
+        return () => document.removeEventListener('keydown', handleKeyDown, CAPTURE_PHASE)
+    }, [handleKeyDown])
+
+    return null
+}
+
+// CodeMirror does not prevent bubbeling of the escape keyboard event so we need to check if the dropdown are open.
+export function isJetBrainsDropdownOpen(): boolean {
+    const isCodeMirrorDropdownOpen = document.querySelector('.cm-tooltip-autocomplete') !== null
+    const isSearchContextDropdownOpen = document.querySelector('.jb-search-context-dropdown.show') !== null
+    return isCodeMirrorDropdownOpen || isSearchContextDropdownOpen
+}

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
@@ -103,7 +103,7 @@ export const JetBrainsSearchBox: React.FunctionComponent<React.PropsWithChildren
                             {...props}
                             query={queryState.query}
                             submitSearch={props.submitSearchOnSearchContextChange}
-                            className={styles.searchBoxContextDropdown}
+                            className={classNames(styles.searchBoxContextDropdown, 'jb-search-context-dropdown')}
                             menuClassName={styles.searchBoxContextMenu}
                             onEscapeMenuClose={focusEditor}
                         />

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -70,6 +70,10 @@ interface IndicateFinishedLoadingRequest {
     action: 'indicateFinishedLoading'
 }
 
+interface WindowCloseRequest {
+    action: 'windowClose'
+}
+
 export type Request =
     | PreviewLoadingRequest
     | PreviewRequest
@@ -80,6 +84,7 @@ export type Request =
     | LoadLastSearchRequest
     | ClearPreviewRequest
     | IndicateFinishedLoadingRequest
+    | WindowCloseRequest
 
 let lastPreviewUpdateCallSendDateTime = new Date()
 
@@ -157,6 +162,14 @@ export async function onOpen(match: SearchMatch, lineOrSymbolMatchIndex?: number
         await callJava({ action: 'open', arguments: await createPreviewContent(match, lineOrSymbolMatchIndex) })
     } catch (error) {
         console.error(`Failed to open match: ${(error as Error).message}`)
+    }
+}
+
+export async function onWindowClose(): Promise<void> {
+    try {
+        await callJava({ action: 'windowClose' })
+    } catch (error) {
+        console.error(`Failed to close window: ${(error as Error).message}`)
     }
 }
 

--- a/client/jetbrains/webview/src/search/results/SearchResultList.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.tsx
@@ -2,7 +2,7 @@ import React, { createRef, useCallback, useEffect, useMemo, useState } from 'rea
 
 import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
-import { isJetBrainsDropdownOpen } from '../GlobalKeyboardListeners'
+import { isAnyDropdownOpen } from '../GlobalKeyboardListeners'
 
 import { CommitSearchResult } from './CommitSearchResult'
 import { FileSearchResult } from './FileSearchResult'
@@ -89,7 +89,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
             }
 
             // Ignore events when the autocomplete dropdown is open
-            if (isJetBrainsDropdownOpen()) {
+            if (isAnyDropdownOpen()) {
                 return
             }
 

--- a/client/jetbrains/webview/src/search/results/SearchResultList.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.tsx
@@ -2,6 +2,8 @@ import React, { createRef, useCallback, useEffect, useMemo, useState } from 'rea
 
 import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
+import { isJetBrainsDropdownOpen } from '../GlobalKeyboardListeners'
+
 import { CommitSearchResult } from './CommitSearchResult'
 import { FileSearchResult } from './FileSearchResult'
 import { PathSearchResult } from './PathSearchResult'
@@ -87,8 +89,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
             }
 
             // Ignore events when the autocomplete dropdown is open
-            const isAutocompleteOpen = document.querySelector('.cm-tooltip-autocomplete') !== null
-            if (isAutocompleteOpen) {
+            if (isJetBrainsDropdownOpen()) {
                 return
             }
 


### PR DESCRIPTION
Close #37313

We don't want to close the popup while a dropdown is opened but instead just want to close the dropdown. To do this, we need to defer the decision making for when to close something into the web view (since this is the only place that knows if dropdown are open).

Ideally we could rely on event bubbling to have the escape event not propagate to the document root when a children handles the event. Unfortunately we can't do this here since we do not control the dropdown implementation in CodeMirror. Since this does not cancel the propagation, we'll need to manually find out if a dropdown is open or not (a behavior that we have already implemented for the arrow up/down navigation).

We also need to make sure to attach event handlers in `capture` mode, This makes it so that our event listeners are called _before_ the React tree can react (he-he) to the changes. This is necessary because otherwise the dropdown already appeared closed by the time we get a callback. The capture mode does bypass all event bubbling cancellation (because the capture phase happens before the bubble phase) which means that we can also not rely on `stopPropagation` for the event handlers we do control. 🙁 

## Test plan

Manually tested the changes:

https://user-images.githubusercontent.com/458591/176447188-d59a7cb6-dbc9-44b2-ad72-69f2648b5c9b.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-ignore-esc-in.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ekrvnezspq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
