### PR TITLE
[SG-35149] Accessibility: Main nav dropdown doesn't automatically collapse on page load

### DIFF
--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -40,24 +40,24 @@ export interface NavLinkProps extends NavItemProps, Pick<LinkProps<H.LocationSta
     variant?: 'compact'
 }
 
-const useOutsideClickDetector = (
+const useOnClickDetector = (
     reference: React.RefObject<HTMLDivElement>
 ): [boolean, React.Dispatch<React.SetStateAction<boolean>>] => {
-    const [outsideClick, setOutsideClick] = useState(false)
+    const [onClick, setOnClick] = useState(false)
 
     useEffect(() => {
-        function handleClickOutside(event: MouseEvent): void {
-            if (reference.current && !reference.current.contains(event.target as Node | null)) {
-                setOutsideClick(false)
+        function handleToggleOpen(): void {
+            if (reference.current) {
+                setOnClick(false)
             }
         }
-        document.addEventListener('mouseup', handleClickOutside)
+        document.addEventListener('mouseup', handleToggleOpen)
         return () => {
-            document.removeEventListener('mouseup', handleClickOutside)
+            document.removeEventListener('mouseup', handleToggleOpen)
         }
-    }, [reference, setOutsideClick])
+    }, [reference, setOnClick])
 
-    return [outsideClick, setOutsideClick]
+    return [onClick, setOnClick]
 }
 
 export const NavBar = forwardRef(
@@ -76,7 +76,7 @@ export const NavBar = forwardRef(
 
 export const NavGroup = ({ children }: NavGroupProps): JSX.Element => {
     const menuReference = useRef<HTMLDivElement>(null)
-    const [open, setOpen] = useOutsideClickDetector(menuReference)
+    const [open, setOpen] = useOnClickDetector(menuReference)
 
     return (
         <div className={navBarStyles.menu} ref={menuReference}>


### PR DESCRIPTION
### Audit type
Mobile device navigation

### Problem description
When one clicks on any `menu item` for instance the `Monitoring link` from the dropdown, the dropdown remains expanded when the page load.

![notes marker](https://user-images.githubusercontent.com/4605817/167482316-70e3dc08-b8eb-4493-9d5b-f495706cbd29.png)

### Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35149)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35149)

### Expected behavior
It is expected that the dropdown collapses when the Monitoring page loads (or as soon as I click on it and the new page is loading).

### Test Plan
- Go to mobile view
- Clicking on a `menu item` should collapse the menu.

### Demo Test Video
https://www.loom.com/share/08e713c552b4479d81c44e312c8941bc

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
