### PR TITLE
Code monitors: refer to the correct ID when joining monitors

### DIFF
--- a/enterprise/internal/database/code_monitor_emails.go
+++ b/enterprise/internal/database/code_monitor_emails.go
@@ -36,7 +36,7 @@ WHERE
 	id = %s
 	AND EXISTS (
 		SELECT 1 FROM cm_monitors
-		WHERE cm_monitors.id = id
+		WHERE cm_monitors.id = cm_emails.monitor
 			AND cm_monitors.namespace_user_id = %s
 	)
 RETURNING %s;

--- a/enterprise/internal/database/code_monitor_emails_test.go
+++ b/enterprise/internal/database/code_monitor_emails_test.go
@@ -15,6 +15,7 @@ func TestUpdateEmail(t *testing.T) {
 	uid2 := insertTestUser(ctx, t, db, "u2", false)
 	ctx2 := actor.WithActor(ctx, actor.FromUser(uid2))
 	fixtures := s.insertTestMonitor(ctx1, t)
+	_ = s.insertTestMonitor(ctx2, t) // user2 also has monitors
 
 	ea, err := s.CreateEmailAction(ctx1, fixtures.monitor.ID, &EmailActionArgs{
 		Priority: "NORMAL",

--- a/enterprise/internal/database/code_monitor_queries.go
+++ b/enterprise/internal/database/code_monitor_queries.go
@@ -72,7 +72,7 @@ WHERE
 	id = %s
 	AND EXISTS (
 		SELECT 1 FROM cm_monitors
-		WHERE cm_monitors.id = id
+		WHERE cm_monitors.id = cm_queries.monitor
 			AND cm_monitors.namespace_user_id = %s
 	)
 RETURNING %s;

--- a/enterprise/internal/database/code_monitor_queries_test.go
+++ b/enterprise/internal/database/code_monitor_queries_test.go
@@ -65,6 +65,7 @@ func TestUpdateTrigger(t *testing.T) {
 	uid2 := insertTestUser(ctx, t, db, "u2", false)
 	ctx2 := actor.WithActor(ctx, actor.FromUser(uid2))
 	fixtures := s.insertTestMonitor(ctx1, t)
+	_ = s.insertTestMonitor(ctx2, t)
 
 	// User1 can update it
 	err := s.UpdateQueryTrigger(ctx1, fixtures.query.ID, "query1")

--- a/enterprise/internal/database/code_monitor_slack_webhook.go
+++ b/enterprise/internal/database/code_monitor_slack_webhook.go
@@ -35,7 +35,7 @@ WHERE
 	id = %s
 	AND EXISTS (
 		SELECT 1 FROM cm_monitors
-		WHERE cm_monitors.id = id
+		WHERE cm_monitors.id = cm_slack_webhooks.monitor
 			AND cm_monitors.namespace_user_id = %s
 	)
 RETURNING %s;

--- a/enterprise/internal/database/code_monitor_slack_webhook_test.go
+++ b/enterprise/internal/database/code_monitor_slack_webhook_test.go
@@ -148,6 +148,7 @@ func TestCodeMonitorStoreSlackWebhooks(t *testing.T) {
 		uid2 := insertTestUser(ctx, t, db, "u2", false)
 		ctx2 := actor.WithActor(ctx, actor.FromUser(uid2))
 		fixtures := s.insertTestMonitor(ctx1, t)
+		_ = s.insertTestMonitor(ctx2, t)
 
 		wa, err := s.CreateSlackWebhookAction(ctx1, fixtures.monitor.ID, true, true, "https://true.com")
 		require.NoError(t, err)

--- a/enterprise/internal/database/code_monitor_webhook.go
+++ b/enterprise/internal/database/code_monitor_webhook.go
@@ -35,7 +35,7 @@ WHERE
 	id = %s
 	AND EXISTS (
 		SELECT 1 FROM cm_monitors
-		WHERE cm_monitors.id = id
+		WHERE cm_monitors.id = cm_webhooks.monitor
 			AND cm_monitors.namespace_user_id = %s
 	)
 RETURNING %s;

--- a/enterprise/internal/database/code_monitor_webhook_test.go
+++ b/enterprise/internal/database/code_monitor_webhook_test.go
@@ -148,6 +148,7 @@ func TestCodeMonitorStoreWebhooks(t *testing.T) {
 		uid2 := insertTestUser(ctx, t, db, "u2", false)
 		ctx2 := actor.WithActor(ctx, actor.FromUser(uid2))
 		fixtures := s.insertTestMonitor(ctx1, t)
+		_ = s.insertTestMonitor(ctx2, t)
 
 		wa, err := s.CreateWebhookAction(ctx1, fixtures.monitor.ID, true, true, "https://true.com")
 		require.NoError(t, err)


### PR DESCRIPTION
Fixes an issue where we would select the monitor based on the condition that its own ID matches its own ID. This did nothing, so made the filter ineffective. 

Stacked on #38039 

## Test plan

First commit updates tests to demonstrate the issue, second commit fixes the issue. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
