### PR TITLE
internal/trace: extract trace policy to OT-agnostic package

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -29,7 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	sgtrace "github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -54,7 +54,7 @@ type prometheusTracer struct {
 func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]any, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
 	start := time.Now()
 	var finish trace.TraceQueryFinishFunc
-	if ot.ShouldTrace(ctx) {
+	if policy.ShouldTrace(ctx) {
 		ctx, finish = t.tracer.TraceQuery(ctx, queryString, operationName, variables, varTypes)
 	}
 
@@ -145,7 +145,7 @@ func (prometheusTracer) TraceField(ctx context.Context, label, typeName, fieldNa
 
 func (t prometheusTracer) TraceValidation(ctx context.Context) trace.TraceValidationFinishFunc {
 	var finish trace.TraceValidationFinishFunc
-	if ot.ShouldTrace(ctx) {
+	if policy.ShouldTrace(ctx) {
 		finish = t.tracer.TraceValidation(ctx)
 	}
 	return func(queryErrors []*gqlerrors.QueryError) {

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -444,7 +445,7 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, definitions []ityp
 }
 
 func (a *backfillAnalyzer) buildForRepo(ctx context.Context, definitions []itypes.InsightSeries, repoName string, id api.RepoID) (jobs []*queryrunner.Job, preempted []store.RecordSeriesPointArgs, err error, softErr error) {
-	span, ctx := ot.StartSpanFromContext(ot.WithShouldTrace(ctx, true), "historical_enqueuer.buildForRepo")
+	span, ctx := ot.StartSpanFromContext(policy.WithShouldTrace(ctx, true), "historical_enqueuer.buildForRepo")
 	span.SetTag("repo_id", id)
 	defer func() {
 		if err != nil {

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -360,7 +360,7 @@ func TracedTransportOpt(cli *http.Client) error {
 		cli.Transport = http.DefaultTransport
 	}
 
-	cli.Transport = &ot.Transport{RoundTripper: cli.Transport}
+	cli.Transport = &policy.Transport{RoundTripper: cli.Transport}
 	return nil
 }
 

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 )
 
 var requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -92,7 +93,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		event.AddLogFields(fields)
 	}
 
-	if isLeaf && opts != nil && ot.ShouldTrace(ctx) {
+	if isLeaf && opts != nil && policy.ShouldTrace(ctx) {
 		// Replace any existing spanContext with a new one, given we've done additional tracing
 		spanContext := make(map[string]string)
 		if err := ot.GetTracer(ctx).Inject(opentracing.SpanFromContext(ctx).Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err == nil {

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -96,7 +96,7 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 	final := zoektquery.Simplify(zoektquery.NewAnd(ands...))
 	match := limitOrDefault(first) + 1
 	resp, err := search.Indexed().Search(ctx, final, &zoekt.SearchOptions{
-		Trace:                  ot.ShouldTrace(ctx),
+		Trace:                  policy.ShouldTrace(ctx),
 		MaxWallTime:            3 * time.Second,
 		ShardMaxMatchCount:     match * 25,
 		TotalMaxMatchCount:     match * 25,

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -60,7 +61,7 @@ func parseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSen
 }
 
 func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[string]string) {
-	if !ot.ShouldTrace(ctx) {
+	if !policy.ShouldTrace(ctx) {
 		return false, nil
 	}
 

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -1,0 +1,86 @@
+package trace
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/sourcegraph/log/otfields"
+	"github.com/uber/jaeger-client-go"
+
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
+)
+
+type traceContextKey string
+
+const traceKey = traceContextKey("trace")
+
+// contextWithTrace returns a new context.Context that holds a reference to trace's
+// SpanContext. External callers should likely use CopyContext, as this properly propagates all
+// tracing context from one context to another.
+func contextWithTrace(ctx context.Context, tr *Trace) context.Context {
+	ctx = opentracing.ContextWithSpan(ctx, tr.span)
+	ctx = context.WithValue(ctx, traceKey, tr)
+	return ctx
+}
+
+// TraceFromContext returns the Trace previously associated with ctx, or
+// nil if no such Trace could be found.
+func TraceFromContext(ctx context.Context) *Trace {
+	tr, _ := ctx.Value(traceKey).(*Trace)
+	return tr
+}
+
+// CopyContext copies the tracing-related context items from one context to another and returns that
+// context.
+func CopyContext(ctx context.Context, from context.Context) context.Context {
+	if tr := TraceFromContext(from); tr != nil {
+		ctx = contextWithTrace(ctx, tr)
+	}
+	if shouldTrace := policy.ShouldTrace(from); shouldTrace {
+		ctx = policy.WithShouldTrace(ctx, shouldTrace)
+	}
+	return ctx
+}
+
+// ID returns a trace ID, if any, found in the given context. If you need both trace and
+// span ID, use trace.Context.
+func ID(ctx context.Context) string {
+	span := opentracing.SpanFromContext(ctx)
+	if span == nil {
+		return ""
+	}
+	return IDFromSpan(span)
+}
+
+// IDFromSpan returns a trace ID, if any, found in the given span.
+func IDFromSpan(span opentracing.Span) string {
+	traceCtx := ContextFromSpan(span)
+	if traceCtx == nil {
+		return ""
+	}
+	return traceCtx.TraceID
+}
+
+// Context retrieves the full trace context, if any, from context - this includes
+// both TraceID and SpanID.
+func Context(ctx context.Context) *otfields.TraceContext {
+	span := opentracing.SpanFromContext(ctx)
+	if span == nil {
+		return nil
+	}
+	return ContextFromSpan(span)
+}
+
+// Context retrieves the full trace context, if any, from the span - this includes
+// both TraceID and SpanID.
+func ContextFromSpan(span opentracing.Span) *otfields.TraceContext {
+	spanCtx, ok := span.Context().(jaeger.SpanContext)
+	if ok {
+		return &otfields.TraceContext{
+			TraceID: spanCtx.TraceID().String(),
+			SpanID:  spanCtx.SpanID().String(),
+		}
+	}
+
+	return nil
+}

--- a/internal/trace/ot/ot.go
+++ b/internal/trace/ot/ot.go
@@ -7,37 +7,12 @@ package ot
 import (
 	"context"
 	"net/http"
-	"strconv"
-	"strings"
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
-	"go.uber.org/atomic"
+
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 )
-
-type TracePolicy string
-
-const (
-	// TraceNone turns off tracing.
-	TraceNone TracePolicy = "none"
-
-	// TraceSelective turns on tracing only for requests with the X-Sourcegraph-Should-Trace header
-	// set to a truthy value.
-	TraceSelective TracePolicy = "selective"
-
-	// TraceAll turns on tracing for all requests.
-	TraceAll TracePolicy = "all"
-)
-
-var trPolicy = atomic.NewString(string(TraceNone))
-
-func SetTracePolicy(newTracePolicy TracePolicy) {
-	trPolicy.Store(string(newTracePolicy))
-}
-
-func GetTracePolicy() TracePolicy {
-	return TracePolicy(trPolicy.Load())
-}
 
 // HTTPMiddleware wraps the handler with the following:
 //
@@ -54,73 +29,21 @@ func HTTPMiddleware(h http.Handler, opts ...nethttp.MWOption) http.Handler {
 func MiddlewareWithTracer(tr opentracing.Tracer, h http.Handler, opts ...nethttp.MWOption) http.Handler {
 	nethttpMiddleware := nethttp.Middleware(tr, h, append([]nethttp.MWOption{
 		nethttp.MWSpanFilter(func(r *http.Request) bool {
-			return ShouldTrace(r.Context())
+			return policy.ShouldTrace(r.Context())
 		}),
 	}, opts...)...)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var trace bool
-		switch GetTracePolicy() {
-		case TraceSelective:
-			trace = requestWantsTracing(r)
-		case TraceAll:
+		switch policy.GetTracePolicy() {
+		case policy.TraceSelective:
+			trace = policy.RequestWantsTracing(r)
+		case policy.TraceAll:
 			trace = true
 		default:
 			trace = false
 		}
-		nethttpMiddleware.ServeHTTP(w, r.WithContext(WithShouldTrace(r.Context(), trace)))
+		nethttpMiddleware.ServeHTTP(w, r.WithContext(policy.WithShouldTrace(r.Context(), trace)))
 	})
-}
-
-const traceHeader = "X-Sourcegraph-Should-Trace"
-const traceQuery = "trace"
-
-// requestWantsTrace returns true if a request is opting into tracing either
-// via our HTTP Header or our URL Query.
-func requestWantsTracing(r *http.Request) bool {
-	// Prefer header over query param.
-	if v := r.Header.Get(traceHeader); v != "" {
-		b, _ := strconv.ParseBool(v)
-		return b
-	}
-	// PERF: Avoid parsing RawQuery if "trace=" is not present
-	if strings.Contains(r.URL.RawQuery, "trace=") {
-		v := r.URL.Query().Get(traceQuery)
-		b, _ := strconv.ParseBool(v)
-		return b
-	}
-	return false
-}
-
-// Transport wraps an underlying HTTP RoundTripper, injecting the X-Sourcegraph-Should-Trace header
-// into outgoing requests whenever the shouldTraceKey context value is true.
-type Transport struct {
-	http.RoundTripper
-}
-
-func (r *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set(traceHeader, strconv.FormatBool(ShouldTrace(req.Context())))
-	t := nethttp.Transport{RoundTripper: r.RoundTripper}
-	return t.RoundTrip(req)
-}
-
-type key int
-
-const (
-	shouldTraceKey key = iota
-)
-
-// ShouldTrace returns true if the shouldTraceKey context value is true.
-func ShouldTrace(ctx context.Context) bool {
-	v, ok := ctx.Value(shouldTraceKey).(bool)
-	if !ok {
-		return false
-	}
-	return v
-}
-
-// WithShouldTrace sets the shouldTraceKey context value.
-func WithShouldTrace(ctx context.Context, shouldTrace bool) context.Context {
-	return context.WithValue(ctx, shouldTraceKey, shouldTrace)
 }
 
 // GetTracer returns the tracer to use for the given context. If ShouldTrace returns true, it
@@ -133,7 +56,7 @@ func GetTracer(ctx context.Context) opentracing.Tracer {
 // it returns the NoopTracer. If it returns true and the passed-in tracer is not nil, it returns the
 // passed-in tracer. Otherwise, it returns the global tracer.
 func getTracer(ctx context.Context, tracer opentracing.Tracer) opentracing.Tracer {
-	if !ShouldTrace(ctx) {
+	if !policy.ShouldTrace(ctx) {
 		return opentracing.NoopTracer{}
 	}
 	if tracer == nil {

--- a/internal/trace/policy/policy.go
+++ b/internal/trace/policy/policy.go
@@ -1,0 +1,88 @@
+// Package policy exports functionality related to whether or not to trace.
+package policy
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"go.uber.org/atomic"
+)
+
+type TracePolicy string
+
+const (
+	// TraceNone turns off tracing.
+	TraceNone TracePolicy = "none"
+
+	// TraceSelective turns on tracing only for requests with the X-Sourcegraph-Should-Trace header
+	// set to a truthy value.
+	TraceSelective TracePolicy = "selective"
+
+	// TraceAll turns on tracing for all requests.
+	TraceAll TracePolicy = "all"
+)
+
+var trPolicy = atomic.NewString(string(TraceNone))
+
+func SetTracePolicy(newTracePolicy TracePolicy) {
+	trPolicy.Store(string(newTracePolicy))
+}
+
+func GetTracePolicy() TracePolicy {
+	return TracePolicy(trPolicy.Load())
+}
+
+type key int
+
+const shouldTraceKey key = iota
+
+// ShouldTrace returns true if the shouldTraceKey context value is true.
+func ShouldTrace(ctx context.Context) bool {
+	v, ok := ctx.Value(shouldTraceKey).(bool)
+	if !ok {
+		return false
+	}
+	return v
+}
+
+// WithShouldTrace sets the shouldTraceKey context value.
+func WithShouldTrace(ctx context.Context, shouldTrace bool) context.Context {
+	return context.WithValue(ctx, shouldTraceKey, shouldTrace)
+}
+
+const (
+	traceHeader = "X-Sourcegraph-Should-Trace"
+	traceQuery  = "trace"
+)
+
+// Transport wraps an underlying HTTP RoundTripper, injecting the X-Sourcegraph-Should-Trace header
+// into outgoing requests whenever the shouldTraceKey context value is true.
+type Transport struct {
+	http.RoundTripper
+}
+
+func (r *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(traceHeader, strconv.FormatBool(ShouldTrace(req.Context())))
+	t := nethttp.Transport{RoundTripper: r.RoundTripper}
+	return t.RoundTrip(req)
+}
+
+// requestWantsTrace returns true if a request is opting into tracing either
+// via our HTTP Header or our URL Query.
+func RequestWantsTracing(r *http.Request) bool {
+	// Prefer header over query param.
+	if v := r.Header.Get(traceHeader); v != "" {
+		b, _ := strconv.ParseBool(v)
+		return b
+	}
+	// PERF: Avoid parsing RawQuery if "trace=" is not present
+	if strings.Contains(r.URL.RawQuery, "trace=") {
+		v := r.URL.Query().Get(traceQuery)
+		b, _ := strconv.ParseBool(v)
+		return b
+	}
+	return false
+}

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -6,94 +6,11 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/log/otfields"
-	"github.com/uber/jaeger-client-go"
 	nettrace "golang.org/x/net/trace"
 
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-// New returns a new Trace with the specified family and title.
-func New(ctx context.Context, family, title string, tags ...Tag) (*Trace, context.Context) {
-	tr := Tracer{Tracer: ot.GetTracer(ctx)}
-	return tr.New(ctx, family, title, tags...)
-}
-
-// ID returns a trace ID, if any, found in the given context. If you need both trace and
-// span ID, use trace.Context.
-func ID(ctx context.Context) string {
-	span := opentracing.SpanFromContext(ctx)
-	if span == nil {
-		return ""
-	}
-	return IDFromSpan(span)
-}
-
-// IDFromSpan returns a trace ID, if any, found in the given span.
-func IDFromSpan(span opentracing.Span) string {
-	traceCtx := ContextFromSpan(span)
-	if traceCtx == nil {
-		return ""
-	}
-	return traceCtx.TraceID
-}
-
-// Context retrieves the full trace context, if any, from context - this includes
-// both TraceID and SpanID.
-func Context(ctx context.Context) *otfields.TraceContext {
-	span := opentracing.SpanFromContext(ctx)
-	if span == nil {
-		return nil
-	}
-	return ContextFromSpan(span)
-}
-
-// Context retrieves the full trace context, if any, from the span - this includes
-// both TraceID and SpanID.
-func ContextFromSpan(span opentracing.Span) *otfields.TraceContext {
-	spanCtx, ok := span.Context().(jaeger.SpanContext)
-	if ok {
-		return &otfields.TraceContext{
-			TraceID: spanCtx.TraceID().String(),
-			SpanID:  spanCtx.SpanID().String(),
-		}
-	}
-
-	return nil
-}
-
-type traceContextKey string
-
-const traceKey = traceContextKey("trace")
-
-// contextWithTrace returns a new context.Context that holds a reference to trace's
-// SpanContext. External callers should likely use CopyContext, as this properly propagates all
-// tracing context from one context to another.
-func contextWithTrace(ctx context.Context, tr *Trace) context.Context {
-	ctx = opentracing.ContextWithSpan(ctx, tr.span)
-	ctx = context.WithValue(ctx, traceKey, tr)
-	return ctx
-}
-
-// TraceFromContext returns the Trace previously associated with ctx, or
-// nil if no such Trace could be found.
-func TraceFromContext(ctx context.Context) *Trace {
-	tr, _ := ctx.Value(traceKey).(*Trace)
-	return tr
-}
-
-// CopyContext copies the tracing-related context items from one context to another and returns that
-// context.
-func CopyContext(ctx context.Context, from context.Context) context.Context {
-	if tr := TraceFromContext(from); tr != nil {
-		ctx = contextWithTrace(ctx, tr)
-	}
-	if shouldTrace := ot.ShouldTrace(from); shouldTrace {
-		ctx = ot.WithShouldTrace(ctx, shouldTrace)
-	}
-	return ctx
-}
 
 // Trace is a combined version of golang.org/x/net/trace.Trace and
 // opentracing.Span. Use New to construct one.
@@ -101,6 +18,12 @@ type Trace struct {
 	trace  nettrace.Trace
 	span   opentracing.Span
 	family string
+}
+
+// New returns a new Trace with the specified family and title.
+func New(ctx context.Context, family, title string, tags ...Tag) (*Trace, context.Context) {
+	tr := Tracer{Tracer: ot.GetTracer(ctx)}
+	return tr.New(ctx, family, title, tags...)
 }
 
 // LazyPrintf evaluates its arguments with fmt.Sprintf each time the

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -96,16 +96,16 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 	go c.Watch(func() {
 		siteConfig := c.SiteConfig()
 
-		samplingStrategy := ot.TraceNone
+		samplingStrategy := policy.TraceNone
 		shouldLog := false
 		setTracer := None
 		if tracingConfig := siteConfig.ObservabilityTracing; tracingConfig != nil {
 			switch tracingConfig.Sampling {
 			case "all":
-				samplingStrategy = ot.TraceAll
+				samplingStrategy = policy.TraceAll
 				setTracer = Ot
 			case "selective":
-				samplingStrategy = ot.TraceSelective
+				samplingStrategy = policy.TraceSelective
 				setTracer = Ot
 			}
 			if t := TracerType(tracingConfig.Type); t.isSetByUser() {
@@ -113,11 +113,11 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 			}
 			shouldLog = tracingConfig.Debug
 		}
-		if tracePolicy := ot.GetTracePolicy(); tracePolicy != samplingStrategy && !initial {
+		if tracePolicy := policy.GetTracePolicy(); tracePolicy != samplingStrategy && !initial {
 			log15.Info("opentracing: TracePolicy", "oldValue", tracePolicy, "newValue", samplingStrategy)
 		}
 		initial = false
-		ot.SetTracePolicy(samplingStrategy)
+		policy.SetTracePolicy(samplingStrategy)
 
 		opts := options{
 			externalURL: siteConfig.ExternalURL,

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -282,7 +283,7 @@ func (w *Worker) dequeueAndHandle() (dequeued bool, err error) {
 	}
 
 	// Create context and span based on the root context
-	workerSpan, workerCtxWithSpan := ot.StartSpanFromContext(ot.WithShouldTrace(w.rootCtx, true), w.options.Name)
+	workerSpan, workerCtxWithSpan := ot.StartSpanFromContext(policy.WithShouldTrace(w.rootCtx, true), w.options.Name)
 	handleCtx, cancel := context.WithCancel(workerCtxWithSpan)
 	processLog := w.options.Metrics.logger.WithTrace(log.TraceContext{TraceID: trace.IDFromSpan(workerSpan)})
 


### PR DESCRIPTION
This change extracts generic "should we trace" logic into a new package, `trace/policy`, in an effort to disentangle from OpenTracing and migrate to the OpenTelemetry package. No logic changes, just code moves.

Part of https://github.com/sourcegraph/sourcegraph/issues/27386

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tests pass