### PR TITLE
insights: ensure that priority from time interval does not exceed HIGH

### DIFF
--- a/internal/insights/priority/priority.go
+++ b/internal/insights/priority/priority.go
@@ -15,8 +15,9 @@ const (
 // FromTimeInterval calculates a Priority value for an insight by deriving a value based on a time range. This value will rank more recent data points
 // higher priority than older ones. This can be useful for backfilling and ensuring multiple insights backfill at roughly the same rate.
 func FromTimeInterval(from time.Time, to time.Time) Priority {
+	minPriority := High + 1
 	days := to.Sub(from).Hours() / 24
-	return Priority(days)
+	return Priority(days + float64(minPriority))
 }
 
 func (p Priority) LowerBy(val int) Priority {

--- a/internal/insights/priority/priority_test.go
+++ b/internal/insights/priority/priority_test.go
@@ -21,7 +21,7 @@ func TestFromTimeInterval(t *testing.T) {
 				from: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				to:   time.Date(2021, 1, 6, 0, 0, 0, 0, time.UTC),
 			},
-			want: 5,
+			want: 16,
 		},
 		{
 			name: "30 days",
@@ -29,7 +29,15 @@ func TestFromTimeInterval(t *testing.T) {
 				from: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				to:   time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC).Add(30 * 24 * time.Hour),
 			},
-			want: 30,
+			want: 41,
+		},
+		{
+			name: "0 days",
+			args: args{
+				from: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				to:   time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			want: High + 1,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
priority.FromTimeInterval was return a higher priority than CRITICAL or HIGH when the interval in days was between 0 - 10.  This sets the minimum  priority to HIGH +1 so that any interval based priority does not exceed that of HIGH or Critical items.  

Discovered because search jobs for the first data point (some times more depending on interval) for all repo insights where getting queued with higher priority than scoped insights.

resolves https://github.com/sourcegraph/sourcegraph/issues/38115

## Test plan
unit tests pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
