### PR TITLE
web: fix `blog-viewer` integration test flake

### DIFF
--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -73,9 +73,9 @@ describe('Blob viewer', () => {
     describe('general layout for viewing a file', () => {
         it('populates editor content and FILES tab', async () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}`)
-            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
             const blobContent = await driver.page.evaluate(
-                () => document.querySelector<HTMLElement>('.test-repo-blob')?.textContent
+                () => document.querySelector<HTMLElement>('[data-testid="repo-blob"]')?.textContent
             )
 
             // editor shows the return string content from Blob request
@@ -145,13 +145,13 @@ describe('Blob viewer', () => {
 
         it('should redirect from line number hash to query parameter', async () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}#2`)
-            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
             await driver.assertWindowLocation(`/${repositoryName}/-/blob/${fileName}?L2`)
         })
 
         it('should redirect from line range hash to query parameter', async () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}#1-3`)
-            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
             await driver.assertWindowLocation(`/${repositoryName}/-/blob/${fileName}?L1-3`)
         })
     })
@@ -272,7 +272,7 @@ describe('Blob viewer', () => {
             await driver.page.goto(
                 `${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/this_is_a_long_file_path/apps/rest-showcase/src/main/java/org/demo/rest/example/OrdersController.java`
             )
-            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
             await driver.page.waitForSelector('.test-breadcrumb')
             // Uncomment this snapshot once https://github.com/sourcegraph/sourcegraph/issues/15126 is resolved
             // await percySnapshot(driver.page, this.test!.fullTitle())
@@ -280,7 +280,7 @@ describe('Blob viewer', () => {
 
         it.skip('shows a hover overlay from a hover provider when a token is hovered', async () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}`)
-            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
             // TODO
         })
 
@@ -598,7 +598,7 @@ describe('Blob viewer', () => {
             )
         })
 
-        it('sends the latest document to extensions', async () => {
+        it.only('sends the latest document to extensions', async () => {
             // This test is meant to prevent regression of
             // "extensions receive wrong text documents": https://github.com/sourcegraph/sourcegraph/issues/14965
 
@@ -786,6 +786,7 @@ describe('Blob viewer', () => {
 
             const timeout = 5000
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/github.com/sourcegraph/test/-/blob/test.ts`)
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             // File 1 (test.ts). Only line two contains 'word'
             try {
@@ -1073,7 +1074,7 @@ describe('Blob viewer', () => {
                 await driver.page.waitForFunction(
                     () =>
                         document
-                            .querySelector('.test-repo-blob [data-line="1"]')
+                            .querySelector('[data-testid="repo-blob"] [data-line="1"]')
                             ?.nextElementSibling?.textContent?.includes('file path: test spaces.ts'),
                     { timeout: 5000 }
                 )

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -598,7 +598,7 @@ describe('Blob viewer', () => {
             )
         })
 
-        it.only('sends the latest document to extensions', async () => {
+        it('sends the latest document to extensions', async () => {
             // This test is meant to prevent regression of
             // "extensions receive wrong text documents": https://github.com/sourcegraph/sourcegraph/issues/14965
 

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -412,7 +412,7 @@ describe('Repository', () => {
                 })
             }, 'Blob')
 
-            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
             await driver.assertWindowLocation(`/${repositoryName}/-/blob/${clickedFileName}`)
 
             // Assert breadcrumb order
@@ -495,7 +495,7 @@ describe('Repository', () => {
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement
             await driver.page.$eval('.test-tree-file-link', linkElement => (linkElement as HTMLElement).click())
-            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             await driver.page.waitForSelector('.test-breadcrumb')
             const breadcrumbTexts = await driver.page.evaluate(() =>
@@ -528,7 +528,9 @@ describe('Repository', () => {
                 "https://github.com/ggilmore/q-test/blob/master/Geoffrey's%20random%20queries.32r242442bf/%25%20token.4288249258.sql"
             )
 
-            const blobContent = await driver.page.evaluate(() => document.querySelector('.test-repo-blob')?.textContent)
+            const blobContent = await driver.page.evaluate(
+                () => document.querySelector('[data-testid="repo-blob"]')?.textContent
+            )
             assert.strictEqual(blobContent, `content for: ${filePath}\nsecond line\nthird line`)
         })
 
@@ -560,7 +562,7 @@ describe('Repository', () => {
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement
             await driver.page.$eval('.test-tree-file-link', linkElement => (linkElement as HTMLElement).click())
-            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             await driver.page.waitForSelector('.test-breadcrumb')
             const breadcrumbTexts = await driver.page.evaluate(() =>
@@ -587,7 +589,7 @@ describe('Repository', () => {
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement
             await driver.page.$eval('.test-tree-file-link', linkElement => (linkElement as HTMLElement).click())
-            await driver.page.waitForSelector('.test-repo-blob')
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             await driver.page.waitForSelector('.test-breadcrumb')
             const breadcrumbTexts = await driver.page.evaluate(() =>

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -113,6 +113,7 @@ export interface BlobProps
     wrapCode: boolean
     /** The current text document to be rendered and provided to extensions */
     blobInfo: BlobInfo
+    'data-testid'?: string
 
     // Experimental reference panel
     disableStatusBar: boolean
@@ -196,7 +197,15 @@ const STATUS_BAR_VERTICAL_GAP_VAR = '--blob-status-bar-vertical-gap'
  * in this state, hovers can lead to errors like `DocumentNotFoundError`.
  */
 export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> = props => {
-    const { location, isLightTheme, extensionsController, blobInfo, platformContext, settingsCascade } = props
+    const {
+        location,
+        isLightTheme,
+        extensionsController,
+        blobInfo,
+        platformContext,
+        settingsCascade,
+        'data-testid': dataTestId,
+    } = props
 
     const settingsChanges = useMemo(() => new BehaviorSubject<Settings | null>(null), [])
     useEffect(() => {
@@ -792,7 +801,12 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
 
     return (
         <>
-            <div className={classNames(props.className, styles.blob)} ref={nextBlobElement} tabIndex={-1}>
+            <div
+                data-testid={dataTestId}
+                className={classNames(props.className, styles.blob)}
+                ref={nextBlobElement}
+                tabIndex={-1}
+            >
                 <Code
                     className={classNames('test-blob', styles.blobCode, props.wrapCode && styles.blobCodeWrapped)}
                     ref={nextCodeViewElement}

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -365,7 +365,8 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
             {/* Render the (unhighlighted) blob also in the case highlighting timed out */}
             {renderMode === 'code' && (
                 <Blob
-                    className={classNames('test-repo-blob', styles.blob, styles.border)}
+                    data-testid="repo-blob"
+                    className={classNames(styles.blob, styles.border)}
                     blobInfo={blobInfoOrError}
                     wrapCode={wrapCode}
                     platformContext={props.platformContext}


### PR DESCRIPTION
## Context

Fixing [one of two flakes caused](https://buildkite.com/sourcegraph/sourcegraph/builds/152851) by waiting for the blob view to load.

## Test plan

Ensure that `blog-viewer` integration tests are green on CI.

## App preview:

- [Web](https://sg-web-vb-fix-blog-viewer-test.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vujaukokzd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
