### PR TITLE
insights: Add groupBy field for compute insights

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -225,6 +225,7 @@ type SearchInsightDataSeriesDefinitionResolver interface {
 	TimeScope(ctx context.Context) (InsightTimeScope, error)
 	GeneratedFromCaptureGroups() (bool, error)
 	IsCalculated() (bool, error)
+	GroupBy() (*string, error)
 }
 
 type InsightPresentation interface {
@@ -400,6 +401,7 @@ type LineChartSearchInsightDataSeriesInput struct {
 	RepositoryScope            RepositoryScopeInput
 	Options                    LineChartDataSeriesOptionsInput
 	GeneratedFromCaptureGroups *bool
+	GroupBy                    *string
 }
 
 type LineChartDataSeriesOptionsInput struct {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -743,6 +743,11 @@ input LineChartSearchInsightDataSeriesInput {
     Whether or not to generate the timeseries results from the query capture groups. Defaults to false if not provided.
     """
     generatedFromCaptureGroups: Boolean
+
+    """
+    The field to group results by. (For compute powered insights only.)
+    """
+    groupBy: String
 }
 
 """
@@ -993,6 +998,11 @@ type SearchInsightDataSeriesDefinition {
     for the code insights webapp, and should be considered unstable (planned to be deprecated in a future release).
     """
     isCalculated: Boolean!
+
+    """
+    The field to group results by. (For compute powered insights only.)
+    """
+    groupBy: String
 }
 
 """

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -393,8 +393,13 @@ func (s *searchInsightDataSeriesDefinitionResolver) TimeScope(ctx context.Contex
 
 	return &insightTimeScopeUnionResolver{resolver: intervalResolver}, nil
 }
+
 func (s *searchInsightDataSeriesDefinitionResolver) GeneratedFromCaptureGroups() (bool, error) {
 	return s.series.GeneratedFromCaptureGroups, nil
+}
+
+func (s *searchInsightDataSeriesDefinitionResolver) GroupBy() (*string, error) {
+	return s.series.GroupBy, nil
 }
 
 type insightIntervalTimeScopeResolver struct {
@@ -1016,6 +1021,7 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, scopedBa
 			StepIntervalUnit:          series.TimeScope.StepInterval.Unit,
 			StepIntervalValue:         int(series.TimeScope.StepInterval.Value),
 			GenerateFromCaptureGroups: dynamic,
+			GroupBy:                   series.GroupBy,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "FindMatchingSeries")
@@ -1036,8 +1042,8 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, scopedBa
 			SampleIntervalValue:        int(series.TimeScope.StepInterval.Value),
 			GeneratedFromCaptureGroups: dynamic,
 			JustInTime:                 len(repos) > 0 && !deprecateJustInTime,
-			// JustInTime:       false,
-			GenerationMethod: searchGenerationMethod(series),
+			GenerationMethod:           searchGenerationMethod(series),
+			GroupBy:                    series.GroupBy,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "CreateSeries")

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -37,6 +37,7 @@ type InsightViewSeries struct {
 	SeriesSortMode                *SeriesSortMode
 	SeriesSortDirection           *SeriesSortDirection
 	SeriesLimit                   *int32
+	GroupBy                       *string
 }
 
 type Insight struct {
@@ -100,6 +101,7 @@ type InsightSeries struct {
 	GeneratedFromCaptureGroups bool
 	JustInTime                 bool
 	GenerationMethod           GenerationMethod
+	GroupBy                    *string
 }
 
 type IntervalUnit string

--- a/migrations/codeinsights/1656517037/down.sql
+++ b/migrations/codeinsights/1656517037/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS insight_series DROP COLUMN IF EXISTS group_by;

--- a/migrations/codeinsights/1656517037/metadata.yaml
+++ b/migrations/codeinsights/1656517037/metadata.yaml
@@ -1,0 +1,2 @@
+name: group_by
+parents: [1651021000, 1652289966]

--- a/migrations/codeinsights/1656517037/up.sql
+++ b/migrations/codeinsights/1656517037/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS insight_series ADD COLUMN IF NOT EXISTS group_by TEXT;


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/37864

## Description

In order to quickly get compute insights out to customers and validate how useful they are, we'll add this functionality into our existing `LineChartSearchInsight` API and infer that it's a compute insight by the presence of the `groupBy` value. This PR adds this new field into the API so it can be used for both the create and update mutations, and can be read from the `SearchInsightDataSeriesDefinition`.

I made it a nullable field so that we can safely ignore it and only use it when necessary. And I went with a string instead of an enum because it's more lightweight for this type of quick change.

## Test plan

Try creating a new `LineChartSearchInsight` with and without the new `groupBy` field in the series. Example with:

```gql
mutation {
    createLineChartSearchInsight (input: {
        options: {
            title: "new test insight"
        },
        dataSeries: [{
            query: "test function",
            options: {
                label: "test function",
                lineColor: "var(--oc-grape-7)"
        },
        repositoryScope: {
            repositories: []
        },
        timeScope: {
           stepInterval: {
                  unit: MONTH,
                  value: 1
            }
        },
        groupBy: "repo"
        }]
    })
    {
      view {
          id,
          dataSeriesDefinitions {
              ... on SearchInsightDataSeriesDefinition {
                  seriesId,
                  query,
                  repositoryScope {
                      repositories
                  }
                  timeScope {
                  ... on InsightIntervalTimeScope {
                          unit,
                          value
                      }
                  },
                  groupBy
              }
          }
    }
}
```
I also loaded up some insights pages and backfilled a new insight to check for regressions. This change does touch the core path for fetching insights (by modifying the sql queries in the store,) so regressions are a concern.

The last thing to check for is that the series matching is still working as expected. I tried creating the same series multiple times, and verifying that it matches as expected, (both when `groupBy` is missing, and when it's filled in.)