### PR TITLE
[Accessibility]: Announce file decoration <meter> element aria-label

### DIFF
--- a/client/web/src/tree/FileDecorator.tsx
+++ b/client/web/src/tree/FileDecorator.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { FileDecoration } from 'sourcegraph'
 
@@ -74,20 +75,23 @@ export const FileDecorator: React.FunctionComponent<React.PropsWithChildren<File
                                 </small>
                             )}
                             {fileDecoration.meter && (
-                                <meter
-                                    className={classNames('test-file-decoration-meter', styles.meter, {
-                                        'ml-2': !!fileDecoration.after,
-                                    })}
-                                    min={fileDecoration.meter.min}
-                                    low={fileDecoration.meter.low}
-                                    high={fileDecoration.meter.high}
-                                    max={fileDecoration.meter.max}
-                                    optimum={fileDecoration.meter.optimum}
-                                    value={fileDecoration.meter.value}
-                                    data-tooltip={fileDecoration.meter.hoverMessage}
-                                    aria-label={fileDecoration.meter.hoverMessage}
-                                    data-placement="bottom"
-                                />
+                                <div>
+                                    <VisuallyHidden>{fileDecoration.meter.hoverMessage}</VisuallyHidden>
+                                    <meter
+                                        className={classNames('test-file-decoration-meter', styles.meter, {
+                                            'ml-2': !!fileDecoration.after,
+                                        })}
+                                        min={fileDecoration.meter.min}
+                                        low={fileDecoration.meter.low}
+                                        high={fileDecoration.meter.high}
+                                        max={fileDecoration.meter.max}
+                                        optimum={fileDecoration.meter.optimum}
+                                        value={fileDecoration.meter.value}
+                                        data-tooltip={fileDecoration.meter.hoverMessage}
+                                        aria-hidden={true}
+                                        data-placement="bottom"
+                                    />
+                                </div>
                             )}
                         </div>
                     )

--- a/client/web/src/tree/__snapshots__/FileDecorator.test.tsx.snap
+++ b/client/web/src/tree/__snapshots__/FileDecorator.test.tsx.snap
@@ -33,16 +33,22 @@ exports[`FileDecorator renders both after text content and meter 1`] = `
       >
         src decoration
       </small>
-      <meter
-        class="test-file-decoration-meter meter ml-2"
-        data-placement="bottom"
-        high="60"
-        low="50"
-        max="100"
-        min="0"
-        optimum="70"
-        value="40"
-      />
+      <div>
+        <span
+          style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+        />
+        <meter
+          aria-hidden="true"
+          class="test-file-decoration-meter meter ml-2"
+          data-placement="bottom"
+          high="60"
+          low="50"
+          max="100"
+          min="0"
+          optimum="70"
+          value="40"
+        />
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -56,16 +62,22 @@ exports[`FileDecorator renders meter 1`] = `
     <div
       class="d-flex align-items-center fileDecoration"
     >
-      <meter
-        class="test-file-decoration-meter meter"
-        data-placement="bottom"
-        high="60"
-        low="50"
-        max="100"
-        min="0"
-        optimum="70"
-        value="40"
-      />
+      <div>
+        <span
+          style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+        />
+        <meter
+          aria-hidden="true"
+          class="test-file-decoration-meter meter"
+          data-placement="bottom"
+          high="60"
+          low="50"
+          max="100"
+          min="0"
+          optimum="70"
+          value="40"
+        />
+      </div>
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36857

Part of https://github.com/sourcegraph/sourcegraph/issues/36751

## Test plan
- `sg start web-standalone`
- follow [steps to replicate the user journey](https://github.com/sourcegraph/sourcegraph/issues/34060) (ensure `codecov.fileDecorations.show` setting is enabled)
- follow the instructions to [audit a user journey](https://docs.sourcegraph.com/dev/background-information/web/accessibility/how-to-audit#auditing-a-user-journey)
- ensure *meter* element hover message is announced by the screen reader  

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-a11y-announce-meter.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-evynnnbmng.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
