### PR TITLE
JetBrains: Change editor popup item order

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
@@ -135,8 +135,6 @@ public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
 
     private ActionGroup createActionGroup() {
         DefaultActionGroup group = new DefaultActionGroup();
-        group.add(new SimpleEditorFileAction("Open on Sourcegraph", new OpenFile(), editor));
-        group.add(new SimpleEditorFileAction("Copy Sourcegraph File Link", new Copy(), editor));
         group.add(new DumbAwareAction("Open File in Editor", "Open File in Editor", Icons.Logo) {
             @Override
             public void actionPerformed(@NotNull AnActionEvent e) {
@@ -148,6 +146,8 @@ public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
                 }
             }
         });
+        group.add(new SimpleEditorFileAction("Open on Sourcegraph", new OpenFile(), editor));
+        group.add(new SimpleEditorFileAction("Copy Sourcegraph File Link", new Copy(), editor));
         return group;
     }
 


### PR DESCRIPTION
Based on feedback by @jjinnii in https://github.com/sourcegraph/sourcegraph/issues/37811#issuecomment-1171119410

This moves the `Open File in Editor` option to the top of the list.

## Test plan

![Screenshot 2022-06-30 at 14 29 50](https://user-images.githubusercontent.com/458591/176677451-b3fc36db-e990-42f6-b268-32599e281f10.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-editor-context-menu.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-eijramlula.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
