### PR TITLE
JetBrains: Properly set z-index when configuring JLayeredPane

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/BrowserAndLoadingPanel.java
@@ -10,6 +10,7 @@ import java.awt.*;
  * Inspired by <a href="https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java">FindPopupPanel.java</a>
  */
 public class BrowserAndLoadingPanel extends JLayeredPane {
+    private final JBPanelWithEmptyText overlayPanel;
     private boolean isBrowserVisible = false;
     private final JBPanelWithEmptyText jcefPanel;
 
@@ -17,12 +18,14 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
         jcefPanel = new JBPanelWithEmptyText(new BorderLayout()).withEmptyText(
             "Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
 
-        JBPanelWithEmptyText overlayPanel = new JBPanelWithEmptyText();
+        overlayPanel = new JBPanelWithEmptyText();
         //noinspection DialogTitleCapitalization
         overlayPanel.getEmptyText().setText("Loading Sourcegraph...");
 
-        add(overlayPanel, 0);
-        add(jcefPanel, 1);
+        // We need to use the add(Component, Object) overload of the add method to ensure that the constraints are
+        // properly set.
+        add(overlayPanel, Integer.valueOf(1));
+        add(jcefPanel, Integer.valueOf(2));
     }
 
     public void setBrowser(@NotNull SourcegraphJBCefBrowser browser) {
@@ -31,14 +34,12 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
 
     @Override
     public void doLayout() {
-        Component overlay = getComponent(0);
-        Component browser = getComponent(1);
         if (isBrowserVisible) {
-            browser.setBounds(0, 0, getWidth(), getHeight());
+            jcefPanel.setBounds(0, 0, getWidth(), getHeight());
         } else {
-            browser.setBounds(0, 0, 1, 1);
+            jcefPanel.setBounds(0, 0, 1, 1);
         }
-        overlay.setBounds(0, 0, getWidth(), getHeight());
+        overlayPanel.setBounds(0, 0, getWidth(), getHeight());
     }
 
     @Override


### PR DESCRIPTION
We have gotten bug reports about loading indicator displaying forever for some Linux users on Debian.

Upon investigation, the web view seems to be loading correctly which got me into researching issues with the Java UI hierarchy.

I noticed that removing the JLayeredPane and mounting the browser component directly would make it work in these scenarios, which lead me to look into the JLayeredPane implementation.

The [official documentation](https://docs.oracle.com/javase/7/docs/api/javax/swing/JLayeredPane.html) used a weird syntax for adding panes which got me thinking. Instead of `add(Component, integer)` it was casting the integer to an object, using a different overlay of the add method `add(Component, Object)` (You can learn more about these overloads [here](https://docs.oracle.com/javase/7/docs/api/java/awt/Container.html).

It turns out that `add(Component, integer)` would only define the index in which a component rendered but would not set a constraint that the layout implementation would later use to properly align the z-axis. To give JLayeredComponent this information, we have to use the `add(Component, Object)` overload and thus cast the integer to an Object (or `Integer` our case, which is the [boxed object](https://docs.oracle.com/javase/tutorial/java/data/autoboxing.html) representation of integer`.

Without providing a constraint, the default z-axis behavior was undefined which explains the differences between macOS and Linux. 

## Test plan

I tested on Linux (Debian) and macOS to avoid regression. Here's a very bad quality video (lol the remote VM isn't very fast) that shows that this is working now:

https://user-images.githubusercontent.com/458591/176662639-2688cef2-0d16-48cd-8ca6-32c4cd91936e.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-fix-jlayerdpane-issue.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qxckanolut.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
