### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -5,6 +5,9 @@ on:
   - cron: '0 0 * * SUN'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -5,6 +5,9 @@ on:
   - cron: '*/15 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
 
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/container-scanning.yml
+++ b/.github/workflows/container-scanning.yml
@@ -3,8 +3,13 @@ on:
   schedule:
   - cron: '5 5 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   scan:
+    permissions:
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     name: container-scan
     runs-on: ubuntu-latest
 

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -14,6 +14,9 @@ on:
       paths:
        - client/jetbrains/**
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -2,6 +2,9 @@ name: Move labeled or milestoned issue to a specific project colum
 on:
   issues:
     types: [labeled]
+permissions:
+  contents: read
+
 jobs:
   # Uses issues beta API - see https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects#example-workflow
   # To get your PROJECT_ID, use:
@@ -15,6 +18,8 @@ jobs:
   #   }
   #   }' -F project=212
   code-intel-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: MDExOlByb2plY3ROZXh0NDI1MA== # https://github.com/orgs/sourcegraph/projects/211
@@ -42,6 +47,8 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   dev-experience-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: MDExOlByb2plY3ROZXh0NDI1Nw== # https://github.com/orgs/sourcegraph/projects/212
@@ -69,6 +76,8 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   integrations-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: MDExOlByb2plY3ROZXh0NDMyNg== # https://github.com/orgs/sourcegraph/projects/213
@@ -96,6 +105,8 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   batchers-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: PN_kwDOADy5QM0WXg== # https://github.com/orgs/sourcegraph/projects/216
@@ -123,6 +134,8 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   dev-ops-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: PN_kwDOADy5QM1D1Q # https://github.com/orgs/sourcegraph/projects/220
@@ -150,6 +163,8 @@ jobs:
               }
             }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   frontend-platform-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: PN_kwDOADy5QM2FqQ== # https://github.com/orgs/sourcegraph/projects/222
@@ -172,6 +187,8 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   delivery-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: MDExOlByb2plY3ROZXh0Mzg2Mw== # https://github.com/orgs/sourcegraph/projects/205
@@ -199,6 +216,8 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   wcag-accessibility-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: PN_kwDOADy5QM4AAyDB # https://github.com/orgs/sourcegraph/projects/238
@@ -221,6 +240,8 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   growth-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: PN_kwDOADy5QM4ABLw3 # https://github.com/orgs/sourcegraph/projects/253
@@ -248,6 +269,8 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   iam-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: PN_kwDOADy5QM4ABlJF # https://github.com/orgs/sourcegraph/projects/259
@@ -275,6 +298,8 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
   executors-board:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: PN_kwDOADy5QM4ADYmX # https://github.com/orgs/sourcegraph/projects/267

--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -1,6 +1,9 @@
 name: Licenses Check
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse-production.yml
+++ b/.github/workflows/lighthouse-production.yml
@@ -6,6 +6,9 @@ on:
   # # Every Monday at 12pm UTC
   # - cron: '0 12 * * MON'
 
+permissions:
+  contents: read
+
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ closed, edited, opened, synchronize, ready_for_review ]
 
+permissions:
+  contents: read
+
 jobs:
   check-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -8,6 +8,9 @@ on:
     # At minute 0 past every 12th hour
     - cron: '0 */12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   remove-pr-preview-app:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -16,6 +16,9 @@ on:
         default: 'progress'
   schedule:
   - cron: "0 0 * * *"   # Every day 00:00 UTC (4pm PST)
+permissions:
+  contents: read
+
 jobs:
   report-to-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-schema.yml
+++ b/.github/workflows/push-schema.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   sync-schema:
     runs-on: ubuntu-latest

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -12,8 +12,13 @@ env:
   GOFLAGS: -trimpath
   CGO_ENABLED: '1'
 
+permissions:
+  contents: read
+
 jobs:
   touch_sg:
+    permissions:
+      contents: write  # for Git to git push
     name: Touch sourcegraph/sg
     runs-on: ubuntu-latest
     steps:
@@ -33,6 +38,8 @@ jobs:
           git push
 
   create_release:
+    permissions:
+      contents: none
     name: create-github-release
     needs: touch_sg
     runs-on: ubuntu-latest

--- a/.github/workflows/sg-setup.yml
+++ b/.github/workflows/sg-setup.yml
@@ -6,6 +6,9 @@ on:
       - 'dev/sg/dependencies/**.go'
       - 'dev/sg/internal/check/**.go'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -25,8 +25,13 @@ on:
     - unassigned
     - labeled
     - unlabeled
+permissions:
+  contents: read
+
 jobs:
   sync-tracking-issues:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - uses: docker://sourcegraph/tracking-issue:latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
