### PR TITLE
web: fix `web-standalone` proxy-warning contrast issue

### DIFF
--- a/client/web/src/global/GlobalAlerts.module.scss
+++ b/client/web/src/global/GlobalAlerts.module.scss
@@ -28,3 +28,7 @@
         margin-bottom: 0;
     }
 }
+
+.proxy-link {
+    color: var(--body-color);
+}

--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -109,7 +109,7 @@ export const GlobalAlerts: React.FunctionComponent<Props> = ({
                 >
                     <div>
                         <strong>Warning!</strong> This build uses data from the proxied API:{' '}
-                        <Link target="__blank" to={process.env.SOURCEGRAPH_API_URL}>
+                        <Link className={styles.proxyLink} target="__blank" to={process.env.SOURCEGRAPH_API_URL}>
                             {process.env.SOURCEGRAPH_API_URL}
                         </Link>
                     </div>


### PR DESCRIPTION
## Context

While using the combination of `yarn test-integration:debug` and `sg start web-standalone`, tests will fail when they include a11y verification because the banner says that requests are proxied to another domain doesn't meet color contrast requirements.

This PR temporarily changes the text of the link inside of the banner. I created [an issue](https://github.com/sourcegraph/sourcegraph/issues/38066) to address the root cause of the problem later because the design input is needed.

[Slack thread for context](https://sourcegraph.slack.com/archives/C07KZF47K/p1656575459207169?thread_ts=1656564661.247899&cid=C07KZF47K).

## Test plan

Ensure that the web-standalone warning doesn't cause the accessibility check error.

## App preview:

- [Web](https://sg-web-vb-fix-proxy-warning.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vlzjclzngp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
