### PR TITLE
Resource Estimator:  Update disk space calculation

### DIFF
--- a/doc/admin/deploy/resource_estimator.md
+++ b/doc/admin/deploy/resource_estimator.md
@@ -40,7 +40,7 @@
 </style>
 
 <script src="https://storage.googleapis.com/sourcegraph-resource-estimator/go_1_18_wasm_exec.js"></script>
-<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="dbc14f6"></script>
+<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="a446673"></script>
 
 # Sourcegraph resource estimator
 


### PR DESCRIPTION
Update version number for the build from https://github.com/sourcegraph/resource-estimator/pull/17 that update disk space calculation

Based on the discussion that happened [here](https://sourcegraph.slack.com/archives/C07KZF47K/p1656534919855799?thread_ts=1656436334.261969&cid=C07KZF47K)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Tested locally. See https://github.com/sourcegraph/resource-estimator/pull/17