### PR TITLE
Predicates: add visitor for typed predicates

### DIFF
--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -340,25 +340,11 @@ func (p Parameters) RepoContainsFile() (include, exclude []string) {
 		}
 	})
 
-	VisitField(nodes, FieldRepo, func(v string, negated bool, ann Annotation) {
-		if !ann.Labels.IsSet(IsPredicate) {
-			return
-		}
-
-		name, params := ParseAsPredicate(v)
-		if name != "contains.file" {
-			return
-		}
-
-		var p RepoContainsFilePredicate
-		if err := p.ParseParams(params); err != nil {
-			return
-		}
-
+	VisitTypedPredicate(nodes, func(pred *RepoContainsFilePredicate, negated bool) {
 		if negated {
-			exclude = append(exclude, p.Pattern)
+			exclude = append(exclude, pred.Pattern)
 		} else {
-			include = append(include, p.Pattern)
+			include = append(include, pred.Pattern)
 		}
 	})
 

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -82,3 +82,33 @@ func VisitPredicate(nodes []Node, f func(field, name, value string)) {
 		}
 	})
 }
+
+// PredicatePointer is a pointer to a type that implements Predicate.
+// This is useful so we can construct the zero-value of the non-pointer
+// type T rather than getting the zero value of the pointer type,
+// which is a nil pointer.
+type predicatePointer[T any] interface {
+	Predicate
+	*T
+}
+
+func VisitTypedPredicate[T any, PT predicatePointer[T]](nodes []Node, f func(pred PT, negated bool)) {
+	var zeroPred PT
+	VisitField(nodes, zeroPred.Field(), func(value string, negated bool, annotation Annotation) {
+		if !annotation.Labels.IsSet(IsPredicate) {
+			return // skip non-predicates
+		}
+
+		predName, predArgs := ParseAsPredicate(value)
+		if predName != zeroPred.Name() { // NOTE(camdencheek): we don't handle aliases here
+			return // skip unrequested predicates
+		}
+
+		newPred := PT(new(T))
+		err := newPred.ParseParams(predArgs)
+		if err != nil {
+			panic(err) // should already be validated
+		}
+		f(newPred, negated)
+	})
+}

--- a/internal/search/query/visitor_test.go
+++ b/internal/search/query/visitor_test.go
@@ -22,3 +22,27 @@ func TestSubstitute(t *testing.T) {
 		"contains value is file:foo").
 		Equal(t, test("repo:contains(file:foo)"))
 }
+
+func TestVisitTypedPredicate(t *testing.T) {
+	cases := []struct {
+		query  string
+		output autogold.Value
+	}{{
+		"repo:test",
+		autogold.Want("no predicates", []*RepoContainsFilePredicate{}),
+	}, {
+		"repo:test repo:contains.file(test)",
+		autogold.Want("one predicate", []*RepoContainsFilePredicate{{Pattern: "test"}}),
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.output.Name(), func(t *testing.T) {
+			q, _ := ParseLiteral(tc.query)
+			var result []*RepoContainsFilePredicate
+			VisitTypedPredicate(q, func(pred *RepoContainsFilePredicate, negated bool) {
+				result = append(result, pred)
+			})
+			tc.output.Equal(t, result)
+		})
+	}
+}


### PR DESCRIPTION
This adds a visitor that yields _typed_ predicates. We can do this because each predicate type is self-describing: it knows its own parent field, it knows its own name, and it knows how to unmarshal its own args. This was kinda what I had in mind all along, but the lack of generics made it infeasible.

For now, it's called `VisitTypedPredicate`, but I'll probably replaces uses of `VisitPredicate` over time and rename this `VisitPredicate`.

## Test plan

Added test for `RepoContainsFile`, which is the only place that uses it right now.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
