### PR TITLE
dev: add enterprise-frontend to SRC_PROF_SERVICES

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -46,6 +46,7 @@ env:
   SRC_PROF_SERVICES: |
     [
       { "Name": "oss-frontend", "Host": "127.0.0.1:6063" },
+      { "Name": "enterprise-frontend", "Host": "127.0.0.1:6063" },
       { "Name": "frontend", "Host": "127.0.0.1:6063" },
       { "Name": "gitserver", "Host": "127.0.0.1:6068" },
       { "Name": "searcher", "Host": "127.0.0.1:6069" },


### PR DESCRIPTION
running `sg start` will not start the debug server in frontend because
the service name doesn't match the name in SRC_PROF_SERVICES. This
fixes it.

## Test plan
- tested locally with `curl http://localhost:6063/debug -sS`

