### PR TITLE
JetBrains: Add popup open action to main menu

### DIFF
--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -65,15 +65,17 @@
             <add-to-group group-id="VcsSelectionHistoryDialog.Popup" anchor="last"/>
         </action>
         <action
-            id="sourcegraph.openSearch"
+            id="sourcegraph.openFindPopup"
             class="com.sourcegraph.find.OpenFindAction"
-            text="Open Sourcegraph Search View"
-            description="Open Sourcegraph search view"
+            text="Find on Sourcegraph..."
+            description="Search all your repos on Sourcegraph"
             icon="/icons/icon.png">
             <keyboard-shortcut first-keystroke="alt a" keymap="$default"/>
+            <add-to-group group-id="FindMenuGroup" anchor="after" relative-to-action="ReplaceInPath"/>
         </action>
+
         <group id="SourcegraphEditor" icon="/icons/icon.png" popup="true" text="Sourcegraph">
-            <reference ref="sourcegraph.openSearch"/>
+            <reference ref="sourcegraph.openFindPopup"/>
             <reference ref="sourcegraph.searchSelection"/>
             <reference ref="sourcegraph.searchRepository"/>
             <reference ref="sourcegraph.openFile"/>


### PR DESCRIPTION
Was not on our roadmap but I realized this was missing and would be cool to add.

<img width="1392" alt="CleanShot 2022-07-01 at 13 27 30@2x" src="https://user-images.githubusercontent.com/2552265/176885954-f13d3fa1-ac50-45cf-ab92-88a4fbfe6469.png">

Also changed the action label to match the native action.

## Test plan

See it work: [20-sec Loom](https://www.loom.com/share/f60b2ece210d45c2a0b0e6f009a2fac7)

## App preview:

- [Web](https://sg-web-dv-jetbrains-add-popup-to-main.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lopebwdqrq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
