### PR TITLE
fix(buildchecker-reports): split webhooks for history as well

### DIFF
--- a/dev/buildchecker/main.go
+++ b/dev/buildchecker/main.go
@@ -409,7 +409,8 @@ func cmdHistory(ctx context.Context, flags *Flags, historyFlags *cmdHistoryFlags
 
 		message := generateWeeklySummary(historyFlags.createdFromDate, historyFlags.createdToDate, totalBuilds, totalFlakes, avgFlakes, time.Duration(totalTime*int(time.Minute)))
 
-		if _, err := postSlackUpdate([]string{historyFlags.slackReportWebHook}, message); err != nil {
+		webhooks := strings.Split(historyFlags.slackReportWebHook, ",")
+		if _, err := postSlackUpdate(webhooks, message); err != nil {
 			log.Fatal("postSlackUpdate: ", err)
 		}
 	}

--- a/dev/buildchecker/slack.go
+++ b/dev/buildchecker/slack.go
@@ -69,6 +69,7 @@ For a high-level overview, view the dashboards at <https://app.okayhq.com/dashbo
 
 // postSlackUpdate attempts to send the given summary to at each of the provided webhooks.
 func postSlackUpdate(webhooks []string, summary string) (bool, error) {
+	log.Printf("postSlackUpdate. len(webhooks)=%d\n", len(webhooks))
 	if len(webhooks) == 0 {
 		return false, nil
 	}
@@ -101,7 +102,6 @@ func postSlackUpdate(webhooks []string, summary string) (bool, error) {
 	log.Println("slackBody: ", string(body))
 
 	// Attempt to send a message out to each
-	var errs error
 	var oneSucceeded bool
 	for i, webhook := range webhooks {
 		if len(webhook) == 0 {
@@ -112,7 +112,7 @@ func postSlackUpdate(webhooks []string, summary string) (bool, error) {
 
 		req, err := http.NewRequest(http.MethodPost, webhook, bytes.NewBuffer(body))
 		if err != nil {
-			errs = errors.CombineErrors(errs, errors.Newf("%s: NewRequest: %w", webhook, err))
+			err = errors.CombineErrors(err, errors.Newf("%s: NewRequest: %w", webhook, err))
 			continue
 		}
 		req.Header.Add("Content-Type", "application/json")
@@ -121,7 +121,7 @@ func postSlackUpdate(webhooks []string, summary string) (bool, error) {
 		client := &http.Client{Timeout: 10 * time.Second}
 		resp, err := client.Do(req)
 		if err != nil {
-			errs = errors.CombineErrors(errs, errors.Newf("%s: client.Do: %w", webhook, err))
+			err = errors.CombineErrors(err, errors.Newf("%s: client.Do: %w", webhook, err))
 			continue
 		}
 
@@ -129,12 +129,12 @@ func postSlackUpdate(webhooks []string, summary string) (bool, error) {
 		buf := new(bytes.Buffer)
 		_, err = buf.ReadFrom(resp.Body)
 		if err != nil {
-			errs = errors.CombineErrors(errs, errors.Newf("%s: buf.ReadFrom(resp.Body): %w", webhook, err))
+			err = errors.CombineErrors(err, errors.Newf("%s: buf.ReadFrom(resp.Body): %w", webhook, err))
 			continue
 		}
 		defer resp.Body.Close()
-		if buf.String() != "ok" {
-			errs = errors.CombineErrors(errs, errors.Newf("%s: non-ok response from Slack: %s", webhook, buf.String()))
+		if resp.StatusCode != 200 {
+			err = errors.CombineErrors(err, errors.Newf("%s: Status code %d response from Slack: %s", webhook, resp.StatusCode, buf.String()))
 			continue
 		}
 


### PR DESCRIPTION
The webhooks were being split for `check` but not for `history` ... this fixes it

Closes #37807 
## Test plan
Tested it locally by posted to `william-buildchecker-webhook-test`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
