### PR TITLE
codemirror: Show a loading indicator for search query suggestions

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -25,6 +25,11 @@
             color: var(--search-query-text-color);
             // Disable default padding
             padding: 0;
+
+            &:global(.focus-visible),
+            &:focus-visible {
+                box-shadow: none;
+            }
         }
 
         :global(.cm-line) {
@@ -337,5 +342,35 @@
         &Wildcard {
             color: var(--oc-cyan-4);
         }
+    }
+}
+
+// Copied and adapted from the Wildcard LoadingSpinner component
+.loading-spinner {
+    :global(.theme-light) & {
+        --loading-spinner-outer-color: var(--gray-05);
+        --loading-spinner-inner-color: var(--gray-08);
+    }
+    :global(.theme-dark) & {
+        --loading-spinner-outer-color: var(--gray-07);
+        --loading-spinner-inner-color: var(--white);
+    }
+
+    flex-shrink: 0;
+    margin: 0.125rem;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 50%;
+    animation: loading-spinner-spin 1s linear infinite;
+    border: 2px solid var(--loading-spinner-outer-color, rgba(0, 0, 0, 0.3));
+    border-top: 2px solid var(--loading-spinner-inner-color, rgba(0, 0, 0, 1));
+}
+
+@keyframes loading-spinner-spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
     }
 }

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -512,7 +512,7 @@ const highlightFocusedFilter = ViewPlugin.define(
 
 // Extension for providing token information. This includes showing a popover on
 // hover and highlighting the hovered token.
-function tokenInfo(): Extension[] {
+function tokenInfo(): Extension {
     const setHighlighedTokenPosition = StateEffect.define<number | null>()
     const highlightedTokenPosition = StateField.define<number | null>({
         create() {
@@ -681,7 +681,7 @@ const diagnosticDecos: { [key in MarkerSeverity]: Decoration } = {
     [MarkerSeverity.Warning]: Decoration.mark({ class: styles.diagnosticWarning }),
     [MarkerSeverity.Error]: Decoration.mark({ class: styles.diagnosticError }),
 }
-const queryDiagnostic: Extension[] = [
+const queryDiagnostic: Extension = [
     // Compute diagnostics when query changes
     diagnostics.compute([parsedQuery], state => {
         const query = state.facet(parsedQuery)

--- a/client/search-ui/src/input/extensions/index.ts
+++ b/client/search-ui/src/input/extensions/index.ts
@@ -7,6 +7,7 @@ import { createCancelableFetchSuggestions } from '@sourcegraph/shared/src/search
 import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
 import { createDefaultSuggestionSources, searchQueryAutocompletion } from './completion'
+import { loadingIndicator } from './loading-indicator'
 
 export { createDefaultSuggestionSources, searchQueryAutocompletion }
 
@@ -67,7 +68,7 @@ export const createDefaultSuggestions = ({
     fetchSuggestions: (query: string) => Observable<SearchMatch[]>
     disableSymbolCompletion?: true
     disableFilterCompletion?: true
-}): Extension =>
+}): Extension => [
     searchQueryAutocompletion(
         createDefaultSuggestionSources({
             fetchSuggestions: createCancelableFetchSuggestions(fetchSuggestions),
@@ -76,7 +77,9 @@ export const createDefaultSuggestions = ({
             disableSymbolCompletion,
             disableFilterCompletion,
         })
-    )
+    ),
+    loadingIndicator(),
+]
 
 /**
  * A helper function for creating an extension that operates on the value which

--- a/client/search-ui/src/input/extensions/loading-indicator.ts
+++ b/client/search-ui/src/input/extensions/loading-indicator.ts
@@ -19,7 +19,7 @@ export function loadingIndicator({ timeout = DEFAULT_TIMEOUT }: { timeout?: numb
     return [
         ViewPlugin.fromClass(
             class {
-                private dom: HTMLSpanElement
+                public dom: HTMLSpanElement
                 private timeout: NodeJS.Timeout | null = null
 
                 constructor(public view: EditorView) {

--- a/client/search-ui/src/input/extensions/loading-indicator.ts
+++ b/client/search-ui/src/input/extensions/loading-indicator.ts
@@ -1,0 +1,81 @@
+import { completionStatus } from '@codemirror/autocomplete'
+import { Extension } from '@codemirror/state'
+import { EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view'
+
+import styles from '../CodeMirrorQueryInput.module.scss'
+
+const DEFAULT_TIMEOUT = 350
+
+/**
+ * Creates an extension that renders a autocompletion loading indicator on the
+ * right hand side of the editor (like a right hand side gutter).
+ *
+ * The indicator will be shown if fetching completion results takes longer than
+ * 'timeout' milliseconds. The default value is 350ms. Using a value > 0
+ * prevents the indicator from being shown for static suggestions (which are
+ * fast), which otherwise can be quite distracting.
+ */
+export function loadingIndicator({ timeout = DEFAULT_TIMEOUT }: { timeout?: number } = {}): Extension {
+    return [
+        ViewPlugin.fromClass(
+            class {
+                private dom: HTMLSpanElement
+                private timeout: NodeJS.Timeout | null = null
+
+                constructor(public view: EditorView) {
+                    const spinner = document.createElement('div')
+                    // I'm using a class from a CSS module here because I don't know
+                    // whether CodeMirror's CSS-in-JS solution supports keyframes.
+                    spinner.className = styles.loadingSpinner
+
+                    // The container is used to add some padding between the
+                    // document and the spinner
+                    this.dom = document.createElement('div')
+                    this.dom.className = 'cm-sg-loading-spinner-container'
+                    this.dom.append(spinner)
+                    // The element is always takes part in the layout. This makes it
+                    // easier to ensure that there is always enough space for the
+                    // spinner to be visible in inputs that scroll horizontally
+                    this.dom.style.visibility = 'hidden'
+                    this.view.contentDOM.after(this.dom)
+                }
+
+                public update(update: ViewUpdate): void {
+                    const status = completionStatus(update.state)
+                    if (status === 'pending') {
+                        this.showIndicatorDebounced()
+                    } else {
+                        this.dom.style.visibility = 'hidden'
+                        if (this.timeout !== null) {
+                            clearTimeout(this.timeout)
+                        }
+                    }
+                }
+
+                private showIndicatorDebounced(): void {
+                    if (this.timeout !== null) {
+                        clearTimeout(this.timeout)
+                    }
+                    this.timeout = setTimeout(() => {
+                        this.dom.style.visibility = 'visible'
+                    }, timeout)
+                }
+            },
+            {
+                provide: plugin =>
+                    EditorView.scrollMargins.of(view => {
+                        const value = view.plugin(plugin)
+                        if (!value) {
+                            return null
+                        }
+                        return { right: value.dom.offsetWidth }
+                    }),
+            }
+        ),
+        EditorView.baseTheme({
+            'cm-sg-loading-spinner-container': {
+                marginLeft: '0.5rem',
+            },
+        }),
+    ]
+}


### PR DESCRIPTION
Closes #33008

This PR adds an extension to the default search query completion extension to also show a loading indicator in the upper right corner of the editor if fetching suggestions takes longer than 350ms.


https://user-images.githubusercontent.com/179026/176922185-b0c52c78-23ee-49c8-af5a-a234f97a1bf3.mp4



## Test plan

Triggered completion logic in the main search input (single line) and the Notebook query block (multi line).

## App preview:

- [Web](https://sg-web-fkling-cm-loading-indicator.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gworprogrq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
