### PR TITLE
Code monitors: fix panic

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -23,7 +23,7 @@ import (
 
 // NewResolver returns a new Resolver that uses the given database
 func NewResolver(db edb.EnterpriseDB) graphqlbackend.CodeMonitorsResolver {
-	return &Resolver{db: db}
+	return &Resolver{db: db, log: log.Scoped("codeMonitorResolver", "")}
 }
 
 type Resolver struct {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -643,7 +643,8 @@ func (r *Resolver) transact(ctx context.Context) (*Resolver, error) {
 		return nil, err
 	}
 	return &Resolver{
-		db: edb.NewEnterpriseDB(tx),
+		db:  edb.NewEnterpriseDB(tx),
+		log: r.log,
 	}, nil
 }
 


### PR DESCRIPTION
A recent change to propagate loggers missed instantiating the logger, so
code monitor resolver operations are panicking.

## Test plan

Manually tested that panicking operation was no longer panicking.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
