### PR TITLE
JetBrains: Add “Open” button to bottom-right

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridge.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridge.java
@@ -17,6 +17,7 @@ public class JSToJavaBridge implements Disposable {
                           JSToJavaBridgeRequestHandler requestHandler,
                           String jsCodeToRunAfterBridgeInit) {
         // Using a deprecated method because JBCefBrowserBase is not present in older JetBrains versions
+        //noinspection removal - Using this old method intentionally for backwards compatibility
         query = JBCefJSQuery.create(browser);
         query.addHandler((String requestAsString) -> {
             try {

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
@@ -25,6 +25,7 @@ public class JavaToJSBridge {
     public JavaToJSBridge(JBCefBrowser browser) {
         this.browser = browser;
         // Using a deprecated method because JBCefBrowserBase is not present in older JetBrains versions
+        //noinspection removal - Using this old method intentionally for backwards compatibility
         this.query = JBCefJSQuery.create(browser);
         this.lock = new ReentrantLock();
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -80,7 +80,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         browserAndLoadingPanel.setState(wasServerAccessSuccessful
             ? (authenticated ? BrowserAndLoadingPanel.State.AUTHENTICATED : BrowserAndLoadingPanel.State.COULD_CONNECT_BUT_NOT_AUTHENTICATED)
             : BrowserAndLoadingPanel.State.COULD_NOT_CONNECT);
-        if (!authenticated) {
+        if (!wasServerAccessSuccessful) {
             selectionMetadataPanel.clearSelectionMetadataLabel();
             previewPanel.setState(PreviewPanel.State.NO_PREVIEW_AVAILABLE);
         } else {

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Splitter;
 import com.intellij.ui.OnePixelSplitter;
 import com.intellij.ui.PopupBorder;
-import com.intellij.ui.components.JBPanel;
 import com.intellij.ui.jcef.JBCefApp;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
@@ -21,15 +20,16 @@ import java.util.Date;
 /**
  * Inspired by <a href="https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java">FindPopupPanel.java</a>
  */
-public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposable {
+public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
     private final SourcegraphJBCefBrowser browser;
     private final PreviewPanel previewPanel;
     private final BrowserAndLoadingPanel browserAndLoadingPanel;
     private final SelectionMetadataPanel selectionMetadataPanel;
+    private final FooterPanel footerPanel;
     private Date lastPreviewUpdate;
 
     public FindPopupPanel(@NotNull Project project, @NotNull FindService findService) {
-        super(new BorderLayout());
+        super();
 
         setPreferredSize(JBUI.size(1200, 800));
         setBorder(PopupBorder.Factory.create(true, true));
@@ -40,10 +40,12 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
 
         selectionMetadataPanel = new SelectionMetadataPanel();
         previewPanel = new PreviewPanel(project);
+        footerPanel = new FooterPanel();
 
         BorderLayoutPanel bottomPanel = new BorderLayoutPanel();
         bottomPanel.add(selectionMetadataPanel, BorderLayout.NORTH);
         bottomPanel.add(previewPanel, BorderLayout.CENTER);
+        bottomPanel.add(footerPanel, BorderLayout.SOUTH);
 
         browserAndLoadingPanel = new BrowserAndLoadingPanel(project);
         JSToJavaBridgeRequestHandler requestHandler = new JSToJavaBridgeRequestHandler(project, this, findService);
@@ -83,8 +85,10 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         if (!wasServerAccessSuccessful) {
             selectionMetadataPanel.clearSelectionMetadataLabel();
             previewPanel.setState(PreviewPanel.State.NO_PREVIEW_AVAILABLE);
+            footerPanel.setPreviewContent(null);
         } else {
             previewPanel.setState(PreviewPanel.State.PREVIEW_AVAILABLE);
+            footerPanel.setPreviewContent(previewPanel.getPreviewContent());
         }
     }
 
@@ -92,6 +96,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         if (lastPreviewUpdate.before(date)) {
             selectionMetadataPanel.clearSelectionMetadataLabel();
             previewPanel.setState(PreviewPanel.State.LOADING);
+            footerPanel.setPreviewContent(null);
         }
     }
 
@@ -100,6 +105,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
             this.lastPreviewUpdate = previewContent.getReceivedDateTime();
             selectionMetadataPanel.setSelectionMetadataLabel(previewContent);
             previewPanel.setContent(previewContent);
+            footerPanel.setPreviewContent(previewContent);
         }
     }
 
@@ -108,6 +114,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
             this.lastPreviewUpdate = date;
             selectionMetadataPanel.clearSelectionMetadataLabel();
             previewPanel.setState(PreviewPanel.State.NO_PREVIEW_AVAILABLE);
+            footerPanel.setPreviewContent(null);
         }
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FooterPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FooterPanel.java
@@ -1,0 +1,53 @@
+package com.sourcegraph.find;
+
+import com.intellij.openapi.actionSystem.KeyboardShortcut;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.keymap.KeymapUtil;
+import com.intellij.ui.components.JBPanel;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+public class FooterPanel extends JBPanel<FooterPanel> {
+    private final JButton openButton;
+    private final JLabel openShortcutLabel;
+    @Nullable
+    private PreviewContent previewContent;
+
+    public FooterPanel() {
+        super(new FlowLayout(FlowLayout.RIGHT));
+
+        KeyboardShortcut altEnterShortcut = new KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.ALT_DOWN_MASK), null);
+        String altEnterShortcutText = KeymapUtil.getShortcutText(altEnterShortcut);
+        openShortcutLabel = new JLabel(altEnterShortcutText);
+        openShortcutLabel.setEnabled(false);
+        openShortcutLabel.setVisible(false);
+
+        openButton = new JButton("");
+        openButton.addActionListener(event -> {
+            if (previewContent != null) {
+                try {
+                    previewContent.openInEditorOrBrowser();
+                } catch (Exception e) {
+                    Logger logger = Logger.getInstance(FooterPanel.class);
+                    logger.warn("Error while opening preview content externally: " + e.getClass().getName() + ": " + e.getMessage());
+                }
+            }
+        });
+
+        add(openShortcutLabel);
+        add(openButton);
+
+        setPreviewContent(null);
+    }
+
+    public void setPreviewContent(@Nullable PreviewContent previewContent) {
+        this.previewContent = previewContent;
+        openShortcutLabel.setVisible(previewContent != null);
+        openButton.setEnabled(previewContent != null);
+        openButton.setText((previewContent == null || previewContent.opensInEditor()) ? "Open in Editor" : "Open in Browser");
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
@@ -120,6 +120,7 @@ public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
         }
     }
 
+    @NotNull
     private ActionGroup createActionGroup() {
         DefaultActionGroup group = new DefaultActionGroup();
         group.add(new DumbAwareAction("Open File in Editor", "Open file in editor", Icons.Logo) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
@@ -14,7 +14,7 @@ import java.awt.event.KeyEvent;
 import java.util.Objects;
 
 public class SelectionMetadataPanel extends JPanel {
-    private LinkLabel selectionMetadataLabel = null;
+    private LinkLabel<String> selectionMetadataLabel = null;
     private final JLabel externalLinkLabel;
     private final JLabel openShortcutLabel;
     private PreviewContent previewContent;
@@ -22,7 +22,7 @@ public class SelectionMetadataPanel extends JPanel {
     public SelectionMetadataPanel() {
         super(new FlowLayout(FlowLayout.LEFT, 0, 8));
 
-        selectionMetadataLabel = new LinkLabel("", null, (aSource, aLinkData) -> {
+        selectionMetadataLabel = new LinkLabel<>("", null, (aSource, aLinkData) -> {
             if (previewContent != null) {
                 try {
                     previewContent.openInEditorOrBrowser();


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/37812

See the button at the bottom-right:

“Find in Files”:

<img width="1024" alt="Screenshot 1" src="https://user-images.githubusercontent.com/2552265/176875457-ef31c4d8-f195-4482-84bd-ed567c2fd925.png">

Our solution:

<img width="1024" alt="Screenshot 2" src="https://user-images.githubusercontent.com/2552265/176875479-38d75157-70df-4f30-b570-8b8f60ee9306.png">

Notes:

- I've based this PR on https://github.com/sourcegraph/sourcegraph/pull/37938 to avoid conflicts, so these need to be merged in order.
- I've also fixed a few warnings that are results of https://github.com/sourcegraph/sourcegraph/pull/37836

## Test plan

- Tech: Check the source code
- Design: See the screenshots
- Functionality: 20-sec Loom: https://www.loom.com/share/d7fe2e3744074cf18c0309da1e7c09ab

## App preview:

- [Web](https://sg-web-dv-jetbrains-add-open-button.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-eorokpyeki.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
