### PR TITLE
web: fix inline decorations display

### DIFF
--- a/client/web/src/repo/blob/LineDecorator.tsx
+++ b/client/web/src/repo/blob/LineDecorator.tsx
@@ -102,7 +102,7 @@ export const LineDecorator = React.memo<LineDecoratorProps>(
                     innerPortalNode.id = portalID
                     innerPortalNode.dataset.testid = 'line-decoration'
                     innerPortalNode.dataset.lineDecorationAttachmentPortal = 'true'
-                    codeCell?.append(innerPortalNode)
+                    codeCell?.insertBefore(innerPortalNode, codeCell?.querySelector('.bottom-spacer'))
                     setPortalNode(innerPortalNode)
                 } else {
                     // code view ref passed `null`, so element is leaving DOM


### PR DESCRIPTION
Insert last file line inline decorations *before* the bottom spacer.

| Before | After |
| -- | -- |
| <img width="1717" alt="Screenshot 2022-06-29 at 16 57 51" src="https://user-images.githubusercontent.com/25318659/176455207-c1a96a89-a1b0-4f6b-9154-b6210abdf4ae.png"> | <img width="1717" alt="Screenshot 2022-06-29 at 16 59 16" src="https://user-images.githubusercontent.com/25318659/176455378-6724a104-dc72-442e-b96b-86792d47cb4e.png"> |


## Test plan
- `sg start web-standalone`
- open file with the last line having decorations decorated (for example, [this one](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/main.tsx) with enabled `git-extras` extension and `enableExtensionsDecorationsColumnView` experimental feature disabled)
- ensure there's no extra spacing between the last line code and decoration (see screenshots)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
