### PR TITLE
Code intel: Codemod `<Icon />` to `@mdi/js`

### DIFF
--- a/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
+import { mdiBrain } from '@mdi/js'
 import classNames from 'classnames'
-import BrainIcon from 'mdi-react/BrainIcon'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
@@ -103,7 +103,7 @@ export const CodeIntelligenceBadgeMenu: React.FunctionComponent<
                     onClick={() => setBadgeUsed(true)}
                     aria-label="Code intelligence"
                 >
-                    <Icon aria-hidden={true} as={BrainIcon} />
+                    <Icon aria-hidden={true} svgPath={mdiBrain} />
                 </MenuButton>
 
                 <MenuList position={Position.bottomEnd} className={styles.dropdownMenu} isOpen={isStorybook}>

--- a/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPattern.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPattern.tsx
@@ -1,8 +1,8 @@
 import { FunctionComponent, useEffect, useMemo, useState } from 'react'
 
+import { mdiDelete } from '@mdi/js'
 import classNames from 'classnames'
 import { debounce } from 'lodash'
-import TrashIcon from 'mdi-react/TrashIcon'
 
 import { Button, Icon, Input } from '@sourcegraph/wildcard'
 
@@ -55,7 +55,7 @@ export const ReposMatchingPattern: FunctionComponent<React.PropsWithChildren<Rep
                     className="p-0"
                     disabled={disabled}
                 >
-                    <Icon className="text-danger" aria-hidden={true} as={TrashIcon} />
+                    <Icon className="text-danger" aria-hidden={true} svgPath={mdiDelete} />
                 </Button>
             </span>
         </>

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -1,8 +1,8 @@
 import { FunctionComponent, useCallback, useEffect, useState } from 'react'
 
 import { ApolloError } from '@apollo/client'
+import { mdiDelete } from '@mdi/js'
 import * as H from 'history'
-import DeleteIcon from 'mdi-react/DeleteIcon'
 import { RouteComponentProps } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
@@ -156,7 +156,7 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<
                         >
                             {!isDeleting && (
                                 <>
-                                    <Icon aria-hidden={true} as={DeleteIcon} /> Delete policy
+                                    <Icon aria-hidden={true} svgPath={mdiDelete} /> Delete policy
                                 </>
                             )}
                             {isDeleting && (

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelDeleteIndex.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelDeleteIndex.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react'
 
-import DeleteIcon from 'mdi-react/DeleteIcon'
+import { mdiDelete } from '@mdi/js'
 
 import { ErrorLike } from '@sourcegraph/common'
 import { Button, Icon } from '@sourcegraph/wildcard'
@@ -22,6 +22,6 @@ export const CodeIntelDeleteIndex: FunctionComponent<React.PropsWithChildren<Cod
         aria-describedby="upload-delete-button-help"
         data-tooltip="Deleting this index will remove it from the index queue."
     >
-        <Icon aria-hidden={true} as={DeleteIcon} /> Delete index
+        <Icon aria-hidden={true} svgPath={mdiDelete} /> Delete index
     </Button>
 )

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexTimeline.tsx
@@ -1,9 +1,6 @@
 import { FunctionComponent, useMemo } from 'react'
 
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckIcon from 'mdi-react/CheckIcon'
-import ProgressClockIcon from 'mdi-react/ProgressClockIcon'
-import TimerSandIcon from 'mdi-react/TimerSandIcon'
+import { mdiTimerSand, mdiCheck, mdiAlertCircle, mdiProgressClock } from '@mdi/js'
 
 import { isDefined } from '@sourcegraph/common'
 import { LSIFIndexState } from '@sourcegraph/shared/src/graphql-operations'
@@ -30,13 +27,13 @@ export const CodeIntelIndexTimeline: FunctionComponent<React.PropsWithChildren<C
         () =>
             [
                 {
-                    icon: <Icon as={TimerSandIcon} aria-label="Success" />,
+                    icon: <Icon aria-label="Success" svgPath={mdiTimerSand} />,
                     text: 'Queued',
                     date: index.queuedAt,
                     className: 'bg-success',
                 },
                 {
-                    icon: <Icon as={CheckIcon} aria-label="Success" />,
+                    icon: <Icon aria-label="Success" svgPath={mdiCheck} />,
                     text: 'Began processing',
                     date: index.startedAt,
                     className: 'bg-success',
@@ -50,13 +47,13 @@ export const CodeIntelIndexTimeline: FunctionComponent<React.PropsWithChildren<C
 
                 index.state === LSIFIndexState.COMPLETED
                     ? {
-                          icon: <Icon as={CheckIcon} aria-label="Success" />,
+                          icon: <Icon aria-label="Success" svgPath={mdiCheck} />,
                           text: 'Finished',
                           date: index.finishedAt,
                           className: 'bg-success',
                       }
                     : {
-                          icon: <Icon as={AlertCircleIcon} aria-label="Failed" />,
+                          icon: <Icon aria-label="Failed" svgPath={mdiAlertCircle} />,
                           text: 'Failed',
                           date: index.finishedAt,
                           className: 'bg-danger',
@@ -159,11 +156,11 @@ const genericStage = <E extends { startTime: string; exitCode: number | null }>(
 
     return {
         icon: !finished ? (
-            <Icon as={ProgressClockIcon} aria-label="Success" />
+            <Icon aria-label="Success" svgPath={mdiProgressClock} />
         ) : success ? (
-            <Icon as={CheckIcon} aria-label="Success" />
+            <Icon aria-label="Success" svgPath={mdiCheck} />
         ) : (
-            <Icon as={AlertCircleIcon} aria-label="Failed" />
+            <Icon aria-label="Failed" svgPath={mdiAlertCircle} />
         ),
         date: Array.isArray(value) ? value[0].startTime : value.startTime,
         className: success || !finished ? 'bg-success' : 'bg-danger',

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelDeleteUpload.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelDeleteUpload.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react'
 
-import DeleteIcon from 'mdi-react/DeleteIcon'
+import { mdiDelete } from '@mdi/js'
 
 import { ErrorLike } from '@sourcegraph/common'
 import { LSIFUploadState } from '@sourcegraph/shared/src/graphql-operations'
@@ -32,6 +32,6 @@ export const CodeIntelDeleteUpload: FunctionComponent<React.PropsWithChildren<Co
                     : 'Delete this upload immediately'
             }
         >
-            <Icon aria-hidden={true} as={DeleteIcon} /> Delete upload
+            <Icon aria-hidden={true} svgPath={mdiDelete} /> Delete upload
         </Button>
     )

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadTimeline.tsx
@@ -1,9 +1,6 @@
 import { FunctionComponent, useMemo } from 'react'
 
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckIcon from 'mdi-react/CheckIcon'
-import FileUploadIcon from 'mdi-react/FileUploadIcon'
-import ProgressClockIcon from 'mdi-react/ProgressClockIcon'
+import { mdiFileUpload, mdiProgressClock, mdiCheck, mdiAlertCircle } from '@mdi/js'
 
 import { LSIFUploadState } from '@sourcegraph/shared/src/graphql-operations'
 import { Icon } from '@sourcegraph/wildcard'
@@ -49,7 +46,6 @@ const uploadStages = (upload: LsifUploadFields, failedStage: FailedStage | null)
     {
         icon: (
             <Icon
-                as={FileUploadIcon}
                 aria-label={
                     upload.state === LSIFUploadState.UPLOADING
                         ? 'In progress'
@@ -59,6 +55,7 @@ const uploadStages = (upload: LsifUploadFields, failedStage: FailedStage | null)
                             : 'Success'
                         : 'Success'
                 }
+                svgPath={mdiFileUpload}
             />
         ),
         text:
@@ -85,7 +82,6 @@ const processingStages = (
     {
         icon: (
             <Icon
-                as={ProgressClockIcon}
                 aria-label={
                     upload.state === LSIFUploadState.PROCESSING
                         ? 'In progress'
@@ -93,6 +89,7 @@ const processingStages = (
                         ? 'Failed'
                         : 'Success'
                 }
+                svgPath={mdiProgressClock}
             />
         ),
         text:
@@ -114,7 +111,7 @@ const terminalStages = (upload: LsifUploadFields): (TimelineStage | { date: null
     upload.state === LSIFUploadState.COMPLETED
         ? [
               {
-                  icon: <Icon as={CheckIcon} aria-label="Success" />,
+                  icon: <Icon aria-label="Success" svgPath={mdiCheck} />,
                   text: 'Finished',
                   date: upload.finishedAt,
                   className: 'bg-success',
@@ -123,7 +120,7 @@ const terminalStages = (upload: LsifUploadFields): (TimelineStage | { date: null
         : upload.state === LSIFUploadState.ERRORED
         ? [
               {
-                  icon: <Icon as={AlertCircleIcon} aria-label="Failed" />,
+                  icon: <Icon aria-label="Failed" svgPath={mdiAlertCircle} />,
                   text: 'Failed',
                   date: upload.finishedAt,
                   className: 'bg-danger',

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
@@ -1,7 +1,6 @@
 import { FunctionComponent, ReactNode } from 'react'
 
-import DatabaseEditIcon from 'mdi-react/DatabaseEditIcon'
-import DatabasePlusIcon from 'mdi-react/DatabasePlusIcon'
+import { mdiDatabasePlus, mdiDatabaseEdit } from '@mdi/js'
 
 import { Container, Icon } from '@sourcegraph/wildcard'
 
@@ -21,9 +20,9 @@ export const UploadAuditLogTimeline: FunctionComponent<React.PropsWithChildren<U
         (log): TimelineStage => ({
             icon:
                 log.operation === AuditLogOperation.CREATE ? (
-                    <Icon as={DatabasePlusIcon} aria-label="Success" />
+                    <Icon aria-label="Success" svgPath={mdiDatabasePlus} />
                 ) : (
-                    <Icon as={DatabaseEditIcon} aria-label="Warn" />
+                    <Icon aria-label="Warn" svgPath={mdiDatabaseEdit} />
                 ),
             text: stageText(log),
             className: log.operation === AuditLogOperation.CREATE ? 'bg-success' : 'bg-warning',

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react'
 
+import { mdiInformationOutline } from '@mdi/js'
 import classNames from 'classnames'
-import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 
 import { pluralize } from '@sourcegraph/common'
 import { Link, Icon, H3 } from '@sourcegraph/wildcard'
@@ -61,7 +61,7 @@ const RetentionPolicyRetentionMatchNode: FunctionComponent<
                                 className="ml-1"
                                 aria-label="This upload is retained to service code-intel queries for commit(s) with applicable retention policies."
                                 data-tooltip="This upload is retained to service code-intel queries for commit(s) with applicable retention policies."
-                                as={InformationOutlineIcon}
+                                svgPath={mdiInformationOutline}
                             />
                         </>
                     )}
@@ -70,7 +70,7 @@ const RetentionPolicyRetentionMatchNode: FunctionComponent<
                             className="ml-1"
                             aria-label="Uploads at the tip of the default branch are always retained indefinitely."
                             data-tooltip="Uploads at the tip of the default branch are always retained indefinitely."
-                            as={InformationOutlineIcon}
+                            svgPath={mdiInformationOutline}
                         />
                     )}
                 </div>
@@ -102,7 +102,7 @@ const UploadReferenceRetentionMatchNode: FunctionComponent<
                         className="ml-1"
                         aria-label="Uploads that are dependencies of other upload(s) are retained to service cross-repository code-intel queries."
                         data-tooltip="Uploads that are dependencies of other upload(s) are retained to service cross-repository code-intel queries."
-                        as={InformationOutlineIcon}
+                        svgPath={mdiInformationOutline}
                     />
                 </div>
             </div>

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
@@ -1,8 +1,8 @@
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useApolloClient } from '@apollo/client'
+import { mdiInformationOutline } from '@mdi/js'
 import classNames from 'classnames'
-import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { Redirect, RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
@@ -218,9 +218,9 @@ export const CodeIntelUploadPage: FunctionComponent<React.PropsWithChildren<Code
                         />
                         {uploadOrError.isLatestForRepo && (
                             <div>
-                                <Icon aria-hidden={true} as={InformationOutlineIcon} /> This upload can answer queries
-                                for the tip of the default branch and are targets of cross-repository find reference
-                                operations.
+                                <Icon aria-hidden={true} svgPath={mdiInformationOutline} /> This upload can answer
+                                queries for the tip of the default branch and are targets of cross-repository find
+                                reference operations.
                             </div>
                         )}
                     </Container>


### PR DESCRIPTION
**Migration automated through codemod: https://github.com/sourcegraph/codemod/pull/140**

## Description

Migrates simple `<Icon />` usage from `mdi-react` to `@mdi/js`.

**Why?**

We've had numerous problems with `mdi-react` previously, and this library is better supported and gives us better control over our icons. See https://github.com/sourcegraph/sourcegraph/pull/37387 for more context.

## Test plan

Icon edge cases tested through https://github.com/sourcegraph/sourcegraph/pull/37387, this diff is tested through automated tests.

## App preview:

- [Web](https://sg-web-tr-icon-v2-codeintel.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uthgnqbsgu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
