### PR TITLE
[SG-25227]: Update Storybook stories to use Component Story Format

### DIFF
--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
@@ -1,5 +1,5 @@
 import { select } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { DecoratorFn, Story, Meta } from '@storybook/react'
 import { noop } from 'lodash'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
@@ -12,16 +12,22 @@ import { ExternalServiceKind } from '../../../graphql-operations'
 import { AddCredentialModal } from './AddCredentialModal'
 import { CREATE_BATCH_CHANGES_CREDENTIAL } from './backend'
 
-const { add } = storiesOf('web/batches/settings/AddCredentialModal', module)
-    .addDecorator(story => <div className="p-3 container">{story()}</div>)
-    .addParameters({
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/batches/settings/AddCredentialModal',
+    decorators: [decorator],
+    parameters: {
         chromatic: {
             // Delay screenshot taking, so the modal has opened by the time the screenshot is taken.
             delay: 2000,
         },
-    })
+    },
+}
 
-add('Requires SSH - step 1', () => (
+export default config
+
+export const RequiresSSHstep1: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
@@ -64,8 +70,11 @@ add('Requires SSH - step 1', () => (
             </MockedTestProvider>
         )}
     </WebStory>
-))
-add('Requires SSH - step 2', () => (
+)
+
+RequiresSSHstep1.storyName = 'Requires SSH - step 1'
+
+export const RequiresSSHstep2: Story = () => (
     <WebStory>
         {props => (
             <AddCredentialModal
@@ -85,9 +94,11 @@ add('Requires SSH - step 2', () => (
             />
         )}
     </WebStory>
-))
+)
 
-add('GitHub', () => (
+RequiresSSHstep2.storyName = 'Requires SSH - step 2'
+
+export const GitHub: Story = () => (
     <WebStory>
         {props => (
             <AddCredentialModal
@@ -102,9 +113,11 @@ add('GitHub', () => (
             />
         )}
     </WebStory>
-))
+)
 
-add('GitLab', () => (
+GitHub.storyName = 'GitHub'
+
+export const GitLab: Story = () => (
     <WebStory>
         {props => (
             <AddCredentialModal
@@ -119,9 +132,11 @@ add('GitLab', () => (
             />
         )}
     </WebStory>
-))
+)
 
-add('Bitbucket Server', () => (
+GitLab.storyName = 'GitLab'
+
+export const BitbucketServer: Story = () => (
     <WebStory>
         {props => (
             <AddCredentialModal
@@ -136,9 +151,9 @@ add('Bitbucket Server', () => (
             />
         )}
     </WebStory>
-))
+)
 
-add('Bitbucket Cloud', () => (
+export const BitbucketCloud: Story = () => (
     <WebStory>
         {props => (
             <AddCredentialModal
@@ -153,4 +168,4 @@ add('Bitbucket Cloud', () => (
             />
         )}
     </WebStory>
-))
+)

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import { storiesOf } from '@storybook/react'
+import { DecoratorFn, Story, Meta } from '@storybook/react'
 import { of } from 'rxjs'
 
 import { WebStory } from '../../../../../../../components/WebStory'
@@ -11,13 +11,19 @@ import { CustomInsightDashboard, InsightsDashboardOwnerType, InsightsDashboardTy
 
 import { AddInsightModal } from './AddInsightModal'
 
-const { add } = storiesOf('web/insights/AddInsightModal', module)
-    .addDecorator(story => <WebStory>{() => story()}</WebStory>)
-    .addParameters({
+const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+
+const config: Meta = {
+    title: 'web/insights/AddInsightModal',
+    decorators: [decorator],
+    parameters: {
         chromatic: {
             viewports: [576, 1440],
         },
-    })
+    },
+}
+
+export default config
 
 const dashboard: CustomInsightDashboard = {
     type: InsightsDashboardType.Custom,
@@ -56,7 +62,7 @@ const codeInsightsBackend: Partial<CodeInsightsGqlBackend> = {
     getDashboardOwners: () => of([]),
 }
 
-add('AddInsightModal', () => {
+export const AddInsightModalStory: Story = () => {
     const [open, setOpen] = useState<boolean>(true)
 
     return (
@@ -64,4 +70,6 @@ add('AddInsightModal', () => {
             {open && <AddInsightModal dashboard={dashboard} onClose={() => setOpen(false)} />}
         </CodeInsightsBackendStoryMock>
     )
-})
+}
+
+AddInsightModalStory.storyName = 'AddInsightModal'

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.story.tsx
@@ -1,19 +1,25 @@
 import { useState } from 'react'
 
-import { storiesOf } from '@storybook/react'
+import { DecoratorFn, Story, Meta } from '@storybook/react'
 
 import { WebStory } from '../../../../../../../components/WebStory'
 import { InsightDashboard, InsightsDashboardOwnerType, InsightsDashboardType } from '../../../../../core/types'
 
 import { DashboardSelect } from './DashboardSelect'
 
-const { add } = storiesOf('web/insights/DashboardSelect', module)
-    .addDecorator(story => <WebStory>{() => story()}</WebStory>)
-    .addParameters({
+const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+
+const config: Meta = {
+    title: 'web/insights/DashboardSelect',
+    decorators: [decorator],
+    parameters: {
         chromatic: {
             viewports: [576, 1440],
         },
-    })
+    },
+}
+
+export default config
 
 const DASHBOARDS: InsightDashboard[] = [
     {
@@ -60,8 +66,10 @@ const DASHBOARDS: InsightDashboard[] = [
     },
 ]
 
-add('DashboardSelect', () => {
+export const DashboardSelectStory: Story = () => {
     const [value, setValue] = useState<string>()
 
     return <DashboardSelect value={value} dashboards={DASHBOARDS} onSelect={dashboard => setValue(dashboard.id)} />
-})
+}
+
+DashboardSelectStory.storyName = 'DashboardSelect'

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
@@ -1,4 +1,4 @@
-import { storiesOf } from '@storybook/react'
+import { DecoratorFn, Story, Meta } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../../../../../../../components/WebStory'
@@ -6,15 +6,21 @@ import { InsightDashboard, InsightsDashboardOwnerType, InsightsDashboardType } f
 
 import { EmptyInsightDashboard } from './EmptyInsightDashboard'
 
-const { add } = storiesOf('web/insights/EmptyInsightDashboard', module)
-    .addDecorator(story => <WebStory>{() => story()}</WebStory>)
-    .addParameters({
+const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+
+const config: Meta = {
+    title: 'web/insights/EmptyInsightDashboard',
+    decorators: [decorator],
+    parameters: {
         chromatic: {
             viewports: [576, 1440],
         },
-    })
+    },
+}
 
-add('EmptyInsightDashboard', () => {
+export default config
+
+export const EmptyInsightDashboardStory: Story = () => {
     const dashboard: InsightDashboard = {
         type: InsightsDashboardType.Custom,
         id: '101',
@@ -24,4 +30,6 @@ add('EmptyInsightDashboard', () => {
     }
 
     return <EmptyInsightDashboard dashboard={dashboard} onAddInsight={noop} />
-})
+}
+
+EmptyInsightDashboardStory.storyName = 'EmptyInsightDashboard'


### PR DESCRIPTION
## Description

The [Component Story Format](https://storybook.js.org/docs/react/api/csf) is the recommended way to write stories in Storybook. The new format is easier to understand and it is also important that we update our existing stories to ensure we stay up to date with new features, and are able to follow future documentation.

## Refs
- [Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/25227)
- [Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-25227)

## Files to be Migrated
- client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
- client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
- client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.story.tsx
- client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx

## Success criteria
- All stories in the repo are using the Component Story Format
- All stories still usable when running `yarn storybook`

## Implementation details
[Please see this PR description](https://github.com/sourcegraph/sourcegraph/pull/25222) as an example of how this change can be implemented.
In summary, follow these implementation steps:
1. Modify existing storiesOf usage to ensure any add or alternative function calls are chained onto the original storiesOf function call. See this diff for an example of this change: [e3a39ca](https://github.com/sourcegraph/sourcegraph/commit/e3a39cae40c69cb74de1d0461bd70fb31bdb281a).
2. Run the [storiesof-to-csf Storybook codemod](https://github.com/storybookjs/storybook/blob/next/lib/codemod/README.md#storiesof-to-csf) with this command: npx sb migrate storiesof-to-csf --glob="client/web/**/*.story.tsx". For an expected diff (on different files) see this commit: [5a5b716](https://github.com/sourcegraph/sourcegraph/commit/5a5b716337da4a768b4b26157d06728035c57816).
3. Run the [csf-hoist-story-annotations Storybook codemod](https://github.com/storybookjs/storybook/blob/next/lib/codemod/README.md#csf-hoist-story-annotations) with this command: npx sb migrate csf-hoist-story-annotations --glob="client/web/**/*.story.tsx". For an expected diff (on different files) see this commit: [b228f5d](https://github.com/sourcegraph/sourcegraph/commit/b228f5d5879b5164d23565c7d63480793e6004da).
4. You will likely see TypeScript warnings on the newly-modified files. Update these by adding the Storybook types. See this commit for reference: [810e8e2](https://github.com/sourcegraph/sourcegraph/commit/810e8e217d6a665f109ca2a0a92ba4125f6b27ea)

## Test plan
1. All stories in the requested directories are using this [Component Story Format](https://storybook.js.org/docs/react/api/csf).
2. All stories still usable when running `yarn storybook`

## App preview:

- [Web](https://sg-web-contractors-sg-25227.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

