### PR TITLE
compute: enrich streaming API ComputeText with repository metadata

### DIFF
--- a/enterprise/internal/compute/output_command.go
+++ b/enterprise/internal/compute/output_command.go
@@ -117,5 +117,16 @@ func (c *Output) Run(ctx context.Context, db database.DB, r result.Match) (Resul
 		return &Text{Value: outputPattern, Kind: "output"}, nil
 	}
 
-	return output(ctx, content, c.SearchPattern, outputPattern, c.Separator)
+	text, err := output(ctx, content, c.SearchPattern, outputPattern, c.Separator)
+	if err != nil {
+		return nil, err
+	}
+	return enrichTextWithRepoMetadata(text, r), nil
+}
+
+func enrichTextWithRepoMetadata(text *Text, r result.Match) *Text {
+	text.RepositoryID = int32(r.RepoName().ID)
+	text.Repository = string(r.RepoName().Name)
+
+	return text
 }

--- a/enterprise/internal/compute/output_command_test.go
+++ b/enterprise/internal/compute/output_command_test.go
@@ -56,7 +56,7 @@ func fileMatch(content string) result.Match {
 	}
 	return &result.FileMatch{
 		File: result.File{
-			Repo: types.MinimalRepo{Name: "my/awesome/repo"},
+			Repo: types.MinimalRepo{Name: "my/awesome/repo", ID: api.RepoID(11)},
 			Path: "my/awesome/path.ml",
 		},
 	}
@@ -116,5 +116,25 @@ func TestRun(t *testing.T) {
 	autogold.Want(
 		"substitute language",
 		"OCaml\n").
+		Equal(t, test(`content:output((.|\n)* -> $lang)`, fileMatch("anything")))
+}
+
+func TestRunOutputRepoMetadata(t *testing.T) {
+	test := func(q string, m result.Match) *Text {
+		defer gitserver.ResetMocks()
+		computeQuery, _ := Parse(q)
+		res, err := computeQuery.Command.Run(context.Background(), database.NewMockDB(), m)
+		if err != nil {
+			t.Error(err)
+		}
+		return res.(*Text)
+	}
+
+	autogold.Want(
+		"verify repo metadata exists",
+		&Text{
+			Value: "OCaml\n", Kind: "output", RepositoryID: 11,
+			Repository: "my/awesome/repo",
+		}).
 		Equal(t, test(`content:output((.|\n)* -> $lang)`, fileMatch("anything")))
 }

--- a/enterprise/internal/compute/replace_command.go
+++ b/enterprise/internal/compute/replace_command.go
@@ -57,7 +57,12 @@ func (c *Replace) Run(ctx context.Context, db database.DB, r result.Match) (Resu
 		if err != nil {
 			return nil, err
 		}
-		return replace(ctx, content, c.SearchPattern, c.ReplacePattern)
+
+		text, err := replace(ctx, content, c.SearchPattern, c.ReplacePattern)
+		if err != nil {
+			return nil, err
+		}
+		return enrichTextWithRepoMetadata(text, r), nil
 	}
 	return nil, nil
 }

--- a/enterprise/internal/compute/replace_command_test.go
+++ b/enterprise/internal/compute/replace_command_test.go
@@ -5,6 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+
 	"github.com/grafana/regexp"
 	"github.com/hexops/autogold"
 
@@ -40,4 +44,24 @@ func Test_replace(t *testing.T) {
 			SearchPattern:  &Comby{Value: `foo(:[x], :[y])`},
 			ReplacePattern: "foo(:[y], :[x])",
 		}))
+}
+
+func TestRunReplaceRepoMetadata(t *testing.T) {
+	test := func(q string, m result.Match) *Text {
+		defer gitserver.ResetMocks()
+		computeQuery, _ := Parse(q)
+		res, err := computeQuery.Command.Run(context.Background(), database.NewMockDB(), m)
+		if err != nil {
+			t.Error(err)
+		}
+		return res.(*Text)
+	}
+
+	autogold.Want(
+		"verify repo metadata exists",
+		&Text{
+			Value: "abc", Kind: "replace-in-place", RepositoryID: 11,
+			Repository: "my/awesome/repo",
+		}).
+		Equal(t, test(`content:replace(anything -> abc)`, fileMatch("anything")))
 }

--- a/enterprise/internal/compute/text_result.go
+++ b/enterprise/internal/compute/text_result.go
@@ -1,6 +1,8 @@
 package compute
 
 type Text struct {
-	Value string `json:"value"`
-	Kind  string `json:"kind"`
+	Value        string `json:"value"`
+	Kind         string `json:"kind"`
+	RepositoryID int32  `json:"repositoryID"`
+	Repository   string `json:"repository"`
 }


### PR DESCRIPTION
Closes #37949

Adds repository metadata to the ComputeText type in the compute streaming API. Similar to https://github.com/sourcegraph/sourcegraph/pull/34233

## Test plan

Ran compute queries and got results:

`repo:^github\.com/sourcegraph/sourcegraph$ lang:go content:output(historical -> $lang)`

```
event: results
data: [{"value":"Go\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\nGo\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"}]

event: progress
data: {"done":false,"matchCount":0,"durationMs":29,"skipped":[]}

event: results
data: [{"value":"Go\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\nGo\nGo\nGo\nGo\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\nGo\nGo\nGo\nGo\nGo\nGo\nGo\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\nGo\nGo\nGo\nGo\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\nGo\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\nGo\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\nGo\nGo\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"Go\n","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"}]

event: progress
data: {"done":false,"matchCount":0,"durationMs":102,"skipped":[]}

event: results
data: [{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"value":"","kind":"output","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"}]

event: progress
data: {"done":false,"matchCount":0,"durationMs":108,"skipped":[]}

event: progress
data: {"done":true,"matchCount":0,"durationMs":108,"skipped":[]}

event: done
data: {}
```
