### PR TITLE
vsce: patch release v2.2.6

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -10,7 +10,13 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 
 ### Changes
 
--
+### Fixes
+
+## 2.2.6
+
+### Changes
+
+- Remove notification to add Sourcegraph extension to the workspace [issues/37772](https://github.com/sourcegraph/sourcegraph/issues/37772)
 
 ### Fixes
 

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@sourcegraph/vscode",
   "displayName": "Sourcegraph",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Sourcegraph for VS Code",
   "publisher": "sourcegraph",
   "sideEffects": true,
@@ -23,7 +23,7 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "main": "./dist/node/main.js",
   "browser": "./dist/webworker/main.js",
@@ -229,12 +229,11 @@
     "build:node": "NODE_ENV=production TARGET_TYPE=node yarn task:gulp webpack",
     "build:web": "NODE_ENV=production TARGET_TYPE=webworker yarn task:gulp webpack",
     "build:test": "NODE_ENV=production TARGET_TYPE=webworker IS_TEST=true yarn task:gulp webpack",
-    "watch": "yarn check:version && yarn task:gulp watchWebpack",
+    "watch": "yarn task:gulp watchWebpack",
     "watch:node": "NODE_ENV=development TARGET_TYPE=node yarn task:gulp watchWebpack",
     "watch:web": "NODE_ENV=development TARGET_TYPE=webworker yarn task:gulp watchWebpack",
     "watch:test": "NODE_ENV=development TARGET_TYPE=webworker IS_TEST=true yarn task:gulp watchWebpack",
     "test-integration": "TS_NODE_PROJECT=tests/tsconfig.json mocha --parallel=$CI --retries=2 ./tests/**/*.test.ts",
-    "check:version": "ts-node ./scripts/version-check.ts",
     "release": "ts-node ./scripts/publish.ts",
     "release:major": "VSCE_RELEASE_TYPE=major ts-node ./scripts/release.ts",
     "release:minor": "VSCE_RELEASE_TYPE=minor ts-node ./scripts/release.ts",

--- a/client/vscode/src/extension.ts
+++ b/client/vscode/src/extension.ts
@@ -24,7 +24,6 @@ import { accessTokenSetting, updateAccessTokenSetting } from './settings/accessT
 import { endpointRequestHeadersSetting, endpointSetting, updateEndpointSetting } from './settings/endpointSetting'
 import { invalidateContextOnSettingsChange } from './settings/invalidation'
 import { LocalStorageService, SELECTED_SEARCH_CONTEXT_SPEC_KEY } from './settings/LocalStorageService'
-import { recommendSourcegraph } from './settings/recommendations'
 import { watchUninstall } from './settings/uninstall'
 import { createVSCEStateMachine, VSCEQueryState } from './state'
 import { focusSearchPanel, registerWebviews } from './webview/commands'
@@ -119,6 +118,8 @@ export function activate(context: vscode.ExtensionContext): void {
     initializeCodeSharingCommands(context, eventSourceType, localStorageService)
     // Watch for uninstall to log uninstall event
     watchUninstall(eventSourceType, localStorageService)
-    // Add Sourcegraph to workspace recommendations
-    recommendSourcegraph(localStorageService).catch(() => {})
+
+    // Add Sourcegraph to workspace recommendations (disabled for now as it was reported to violate
+    // VS Code's UX guidelines for notifications: https://code.visualstudio.com/api/ux-guidelines/notifications)
+    // recommendSourcegraph(localStorageService).catch(() => {})
 }

--- a/client/vscode/src/settings/recommendations.ts
+++ b/client/vscode/src/settings/recommendations.ts
@@ -1,3 +1,8 @@
+/**
+ * Disabled due to violation of the VS Code's UX guidelines for notifications
+ * To be revaluated in the future
+ */
+
 import * as vscode from 'vscode'
 
 import { DISMISS_WORKSPACERECS_CTA_KEY, LocalStorageService } from './LocalStorageService'


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/37772

Removes add to workspace notification.

## Test plan
- run VSCE locally
- ensure add to workspace notification is not displayed
- ensure tests pass in CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
