### PR TITLE
notebooks: Fix markdown block height

### DIFF
--- a/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.tsx
+++ b/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.tsx
@@ -81,7 +81,7 @@ const staticExtensions: Extension[] = [
             { tag: tags.url, class: styles.markdownCode },
         ])
     ),
-    editorHeight({ height: '60rem' }),
+    editorHeight({ maxHeight: '60rem' }),
 ]
 
 interface NotebookMarkdownBlockProps extends BlockProps<MarkdownBlock>, ThemeProps {


### PR DESCRIPTION
I accidentally replaced max-height with height in
b62f63dd3d7d68bd4ef9e7c64b9ef6279b5b85fe.



## Test plan

Adding a markdown block with in Notebooks inserts a block with an initial height of one line.

## App preview:

- [Web](https://sg-web-fkling-fix-notebook-markdown.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gcppugttvg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
