### PR TITLE
Enterprise: Codemod remaining `<Icon />` usage to `@mdi/js`

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react'
 
+import { mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
-import PlusIcon from 'mdi-react/PlusIcon'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Link, Button, CardBody, Card, Icon, H2, H3, H4, Text } from '@sourcegraph/wildcard'
@@ -94,7 +94,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
                     </ul>
                     {isSignedIn ? (
                         <Button to="/code-monitoring/new" className={styles.createButton} variant="primary" as={Link}>
-                            <Icon aria-hidden={true} className="mr-2" as={PlusIcon} />
+                            <Icon aria-hidden={true} className="mr-2" svgPath={mdiPlus} />
                             Create a code monitor
                         </Button>
                     ) : (

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useEffect, useState, useLayoutEffect } from 'react'
 
+import { mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
-import PlusIcon from 'mdi-react/PlusIcon'
 import { of } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
 
@@ -113,7 +113,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                 actions={
                     authenticatedUser && (
                         <Button to="/code-monitoring/new" variant="primary" as={Link}>
-                            <Icon as={PlusIcon} aria-hidden={true} /> Create code monitor
+                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Create code monitor
                         </Button>
                     )
                 }

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -1,11 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { mdiCheck, mdiRadioboxBlank, mdiHelpCircle, mdiOpenInNew } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
-import CheckIcon from 'mdi-react/CheckIcon'
-import HelpCircleIcon from 'mdi-react/HelpCircleIcon'
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
-import RadioboxBlankIcon from 'mdi-react/RadioboxBlankIcon'
 
 import { QueryState } from '@sourcegraph/search'
 import { LazyMonacoQueryInput } from '@sourcegraph/search-ui'
@@ -56,13 +53,13 @@ const ValidQueryChecklistItem: React.FunctionComponent<
                     <Icon
                         className={classNames('text-success', styles.checklistCheckbox)}
                         aria-hidden={true}
-                        as={CheckIcon}
+                        svgPath={mdiCheck}
                     />
                 ) : (
                     <Icon
                         className={classNames(styles.checklistCheckbox, styles.checklistCheckboxUnchecked)}
                         aria-hidden={true}
-                        as={RadioboxBlankIcon}
+                        svgPath={mdiRadioboxBlank}
                     />
                 )}
 
@@ -76,7 +73,7 @@ const ValidQueryChecklistItem: React.FunctionComponent<
                             <Icon
                                 className={classNames(styles.checklistHint, checked && styles.checklistHintFaded)}
                                 aria-hidden={true}
-                                as={HelpCircleIcon}
+                                svgPath={mdiHelpCircle}
                             />
                         </span>
                     </>
@@ -256,7 +253,7 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                                     <Icon
                                         aria-label="Open in new window"
                                         className={classNames('ml-1', styles.queryInputPreviewLinkIcon)}
-                                        as={OpenInNewIcon}
+                                        svgPath={mdiOpenInNew}
                                     />
                                 </Link>
                             </div>

--- a/client/web/src/enterprise/code-monitoring/components/logs/CollapsibleDetailsWithStatus.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/CollapsibleDetailsWithStatus.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
+import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
 import { Badge, Button, Icon } from '@sourcegraph/wildcard'
 
@@ -51,7 +50,7 @@ export const CollapsibleDetailsWithStatus: React.FunctionComponent<
     return (
         <li className={styles.wrapper}>
             <Button onClick={toggleExpanded} className={classNames('btn-icon d-block', styles.expandButton)}>
-                <Icon aria-hidden={true} className="mr-2" as={expanded ? ChevronDownIcon : ChevronRightIcon} />
+                <Icon aria-hidden={true} className="mr-2" svgPath={expanded ? mdiChevronDown : mdiChevronRight} />
                 <span>{title}</span>
                 <Badge variant={statusBadge} className="ml-2 text-uppercase">
                     {statusText}

--- a/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
@@ -1,11 +1,9 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
+import { mdiAlertCircle, mdiCheckBold, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckBoldIcon from 'mdi-react/CheckBoldIcon'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 
 import { Button, Icon, Link } from '@sourcegraph/wildcard'
 
@@ -66,19 +64,19 @@ export const MonitorLogNode: React.FunctionComponent<
                     )}
                     {hasError ? (
                         <Icon
-                            as={AlertCircleIcon}
                             className={classNames(styles.errorIcon, 'mr-1 flex-shrink-0')}
                             aria-label="One or more runs of this code monitor have an error"
                             data-tooltip="One or more runs of this code monitor have an error"
                             data-placement="top"
+                            svgPath={mdiAlertCircle}
                         />
                     ) : (
                         <Icon
-                            as={CheckBoldIcon}
                             className={classNames(styles.checkIcon, 'mr-1 flex-shrink-0')}
                             aria-label="Monitor running as normal"
                             data-tooltip="Monitor running as normal"
                             data-placement="top"
+                            svgPath={mdiCheckBold}
                         />
                     )}
                     {monitor.description}
@@ -90,7 +88,7 @@ export const MonitorLogNode: React.FunctionComponent<
                         rel="noopener noreferrer"
                         onClick={clickCatcher}
                     >
-                        Monitor details <Icon role="img" aria-hidden={true} as={OpenInNewIcon} />
+                        Monitor details <Icon role="img" aria-hidden={true} svgPath={mdiOpenInNew} />
                     </Link>
                 </Button>
                 <span className="text-nowrap mr-2">

--- a/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
@@ -1,10 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
+import { mdiAlertCircle, mdiChevronDown, mdiChevronRight, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 
 import { pluralize } from '@sourcegraph/common'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
@@ -62,10 +59,14 @@ export const TriggerEvent: React.FunctionComponent<
     return (
         <li>
             <Button onClick={toggleExpanded} className={classNames('btn-icon d-block', styles.expandButton)}>
-                <Icon aria-hidden={true} className="mr-2" as={expanded ? ChevronDownIcon : ChevronRightIcon} />
+                <Icon aria-hidden={true} className="mr-2" svgPath={expanded ? mdiChevronDown : mdiChevronRight} />
 
                 {hasError ? (
-                    <Icon aria-hidden={true} className={classNames(styles.errorIcon, 'mr-2')} as={AlertCircleIcon} />
+                    <Icon
+                        aria-hidden={true}
+                        className={classNames(styles.errorIcon, 'mr-2')}
+                        svgPath={mdiAlertCircle}
+                    />
                 ) : (
                     <span />
                 )}
@@ -81,7 +82,7 @@ export const TriggerEvent: React.FunctionComponent<
                             className="font-weight-normal ml-2"
                         >
                             {triggerEvent.resultCount} new {pluralize('result', triggerEvent.resultCount)}{' '}
-                            <Icon aria-hidden={true} as={OpenInNewIcon} />
+                            <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
                         </Link>
                     )}
                 </span>

--- a/client/web/src/enterprise/executors/ExecutorsListPage.tsx
+++ b/client/web/src/enterprise/executors/ExecutorsListPage.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
 
 import { useApolloClient } from '@apollo/client'
-import CheckboxBlankCircleIcon from 'mdi-react/CheckboxBlankCircleIcon'
+import { mdiCheckboxBlankCircle } from '@mdi/js'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { RouteComponentProps, useHistory } from 'react-router'
 import { Subject } from 'rxjs'
@@ -131,13 +131,17 @@ export const ExecutorNode: FunctionComponent<React.PropsWithChildren<ExecutorNod
                     <div>
                         <H4 className="mb-0">
                             {node.active ? (
-                                <Icon aria-hidden={true} className="text-success mr-2" as={CheckboxBlankCircleIcon} />
+                                <Icon
+                                    aria-hidden={true}
+                                    className="text-success mr-2"
+                                    svgPath={mdiCheckboxBlankCircle}
+                                />
                             ) : (
                                 <Icon
                                     className="text-warning mr-2"
                                     aria-label="This executor missed at least three heartbeats."
                                     data-tooltip="This executor missed at least three heartbeats."
-                                    as={CheckboxBlankCircleIcon}
+                                    svgPath={mdiCheckboxBlankCircle}
                                 />
                             )}
                             {node.hostname}{' '}

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionDeleteButton.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionDeleteButton.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
 
+import { mdiDelete, mdiAlert } from '@mdi/js'
 import { upperFirst } from 'lodash'
-import DeleteIcon from 'mdi-react/DeleteIcon'
-import WarningIcon from 'mdi-react/WarningIcon'
 import { Subject, Subscription } from 'rxjs'
 import { catchError, map, mapTo, startWith, switchMap, tap } from 'rxjs/operators'
 
@@ -81,7 +80,7 @@ export class RegistryExtensionDeleteButton extends React.PureComponent<
                     title={this.props.compact ? 'Delete extension' : ''}
                     variant="danger"
                 >
-                    <Icon aria-hidden={true} as={DeleteIcon} /> {!this.props.compact && 'Delete extension'}
+                    <Icon aria-hidden={true} svgPath={mdiDelete} /> {!this.props.compact && 'Delete extension'}
                 </Button>
                 {isErrorLike(this.state.deletionOrError) && (
                     <Button
@@ -90,7 +89,7 @@ export class RegistryExtensionDeleteButton extends React.PureComponent<
                         title={upperFirst(this.state.deletionOrError.message)}
                         variant="danger"
                     >
-                        <Icon aria-hidden={true} as={WarningIcon} />
+                        <Icon aria-hidden={true} svgPath={mdiAlert} />
                     </Button>
                 )}
             </ButtonGroup>

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 
+import { mdiCheckCircle } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import { RouteComponentProps } from 'react-router'
 import { concat, Observable, Subject, Subscription } from 'rxjs'
 import { catchError, concatMap, map, tap } from 'rxjs/operators'
@@ -194,7 +194,8 @@ export const RegistryExtensionManagePage = withAuthenticatedUser(
                                     <LoadingSpinner />
                                 ) : (
                                     <span className="text-success ml-2">
-                                        <Icon aria-hidden={true} as={CheckCircleIcon} /> Updated extension successfully.
+                                        <Icon aria-hidden={true} svgPath={mdiCheckCircle} /> Updated extension
+                                        successfully.
                                     </span>
                                 ))}
                         </div>

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useState } from 'react'
 
+import { mdiCheckCircle } from '@mdi/js'
 import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import { of, Observable, concat, from } from 'rxjs'
 import { fromFetch } from 'rxjs/fetch'
 import { map, catchError, tap, concatMap } from 'rxjs/operators'
@@ -228,7 +228,7 @@ export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(
                                         <LoadingSpinner />
                                     ) : (
                                         <span className="text-success">
-                                            <Icon aria-hidden={true} as={CheckCircleIcon} /> Published release
+                                            <Icon aria-hidden={true} svgPath={mdiCheckCircle} /> Published release
                                             successfully.
                                         </span>
                                     ))}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -1,11 +1,9 @@
 import { FunctionComponent, useMemo, useState } from 'react'
 
 import { useApolloClient } from '@apollo/client'
+import { mdiArrowExpand, mdiArrowCollapse, mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
 import { isEqual, noop } from 'lodash'
-import ArrowCollapseIcon from 'mdi-react/ArrowCollapseIcon'
-import ArrowExpandIcon from 'mdi-react/ArrowExpandIcon'
-import PlusIcon from 'mdi-react/PlusIcon'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Button, Icon, Link, H4 } from '@sourcegraph/wildcard'
@@ -160,7 +158,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                     onClick={() => onVisualModeChange(FilterSectionVisualMode.HorizontalSections)}
                     aria-label="Switch to horizontal mode"
                 >
-                    <Icon as={ArrowExpandIcon} aria-hidden={true} />
+                    <Icon aria-hidden={true} svgPath={mdiArrowExpand} />
                 </Button>
             </header>
         )
@@ -189,7 +187,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         onClick={() => onVisualModeChange(FilterSectionVisualMode.Preview)}
                         aria-label="Switch to preview mode"
                     >
-                        <Icon as={ArrowCollapseIcon} aria-hidden={true} />
+                        <Icon aria-hidden={true} svgPath={mdiArrowCollapse} />
                     </Button>
                 )}
             </header>
@@ -339,7 +337,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         disabled={(!hasFiltersChanged && !hasSeriesDisplayOptionsChanged) || !formAPI.valid}
                         onClick={onCreateInsightRequest}
                     >
-                        <Icon aria-hidden={true} className="mr-1" as={PlusIcon} />
+                        <Icon aria-hidden={true} className="mr-1" svgPath={mdiPlus} />
                         Save as new view
                     </Button>
                 </div>

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, Suspense } from 'react'
 
-import PlusIcon from 'mdi-react/PlusIcon'
+import { mdiPlus } from '@mdi/js'
 import { matchPath, useHistory } from 'react-router'
 import { useLocation } from 'react-router-dom'
 
@@ -97,7 +97,7 @@ export const CodeInsightsRootPage: React.FunctionComponent<
                             className="mr-2"
                             aria-label="add dashboard button"
                         >
-                            <Icon aria-hidden={true} as={PlusIcon} /> Add dashboard
+                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Add dashboard
                         </Button>
                         <Button
                             as={Link}
@@ -105,7 +105,7 @@ export const CodeInsightsRootPage: React.FunctionComponent<
                             variant="primary"
                             onClick={() => telemetryService.log('InsightAddMoreClick')}
                         >
-                            <Icon aria-hidden={true} as={PlusIcon} /> Create insight
+                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Create insight
                         </Button>
                     </>
                 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 
+import { mdiClose, mdiRadioboxBlank } from '@mdi/js'
 import classNames from 'classnames'
 import Check from 'mdi-react/CheckIcon'
-import CloseIcon from 'mdi-react/CloseIcon'
-import RadioboxBlankIcon from 'mdi-react/RadioboxBlankIcon'
 
 import { Icon, Code } from '@sourcegraph/wildcard'
 
@@ -35,7 +34,7 @@ const CheckListItem: React.FunctionComponent<React.PropsWithChildren<{ valid: tr
     if (valid === false) {
         return (
             <>
-                <Icon aria-hidden={true} className={classNames(styles.icon, 'text-danger')} as={CloseIcon} />
+                <Icon aria-hidden={true} className={classNames(styles.icon, 'text-danger')} svgPath={mdiClose} />
                 <span className="text-muted">{children}</span>
             </>
         )
@@ -43,7 +42,7 @@ const CheckListItem: React.FunctionComponent<React.PropsWithChildren<{ valid: tr
 
     return (
         <>
-            <Icon aria-hidden={true} className={classNames(styles.icon, styles.smaller)} as={RadioboxBlankIcon} />{' '}
+            <Icon aria-hidden={true} className={classNames(styles.icon, styles.smaller)} svgPath={mdiRadioboxBlank} />{' '}
             <span className="text-muted">{children}</span>
         </>
     )

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useRef, useState } from 'react'
 
-import LinkVariantIcon from 'mdi-react/LinkVariantIcon'
+import { mdiLinkVariant } from '@mdi/js'
 import { useHistory } from 'react-router'
 
 import { Button, Link, Icon } from '@sourcegraph/wildcard'
@@ -47,7 +47,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
                 data-tooltip={isCopied ? 'Copied!' : undefined}
                 onClick={handleCopyLinkClick}
             >
-                <Icon aria-hidden={true} as={LinkVariantIcon} /> Copy link
+                <Icon aria-hidden={true} svgPath={mdiLinkVariant} /> Copy link
             </Button>
             <Button variant="danger" onClick={handleDeleteClick}>
                 Delete

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, HTMLAttributes } from 'react'
 
+import { mdiViewDashboard } from '@mdi/js'
 import classNames from 'classnames'
-import ViewDashboardIcon from 'mdi-react/ViewDashboardIcon'
 
 import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
 
@@ -35,7 +35,7 @@ export const StandaloneInsightDashboardPills: FunctionComponent<StandaloneInsigh
                     rel="noopener"
                     className={styles.pill}
                 >
-                    <Icon as={ViewDashboardIcon} aria-hidden={true} />
+                    <Icon aria-hidden={true} svgPath={mdiViewDashboard} />
                     {dashboard.title}
                 </Button>
             ))}

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -1,7 +1,7 @@
 import React, { MouseEvent, useContext, useState } from 'react'
 
+import { mdiContentCopy } from '@mdi/js'
 import copy from 'copy-to-clipboard'
-import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -226,7 +226,7 @@ const QueryPanel: React.FunctionComponent<React.PropsWithChildren<QueryPanelProp
                 aria-label="Copy Docker command to clipboard"
                 variant="icon"
             >
-                <Icon aria-hidden={true} as={ContentCopyIcon} />
+                <Icon aria-hidden={true} svgPath={mdiContentCopy} />
             </Button>
         </CodeInsightsQueryBlock>
     )

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo, useEffect } from 'react'
 
+import { mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
-import PlusIcon from 'mdi-react/PlusIcon'
 import { noop } from 'rxjs'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -153,7 +153,7 @@ export const DynamicCodeInsightExample: React.FunctionComponent<
                 <footer className={styles.footer}>
                     {licensed ? (
                         <Button variant="primary" as={Link} to="/insights/create" onClick={handleGetStartedClick}>
-                            <Icon aria-hidden={true} as={PlusIcon} /> Create your first insight
+                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Create your first insight
                         </Button>
                     ) : (
                         <Button

--- a/client/web/src/enterprise/search/stats/SearchStatsPage.tsx
+++ b/client/web/src/enterprise/search/stats/SearchStatsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState, useMemo } from 'react'
 
+import { mdiChartLine } from '@mdi/js'
 import * as H from 'history'
-import ChartLineIcon from 'mdi-react/ChartLineIcon'
 import { of } from 'rxjs'
 import { catchError } from 'rxjs/operators'
 
@@ -56,7 +56,7 @@ export const SearchStatsPage: React.FunctionComponent<React.PropsWithChildren<Pr
         <div className="search-stats-page container mt-4">
             <header className="d-flex align-items-center justify-content-between mb-3">
                 <H2 className="d-flex align-items-center mb-0">
-                    <Icon aria-hidden={true} className="mr-2" as={ChartLineIcon} /> Code statistics{' '}
+                    <Icon aria-hidden={true} className="mr-2" svgPath={mdiChartLine} /> Code statistics{' '}
                     <Badge variant="secondary" className="text-uppercase ml-2" as="small">
                         Experimental
                     </Badge>

--- a/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
+++ b/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`SearchStatsPage limitHit 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="mdi-icon iconInline mr-2"
+          class="iconInline mr-2"
           fill="currentColor"
           height="24"
           role="img"
@@ -89,7 +89,7 @@ exports[`SearchStatsPage renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="mdi-icon iconInline mr-2"
+          class="iconInline mr-2"
           fill="currentColor"
           height="24"
           role="img"

--- a/client/web/src/enterprise/searchContexts/SearchContextOwnerDropdown.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextOwnerDropdown.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 
-import MenuDownIcon from 'mdi-react/MenuDownIcon'
+import { mdiMenuDown } from '@mdi/js'
 
 import { Namespace } from '@sourcegraph/shared/src/schema'
 import { Menu, MenuButton, MenuDivider, MenuItem, MenuList, Icon } from '@sourcegraph/wildcard'
@@ -57,7 +57,7 @@ export const SearchContextOwnerDropdown: React.FunctionComponent<
                 data-tooltip={isDisabled ? "Owner can't be changed." : ''}
             >
                 {selectedNamespace.type === 'global-owner' ? 'Global' : `@${selectedNamespace.name}`}{' '}
-                <Icon aria-hidden={true} as={MenuDownIcon} />
+                <Icon aria-hidden={true} svgPath={mdiMenuDown} />
             </MenuButton>
             <MenuList className={styles.menuList}>
                 <MenuItem onSelect={() => setSelectedNamespace(selectedUserNamespace)}>

--- a/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useState } from 'react'
 
+import { mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
-import PlusIcon from 'mdi-react/PlusIcon'
 
 import { SearchContextProps } from '@sourcegraph/search'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -72,7 +72,7 @@ export const SearchContextsListPage: React.FunctionComponent<
                 <PageHeader
                     actions={
                         <Button to="/contexts/new" variant="primary" as={Link}>
-                            <Icon aria-hidden={true} as={PlusIcon} />
+                            <Icon aria-hidden={true} svgPath={mdiPlus} />
                             Create search context
                         </Button>
                     }

--- a/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
+import { mdiPlus } from '@mdi/js'
 import * as H from 'history'
-import AddIcon from 'mdi-react/AddIcon'
 import { RouteComponentProps } from 'react-router'
 import { Observable, Subject, Subscription } from 'rxjs'
 import { catchError, map, mapTo, startWith, switchMap, tap } from 'rxjs/operators'
@@ -194,7 +194,7 @@ export class SiteAdminRegistryExtensionsPage extends React.PureComponent<Props> 
                             View extensions
                         </Button>
                         <Button to="/extensions/registry/new" variant="primary" as={Link}>
-                            <Icon aria-hidden={true} as={AddIcon} /> Publish new extension
+                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Publish new extension
                         </Button>
                     </div>
                 </div>

--- a/client/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomerBillingLink.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomerBillingLink.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react'
 
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
+import { mdiOpenInNew, mdiAlertCircle } from '@mdi/js'
 import { Observable } from 'rxjs'
 import { catchError, map, mapTo, startWith, switchMap, tap } from 'rxjs/operators'
 
@@ -69,7 +68,7 @@ export const SiteAdminCustomerBillingLink: React.FunctionComponent<React.PropsWi
             <div className="d-flex align-items-center">
                 {customer.urlForSiteAdminBilling && (
                     <Link to={customer.urlForSiteAdminBilling} className="mr-2 d-flex align-items-center">
-                        View customer account <Icon aria-hidden={true} className="ml-1" as={ExternalLinkIcon} />
+                        View customer account <Icon aria-hidden={true} className="ml-1" svgPath={mdiOpenInNew} />
                     </Link>
                 )}
                 {isErrorLike(update) && (
@@ -77,7 +76,7 @@ export const SiteAdminCustomerBillingLink: React.FunctionComponent<React.PropsWi
                         aria-label={update.message}
                         className="text-danger mr-2"
                         data-tooltip={update.message}
-                        as={AlertCircleIcon}
+                        svgPath={mdiAlertCircle}
                     />
                 )}
                 <Button

--- a/client/web/src/enterprise/site-admin/dotcom/customers/__snapshots__/SiteAdminCustomerBillingLink.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/customers/__snapshots__/SiteAdminCustomerBillingLink.test.tsx.snap
@@ -13,11 +13,19 @@ exports[`SiteAdminCustomerBillingLink linked billing account 1`] = `
         href="https://example.com"
       >
         View customer account 
-        <externallinkicon
+        <svg
           aria-hidden="true"
           class="iconInline ml-1"
+          fill="currentColor"
+          height="24"
           role="img"
-        />
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+          />
+        </svg>
       </a>
       <button
         class="btn btnSecondary"

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect } from 'react'
 
+import { mdiPlus } from '@mdi/js'
 import * as H from 'history'
-import AddIcon from 'mdi-react/AddIcon'
 import { Redirect, RouteComponentProps } from 'react-router'
 import { merge, of, Observable } from 'rxjs'
 import { catchError, concatMapTo, map, tap } from 'rxjs/operators'
@@ -95,7 +95,7 @@ const UserCreateSubscriptionNode: React.FunctionComponent<React.PropsWithChildre
                                 variant="secondary"
                                 size="sm"
                             >
-                                <Icon aria-hidden={true} as={AddIcon} /> Create new subscription
+                                <Icon aria-hidden={true} svgPath={mdiPlus} /> Create new subscription
                             </Button>
                         </Form>
                     </div>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionBillingLink.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionBillingLink.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react'
 
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
+import { mdiOpenInNew, mdiAlertCircle } from '@mdi/js'
 import { Observable } from 'rxjs'
 import { catchError, map, mapTo, startWith, switchMap, tap } from 'rxjs/operators'
 
@@ -73,7 +72,7 @@ export const SiteAdminProductSubscriptionBillingLink: React.FunctionComponent<Re
             <div className="d-flex align-items-center">
                 {productSubscription.urlForSiteAdminBilling && (
                     <Link to={productSubscription.urlForSiteAdminBilling} className="mr-2 d-flex align-items-center">
-                        View billing subscription <Icon aria-hidden={true} className="ml-1" as={ExternalLinkIcon} />
+                        View billing subscription <Icon aria-hidden={true} className="ml-1" svgPath={mdiOpenInNew} />
                     </Link>
                 )}
                 {isErrorLike(update) && (
@@ -81,7 +80,7 @@ export const SiteAdminProductSubscriptionBillingLink: React.FunctionComponent<Re
                         className="text-danger mr-2"
                         aria-label={update.message}
                         data-tooltip={update.message}
-                        as={AlertCircleIcon}
+                        svgPath={mdiAlertCircle}
                     />
                 )}
                 <Button

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react'
 
+import { mdiArrowLeft, mdiPlus } from '@mdi/js'
 import * as H from 'history'
-import AddIcon from 'mdi-react/AddIcon'
-import ArrowLeftIcon from 'mdi-react/ArrowLeftIcon'
 import { RouteComponentProps } from 'react-router'
 import { Observable, Subject, NEVER } from 'rxjs'
 import { catchError, map, mapTo, startWith, switchMap, tap, filter } from 'rxjs/operators'
@@ -145,7 +144,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
             <PageTitle title="Product subscription" />
             <div className="mb-2">
                 <Button to="/site-admin/dotcom/product/subscriptions" variant="link" size="sm" as={Link}>
-                    <Icon aria-hidden={true} as={ArrowLeftIcon} /> All subscriptions
+                    <Icon aria-hidden={true} svgPath={mdiArrowLeft} /> All subscriptions
                 </Button>
             </div>
             {productSubscription === LOADING ? (
@@ -218,7 +217,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
                                 </Button>
                             ) : (
                                 <Button onClick={toggleShowGenerate} variant="primary" size="sm">
-                                    <Icon aria-hidden={true} as={AddIcon} /> Generate new license manually
+                                    <Icon aria-hidden={true} svgPath={mdiPlus} /> Generate new license manually
                                 </Button>
                             )}
                         </CardHeader>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 
-import AddIcon from 'mdi-react/AddIcon'
+import { mdiPlus } from '@mdi/js'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
@@ -42,7 +42,7 @@ export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<React.Pr
             <div className="d-flex justify-content-between align-items-center mb-3">
                 <H2 className="mb-0">Product subscriptions</H2>
                 <Button to="/site-admin/dotcom/product/subscriptions/new" variant="primary" as={Link}>
-                    <Icon aria-hidden={true} as={AddIcon} />
+                    <Icon aria-hidden={true} svgPath={mdiPlus} />
                     Create product subscription
                 </Button>
             </div>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionBillingLink.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionBillingLink.test.tsx.snap
@@ -13,11 +13,19 @@ exports[`SiteAdminProductSubscriptionBillingLink linked billing 1`] = `
         href="https://example.com"
       >
         View billing subscription 
-        <externallinkicon
+        <svg
           aria-hidden="true"
           class="iconInline ml-1"
+          fill="currentColor"
+          height="24"
           role="img"
-        />
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+          />
+        </svg>
       </a>
       <button
         class="btn btnSecondary btnSm"

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionPage.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionPage.test.tsx.snap
@@ -12,11 +12,19 @@ exports[`SiteAdminProductSubscriptionPage renders 1`] = `
         class="anchorLink btn btnLink btnSm"
         href="/site-admin/dotcom/product/subscriptions"
       >
-        <arrowlefticon
+        <svg
           aria-hidden="true"
           class="iconInline"
+          fill="currentColor"
+          height="24"
           role="img"
-        />
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"
+          />
+        </svg>
          All subscriptions
       </a>
     </div>
@@ -164,11 +172,19 @@ exports[`SiteAdminProductSubscriptionPage renders 1`] = `
           class="btn btnPrimary btnSm"
           type="button"
         >
-          <addicon
+          <svg
             aria-hidden="true"
             class="iconInline"
+            fill="currentColor"
+            height="24"
             role="img"
-          />
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+            />
+          </svg>
            Generate new license manually
         </button>
       </div>

--- a/client/web/src/enterprise/user/productSubscriptions/BackToAllSubscriptionsLink.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/BackToAllSubscriptionsLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import ArrowLeftIcon from 'mdi-react/ArrowLeftIcon'
+import { mdiArrowLeft } from '@mdi/js'
 
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { Button, Link, Icon } from '@sourcegraph/wildcard'
@@ -9,6 +9,6 @@ export const BackToAllSubscriptionsLink: React.FunctionComponent<
     React.PropsWithChildren<{ user: Pick<GQL.IUser, 'settingsURL'> }>
 > = ({ user }) => (
     <Button to={`${user.settingsURL!}/subscriptions`} className="mb-3" variant="link" size="sm" as={Link}>
-        <Icon aria-hidden={true} as={ArrowLeftIcon} /> All subscriptions
+        <Icon aria-hidden={true} svgPath={mdiArrowLeft} /> All subscriptions
     </Button>
 )

--- a/client/web/src/enterprise/user/productSubscriptions/NewProductSubscriptionPaymentSection.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/NewProductSubscriptionPaymentSection.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useMemo } from 'react'
 
+import { mdiAlertCircle } from '@mdi/js'
 import { parseISO } from 'date-fns'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 import { isEqual } from 'lodash'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import { Observable, of } from 'rxjs'
 import { catchError, map, startWith } from 'rxjs/operators'
 
@@ -110,7 +110,7 @@ export const NewProductSubscriptionPaymentSection: React.FunctionComponent<React
                         <Icon
                             aria-label={previewInvoice.message}
                             data-tooltip={previewInvoice.message}
-                            as={AlertCircleIcon}
+                            svgPath={mdiAlertCircle}
                         />{' '}
                         Error
                     </span>

--- a/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionHistory.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionHistory.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
+import { mdiOpenInNew } from '@mdi/js'
 import { parseISO } from 'date-fns'
 import format from 'date-fns/format'
-import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import * as GQL from '@sourcegraph/shared/src/schema'
@@ -32,7 +32,7 @@ export const ProductSubscriptionHistory: React.FunctionComponent<
                         <td className="w-100">
                             <LinkOrSpan to={event.url} target="_blank" rel="noopener noreferrer">
                                 {event.title}
-                                {event.url && <Icon aria-hidden={true} className="ml-1" as={ExternalLinkIcon} />}
+                                {event.url && <Icon aria-hidden={true} className="ml-1" svgPath={mdiOpenInNew} />}
                             </LinkOrSpan>
                             {event.description && <small className="d-block text-muted">{event.description}</small>}
                         </td>

--- a/client/web/src/enterprise/user/productSubscriptions/UserProductSubscriptionStatus.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserProductSubscriptionStatus.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback } from 'react'
 
-import InformationIcon from 'mdi-react/InformationIcon'
-import KeyIcon from 'mdi-react/KeyIcon'
+import { mdiKey, mdiInformation } from '@mdi/js'
 
 import { Button, CardFooter, Link, Icon, Code, H3 } from '@sourcegraph/wildcard'
 
@@ -47,7 +46,8 @@ export const UserProductSubscriptionStatus: React.FunctionComponent<React.PropsW
                 <>
                     <CardFooter className="d-flex align-items-center justify-content-between flex-wrap">
                         <Button className="mr-4 my-1" onClick={toggleShowLicenseKey} variant="primary">
-                            <Icon aria-hidden={true} as={KeyIcon} /> {showLicenseKey ? 'Hide' : 'Reveal'} license key
+                            <Icon aria-hidden={true} svgPath={mdiKey} /> {showLicenseKey ? 'Hide' : 'Reveal'} license
+                            key
                         </Button>
                         <div className="flex-fill" />
                         <div className="my-1" />
@@ -59,7 +59,7 @@ export const UserProductSubscriptionStatus: React.FunctionComponent<React.PropsW
                                 <>
                                     <CopyableText text={licenseKey} className="d-block" />
                                     <small className="mt-2 d-flex align-items-center">
-                                        <Icon aria-hidden={true} className="mr-1" as={InformationIcon} />{' '}
+                                        <Icon aria-hidden={true} className="mr-1" svgPath={mdiInformation} />{' '}
                                         <span>
                                             Use this license key as the <Code weight="bold">licenseKey</Code> property
                                             value in Sourcegraph site configuration.

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useCallback } from 'react'
 
+import { mdiArrowLeft } from '@mdi/js'
 import * as H from 'history'
-import ArrowLeftIcon from 'mdi-react/ArrowLeftIcon'
 import { RouteComponentProps } from 'react-router'
 import { Observable, throwError } from 'rxjs'
 import { catchError, map, mapTo, startWith, switchMap, tap } from 'rxjs/operators'
@@ -105,7 +105,7 @@ export const UserSubscriptionsEditProductSubscriptionPage: React.FunctionCompone
             ) : (
                 <>
                     <Button to={productSubscription.url} className="mb-3" variant="link" size="sm" as={Link}>
-                        <Icon aria-hidden={true} as={ArrowLeftIcon} /> Subscription
+                        <Icon aria-hidden={true} svgPath={mdiArrowLeft} /> Subscription
                     </Button>
                     <H2>Upgrade or change subscription {productSubscription.name}</H2>
                     <ProductSubscriptionForm

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserProductSubscriptionStatus.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserProductSubscriptionStatus.test.tsx.snap
@@ -49,11 +49,19 @@ exports[`UserProductSubscriptionStatus toggle: license key hidden 1`] = `
           class="btn btnPrimary mr-4 my-1"
           type="button"
         >
-          <keyicon
+          <svg
             aria-hidden="true"
             class="iconInline"
+            fill="currentColor"
+            height="24"
             role="img"
-          />
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M7 14C5.9 14 5 13.1 5 12S5.9 10 7 10 9 10.9 9 12 8.1 14 7 14M12.6 10C11.8 7.7 9.6 6 7 6C3.7 6 1 8.7 1 12S3.7 18 7 18C9.6 18 11.8 16.3 12.6 14H16V18H20V14H23V10H12.6Z"
+            />
+          </svg>
            Reveal license key
         </button>
         <div
@@ -117,11 +125,19 @@ exports[`UserProductSubscriptionStatus toggle: license key revealed 1`] = `
           class="btn btnPrimary mr-4 my-1"
           type="button"
         >
-          <keyicon
+          <svg
             aria-hidden="true"
             class="iconInline"
+            fill="currentColor"
+            height="24"
             role="img"
-          />
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M7 14C5.9 14 5 13.1 5 12S5.9 10 7 10 9 10.9 9 12 8.1 14 7 14M12.6 10C11.8 7.7 9.6 6 7 6C3.7 6 1 8.7 1 12S3.7 18 7 18C9.6 18 11.8 16.3 12.6 14H16V18H20V14H23V10H12.6Z"
+            />
+          </svg>
            Hide license key
         </button>
         <div
@@ -146,11 +162,19 @@ exports[`UserProductSubscriptionStatus toggle: license key revealed 1`] = `
         <small
           class="mt-2 d-flex align-items-center"
         >
-          <informationicon
+          <svg
             aria-hidden="true"
             class="iconInline mr-1"
+            fill="currentColor"
+            height="24"
             role="img"
-          />
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+            />
+          </svg>
            
           <span>
             Use this license key as the 

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsEditProductSubscriptionPage.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsEditProductSubscriptionPage.test.tsx.snap
@@ -9,11 +9,19 @@ exports[`UserSubscriptionsEditProductSubscriptionPage renders 1`] = `
       class="anchorLink btn btnLink btnSm mb-3"
       href="/s"
     >
-      <arrowlefticon
+      <svg
         aria-hidden="true"
         class="iconInline"
+        fill="currentColor"
+        height="24"
         role="img"
-      />
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"
+        />
+      </svg>
        Subscription
     </a>
     <h2

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsProductSubscriptionPage.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsProductSubscriptionPage.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`UserSubscriptionsProductSubscriptionPage renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="mdi-icon iconInline"
+          class="iconInline"
           fill="currentColor"
           height="24"
           role="img"


### PR DESCRIPTION
**Migration automated through codemod: https://github.com/sourcegraph/codemod/pull/140**

## Description

Migrates simple `<Icon />` usage from `mdi-react` to `@mdi/js`.

**Why?**

We've had numerous problems with `mdi-react` previously, and this library is better supported and gives us better control over our icons. See https://github.com/sourcegraph/sourcegraph/pull/37387 for more context.

## Test plan

Icon edge cases tested through https://github.com/sourcegraph/sourcegraph/pull/37387, this diff is tested through automated tests.

## App preview:

- [Web](https://sg-web-tr-icon-v2-enterprise-rest.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yjyvlygupb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
