### PR TITLE
Revert "sg start, use local universal-ctags by default, if available"

### DIFF
--- a/cmd/symbols/build-ctags.sh
+++ b/cmd/symbols/build-ctags.sh
@@ -12,12 +12,9 @@ if [[ "${CTAGS_COMMAND}" != "cmd/symbols/universal-ctags-dev" ]]; then
   exit 0
 fi
 
-# If we already have universal-ctags installed, skip building the docker image.
-if ! hash ctags >/dev/null; then
-  # Build ctags docker image for universal-ctags-dev
-  echo "Building ctags docker image"
-  docker build -f cmd/symbols/Dockerfile -t ctags . \
-    --target=ctags \
-    --progress=plain \
-    --quiet >/dev/null
-fi
+# Build ctags docker image for universal-ctags-dev
+echo "Building ctags docker image"
+docker build -f cmd/symbols/Dockerfile -t ctags . \
+  --target=ctags \
+  --progress=plain \
+  --quiet >/dev/null

--- a/cmd/symbols/universal-ctags-dev
+++ b/cmd/symbols/universal-ctags-dev
@@ -5,14 +5,9 @@
 # To use your own `universal-ctags` binary instead of this wrapper in your local dev server, use
 # `CTAGS_COMMAND=path/to/ctags sg start`.
 
-
-if hash ctags >/dev/null; then
-  ctags "$@"
-else
-  exec docker run --rm -i \
+exec docker run --rm -i \
     -a stdin -a stdout -a stderr \
     --user guest \
     --name=universal-ctags-$$ \
     --entrypoint /usr/local/bin/universal-ctags \
     ctags "$@"
-fi

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -65,12 +65,6 @@ var Mac = []category{
 				Fix:   cmdFix(`brew install sqlite`),
 			},
 			{
-				Name:        "universal-ctags",
-				Description: "Required by the symbols service",
-				Check:       checkAction(check.Combine(check.InPath("ctags"), check.CommandOutputContains("ctags --help", "+interactive"))),
-				Fix:         cmdFix(`brew install universal-ctags`),
-			},
-			{
 				Name:  "jq",
 				Check: checkAction(check.InPath("jq")),
 				Fix:   cmdFix(`brew install jq`),

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -61,12 +61,6 @@ var Ubuntu = []category{
 				Fix:   aptGetInstall("jq"),
 			},
 			{
-				Name:        "universal-ctags",
-				Description: "Required by the symbols service",
-				Check:       checkAction(check.Combine(check.InPath("ctags"), check.CommandOutputContains("ctags --help", "+interactive"))),
-				Fix:         aptGetInstall("universal-ctags"),
-			},
-			{
 				Name:  "curl",
 				Check: checkAction(check.InPath("curl")),
 				Fix:   aptGetInstall("curl"),

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -122,7 +122,7 @@ commands:
         export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/oss-frontend github.com/sourcegraph/sourcegraph/cmd/frontend
-    checkBinary: .bin/oss-frontend
+    checkBinary: .bin/frontend
     env:
       CONFIGURATION_MODE: server
       USE_ENHANCED_LANGUAGE_DETECTION: false
@@ -258,7 +258,7 @@ commands:
 
       ./cmd/symbols/build-ctags.sh &&
       go build -gcflags="$GCFLAGS" -o .bin/oss-symbols github.com/sourcegraph/sourcegraph/cmd/symbols
-    checkBinary: .bin/oss-symbols
+    checkBinary: .bin/symbols
     env:
       CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
       CTAGS_PROCESSES: 2


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#38012

https://sourcegraph.slack.com/archives/C01N83PS4TU/p1656666149485829 

When doing the initial PR, missed a case where it's possible that the packaged version is simply too old, even if we're quite loose with the requirements unless when working on the symbols package.

Test Plan: It's just a revert