### PR TITLE
Revert "Revert "Code Insights: Add pings for the standalone insight page" (#37865)"

### DIFF
--- a/client/web/src/enterprise/insights/components/form/hooks/useForm.ts
+++ b/client/web/src/enterprise/insights/components/form/hooks/useForm.ts
@@ -1,4 +1,6 @@
 import {
+    DependencyList,
+    EffectCallback,
     EventHandler,
     FormEventHandler,
     RefObject,
@@ -47,9 +49,15 @@ interface UseFormProps<FormValues extends object> {
 
     /**
      * Change handler will be called every time when some field withing the form
-     * has been changed with last fields values.
+     * has been changed.
      */
     onChange?: ChangeHandler<FormValues>
+
+    /**
+     * It fires whenever a user is changing some form field value through typing.
+     * @param values - aggregated all fields form values
+     */
+    onPureValueChange?: (values: FormValues) => void
 }
 
 /**
@@ -113,7 +121,7 @@ export interface FormAPI<FormValues> {
 
     /**
      * State to understand that form submitting is going on.
-     * Also might be used as a sign to disable or show loading
+     * Also, might be used as a sign to disable or show loading
      * state for submit button.
      */
     submitting: boolean
@@ -199,7 +207,7 @@ type FieldsState<FormValues> = {
  * hook.
  */
 export function useForm<FormValues extends object>(props: UseFormProps<FormValues>): Form<FormValues> {
-    const { onSubmit = noop, initialValues, touched = false, onChange = noop } = props
+    const { onSubmit = noop, initialValues, touched = false, onChange = noop, onPureValueChange = noop } = props
 
     const [submitted, setSubmitted] = useState(false)
     const [submitting, setSubmitting] = useState(false)
@@ -212,6 +220,7 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
 
     // Debounced onChange handler.
     const onChangeReference = useRef<DebouncedFunc<ChangeHandler<FormValues>>>(debounce(onChange, 0))
+    const onPureValueChangeReference = useRef<(values: FormValues) => void>(onPureValueChange)
 
     // Track unmounted state to prevent setState if async validation or async submitting
     // will be resolved after component has been unmounted.
@@ -229,7 +238,7 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
         })
     }
 
-    const values = useMemo(() => getFormValues<FormValues>(fields), [fields])
+    const values = useDistinctValue(useMemo(() => getFormValues<FormValues>(fields), [fields]))
 
     const changeEvent = useDistinctValue(
         useMemo<{ values: FormValues; valid: boolean }>(
@@ -243,13 +252,8 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
         )
     )
 
-    useEffect(() => {
-        if (Object.keys(changeEvent.values).length === 0) {
-            return
-        }
-
-        onChangeReference.current?.(changeEvent)
-    }, [changeEvent])
+    useEffect(() => onChangeReference.current?.(changeEvent), [changeEvent])
+    useUpdateEffect(() => onPureValueChangeReference.current?.(values), [values])
 
     useEffect(
         () => () => {
@@ -333,4 +337,18 @@ export function generateInitialFieldsState<FormValues extends {}>(initialValues:
 
         return store
     }, {} as FieldsState<FormValues>)
+}
+
+function useUpdateEffect(effect: EffectCallback, deps?: DependencyList): void {
+    const isInitialMount = useRef(true)
+    const effectReference = useRef(effect)
+
+    useEffect(() => {
+        if (isInitialMount.current) {
+            isInitialMount.current = false
+        } else {
+            return effectReference.current?.()
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, deps)
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -60,6 +60,8 @@ interface DrillDownInsightFilters {
     /** Fires whenever the user changes filter value in any form input. */
     onFiltersChange: (filters: FormChangeEvent<DrillDownFiltersFormValues>) => void
 
+    onFilterValuesChange?: (values: DrillDownFiltersFormValues) => void
+
     /** Fires whenever the user clicks the save/update filter button. */
     onFilterSave: (filters: DrillDownFiltersFormValues, displayOptions: SeriesDisplayOptionsInput) => SubmissionResult
 
@@ -85,6 +87,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
         originalSeriesDisplayOptions,
         onSeriesDisplayOptionsChange,
         onVisualModeChange = noop,
+        onFilterValuesChange = noop,
     } = props
 
     const [activeSection, setActiveSection] = useState<FilterSection | null>(FilterSection.RegularExpressions)
@@ -93,6 +96,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
     const { ref, formAPI, handleSubmit, values } = useForm<DrillDownFiltersFormValues>({
         initialValues,
         onChange: onFiltersChange,
+        onPureValueChange: onFilterValuesChange,
         onSubmit: values => onFilterSave(values, seriesDisplayOptions),
     })
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useContext, useMemo } from 'react'
+import { FunctionComponent, useContext, useEffect, useMemo } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, useObservable } from '@sourcegraph/wildcard'
@@ -25,6 +25,10 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
 
     const insight = useObservable(useMemo(() => getInsightById(insightId), [getInsightById, insightId]))
 
+    useEffect(() => {
+        telemetryService.logPageView('StandaloneInsightPage')
+    }, [telemetryService])
+
     if (insight === undefined) {
         return <LoadingSpinner inline={false} />
     }
@@ -38,10 +42,11 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
             <PageTitle title={`${insight.title} - Code Insights`} />
             <PageHeader
                 path={[{ to: '/insights/dashboards/all', icon: CodeInsightsIcon }, { text: insight.title }]}
-                actions={<CodeInsightIndependentPageActions insight={insight} />}
+                actions={<CodeInsightIndependentPageActions insight={insight} telemetryService={telemetryService} />}
             />
 
             <StandaloneInsightDashboardPills
+                telemetryService={telemetryService}
                 dashboards={insight.dashboards}
                 insightId={insight.id}
                 className={styles.dashboards}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent, useRef, useState } from 'react'
 import { mdiLinkVariant } from '@mdi/js'
 import { useHistory } from 'react-router'
 
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Icon } from '@sourcegraph/wildcard'
 
 import { ConfirmDeleteModal } from '../../../../../components/modals/ConfirmDeleteModal'
@@ -11,12 +12,12 @@ import { useCopyURLHandler } from '../../../../../hooks/use-copy-url-handler'
 
 import styles from './CodeInsightIndependentPageActions.module.scss'
 
-interface Props {
+interface Props extends TelemetryProps {
     insight: Pick<Insight, 'title' | 'id' | 'type'>
 }
 
 export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props => {
-    const { insight } = props
+    const { insight, telemetryService } = props
 
     const history = useHistory()
 
@@ -39,6 +40,10 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
         setShowDeleteConfirm(true)
     }
 
+    const handleEditClick = (): void => {
+        telemetryService.log('StandaloneInsightPageEditClick')
+    }
+
     return (
         <div className={styles.container}>
             <Button
@@ -52,7 +57,12 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
             <Button variant="danger" onClick={handleDeleteClick}>
                 Delete
             </Button>
-            <Button variant="primary" as={Link} to={`/insights/edit/${insight.id}?insight=${insight.id}`}>
+            <Button
+                variant="primary"
+                as={Link}
+                to={`/insights/edit/${insight.id}?insight=${insight.id}`}
+                onClick={handleEditClick}
+            >
                 Edit
             </Button>
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
@@ -3,19 +3,24 @@ import { FunctionComponent, HTMLAttributes } from 'react'
 import { mdiViewDashboard } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
 
 import { ALL_INSIGHTS_DASHBOARD, InsightDashboardReference } from '../../../../../core'
 
 import styles from './StandaloneInsightDashboardPills.module.scss'
 
-interface StandaloneInsightDashboardPillsProps extends HTMLAttributes<HTMLDivElement> {
+interface StandaloneInsightDashboardPillsProps extends HTMLAttributes<HTMLDivElement>, TelemetryProps {
     dashboards: InsightDashboardReference[]
     insightId: string
 }
 
 export const StandaloneInsightDashboardPills: FunctionComponent<StandaloneInsightDashboardPillsProps> = props => {
-    const { dashboards, insightId, className, ...attributes } = props
+    const { dashboards, insightId, className, telemetryService, ...attributes } = props
+
+    const handleDashboardClick = (): void => {
+        telemetryService.log('StandaloneInsightDashboardClick')
+    }
 
     return (
         <div {...attributes} className={classNames(className, styles.list)}>
@@ -34,6 +39,7 @@ export const StandaloneInsightDashboardPills: FunctionComponent<StandaloneInsigh
                     target="_blank"
                     rel="noopener"
                     className={styles.pill}
+                    onClick={handleDashboardClick}
                 >
                     <Icon aria-hidden={true} svgPath={mdiViewDashboard} />
                     {dashboard.title}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -54,6 +54,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
     const { telemetryService, insight, className } = props
     const history = useHistory()
     const { createInsight, updateInsight } = useContext(CodeInsightsBackendContext)
+
     const seriesToggleState = useSeriesToggle()
     const [insightData, setInsightData] = useState<BackendInsightData | undefined>()
     const [enablePolling] = useFeatureFlag('insight-polling-enabled', true)
@@ -107,7 +108,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         }
     )
 
-    const { trackMouseLeave, trackMouseEnter, trackDatumClicks } = useCodeInsightViewPings({
+    const { trackMouseLeave, trackMouseEnter, trackDatumClicks, trackFilterChanges } = useCodeInsightViewPings({
         telemetryService,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
@@ -163,6 +164,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
                         visualMode={filterVisualMode}
                         onVisualModeChange={setFilterVisualMode}
                         onFiltersChange={handleFilterChange}
+                        onFilterValuesChange={trackFilterChanges}
                         onFilterSave={handleFilterSave}
                         onCreateInsightRequest={() => setStep(DrillDownFiltersStep.ViewCreation)}
                         originalSeriesDisplayOptions={DEFAULT_SERIES_DISPLAY_OPTIONS}

--- a/client/web/src/enterprise/insights/pings/use-code-insight-view-pings.ts
+++ b/client/web/src/enterprise/insights/pings/use-code-insight-view-pings.ts
@@ -1,5 +1,7 @@
 import { useCallback, useRef } from 'react'
 
+import { useDebouncedCallback } from 'use-debounce'
+
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { CodeInsightTrackType } from './types'
@@ -16,6 +18,7 @@ interface PingHandlers {
     trackMouseEnter: () => void
     trackMouseLeave: () => void
     trackDatumClicks: () => void
+    trackFilterChanges: () => void
 }
 
 /**
@@ -42,9 +45,14 @@ export function useCodeInsightViewPings(props: UseCodeInsightViewPingsInput): Pi
         telemetryService.log('InsightDataPointClick', { insightType }, { insightType })
     }, [insightType, telemetryService])
 
+    const trackFilterChanges = useDebouncedCallback(() => {
+        telemetryService.log('InsightFiltersChange', { insightType }, { insightType })
+    }, 1000)
+
     return {
         trackDatumClicks,
         trackMouseEnter,
         trackMouseLeave,
+        trackFilterChanges,
     }
 }

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -27,7 +27,6 @@ We keep this docs page up to date because pings are a vital component of our pro
 - **Version Added:** 3.25
 - **Version(s) broken:**  3.31-3.35.0 (does not count backend insights) ([fix PR](https://github.com/sourcegraph/sourcegraph/pull/25317))
 
-
 ### Hovers count
 
 **Type:** FE event
@@ -88,7 +87,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 **Other considerations:** As we add new insights pages it's important to make sure we're adding pages to this counter. 
 
 - Aggregation: By week 
-- Event Code: [InsightsPageView](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+InsightsPageView&patternType=regexp) 
+- Event Code: [ViewInsights](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+ViewInsights&patternType=regexp), [StandaloneInsightPageViewed](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+StandaloneInsightPageViewed&patternType=regexp),
 - PRs: [#17805](https://github.com/sourcegraph/sourcegraph/pull/17805/files)
 - **Version Added:** 3.25
 - **Version(s) broken:** 3.25-3.26 (not weekly)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/20070/files)), 3.30 (broken when switching to dashboard pages, didn't track dashboard views)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/24129/files))
@@ -108,6 +107,51 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 - PRs: [#17805](https://github.com/sourcegraph/sourcegraph/pull/17805/files)
 - **Version Added:** 3.25
 - **Version(s) broken:** 3.25-3.26 (not weekly)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/20070/files)), 3.30 (broken when switching to dashboard pages, didn't track dashboard views)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/24129/files))
+
+### Standalone insights page filters edits count
+
+**Type:** FE event
+
+**Intended purpose:** To track how many users actively re-filter insights through the standalone insight page's filter panel.
+
+**Functional implementation:** This ping works by firing a telemetry event on the client when a user changes insights filters (include/exclude repository regexp, search context, etc).
+
+**Other considerations:** N/A
+
+- Aggregation: By week
+- Event Code: [InsightFiltersChange](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27InsightFiltersChange%27&patternType=literal)
+- PRs: [#37521](https://github.com/sourcegraph/sourcegraph/pull/37521)
+- **Version Added:** 3.41
+
+### Standalone insights page dashboard clicks count
+
+**Type:** FE event
+
+**Intended purpose:** To track how many users are discovering dashboards from this page.
+
+**Functional implementation:** This ping works by firing a telemetry event on the client when a user clicks any dashboard pills on the standalone insight page.
+
+**Other considerations:** N/A
+
+- Aggregation: By week
+- Event Code: [StandaloneInsightDashboardClick](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27StandaloneInsightDashboardClick%27&patternType=literal)
+- PRs: [#37521](https://github.com/sourcegraph/sourcegraph/pull/37521)
+- **Version Added:** 3.41
+
+### Standalone insights page edit button clicks count
+
+**Type:** FE event
+
+**Intended purpose:** To track how many users are going to the edit page through the standalone insight page.
+
+**Functional implementation:** This ping works by firing a telemetry event on the client when a user clicks on the edit button on the standalone insight page.
+
+**Other considerations:** N/A
+
+- Aggregation: By week
+- Event Code: [StandaloneInsightPageEditClick](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27StandaloneInsightPageEditClick%27&patternType=literal)
+- PRs: [#37521](https://github.com/sourcegraph/sourcegraph/pull/37521)
+- **Version Added:** 3.41
 
 ### In-product landing page events (hover, data points click, template section clicks)
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1336,25 +1336,31 @@ type ExtensionUsageStatistics struct {
 }
 
 type CodeInsightsUsageStatistics struct {
-	WeeklyUsageStatisticsByInsight          []*InsightUsageStatistics
-	WeeklyInsightsPageViews                 *int32
-	WeeklyInsightsGetStartedPageViews       *int32
-	WeeklyInsightsUniquePageViews           *int32
-	WeeklyInsightsGetStartedUniquePageViews *int32
-	WeeklyInsightConfigureClick             *int32
-	WeeklyInsightAddMoreClick               *int32
-	WeekStart                               time.Time
-	WeeklyInsightCreators                   *int32
-	WeeklyFirstTimeInsightCreators          *int32
-	WeeklyAggregatedUsage                   []AggregatedPingStats
-	WeeklyGetStartedTabClickByTab           []InsightGetStartedTabClickPing
-	WeeklyGetStartedTabMoreClickByTab       []InsightGetStartedTabClickPing
-	InsightTimeIntervals                    []InsightTimeIntervalPing
-	InsightOrgVisible                       []OrgVisibleInsightPing
-	InsightTotalCounts                      InsightTotalCounts
-	TotalOrgsWithDashboard                  *int32
-	TotalDashboardCount                     *int32
-	InsightsPerDashboard                    InsightsPerDashboardPing
+	WeeklyUsageStatisticsByInsight               []*InsightUsageStatistics
+	WeeklyInsightsPageViews                      *int32
+	WeeklyStandaloneInsightPageViews             *int32
+	WeeklyStandaloneDashboardClicks              *int32
+	WeeklyStandaloneEditClicks                   *int32
+	WeeklyInsightsGetStartedPageViews            *int32
+	WeeklyInsightsUniquePageViews                *int32
+	WeeklyInsightsGetStartedUniquePageViews      *int32
+	WeeklyStandaloneInsightUniquePageViews       *int32
+	WeeklyStandaloneInsightUniqueDashboardClicks *int32
+	WeeklyStandaloneInsightUniqueEditClicks      *int32
+	WeeklyInsightConfigureClick                  *int32
+	WeeklyInsightAddMoreClick                    *int32
+	WeekStart                                    time.Time
+	WeeklyInsightCreators                        *int32
+	WeeklyFirstTimeInsightCreators               *int32
+	WeeklyAggregatedUsage                        []AggregatedPingStats
+	WeeklyGetStartedTabClickByTab                []InsightGetStartedTabClickPing
+	WeeklyGetStartedTabMoreClickByTab            []InsightGetStartedTabClickPing
+	InsightTimeIntervals                         []InsightTimeIntervalPing
+	InsightOrgVisible                            []OrgVisibleInsightPing
+	InsightTotalCounts                           InsightTotalCounts
+	TotalOrgsWithDashboard                       *int32
+	TotalDashboardCount                          *int32
+	InsightsPerDashboard                         InsightsPerDashboardPing
 }
 
 type CodeInsightsCriticalTelemetry struct {
@@ -1370,6 +1376,7 @@ type InsightUsageStatistics struct {
 	Hovers           *int32
 	UICustomizations *int32
 	DataPointClicks  *int32
+	FiltersChange    *int32
 }
 
 type PingName string

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -19,24 +19,35 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 
 	const platformQuery = `
 	SELECT
-		COUNT(*) FILTER (WHERE name = 'ViewInsights')                       		AS weekly_insights_page_views,
-		COUNT(*) FILTER (WHERE name = 'ViewInsightsGetStartedPage')         		AS weekly_insights_get_started_page_views,
-		COUNT(distinct user_id) FILTER (WHERE name = 'ViewInsights')        		AS weekly_insights_unique_page_views,
-		COUNT(distinct user_id) FILTER (WHERE name = 'ViewInsightsGetStartedPage')  AS weekly_insights_get_started_unique_page_views,
-		COUNT(distinct user_id)
-			FILTER (WHERE name = 'InsightAddition')									AS weekly_insight_creators,
-		COUNT(*) FILTER (WHERE name = 'InsightConfigureClick') 						AS weekly_insight_configure_click,
-		COUNT(*) FILTER (WHERE name = 'InsightAddMoreClick') 						AS weekly_insight_add_more_click
+		COUNT(*) FILTER (WHERE name = 'ViewInsights')                       			AS weekly_insights_page_views,
+		COUNT(*) FILTER (WHERE name = 'ViewInsightsGetStartedPage')         			AS weekly_insights_get_started_page_views,
+		COUNT(*) FILTER (WHERE name = 'StandaloneInsightPageViewed')					AS weekly_standalone_insight_page_views,
+		COUNT(*) FILTER (WHERE name = 'StandaloneInsightDashboardClick') 				AS weekly_standalone_dashboard_clicks,
+        COUNT(*) FILTER (WHERE name = 'StandaloneInsightPageEditClick') 				AS weekly_standalone_edit_clicks,
+		COUNT(distinct user_id) FILTER (WHERE name = 'ViewInsights')        			AS weekly_insights_unique_page_views,
+		COUNT(distinct user_id) FILTER (WHERE name = 'ViewInsightsGetStartedPage')  	AS weekly_insights_get_started_unique_page_views,
+		COUNT(distinct user_id) FILTER (WHERE name = 'StandaloneInsightPageViewed') 	AS weekly_standalone_insight_unique_page_views,
+		COUNT(distinct user_id) FILTER (WHERE name = 'StandaloneInsightDashboardClick') AS weekly_standalone_insight_unique_dashboard_clicks,
+		COUNT(distinct user_id) FILTER (WHERE name = 'StandaloneInsightPageEditClick')  AS weekly_standalone_insight_unique_edit_clicks,
+		COUNT(distinct user_id) FILTER (WHERE name = 'InsightAddition')					AS weekly_insight_creators,
+		COUNT(*) FILTER (WHERE name = 'InsightConfigureClick') 							AS weekly_insight_configure_click,
+		COUNT(*) FILTER (WHERE name = 'InsightAddMoreClick') 							AS weekly_insight_add_more_click
 	FROM event_logs
-	WHERE name in ('ViewInsights', 'ViewInsightsGetStartedPage', 'InsightAddition', 'InsightConfigureClick', 'InsightAddMoreClick')
+	WHERE name in ('ViewInsights', 'StandaloneInsightPageViewed', 'StandaloneInsightDashboardClick', 'StandaloneInsightPageEditClick', 'ViewInsightsGetStartedPage', 'InsightAddition', 'InsightConfigureClick', 'InsightAddMoreClick')
 		AND timestamp > DATE_TRUNC('week', $1::timestamp);
 	`
 
 	if err := db.QueryRowContext(ctx, platformQuery, timeNow()).Scan(
 		&stats.WeeklyInsightsPageViews,
 		&stats.WeeklyInsightsGetStartedPageViews,
+		&stats.WeeklyStandaloneInsightPageViews,
+		&stats.WeeklyStandaloneDashboardClicks,
+		&stats.WeeklyStandaloneEditClicks,
 		&stats.WeeklyInsightsUniquePageViews,
 		&stats.WeeklyInsightsGetStartedUniquePageViews,
+		&stats.WeeklyStandaloneInsightUniquePageViews,
+		&stats.WeeklyStandaloneInsightUniqueDashboardClicks,
+		&stats.WeeklyStandaloneInsightUniqueEditClicks,
 		&stats.WeeklyInsightCreators,
 		&stats.WeeklyInsightConfigureClick,
 		&stats.WeeklyInsightAddMoreClick,
@@ -51,9 +62,10 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
         COUNT(*) FILTER (WHERE name = 'InsightRemoval') 		             		AS removals,
 		COUNT(*) FILTER (WHERE name = 'InsightHover') 			             		AS hovers,
 		COUNT(*) FILTER (WHERE name = 'InsightUICustomization') 			 		AS ui_customizations,
-		COUNT(*) FILTER (WHERE name = 'InsightDataPointClick') 				 		AS data_point_clicks
+		COUNT(*) FILTER (WHERE name = 'InsightDataPointClick') 				 		AS data_point_clicks,
+		COUNT(*) FILTER (WHERE name = 'InsightFiltersChange') 				 		AS filters_change
 	FROM event_logs
-	WHERE name in ('InsightAddition', 'InsightEdit', 'InsightRemoval', 'InsightHover', 'InsightUICustomization', 'InsightDataPointClick')
+	WHERE name in ('InsightAddition', 'InsightEdit', 'InsightRemoval', 'InsightHover', 'InsightUICustomization', 'InsightDataPointClick', 'InsightFiltersChange')
 		AND timestamp > DATE_TRUNC('week', $1::timestamp)
 	GROUP BY insight_type;
 	`
@@ -77,6 +89,7 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 			&weeklyInsightUsageStatistics.Hovers,
 			&weeklyInsightUsageStatistics.UICustomizations,
 			&weeklyInsightUsageStatistics.DataPointClicks,
+			&weeklyInsightUsageStatistics.FiltersChange,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -46,7 +46,6 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 			(6, 'InsightEdit', '{"insightType": "searchInsights"}', '', 2, '420657f0-d443-4d16-ac7d-003d8cdc19ac', 'WEB', '3.23.0', $1::timestamp - interval '2 days'),
 			(7, 'InsightAddition', '{"insightType": "codeStatsInsights"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', '3.23.0', $1::timestamp - interval '8 days'),
 			(8, 'CodeInsightsSearchBasedCreationPageSubmitClick', '{}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', '3.23.0', $1::timestamp - interval '1 day')
-
 	`, now)
 	if err != nil {
 		t.Fatal(err)
@@ -73,6 +72,7 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 			Hovers:           &zeroInt,
 			UICustomizations: &zeroInt,
 			DataPointClicks:  &zeroInt,
+			FiltersChange:    &zeroInt,
 		},
 		{
 			InsightType:      &searchInsightsType,
@@ -82,24 +82,31 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 			Hovers:           &zeroInt,
 			UICustomizations: &zeroInt,
 			DataPointClicks:  &zeroInt,
+			FiltersChange:    &zeroInt,
 		},
 	}
 
 	want := &types.CodeInsightsUsageStatistics{
-		WeeklyUsageStatisticsByInsight:          weeklyUsageStatisticsByInsight,
-		WeeklyInsightsPageViews:                 &twoInt,
-		WeeklyInsightsGetStartedPageViews:       &zeroInt,
-		WeeklyInsightsUniquePageViews:           &oneInt,
-		WeeklyInsightsGetStartedUniquePageViews: &zeroInt,
-		WeeklyInsightConfigureClick:             &zeroInt,
-		WeeklyInsightAddMoreClick:               &zeroInt,
-		WeekStart:                               weekStart,
-		WeeklyInsightCreators:                   &twoInt,
-		WeeklyFirstTimeInsightCreators:          &oneInt,
-		WeeklyGetStartedTabClickByTab:           []types.InsightGetStartedTabClickPing{},
-		WeeklyGetStartedTabMoreClickByTab:       []types.InsightGetStartedTabClickPing{},
-		TotalDashboardCount:                     &zeroInt,
-		TotalOrgsWithDashboard:                  &zeroInt,
+		WeeklyUsageStatisticsByInsight:               weeklyUsageStatisticsByInsight,
+		WeeklyInsightsPageViews:                      &twoInt,
+		WeeklyInsightsGetStartedPageViews:            &zeroInt,
+		WeeklyInsightsUniquePageViews:                &oneInt,
+		WeeklyInsightsGetStartedUniquePageViews:      &zeroInt,
+		WeeklyInsightConfigureClick:                  &zeroInt,
+		WeeklyInsightAddMoreClick:                    &zeroInt,
+		WeekStart:                                    weekStart,
+		WeeklyInsightCreators:                        &twoInt,
+		WeeklyFirstTimeInsightCreators:               &oneInt,
+		WeeklyGetStartedTabClickByTab:                []types.InsightGetStartedTabClickPing{},
+		WeeklyGetStartedTabMoreClickByTab:            []types.InsightGetStartedTabClickPing{},
+		TotalDashboardCount:                          &zeroInt,
+		TotalOrgsWithDashboard:                       &zeroInt,
+		WeeklyStandaloneDashboardClicks:              &zeroInt,
+		WeeklyStandaloneInsightUniqueEditClicks:      &zeroInt,
+		WeeklyStandaloneInsightUniquePageViews:       &zeroInt,
+		WeeklyStandaloneInsightUniqueDashboardClicks: &zeroInt,
+		WeeklyStandaloneInsightPageViews:             &zeroInt,
+		WeeklyStandaloneEditClicks:                   &zeroInt,
 	}
 
 	wantedWeeklyUsage := []types.AggregatedPingStats{

--- a/package.json
+++ b/package.json
@@ -472,6 +472,7 @@
     "ts-key-enum": "^2.0.7",
     "tslib": "^2.1.0",
     "use-callback-ref": "^1.2.5",
+    "use-debounce": "^8.0.1",
     "use-deep-compare-effect": "^1.6.1",
     "use-resize-observer": "^7.0.0",
     "utility-types": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24608,6 +24608,11 @@ use-callback-ref@^1.2.3, use-callback-ref@^1.2.5:
   resolved "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz#6115ed242cfbaed5915499c0a9842ca2912f38a5"
   integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
 
+use-debounce@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/use-debounce/-/use-debounce-8.0.1.tgz#5f3e11b067bdf9f2c554a20b4764e38b48022664"
+  integrity sha512-6tGAFJKJ0qCalecaV7/gm/M6n238nmitNppvR89ff1yfwSFjwFKR7IQZzIZf1KZRQhqNireBzytzU6jgb29oVg==
+
 use-deep-compare-effect@^1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.6.1.tgz#061a0ac5400aa0461e33dddfaa2a98bca873182a"


### PR DESCRIPTION
This is a revert PR for the https://github.com/sourcegraph/sourcegraph/pull/37865
This reverts commit 71da598f59ee8e678ecdd232bceb7f4f929a9bce.

Orignal PR https://github.com/sourcegraph/sourcegraph/pull/37521 was reverted because we hadn't updated the big query schema before merging the new standalone insight page pings into the main.

Since [big query schema PR](https://github.com/sourcegraph/analytics/pull/525) is merged we can bring back new pings. 

## Test plan
- N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
