### PR TITLE
JetBrains: Add settings to app-level config

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -26,38 +26,65 @@ public class ConfigUtil {
 
     @NotNull
     public static String getSourcegraphUrl(@NotNull Project project) {
-        String url = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getSourcegraphUrl();
-        if (url == null || url.length() == 0) {
-            return UserLevelConfig.getSourcegraphUrl();
+        String projectLevelUrl = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getSourcegraphUrl();
+        if (projectLevelUrl != null && projectLevelUrl.length() > 0) {
+            return addSlashIfNeeded(projectLevelUrl);
         }
+
+        String applicationLevelUrl = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getSourcegraphUrl();
+        if (applicationLevelUrl != null && applicationLevelUrl.length() > 0) {
+            return addSlashIfNeeded(applicationLevelUrl);
+        }
+
+        return addSlashIfNeeded(UserLevelConfig.getSourcegraphUrl());
+    }
+
+    @NotNull
+    private static String addSlashIfNeeded(@NotNull String url) {
         return url.endsWith("/") ? url : url + "/";
     }
 
     @Nullable
     public static String getAccessToken(Project project) {
-        return getProjectLevelConfig(project).getAccessToken();
+        String projectLevelAccessToken = getProjectLevelConfig(project).getAccessToken();
+        return projectLevelAccessToken != null ? projectLevelAccessToken : getApplicationLevelConfig().getAccessToken();
     }
 
-    @Nullable
+    @NotNull
     public static String getDefaultBranchName(@NotNull Project project) {
-        String defaultBranch = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getDefaultBranchName();
-        if (defaultBranch == null || defaultBranch.length() == 0) {
-            return UserLevelConfig.getDefaultBranchName();
+        String projectLevelDefaultBranchName = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getDefaultBranchName();
+        if (projectLevelDefaultBranchName != null && projectLevelDefaultBranchName.length() > 0) {
+            return projectLevelDefaultBranchName;
         }
-        return defaultBranch;
+
+        String applicationLevelDefaultBranchName = Objects.requireNonNull(SourcegraphApplicationService.getInstance()).getDefaultBranchName();
+        if (applicationLevelDefaultBranchName != null && applicationLevelDefaultBranchName.length() > 0) {
+            return applicationLevelDefaultBranchName;
+        }
+
+        String userLevelDefaultBranchName = UserLevelConfig.getDefaultBranchName();
+        return userLevelDefaultBranchName != null ? userLevelDefaultBranchName : "main";
     }
 
-    @Nullable
+    @NotNull
     public static String getRemoteUrlReplacements(@NotNull Project project) {
-        String replacements = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getRemoteUrlReplacements();
-        if (replacements == null || replacements.length() == 0) {
-            return UserLevelConfig.getRemoteUrlReplacements();
+        String projectLevelReplacements = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getRemoteUrlReplacements();
+        if (projectLevelReplacements != null && projectLevelReplacements.length() > 0) {
+            return projectLevelReplacements;
         }
-        return replacements;
+
+        String applicationLevelReplacements = Objects.requireNonNull(SourcegraphApplicationService.getInstance()).getRemoteUrlReplacements();
+        if (applicationLevelReplacements != null && applicationLevelReplacements.length() > 0) {
+            return applicationLevelReplacements;
+        }
+
+        String userLevelRemoteUrlReplacements = UserLevelConfig.getRemoteUrlReplacements();
+        return userLevelRemoteUrlReplacements != null ? userLevelRemoteUrlReplacements : "";
     }
 
     public static boolean isGlobbingEnabled(@NotNull Project project) {
-        return getProjectLevelConfig(project).isGlobbingEnabled();
+        Boolean projectLevelIsGlobbingEnabled = getProjectLevelConfig(project).isGlobbingEnabled();
+        return projectLevelIsGlobbingEnabled != null ? projectLevelIsGlobbingEnabled : getApplicationLevelConfig().isGlobbingEnabled();
     }
 
     @Nullable
@@ -95,6 +122,11 @@ public class ConfigUtil {
 
     public static void setInstallEventLogged(boolean value) {
         SourcegraphApplicationService.getInstance().isInstallEventLogged = value;
+    }
+
+    @NotNull
+    private static SourcegraphApplicationService getApplicationLevelConfig() {
+        return Objects.requireNonNull(SourcegraphApplicationService.getInstance());
     }
 
     @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -12,6 +12,15 @@ import org.jetbrains.annotations.Nullable;
     storages = {@Storage("sourcegraph.xml")})
 public class SourcegraphApplicationService implements PersistentStateComponent<SourcegraphApplicationService> {
     @Nullable
+    public String url;
+    @Nullable
+    public String accessToken;
+    @Nullable
+    public String defaultBranch;
+    @Nullable
+    public String remoteUrlReplacements;
+    public boolean isGlobbingEnabled; // This can be a primitive boolean, we need no "null" state
+    @Nullable
     public String anonymousUserId;
     public boolean isInstallEventLogged;
 
@@ -19,6 +28,30 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     public static SourcegraphApplicationService getInstance() {
         return ApplicationManager.getApplication()
             .getService(SourcegraphApplicationService.class);
+    }
+
+    @Nullable
+    public String getSourcegraphUrl() {
+        return url;
+    }
+
+    @Nullable
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    @Nullable
+    public String getDefaultBranchName() {
+        return defaultBranch;
+    }
+
+    @Nullable
+    public String getRemoteUrlReplacements() {
+        return remoteUrlReplacements;
+    }
+
+    public boolean isGlobbingEnabled() {
+        return this.isGlobbingEnabled;
     }
 
     @Nullable
@@ -37,7 +70,12 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     }
 
     @Override
-    public void loadState(@NotNull SourcegraphApplicationService config) {
-        this.anonymousUserId = config.anonymousUserId;
+    public void loadState(@NotNull SourcegraphApplicationService settings) {
+        this.url = settings.url;
+        this.accessToken = settings.accessToken;
+        this.defaultBranch = settings.defaultBranch;
+        this.remoteUrlReplacements = settings.remoteUrlReplacements;
+        this.isGlobbingEnabled = settings.isGlobbingEnabled;
+        this.anonymousUserId = settings.anonymousUserId;
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -12,14 +12,22 @@ import org.jetbrains.annotations.Nullable;
     name = "Config",
     storages = {@Storage("sourcegraph.xml")})
 public class SourcegraphProjectService implements PersistentStateComponent<SourcegraphProjectService> {
+    @Nullable
     public String url;
+    @Nullable
     public String accessToken;
+    @Nullable
     public String defaultBranch;
+    @Nullable
     public String remoteUrlReplacements;
-    public boolean isGlobbingEnabled;
+    @Nullable
+    public Boolean isGlobbingEnabled; // This needs to be a Boolean rather than a primitive: we need the "null" state
+    @Nullable
     public String lastSearchQuery;
     public boolean lastSearchCaseSensitive;
+    @Nullable
     public String lastSearchPatternType;
+    @Nullable
     public String lastSearchContextSpec;
 
     @NotNull
@@ -47,7 +55,8 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
         return remoteUrlReplacements;
     }
 
-    public boolean isGlobbingEnabled() {
+    @Nullable
+    public Boolean isGlobbingEnabled() {
         return this.isGlobbingEnabled;
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -13,14 +13,14 @@ import org.jetbrains.annotations.Nullable;
     storages = {@Storage("sourcegraph.xml")})
 public class SourcegraphProjectService implements PersistentStateComponent<SourcegraphProjectService> {
     public String url;
+    public String accessToken;
     public String defaultBranch;
     public String remoteUrlReplacements;
+    public boolean isGlobbingEnabled;
     public String lastSearchQuery;
     public boolean lastSearchCaseSensitive;
     public String lastSearchPatternType;
     public String lastSearchContextSpec;
-    public boolean isGlobbingEnabled;
-    public String accessToken;
 
     @NotNull
     public static SourcegraphProjectService getInstance(@NotNull Project project) {
@@ -33,6 +33,11 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     }
 
     @Nullable
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    @Nullable
     public String getDefaultBranchName() {
         return defaultBranch;
     }
@@ -40,6 +45,10 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     @Nullable
     public String getRemoteUrlReplacements() {
         return remoteUrlReplacements;
+    }
+
+    public boolean isGlobbingEnabled() {
+        return this.isGlobbingEnabled;
     }
 
     @Nullable
@@ -51,15 +60,6 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
         }
     }
 
-    public boolean isGlobbingEnabled() {
-        return this.isGlobbingEnabled;
-    }
-
-    @Nullable
-    public String getAccessToken() {
-        return accessToken;
-    }
-
     @Nullable
     @Override
     public SourcegraphProjectService getState() {
@@ -69,13 +69,13 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     @Override
     public void loadState(@NotNull SourcegraphProjectService settings) {
         this.url = settings.url;
+        this.accessToken = settings.accessToken;
         this.defaultBranch = settings.defaultBranch;
         this.remoteUrlReplacements = settings.remoteUrlReplacements;
+        this.isGlobbingEnabled = settings.isGlobbingEnabled;
         this.lastSearchQuery = settings.lastSearchQuery != null ? settings.lastSearchQuery : "";
         this.lastSearchCaseSensitive = settings.lastSearchCaseSensitive;
         this.lastSearchPatternType = settings.lastSearchPatternType != null ? settings.lastSearchPatternType : "literal";
         this.lastSearchContextSpec = settings.lastSearchContextSpec != null ? settings.lastSearchContextSpec : "global";
-        this.isGlobbingEnabled = settings.isGlobbingEnabled;
-        this.accessToken = settings.accessToken;
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -27,8 +27,7 @@ public class UserLevelConfig {
     @NotNull
     public static String getSourcegraphUrl() {
         Properties properties = readProperties();
-        String url = properties.getProperty("url", "https://sourcegraph.com/");
-        return url.endsWith("/") ? url : url + "/";
+        return properties.getProperty("url", "https://sourcegraph.com/");
     }
 
     // readProps returns the first properties file it's able to parse from the following paths:

--- a/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
@@ -20,7 +20,6 @@ public class GitUtil {
         String remoteUrl = "";
         String branchName = "";
         try {
-            String defaultBranchNameSetting = ConfigUtil.getDefaultBranchName(project);
             String directoryPath = filePath.substring(0, filePath.lastIndexOf("/"));
             String repoRootPath = getRepoRootPath(directoryPath);
 
@@ -30,18 +29,15 @@ public class GitUtil {
             // If the current branch doesn’t exist on the remote, use the default branch.
             branchName = getCurrentBranchName(repoRootPath);
             if (!doesRemoteBranchExist(branchName, repoRootPath)) {
-                branchName = defaultBranchNameSetting != null ? defaultBranchNameSetting : "main";
+                branchName = ConfigUtil.getDefaultBranchName(project);
             }
 
             remoteUrl = getConfiguredRemoteUrl(repoRootPath);
-            // replace remoteURL if config option is not null
             String r = ConfigUtil.getRemoteUrlReplacements(project);
-            if (r != null) {
-                String[] replacements = r.trim().split("\\s*,\\s*");
-                // Check if the entered values are pairs
-                for (int i = 0; i < replacements.length && replacements.length % 2 == 0; i += 2) {
-                    remoteUrl = remoteUrl.replace(replacements[i], replacements[i + 1]);
-                }
+            String[] replacements = r.trim().split("\\s*,\\s*");
+            // Check if the entered values are pairs
+            for (int i = 0; i < replacements.length && replacements.length % 2 == 0; i += 2) {
+                remoteUrl = remoteUrl.replace(replacements[i], replacements[i + 1]);
             }
         } catch (Exception err) {
             Logger.getInstance(GitUtil.class).info(err);


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/38036

Settings that this change affects:
- Sourcegraph URL
- Access token
- Default branch name
- Remote URL replacements
- isGlobbingEnabled

I did this with migration in mind, so the transition should be smooth for all legacy users.
There is no UI for new users to overwrite the app-level settings on the project level, but they can still overwrite the settings by manually creating/editing an XML file.
This was the best compromise without making the UI more complicated and/or working on the UI a lot.

## Test plan

- There are quite a few cases to cover. Here is a [4-min Loom](https://www.loom.com/share/e3633ba30eea431d920ace425e10eb25) where I did a bunch of testing

## App preview:

- [Web](https://sg-web-dv-jetbrains-move-auth-settings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qptjviazsb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
