### PR TITLE
feature(sg/analytics): add pending messages while your analytics are being submitted

### DIFF
--- a/dev/sg/internal/analytics/actions.go
+++ b/dev/sg/internal/analytics/actions.go
@@ -56,6 +56,11 @@ func Reset() error {
 	if err != nil {
 		return err
 	}
+
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		// don't have to remove something that doesn't exist
+		return nil
+	}
 	return os.Remove(p)
 }
 


### PR DESCRIPTION
Add some information while analytics is doing it's thang!

Closes #37946
## Test plan
When it's busy submitting your analytics
<img width="410" alt="image" src="https://user-images.githubusercontent.com/1001709/176911900-800359cc-0c65-4d1a-ba6d-0c45e2be2bff.png">
And when it is done
![image](https://user-images.githubusercontent.com/1001709/176911687-fdfbf6ec-ae76-4949-9c9b-eb23236b4ca9.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
