### PR TITLE
dev/buildchecker: attempt to run all reporters before exiting

### DIFF
--- a/dev/buildchecker/main.go
+++ b/dev/buildchecker/main.go
@@ -7,20 +7,15 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"math"
-	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/google/go-github/v41/github"
-	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/slack-go/slack"
 	"golang.org/x/oauth2"
 
-	"github.com/sourcegraph/sourcegraph/dev/okay"
 	"github.com/sourcegraph/sourcegraph/dev/team"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -299,121 +294,28 @@ func cmdHistory(ctx context.Context, flags *Flags, historyFlags *cmdHistoryFlags
 	log.Printf("running analysis with options: %+v\n", checkOpts)
 	totals, flakes, incidents := generateHistory(builds, createdTo, checkOpts)
 
-	// Prepare output
+	// Prepare history reporting destinations
+	reporters := []reporter{}
 	if historyFlags.resultsCsvPath != "" {
-		// Write to files
-		log.Printf("Writing CSV results to %s\n", historyFlags.resultsCsvPath)
-		var errs error
-		errs = errors.CombineErrors(errs, writeCSV(filepath.Join(historyFlags.resultsCsvPath, "totals.csv"), mapToRecords(totals)))
-		errs = errors.CombineErrors(errs, writeCSV(filepath.Join(historyFlags.resultsCsvPath, "flakes.csv"), mapToRecords(flakes)))
-		errs = errors.CombineErrors(errs, writeCSV(filepath.Join(historyFlags.resultsCsvPath, "incidents.csv"), mapToRecords(incidents)))
-		if errs != nil {
-			log.Fatal("csv.WriteAll: ", errs)
-		}
+		reporters = append(reporters, reportToCSV)
 	}
 	if historyFlags.honeycombDataset != "" {
-		// Send to honeycomb
-		log.Printf("Sending results to honeycomb dataset %q\n", historyFlags.honeycombDataset)
-		hc, err := libhoney.NewClient(libhoney.ClientConfig{
-			Dataset: historyFlags.honeycombDataset,
-			APIKey:  historyFlags.honeycombToken,
-		})
-		if err != nil {
-			log.Fatal("libhoney.NewClient: ", err)
-		}
-		var events []*libhoney.Event
-		for _, record := range mapToRecords(totals) {
-			recordDateString := record[0]
-			ev := hc.NewEvent()
-			ev.Timestamp, _ = time.Parse(dateFormat, recordDateString)
-			ev.AddField("build_count", totals[recordDateString])         // date:count
-			ev.AddField("incident_minutes", incidents[recordDateString]) // date:minutes
-			ev.AddField("flake_count", flakes[recordDateString])         // date:count
-			events = append(events, ev)
-		}
-
-		// send all at once
-		log.Printf("Sending %d events to Honeycomb\n", len(events))
-		var errs error
-		for _, ev := range events {
-			if err := ev.Send(); err != nil {
-				errs = errors.Append(errs, err)
-			}
-		}
-		hc.Close()
-		if err != nil {
-			log.Fatal("honeycomb.Send: ", err)
-		}
-		// log events that do not send
-		for _, ev := range events {
-			if strings.Contains(ev.String(), "sent:false") {
-				log.Printf("An event did not send: %s", ev.String())
-			}
-		}
+		reporters = append(reporters, reportToHoneycomb)
 	}
 	if historyFlags.okayHQToken != "" {
-		okayCli := okay.NewClient(http.DefaultClient, historyFlags.okayHQToken)
-
-		for _, record := range mapToRecords(totals) {
-			recordDateString := record[0]
-			eventTime, err := time.Parse("2006-01-02T00:00:00Z", recordDateString+"T00:00:00Z")
-			if err != nil {
-				log.Fatal("time.Parse: ", err)
-			}
-
-			metrics := map[string]okay.Metric{
-				"totalCount":       okay.Count(totals[recordDateString]),
-				"incidentDuration": okay.Duration(time.Duration(incidents[recordDateString]) * time.Minute),
-				"flakeCount":       okay.Count(flakes[recordDateString]),
-			}
-			event := okay.Event{
-				Name:      "buildStats",
-				Timestamp: eventTime,
-				UniqueKey: []string{"ts", "pipeline", "branch"},
-				Properties: map[string]string{
-					"ts":           eventTime.Format(time.RFC3339),
-					"organization": "sourcegraph",
-					"pipeline":     "sourcegraph",
-					"branch":       "main",
-				},
-				Metrics: metrics,
-			}
-
-			err = okayCli.Push(&event)
-			if err != nil {
-				log.Fatal("Error storing OKAYHQ event okay.Push: ", err.Error())
-			}
-		}
-		if err := okayCli.Flush(); err != nil {
-			log.Fatal("Error posting to OKAYHQ okay.Flush: ", err.Error())
-		}
+		reporters = append(reporters, reportToOkayHQ)
 	}
 	if historyFlags.slackReportWebHook != "" {
-		var totalBuilds int
-		var totalTime int
-		var totalFlakes int
-
-		for _, total := range totals {
-			totalBuilds += total
-		}
-
-		for _, incident := range incidents {
-			totalTime += incident
-		}
-
-		for _, flake := range flakes {
-			totalFlakes += flake
-		}
-
-		avgFlakes := math.Round(float64(totalFlakes) / float64(totalBuilds) * 100)
-
-		message := generateWeeklySummary(historyFlags.createdFromDate, historyFlags.createdToDate, totalBuilds, totalFlakes, avgFlakes, time.Duration(totalTime*int(time.Minute)))
-
-		webhooks := strings.Split(historyFlags.slackReportWebHook, ",")
-		if _, err := postSlackUpdate(webhooks, message); err != nil {
-			log.Fatal("postSlackUpdate: ", err)
-		}
+		reporters = append(reporters, reportToSlack)
 	}
+
+	// Deliver reports
+	log.Printf("sending reports to %d reporters", len(reporters))
+	var mErrs error
+	for _, report := range reporters {
+		errors.Append(mErrs, report(ctx, *historyFlags, totals, incidents, flakes))
+	}
+
 	log.Println("done!")
 }
 

--- a/dev/buildchecker/report.go
+++ b/dev/buildchecker/report.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"log"
+	"math"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/honeycombio/libhoney-go"
+
+	"github.com/sourcegraph/sourcegraph/dev/okay"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// reporter implementations should generate history reports to a given target
+type reporter func(
+	ctx context.Context,
+	historyFlags cmdHistoryFlags,
+	totals map[string]int,
+	incidents map[string]int,
+	flakes map[string]int,
+) error
+
+func reportToCSV(
+	ctx context.Context,
+	historyFlags cmdHistoryFlags,
+	totals map[string]int,
+	incidents map[string]int,
+	flakes map[string]int,
+) error {
+	// Write to files
+	log.Printf("Writing CSV results to %s\n", historyFlags.resultsCsvPath)
+	var errs error
+	errs = errors.CombineErrors(errs, writeCSV(filepath.Join(historyFlags.resultsCsvPath, "totals.csv"), mapToRecords(totals)))
+	errs = errors.CombineErrors(errs, writeCSV(filepath.Join(historyFlags.resultsCsvPath, "flakes.csv"), mapToRecords(flakes)))
+	errs = errors.CombineErrors(errs, writeCSV(filepath.Join(historyFlags.resultsCsvPath, "incidents.csv"), mapToRecords(incidents)))
+	if errs != nil {
+		return errors.Wrap(errs, "csv.WriteAll")
+	}
+	return nil
+}
+
+func reportToHoneycomb(
+	ctx context.Context,
+	historyFlags cmdHistoryFlags,
+	totals map[string]int,
+	incidents map[string]int,
+	flakes map[string]int,
+) error {
+	// Send to honeycomb
+	log.Printf("Sending results to honeycomb dataset %q\n", historyFlags.honeycombDataset)
+	hc, err := libhoney.NewClient(libhoney.ClientConfig{
+		Dataset: historyFlags.honeycombDataset,
+		APIKey:  historyFlags.honeycombToken,
+	})
+	if err != nil {
+		return errors.Wrap(err, "libhoney.NewClient")
+	}
+	var events []*libhoney.Event
+	for _, record := range mapToRecords(totals) {
+		recordDateString := record[0]
+		ev := hc.NewEvent()
+		ev.Timestamp, _ = time.Parse(dateFormat, recordDateString)
+		ev.AddField("build_count", totals[recordDateString])         // date:count
+		ev.AddField("incident_minutes", incidents[recordDateString]) // date:minutes
+		ev.AddField("flake_count", flakes[recordDateString])         // date:count
+		events = append(events, ev)
+	}
+
+	// send all at once
+	log.Printf("Sending %d events to Honeycomb\n", len(events))
+	var errs error
+	for _, ev := range events {
+		if err := ev.Send(); err != nil {
+			errs = errors.Append(errs, err)
+		}
+	}
+	hc.Close()
+	if err != nil {
+		return errors.Wrap(err, "honeycomb.Send")
+	}
+
+	// log events that do not send
+	for _, ev := range events {
+		if strings.Contains(ev.String(), "sent:false") {
+			log.Printf("An event did not send: %s", ev.String())
+		}
+	}
+
+	return nil
+}
+
+func reportToOkayHQ(
+	ctx context.Context,
+	historyFlags cmdHistoryFlags,
+	totals map[string]int,
+	incidents map[string]int,
+	flakes map[string]int,
+) error {
+	okayCli := okay.NewClient(http.DefaultClient, historyFlags.okayHQToken)
+
+	for _, record := range mapToRecords(totals) {
+		recordDateString := record[0]
+		eventTime, err := time.Parse("2006-01-02T00:00:00Z", recordDateString+"T00:00:00Z")
+		if err != nil {
+			return errors.Wrap(err, "time.Parse")
+		}
+
+		metrics := map[string]okay.Metric{
+			"totalCount":       okay.Count(totals[recordDateString]),
+			"incidentDuration": okay.Duration(time.Duration(incidents[recordDateString]) * time.Minute),
+			"flakeCount":       okay.Count(flakes[recordDateString]),
+		}
+		event := okay.Event{
+			Name:      "buildStats",
+			Timestamp: eventTime,
+			UniqueKey: []string{"ts", "pipeline", "branch"},
+			Properties: map[string]string{
+				"ts":           eventTime.Format(time.RFC3339),
+				"organization": "sourcegraph",
+				"pipeline":     "sourcegraph",
+				"branch":       "main",
+			},
+			Metrics: metrics,
+		}
+
+		err = okayCli.Push(&event)
+		if err != nil {
+			return errors.Wrap(err, "Error storing OKAYHQ event okay.Push")
+		}
+	}
+	if err := okayCli.Flush(); err != nil {
+		return errors.Wrap(err, "Error posting to OkayHQ okay.Flush")
+	}
+	return nil
+}
+
+func reportToSlack(
+	ctx context.Context,
+	historyFlags cmdHistoryFlags,
+	totals map[string]int,
+	incidents map[string]int,
+	flakes map[string]int,
+) error {
+	var totalBuilds, totalTime, totalFlakes int
+	for _, total := range totals {
+		totalBuilds += total
+	}
+	for _, incident := range incidents {
+		totalTime += incident
+	}
+	for _, flake := range flakes {
+		totalFlakes += flake
+	}
+
+	avgFlakes := math.Round(float64(totalFlakes) / float64(totalBuilds) * 100)
+
+	message := generateWeeklySummary(historyFlags.createdFromDate, historyFlags.createdToDate, totalBuilds, totalFlakes, avgFlakes, time.Duration(totalTime*int(time.Minute)))
+
+	webhooks := strings.Split(historyFlags.slackReportWebHook, ",")
+	if _, err := postSlackUpdate(webhooks, message); err != nil {
+		log.Fatal("postSlackUpdate: ", err)
+		return errors.Wrap(err, "postSlackUpdate")
+	}
+	return nil
+}

--- a/dev/sg/linters/liblog.go
+++ b/dev/sg/linters/liblog.go
@@ -24,6 +24,8 @@ func lintLoggingLibraries() *linter {
 		}
 
 		allowedFiles = []string{
+			// Let everything in dev use whatever they want
+			"dev", "enterprise/dev",
 			// Banned imports will match on the linter here
 			"dev/sg/linters/liblog.go",
 			// We allow one usage of a direct zap import here

--- a/dev/sg/linters/liblog_test.go
+++ b/dev/sg/linters/liblog_test.go
@@ -43,4 +43,17 @@ func TestLibLogLinter(t *testing.T) {
 		}))
 		assert.NotNil(t, err)
 	})
+
+	t.Run("allowlist", func(t *testing.T) {
+		err := lint.Check(context.Background(), discard, repo.NewMockState(repo.Diff{
+			"dev/foobar.go": []repo.DiffHunk{
+				{
+					AddedLines: []string{
+						`log15.Info("hi!")`,
+					},
+				},
+			},
+		}))
+		assert.Nil(t, err)
+	})
 }


### PR DESCRIPTION
With our growing number of reporters, it would be less than ideal if one failed and all the others failed as well. Additionally, the number of reporting implementations is making `main.go` hard to read, so we extract them to more isolated functions.

This refactor is mostly geared towards https://github.com/sourcegraph/sourcegraph/pull/38020

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

yolo merge and fix if broken