### PR TITLE
ci: disable flaky code search test (structural...)

### DIFF
--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -440,7 +440,7 @@ func bar() {
 
 	t.Run("unlimited", test(10000, 4, &protocol.PatternInfo{Pattern: "{:[body]}"}))
 	t.Run("exact limit", test(4, 4, &protocol.PatternInfo{Pattern: "{:[body]}"}))
-	t.Run("limited", test(2, 2, &protocol.PatternInfo{Pattern: "{:[body]}"}))
+	t.Run("limited", func(t *testing.T) { t.Skip("disabled because flaky") }) // test(2, 2, &protocol.PatternInfo{Pattern: "{:[body]}"}))
 	t.Run("many", test(12, 8, &protocol.PatternInfo{Pattern: "(:[_])"}))
 }
 


### PR DESCRIPTION
StructuralLimits/limited has failed 7 times in the last 24 hours on main alone: https://sourcegraph.grafana.net/goto/uC5B2jqnz?orgId=1

[Slack context](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1656605688287039)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a, disabling a flake 
