### PR TITLE
Search backend: ignore subprocess errors caused by canceled context

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -478,7 +478,12 @@ func runCombyAgainstTar(ctx context.Context, args comby.Args, tarInput comby.Tar
 		}
 	}()
 
-	return comby.StartAndWaitForCompletion(cmd)
+	err = comby.StartAndWaitForCompletion(cmd)
+	if ctx.Err() != nil {
+		// context has been canceled, ignore any "process killed" errors from the subprocess
+		return nil
+	}
+	return err
 }
 
 // runCombyAgainstZip runs comby with the flag `-zip`. It reads matches from comby's stdout as they are returned and


### PR DESCRIPTION
A canceled context will send a kill signal to the subprocess, which will
cause it to return an error code. If the subprocess is exiting due to a
context error, we don't care that the subprocess failed, so we just
ignore the error.



## Test plan

I couldn't reproduce the test failures locally, but this is a strong hunch.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
