### PR TITLE
display banner when creating batch change from search

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -22,7 +22,9 @@ import {
 import { EXECUTORS, GET_BATCH_CHANGE_TO_EDIT } from '../../create/backend'
 import { ConfigurationForm } from '../../create/ConfigurationForm'
 import { InsightTemplatesBanner } from '../../create/InsightTemplatesBanner'
+import { SearchTemplatesBanner } from '../../create/SearchTemplatesBanner'
 import { useInsightTemplates } from '../../create/useInsightTemplates'
+import { useSearchTemplate } from '../../create/useSearchTemplate'
 import { BatchSpecContextProvider, useBatchSpecContext, BatchSpecContextState } from '../BatchSpecContext'
 import { ActionButtons } from '../header/ActionButtons'
 import { BatchChangeHeader } from '../header/BatchChangeHeader'
@@ -126,6 +128,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
     const history = useHistory()
 
     const { insightTitle } = useInsightTemplates(settingsCascade)
+    const { searchQuery } = useSearchTemplate()
 
     const [activeTabKey, setActiveTabKey] = useState<TabKey>('spec')
     const tabsConfig = useMemo<TabsConfig[]>(
@@ -250,6 +253,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
 
     return (
         <div className={layoutStyles.pageContainer}>
+            {searchQuery && <SearchTemplatesBanner />}
             {insightTitle && <InsightTemplatesBanner insightTitle={insightTitle} type="create" className="mb-3" />}
             <div className={layoutStyles.headerContainer}>
                 <BatchChangeHeader

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react'
 import { mdiInformationOutline, mdiLock } from '@mdi/js'
 import classNames from 'classnames'
 import { noop } from 'lodash'
-import { useHistory } from 'react-router'
+import { useHistory, useLocation } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
@@ -99,9 +99,10 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
     }, [])
 
     const history = useHistory()
+    const location = useLocation()
     const handleCancel = (): void => history.goBack()
     const handleCreate = (): void => {
-        const redirectSearchParameters = new URLSearchParams()
+        const redirectSearchParameters = new URLSearchParams(location.search)
         if (insightTitle) {
             redirectSearchParameters.set('title', insightTitle)
         }

--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
@@ -16,6 +16,7 @@ import { TabBar, TabsConfig } from '../batch-spec/TabBar'
 import { ConfigurationForm } from './ConfigurationForm'
 import { InsightTemplatesBanner } from './InsightTemplatesBanner'
 import { OldBatchChangePageContent } from './OldCreateBatchChangeContent'
+import { SearchTemplatesBanner } from './SearchTemplatesBanner'
 import { useInsightTemplates } from './useInsightTemplates'
 import { useSearchTemplate } from './useSearchTemplate'
 
@@ -64,10 +65,11 @@ const NewBatchChangePageContent: React.FunctionComponent<
     React.PropsWithChildren<Omit<CreateBatchChangePageProps, 'headingElement'>>
 > = ({ settingsCascade, initialNamespaceID }) => {
     const { renderTemplate: insightRenderTemplate, insightTitle } = useInsightTemplates(settingsCascade)
-    const { renderTemplate: searchRenderTemplate } = useSearchTemplate()
+    const { renderTemplate: searchRenderTemplate, searchQuery } = useSearchTemplate()
     return (
         <div className={layoutStyles.pageContainer}>
             <PageTitle title="Create new batch change" />
+            {searchQuery && <SearchTemplatesBanner />}
             {insightTitle && <InsightTemplatesBanner insightTitle={insightTitle} type="create" className="mb-5" />}
             <div className={layoutStyles.headerContainer}>
                 <BatchChangeHeader title={{ text: 'Create batch change' }} />

--- a/client/web/src/enterprise/batches/create/SearchTemplatesBanner.module.scss
+++ b/client/web/src/enterprise/batches/create/SearchTemplatesBanner.module.scss
@@ -1,13 +1,13 @@
 .banner {
     box-shadow: var(--box-shadow);
     margin-bottom: 2.5rem;
+
+    &__description {
+        font-size: 0.75rem;
+        margin-bottom: 0;
+    }
 }
 
 .icon {
     margin-right: 1.25rem;
-}
-
-.bannerDescription {
-    font-size: 0.75rem;
-    margin-bottom: 0;
 }

--- a/client/web/src/enterprise/batches/create/SearchTemplatesBanner.module.scss
+++ b/client/web/src/enterprise/batches/create/SearchTemplatesBanner.module.scss
@@ -1,0 +1,13 @@
+.banner {
+    box-shadow: var(--box-shadow);
+    margin-bottom: 2.5rem;
+}
+
+.icon {
+    margin-right: 1.25rem;
+}
+
+.bannerDescription {
+    font-size: 0.75rem;
+    margin-bottom: 0;
+}

--- a/client/web/src/enterprise/batches/create/SearchTemplatesBanner.story.tsx
+++ b/client/web/src/enterprise/batches/create/SearchTemplatesBanner.story.tsx
@@ -7,7 +7,7 @@ import { SearchTemplatesBanner } from './SearchTemplatesBanner'
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
-    title: 'web/batches/create/InsightTemplatesBanner',
+    title: 'web/batches/create/SearcTemplatesBanner',
     decorators: [decorator],
 }
 

--- a/client/web/src/enterprise/batches/create/SearchTemplatesBanner.story.tsx
+++ b/client/web/src/enterprise/batches/create/SearchTemplatesBanner.story.tsx
@@ -7,7 +7,7 @@ import { SearchTemplatesBanner } from './SearchTemplatesBanner'
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
-    title: 'web/batches/create/SearcTemplatesBanner',
+    title: 'web/batches/create/SearchTemplatesBanner',
     decorators: [decorator],
 }
 

--- a/client/web/src/enterprise/batches/create/SearchTemplatesBanner.story.tsx
+++ b/client/web/src/enterprise/batches/create/SearchTemplatesBanner.story.tsx
@@ -1,0 +1,20 @@
+import { Meta, Story, DecoratorFn } from '@storybook/react'
+
+import { WebStory } from '../../../components/WebStory'
+
+import { SearchTemplatesBanner } from './SearchTemplatesBanner'
+
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/batches/create/InsightTemplatesBanner',
+    decorators: [decorator],
+}
+
+export default config
+
+export const CreatingNewBatchChangeFromSearch: Story = () => (
+    <WebStory>{props => <SearchTemplatesBanner {...props} />}</WebStory>
+)
+
+CreatingNewBatchChangeFromSearch.storyName = 'Creating new batch change from search'

--- a/client/web/src/enterprise/batches/create/SearchTemplatesBanner.tsx
+++ b/client/web/src/enterprise/batches/create/SearchTemplatesBanner.tsx
@@ -13,7 +13,7 @@ export const SearchTemplatesBanner: React.FunctionComponent = () => (
             <div className="flex-grow-1 justify-content-between align-items-center">
                 <H4 className="mb-1">You are creating a Batch Change from a Code Search</H4>
                 <Text className={styles.bannerDescription}>
-                    Let Sourcegraph help you refactoring your code by preparing a Batch Change from your search query
+                    Let Sourcegraph help you refactor your code by preparing a Batch Change from your search query
                 </Text>
             </div>
         </CardBody>

--- a/client/web/src/enterprise/batches/create/SearchTemplatesBanner.tsx
+++ b/client/web/src/enterprise/batches/create/SearchTemplatesBanner.tsx
@@ -9,7 +9,6 @@ import styles from './SearchTemplatesBanner.module.scss'
 export const SearchTemplatesBanner: React.FunctionComponent = () => (
     <Card className={styles.banner}>
         <CardBody className="d-flex justify-content-between align-items-center">
-            {/* <div className="d-flex justify-content-between align-items-center"> */}
             <CodeInsightsBatchesIcon className={styles.icon} />
             <div className="flex-grow-1 justify-content-between align-items-center">
                 <H4 className="mb-1">You are creating a Batch Change from a Code Search</H4>
@@ -17,7 +16,6 @@ export const SearchTemplatesBanner: React.FunctionComponent = () => (
                     Let Sourcegraph help you refactoring your code by preparing a Batch Change from your search query
                 </Text>
             </div>
-            {/* </div> */}
         </CardBody>
     </Card>
 )

--- a/client/web/src/enterprise/batches/create/SearchTemplatesBanner.tsx
+++ b/client/web/src/enterprise/batches/create/SearchTemplatesBanner.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import { Card, CardBody, H4, Text } from '@sourcegraph/wildcard'
+
+import { CodeInsightsBatchesIcon } from './CodeInsightsBatchesIcon'
+
+import styles from './SearchTemplatesBanner.module.scss'
+
+export const SearchTemplatesBanner: React.FunctionComponent = () => (
+    <Card className={styles.banner}>
+        <CardBody className="d-flex justify-content-between align-items-center">
+            {/* <div className="d-flex justify-content-between align-items-center"> */}
+            <CodeInsightsBatchesIcon className={styles.icon} />
+            <div className="flex-grow-1 justify-content-between align-items-center">
+                <H4 className="mb-1">You are creating a Batch Change from a Code Search</H4>
+                <Text className={styles.bannerDescription}>
+                    Let Sourcegraph help you refactoring your code by preparing a Batch Change from your search query
+                </Text>
+            </div>
+            {/* </div> */}
+        </CardBody>
+    </Card>
+)

--- a/client/web/src/enterprise/batches/create/useSearchTemplate.ts
+++ b/client/web/src/enterprise/batches/create/useSearchTemplate.ts
@@ -4,6 +4,7 @@ import helloWorldSample from '../batch-spec/edit/library/hello-world.batch.yaml'
 import { insertQueryIntoLibraryItem, insertNameIntoLibraryItem } from '../batch-spec/yaml-util'
 
 interface UseSearchTemplateResult {
+    searchQuery?: string
     renderTemplate?: (title: string) => string
 }
 
@@ -31,8 +32,8 @@ export const useSearchTemplate = (): UseSearchTemplateResult => {
     if (query) {
         const searchQuery = `${query} ${patternType ? `patternType:${patternType}` : ''}`
         const renderTemplate = createRenderTemplate(searchQuery)
-        return { renderTemplate }
+        return { renderTemplate, searchQuery }
     }
 
-    return { renderTemplate: undefined }
+    return { renderTemplate: undefined, searchQuery: undefined }
 }


### PR DESCRIPTION
Closes #37343

![CleanShot 2022-07-01 at 18 14 57](https://user-images.githubusercontent.com/25608335/176940652-8294efd2-be2f-4c35-9823-e2a0bb018c73.png)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Added a storybook file for banner
* Click on `Create Batch Change` from Search results page and confirm the banner is displayed.
* Create a batch change through the navbar, and confirm the banner isn't displayed.

## App preview:

- [Web](https://sg-web-bo-show-banner-bc-from-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-reiwoghkoz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
