### PR TITLE
sg start, use local universal-ctags by default, if available

### DIFF
--- a/cmd/symbols/build-ctags.sh
+++ b/cmd/symbols/build-ctags.sh
@@ -12,9 +12,12 @@ if [[ "${CTAGS_COMMAND}" != "cmd/symbols/universal-ctags-dev" ]]; then
   exit 0
 fi
 
-# Build ctags docker image for universal-ctags-dev
-echo "Building ctags docker image"
-docker build -f cmd/symbols/Dockerfile -t ctags . \
-  --target=ctags \
-  --progress=plain \
-  --quiet >/dev/null
+# If we already have universal-ctags installed, skip building the docker image.
+if ! hash ctags >/dev/null; then
+  # Build ctags docker image for universal-ctags-dev
+  echo "Building ctags docker image"
+  docker build -f cmd/symbols/Dockerfile -t ctags . \
+    --target=ctags \
+    --progress=plain \
+    --quiet >/dev/null
+fi

--- a/cmd/symbols/universal-ctags-dev
+++ b/cmd/symbols/universal-ctags-dev
@@ -5,9 +5,14 @@
 # To use your own `universal-ctags` binary instead of this wrapper in your local dev server, use
 # `CTAGS_COMMAND=path/to/ctags sg start`.
 
-exec docker run --rm -i \
+
+if hash ctags >/dev/null; then
+  ctags "$@"
+else
+  exec docker run --rm -i \
     -a stdin -a stdout -a stderr \
     --user guest \
     --name=universal-ctags-$$ \
     --entrypoint /usr/local/bin/universal-ctags \
     ctags "$@"
+fi

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -65,6 +65,11 @@ var Mac = []category{
 				Fix:   cmdFix(`brew install sqlite`),
 			},
 			{
+				Name:  "universal-ctags",
+				Check: checkAction(check.InPath("ctags")),
+				Fix:   cmdFix(`brew install universal-ctags`),
+			},
+			{
 				Name:  "jq",
 				Check: checkAction(check.InPath("jq")),
 				Fix:   cmdFix(`brew install jq`),

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -61,6 +61,11 @@ var Ubuntu = []category{
 				Fix:   aptGetInstall("jq"),
 			},
 			{
+				Name:  "universal-ctags",
+				Check: checkAction(check.InPath("ctags")),
+				Fix:   aptGetInstall("universal-ctags"),
+			},
+			{
 				Name:  "curl",
 				Check: checkAction(check.InPath("curl")),
 				Fix:   aptGetInstall("curl"),

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -121,7 +121,7 @@ commands:
         export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/oss-frontend github.com/sourcegraph/sourcegraph/cmd/frontend
-    checkBinary: .bin/frontend
+    checkBinary: .bin/oss-frontend
     env:
       CONFIGURATION_MODE: server
       USE_ENHANCED_LANGUAGE_DETECTION: false
@@ -257,7 +257,7 @@ commands:
 
       ./cmd/symbols/build-ctags.sh &&
       go build -gcflags="$GCFLAGS" -o .bin/oss-symbols github.com/sourcegraph/sourcegraph/cmd/symbols
-    checkBinary: .bin/symbols
+    checkBinary: .bin/oss-symbols
     env:
       CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
       CTAGS_PROCESSES: 2


### PR DESCRIPTION
We're using the dockerized version of universal-ctags because a long time ago, this was annoying to build on our machines. Nowadays, it's a package install away, on both ubuntu and mac. 

Teammates working on the symbols service can still override the `CTAGS_COMMAND` to use a specific version of their choosing. 

This should dramatically reduce the initial startup time, because we won't be building the dockerized version of universal-ctags when running the symbols service if it's already installed. 

Universal ctags has been also added to `sg setup` on both mac and ubuntu. 

Side note: some stuff with the oss commands was broken, fixed it along the way. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested on my local machine, checked that the universal ctags is installable on ubuntu as well. 
