### PR TITLE
codeintel: allow listing deleted LSIF uploads reconstructed from audit logs in graphql layer

### DIFF
--- a/client/web/src/enterprise/codeintel/uploads/hooks/queryLsifUploadsByRepository.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/hooks/queryLsifUploadsByRepository.tsx
@@ -55,10 +55,20 @@ export interface UploadListVariables {
     first?: number | null
     after?: string | null
     query?: string | null
+    includeDeleted?: boolean | null
 }
 
 export const queryLsifUploadsByRepository = (
-    { query, state, isLatestForRepo, dependencyOf, dependentOf, first, after }: GQL.ILsifUploadsOnRepositoryArguments,
+    {
+        query,
+        state,
+        isLatestForRepo,
+        dependencyOf,
+        dependentOf,
+        first,
+        after,
+        includeDeleted,
+    }: GQL.ILsifUploadsOnRepositoryArguments,
     repository: string,
     client: ApolloClient<object>
 ): Observable<LsifUploadConnectionFields> => {
@@ -70,6 +80,7 @@ export const queryLsifUploadsByRepository = (
         dependentOf: dependentOf ?? null,
         first: first ?? null,
         after: after ?? null,
+        includeDeleted: includeDeleted ?? null,
     }
 
     return from(

--- a/client/web/src/enterprise/codeintel/uploads/hooks/queryLsifUploadsList.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/hooks/queryLsifUploadsList.tsx
@@ -70,7 +70,7 @@ export const queryLsifUploadsList = (
         first,
         after,
         includeDeleted,
-    }: GQL.ILsifUploadsOnRepositoryArguments,
+    }: GQL.ILsifUploadsOnQueryArguments,
     client: ApolloClient<object>
 ): Observable<LsifUploadConnectionFields> => {
     const variables: LsifUploadsVariables = {

--- a/client/web/src/enterprise/codeintel/uploads/hooks/queryLsifUploadsList.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/hooks/queryLsifUploadsList.tsx
@@ -23,6 +23,7 @@ const LSIF_UPLOAD_LIST = gql`
         $first: Int
         $after: String
         $query: String
+        $includeDeleted: Boolean
     ) {
         lsifUploads(
             query: $query
@@ -32,6 +33,7 @@ const LSIF_UPLOAD_LIST = gql`
             dependentOf: $dependentOf
             first: $first
             after: $after
+            includeDeleted: $includeDeleted
         ) {
             nodes {
                 ...LsifUploadFields
@@ -55,10 +57,20 @@ export interface UploadListVariables {
     first?: number | null
     after?: string | null
     query?: string | null
+    includeDeleted?: boolean | null
 }
 
 export const queryLsifUploadsList = (
-    { query, state, isLatestForRepo, dependencyOf, dependentOf, first, after }: GQL.ILsifUploadsOnRepositoryArguments,
+    {
+        query,
+        state,
+        isLatestForRepo,
+        dependencyOf,
+        dependentOf,
+        first,
+        after,
+        includeDeleted,
+    }: GQL.ILsifUploadsOnRepositoryArguments,
     client: ApolloClient<object>
 ): Observable<LsifUploadConnectionFields> => {
     const variables: LsifUploadsVariables = {
@@ -69,6 +81,7 @@ export const queryLsifUploadsList = (
         dependentOf: dependentOf ?? null,
         first: first ?? null,
         after: after ?? null,
+        includeDeleted: includeDeleted ?? null,
     }
 
     return from(

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -12,12 +12,6 @@ import (
 )
 
 type CodeIntelResolver interface {
-	LSIFUploadByID(ctx context.Context, id graphql.ID) (LSIFUploadResolver, error)
-	LSIFUploads(ctx context.Context, args *LSIFUploadsQueryArgs) (LSIFUploadConnectionResolver, error)
-	LSIFUploadsByRepo(ctx context.Context, args *LSIFRepositoryUploadsQueryArgs) (LSIFUploadConnectionResolver, error)
-	DeleteLSIFUpload(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error)
-
-	CommitGraph(ctx context.Context, id graphql.ID) (CodeIntelligenceCommitGraphResolver, error)
 	GitBlobLSIFData(ctx context.Context, args *GitBlobLSIFDataArgs) (GitBlobLSIFDataResolver, error)
 	GitBlobCodeIntelInfo(ctx context.Context, args *GitTreeEntryCodeIntelInfoArgs) (GitBlobCodeIntelSupportResolver, error)
 	GitTreeCodeIntelInfo(ctx context.Context, args *GitTreeEntryCodeIntelInfoArgs) (GitTreeCodeIntelSupportResolver, error)
@@ -50,10 +44,10 @@ type ExecutorResolver interface {
 
 type UploadsServiceResolver interface {
 	CommitGraph(ctx context.Context, id graphql.ID) (CodeIntelligenceCommitGraphResolver, error)
-	DeleteLSIFUpload(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error)
 	LSIFUploadByID(ctx context.Context, id graphql.ID) (LSIFUploadResolver, error)
 	LSIFUploads(ctx context.Context, args *LSIFUploadsQueryArgs) (LSIFUploadConnectionResolver, error)
 	LSIFUploadsByRepo(ctx context.Context, args *LSIFRepositoryUploadsQueryArgs) (LSIFUploadConnectionResolver, error)
+	DeleteLSIFUpload(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error)
 }
 type PoliciesServiceResolver interface {
 	CodeIntelligenceConfigurationPolicies(ctx context.Context, args *CodeIntelligenceConfigurationPoliciesArgs) (CodeIntelligenceConfigurationPolicyConnectionResolver, error)
@@ -73,6 +67,7 @@ type LSIFUploadsQueryArgs struct {
 	DependencyOf    *graphql.ID
 	DependentOf     *graphql.ID
 	After           *string
+	IncludeDeleted  *bool
 }
 
 type LSIFRepositoryUploadsQueryArgs struct {

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -471,6 +471,13 @@ extend type Repository {
         'LSIFUploadConnection.pageInfo.endCursor' that is returned.
         """
         after: String
+
+        """
+        When specified, merges the list of existing uploads with data from
+        uploads that have been deleted but for which audit logs still exist.
+        Only makes sense when state filter is unset or equal to 'DELETED'.
+        """
+        includeDeleted: Boolean
     ): LSIFUploadConnection!
 
     """

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -175,6 +175,13 @@ extend type Query {
         'LSIFUploadConnection.pageInfo.endCursor' that is returned.
         """
         after: String
+
+        """
+        When specified, merges the list of existing uploads with data from
+        uploads that have been deleted but for which audit logs still exist.
+        Only makes sense when state filter is unset or equal to 'DELETED'.
+        """
+        includeDeleted: Boolean
     ): LSIFUploadConnection!
 
     """
@@ -946,6 +953,12 @@ enum LSIFUploadState {
     point the upload will become unreachable.
     """
     DELETING
+
+    """
+    This upload is deleted and its metadata is reconstructed from existing
+    audit log entries.
+    """
+    DELETED
 }
 
 """

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -711,15 +711,16 @@ func makeGetUploadsOptions(args *gql.LSIFRepositoryUploadsQueryArgs) (store.GetU
 	}
 
 	return store.GetUploadsOptions{
-		RepositoryID: repositoryID,
-		State:        strings.ToLower(derefString(args.State, "")),
-		Term:         derefString(args.Query, ""),
-		VisibleAtTip: derefBool(args.IsLatestForRepo, false),
-		DependencyOf: int(dependencyOf),
-		DependentOf:  int(dependentOf),
-		Limit:        derefInt32(args.First, DefaultUploadPageSize),
-		Offset:       offset,
-		AllowExpired: true,
+		RepositoryID:       repositoryID,
+		State:              strings.ToLower(derefString(args.State, "")),
+		Term:               derefString(args.Query, ""),
+		VisibleAtTip:       derefBool(args.IsLatestForRepo, false),
+		DependencyOf:       int(dependencyOf),
+		DependentOf:        int(dependentOf),
+		Limit:              derefInt32(args.First, DefaultUploadPageSize),
+		Offset:             offset,
+		AllowExpired:       true,
+		AllowDeletedUpload: derefBool(args.IncludeDeleted, false),
 	}, nil
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/uploads.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/uploads.go
@@ -14,7 +14,7 @@ type UploadsResolver struct {
 	dbStore DBStore
 	opts    store.GetUploadsOptions
 	once    sync.Once
-	//
+
 	Uploads    []store.Upload
 	TotalCount int
 	NextOffset *int

--- a/internal/codeintel/stores/dbstore/helpers_test.go
+++ b/internal/codeintel/stores/dbstore/helpers_test.go
@@ -155,7 +155,16 @@ func updateUploads(t testing.TB, db database.DB, uploads ...Upload) {
 			upload.ID)
 
 		if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
-			t.Fatalf("unexpected error while inserting upload: %s", err)
+			t.Fatalf("unexpected error while updating upload: %s", err)
+		}
+	}
+}
+
+func deleteUploads(t testing.TB, db database.DB, uploads ...int) {
+	for _, upload := range uploads {
+		query := sqlf.Sprintf(`DELETE FROM lsif_uploads WHERE id = %s`, upload)
+		if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+			t.Fatalf("unexpected error while deleting upload: %s", err)
 		}
 	}
 }

--- a/internal/codeintel/stores/dbstore/uploads.go
+++ b/internal/codeintel/stores/dbstore/uploads.go
@@ -539,7 +539,7 @@ FROM (
 JOIN lsif_uploads_audit_logs au ON au.upload_id = s.upload_id
 `
 
-var rankedDependencyCandidateCTEQuery = `
+const rankedDependencyCandidateCTEQuery = `
 SELECT
 	p.dump_id as pkg_id,
 	r.dump_id as ref_id,
@@ -560,7 +560,7 @@ WHERE
 	%s
 `
 
-var rankedDependentCandidateCTEQuery = `
+const rankedDependentCandidateCTEQuery = `
 SELECT
 	p.dump_id as pkg_id,
 	p.scheme as scheme,
@@ -1216,7 +1216,7 @@ func (s *Store) UpdateReferenceCounts(ctx context.Context, ids []int, dependency
 	return int(affected), nil
 }
 
-var updateReferenceCountsQuery = `
+const updateReferenceCountsQuery = `
 -- source: internal/codeintel/stores/dbstore/uploads.go:UpdateReferenceCounts
 WITH
 -- Select the set of package identifiers provided by the target upload list. This

--- a/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/internal/codeintel/stores/dbstore/uploads_test.go
@@ -271,8 +271,13 @@ func TestGetUploads(t *testing.T) {
 
 		// deleted repo
 		Upload{ID: 15, Commit: makeCommit(3334), UploadedAt: t4, State: "deleted", RepositoryID: 53, RepositoryName: "DELETED-barfoo"},
+
+		// to-be hard deleted
+		Upload{ID: 16, Commit: makeCommit(3333), UploadedAt: t4, FinishedAt: &t3, State: "deleted"},
 	)
 	insertVisibleAtTip(t, db, 50, 2, 5, 7, 8)
+
+	deleteUploads(t, db, 16)
 
 	// upload 10 depends on uploads 7 and 8
 	insertPackages(t, store, []shared.Package{
@@ -332,12 +337,12 @@ func TestGetUploads(t *testing.T) {
 		{dependentOf: 10, expectedIDs: []int{}},
 		{dependencyOf: 11, expectedIDs: []int{8}},
 		{dependentOf: 11, expectedIDs: []int{}},
-		{allowDeletedRepo: true, state: "deleted", expectedIDs: []int{12, 13, 14, 15}},
+		{allowDeletedRepo: true, state: "deleted", expectedIDs: []int{12, 13, 14, 15, 16}},
 	}
 
 	runTest := func(testCase testCase, lo, hi int) (errors int) {
 		name := fmt.Sprintf(
-			"repositoryID=%d state=%s term=%s visibleAtTip=%v dependencyOf=%d dependentOf=%d offset=%d",
+			"repositoryID=%d|state='%s'|term='%s'|visibleAtTip=%v|dependencyOf=%d|dependentOf=%d|offset=%d",
 			testCase.repositoryID,
 			testCase.state,
 			testCase.term,

--- a/internal/codeintel/uploads/internal/store/store_commits_test.go
+++ b/internal/codeintel/uploads/internal/store/store_commits_test.go
@@ -270,6 +270,15 @@ func insertUploads(t testing.TB, db database.DB, uploads ...shared.Upload) {
 	}
 }
 
+func deleteUploads(t testing.TB, db database.DB, uploads ...int) {
+	for _, upload := range uploads {
+		query := sqlf.Sprintf(`DELETE FROM lsif_uploads WHERE id = %s`, upload)
+		if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+			t.Fatalf("unexpected error while deleting upload: %s", err)
+		}
+	}
+}
+
 // insertRepo creates a repository record with the given id and name. If there is already a repository
 // with the given identifier, nothing happens
 func insertRepo(t testing.TB, db database.DB, id int, name string) {
@@ -309,6 +318,36 @@ func getUploadStates(db database.DB, ids ...int) (map[int]string, error) {
 	)
 
 	return scanStates(db.QueryContext(context.Background(), q.Query(sqlf.PostgresBindVar), q.Args()...))
+}
+
+// insertVisibleAtTip populates rows of the lsif_uploads_visible_at_tip table for the given repository
+// with the given identifiers. Each upload is assumed to refer to the tip of the default branch. To mark
+// an upload as protected (visible to _some_ branch) butn ot visible from the default branch, use the
+// insertVisibleAtTipNonDefaultBranch method instead.
+func insertVisibleAtTip(t testing.TB, db database.DB, repositoryID int, uploadIDs ...int) {
+	insertVisibleAtTipInternal(t, db, repositoryID, true, uploadIDs...)
+}
+
+// insertVisibleAtTipNonDefaultBranch populates rows of the lsif_uploads_visible_at_tip table for the
+// given repository with the given identifiers. Each upload is assumed to refer to the tip of a branch
+// distinct from the default branch or a tag.
+func insertVisibleAtTipNonDefaultBranch(t testing.TB, db database.DB, repositoryID int, uploadIDs ...int) {
+	insertVisibleAtTipInternal(t, db, repositoryID, false, uploadIDs...)
+}
+
+func insertVisibleAtTipInternal(t testing.TB, db database.DB, repositoryID int, isDefaultBranch bool, uploadIDs ...int) {
+	var rows []*sqlf.Query
+	for _, uploadID := range uploadIDs {
+		rows = append(rows, sqlf.Sprintf("(%s, %s, %s)", repositoryID, uploadID, isDefaultBranch))
+	}
+
+	query := sqlf.Sprintf(
+		`INSERT INTO lsif_uploads_visible_at_tip (repository_id, upload_id, is_default_branch) VALUES %s`,
+		sqlf.Join(rows, ","),
+	)
+	if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		t.Fatalf("unexpected error while updating uploads visible at tip: %s", err)
+	}
 }
 
 // scanStates scans pairs of id/states from the return value of `*Store.query`.

--- a/internal/codeintel/uploads/internal/store/store_uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"sort"
 	"testing"
 	"time"
@@ -11,12 +13,215 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
+
+func TestGetUploads(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(db, &observation.TestContext)
+	ctx := context.Background()
+
+	t1 := time.Unix(1587396557, 0).UTC()
+	t2 := t1.Add(-time.Minute * 1)
+	t3 := t1.Add(-time.Minute * 2)
+	t4 := t1.Add(-time.Minute * 3)
+	t5 := t1.Add(-time.Minute * 4)
+	t6 := t1.Add(-time.Minute * 5)
+	t7 := t1.Add(-time.Minute * 6)
+	t8 := t1.Add(-time.Minute * 7)
+	t9 := t1.Add(-time.Minute * 8)
+	t10 := t1.Add(-time.Minute * 9)
+	t11 := t1.Add(-time.Minute * 10)
+	failureMessage := "unlucky 333"
+
+	insertUploads(t, db,
+		shared.Upload{ID: 1, Commit: makeCommit(3331), UploadedAt: t1, Root: "sub1/", State: "queued"},
+		shared.Upload{ID: 2, UploadedAt: t2, FinishedAt: &t1, State: "errored", FailureMessage: &failureMessage, Indexer: "scip-typescript"},
+		shared.Upload{ID: 3, Commit: makeCommit(3333), UploadedAt: t3, Root: "sub2/", State: "queued"},
+		shared.Upload{ID: 4, UploadedAt: t4, State: "queued", RepositoryID: 51, RepositoryName: "foo bar x"},
+		shared.Upload{ID: 5, Commit: makeCommit(3333), UploadedAt: t5, Root: "sub1/", State: "processing", Indexer: "scip-typescript"},
+		shared.Upload{ID: 6, UploadedAt: t6, Root: "sub2/", State: "processing", RepositoryID: 52, RepositoryName: "foo bar y"},
+		shared.Upload{ID: 7, UploadedAt: t7, FinishedAt: &t4, Root: "sub1/", Indexer: "scip-typescript"},
+		shared.Upload{ID: 8, UploadedAt: t8, FinishedAt: &t4, Indexer: "scip-typescript"},
+		shared.Upload{ID: 9, UploadedAt: t9, State: "queued"},
+		shared.Upload{ID: 10, UploadedAt: t10, FinishedAt: &t6, Root: "sub1/", Indexer: "scip-typescript"},
+		shared.Upload{ID: 11, UploadedAt: t11, FinishedAt: &t6, Root: "sub1/", Indexer: "scip-typescript"},
+
+		// Deleted duplicates
+		shared.Upload{ID: 12, Commit: makeCommit(3331), UploadedAt: t1, FinishedAt: &t1, Root: "sub1/", State: "deleted"},
+		shared.Upload{ID: 13, UploadedAt: t2, FinishedAt: &t1, State: "deleted", FailureMessage: &failureMessage, Indexer: "scip-typescript"},
+		shared.Upload{ID: 14, Commit: makeCommit(3333), UploadedAt: t3, FinishedAt: &t2, Root: "sub2/", State: "deleted"},
+
+		// deleted repo
+		shared.Upload{ID: 15, Commit: makeCommit(3334), UploadedAt: t4, State: "deleted", RepositoryID: 53, RepositoryName: "DELETED-barfoo"},
+
+		// to-be hard deleted
+		shared.Upload{ID: 16, Commit: makeCommit(3333), UploadedAt: t4, FinishedAt: &t3, State: "deleted"},
+	)
+	insertVisibleAtTip(t, db, 50, 2, 5, 7, 8)
+
+	deleteUploads(t, db, 16)
+
+	// upload 10 depends on uploads 7 and 8
+	insertPackages(t, store, []shared.Package{
+		{DumpID: 7, Scheme: "npm", Name: "foo", Version: "0.1.0"},
+		{DumpID: 8, Scheme: "npm", Name: "bar", Version: "1.2.3"},
+		{DumpID: 11, Scheme: "npm", Name: "foo", Version: "0.1.0"}, // duplicate package
+	})
+	insertPackageReferences(t, store, []shared.PackageReference{
+		{Package: shared.Package{DumpID: 7, Scheme: "npm", Name: "bar", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 10, Scheme: "npm", Name: "foo", Version: "0.1.0"}},
+		{Package: shared.Package{DumpID: 10, Scheme: "npm", Name: "bar", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 11, Scheme: "npm", Name: "bar", Version: "1.2.3"}},
+	})
+
+	t.Logf("%v", sqlf.Sprintf(
+		`INSERT INTO lsif_dirty_repositories(repository_id, update_token, dirty_token, updated_at) VALUES (%s, 10, 20, %s)`,
+		50,
+		t5,
+	).Query(sqlf.PostgresBindVar))
+
+	dirtyRepositoryQuery := sqlf.Sprintf(
+		`INSERT INTO lsif_dirty_repositories(repository_id, update_token, dirty_token, updated_at) VALUES (%s, 10, 20, %s)`,
+		50,
+		t5,
+	)
+	if _, err := db.ExecContext(ctx, dirtyRepositoryQuery.Query(sqlf.PostgresBindVar), dirtyRepositoryQuery.Args()...); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	type testCase struct {
+		repositoryID     int
+		state            string
+		term             string
+		visibleAtTip     bool
+		dependencyOf     int
+		dependentOf      int
+		uploadedBefore   *time.Time
+		uploadedAfter    *time.Time
+		inCommitGraph    bool
+		oldestFirst      bool
+		allowDeletedRepo bool
+		expectedIDs      []int
+	}
+	testCases := []testCase{
+		{expectedIDs: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+		{oldestFirst: true, expectedIDs: []int{11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}},
+		{repositoryID: 50, expectedIDs: []int{1, 2, 3, 5, 7, 8, 9, 10, 11}},
+		{state: "completed", expectedIDs: []int{7, 8, 10, 11}},
+		{term: "sub", expectedIDs: []int{1, 3, 5, 6, 7, 10, 11}},     // searches root
+		{term: "003", expectedIDs: []int{1, 3, 5}},                   // searches commits
+		{term: "333", expectedIDs: []int{1, 2, 3, 5}},                // searches commits and failure message
+		{term: "typescript", expectedIDs: []int{2, 5, 7, 8, 10, 11}}, // searches indexer
+		{term: "QuEuEd", expectedIDs: []int{1, 3, 4, 9}},             // searches text status
+		{term: "bAr", expectedIDs: []int{4, 6}},                      // search repo names
+		{state: "failed", expectedIDs: []int{2}},                     // treats errored/failed states equivalently
+		{visibleAtTip: true, expectedIDs: []int{2, 5, 7, 8}},
+		{uploadedBefore: &t5, expectedIDs: []int{6, 7, 8, 9, 10, 11}},
+		{uploadedAfter: &t4, expectedIDs: []int{1, 2, 3}},
+		{inCommitGraph: true, expectedIDs: []int{10, 11}},
+		{dependencyOf: 7, expectedIDs: []int{8}},
+		{dependentOf: 7, expectedIDs: []int{10}},
+		{dependencyOf: 8, expectedIDs: []int{}},
+		{dependentOf: 8, expectedIDs: []int{7, 10, 11}},
+		{dependencyOf: 10, expectedIDs: []int{7, 8}},
+		{dependentOf: 10, expectedIDs: []int{}},
+		{dependencyOf: 11, expectedIDs: []int{8}},
+		{dependentOf: 11, expectedIDs: []int{}},
+		{allowDeletedRepo: true, state: "deleted", expectedIDs: []int{12, 13, 14, 15, 16}},
+	}
+
+	runTest := func(testCase testCase, lo, hi int) (errors int) {
+		name := fmt.Sprintf(
+			"repositoryID=%d|state='%s'|term='%s'|visibleAtTip=%v|dependencyOf=%d|dependentOf=%d|offset=%d",
+			testCase.repositoryID,
+			testCase.state,
+			testCase.term,
+			testCase.visibleAtTip,
+			testCase.dependencyOf,
+			testCase.dependentOf,
+			lo,
+		)
+
+		t.Run(name, func(t *testing.T) {
+			uploads, totalCount, err := store.GetUploads(ctx, shared.GetUploadsOptions{
+				RepositoryID:     testCase.repositoryID,
+				State:            testCase.state,
+				Term:             testCase.term,
+				VisibleAtTip:     testCase.visibleAtTip,
+				DependencyOf:     testCase.dependencyOf,
+				DependentOf:      testCase.dependentOf,
+				UploadedBefore:   testCase.uploadedBefore,
+				UploadedAfter:    testCase.uploadedAfter,
+				InCommitGraph:    testCase.inCommitGraph,
+				OldestFirst:      testCase.oldestFirst,
+				AllowDeletedRepo: testCase.allowDeletedRepo,
+				Limit:            3,
+				Offset:           lo,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error getting uploads for repo: %s", err)
+			}
+			if totalCount != len(testCase.expectedIDs) {
+				t.Errorf("unexpected total count. want=%d have=%d", len(testCase.expectedIDs), totalCount)
+				errors++
+			}
+
+			if totalCount != 0 {
+				var ids []int
+				for _, upload := range uploads {
+					ids = append(ids, upload.ID)
+				}
+				if diff := cmp.Diff(testCase.expectedIDs[lo:hi], ids); diff != "" {
+					t.Errorf("unexpected upload ids at offset %d-%d (-want +got):\n%s", lo, hi, diff)
+					errors++
+				}
+			}
+		})
+
+		return errors
+	}
+
+	for _, testCase := range testCases {
+		if n := len(testCase.expectedIDs); n == 0 {
+			runTest(testCase, 0, 0)
+		} else {
+			for lo := 0; lo < n; lo++ {
+				if numErrors := runTest(testCase, lo, int(math.Min(float64(lo)+3, float64(n)))); numErrors > 0 {
+					break
+				}
+			}
+		}
+	}
+
+	t.Run("enforce repository permissions", func(t *testing.T) {
+		// Enable permissions user mapping forces checking repository permissions
+		// against permissions tables in the database, which should effectively block
+		// all access because permissions tables are empty.
+		before := globals.PermissionsUserMapping()
+		globals.SetPermissionsUserMapping(&schema.PermissionsUserMapping{Enabled: true})
+		defer globals.SetPermissionsUserMapping(before)
+
+		uploads, totalCount, err := store.GetUploads(ctx,
+			shared.GetUploadsOptions{
+				Limit: 1,
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(uploads) > 0 || totalCount > 0 {
+			t.Fatalf("Want no upload but got %d uploads with totalCount %d", len(uploads), totalCount)
+		}
+	})
+}
 
 func TestDeleteUploadsWithoutRepository(t *testing.T) {
 	logger := logtest.Scoped(t)

--- a/internal/codeintel/uploads/shared/types.go
+++ b/internal/codeintel/uploads/shared/types.go
@@ -46,6 +46,7 @@ type GetUploadsOptions struct {
 	LastRetentionScanBefore *time.Time
 	AllowExpired            bool
 	AllowDeletedRepo        bool
+	AllowDeletedUpload      bool
 	OldestFirst             bool
 	Limit                   int
 	Offset                  int

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -133,6 +133,10 @@
       "Definition": "CREATE OR REPLACE FUNCTION public.invalidate_session_for_userid_on_password_change()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        IF OLD.passwd != NEW.passwd THEN\n            NEW.invalidated_sessions_at = now() + (1 * interval '1 second');\n            RETURN NEW;\n        END IF;\n    RETURN NEW;\n    END;\n$function$\n"
     },
     {
+      "Name": "merge_audit_log_transitions",
+      "Definition": "CREATE OR REPLACE FUNCTION public.merge_audit_log_transitions(internal hstore, arrayhstore hstore[])\n RETURNS hstore\n LANGUAGE plpgsql\n IMMUTABLE\nAS $function$\n    DECLARE\n        trans hstore;\n    BEGIN\n      FOREACH trans IN ARRAY arrayhstore\n      LOOP\n          internal := internal || hstore(trans-\u003e'column', trans-\u003e'new');\n      END LOOP;\n\n      RETURN internal;\n    END;\n$function$\n"
+    },
+    {
       "Name": "repo_block",
       "Definition": "CREATE OR REPLACE FUNCTION public.repo_block(reason text, at timestamp with time zone)\n RETURNS jsonb\n LANGUAGE sql\n IMMUTABLE STRICT\nAS $function$\nSELECT jsonb_build_object(\n    'reason', reason,\n    'at', extract(epoch from timezone('utc', at))::bigint\n);\n$function$\n"
     },

--- a/migrations/frontend/1655226733/down.sql
+++ b/migrations/frontend/1655226733/down.sql
@@ -1,0 +1,3 @@
+DROP AGGREGATE IF EXISTS snapshot_transition_columns(HSTORE[]);
+
+DROP FUNCTION IF EXISTS merge_audit_log_transitions;

--- a/migrations/frontend/1655226733/metadata.yaml
+++ b/migrations/frontend/1655226733/metadata.yaml
@@ -1,0 +1,2 @@
+name: hstore_aggregate_func
+parents: [1654116265, 1654168174]

--- a/migrations/frontend/1655226733/up.sql
+++ b/migrations/frontend/1655226733/up.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION merge_audit_log_transitions(internal hstore, arrayhstore hstore[]) RETURNS hstore AS $$
+    DECLARE
+        trans hstore;
+    BEGIN
+      FOREACH trans IN ARRAY arrayhstore
+      LOOP
+          internal := internal || hstore(trans->'column', trans->'new');
+      END LOOP;
+
+      RETURN internal;
+    END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE AGGREGATE snapshot_transition_columns(HSTORE[]) (
+    SFUNC = merge_audit_log_transitions,
+    STYPE = HSTORE,
+    INITCOND = ''
+);


### PR DESCRIPTION
Previously, it was not possible to get the audit logs for deleted uploads via the API, only through Postgres access. This is a hurdle that makes it less likely for site-admins to deal with deeper exploration into explaining upload state-change behaviour, and also for our QA tests.

This PR addresses this by allowing (partial) upload objects to be synthesized from the audit logs for an upload through a custom Postgres aggregation function. We then allow these synthesized uploads to be merged alongside non-deleted uploads in the `lsifUploads` top-level GraphQL query.

Closes https://github.com/sourcegraph/sourcegraph/issues/38006

## Test plan

Created a new entry in the `GetUploads` test and tested manually. Probably some weird input edge case that was missed but unlikely to occur from our frontend
