### PR TITLE
compute: add another output command that exposes more metadata

### DIFF
--- a/enterprise/internal/compute/query.go
+++ b/enterprise/internal/compute/query.go
@@ -103,6 +103,7 @@ var ComputePredicateRegistry = query.PredicateRegistry{
 		"output":             func() query.Predicate { return query.EmptyPredicate{} },
 		"output.regexp":      func() query.Predicate { return query.EmptyPredicate{} },
 		"output.structural":  func() query.Predicate { return query.EmptyPredicate{} },
+		"output.extra":       func() query.Predicate { return query.EmptyPredicate{} },
 	},
 }
 
@@ -180,7 +181,7 @@ func parseOutput(q *query.Basic) (Command, bool, error) {
 
 	var matchPattern MatchPattern
 	switch name {
-	case "output", "output.regexp":
+	case "output", "output.regexp", "output.extra":
 		var err error
 		matchPattern, err = toRegexpPattern(left)
 		if err != nil {
@@ -189,6 +190,7 @@ func parseOutput(q *query.Basic) (Command, bool, error) {
 	case "output.structural":
 		// structural search doesn't do any match pattern validation
 		matchPattern = &Comby{Value: left}
+
 	default:
 		// unrecognized name
 		return nil, false, nil
@@ -211,6 +213,7 @@ func parseOutput(q *query.Basic) (Command, bool, error) {
 		Separator:     "\n",
 		TypeValue:     typeValue,
 		Selector:      selector,
+		Kind:          name,
 	}, true, nil
 }
 

--- a/enterprise/internal/compute/result.go
+++ b/enterprise/internal/compute/result.go
@@ -7,7 +7,9 @@ type Result interface {
 var (
 	_ Result = (*MatchContext)(nil)
 	_ Result = (*Text)(nil)
+	_ Result = (*TextExtra)(nil)
 )
 
 func (*MatchContext) result() {}
 func (*Text) result()         {}
+func (*TextExtra) result()    {}

--- a/enterprise/internal/compute/text_result.go
+++ b/enterprise/internal/compute/text_result.go
@@ -4,3 +4,10 @@ type Text struct {
 	Value string `json:"value"`
 	Kind  string `json:"kind"`
 }
+
+// TextExtra provides extra contextual information on top of the Text result.
+type TextExtra struct {
+	Text
+	RepositoryID int32  `json:"repositoryID"`
+	Repository   string `json:"repository"`
+}


### PR DESCRIPTION
This implements a `output.extra(...)` command on compute queries which can serve purposes where more contextual data is needed from results (`Repo` metadata, etc.). Open to other name suggestions beside `extra`, but this seems good enough. This is a follow up to help resolve needs from https://github.com/sourcegraph/sourcegraph/pull/37952

The need for a separate command is for compartmentalizing concerns, where those concerns are very likely to change over time for an API that should be considered unstable. Those concrete concerns are:

- `output(...)` right is minimal (exposes only `kind` and `value`). This is desirable and sufficient for many applications, where more metadata does not need to be in the resulting JSON.

- `output.extra(...)` current exposes repo metadata, for a use case that benefits from it. It could expose any other data too. It should be kept separate because:
  - this metadata will be sent unconditionally, there is no GQL or REST-like query to request only certain fields here. Implementing such a thing right now is not an appropriate use of time, because we don't know what that would like yet. On the other hand, adding a little command to iterate against is lightweight, easy to remove, and can be modified for whatever application with minimal impact to existing implementation.
 
  - this metadata may not apply to opaque result values appropriate for `output(...)`. Rather than creating an implementation need that might need to distinguish this on a single `Text` result type and optionally populate field, it's in my opionion better to just make that situation impossible and create a separate result type for this need.

Taking the above, consider the opposite, that we just populate whatever metadata in the output field. What I anticipate happening is that clients start to rely on this behavior and it becomes impossible to undo the bloating/metadata additions from `output(...)` when that becomes a problem in other contexts. Then to get back the minimal, opaque result type will then need "something else" + migration. Maybe `output2(...)`. Maybe `package compute2`. And that, friends, is how you end up with [`File2`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/schema.graphql?L4218) (I'm told [the name will change soon](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/schema.graphql?L4216) 🙂  ).


## Test plan
Added tests.