### PR TITLE
batches: Signify unsupported and ignored workspaces in lists

### DIFF
--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
@@ -19,7 +19,7 @@
 
 .badge {
     display: block;
-    background: #e6ebf2;
+    background: var(--gray-03);
     border-radius: 0.125rem;
     padding: 0 0.25rem;
     margin-right: 0.625rem;

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
@@ -16,3 +16,12 @@
     color: var(--text-muted);
     padding-top: 0.25rem;
 }
+
+.badge {
+    display: block;
+    background: #e6ebf2;
+    border-radius: 0.125rem;
+    padding: 0 0.25rem;
+    margin-right: 0.625rem;
+    font-size: 0.6875rem;
+}

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
@@ -18,10 +18,6 @@
 }
 
 .badge {
-    display: block;
-    background: var(--gray-03);
-    border-radius: 0.125rem;
-    padding: 0 0.25rem;
     margin-right: 0.625rem;
     font-size: 0.6875rem;
 }

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react'
 
 import { mdiSourceBranch } from '@mdi/js'
 
-import { Icon, H4 } from '@sourcegraph/wildcard'
+import { Icon, H4, Badge } from '@sourcegraph/wildcard'
 
 import styles from './Descriptor.module.scss'
 
@@ -14,6 +14,8 @@ interface WorkspaceBaseFields {
     repository: {
         name: string
     }
+    ignored: boolean
+    unsupported: boolean
 }
 
 interface DescriptorProps<Workspace extends WorkspaceBaseFields> {
@@ -35,6 +37,8 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
             ) : null}
             {workspace && (
                 <div className="d-flex align-items-center text-muted text-monospace pt-1">
+                    {workspace.ignored && <Badge variant="secondary" className="mr-2">IGNORED</Badge>}
+                    {workspace.unsupported && <Badge variant="secondary" className="mr-2">UNSUPPORTED</Badge>}
                     <Icon aria-hidden={true} className="mr-1" svgPath={mdiSourceBranch} />
                     <small>{workspace.branch.displayName}</small>
                 </div>

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -37,8 +37,16 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
             ) : null}
             {workspace && (
                 <div className="d-flex align-items-center text-muted text-monospace pt-1">
-                    {workspace.ignored && <Badge variant="secondary" className="mr-2">IGNORED</Badge>}
-                    {workspace.unsupported && <Badge variant="secondary" className="mr-2">UNSUPPORTED</Badge>}
+                    {workspace.ignored && (
+                        <Badge variant="secondary" className="mr-2">
+                            IGNORED
+                        </Badge>
+                    )}
+                    {workspace.unsupported && (
+                        <Badge variant="secondary" className="mr-2">
+                            UNSUPPORTED
+                        </Badge>
+                    )}
                     <Icon aria-hidden={true} className="mr-1" svgPath={mdiSourceBranch} />
                     <small>{workspace.branch.displayName}</small>
                 </div>

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react'
 
 import { mdiSourceBranch } from '@mdi/js'
 
-import { Icon, H4, Tooltip } from '@sourcegraph/wildcard'
+import { Icon, H4, Badge } from '@sourcegraph/wildcard'
 
 import styles from './Descriptor.module.scss'
 
@@ -38,19 +38,22 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
             {workspace && (
                 <div className="d-flex align-items-center text-muted text-monospace pt-1">
                     {workspace.ignored && (
-                        <Tooltip content="This workspace is going to be ignored. A .batchignore file was found in it.">
-                            {/*
-                                We are unable to make use of `Badge` here because nesting a badge in a tooltip results in an error.
-                                The error is caused because the Tooltip component forwards a ref to whatever the child component is,
-                                however the `Badge` component doesn't support forwarding of ref at this time.
-                             */}
-                            <span className={styles.badge}>IGNORED</span>
-                        </Tooltip>
+                        <Badge
+                            className={styles.badge}
+                            variant="secondary"
+                            tooltip="This workspace is going to be ignored. A .batchignore file was found in it."
+                        >
+                            IGNORED
+                        </Badge>
                     )}
                     {workspace.unsupported && (
-                        <Tooltip content="This workspace is going to be skipped. It was found on a code-host that is not yet supported by batch changes.">
-                            <span className={styles.badge}>UNSUPPORTED</span>
-                        </Tooltip>
+                        <Badge
+                            className={styles.badge}
+                            variant="secondary"
+                            tooltip="This workspace is going to be skipped. It was found on a code-host that is not yet supported by batch changes."
+                        >
+                            UNSUPPORTED
+                        </Badge>
                     )}
                     <Icon aria-hidden={true} className="mr-1" svgPath={mdiSourceBranch} />
                     <small>{workspace.branch.displayName}</small>

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react'
 
 import { mdiSourceBranch } from '@mdi/js'
 
-import { Icon, H4, Badge } from '@sourcegraph/wildcard'
+import { Icon, H4, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './Descriptor.module.scss'
 
@@ -38,14 +38,19 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
             {workspace && (
                 <div className="d-flex align-items-center text-muted text-monospace pt-1">
                     {workspace.ignored && (
-                        <Badge variant="secondary" className="mr-2">
-                            IGNORED
-                        </Badge>
+                        <Tooltip content="This workspace is going to be ignored. A .batchignore file was found in it.">
+                            {/*
+                                We are unable to make use of `Badge` here because nesting a badge in a tooltip results in an error.
+                                The error is caused because the Tooltip component forwards a ref to whatever the child component is,
+                                however the `Badge` component doesn't support forwarding of ref at this time.
+                             */}
+                            <span className={styles.badge}>IGNORED</span>
+                        </Tooltip>
                     )}
                     {workspace.unsupported && (
-                        <Badge variant="secondary" className="mr-2">
-                            UNSUPPORTED
-                        </Badge>
+                        <Tooltip content="This workspace is going to be skipped. It was found on a code-host that is not yet supported by batch changes.">
+                            <span className={styles.badge}>UNSUPPORTED</span>
+                        </Tooltip>
                     )}
                     <Icon aria-hidden={true} className="mr-1" svgPath={mdiSourceBranch} />
                     <small>{workspace.branch.displayName}</small>


### PR DESCRIPTION
Closes #34294

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Added unsupported repositories on my `sourcegraph` instance and tried to run a btach change on a mixture of supported & unsupported repositories.

Verified the correct badge show up in the preview panel.

![CleanShot 2022-07-01 at 09 30 58@2x](https://user-images.githubusercontent.com/25608335/176857083-22239dd5-a647-400a-9350-a410c1c5e790.png)

## App preview:

- [Web](https://sg-web-bo-signify-unsupported-ignored.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vsuweddkuz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
