### PR TITLE
gitserver: add metric for repo count

### DIFF
--- a/cmd/gitserver/server/servermetrics.go
+++ b/cmd/gitserver/server/servermetrics.go
@@ -87,6 +87,26 @@ func (s *Server) RegisterMetrics(db dbutil.DB, observationContext *observation.C
 	})
 	prometheus.MustRegister(c)
 
+	c = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "src_gitserver_repo_count",
+		Help: "Number of repos.",
+	}, func() float64 {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		var count int64
+		err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM repo AS r
+			WHERE r.deleted_at IS NULL
+		`).Scan(&count)
+		if err != nil {
+			s.Logger.Error("failed to count repositories", log.Error(err))
+			return 0
+		}
+		return float64(count)
+	})
+	prometheus.MustRegister(c)
+
 	// Register uniform observability via internal/observation
 	s.operations = newOperations(observationContext)
 }


### PR DESCRIPTION
Add in metric to show total number of non-deleted git repos.

Co-authored-by: Michael Lin <hi@michaellin.me>

## Test plan
1. `sg start` and `sg start monitoring`
2. [Query grafana](http://localhost:3370/-/debug/grafana/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Prometheus%22,%7B%22exemplar%22:true,%22expr%22:%22src_gitserver_repo_count%22,%22requestId%22:%22Q-1c6fe60c-23ac-416a-b16f-3ab54b1fbf6d-0A%22%7D%5D)
3. Verify the metric value matches the result of this query:
```sql

SELECT COUNT(*) FROM repo WHERE deleted_at IS NULL;
```
