### PR TITLE
Search backend: use efficient implementation for repo:contains.commit.after()

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -636,7 +636,6 @@ func toRepoOptions(b query.Basic, userSettings *schema.Settings) search.RepoOpti
 	}
 
 	visibility := b.Visibility()
-	commitAfter := b.FindValue(query.FieldRepoHasCommitAfter)
 	searchContextSpec := b.FindValue(query.FieldContext)
 
 	return search.RepoOptions{
@@ -652,7 +651,7 @@ func toRepoOptions(b query.Basic, userSettings *schema.Settings) search.RepoOpti
 		OnlyArchived:      archived == query.Only,
 		NoArchived:        archived == query.No,
 		Visibility:        visibility,
-		CommitAfter:       commitAfter,
+		CommitAfter:       b.RepoContainsCommitAfter(),
 	}
 }
 

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -257,17 +257,8 @@ func (f RepoContainsCommitAfterPredicate) Name() string {
 	return "contains.commit.after"
 }
 func (f *RepoContainsCommitAfterPredicate) Plan(parent Basic) (Plan, error) {
-	nodes := make([]Node, 0, 3)
-	nodes = append(nodes, Parameter{
-		Field: FieldCount,
-		Value: "99999",
-	}, Parameter{
-		Field: FieldRepoHasCommitAfter,
-		Value: f.TimeRef,
-	})
-
-	nodes = append(nodes, nonPredicateRepos(parent)...)
-	return BuildPlan(nodes), nil
+	// Handled by repo pagination code
+	return nil, nil
 }
 
 // RepoDependenciesPredicate represents the `repo:dependencies(regex@rev)` predicate,

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -354,7 +354,7 @@ func (p Parameters) RepoContainsFile() (include, exclude []string) {
 func (p Parameters) RepoContainsCommitAfter() (value string) {
 	nodes := toNodes(p)
 
-	// Look for values values of repohascommitafter:
+	// Look for values of repohascommitafter:
 	value = p.FindValue(FieldRepoHasCommitAfter)
 
 	// Look for values of repo:contains.commit.after()

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -351,6 +351,20 @@ func (p Parameters) RepoContainsFile() (include, exclude []string) {
 	return include, exclude
 }
 
+func (p Parameters) RepoContainsCommitAfter() (value string) {
+	nodes := toNodes(p)
+
+	// Look for values values of repohascommitafter:
+	value = p.FindValue(FieldRepoHasCommitAfter)
+
+	// Look for values of repo:contains.commit.after()
+	VisitTypedPredicate(nodes, func(pred *RepoContainsCommitAfterPredicate, _ bool) {
+		value = pred.TimeRef
+	})
+
+	return value
+}
+
 // Exists returns whether a parameter exists in the query (whether negated or not).
 func (p Parameters) Exists(field string) bool {
 	found := false

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -95,7 +95,7 @@ type predicatePointer[T any] interface {
 // VisitTypedPredicate visits every predicate of the type given to the callback function. The callback
 // will be called with a value of the predicate with its fields populated with its parsed arguments.
 func VisitTypedPredicate[T any, PT predicatePointer[T]](nodes []Node, f func(pred PT, negated bool)) {
-	var zeroPred PT
+	zeroPred := PT(new(T))
 	VisitField(nodes, zeroPred.Field(), func(value string, negated bool, annotation Annotation) {
 		if !annotation.Labels.IsSet(IsPredicate) {
 			return // skip non-predicates


### PR DESCRIPTION
This just plugs the `repo:contains.commit.after()` predicate into the more-efficient machinery we use for `repohascommitafter`. 

A little more on direction here: I think I'm going to make it my near-term goal to completely remove the `Plan()` method from the `Predicate` interface. The method is very restrictive in that 1) it requires the result to be representable as a search query fragment, and 2) it requires the predicate to be evaluated in advance. Getting rid of `Plan()` also lets us get rid of the awkward "expand predicates" step which breaks us out of our very nice pattern of "create a plan, execute a plan."

## Test plan

Unit tests, integration tests, and light manual tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
