### PR TITLE
JetBrains: Handle “not logged in” state gracefully

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/BrowserAndLoadingPanel.java
@@ -1,25 +1,35 @@
 package com.sourcegraph.browser;
 
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.ui.components.JBPanelWithEmptyText;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.StatusText;
+import com.sourcegraph.config.SettingsConfigurable;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
 
+import static com.intellij.ui.SimpleTextAttributes.STYLE_PLAIN;
+
 /**
  * Inspired by <a href="https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java">FindPopupPanel.java</a>
  */
 public class BrowserAndLoadingPanel extends JLayeredPane {
+    private final Project project;
+    private final JBPanelWithEmptyText overlayPanel;
     private boolean isBrowserVisible = false;
     private final JBPanelWithEmptyText jcefPanel;
 
-    public BrowserAndLoadingPanel() {
+    public BrowserAndLoadingPanel(Project project) {
+        this.project = project;
         jcefPanel = new JBPanelWithEmptyText(new BorderLayout()).withEmptyText(
             "Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
 
-        JBPanelWithEmptyText overlayPanel = new JBPanelWithEmptyText();
-        //noinspection DialogTitleCapitalization
-        overlayPanel.getEmptyText().setText("Loading Sourcegraph...");
+        overlayPanel = new JBPanelWithEmptyText();
+        setLoading(true);
 
         add(overlayPanel, 0);
         add(jcefPanel, 1);
@@ -27,6 +37,21 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
 
     public void setBrowser(@NotNull SourcegraphJBCefBrowser browser) {
         jcefPanel.add(browser.getComponent());
+    }
+
+    public void setLoading(boolean isLoading) {
+        StatusText emptyText = overlayPanel.getEmptyText();
+
+        if (isLoading) {
+            emptyText.setText("Loading...");
+        } else {
+            emptyText.setText("Could not connect to Sourcegraph.");
+            emptyText.appendLine("Make sure your Sourcegraph URL and access token are correct to use search.");
+            emptyText.appendLine("Click here to configure your Sourcegraph settings.",
+                new SimpleTextAttributes(STYLE_PLAIN, JBUI.CurrentTheme.Link.Foreground.ENABLED),
+                __ -> ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class)
+            );
+        }
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/BrowserAndLoadingPanel.java
@@ -29,22 +29,19 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
             "Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
 
         overlayPanel = new JBPanelWithEmptyText();
-        setLoading(true);
+        setState(State.LOADING);
 
         add(overlayPanel, 0);
         add(jcefPanel, 1);
     }
 
-    public void setBrowser(@NotNull SourcegraphJBCefBrowser browser) {
-        jcefPanel.add(browser.getComponent());
-    }
-
-    public void setLoading(boolean isLoading) {
+    public void setState(State state) {
         StatusText emptyText = overlayPanel.getEmptyText();
 
-        if (isLoading) {
+        isBrowserVisible = state == State.AUTHENTICATED || state == State.COULD_CONNECT_BUT_NOT_AUTHENTICATED;
+        if (state == State.LOADING) {
             emptyText.setText("Loading...");
-        } else {
+        } else if (state == State.COULD_NOT_CONNECT) {
             emptyText.setText("Could not connect to Sourcegraph.");
             emptyText.appendLine("Make sure your Sourcegraph URL and access token are correct to use search.");
             emptyText.appendLine("Click here to configure your Sourcegraph settings.",
@@ -52,6 +49,19 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
                 __ -> ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class)
             );
         }
+        revalidate();
+        repaint();
+    }
+
+    public void setBrowser(@NotNull SourcegraphJBCefBrowser browser) {
+        jcefPanel.add(browser.getComponent());
+    }
+
+    public enum State {
+        LOADING,
+        AUTHENTICATED,
+        COULD_NOT_CONNECT,
+        COULD_CONNECT_BUT_NOT_AUTHENTICATED
     }
 
     @Override
@@ -69,11 +79,5 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
     @Override
     public Dimension getPreferredSize() {
         return getBounds().getSize();
-    }
-
-    public void setBrowserVisible(boolean browserVisible) {
-        isBrowserVisible = browserVisible;
-        revalidate();
-        repaint();
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -97,7 +97,7 @@ public class JSToJavaBridgeRequestHandler {
                     return createSuccessResponse(null);
                 case "indicateFinishedLoading":
                     arguments = request.getAsJsonObject("arguments");
-                    ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.indicateAuthenticationStatus(arguments.get("wasAuthenticationSuccessful").getAsBoolean()));
+                    ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.indicateAuthenticationStatus(arguments.get("wasServerAccessSuccessful").getAsBoolean(), arguments.get("wasAuthenticationSuccessful").getAsBoolean()));
                     return createSuccessResponse(null);
                 default:
                     return createErrorResponse("Unknown action: '" + action + "'.", "No stack trace");

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -97,7 +97,7 @@ public class JSToJavaBridgeRequestHandler {
                     return createSuccessResponse(null);
                 case "indicateFinishedLoading":
                     arguments = request.getAsJsonObject("arguments");
-                    findPopupPanel.indicateAuthenticationStatus(arguments.get("wasAuthenticationSuccessful").getAsBoolean());
+                    ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.indicateAuthenticationStatus(arguments.get("wasAuthenticationSuccessful").getAsBoolean()));
                     return createSuccessResponse(null);
                 default:
                     return createErrorResponse("Unknown action: '" + action + "'.", "No stack trace");

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -96,7 +96,8 @@ public class JSToJavaBridgeRequestHandler {
                     }
                     return createSuccessResponse(null);
                 case "indicateFinishedLoading":
-                    findPopupPanel.setBrowserVisible(true);
+                    arguments = request.getAsJsonObject("arguments");
+                    findPopupPanel.indicateAuthenticationStatus(arguments.get("wasAuthenticationSuccessful").getAsBoolean());
                     return createSuccessResponse(null);
                 default:
                     return createErrorResponse("Unknown action: '" + action + "'.", "No stack trace");

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -76,9 +76,10 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         return previewPanel;
     }
 
-    public void indicateAuthenticationStatus(boolean authenticated) {
-        browserAndLoadingPanel.setBrowserVisible(authenticated);
-        browserAndLoadingPanel.setLoading(authenticated);
+    public void indicateAuthenticationStatus(boolean wasServerAccessSuccessful, boolean authenticated) {
+        browserAndLoadingPanel.setState(wasServerAccessSuccessful
+            ? (authenticated ? BrowserAndLoadingPanel.State.AUTHENTICATED : BrowserAndLoadingPanel.State.COULD_CONNECT_BUT_NOT_AUTHENTICATED)
+            : BrowserAndLoadingPanel.State.COULD_NOT_CONNECT);
         if (!authenticated) {
             selectionMetadataPanel.clearSelectionMetadataLabel();
             previewPanel.setContent(null);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -45,7 +45,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         bottomPanel.add(selectionMetadataPanel, BorderLayout.NORTH);
         bottomPanel.add(previewPanel, BorderLayout.CENTER);
 
-        browserAndLoadingPanel = new BrowserAndLoadingPanel();
+        browserAndLoadingPanel = new BrowserAndLoadingPanel(project);
         JSToJavaBridgeRequestHandler requestHandler = new JSToJavaBridgeRequestHandler(project, this);
         browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(requestHandler) : null;
         if (browser != null) {
@@ -76,8 +76,13 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         return previewPanel;
     }
 
-    public void setBrowserVisible(boolean visible) {
-        browserAndLoadingPanel.setBrowserVisible(visible);
+    public void indicateAuthenticationStatus(boolean authenticated) {
+        browserAndLoadingPanel.setBrowserVisible(authenticated);
+        browserAndLoadingPanel.setLoading(authenticated);
+        if (!authenticated) {
+            selectionMetadataPanel.clearSelectionMetadataLabel();
+            previewPanel.setContent(null);
+        }
     }
 
     public void indicateLoadingIfInTime(@NotNull Date date) {

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -23,7 +23,6 @@ import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestio
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { useObservable, WildcardThemeContext } from '@sourcegraph/wildcard'
 
-import { getAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
 import { initializeSourcegraphSettings } from '../sourcegraphSettings'
 import { EventLogger } from '../telemetry/EventLogger'
 
@@ -44,7 +43,7 @@ interface Props {
     onPreviewClear: () => Promise<void>
     onOpen: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
     initialSearch: Search | null
-    initialAuthenticatedUser: AuthenticatedUser | null
+    authenticatedUser: AuthenticatedUser | null
     telemetryService: EventLogger
 }
 
@@ -61,11 +60,10 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     onPreviewClear,
     onOpen,
     initialSearch,
-    initialAuthenticatedUser,
+    authenticatedUser,
     telemetryService,
 }: Props) => {
-    const [authState, setAuthState] = useState<'initial' | 'validating' | 'success' | 'failure'>('initial')
-    const [authenticatedUser, setAuthenticatedUser] = useState<AuthenticatedUser | null>(initialAuthenticatedUser)
+    const authState = authenticatedUser !== null ? 'success' : 'failure'
 
     const requestGraphQL = useCallback<PlatformContext['requestGraphQL']>(
         args =>
@@ -85,22 +83,6 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     const settingsCascade: SettingsCascadeOrError =
         useObservable(useMemo(() => initializeSourcegraphSettings(requestGraphQL).settings, [requestGraphQL])) ||
         EMPTY_SETTINGS_CASCADE
-
-    useEffect(() => {
-        setAuthState('validating')
-        getAuthenticatedUser(instanceURL, accessToken)
-            .then(authenticatedUser => {
-                setAuthState(authenticatedUser ? 'success' : 'failure')
-                if (accessToken) {
-                    console.warn(`No authenticated user with access token “${accessToken || ''}”`)
-                }
-                setAuthenticatedUser(authenticatedUser)
-            })
-            .catch(() => {
-                setAuthState('failure')
-                console.warn(`Failed to validate authentication with access token “${accessToken || ''}”`)
-            })
-    }, [instanceURL, accessToken])
 
     const platformContext = {
         requestGraphQL,

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -167,12 +167,12 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
         [lastSearch, userQueryState.query, telemetryService]
     )
 
-    const [didInitialSubmit, setDidInitialSubmit] = useState(false)
+    const [lastInitialSubmitUser, setLastInitialSubmitUser] = useState<AuthenticatedUser | null>(null)
     useEffect(() => {
-        if (didInitialSubmit) {
+        if (lastInitialSubmitUser === authenticatedUser) {
             return
         }
-        setDidInitialSubmit(true)
+        setLastInitialSubmitUser(authenticatedUser)
         if (initialSearch !== null) {
             onSubmit({
                 caseSensitive: initialSearch.caseSensitive,
@@ -181,7 +181,7 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                 forceNewSearch: true,
             })
         }
-    }, [initialSearch, onSubmit, didInitialSubmit])
+    }, [initialSearch, onSubmit, lastInitialSubmitUser, authenticatedUser])
 
     const statusBar = useMemo(
         () => <StatusBar progress={progress} progressState={progressState} authState={authState} />,

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -43,8 +43,10 @@ window.initializeSourcegraph = async () => {
     applyTheme(theme)
     applyLastSearch(lastSearch)
 
+    let isServerAccessSuccessful = false
     try {
         authenticatedUser = await getAuthenticatedUser(instanceURL, accessToken)
+        isServerAccessSuccessful = true
     } catch (error) {
         console.info('Could not authenticate with current URL and token settings', instanceURL, accessToken, error)
     }
@@ -57,7 +59,7 @@ window.initializeSourcegraph = async () => {
 
     renderReactApp()
 
-    await indicateFinishedLoading(!!authenticatedUser)
+    await indicateFinishedLoading(isServerAccessSuccessful, !!authenticatedUser)
 }
 
 window.callJS = handleRequest

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -69,7 +69,7 @@ export function renderReactApp(): void {
             onOpen={onOpen}
             onPreviewChange={onPreviewChange}
             onPreviewClear={onPreviewClear}
-            initialAuthenticatedUser={initialAuthenticatedUser}
+            authenticatedUser={initialAuthenticatedUser}
             telemetryService={telemetryService}
         />,
         node

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -52,7 +52,7 @@ window.initializeSourcegraph = async () => {
 
     renderReactApp()
 
-    await indicateFinishedLoading()
+    await indicateFinishedLoading(authenticatedUser.status === 'fulfilled' && !!authenticatedUser.value)
 }
 
 window.callJS = handleRequest

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -29,7 +29,7 @@ let accessToken: string | null = null
 let anonymousUserId: string
 let pluginVersion: string
 let initialSearch: Search | null = null
-let initialAuthenticatedUser: AuthenticatedUser | null
+let authenticatedUser: AuthenticatedUser | null = null
 let telemetryService: EventLogger
 
 window.initializeSourcegraph = async () => {
@@ -43,9 +43,11 @@ window.initializeSourcegraph = async () => {
     applyTheme(theme)
     applyLastSearch(lastSearch)
 
-    const authenticatedUser = await getAuthenticatedUser(instanceURL, accessToken)
-
-    applyAuthenticatedUser(authenticatedUser)
+    try {
+        authenticatedUser = await getAuthenticatedUser(instanceURL, accessToken)
+    } catch (error) {
+        console.info('Could not authenticate with current URL and token settings', instanceURL, accessToken, error)
+    }
 
     if (accessToken && !authenticatedUser) {
         console.warn(`No initial authenticated user with access token “${accessToken}”`)
@@ -72,7 +74,7 @@ export function renderReactApp(): void {
             onOpen={onOpen}
             onPreviewChange={onPreviewChange}
             onPreviewClear={onPreviewClear}
-            authenticatedUser={initialAuthenticatedUser}
+            authenticatedUser={authenticatedUser}
             telemetryService={telemetryService}
         />,
         node
@@ -117,10 +119,6 @@ export function applyTheme(theme: Theme): void {
 
 function applyLastSearch(lastSearch: Search | null): void {
     initialSearch = lastSearch
-}
-
-function applyAuthenticatedUser(authenticatedUser: AuthenticatedUser | null): void {
-    initialAuthenticatedUser = authenticatedUser
 }
 
 export function getAccessToken(): string | null {

--- a/client/jetbrains/webview/src/search/java-to-js-bridge.ts
+++ b/client/jetbrains/webview/src/search/java-to-js-bridge.ts
@@ -31,9 +31,9 @@ export async function handleRequest(
                 (argumentsAsObject as PluginSettingsChangedRequestArguments).instanceURL,
                 (argumentsAsObject as PluginSettingsChangedRequestArguments).accessToken
             )
-            await indicateFinishedLoading(!!authenticatedUser)
+            await indicateFinishedLoading(true, !!authenticatedUser)
         } catch {
-            await indicateFinishedLoading(false)
+            await indicateFinishedLoading(false, false)
         }
         renderReactApp()
         return callback(JSON.stringify(null))

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -68,7 +68,7 @@ interface LoadLastSearchRequest {
 
 interface IndicateFinishedLoadingRequest {
     action: 'indicateFinishedLoading'
-    arguments: { wasAuthenticationSuccessful: boolean }
+    arguments: { wasServerAccessSuccessful: boolean; wasAuthenticationSuccessful: boolean }
 }
 
 export type Request =
@@ -111,9 +111,15 @@ export async function getThemeAlwaysFulfill(): Promise<Theme> {
     }
 }
 
-export async function indicateFinishedLoading(wasAuthenticationSuccessful: boolean): Promise<void> {
+export async function indicateFinishedLoading(
+    wasServerAccessSuccessful: boolean,
+    wasAuthenticationSuccessful: boolean
+): Promise<void> {
     try {
-        await callJava({ action: 'indicateFinishedLoading', arguments: { wasAuthenticationSuccessful } })
+        await callJava({
+            action: 'indicateFinishedLoading',
+            arguments: { wasServerAccessSuccessful, wasAuthenticationSuccessful },
+        })
     } catch (error) {
         console.error(`Failed to indicate “finished loading”: ${(error as Error).message}`)
     }

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -68,6 +68,7 @@ interface LoadLastSearchRequest {
 
 interface IndicateFinishedLoadingRequest {
     action: 'indicateFinishedLoading'
+    arguments: { wasAuthenticationSuccessful: boolean }
 }
 
 export type Request =
@@ -110,9 +111,9 @@ export async function getThemeAlwaysFulfill(): Promise<Theme> {
     }
 }
 
-export async function indicateFinishedLoading(): Promise<void> {
+export async function indicateFinishedLoading(wasAuthenticationSuccessful: boolean): Promise<void> {
     try {
-        await callJava({ action: 'indicateFinishedLoading' })
+        await callJava({ action: 'indicateFinishedLoading', arguments: { wasAuthenticationSuccessful } })
     } catch (error) {
         console.error(`Failed to indicate “finished loading”: ${(error as Error).message}`)
     }

--- a/client/jetbrains/webview/src/search/lib/blob.ts
+++ b/client/jetbrains/webview/src/search/lib/blob.ts
@@ -31,7 +31,7 @@ async function fetchBlobContent(match: ContentMatch | PathMatch | SymbolMatch): 
         repoName: match.repository,
     })
 
-    const content: undefined | string = response?.data?.repository?.commit?.file?.content
+    const content: undefined | string = response.data?.repository?.commit?.file?.content
     if (content === undefined) {
         console.error('No content found in query response', response)
         return null

--- a/client/jetbrains/webview/src/search/types.d.ts
+++ b/client/jetbrains/webview/src/search/types.d.ts
@@ -8,7 +8,7 @@ declare global {
     interface Window {
         initializeSourcegraph: () => Promise<void>
         callJava: (request: Request) => Promise<object>
-        callJS: (action: ActionName, data: string, callback: (result: string) => void) => void
+        callJS: (action: ActionName, data: string, callback: (result: string) => void) => Promise<void>
     }
 }
 

--- a/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
+++ b/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
@@ -6,7 +6,7 @@ export async function getAuthenticatedUser(
     instanceURL: string,
     accessToken: string | null
 ): Promise<AuthenticatedUser | null> {
-    if (!accessToken || !instanceURL) {
+    if (!instanceURL) {
         return null
     }
 

--- a/client/jetbrains/webview/src/sourcegraphSettings.ts
+++ b/client/jetbrains/webview/src/sourcegraphSettings.ts
@@ -38,8 +38,8 @@ export function initializeSourcegraphSettings(
                 }
                 return gqlToCascade(data?.viewerSettings as ISettingsCascade)
             }),
-            catchError(() => {
-                console.warn('Failed to load settings')
+            catchError(error => {
+                console.warn('Failed to load Sourcegraph settings', error)
                 return of(EMPTY_SETTINGS_CASCADE)
             })
         )


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/37685
Fixes https://github.com/sourcegraph/sourcegraph/issues/36157

It needed some care to make sure that we're sending data, doing new searches, and updating the preview in all cases.

- Also fixed a bug: auth actually depended on the config, but the config was loaded in parallel with the auth. :o This was only not apparent because of the duplication of auth calls.

## Test plan

TODO: Add Loom when I fixed the last tiny bug