### PR TITLE
Code Insights: Fix query data points link generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fix an issue where updating the title or body of a Bitbucket Cloud pull request opened by a batch change could fail when the pull request was not on a fork of the target repository. [#37585](https://github.com/sourcegraph/sourcegraph/issues/37585)
 - A bug where some complex `repo:` regexes only returned a subset of repository results. [#37925](https://github.com/sourcegraph/sourcegraph/pull/37925)
+- Fix a bug with bad code insights chart data points links. [38102](https://github.com/sourcegraph/sourcegraph/pull/38102)
 
 ### Removed
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../../../../graphql-operations'
 import { useSeriesToggle } from '../../../../../../insights/utils/use-series-toggle'
 import { BackendInsight, BackendInsightData, CodeInsightsBackendContext, InsightFilters } from '../../../../core'
-import { GET_INSIGHT_VIEW_GQL } from '../../../../core/backend/gql-backend/gql/GetInsightView'
+import { GET_INSIGHT_VIEW_GQL } from '../../../../core/backend/gql-backend'
 import { createBackendInsightData } from '../../../../core/backend/gql-backend/methods/get-backend-insight-data/deserializators'
 import { insightPollingInterval } from '../../../../core/backend/gql-backend/utils/insight-polling'
 import { SeriesDisplayOptionsInputRequired } from '../../../../core/types/insight/common'
@@ -104,7 +104,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
             skip: !wasEverVisible,
             context: { concurrentRequests: { key: 'GET_INSIGHT_VIEW' } },
             onCompleted: data => {
-                const parsedData = createBackendInsightData(insight, data.insightViews.nodes[0])
+                const parsedData = createBackendInsightData({ ...insight, filters }, data.insightViews.nodes[0])
                 if (!parsedData.isFetchingHistoricalData) {
                     stopPolling()
                 }

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/deserializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/deserializators.ts
@@ -1,6 +1,6 @@
-import { InsightDataNode, InsightDataSeries } from '../../../../../../../graphql-operations'
+import { InsightDataNode } from '../../../../../../../graphql-operations'
 import { DATA_SERIES_COLORS } from '../../../../../pages/insights/creation/search-insight'
-import { BackendInsight, InsightType, SearchBasedInsightSeries } from '../../../../types'
+import { BackendInsight } from '../../../../types'
 import { BackendInsightData } from '../../../code-insights-backend-types'
 import { createLineChartContent } from '../../../utils/create-line-chart-content'
 
@@ -9,33 +9,11 @@ export const DATA_SERIES_COLORS_LIST = Object.values(DATA_SERIES_COLORS)
 
 export const createBackendInsightData = (insight: BackendInsight, response: InsightDataNode): BackendInsightData => {
     const seriesData = response.dataSeries.slice(0, MAX_NUMBER_OF_SERIES)
-    const seriesMetadata = getParsedDataSeriesMetadata(insight, seriesData)
 
     return {
-        content: createLineChartContent(seriesData, seriesMetadata, insight.filters),
+        content: createLineChartContent(insight, seriesData),
         isFetchingHistoricalData: seriesData.some(
             ({ status: { pendingJobs, backfillQueuedAt } }) => pendingJobs > 0 || backfillQueuedAt === null
         ),
-    }
-}
-
-function getParsedDataSeriesMetadata(
-    insight: BackendInsight,
-    seriesData: InsightDataSeries[]
-): SearchBasedInsightSeries[] {
-    switch (insight.type) {
-        case InsightType.SearchBased:
-            return insight.series
-
-        case InsightType.CaptureGroup: {
-            const { query } = insight
-
-            return seriesData.map((generatedSeries, index) => ({
-                id: generatedSeries.seriesId,
-                name: generatedSeries.label,
-                query,
-                stroke: DATA_SERIES_COLORS_LIST[index % DATA_SERIES_COLORS_LIST.length],
-            }))
-        }
     }
 }

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-insight-preview.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-insight-preview.ts
@@ -76,7 +76,7 @@ export const getInsightsPreview = (
             const seriesMetadata = indexedSeries.map((generatedSeries, index) => ({
                 id: generatedSeries.seriesId,
                 name: generatedSeries.label,
-                query: inputMetadata[generatedSeries.label]?.query || '',
+                query: inputMetadata[`${generatedSeries.label}-${index}`]?.query || '',
                 stroke: getColorForSeries(generatedSeries.label, index),
             }))
 
@@ -91,9 +91,10 @@ export const getInsightsPreview = (
                         value: point.value,
                         dateTime: new Date(point.dateTime),
                         link: generateLinkURL({
-                            previousPoint: line.points[index - 1],
-                            series: seriesDefinitionMap[line.seriesId],
                             point,
+                            previousPoint: line.points[index - 1],
+                            query: seriesDefinitionMap[line.seriesId].query,
+                            repositories: input.repositories,
                         }),
                     })),
                     name: line.label,

--- a/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
@@ -97,7 +97,7 @@ export function generateLinkURL(input: GenerateLinkInput): string {
     const includeRepoFilter = includeRepoRegexp ? `repo:${includeRepoRegexp}` : ''
     const excludeRepoFilter = excludeRepoRegexp ? `-repo:${excludeRepoRegexp}` : ''
 
-    const scopeRepoFilters = `repo:^(${repositories.map(escapeRegExp).join('|')})$`
+    const scopeRepoFilters = repositories.length > 0 ? `repo:^(${repositories.map(escapeRegExp).join('|')})$` : ''
     const contextFilter = context ? `context:${context}` : ''
     const repoFilter = `${includeRepoFilter} ${excludeRepoFilter}`
     const afterFilter = after ? `after:${after}` : ''

--- a/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
@@ -1,51 +1,42 @@
 import { formatISO } from 'date-fns'
+import { escapeRegExp } from 'lodash'
 
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 
 import { Series } from '../../../../../charts'
 import { InsightDataSeries, SearchPatternType } from '../../../../../graphql-operations'
 import { PageRoutes } from '../../../../../routes.constants'
-import { InsightFilters, SearchBasedInsightSeries } from '../../types'
+import { BackendInsight, InsightFilters, InsightType, SearchBasedInsightSeries } from '../../types'
 import { BackendInsightDatum, SeriesChartContent } from '../code-insights-backend-types'
+import { DATA_SERIES_COLORS_LIST } from '../gql-backend/methods/get-backend-insight-data/deserializators'
 
 type SeriesDefinition = Record<string, SearchBasedInsightSeries>
 
 /**
- * Minimal input type model for {@link createLineChartContent} function
- */
-export type InsightDataSeriesData = Pick<InsightDataSeries, 'seriesId' | 'label' | 'points'>
-
-/**
  * Generates line chart content for visx chart. Note that this function relies on the fact that
  * all series are indexed.
- *
- * @param series - insight series with points data
- * @param seriesDefinition - insight definition with line settings (color, name, query)
- * @param filters - insight drill-down filters
  */
 export function createLineChartContent(
-    series: InsightDataSeriesData[],
-    seriesDefinition: SearchBasedInsightSeries[] = [],
-    filters?: InsightFilters
+    insight: BackendInsight,
+    seriesData: InsightDataSeries[]
 ): SeriesChartContent<BackendInsightDatum> {
+    const seriesDefinition = getParsedDataSeriesMetadata(insight, seriesData)
     const seriesDefinitionMap: SeriesDefinition = Object.fromEntries<SearchBasedInsightSeries>(
         seriesDefinition.map(definition => [definition.id, definition])
     )
 
-    const { includeRepoRegexp = '', excludeRepoRegexp = '' } = filters ?? {}
-
     return {
-        series: series.map<Series<BackendInsightDatum>>(line => ({
+        series: seriesData.map<Series<BackendInsightDatum>>(line => ({
             id: line.seriesId,
             data: line.points.map((point, index) => ({
                 dateTime: new Date(point.dateTime),
                 value: point.value,
                 link: generateLinkURL({
-                    previousPoint: line.points[index - 1],
-                    series: seriesDefinitionMap[line.seriesId],
                     point,
-                    includeRepoRegexp,
-                    excludeRepoRegexp,
+                    previousPoint: line.points[index - 1],
+                    query: seriesDefinitionMap[line.seriesId].query,
+                    filters: insight.filters,
+                    repositories: insight.repositories,
                 }),
             })),
             name: seriesDefinitionMap[line.seriesId]?.name ?? line.label,
@@ -57,16 +48,43 @@ export function createLineChartContent(
     }
 }
 
+function getParsedDataSeriesMetadata(
+    insight: BackendInsight,
+    seriesData: InsightDataSeries[]
+): SearchBasedInsightSeries[] {
+    switch (insight.type) {
+        case InsightType.SearchBased:
+            return insight.series
+
+        case InsightType.CaptureGroup: {
+            const { query } = insight
+
+            return seriesData.map((generatedSeries, index) => ({
+                id: generatedSeries.seriesId,
+                name: generatedSeries.label,
+                query,
+                stroke: DATA_SERIES_COLORS_LIST[index % DATA_SERIES_COLORS_LIST.length],
+            }))
+        }
+    }
+}
+
+/**
+ * Minimal input type model for {@link createLineChartContent} function
+ */
+export type InsightDataSeriesData = Pick<InsightDataSeries, 'seriesId' | 'label' | 'points'>
+
 interface GenerateLinkInput {
-    series: SearchBasedInsightSeries
+    query: string
     previousPoint?: { dateTime: string }
     point: { dateTime: string }
-    includeRepoRegexp?: string
-    excludeRepoRegexp?: string
+    repositories: string[]
+    filters?: InsightFilters
 }
 
 export function generateLinkURL(input: GenerateLinkInput): string {
-    const { series, point, previousPoint, includeRepoRegexp, excludeRepoRegexp } = input
+    const { query, point, previousPoint, filters, repositories } = input
+    const { includeRepoRegexp = '', excludeRepoRegexp = '', context } = filters ?? {}
 
     const date = Date.parse(point.dateTime)
 
@@ -79,11 +97,13 @@ export function generateLinkURL(input: GenerateLinkInput): string {
     const includeRepoFilter = includeRepoRegexp ? `repo:${includeRepoRegexp}` : ''
     const excludeRepoFilter = excludeRepoRegexp ? `-repo:${excludeRepoRegexp}` : ''
 
+    const scopeRepoFilters = repositories.reduce((memo, repo) => `${memo} repo:^${escapeRegExp(repo)}`, '')
+    const contextFilter = context ? `context:${context}` : ''
     const repoFilter = `${includeRepoFilter} ${excludeRepoFilter}`
     const afterFilter = after ? `after:${after}` : ''
     const beforeFilter = `before:${before}`
     const dateFilters = `${afterFilter} ${beforeFilter}`
-    const diffQuery = `${repoFilter} type:diff ${dateFilters} ${series.query}`
+    const diffQuery = `${contextFilter} ${scopeRepoFilters} ${repoFilter} type:diff ${dateFilters} ${query}`
     const searchQueryParameter = buildSearchURLQuery(diffQuery, SearchPatternType.literal, false)
 
     return `${window.location.origin}${PageRoutes.Search}?${searchQueryParameter}`

--- a/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
@@ -97,7 +97,7 @@ export function generateLinkURL(input: GenerateLinkInput): string {
     const includeRepoFilter = includeRepoRegexp ? `repo:${includeRepoRegexp}` : ''
     const excludeRepoFilter = excludeRepoRegexp ? `-repo:${excludeRepoRegexp}` : ''
 
-    const scopeRepoFilters = repositories.reduce((memo, repo) => `${memo} repo:^${escapeRegExp(repo)}`, '')
+    const scopeRepoFilters = `repo:^(${repositories.map(escapeRegExp).join('|')})$`
     const contextFilter = context ? `context:${context}` : ''
     const repoFilter = `${includeRepoFilter} ${excludeRepoFilter}`
     const afterFilter = after ? `after:${after}` : ''

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -95,7 +95,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
             context: { concurrentRequests: { key: 'GET_INSIGHT_VIEW' } },
             skip: !wasEverVisible,
             onCompleted: data => {
-                const parsedData = createBackendInsightData(insight, data.insightViews.nodes[0])
+                const parsedData = createBackendInsightData({ ...insight, filters }, data.insightViews.nodes[0])
                 if (!parsedData.isFetchingHistoricalData) {
                     stopPolling()
                 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/38097

During the unification work and refactoring around chart data logic we lost a few important things in the link generation logic (repositories filter and context filter that we recently added in the drill-down filters) 

## Test plan
- Go to the dashboard page 
- Click any data points 
- Make sure that the search page is opened with the right query/filters/context values
- Go to the standalone insight page 
- Change filters and check the search page again
- Go to the edit UI and make sure that the live preview data points links open the search page with the right query/repositories/filters values

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-query-link-generation.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nztmhbqnjw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
