### PR TITLE
internal/trace: reduce direct usages of OpenTracing

### DIFF
--- a/cmd/frontend/backend/mocks.go
+++ b/cmd/frontend/backend/mocks.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	tracepkg "github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 var Mocks MockServices
@@ -21,7 +21,7 @@ func testContext() context.Context {
 
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})
-	_, ctx = ot.StartSpanFromContext(ctx, "dummy")
+	_, ctx = tracepkg.New(ctx, "dummy", "")
 
 	return ctx
 }

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -26,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	tracepkg "github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -174,7 +174,7 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 	ctx, done := trace(ctx, "Repos", "List", opt, &err)
 	defer func() {
 		if err == nil {
-			span := opentracing.SpanFromContext(ctx)
+			span := tracepkg.TraceFromContext(ctx)
 			span.LogFields(otlog.Int("result.len", len(repos)))
 		}
 		done()
@@ -189,7 +189,7 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.MinimalRepo, e
 	ctx, done := trace(ctx, "Repos", "ListIndexable", nil, &err)
 	defer func() {
 		if err == nil {
-			span := opentracing.SpanFromContext(ctx)
+			span := tracepkg.TraceFromContext(ctx)
 			span.LogFields(otlog.Int("result.len", len(repos)))
 		}
 		done()

--- a/cmd/frontend/backend/trace.go
+++ b/cmd/frontend/backend/trace.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	tracepkg "github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 var metricLabels = []string{"method", "success"}
@@ -30,7 +29,7 @@ var requestGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 func trace(ctx context.Context, server, method string, arg any, err *error) (context.Context, func()) {
 	requestGauge.WithLabelValues(server + "." + method).Inc()
 
-	span, ctx := ot.StartSpanFromContext(ctx, server+"."+method)
+	span, ctx := tracepkg.New(ctx, server+"."+method, "")
 	span.SetTag("Server", server)
 	span.SetTag("Method", method)
 	span.SetTag("Argument", fmt.Sprintf("%#v", arg))

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -6,15 +6,13 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/opentracing/opentracing-go/ext"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -100,7 +98,7 @@ func linksForRepository(
 	db database.DB,
 	repo *types.Repo,
 ) (phabRepo *types.PhabricatorRepo, links *protocol.RepoLinks, serviceType string) {
-	span, ctx := ot.StartSpanFromContext(ctx, "externallink.linksForRepository")
+	span, ctx := trace.New(ctx, "externallink.linksForRepository", "")
 	defer span.Finish()
 	span.SetTag("Repo", repo.Name)
 	span.SetTag("ExternalRepo", repo.ExternalRepo)
@@ -108,7 +106,7 @@ func linksForRepository(
 	var err error
 	phabRepo, err = db.Phabricator().GetByName(ctx, repo.Name)
 	if err != nil && !errcode.IsNotFound(err) {
-		ext.Error.Set(span, true)
+		span.SetError(err)
 		span.SetTag("phabErr", err.Error())
 	}
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -253,7 +253,7 @@ func (r *GitCommitResolver) Path(ctx context.Context, args *struct {
 }
 
 func (r *GitCommitResolver) path(ctx context.Context, path string, validate func(fs.FileInfo) error) (*GitTreeEntryResolver, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "commit.path")
+	span, ctx := trace.New(ctx, "commit.path", "")
 	defer span.Finish()
 	span.SetTag("path", path)
 

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 func (r *GitTreeEntryResolver) IsRoot() bool {
@@ -40,7 +40,7 @@ func (r *GitTreeEntryResolver) Files(ctx context.Context, args *gitTreeEntryConn
 }
 
 func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryConnectionArgs, filter func(fi fs.FileInfo) bool) ([]*GitTreeEntryResolver, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "tree.entries")
+	span, ctx := trace.New(ctx, "tree.entries", "")
 	defer span.Finish()
 
 	entries, err := gitserver.NewClient(r.db).ReadDir(

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -26,7 +26,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/symbols"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -134,7 +133,7 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 }
 
 func (r *GitTreeEntryResolver) url(ctx context.Context) *url.URL {
-	span, ctx := ot.StartSpanFromContext(ctx, "treeentry.URL")
+	span, ctx := trace.New(ctx, "treeentry.URL", "")
 	defer span.Finish()
 
 	if submodule := r.Submodule(); submodule != nil {
@@ -199,7 +198,7 @@ func (r *GitTreeEntryResolver) Submodule() *gitSubmoduleResolver {
 }
 
 func cloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (string, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "cloneURLToRepoName")
+	span, ctx := trace.New(ctx, "cloneURLToRepoName", "")
 	defer span.Finish()
 
 	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, db, cloneURL)

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -165,7 +165,7 @@ type RepositoryCommitArgs struct {
 }
 
 func (r *RepositoryResolver) Commit(ctx context.Context, args *RepositoryCommitArgs) (*GitCommitResolver, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "repository.commit")
+	span, ctx := trace.New(ctx, "repository.commit", "")
 	defer span.Finish()
 	span.SetTag("commit", args.Rev)
 

--- a/cmd/frontend/graphqlbackend/site_monitoring.go
+++ b/cmd/frontend/graphqlbackend/site_monitoring.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/opentracing/opentracing-go/ext"
-
 	srcprometheus "github.com/sourcegraph/sourcegraph/internal/src-prometheus"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 // MonitoringAlert implements GraphQL getters on top of srcprometheus.MonitoringAlert
@@ -39,12 +37,12 @@ type siteMonitoringStatisticsResolver struct {
 
 func (r *siteMonitoringStatisticsResolver) Alerts(ctx context.Context) ([]*MonitoringAlert, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	span, ctx := ot.StartSpanFromContext(ctx, "site.MonitoringStatistics.alerts")
+	span, ctx := trace.New(ctx, "site.MonitoringStatistics.alerts", "")
 
 	var err error
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
+			span.SetError(err)
 			span.SetTag("err", err.Error())
 		}
 		cancel()

--- a/cmd/frontend/internal/app/errorutil/handlers.go
+++ b/cmd/frontend/internal/app/errorutil/handlers.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 
 	"github.com/inconshreveable/log15"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -24,9 +22,8 @@ func Handler(h func(http.ResponseWriter, *http.Request) error) http.Handler {
 		Error: func(w http.ResponseWriter, req *http.Request, status int, err error) {
 			if status < 200 || status >= 400 {
 				var traceURL, traceID string
-				if span := opentracing.SpanFromContext(req.Context()); span != nil {
-					ext.Error.Set(span, true)
-					span.SetTag("err", err)
+				if span := trace.TraceFromContext(req.Context()); span != nil {
+					span.SetError(err)
 					traceID = trace.IDFromSpan(span)
 					traceURL = trace.URL(traceID, conf.ExternalURL(), conf.Tracer())
 				}

--- a/cmd/frontend/internal/app/ui/landing.go
+++ b/cmd/frontend/internal/app/ui/landing.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -15,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -41,12 +40,11 @@ func serveRepoLanding(db database.DB) func(http.ResponseWriter, *http.Request) e
 }
 
 func serveDefLanding(w http.ResponseWriter, r *http.Request) (err error) {
-	span, ctx := ot.StartSpanFromContext(r.Context(), "serveDefLanding")
+	span, ctx := trace.New(r.Context(), "serveDefLanding", "")
 	r = r.WithContext(ctx)
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("err", err.Error())
+			span.SetError(err)
 		}
 		span.Finish()
 	}()

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -14,8 +14,6 @@ import (
 	"github.com/NYTimes/gziphandler"
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -470,9 +468,8 @@ func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, db database.DB, e
 
 	// Determine trace URL and log the error.
 	var traceURL string
-	if span := opentracing.SpanFromContext(r.Context()); span != nil {
-		ext.Error.Set(span, true)
-		span.SetTag("err", err)
+	if span := trace.TraceFromContext(r.Context()); span != nil {
+		span.SetError(err)
 		span.SetTag("error-id", errorID)
 		traceURL = trace.URL(trace.IDFromSpan(span), conf.ExternalURL(), conf.Tracer())
 	}

--- a/cmd/frontend/internal/cloneurls/clone_urls.go
+++ b/cmd/frontend/internal/cloneurls/clone_urls.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -23,7 +23,7 @@ import (
 // error if a matching code host could not be found. This function does not actually check the code
 // host to see if the repository actually exists.
 func ReposourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (repoName api.RepoName, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "ReposourceCloneURLToRepoName")
+	span, ctx := trace.New(ctx, "ReposourceCloneURLToRepoName", "")
 	defer span.Finish()
 
 	if repoName := reposource.CustomCloneURLToRepoName(cloneURL); repoName != "" {
@@ -102,7 +102,7 @@ func ReposourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL 
 }
 
 func getRepoNameFromService(ctx context.Context, cloneURL string, svc *types.ExternalService) (api.RepoName, error) {
-	span, _ := ot.StartSpanFromContext(ctx, "getRepoNameFromService")
+	span, _ := trace.New(ctx, "getRepoNameFromService", "")
 	defer span.Finish()
 	span.SetTag("ExternalService.ID", svc.ID)
 	span.SetTag("ExternalService.Kind", svc.Kind)

--- a/cmd/frontend/registry/client/client.go
+++ b/cmd/frontend/registry/client/client.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -34,7 +33,7 @@ const (
 
 // List lists extensions on the remote registry matching the query (or all if the query is empty).
 func List(ctx context.Context, registry *url.URL, query string) (xs []*Extension, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "registry/client.List")
+	span, ctx := trace.New(ctx, "registry/client.List", "")
 	span.SetTag("registry", registry.String())
 	span.SetTag("query", query)
 	defer func() {
@@ -42,8 +41,7 @@ func List(ctx context.Context, registry *url.URL, query string) (xs []*Extension
 			span.SetTag("results", len(xs))
 		}
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("error", err.Error())
+			span.SetError(err)
 		}
 		span.Finish()
 	}()

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -27,7 +27,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -36,6 +35,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -56,7 +56,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repotrackutil"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -102,14 +101,13 @@ func runCommand(ctx context.Context, cmd *exec.Cmd) (exitCode int, err error) {
 	if runCommandMock != nil {
 		return runCommandMock(ctx, cmd)
 	}
-	span, _ := ot.StartSpanFromContext(ctx, "runCommand")
+	span, _ := trace.New(ctx, "runCommand", "")
 	span.SetTag("path", cmd.Path)
 	span.SetTag("args", cmd.Args)
 	span.SetTag("dir", cmd.Dir)
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("err", err.Error())
+			span.SetError(err)
 			span.SetTag("exitCode", exitCode)
 		}
 		span.Finish()
@@ -397,7 +395,7 @@ func (s *Server) Handler() http.Handler {
 	getObjectFunc := gitdomain.GetObjectFunc(func(ctx context.Context, repo api.RepoName, objectName string) (*gitdomain.GitObject, error) {
 		// Tracing is server concern, so add it here. Once generics lands we should be
 		// able to create some simple wrappers
-		span, ctx := ot.StartSpanFromContext(ctx, "Git: GetObject")
+		span, ctx := trace.New(ctx, "Git: GetObject", "")
 		span.SetTag("objectName", objectName)
 		defer span.Finish()
 		return getObjectService.GetObject(ctx, repo, objectName)
@@ -2293,7 +2291,7 @@ func honeySampleRate(cmd string, internal bool) uint {
 var headBranchPattern = lazyregexp.New(`HEAD branch: (.+?)\n`)
 
 func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName) error {
-	span, ctx := ot.StartSpanFromContext(ctx, "Server.doRepoUpdate")
+	span, ctx := trace.New(ctx, "Server.doRepoUpdate", "")
 	span.SetTag("repo", repo)
 	defer span.Finish()
 

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -16,18 +16,18 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	zoektquery "github.com/google/zoekt/query"
-	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -385,12 +385,11 @@ type subset []string
 var all universalSet = struct{}{}
 
 func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatterns, extensionHint, pattern, rule string, languages []string, repo api.RepoName, sender matchSender) (err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "StructuralSearch")
+	span, ctx := trace.New(ctx, "StructuralSearch", "")
 	span.SetTag("repo", repo)
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("err", err.Error())
+			span.SetError(err)
 		}
 		span.Finish()
 	}()

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -42,7 +42,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -445,7 +444,7 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, definitions []ityp
 }
 
 func (a *backfillAnalyzer) buildForRepo(ctx context.Context, definitions []itypes.InsightSeries, repoName string, id api.RepoID) (jobs []*queryrunner.Job, preempted []store.RecordSeriesPointArgs, err error, softErr error) {
-	span, ctx := ot.StartSpanFromContext(policy.WithShouldTrace(ctx, true), "historical_enqueuer.buildForRepo")
+	span, ctx := trace.New(policy.WithShouldTrace(ctx, true), "historical_enqueuer.buildForRepo", "")
 	span.SetTag("repo_id", id)
 	defer func() {
 		if err != nil {

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -221,7 +221,7 @@ func StartAndWaitForCompletion(cmd *exec.Cmd) error {
 
 // Matches returns all matches in all files for which comby finds matches.
 func Matches(ctx context.Context, args Args) ([]*FileMatch, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Matches")
+	span, ctx := trace.New(ctx, "Comby.Matches", "")
 	defer span.Finish()
 
 	args.ResultKind = MatchOnly
@@ -238,7 +238,7 @@ func Matches(ctx context.Context, args Args) ([]*FileMatch, error) {
 
 // Replacements performs in-place replacement for match and rewrite template.
 func Replacements(ctx context.Context, args Args) ([]*FileReplacement, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Replacements")
+	span, ctx := trace.New(ctx, "Comby.Replacements", "")
 	defer span.Finish()
 
 	results, err := Run(ctx, args, toFileReplacement)
@@ -255,7 +255,7 @@ func Replacements(ctx context.Context, args Args) ([]*FileReplacement, error) {
 // Outputs performs substitution of all variables captured in a match
 // pattern in a rewrite template and outputs the result, newline-sparated.
 func Outputs(ctx context.Context, args Args) (string, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Outputs")
+	span, ctx := trace.New(ctx, "Comby.Outputs", "")
 	defer span.Finish()
 
 	results, err := Run(ctx, args, toOutput)

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -662,7 +662,7 @@ func (e *externalServiceStore) maybeEncryptConfig(ctx context.Context, config st
 }
 
 func (e *externalServiceStore) maybeDecryptConfig(ctx context.Context, config string, keyID string) (string, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "ExternalServiceStore.maybeDecryptConfig")
+	span, ctx := trace.New(ctx, "ExternalServiceStore.maybeDecryptConfig", "")
 	defer span.Finish()
 
 	if keyID == "" {
@@ -676,7 +676,7 @@ func (e *externalServiceStore) maybeDecryptConfig(ctx context.Context, config st
 	if key == nil {
 		return config, errors.Errorf("couldn't decrypt encrypted config, key is nil")
 	}
-	decryptSpan, ctx := ot.StartSpanFromContext(ctx, "key.Decrypt")
+	decryptSpan, ctx := trace.New(ctx, "key.Decrypt", "")
 	decrypted, err := key.Decrypt(ctx, []byte(config))
 	decryptSpan.Finish()
 	if err != nil {
@@ -1180,7 +1180,7 @@ ORDER BY es.id, essj.finished_at DESC
 }
 
 func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-	span, _ := ot.StartSpanFromContext(ctx, "ExternalServiceStore.list")
+	span, _ := trace.New(ctx, "ExternalServiceStore.list", "")
 	defer span.Finish()
 
 	if opt.OrderByDirection != "ASC" {

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -1522,7 +1522,7 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auth aut
 
 	var resp *http.Response
 
-	span, ctx := ot.StartSpanFromContext(ctx, "GitHub")
+	span, ctx := trace.New(ctx, "GitHub", "")
 	span.SetTag("URL", req.URL.String())
 	defer func() {
 		if err != nil {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	tracepkg "github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -235,7 +235,7 @@ func (c *Client) doWithBaseURL(ctx context.Context, req *http.Request, result an
 	}
 	var resp *http.Response
 
-	span, ctx := ot.StartSpanFromContext(ctx, "GitLab")
+	span, ctx := tracepkg.New(ctx, "GitLab", "")
 	span.SetTag("URL", req.URL.String())
 	defer func() {
 		if err != nil {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/neelance/parallel"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -44,6 +43,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -466,13 +466,12 @@ func (c *ClientImplementor) Archive(ctx context.Context, repo api.RepoName, opt 
 	if ClientMocks.Archive != nil {
 		return ClientMocks.Archive(ctx, repo, opt)
 	}
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Archive")
+	span, ctx := trace.New(ctx, "Git: Archive", "")
 	span.SetTag("Repo", repo)
 	span.SetTag("Treeish", opt.Treeish)
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.LogFields(log.Error(err))
+			span.SetError(err)
 		}
 		span.Finish()
 	}()
@@ -530,11 +529,10 @@ func (e badRequestError) BadRequest() bool { return true }
 func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, _ http.Header, errRes error) {
 	repoName := protocol.NormalizeRepo(c.repo)
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Client.sendExec")
+	span, ctx := trace.New(ctx, "Client.sendExec", "")
 	defer func() {
 		if errRes != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("err", errRes.Error())
+			span.SetError(errRes)
 		}
 		span.Finish()
 	}()
@@ -579,15 +577,14 @@ func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, _ htt
 }
 
 func (c *ClientImplementor) Search(ctx context.Context, args *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "GitserverClient.Search")
+	span, ctx := trace.New(ctx, "GitserverClient.Search", "")
 	span.SetTag("repo", string(args.Repo))
 	span.SetTag("query", args.Query.String())
 	span.SetTag("diff", args.IncludeDiff)
 	span.SetTag("limit", args.Limit)
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("err", err.Error())
+			span.SetError(err)
 		}
 		span.Finish()
 	}()
@@ -641,11 +638,10 @@ func (c *ClientImplementor) Search(ctx context.Context, args *protocol.SearchReq
 }
 
 func (c *ClientImplementor) P4Exec(ctx context.Context, host, user, password string, args ...string) (_ io.ReadCloser, _ http.Header, errRes error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Client.P4Exec")
+	span, ctx := trace.New(ctx, "Client.P4Exec", "")
 	defer func() {
 		if errRes != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("err", errRes.Error())
+			span.SetError(errRes)
 		}
 		span.Finish()
 	}()
@@ -1348,12 +1344,13 @@ func (c *ClientImplementor) do(ctx context.Context, repo api.RepoName, method, u
 		return nil, errors.Wrap(err, "do")
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Client.do")
+	span, ctx := trace.New(ctx, "Client.do", "")
 	defer func() {
-		span.LogKV("repo", string(repo), "method", method, "path", parsedURL.Path)
+		span.SetTag("repo", string(repo))
+		span.SetTag("method", method)
+		span.SetTag("path", parsedURL.Path)
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.SetTag("err", err.Error())
+			span.SetError(err)
 		}
 		span.Finish()
 	}()
@@ -1370,10 +1367,10 @@ func (c *ClientImplementor) do(ctx context.Context, repo api.RepoName, method, u
 	if c.HTTPLimiter != nil {
 		c.HTTPLimiter.Acquire()
 		defer c.HTTPLimiter.Release()
-		span.LogKV("event", "Acquired HTTP limiter")
+		span.LogFields(log.String("event", "Acquired HTTP limiter"))
 	}
 
-	req, ht := nethttp.TraceRequest(span.Tracer(), req,
+	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), req,
 		nethttp.OperationName("Gitserver Client"),
 		nethttp.ClientTrace(false))
 	defer ht.Finish()

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -36,7 +36,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -120,7 +119,7 @@ type ShortLogOptions struct {
 }
 
 func (c *ClientImplementor) ShortLog(ctx context.Context, repo api.RepoName, opt ShortLogOptions) ([]*gitdomain.PersonCount, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ShortLog")
+	span, ctx := trace.New(ctx, "Git: ShortLog", "")
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
@@ -158,7 +157,7 @@ func (c *ClientImplementor) execReader(ctx context.Context, repo api.RepoName, a
 		return Mocks.ExecReader(args)
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ExecReader")
+	span, ctx := trace.New(ctx, "Git: ExecReader", "")
 	span.SetTag("args", args)
 	defer span.Finish()
 
@@ -348,7 +347,7 @@ func (c *ClientImplementor) ReadDir(
 		return Mocks.ReadDir(commit, path, recurse)
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ReadDir")
+	span, ctx := trace.New(ctx, "Git: ReadDir", "")
 	span.SetTag("Commit", commit)
 	span.SetTag("Path", path)
 	span.SetTag("Recurse", recurse)
@@ -437,7 +436,7 @@ func (oid objectInfo) OID() gitdomain.OID { return gitdomain.OID(oid) }
 // returned FileInfo describes the symbolic link.  lStat makes no attempt to follow the link.
 // TODO(sashaostrikov): make private when git.Stat is moved here as well
 func (c *ClientImplementor) LStat(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (fs.FileInfo, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: lStat")
+	span, ctx := trace.New(ctx, "Git: lStat", "")
 	span.SetTag("Commit", commit)
 	span.SetTag("Path", path)
 	defer span.Finish()
@@ -673,7 +672,7 @@ type Hunk struct {
 
 // BlameFile returns Git blame information about a file.
 func (c *ClientImplementor) BlameFile(ctx context.Context, repo api.RepoName, path string, opt *BlameOptions, checker authz.SubRepoPermissionChecker) ([]*Hunk, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: BlameFile")
+	span, ctx := trace.New(ctx, "Git: BlameFile", "")
 	span.SetTag("repo", repo)
 	span.SetTag("path", path)
 	span.SetTag("opt", opt)
@@ -869,7 +868,7 @@ func (c *ClientImplementor) ResolveRevision(ctx context.Context, repo api.RepoNa
 	}
 	resolveRevisionCounter.WithLabelValues(labelEnsureRevisionValue).Inc()
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ResolveRevision")
+	span, ctx := trace.New(ctx, "Git: ResolveRevision", "")
 	span.SetTag("Spec", spec)
 	span.SetTag("Opt", fmt.Sprintf("%+v", opt))
 	defer span.Finish()
@@ -1085,7 +1084,7 @@ func parseDirectoryChildren(dirnames, paths []string) map[string][]string {
 
 // ListTags returns a list of all tags in the repository. If commitObjs is non-empty, only all tags pointing at those commits are returned.
 func (c *ClientImplementor) ListTags(ctx context.Context, repo api.RepoName, commitObjs ...string) ([]*gitdomain.Tag, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Tags")
+	span, ctx := trace.New(ctx, "Git: Tags", "")
 	defer span.Finish()
 
 	// Support both lightweight tags and tag objects. For creatordate, use an %(if) to prefer the
@@ -1205,7 +1204,7 @@ func (c *ClientImplementor) execSafe(ctx context.Context, repo api.RepoName, par
 		return Mocks.ExecSafe(params)
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: execSafe")
+	span, ctx := trace.New(ctx, "Git: execSafe", "")
 	defer span.Finish()
 
 	if len(params) == 0 {
@@ -1230,7 +1229,7 @@ func (c *ClientImplementor) MergeBase(ctx context.Context, repo api.RepoName, a,
 	if Mocks.MergeBase != nil {
 		return Mocks.MergeBase(repo, a, b)
 	}
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: MergeBase")
+	span, ctx := trace.New(ctx, "Git: MergeBase", "")
 	span.SetTag("A", a)
 	span.SetTag("B", b)
 	defer span.Finish()
@@ -1286,7 +1285,7 @@ func (c *ClientImplementor) RevListEach(stdout io.Reader, onCommit func(commit s
 // GetBehindAhead returns the behind/ahead commit counts information for right vs. left (both Git
 // revspecs).
 func (c *ClientImplementor) GetBehindAhead(ctx context.Context, repo api.RepoName, left, right string) (*gitdomain.BehindAhead, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: BehindAhead")
+	span, ctx := trace.New(ctx, "Git: BehindAhead", "")
 	defer span.Finish()
 
 	if err := checkSpecArgSafety(left); err != nil {
@@ -1320,7 +1319,7 @@ func (c *ClientImplementor) ReadFile(ctx context.Context, repo api.RepoName, com
 		return Mocks.ReadFile(commit, name)
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ReadFile")
+	span, ctx := trace.New(ctx, "Git: ReadFile", "")
 	span.SetTag("Name", name)
 	defer span.Finish()
 
@@ -1351,7 +1350,7 @@ func (c *ClientImplementor) NewFileReader(ctx context.Context, repo api.RepoName
 		return nil, os.ErrNotExist
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: GetFileReader")
+	span, ctx := trace.New(ctx, "Git: GetFileReader", "")
 	span.SetTag("Name", name)
 	defer span.Finish()
 
@@ -1440,7 +1439,7 @@ func (c *ClientImplementor) Stat(ctx context.Context, checker authz.SubRepoPermi
 		return Mocks.Stat(commit, path)
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Stat")
+	span, ctx := trace.New(ctx, "Git: Stat", "")
 	span.SetTag("Commit", commit)
 	span.SetTag("Path", path)
 	defer span.Finish()
@@ -1545,7 +1544,7 @@ func (c *ClientImplementor) getCommit(ctx context.Context, repo api.RepoName, id
 // needed. The Git remote URL is only required if the gitserver doesn't already contain a clone of
 // the repository or if the commit must be fetched from the remote.
 func (c *ClientImplementor) GetCommit(ctx context.Context, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions, checker authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: GetCommit")
+	span, ctx := trace.New(ctx, "Git: GetCommit", "")
 	span.SetTag("Commit", id)
 	defer span.Finish()
 
@@ -1558,7 +1557,7 @@ func (c *ClientImplementor) Commits(ctx context.Context, repo api.RepoName, opt 
 		return Mocks.Commits(repo, opt)
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Commits")
+	span, ctx := trace.New(ctx, "Git: Commits", "")
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
@@ -1677,7 +1676,7 @@ func (c *ClientImplementor) HasCommitAfter(ctx context.Context, repo api.RepoNam
 	if authz.SubRepoEnabled(checker) {
 		return c.hasCommitAfterWithFiltering(ctx, repo, date, revspec, checker)
 	}
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: HasCommitAfter")
+	span, ctx := trace.New(ctx, "Git: HasCommitAfter", "")
 	span.SetTag("Date", date)
 	span.SetTag("RevSpec", revspec)
 	defer span.Finish()
@@ -1899,7 +1898,7 @@ func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err
 
 // commitCount returns the number of commits that would be returned by Commits.
 func (c *ClientImplementor) commitCount(ctx context.Context, repo api.RepoName, opt CommitsOptions) (uint, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: CommitCount")
+	span, ctx := trace.New(ctx, "Git: CommitCount", "")
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
@@ -1925,7 +1924,7 @@ func (c *ClientImplementor) commitCount(ctx context.Context, repo api.RepoName, 
 
 // FirstEverCommit returns the first commit ever made to the repository.
 func (c *ClientImplementor) FirstEverCommit(ctx context.Context, repo api.RepoName, checker authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: FirstEverCommit")
+	span, ctx := trace.New(ctx, "Git: FirstEverCommit", "")
 	defer span.Finish()
 
 	args := []string{"rev-list", "--reverse", "--date-order", "--max-parents=0", "HEAD"}
@@ -1980,7 +1979,7 @@ func (c *ClientImplementor) CommitsExist(ctx context.Context, repoCommits []api.
 // If ignoreErrors is true, then errors arising from any single failed git log operation will cause the
 // resulting commit to be nil, but not fail the entire operation.
 func (c *ClientImplementor) GetCommits(ctx context.Context, repoCommits []api.RepoCommit, ignoreErrors bool, checker authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: getCommits")
+	span, ctx := trace.New(ctx, "Git: getCommits", "")
 	span.SetTag("numRepoCommits", len(repoCommits))
 	defer span.Finish()
 
@@ -2471,7 +2470,7 @@ func (f branchFilter) add(list []string) {
 
 // ListBranches returns a list of all branches in the repository.
 func (c *ClientImplementor) ListBranches(ctx context.Context, repo api.RepoName, opt BranchesOptions) ([]*gitdomain.Branch, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Branches")
+	span, ctx := trace.New(ctx, "Git: Branches", "")
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
@@ -2546,7 +2545,7 @@ func (p byteSlices) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // ListRefs returns a list of all refs in the repository.
 func (c *ClientImplementor) ListRefs(ctx context.Context, repo api.RepoName) ([]gitdomain.Ref, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ListRefs")
+	span, ctx := trace.New(ctx, "Git: ListRefs", "")
 	defer span.Finish()
 	return c.showRef(ctx, repo)
 }

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/PuerkitoBio/rehttp"
 	"github.com/gregjones/httpcache"
 	"github.com/inconshreveable/log15"
-	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -28,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -424,7 +424,7 @@ func NewRetryPolicy(max int) rehttp.RetryFn {
 		defer func() {
 			// Avoid trace log spam if we haven't invoked the retry policy.
 			shouldTraceLog := retry || a.Index > 0
-			if span := opentracing.SpanFromContext(a.Request.Context()); span != nil && shouldTraceLog {
+			if span := trace.TraceFromContext(a.Request.Context()); span != nil && shouldTraceLog {
 				fields := []otlog.Field{
 					otlog.Event("request-retry-decision"),
 					otlog.Bool("retry", retry),

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -95,6 +95,9 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 
 	if isLeaf && opts != nil && policy.ShouldTrace(ctx) {
 		// Replace any existing spanContext with a new one, given we've done additional tracing
+		//
+		// TODO https://github.com/sourcegraph/sourcegraph/issues/27386 might be incompatible
+		// with OTel tracing
 		spanContext := make(map[string]string)
 		if err := ot.GetTracer(ctx).Inject(opentracing.SpanFromContext(ctx).Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err == nil {
 			newOpts := *opts

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	"github.com/neelance/parallel"
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -19,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -87,11 +85,10 @@ func (s *SymbolSearchJob) Tags() []log.Field {
 }
 
 func searchInRepo(ctx context.Context, db database.DB, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.Match, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Search symbols in repo")
+	span, ctx := trace.New(ctx, "Search symbols in repo", "")
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.LogFields(log.Error(err))
+			span.SetError(err)
 		}
 		span.Finish()
 	}()

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -65,6 +65,8 @@ func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[stri
 		return false, nil
 	}
 
+	// TODO https://github.com/sourcegraph/sourcegraph/issues/27386 might be incompatible
+	// with OTel tracing
 	spanContext = make(map[string]string)
 	if err := ot.GetTracer(ctx).Inject(opentracing.SpanFromContext(ctx).Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err != nil {
 		log15.Warn("Error injecting span context into map: %s", err)

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -13,8 +13,7 @@ import (
 	"github.com/gobwas/glob"
 	"github.com/neelance/parallel"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
-	"github.com/opentracing/opentracing-go/ext"
-	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/go-ctags"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/resetonce"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -131,11 +131,10 @@ func (c *Client) ListLanguageMappings(ctx context.Context, repo api.RepoName) (_
 
 // Search performs a symbol search on the symbols service.
 func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (symbols result.Symbols, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "symbols.Client.Search")
+	span, ctx := trace.New(ctx, "symbols.Client.Search", "")
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.LogFields(otlog.Error(err))
+			span.SetError(err)
 		}
 		span.Finish()
 	}()
@@ -200,11 +199,10 @@ func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (sym
 }
 
 func (c *Client) LocalCodeIntel(ctx context.Context, args types.RepoCommitPath) (result *types.LocalCodeIntelPayload, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "squirrel.Client.LocalCodeIntel")
+	span, ctx := trace.New(ctx, "squirrel.Client.LocalCodeIntel", "")
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.LogFields(otlog.Error(err))
+			span.SetError(err)
 		}
 		span.Finish()
 	}()
@@ -236,11 +234,10 @@ func (c *Client) LocalCodeIntel(ctx context.Context, args types.RepoCommitPath) 
 }
 
 func (c *Client) SymbolInfo(ctx context.Context, args types.RepoCommitPathPoint) (result *types.SymbolInfo, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "squirrel.Client.SymbolInfo")
+	span, ctx := trace.New(ctx, "squirrel.Client.SymbolInfo", "")
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.LogFields(otlog.Error(err))
+			span.SetError(err)
 		}
 		span.Finish()
 	}()
@@ -301,11 +298,10 @@ func (c *Client) httpPost(
 	repo api.RepoName,
 	payload any,
 ) (resp *http.Response, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "symbols.Client.httpPost")
+	span, ctx := trace.New(ctx, "symbols.Client.httpPost", "")
 	defer func() {
 		if err != nil {
-			ext.Error.Set(span, true)
-			span.LogFields(otlog.Error(err))
+			span.SetError(err)
 		}
 		span.Finish()
 	}()
@@ -332,13 +328,13 @@ func (c *Client) httpPost(
 	req = req.WithContext(ctx)
 
 	if c.HTTPLimiter != nil {
-		span.LogKV("event", "Waiting on HTTP limiter")
+		span.LogFields(log.String("event", "Waiting on HTTP limiter"))
 		c.HTTPLimiter.Acquire()
 		defer c.HTTPLimiter.Release()
-		span.LogKV("event", "Acquired HTTP limiter")
+		span.LogFields(log.String("event", "Acquired HTTP limiter"))
 	}
 
-	req, ht := nethttp.TraceRequest(span.Tracer(), req,
+	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), req,
 		nethttp.OperationName("Symbols Client"),
 		nethttp.ClientTrace(false))
 	defer ht.Finish()

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -18,7 +18,7 @@ const traceKey = traceContextKey("trace")
 // SpanContext. External callers should likely use CopyContext, as this properly propagates all
 // tracing context from one context to another.
 func contextWithTrace(ctx context.Context, tr *Trace) context.Context {
-	ctx = opentracing.ContextWithSpan(ctx, tr.span)
+	ctx = opentracing.ContextWithSpan(ctx, tr.otSpan)
 	ctx = context.WithValue(ctx, traceKey, tr)
 	return ctx
 }
@@ -49,12 +49,12 @@ func ID(ctx context.Context) string {
 	if span == nil {
 		return ""
 	}
-	return IDFromSpan(span)
+	return IDFromSpan(&Trace{otSpan: span})
 }
 
 // IDFromSpan returns a trace ID, if any, found in the given span.
-func IDFromSpan(span opentracing.Span) string {
-	traceCtx := ContextFromSpan(span)
+func IDFromSpan(span *Trace) string {
+	traceCtx := ContextFromSpan(span.otSpan)
 	if traceCtx == nil {
 		return ""
 	}

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/repotrackutil"
+	internalot "github.com/sourcegraph/sourcegraph/internal/trace/internal/ot"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -151,7 +152,7 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 		}
 
 		// start new span
-		span, ctx := ot.StartSpanFromContext(ctx, "", ext.RPCServerOption(wireContext))
+		span, ctx := internalot.StartSpanFromContext(ctx, "", ext.RPCServerOption(wireContext))
 		ext.HTTPUrl.Set(span, r.URL.String())
 		ext.HTTPMethod.Set(span, r.Method)
 		span.SetTag("http.referer", r.Header.Get("referer"))

--- a/internal/trace/internal/ot/ot.go
+++ b/internal/trace/internal/ot/ot.go
@@ -1,0 +1,35 @@
+// Package ot (internal/ot) exports internal OpenTelemetry helpers for Sourcegraph's trace
+// package.
+package ot
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
+)
+
+// StartSpanFromContext starts a span using the tracer returned by GetTracer.
+func StartSpanFromContext(ctx context.Context, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
+	return StartSpanFromContextWithTracer(ctx, opentracing.GlobalTracer(), operationName, opts...)
+}
+
+// StartSpanFromContextWithTracer starts a span using the tracer returned by invoking getTracer with the
+// passed-in tracer.
+func StartSpanFromContextWithTracer(ctx context.Context, tracer opentracing.Tracer, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
+	return opentracing.StartSpanFromContextWithTracer(ctx, GetTracer(ctx, tracer), operationName, opts...)
+}
+
+// GetTracer is like GetTracer, but accepts a tracer as an argument. If ShouldTrace returns false,
+// it returns the NoopTracer. If it returns true and the passed-in tracer is not nil, it returns the
+// passed-in tracer. Otherwise, it returns the global tracer.
+func GetTracer(ctx context.Context, tracer opentracing.Tracer) opentracing.Tracer {
+	if !policy.ShouldTrace(ctx) {
+		return opentracing.NoopTracer{}
+	}
+	if tracer == nil {
+		return opentracing.GlobalTracer()
+	}
+	return tracer
+}

--- a/internal/trace/logger.go
+++ b/internal/trace/logger.go
@@ -17,7 +17,7 @@ func Logger(ctx context.Context, l log.Logger) log.Logger {
 		if t.family != "" {
 			l = l.Scoped(t.family, "trace family")
 		}
-		if tc := ContextFromSpan(t.span); tc != nil {
+		if tc := ContextFromSpan(t.otSpan); tc != nil {
 			l = l.WithTrace(*tc)
 		}
 	}

--- a/internal/trace/ot/ot.go
+++ b/internal/trace/ot/ot.go
@@ -11,8 +11,17 @@ import (
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 
+	internalot "github.com/sourcegraph/sourcegraph/internal/trace/internal/ot"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 )
+
+// GetTracer returns the tracer to use for the given context. If ShouldTrace returns true, it
+// returns the global tracer. Otherwise, it returns the NoopTracer.
+//
+// TODO OpenTelemetry considerations: https://github.com/sourcegraph/sourcegraph/issues/27386
+func GetTracer(ctx context.Context) opentracing.Tracer {
+	return internalot.GetTracer(ctx, opentracing.GlobalTracer())
+}
 
 // HTTPMiddleware wraps the handler with the following:
 //
@@ -20,12 +29,16 @@ import (
 //   shouldTraceKey context.Context value to true
 // - github.com/opentracing-contrib/go-stdlib/nethttp.HTTPMiddleware, which creates a new span to track
 //   the request handler from the global tracer.
+//
+// TODO OpenTelemetry considerations: https://github.com/sourcegraph/sourcegraph/issues/27386
 func HTTPMiddleware(h http.Handler, opts ...nethttp.MWOption) http.Handler {
 	return MiddlewareWithTracer(opentracing.GlobalTracer(), h)
 }
 
 // MiddlewareWithTracer is like Middleware, but uses the specified tracer instead of the global
 // tracer.
+//
+// TODO OpenTelemetry considerations: https://github.com/sourcegraph/sourcegraph/issues/27386
 func MiddlewareWithTracer(tr opentracing.Tracer, h http.Handler, opts ...nethttp.MWOption) http.Handler {
 	nethttpMiddleware := nethttp.Middleware(tr, h, append([]nethttp.MWOption{
 		nethttp.MWSpanFilter(func(r *http.Request) bool {
@@ -44,34 +57,4 @@ func MiddlewareWithTracer(tr opentracing.Tracer, h http.Handler, opts ...nethttp
 		}
 		nethttpMiddleware.ServeHTTP(w, r.WithContext(policy.WithShouldTrace(r.Context(), trace)))
 	})
-}
-
-// GetTracer returns the tracer to use for the given context. If ShouldTrace returns true, it
-// returns the global tracer. Otherwise, it returns the NoopTracer.
-func GetTracer(ctx context.Context) opentracing.Tracer {
-	return getTracer(ctx, opentracing.GlobalTracer())
-}
-
-// getTracer is like GetTracer, but accepts a tracer as an argument. If ShouldTrace returns false,
-// it returns the NoopTracer. If it returns true and the passed-in tracer is not nil, it returns the
-// passed-in tracer. Otherwise, it returns the global tracer.
-func getTracer(ctx context.Context, tracer opentracing.Tracer) opentracing.Tracer {
-	if !policy.ShouldTrace(ctx) {
-		return opentracing.NoopTracer{}
-	}
-	if tracer == nil {
-		return opentracing.GlobalTracer()
-	}
-	return tracer
-}
-
-// StartSpanFromContext starts a span using the tracer returned by GetTracer.
-func StartSpanFromContext(ctx context.Context, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
-	return StartSpanFromContextWithTracer(ctx, opentracing.GlobalTracer(), operationName, opts...)
-}
-
-// StartSpanFromContextWithTracer starts a span using the tracer returned by invoking getTracer with the
-// passed-in tracer.
-func StartSpanFromContextWithTracer(ctx context.Context, tracer opentracing.Tracer, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
-	return opentracing.StartSpanFromContextWithTracer(ctx, getTracer(ctx, tracer), operationName, opts...)
 }

--- a/internal/trace/tracer.go
+++ b/internal/trace/tracer.go
@@ -6,7 +6,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	nettrace "golang.org/x/net/trace"
 
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	internalot "github.com/sourcegraph/sourcegraph/internal/trace/internal/ot"
 )
 
 // A Tracer for trace creation, parameterised over an
@@ -18,14 +18,14 @@ type Tracer struct {
 
 // New returns a new Trace with the specified family and title.
 func (t Tracer) New(ctx context.Context, family, title string, tags ...Tag) (*Trace, context.Context) {
-	span, ctx := ot.StartSpanFromContextWithTracer(
+	span, ctx := internalot.StartSpanFromContextWithTracer(
 		ctx,
 		t.Tracer,
 		family,
 		tagsOpt{title: title, tags: tags},
 	)
 	tr := nettrace.New(family, title)
-	trace := &Trace{span: span, trace: tr, family: family}
+	trace := &Trace{otSpan: span, trace: tr, family: family}
 	if parent := TraceFromContext(ctx); parent != nil {
 		tr.LazyPrintf("parent: %s", parent.family)
 		trace.family = parent.family + " > " + family

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -283,7 +282,7 @@ func (w *Worker) dequeueAndHandle() (dequeued bool, err error) {
 	}
 
 	// Create context and span based on the root context
-	workerSpan, workerCtxWithSpan := ot.StartSpanFromContext(policy.WithShouldTrace(w.rootCtx, true), w.options.Name)
+	workerSpan, workerCtxWithSpan := trace.New(policy.WithShouldTrace(w.rootCtx, true), w.options.Name, "")
 	handleCtx, cancel := context.WithCancel(workerCtxWithSpan)
 	processLog := w.options.Metrics.logger.WithTrace(log.TraceContext{TraceID: trace.IDFromSpan(workerSpan)})
 


### PR DESCRIPTION
This attempts to consoldiate tracing creation into `internal/trace`, so that we can more effectively control tracing output, and moves some OpenTracing stuff into an internal package

Used Comby directly for a lot of the rewrites so some things e.g. `span.SetError` changes are pretty minimal (`span.SetError` checks for nilness internally but callsites still set it themselves)

There's a few places where I'm not sure how we should migrate so I've just left them as-is and added TODOs

Part of https://github.com/sourcegraph/sourcegraph/issues/27386

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tests pass