### PR TITLE
Code Insights: Use cached data for the all insights dashboard

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
@@ -70,7 +70,12 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
         // we need to use here insightViews query to fetch all available insights
         if (dashboardId === ALL_INSIGHTS_DASHBOARD.id) {
             return fromObservableQuery(
-                this.apolloClient.watchQuery<GetInsightsResult>({ query: GET_INSIGHTS_GQL })
+                this.apolloClient.watchQuery<GetInsightsResult>({
+                    query: GET_INSIGHTS_GQL,
+                    // Prevent unnecessary network request after mutation over dashboard or insights within
+                    // current dashboard
+                    nextFetchPolicy: 'cache-first',
+                })
             ).pipe(map(({ data }) => data.insightViews.nodes.map(createInsightView)))
         }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/37953

## Test plan
1. Go to the all insight dashboard
2. Make sure that you have only one `getInsights` network gql request. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-prevent-multiple-fetching.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pknxluoxby.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
