### PR TITLE
search: disable flaky integration test for structural search

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -699,7 +699,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:  "Structural, index only, nonzero result",
 				query: `repo:^github\.com/sgtest/go-diff$ make(:[1]) index:only patterntype:structural count:3`,
-				skip:  skipStream & skipGraphQL,
+				skip:  skipStream | skipGraphQL,
 			},
 			{
 				name:  "Structural, index only, backcompat, nonzero result",


### PR DESCRIPTION
Failure here: https://buildkite.com/sourcegraph/sourcegraph/builds/157359#0181b063-2fc7-4a43-8cc1-93b2bd6bbc69

Green integration tests on next commit: https://buildkite.com/sourcegraph/sourcegraph/builds/157362#0181b067-c4ee-4bf4-b5cd-05490cfeb957


## Test plan
Removing flaky test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
