### PR TITLE
dev/sg/linters: allow dev tools to use whatever logger they want

### DIFF
--- a/dev/sg/linters/liblog.go
+++ b/dev/sg/linters/liblog.go
@@ -24,6 +24,8 @@ func lintLoggingLibraries() *linter {
 		}
 
 		allowedFiles = []string{
+			// Let everything in dev use whatever they want
+			"dev", "enterprise/dev",
 			// Banned imports will match on the linter here
 			"dev/sg/linters/liblog.go",
 			// We allow one usage of a direct zap import here

--- a/dev/sg/linters/liblog_test.go
+++ b/dev/sg/linters/liblog_test.go
@@ -43,4 +43,17 @@ func TestLibLogLinter(t *testing.T) {
 		}))
 		assert.NotNil(t, err)
 	})
+
+	t.Run("allowlist", func(t *testing.T) {
+		err := lint.Check(context.Background(), discard, repo.NewMockState(repo.Diff{
+			"dev/foobar.go": []repo.DiffHunk{
+				{
+					AddedLines: []string{
+						`log15.Info("hi!")`,
+					},
+				},
+			},
+		}))
+		assert.Nil(t, err)
+	})
 }


### PR DESCRIPTION
For hopefully obvious reasons :)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Unit tests