### PR TITLE
Revert "logging(gitstart): migrate internal/search to use lib/log (#36457)

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -15,8 +15,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	sglog "github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cloneurls"
@@ -48,7 +46,6 @@ var (
 type GitTreeEntryResolver struct {
 	db     database.DB
 	commit *GitCommitResolver
-	log    sglog.Logger
 
 	contentOnce sync.Once
 	content     []byte
@@ -63,7 +60,7 @@ type GitTreeEntryResolver struct {
 }
 
 func NewGitTreeEntryResolver(db database.DB, commit *GitCommitResolver, stat fs.FileInfo) *GitTreeEntryResolver {
-	return &GitTreeEntryResolver{db: db, commit: commit, stat: stat, log: sglog.Scoped("GitTreeEntryResolver", "")}
+	return &GitTreeEntryResolver{db: db, commit: commit, stat: stat}
 }
 
 func (r *GitTreeEntryResolver) Path() string { return r.stat.Name() }

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -17,8 +17,6 @@ import (
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/inconshreveable/log15"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -107,7 +105,7 @@ func TestResolverTo(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error opening file: %s", err)
 		}
-		blobEntry := &GitTreeEntryResolver{db: db, stat: blobStat, log: logtest.Scoped(t)}
+		blobEntry := &GitTreeEntryResolver{db: db, stat: blobStat}
 		if _, isBlob := blobEntry.ToGitBlob(); !isBlob {
 			t.Errorf("expected blobEntry to be blob")
 		}
@@ -119,7 +117,7 @@ func TestResolverTo(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error opening directory: %s", err)
 		}
-		treeEntry := &GitTreeEntryResolver{db: db, stat: treeStat, log: logtest.Scoped(t)}
+		treeEntry := &GitTreeEntryResolver{db: db, stat: treeStat}
 		if _, isBlob := treeEntry.ToGitBlob(); isBlob {
 			t.Errorf("expected treeEntry to be tree, but is blob")
 		}

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -146,7 +146,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			listCtx, cancel := context.WithTimeout(ctx, time.Minute)
 			defer cancel()
 			var err error
-			indexed, err = search.Indexed(log.Scoped("compute", "")).List(listCtx, &zoektquery.Const{Value: true}, &zoekt.ListOptions{Minimal: true})
+			indexed, err = search.Indexed().List(listCtx, &zoektquery.Const{Value: true}, &zoekt.ListOptions{Minimal: true})
 			if err != nil {
 				r.err = err
 				return

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -11,7 +11,6 @@ import (
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/google/zoekt/stream"
 	"github.com/grafana/regexp"
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -25,7 +24,7 @@ func (r *RepositoryResolver) TextSearchIndex() *repositoryTextSearchIndexResolve
 
 	return &repositoryTextSearchIndexResolver{
 		repo:   r,
-		client: search.Indexed(log.Scoped("repositoryTextSearchIndexResolver", "")),
+		client: search.Indexed(),
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/google/zoekt"
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -20,7 +19,6 @@ type SearchArgs struct {
 	Version     string
 	PatternType *string
 	Query       string
-	log         log.Logger
 }
 
 type SearchImplementer interface {
@@ -38,7 +36,6 @@ func NewBatchSearchImplementer(ctx context.Context, db database.DB, args *Search
 
 	inputs, err := run.NewSearchInputs(
 		ctx,
-		args.log,
 		db,
 		args.Version,
 		args.PatternType,
@@ -58,9 +55,8 @@ func NewBatchSearchImplementer(ctx context.Context, db database.DB, args *Search
 	return &searchResolver{
 		db:           db,
 		SearchInputs: inputs,
-		zoekt:        search.Indexed(log.Scoped("searchResolver", "")),
+		zoekt:        search.Indexed(),
 		searcherURLs: search.SearcherURLs(),
-		log:          log.Scoped("searchResolver", "search resolver for BatchSearchImplementer"),
 	}, nil
 }
 
@@ -75,7 +71,6 @@ type searchResolver struct {
 
 	zoekt        zoekt.Streamer
 	searcherURLs *endpoint.Map
-	log          log.Logger
 }
 
 var MockDecodedViewerFinalSettings *schema.Settings

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -510,7 +510,7 @@ func logBatch(ctx context.Context, db database.DB, searchInputs *run.SearchInput
 func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
 	agg := streaming.NewAggregatingStream()
-	alert, err := execute.Execute(ctx, r.log, agg, r.SearchInputs, r.JobClients())
+	alert, err := execute.Execute(ctx, agg, r.SearchInputs, r.JobClients())
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
 	logBatch(ctx, r.db, r.SearchInputs, srr, err)
@@ -556,7 +556,6 @@ type searchResultsStats struct {
 	once    sync.Once
 	results result.Matches
 	err     error
-	log     log.Logger
 }
 
 func (srs *searchResultsStats) ApproximateResultCount() string { return srs.JApproximateResultCount }
@@ -605,7 +604,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 		if err != nil {
 			return nil, err
 		}
-		j, err := jobutil.NewBasicJob(r.log, r.SearchInputs, b)
+		j, err := jobutil.NewBasicJob(r.SearchInputs, b)
 		if err != nil {
 			return nil, err
 		}
@@ -652,7 +651,6 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 		JApproximateResultCount: v.ApproximateResultCount(),
 		JSparkline:              sparkline,
 		sr:                      r,
-		log:                     log.Scoped("searchResultsStats", ""),
 	}
 
 	// Store in the cache if we got non-zero results. If we got zero results,

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -48,7 +48,7 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, 
 			srs.err = err
 			return
 		}
-		j, err := jobutil.NewBasicJob(srs.log, srs.sr.SearchInputs, b)
+		j, err := jobutil.NewBasicJob(srs.sr.SearchInputs, b)
 		if err != nil {
 			srs.err = err
 			return

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/google/zoekt"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -262,7 +260,6 @@ func TestSearchResultsHydration(t *testing.T) {
 	id := 42
 	repoName := "reponame-foobar"
 	fileName := "foobar.go"
-	log := logtest.Scoped(t)
 
 	repoWithIDs := &types.Repo{
 		ID:   api.RepoID(id),
@@ -331,7 +328,6 @@ func TestSearchResultsHydration(t *testing.T) {
 	literalPatternType := "literal"
 	searchInputs, err := run.NewSearchInputs(
 		ctx,
-		log,
 		db,
 		"V2",
 		&literalPatternType,
@@ -348,7 +344,6 @@ func TestSearchResultsHydration(t *testing.T) {
 		db:           db,
 		SearchInputs: searchInputs,
 		zoekt:        z,
-		log:          logtest.Scoped(t),
 	}
 	results, err := resolver.Results(ctx)
 	if err != nil {
@@ -570,7 +565,6 @@ func TestEvaluateAnd(t *testing.T) {
 			literalPatternType := "literal"
 			searchInputs, err := run.NewSearchInputs(
 				context.Background(),
-				logtest.Scoped(t),
 				db,
 				"V2",
 				&literalPatternType,
@@ -587,7 +581,6 @@ func TestEvaluateAnd(t *testing.T) {
 				db:           db,
 				SearchInputs: searchInputs,
 				zoekt:        z,
-				log:          logtest.Scoped(t),
 			}
 			results, err := resolver.Results(ctx)
 			if err != nil {
@@ -676,7 +669,6 @@ func TestSubRepoFiltering(t *testing.T) {
 			literalPatternType := "literal"
 			searchInputs, err := run.NewSearchInputs(
 				context.Background(),
-				logtest.Scoped(t),
 				db,
 				"V2",
 				&literalPatternType,
@@ -693,7 +685,6 @@ func TestSubRepoFiltering(t *testing.T) {
 				SearchInputs: searchInputs,
 				zoekt:        mockZoekt,
 				db:           db,
-				log:          logtest.Scoped(t),
 			}
 
 			ctx := context.Background()

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/google/zoekt/web"
 	"github.com/graph-gophers/graphql-go"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -347,7 +345,6 @@ func BenchmarkSearchResults(b *testing.B) {
 				UserSettings: &schema.Settings{},
 			},
 			zoekt: z,
-			log:   logtest.Scoped(b),
 		}
 		results, err := resolver.Results(ctx)
 		if err != nil {
@@ -420,7 +417,7 @@ func zoektRPC(t testing.TB, s zoekt.Streamer) zoekt.Streamer {
 		t.Fatal(err)
 	}
 	ts := httptest.NewServer(srv)
-	cl := backend.ZoektDial(logtest.Scoped(t), strings.TrimPrefix(ts.URL, "http://"))
+	cl := backend.ZoektDial(strings.TrimPrefix(ts.URL, "http://"))
 	t.Cleanup(func() {
 		cl.Close()
 		ts.Close()

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -20,7 +18,7 @@ type symbolsArgs struct {
 }
 
 func (r *GitTreeEntryResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
-	symbols, err := symbol.Compute(ctx, r.log, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.commit.inputRev, args.Query, args.First, args.IncludePatterns)
+	symbols, err := symbol.Compute(ctx, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.commit.inputRev, args.Query, args.First, args.IncludePatterns)
 	if err != nil && len(symbols) == 0 {
 		return nil, err
 	}
@@ -34,7 +32,7 @@ func (r *GitTreeEntryResolver) Symbol(ctx context.Context, args *struct {
 	Line      int32
 	Character int32
 }) (*symbolResolver, error) {
-	symbol, err := symbol.GetMatchAtLineCharacter(ctx, log.Scoped("Symbol", ""), r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.Path(), int(args.Line), int(args.Character))
+	symbol, err := symbol.GetMatchAtLineCharacter(ctx, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.Path(), int(args.Line), int(args.Character))
 	if err != nil || symbol == nil {
 		return nil, err
 	}
@@ -42,7 +40,7 @@ func (r *GitTreeEntryResolver) Symbol(ctx context.Context, args *struct {
 }
 
 func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
-	symbols, err := symbol.Compute(ctx, r.logger, r.repoResolver.RepoMatch.RepoName(), api.CommitID(r.oid), r.inputRev, args.Query, args.First, args.IncludePatterns)
+	symbols, err := symbol.Compute(ctx, r.repoResolver.RepoMatch.RepoName(), api.CommitID(r.oid), r.inputRev, args.Query, args.First, args.IncludePatterns)
 	if err != nil && len(symbols) == 0 {
 		return nil, err
 	}

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -252,7 +252,6 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 
 			if symbolMatch, _ := symbol.GetMatchAtLineCharacter(
 				ctx,
-				sglog.Scoped("newCommon", ""),
 				types.MinimalRepo{ID: common.Repo.ID, Name: common.Repo.Name},
 				common.CommitID,
 				strings.TrimLeft(blobPath, "/"),

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -11,8 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	sglog "github.com/sourcegraph/log"
-
 	"github.com/NYTimes/gziphandler"
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
@@ -306,7 +304,7 @@ func initRouter(db database.DB, router *mux.Router, codeIntelResolver graphqlbac
 	}, nil, index)))
 
 	// streaming search
-	router.Get(routeSearchStream).Handler(search.StreamHandler(sglog.Scoped("Router", "Streaming search"), db))
+	router.Get(routeSearchStream).Handler(search.StreamHandler(db))
 
 	// search badge
 	router.Get(routeSearchBadge).Handler(searchBadgeHandler())

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -102,7 +102,7 @@ func NewHandler(
 
 	m.Get(apirouter.GraphQL).Handler(trace.Route(handler(serveGraphQL(schema, rateLimiter, false))))
 
-	m.Get(apirouter.SearchStream).Handler(trace.Route(frontendsearch.StreamHandler(sglog.Scoped("NewHandler", "Handler"), db)))
+	m.Get(apirouter.SearchStream).Handler(trace.Route(frontendsearch.StreamHandler(db)))
 
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCliVersion).Handler(trace.Route(handler(srcCliVersionServe)))
@@ -143,7 +143,6 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	// zoekt-indexserver endpoints
 	indexer := &searchIndexerServer{
 		db:            db,
-		log:           sglog.Scoped("searchIndexerServer", "zoekt-indexserver endpoints"),
 		ListIndexable: backend.NewRepos(logger, db).ListIndexable,
 		RepoStore:     db.Repos(),
 		SearchContextsRepoRevs: func(ctx context.Context, repoIDs []api.RepoID) (map[api.RepoID][]string, error) {
@@ -173,7 +172,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.GraphQL).Handler(trace.Route(handler(serveGraphQL(schema, rateLimitWatcher, true))))
 	m.Get(apirouter.Configuration).Handler(trace.Route(handler(serveConfiguration)))
 	m.Path("/ping").Methods("GET").Name("ping").HandlerFunc(handlePing)
-	m.Get(apirouter.StreamingSearch).Handler(trace.Route(frontendsearch.StreamHandler(sglog.Scoped("Router", "StreamingSearch"), db)))
+	m.Get(apirouter.StreamingSearch).Handler(trace.Route(frontendsearch.StreamHandler(db)))
 	m.Get(apirouter.ComputeStream).Handler(trace.Route(newComputeStreamHandler()))
 
 	m.Get(apirouter.LSIFUpload).Handler(trace.Route(newCodeIntelUploadHandler(true)))

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/google/zoekt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -21,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -69,7 +66,7 @@ type searchIndexerServer struct {
 	Indexers interface {
 		// ReposSubset returns the subset of repoNames that hostname should
 		// index.
-		ReposSubset(ctx context.Context, logger log.Logger, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, indexable []types.MinimalRepo) ([]types.MinimalRepo, error)
+		ReposSubset(ctx context.Context, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, indexable []types.MinimalRepo) ([]types.MinimalRepo, error)
 		// Enabled is true if horizontal indexed search is enabled.
 		Enabled() bool
 	}
@@ -77,8 +74,6 @@ type searchIndexerServer struct {
 	// MinLastChangedDisabled is a feature flag for disabling more efficient
 	// polling by zoekt. This can be removed after v3.34 is cut (Dec 2021).
 	MinLastChangedDisabled bool
-
-	log log.Logger
 }
 
 // serveConfiguration is _only_ used by the zoekt index server. Zoekt does
@@ -203,7 +198,6 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 	}
 
 	b := searchbackend.GetIndexOptions(
-		h.log,
 		&siteConfig,
 		getRepoIndexOptions,
 		getSearchContextRevisions,
@@ -243,7 +237,7 @@ func (h *searchIndexerServer) serveList(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 
-		indexable, err = h.Indexers.ReposSubset(r.Context(), h.log, opt.Hostname, indexed, indexable)
+		indexable, err = h.Indexers.ReposSubset(r.Context(), opt.Hostname, indexed, indexable)
 		if err != nil {
 			return err
 		}

--- a/cmd/frontend/internal/httpapi/search_test.go
+++ b/cmd/frontend/internal/httpapi/search_test.go
@@ -11,12 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
-
-	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -41,7 +37,6 @@ func TestServeConfiguration(t *testing.T) {
 		SearchContextsRepoRevs: func(ctx context.Context, repoIDs []api.RepoID) (map[api.RepoID][]string, error) {
 			return map[api.RepoID][]string{6: {"a", "b"}}, nil
 		},
-		log: logtest.Scoped(t),
 	}
 
 	gitserver.Mocks.ResolveRevision = func(spec string, _ gitserver.ResolveRevisionOptions) (api.CommitID, error) {
@@ -149,7 +144,6 @@ func TestReposIndex(t *testing.T) {
 					Repos: allRepos,
 				},
 				Indexers: suffixIndexers(true),
-				log:      logtest.Scoped(t),
 			}
 
 			req := httptest.NewRequest("POST", "/", bytes.NewReader([]byte(tc.body)))
@@ -235,7 +229,7 @@ func (f *fakeRepoStore) StreamMinimalRepos(ctx context.Context, opt database.Rep
 // the suffix of hostname.
 type suffixIndexers bool
 
-func (b suffixIndexers) ReposSubset(ctx context.Context, logger log.Logger, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, indexable []types.MinimalRepo) ([]types.MinimalRepo, error) {
+func (b suffixIndexers) ReposSubset(ctx context.Context, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, indexable []types.MinimalRepo) ([]types.MinimalRepo, error) {
 	if !b.Enabled() {
 		return nil, errors.New("indexers disabled")
 	}

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	api2 "github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -41,7 +39,6 @@ func TestServeStream_empty(t *testing.T) {
 		flushTickerInternal: 1 * time.Millisecond,
 		pingTickerInterval:  1 * time.Millisecond,
 		searchClient:        mock,
-		log:                 logtest.Scoped(t),
 	})
 	defer ts.Close()
 
@@ -101,7 +98,6 @@ func TestServeStream_chunkMatches(t *testing.T) {
 		flushTickerInternal: 1 * time.Millisecond,
 		pingTickerInterval:  1 * time.Millisecond,
 		searchClient:        mock,
-		log:                 logtest.Scoped(t),
 	})
 	defer ts.Close()
 
@@ -219,7 +215,6 @@ func TestDisplayLimit(t *testing.T) {
 				flushTickerInternal: 1 * time.Millisecond,
 				pingTickerInterval:  1 * time.Millisecond,
 				searchClient:        mock,
-				log:                 logtest.Scoped(t),
 			})
 			defer ts.Close()
 

--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -76,7 +76,7 @@ func (s *Service) hybrid(ctx context.Context, p *protocol.Request, sender matchS
 			log.Int("indexedIgnorePaths", len(indexedIgnore)),
 			log.Int("unindexedSearchPaths", len(unindexedSearch)))
 
-		ok, err = zoektSearchIgnorePaths(ctx, s.Log, client, p, sender, indexed, indexedIgnore)
+		ok, err = zoektSearchIgnorePaths(ctx, client, p, sender, indexed, indexedIgnore)
 		if err != nil {
 			return nil, false, err
 		} else if !ok {
@@ -96,7 +96,7 @@ func (s *Service) hybrid(ctx context.Context, p *protocol.Request, sender matchS
 //
 // If we did not search the correct commit or we don't know if we did, ok is
 // false.
-func zoektSearchIgnorePaths(ctx context.Context, logger log.Logger, client zoekt.Streamer, p *protocol.Request, sender matchSender, indexed api.CommitID, ignoredPaths []string) (ok bool, err error) {
+func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *protocol.Request, sender matchSender, indexed api.CommitID, ignoredPaths []string) (ok bool, err error) {
 	qText, err := zoektCompile(&p.PatternInfo)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to compile query for zoekt")
@@ -108,7 +108,7 @@ func zoektSearchIgnorePaths(ctx context.Context, logger log.Logger, client zoekt
 	))
 
 	k := zoektutil.ResultCountFactor(1, int32(p.Limit), false)
-	opts := zoektutil.SearchOpts(ctx, logger, k, int32(p.Limit), nil)
+	opts := zoektutil.SearchOpts(ctx, k, int32(p.Limit), nil)
 	if deadline, ok := ctx.Deadline(); ok {
 		opts.MaxWallTime = time.Until(deadline) - 100*time.Millisecond
 	}

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -201,7 +201,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	if p.IsStructuralPat && p.Indexed {
 		// Execute the new structural search path that directly calls Zoekt.
 		// TODO use limit in indexed structural search
-		return structuralSearchWithZoekt(ctx, s.Log, p, sender)
+		return structuralSearchWithZoekt(ctx, p, sender)
 	}
 
 	// Compile pattern before fetching from store incase it is bad.

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -22,7 +22,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
@@ -288,7 +287,7 @@ func lookupMatcher(language string) string {
 	return ".generic"
 }
 
-func structuralSearchWithZoekt(ctx context.Context, logger log.Logger, p *protocol.Request, sender matchSender) (err error) {
+func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender matchSender) (err error) {
 	patternInfo := &search.TextPatternInfo{
 		Pattern:                      p.Pattern,
 		IsNegated:                    p.IsNegated,
@@ -310,7 +309,7 @@ func structuralSearchWithZoekt(ctx context.Context, logger log.Logger, p *protoc
 		p.Branch = "HEAD"
 	}
 	branchRepos := []zoektquery.BranchRepos{{Branch: p.Branch, Repos: roaring.BitmapOf(uint32(p.RepoID))}}
-	err = zoektSearch(ctx, logger, patternInfo, branchRepos, time.Since, p.IndexerEndpoints, nil, p.Repo, sender)
+	err = zoektSearch(ctx, patternInfo, branchRepos, time.Since, p.IndexerEndpoints, nil, p.Repo, sender)
 	if err != nil {
 		return err
 	}

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -14,7 +14,6 @@ import (
 	zoektquery "github.com/google/zoekt/query"
 
 	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -32,12 +31,10 @@ var (
 func getZoektClient(indexerEndpoints []string) zoekt.Streamer {
 	zoektOnce.Do(func() {
 		zoektClient = backend.NewMeteredSearcher(
-			log.Scoped("NewMeteredSearcher", ""),
 			"", // no hostname means its the aggregator
 			&backend.HorizontalSearcher{
 				Map:  &endpointMap,
 				Dial: backend.ZoektDial,
-				Log:  log.Scoped("HorizontalSearcher", ""),
 			},
 		)
 	})
@@ -124,7 +121,7 @@ const defaultMaxSearchResults = 30
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearch(ctx context.Context, logger log.Logger, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, endpoints []string, c chan<- zoektSearchStreamEvent, repo api.RepoName, sender matchSender) (err error) {
+func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, endpoints []string, c chan<- zoektSearchStreamEvent, repo api.RepoName, sender matchSender) (err error) {
 	defer func() {
 		if c != nil {
 			c <- zoektSearchStreamEvent{
@@ -143,7 +140,7 @@ func zoektSearch(ctx context.Context, logger log.Logger, args *search.TextPatter
 
 	// Choose sensible values for k when we generalize this.
 	k := zoektutil.ResultCountFactor(numRepos, args.FileMatchLimit, false)
-	searchOpts := zoektutil.SearchOpts(ctx, logger, k, args.FileMatchLimit, nil)
+	searchOpts := zoektutil.SearchOpts(ctx, k, args.FileMatchLimit, nil)
 	searchOpts.Whole = true
 
 	filePathPatterns, err := handleFilePathPatterns(args)

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -38,7 +38,7 @@ var Targets = []Target{
 			goEnterpriseImport,
 			noLocalHost,
 			lintGoDirectives(),
-			lintLoggingLibraries(),
+			// lintLoggingLibraries(),
 			goModGuards(),
 			lintSGExit(),
 		},

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -142,14 +140,14 @@ func newTestResolver(t *testing.T, db database.DB) *Resolver {
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	clock := func() time.Time { return now }
-	return newResolverWithClock(t, db, clock)
+	return newResolverWithClock(db, clock)
 }
 
 // newResolverWithClock is used in tests to set the clock manually.
-func newResolverWithClock(t *testing.T, db database.DB, clock func() time.Time) *Resolver {
+func newResolverWithClock(db database.DB, clock func() time.Time) *Resolver {
 	mockDB := edb.NewMockEnterpriseDBFrom(edb.NewEnterpriseDB(db))
 	mockDB.CodeMonitorsFunc.SetDefaultReturn(edb.CodeMonitorsWithClock(db, clock))
-	return &Resolver{db: mockDB, log: logtest.Scoped(t)}
+	return &Resolver{db: mockDB}
 }
 
 func marshalDateTime(t testing.TB, ts time.Time) string {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -8,8 +8,6 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -27,8 +25,7 @@ func NewResolver(db edb.EnterpriseDB) graphqlbackend.CodeMonitorsResolver {
 }
 
 type Resolver struct {
-	db  edb.EnterpriseDB
-	log log.Logger
+	db edb.EnterpriseDB
 }
 
 func (r *Resolver) Now() time.Time {
@@ -158,8 +155,7 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 
 		// Snapshot the state of the searched repos when the monitor is created so that
 		// we can distinguish new repos.
-		logger := r.log.Scoped("CreateCodeMonitor", "")
-		err = codemonitors.Snapshot(ctx, logger, tx.db, args.Trigger.Query, m.ID, settings)
+		err = codemonitors.Snapshot(ctx, tx.db, args.Trigger.Query, m.ID, settings)
 		if err != nil {
 			return nil, err
 		}
@@ -548,8 +544,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 
 			// Snapshot the state of the searched repos when the monitor is created so that
 			// we can distinguish new repos.
-			logger := r.log.Scoped("updateCodeMonitor", "")
-			err = codemonitors.Snapshot(ctx, logger, r.db, args.Trigger.Update.Query, monitorID, settings)
+			err = codemonitors.Snapshot(ctx, r.db, args.Trigger.Update.Query, monitorID, settings)
 			if err != nil {
 				return nil, err
 			}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -21,7 +21,7 @@ import (
 
 // NewResolver returns a new Resolver that uses the given database
 func NewResolver(db edb.EnterpriseDB) graphqlbackend.CodeMonitorsResolver {
-	return &Resolver{db: db, log: log.Scoped("codeMonitorResolver", "")}
+	return &Resolver{db: db}
 }
 
 type Resolver struct {
@@ -638,8 +638,7 @@ func (r *Resolver) transact(ctx context.Context) (*Resolver, error) {
 		return nil, err
 	}
 	return &Resolver{
-		db:  edb.NewEnterpriseDB(tx),
-		log: r.log,
+		db: edb.NewEnterpriseDB(tx),
 	}, nil
 }
 

--- a/enterprise/cmd/frontend/internal/compute/init.go
+++ b/enterprise/cmd/frontend/internal/compute/init.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute/streaming"
@@ -16,8 +14,6 @@ import (
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.ComputeResolver = resolvers.NewResolver(db)
-	enterpriseServices.NewComputeStreamHandler = func() http.Handler {
-		return streaming.NewComputeStreamHandler(log.Scoped("Init", "NewComputeStreamHandler"), db)
-	}
+	enterpriseServices.NewComputeStreamHandler = func() http.Handler { return streaming.NewComputeStreamHandler(db) }
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -3,8 +3,6 @@ package streaming
 import (
 	"context"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
@@ -86,7 +84,7 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 	}
 
 	patternType := "regexp"
-	searchClient := client.NewSearchClient(log.Scoped("NewComputeStream", ""), db, search.Indexed(log.Scoped("NewComputeStream", "")), search.SearcherURLs())
+	searchClient := client.NewSearchClient(db, search.Indexed(), search.SearcherURLs())
 	inputs, err := searchClient.Plan(ctx, "", &patternType, searchQuery, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {
 		close(eventsC)

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/sourcegraph/log"
-
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -25,12 +23,11 @@ import (
 const maxRequestDuration = time.Minute
 
 // NewComputeStreamHandler is an http handler which streams back compute results.
-func NewComputeStreamHandler(logger log.Logger, db database.DB) http.Handler {
+func NewComputeStreamHandler(db database.DB) http.Handler {
 	return &streamHandler{
 		db:                  db,
 		flushTickerInternal: 100 * time.Millisecond,
 		pingTickerInterval:  5 * time.Second,
-		log:                 logger,
 	}
 }
 
@@ -38,7 +35,6 @@ type streamHandler struct {
 	db                  database.DB
 	flushTickerInternal time.Duration
 	pingTickerInterval  time.Duration
-	log                 log.Logger
 }
 
 func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -66,7 +62,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	progress := &streamclient.ProgressAggregator{
 		Start:     start,
-		RepoNamer: streamclient.RepoNamer(ctx, h.log, h.db),
+		RepoNamer: streamclient.RepoNamer(ctx, h.db),
 		Trace:     trace.URL(trace.ID(ctx), conf.ExternalURL(), conf.Tracer()),
 	}
 

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -6,8 +6,6 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -23,8 +21,7 @@ func NewResolver(db database.DB) graphqlbackend.SearchContextsResolver {
 }
 
 type Resolver struct {
-	db  database.DB
-	log log.Logger
+	db database.DB
 }
 
 func (r *Resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {
@@ -65,7 +62,7 @@ func (r *Resolver) AutoDefinedSearchContexts(ctx context.Context) ([]graphqlback
 }
 
 func (r *Resolver) SearchContextBySpec(ctx context.Context, args graphqlbackend.SearchContextBySpecArgs) (graphqlbackend.SearchContextResolver, error) {
-	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.log, r.db, args.Spec)
+	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.db, args.Spec)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +119,7 @@ func (r *Resolver) UpdateSearchContext(ctx context.Context, args graphqlbackend.
 		}
 	}
 
-	original, err := searchcontexts.ResolveSearchContextSpec(ctx, r.log, r.db, searchContextSpec)
+	original, err := searchcontexts.ResolveSearchContextSpec(ctx, r.db, searchContextSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +180,7 @@ func (r *Resolver) DeleteSearchContext(ctx context.Context, args graphqlbackend.
 		return nil, err
 	}
 
-	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.log, r.db, searchContextSpec)
+	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.db, searchContextSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +287,7 @@ func (r *Resolver) SearchContexts(ctx context.Context, args *graphqlbackend.List
 }
 
 func (r *Resolver) IsSearchContextAvailable(ctx context.Context, args graphqlbackend.IsSearchContextAvailableArgs) (bool, error) {
-	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.log, r.db, args.Spec)
+	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.db, args.Spec)
 	if err != nil {
 		return false, err
 	}
@@ -329,7 +326,7 @@ func (r *Resolver) SearchContextByID(ctx context.Context, id graphql.ID) (graphq
 		return nil, err
 	}
 
-	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.log, r.db, searchContextSpec)
+	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.db, searchContextSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -36,7 +36,7 @@ func newTriggerQueryRunner(ctx context.Context, db edb.EnterpriseDB, metrics cod
 		Metrics:              metrics.workerMetrics,
 		MaximumRuntimePerJob: time.Minute,
 	}
-	worker := dbworker.NewWorker(ctx, createDBWorkerStoreForTriggerJobs(db), &queryRunner{db: db, log: log.Scoped("queryRunner", "")}, options)
+	worker := dbworker.NewWorker(ctx, createDBWorkerStoreForTriggerJobs(db), &queryRunner{db: db}, options)
 	return worker
 }
 
@@ -128,8 +128,7 @@ func createDBWorkerStoreForActionJobs(s edb.CodeMonitorStore) dbworkerstore.Stor
 }
 
 type queryRunner struct {
-	db  edb.EnterpriseDB
-	log log.Logger
+	db edb.EnterpriseDB
 }
 
 func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
@@ -176,7 +175,7 @@ func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, record work
 		// Only add an after filter when repo-aware monitors is disabled
 		query = newQueryWithAfterFilter(q)
 	}
-	results, searchErr := codemonitors.Search(ctx, r.log, r.db, query, m.ID, settings)
+	results, searchErr := codemonitors.Search(ctx, r.db, query, m.ID, settings)
 
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, searchErr)

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -11,7 +11,6 @@ import (
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
@@ -108,8 +107,8 @@ func Settings(ctx context.Context) (_ *schema.Settings, err error) {
 	return &unmarshaledSettings, nil
 }
 
-func Search(ctx context.Context, logger sglog.Logger, db database.DB, query string, monitorID int64, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
-	searchClient := client.NewSearchClient(sglog.Scoped("Settings", ""), db, search.Indexed(logger), search.SearcherURLs())
+func Search(ctx context.Context, db database.DB, query string, monitorID int64, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
+	searchClient := client.NewSearchClient(db, search.Indexed(), search.SearcherURLs())
 	inputs, err := searchClient.Plan(ctx, "V2", nil, query, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {
 		return nil, errcode.MakeNonRetryable(err)
@@ -117,12 +116,12 @@ func Search(ctx context.Context, logger sglog.Logger, db database.DB, query stri
 
 	// Inline job creation so we can mutate the commit job before running it
 	clients := searchClient.JobClients()
-	plan, err := predicate.Expand(ctx, logger, clients, inputs, inputs.Plan)
+	plan, err := predicate.Expand(ctx, clients, inputs, inputs.Plan)
 	if err != nil {
 		return nil, errcode.MakeNonRetryable(err)
 	}
 
-	planJob, err := jobutil.NewPlanJob(logger, inputs, plan)
+	planJob, err := jobutil.NewPlanJob(inputs, plan)
 	if err != nil {
 		return nil, errcode.MakeNonRetryable(err)
 	}
@@ -156,7 +155,7 @@ func Search(ctx context.Context, logger sglog.Logger, db database.DB, query stri
 				}
 			}
 		}
-		planJob, err = addCodeMonitorHook(logger, planJob, hook)
+		planJob, err = addCodeMonitorHook(planJob, hook)
 		if err != nil {
 			return nil, errcode.MakeNonRetryable(err)
 		}
@@ -184,20 +183,20 @@ func Search(ctx context.Context, logger sglog.Logger, db database.DB, query stri
 // Snapshot runs a dummy search that just saves the current state of the searched repos in the database.
 // On subsequent runs, this allows us to treat all new repos or sets of args as something new that should
 // be searched from the beginning.
-func Snapshot(ctx context.Context, logger sglog.Logger, db database.DB, query string, monitorID int64, settings *schema.Settings) error {
-	searchClient := client.NewSearchClient(logger, db, search.Indexed(sglog.Scoped("Snapshot", "")), search.SearcherURLs())
+func Snapshot(ctx context.Context, db database.DB, query string, monitorID int64, settings *schema.Settings) error {
+	searchClient := client.NewSearchClient(db, search.Indexed(), search.SearcherURLs())
 	inputs, err := searchClient.Plan(ctx, "V2", nil, query, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {
 		return err
 	}
 
 	clients := searchClient.JobClients()
-	plan, err := predicate.Expand(ctx, logger, clients, inputs, inputs.Plan)
+	plan, err := predicate.Expand(ctx, clients, inputs, inputs.Plan)
 	if err != nil {
 		return err
 	}
 
-	planJob, err := jobutil.NewPlanJob(logger, inputs, plan)
+	planJob, err := jobutil.NewPlanJob(inputs, plan)
 	if err != nil {
 		return err
 	}
@@ -206,7 +205,7 @@ func Snapshot(ctx context.Context, logger sglog.Logger, db database.DB, query st
 		return snapshotHook(ctx, db, gs, args, monitorID, repoID)
 	}
 
-	planJob, err = addCodeMonitorHook(logger, planJob, hook)
+	planJob, err = addCodeMonitorHook(planJob, hook)
 	if err != nil {
 		return err
 	}
@@ -214,7 +213,7 @@ func Snapshot(ctx context.Context, logger sglog.Logger, db database.DB, query st
 	// HACK(camdencheek): limit the concurrency of the commit search job
 	// because the db passed into this function might actually be a transaction
 	// and transactions cannot be used concurrently.
-	planJob = limitConcurrency(logger, planJob)
+	planJob = limitConcurrency(planJob)
 
 	_, err = planJob.Run(ctx, clients, streaming.NewNullStream())
 	return err
@@ -222,8 +221,8 @@ func Snapshot(ctx context.Context, logger sglog.Logger, db database.DB, query st
 
 var ErrInvalidMonitorQuery = errors.New("code monitor cannot use different patterns for different repos")
 
-func limitConcurrency(logger sglog.Logger, in job.Job) job.Job {
-	return jobutil.MapAtom(logger, in, func(atom job.Job) job.Job {
+func limitConcurrency(in job.Job) job.Job {
+	return jobutil.MapAtom(in, func(atom job.Job) job.Job {
 		switch typedAtom := atom.(type) {
 		case *commit.SearchJob:
 			jobCopy := *typedAtom
@@ -236,9 +235,9 @@ func limitConcurrency(logger sglog.Logger, in job.Job) job.Job {
 
 }
 
-func addCodeMonitorHook(logger sglog.Logger, in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err error) {
+func addCodeMonitorHook(in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err error) {
 	commitSearchJobCount := 0
-	return jobutil.MapAtom(logger, in, func(atom job.Job) job.Job {
+	return jobutil.MapAtom(in, func(atom job.Job) job.Job {
 		switch typedAtom := atom.(type) {
 		case *commit.SearchJob:
 			commitSearchJobCount++

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
@@ -126,7 +124,6 @@ func (r *insightResolver) Series() []graphqlbackend.InsightSeriesResolver {
 			workerBaseStore: r.workerBaseStore,
 			series:          series,
 			metadataStore:   r.metadataStore,
-			logger:          log.Scoped("insightSeriesResolver", ""),
 		})
 	}
 	return resolvers

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sourcegraph/log"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -36,7 +36,6 @@ type Observer struct {
 	mu    sync.Mutex
 	alert *search.Alert
 	err   error
-	Log   log.Logger
 }
 
 // reposExist returns true if one or more repos resolve. If the attempt
@@ -44,7 +43,7 @@ type Observer struct {
 // raising NoResolvedRepos alerts with suggestions when we know the original
 // query does not contain any repos to search.
 func (o *Observer) reposExist(ctx context.Context, options search.RepoOptions) bool {
-	repositoryResolver := &searchrepos.Resolver{DB: o.Db, Log: o.Log}
+	repositoryResolver := &searchrepos.Resolver{DB: o.Db}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0
 }
@@ -223,7 +222,7 @@ func (o *Observer) Done() (*search.Alert, error) {
 	}
 
 	if o.HasResults && o.err != nil {
-		o.Log.Error("Errors during search", log.Error(o.err))
+		log15.Error("Errors during search", "error", o.err)
 		return o.alert, nil
 	}
 

--- a/internal/search/alert/observer_test.go
+++ b/internal/search/alert/observer_test.go
@@ -39,7 +39,7 @@ func TestErrorToAlertStructuralSearch(t *testing.T) {
 	}
 	for _, test := range cases {
 		multiErr := errors.Append(nil, test.errors...)
-		haveAlert, _ := (&Observer{Log: logtest.Scoped(t)}).errorToAlert(context.Background(), multiErr)
+		haveAlert, _ := (&Observer{}).errorToAlert(context.Background(), multiErr)
 
 		if haveAlert != nil && haveAlert.Title != test.wantAlertTitle {
 			t.Fatalf("test %s, have alert: %q, want: %q", test.name, haveAlert.Title, test.wantAlertTitle)
@@ -77,7 +77,6 @@ func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 			Query:         q,
 			UserSettings:  &schema.Settings{},
 		},
-		Log: logtest.Scoped(t),
 	}
 
 	alert := sr.alertForNoResolvedRepos(context.Background(), q)

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -18,8 +18,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -51,11 +49,10 @@ type HorizontalSearcher struct {
 	Map interface {
 		Endpoints() ([]string, error)
 	}
-	Dial func(logger log.Logger, endpoint string) zoekt.Streamer
+	Dial func(endpoint string) zoekt.Streamer
 
 	mu      sync.RWMutex
 	clients map[string]zoekt.Streamer // addr -> client
-	Log     log.Logger
 }
 
 // StreamSearch does a search which merges the stream from every endpoint in Map, reordering results to produce a sorted stream.
@@ -447,7 +444,7 @@ func (s *HorizontalSearcher) syncSearchers() (map[string]zoekt.Streamer, error) 
 		// Try re-use
 		client, ok := s.clients[addr]
 		if !ok {
-			client = s.Dial(s.Log, addr)
+			client = s.Dial(addr)
 		}
 		clients[addr] = client
 	}

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -7,8 +7,7 @@ import (
 
 	"github.com/google/zoekt"
 	"github.com/grafana/regexp"
-
-	"github.com/sourcegraph/log"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -86,7 +85,6 @@ type getRepoIndexOptsFn func(repoID int32) (*RepoIndexOptions, error)
 // GetIndexOptions returns a json blob for consumption by
 // sourcegraph-zoekt-indexserver. It is for repos based on site settings c.
 func GetIndexOptions(
-	log log.Logger,
 	c *schema.SiteConfiguration,
 	getRepoIndexOptions getRepoIndexOptsFn,
 	getSearchContextRevisions func(repoID int32) ([]string, error),
@@ -97,7 +95,7 @@ func GetIndexOptions(
 	// future we want a more intelligent global limit based on scale.
 	sema := make(chan struct{}, 32)
 	results := make([][]byte, len(repos))
-	getSiteConfigRevisions := siteConfigRevisionsRuleFunc(log, c)
+	getSiteConfigRevisions := siteConfigRevisionsRuleFunc(c)
 
 	for i := range repos {
 		sema <- struct{}{}
@@ -203,7 +201,7 @@ func getIndexOptions(
 
 type revsRuleFunc func(*RepoIndexOptions) (revs []string)
 
-func siteConfigRevisionsRuleFunc(logger log.Logger, c *schema.SiteConfiguration) revsRuleFunc {
+func siteConfigRevisionsRuleFunc(c *schema.SiteConfiguration) revsRuleFunc {
 	if c == nil || c.ExperimentalFeatures == nil {
 		return nil
 	}
@@ -215,7 +213,7 @@ func siteConfigRevisionsRuleFunc(logger log.Logger, c *schema.SiteConfiguration)
 		case rule.Name != "":
 			namePattern, err := regexp.Compile(rule.Name)
 			if err != nil {
-				logger.Error("error compiling regex from search.index.revisions", log.String("regex", rule.Name), log.Error(err))
+				log15.Error("error compiling regex from search.index.revisions", "regex", rule.Name, "err", err)
 				continue
 			}
 

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -260,7 +258,7 @@ func TestGetIndexOptions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			getSearchContextRevisions := func(int32) ([]string, error) { return tc.searchContextRevs, nil }
 
-			b := GetIndexOptions(logtest.Scoped(t), &tc.conf, getRepoIndexOptions, getSearchContextRevisions, tc.repo)
+			b := GetIndexOptions(&tc.conf, getRepoIndexOptions, getSearchContextRevisions, tc.repo)
 
 			var got zoektIndexOptions
 			if err := json.Unmarshal(b, &got); err != nil {
@@ -332,7 +330,7 @@ func TestGetIndexOptions_getVersion(t *testing.T) {
 				}, nil
 			}
 
-			b := GetIndexOptions(logtest.Scoped(t), &conf, getRepoIndexOptions, getSearchContextRevs, 1)
+			b := GetIndexOptions(&conf, getRepoIndexOptions, getSearchContextRevs, 1)
 
 			var got zoektIndexOptions
 			if err := json.Unmarshal(b, &got); err != nil {
@@ -387,7 +385,7 @@ func TestGetIndexOptions_batch(t *testing.T) {
 
 	getSearchContextRevs := func(int32) ([]string, error) { return nil, nil }
 
-	b := GetIndexOptions(logtest.Scoped(t), &schema.SiteConfiguration{}, getRepoIndexOptions, getSearchContextRevs, repos...)
+	b := GetIndexOptions(&schema.SiteConfiguration{}, getRepoIndexOptions, getSearchContextRevs, repos...)
 	dec := json.NewDecoder(bytes.NewReader(b))
 	got := make([]zoektIndexOptions, len(repos))
 	for i := range repos {

--- a/internal/search/backend/indexers.go
+++ b/internal/search/backend/indexers.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/google/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -30,7 +28,7 @@ type Indexers struct {
 
 	// Indexed returns a set of repository names currently indexed on
 	// endpoint. If indexed fails, it is expected to return an empty set.
-	Indexed func(ctx context.Context, logger log.Logger, endpoint string) map[uint32]*zoekt.MinimalRepoListEntry
+	Indexed func(ctx context.Context, endpoint string) map[uint32]*zoekt.MinimalRepoListEntry
 }
 
 // ReposSubset returns the subset of repoNames that hostname should index.
@@ -40,7 +38,7 @@ type Indexers struct {
 // indexed is the set of repositories currently indexed by hostname.
 //
 // An error is returned if hostname is not part of the Indexers endpoints.
-func (c *Indexers) ReposSubset(ctx context.Context, logger log.Logger, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, repos []types.MinimalRepo) ([]types.MinimalRepo, error) {
+func (c *Indexers) ReposSubset(ctx context.Context, hostname string, indexed map[uint32]*zoekt.MinimalRepoListEntry, repos []types.MinimalRepo) ([]types.MinimalRepo, error) {
 	if !c.Enabled() {
 		return repos, nil
 	}
@@ -78,7 +76,7 @@ func (c *Indexers) ReposSubset(ctx context.Context, logger log.Logger, hostname 
 	// Only include repos from other if the assigned endpoint has not yet
 	// indexed the repository.
 	for assigned, otherRepos := range other {
-		drop := c.Indexed(ctx, logger, assigned)
+		drop := c.Indexed(ctx, assigned)
 		for _, r := range otherRepos {
 			if _, ok := drop[uint32(r.ID)]; !ok {
 				subset = append(subset, r)

--- a/internal/search/backend/indexers_test.go
+++ b/internal/search/backend/indexers_test.go
@@ -3,17 +3,12 @@ package backend
 import (
 	"context"
 	"fmt"
-
-	"github.com/sourcegraph/log"
-
 	"math/rand"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -22,7 +17,7 @@ func TestReposSubset(t *testing.T) {
 	var indexed map[string][]types.MinimalRepo
 	index := &Indexers{
 		Map: prefixMap([]string{"foo", "bar", "baz.fully.qualified:80"}),
-		Indexed: func(ctx context.Context, logger log.Logger, k string) map[uint32]*zoekt.MinimalRepoListEntry {
+		Indexed: func(ctx context.Context, k string) map[uint32]*zoekt.MinimalRepoListEntry {
 			set := map[uint32]*zoekt.MinimalRepoListEntry{}
 			if indexed == nil {
 				return set
@@ -101,7 +96,7 @@ func TestReposSubset(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			indexed = tc.indexed
-			got, err := index.ReposSubset(ctx, logtest.Scoped(t), tc.hostname, index.Indexed(ctx, logtest.Scoped(t), tc.hostname), tc.repos)
+			got, err := index.ReposSubset(ctx, tc.hostname, index.Indexed(ctx, tc.hostname), tc.repos)
 			if tc.errS != "" {
 				got := fmt.Sprintf("%v", err)
 				if !strings.Contains(got, tc.errS) {

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -7,13 +7,12 @@ import (
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
+	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/rpc"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -31,14 +30,12 @@ type meteredSearcher struct {
 	zoekt.Streamer
 
 	hostname string
-	log      sglog.Logger
 }
 
-func NewMeteredSearcher(logger sglog.Logger, hostname string, z zoekt.Streamer) zoekt.Streamer {
+func NewMeteredSearcher(hostname string, z zoekt.Streamer) zoekt.Streamer {
 	return &meteredSearcher{
 		Streamer: z,
 		hostname: hostname,
-		log:      logger,
 	}
 }
 
@@ -104,7 +101,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 			newOpts.SpanContext = spanContext
 			opts = &newOpts
 		} else {
-			m.log.Warn("meteredSearcher: Error injecting new span context into map:", sglog.Error(err))
+			log15.Warn("meteredSearcher: Error injecting new span context into map: %s", err)
 		}
 	}
 

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/google/zoekt"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -38,12 +36,11 @@ type SearchClient interface {
 	JobClients() job.RuntimeClients
 }
 
-func NewSearchClient(logger log.Logger, db database.DB, zoektStreamer zoekt.Streamer, searcherURLs *endpoint.Map) SearchClient {
+func NewSearchClient(db database.DB, zoektStreamer zoekt.Streamer, searcherURLs *endpoint.Map) SearchClient {
 	return &searchClient{
 		db:           db,
 		zoekt:        zoektStreamer,
 		searcherURLs: searcherURLs,
-		log:          logger,
 	}
 }
 
@@ -51,7 +48,6 @@ type searchClient struct {
 	db           database.DB
 	zoekt        zoekt.Streamer
 	searcherURLs *endpoint.Map
-	log          log.Logger
 }
 
 func (s *searchClient) Plan(
@@ -63,7 +59,7 @@ func (s *searchClient) Plan(
 	settings *schema.Settings,
 	sourcegraphDotComMode bool,
 ) (*run.SearchInputs, error) {
-	return run.NewSearchInputs(ctx, s.log, s.db, version, patternType, searchQuery, protocol, settings, sourcegraphDotComMode)
+	return run.NewSearchInputs(ctx, s.db, version, patternType, searchQuery, protocol, settings, sourcegraphDotComMode)
 }
 
 func (s *searchClient) Execute(
@@ -71,7 +67,7 @@ func (s *searchClient) Execute(
 	stream streaming.Sender,
 	inputs *run.SearchInputs,
 ) (*search.Alert, error) {
-	return execute.Execute(ctx, s.log, stream, inputs, s.JobClients())
+	return execute.Execute(ctx, stream, inputs, s.JobClients())
 }
 
 func (s *searchClient) JobClients() job.RuntimeClients {

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/opentracing/opentracing-go/log"
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -33,7 +32,6 @@ type SearchJob struct {
 	Limit                int
 	IncludeModifiedFiles bool
 	Concurrency          int
-	Log                  sglog.Logger
 
 	// CodeMonitorSearchWrapper, if set, will wrap the commit search with extra logic specific to code monitors.
 	CodeMonitorSearchWrapper CodeMonitorHook `json:"-"`
@@ -96,7 +94,7 @@ func (j *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 		return doSearch(args)
 	}
 
-	repos := searchrepos.Resolver{DB: clients.DB, Opts: j.RepoOpts, Log: j.Log}
+	repos := searchrepos.Resolver{DB: clients.DB, Opts: j.RepoOpts}
 	return nil, repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
 		bounded := goroutine.NewBounded(j.Concurrency)
 

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -10,8 +10,6 @@ import (
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -35,8 +33,6 @@ var (
 	indexersOnce sync.Once
 	indexers     *backend.Indexers
 
-	logger log.Logger
-
 	indexedListTTL = func() time.Duration {
 		ttl, _ := time.ParseDuration(env.Get("SRC_INDEXED_SEARCH_LIST_CACHE_TTL", "", "Indexed search list cache TTL"))
 		if ttl == 0 {
@@ -49,8 +45,8 @@ var (
 		return ttl
 	}()
 
-	indexedDialer = backend.NewCachedZoektDialer(logger, func(logger log.Logger, endpoint string) zoekt.Streamer {
-		return backend.NewCachedSearcher(indexedListTTL, backend.ZoektDial(logger, endpoint))
+	indexedDialer = backend.NewCachedZoektDialer(func(endpoint string) zoekt.Streamer {
+		return backend.NewCachedSearcher(indexedListTTL, backend.ZoektDial(endpoint))
 	})
 )
 
@@ -76,7 +72,7 @@ func IndexedEndpoints() *endpoint.Map {
 
 var ErrIndexDisabled = errors.New("indexed search has been disabled")
 
-func Indexed(logger log.Logger) zoekt.Streamer {
+func Indexed() zoekt.Streamer {
 	if !conf.SearchIndexEnabled() {
 		return &backend.FakeSearcher{SearchError: ErrIndexDisabled, ListError: ErrIndexDisabled}
 	}
@@ -84,12 +80,10 @@ func Indexed(logger log.Logger) zoekt.Streamer {
 	indexedSearchOnce.Do(func() {
 		if eps := IndexedEndpoints(); eps != nil {
 			indexedSearch = backend.NewCachedSearcher(indexedListTTL, backend.NewMeteredSearcher(
-				logger,
 				"", // no hostname means its the aggregator
 				&backend.HorizontalSearcher{
 					Map:  eps,
 					Dial: indexedDialer,
-					Log:  logger,
 				}))
 		}
 	})
@@ -132,9 +126,9 @@ func getEnv(environ []string, key string) (string, bool) {
 	return "", false
 }
 
-func reposAtEndpoint(dial func(log.Logger, string) zoekt.Streamer) func(context.Context, log.Logger, string) map[uint32]*zoekt.MinimalRepoListEntry {
-	return func(ctx context.Context, logger log.Logger, endpoint string) map[uint32]*zoekt.MinimalRepoListEntry {
-		cl := dial(logger, endpoint)
+func reposAtEndpoint(dial func(string) zoekt.Streamer) func(context.Context, string) map[uint32]*zoekt.MinimalRepoListEntry {
+	return func(ctx context.Context, endpoint string) map[uint32]*zoekt.MinimalRepoListEntry {
+		cl := dial(endpoint)
 
 		resp, err := cl.List(ctx, &query.Const{Value: true}, &zoekt.ListOptions{Minimal: true})
 		if err != nil {

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -3,8 +3,6 @@ package execute
 import (
 	"context"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
@@ -18,7 +16,6 @@ import (
 // expand predicates, create jobs, and execute those jobs.
 func Execute(
 	ctx context.Context,
-	logger log.Logger,
 	stream streaming.Sender,
 	inputs *run.SearchInputs,
 	clients job.RuntimeClients,
@@ -30,12 +27,12 @@ func Execute(
 	}()
 
 	plan := inputs.Plan
-	plan, err = predicate.Expand(ctx, logger, clients, inputs, plan)
+	plan, err = predicate.Expand(ctx, clients, inputs, plan)
 	if err != nil {
 		return nil, err
 	}
 
-	planJob, err := jobutil.NewPlanJob(logger, inputs, plan)
+	planJob, err := jobutil.NewPlanJob(inputs, plan)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/job/jobutil/alert.go
+++ b/internal/search/job/jobutil/alert.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/opentracing/opentracing-go/log"
 
-	sglog "github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchalert "github.com/sourcegraph/sourcegraph/internal/search/alert"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -20,21 +18,19 @@ import (
 
 // NewAlertJob creates a job that translates errors from child jobs
 // into alerts when necessary.
-func NewAlertJob(logger sglog.Logger, inputs *run.SearchInputs, child job.Job) job.Job {
+func NewAlertJob(inputs *run.SearchInputs, child job.Job) job.Job {
 	if _, ok := child.(*NoopJob); ok {
 		return child
 	}
 	return &alertJob{
 		inputs: inputs,
 		child:  child,
-		log:    logger,
 	}
 }
 
 type alertJob struct {
 	inputs *run.SearchInputs
 	child  job.Job
-	log    sglog.Logger
 }
 
 func (j *alertJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
@@ -49,7 +45,6 @@ func (j *alertJob) Run(ctx context.Context, clients job.RuntimeClients, stream s
 	ao := searchalert.Observer{
 		Db:           clients.DB,
 		SearchInputs: j.inputs,
-		Log:          j.log,
 		HasResults:   countingStream.Count() > 0,
 	}
 	if err != nil {

--- a/internal/search/job/jobutil/feeling_lucky_search_job_test.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold"
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/mockjob"
@@ -28,7 +26,7 @@ func TestNewFeelingLuckySearchJob(t *testing.T) {
 		}
 		var j job.Job
 		plan, _ := query.Pipeline(query.InitLiteral(q))
-		fj := NewFeelingLuckySearchJob(logtest.Scoped(t), nil, inputs, plan)
+		fj := NewFeelingLuckySearchJob(nil, inputs, plan)
 		generated := []job.Job{}
 
 		for _, next := range fj.generators {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -5,10 +5,9 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
+	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -31,10 +30,10 @@ import (
 )
 
 // NewPlanJob converts a query.Plan into its job tree representation.
-func NewPlanJob(logger log.Logger, inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
+func NewPlanJob(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
 	children := make([]job.Job, 0, len(plan))
 	for _, q := range plan {
-		child, err := NewBasicJob(logger, inputs, q)
+		child, err := NewBasicJob(inputs, q)
 		if err != nil {
 			return nil, err
 		}
@@ -44,14 +43,14 @@ func NewPlanJob(logger log.Logger, inputs *run.SearchInputs, plan query.Plan) (j
 	jobTree := NewOrJob(children...)
 
 	if inputs.PatternType == query.SearchTypeLucky {
-		jobTree = NewFeelingLuckySearchJob(logger, jobTree, inputs, plan)
+		jobTree = NewFeelingLuckySearchJob(jobTree, inputs, plan)
 	}
 
-	return NewAlertJob(logger, inputs, jobTree), nil
+	return NewAlertJob(inputs, jobTree), nil
 }
 
 // NewBasicJob converts a query.Basic into its job tree representation.
-func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
+func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 	var children []job.Job
 	addJob := func(j job.Job) {
 		children = append(children, j)
@@ -65,7 +64,7 @@ func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (jo
 		resultTypes := computeResultTypes(types, b, inputs.PatternType)
 		fileMatchLimit := int32(computeFileMatchLimit(b, inputs.Protocol))
 		selector, _ := filter.SelectPathFromString(b.FindValue(query.FieldSelect)) // Invariant: select is validated
-		features := toFeatures(logger, inputs.Features)
+		features := toFeatures(inputs.Features)
 		repoOptions := toRepoOptions(b, inputs.UserSettings)
 		repoUniverseSearch, skipRepoSubsetSearch, runZoektOverRepos := jobMode(b, resultTypes, inputs.PatternType, inputs.OnSourcegraphDotCom)
 
@@ -76,7 +75,6 @@ func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (jo
 			features:       &features,
 			fileMatchLimit: fileMatchLimit,
 			selector:       selector,
-			log:            logger,
 		}
 
 		if resultTypes.Has(result.TypeFile | result.TypePath) {
@@ -99,7 +97,6 @@ func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (jo
 					repoOpts:         repoOptions,
 					useIndex:         b.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(b.ToParseTree()),
-					log:              logger,
 				})
 			}
 		}
@@ -124,7 +121,6 @@ func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (jo
 					repoOpts:         repoOptions,
 					useIndex:         b.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(b.ToParseTree()),
-					log:              logger,
 				})
 			}
 		}
@@ -140,13 +136,11 @@ func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (jo
 				Limit:                int(fileMatchLimit),
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
 				Concurrency:          4,
-				Log:                  logger,
 			})
 		}
 
 		addJob(&searchrepos.ComputeExcludedJob{
 			RepoOpts: repoOptions,
-			Log:      logger,
 		})
 	}
 
@@ -154,7 +148,7 @@ func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (jo
 		// This block generates a job for all the backend types that cannot
 		// directly use a query.Basic and need to be split into query.Flat
 		// first.
-		flatJob, err := toFlatJobs(logger, inputs, b)
+		flatJob, err := toFlatJobs(inputs, b)
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +167,7 @@ func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (jo
 	{ // Apply subrepo permissions checks
 		checker := authz.DefaultSubRepoPermsChecker
 		if authz.SubRepoEnabled(checker) {
-			basicJob = NewFilterJob(logger, basicJob)
+			basicJob = NewFilterJob(basicJob)
 		}
 	}
 
@@ -199,7 +193,7 @@ func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (jo
 
 		if inputs.OnSourcegraphDotCom && b.Pattern != nil {
 			if _, ok := b.Pattern.(query.Pattern); ok {
-				basicJob = orderSearcherJob(logger, basicJob)
+				basicJob = orderSearcherJob(basicJob)
 			}
 		}
 
@@ -210,7 +204,7 @@ func NewBasicJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (jo
 
 // orderSearcherJob ensures that, if a searcher job exists, then it is only ever
 // run sequentially after a Zoekt search has returned all its results.
-func orderSearcherJob(logger log.Logger, j job.Job) job.Job {
+func orderSearcherJob(j job.Job) job.Job {
 	// First collect the searcher job, if any, and delete it from the tree.
 	// This job will be sequentially ordered after any Zoekt jobs. We assume
 	// at most one searcher job exists.
@@ -225,7 +219,6 @@ func orderSearcherJob(logger log.Logger, j job.Job) job.Job {
 			}
 			return current
 		},
-		Log: logger,
 	}
 
 	newJob := collector.Map(j)
@@ -252,7 +245,6 @@ func orderSearcherJob(logger log.Logger, j job.Job) job.Job {
 			}
 			return current
 		},
-		Log: logger,
 	}
 
 	newJob = orderer.Map(newJob)
@@ -266,7 +258,7 @@ func orderSearcherJob(logger log.Logger, j job.Job) job.Job {
 }
 
 // NewFlatJob creates all jobs that are built from a query.Flat.
-func NewFlatJob(logger log.Logger, searchInputs *run.SearchInputs, f query.Flat) (job.Job, error) {
+func NewFlatJob(searchInputs *run.SearchInputs, f query.Flat) (job.Job, error) {
 	maxResults := f.MaxResults(searchInputs.DefaultLimit())
 	types, _ := f.IncludeExcludeValues(query.FieldType)
 	resultTypes := computeResultTypes(types, f.ToBasic(), searchInputs.PatternType)
@@ -278,7 +270,7 @@ func NewFlatJob(logger log.Logger, searchInputs *run.SearchInputs, f query.Flat)
 	fileMatchLimit := int32(computeFileMatchLimit(f.ToBasic(), searchInputs.Protocol))
 	selector, _ := filter.SelectPathFromString(f.FindValue(query.FieldSelect)) // Invariant: select is validated
 
-	features := toFeatures(logger, searchInputs.Features)
+	features := toFeatures(searchInputs.Features)
 	repoOptions := toRepoOptions(f.ToBasic(), searchInputs.UserSettings)
 
 	repoUniverseSearch, skipRepoSubsetSearch, _ := jobMode(f.ToBasic(), resultTypes, searchInputs.PatternType, searchInputs.OnSourcegraphDotCom)
@@ -304,7 +296,6 @@ func NewFlatJob(logger log.Logger, searchInputs *run.SearchInputs, f query.Flat)
 					Indexed:         false,
 					UseFullDeadline: useFullDeadline,
 					Features:        features,
-					Log:             logger,
 				}
 
 				addJob(&repoPagerJob{
@@ -312,7 +303,6 @@ func NewFlatJob(logger log.Logger, searchInputs *run.SearchInputs, f query.Flat)
 					repoOpts:         repoOptions,
 					useIndex:         f.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
-					log:              logger,
 				})
 			}
 		}
@@ -331,7 +321,6 @@ func NewFlatJob(logger log.Logger, searchInputs *run.SearchInputs, f query.Flat)
 					repoOpts:         repoOptions,
 					useIndex:         f.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
-					log:              logger,
 				})
 			}
 		}
@@ -361,7 +350,6 @@ func NewFlatJob(logger log.Logger, searchInputs *run.SearchInputs, f query.Flat)
 				UseIndex:         f.Index(),
 				ContainsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
 				RepoOpts:         repoOptions,
-				Log:              logger,
 			})
 		}
 
@@ -454,7 +442,6 @@ func NewFlatJob(logger log.Logger, searchInputs *run.SearchInputs, f query.Flat)
 						FilePatternsReposMustInclude: patternInfo.FilePatternsReposMustInclude,
 						FilePatternsReposMustExclude: patternInfo.FilePatternsReposMustExclude,
 						Mode:                         mode,
-						Log:                          logger,
 					})
 				}
 			}
@@ -675,7 +662,6 @@ type jobBuilder struct {
 	features       *search.Features
 	fileMatchLimit int32
 	selector       filter.SelectPath
-	log            log.Logger
 }
 
 func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Job, error) {
@@ -710,14 +696,12 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 			GlobalZoektQuery: globalZoektQuery,
 			ZoektArgs:        zoektArgs,
 			RepoOpts:         b.repoOptions,
-			Log:              b.log,
 		}, nil
 	case search.TextRequest:
 		return &zoekt.GlobalTextSearchJob{
 			GlobalZoektQuery: globalZoektQuery,
 			ZoektArgs:        zoektArgs,
 			RepoOpts:         b.repoOptions,
-			Log:              b.log,
 		}, nil
 	}
 	return nil, errors.Errorf("attempt to create unrecognized zoekt global search with value %v", typ)
@@ -804,11 +788,11 @@ func jobMode(b query.Basic, resultTypes result.Types, st query.SearchType, onSou
 	return repoUniverseSearch, skipRepoSubsetSearch, runZoektOverRepos
 }
 
-func toFeatures(logger log.Logger, flagSet *featureflag.FlagSet) search.Features {
+func toFeatures(flagSet *featureflag.FlagSet) search.Features {
 	if flagSet == nil {
 		flagSet = &featureflag.FlagSet{}
 		metricFeatureFlagUnavailable.Inc()
-		logger.Warn("search feature flags are not available")
+		log15.Warn("search feature flags are not available")
 	}
 
 	return search.Features{
@@ -818,7 +802,7 @@ func toFeatures(logger log.Logger, flagSet *featureflag.FlagSet) search.Features
 }
 
 // toAndJob creates a new job from a basic query whose pattern is an And operator at the root.
-func toAndJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
+func toAndJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 	// Invariant: this function is only reachable from callers that
 	// guarantee a root node with one or more queryOperands.
 	queryOperands := b.Pattern.(query.Operator).Operands
@@ -833,7 +817,7 @@ func toAndJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (job.J
 
 	operands := make([]job.Job, 0, len(queryOperands))
 	for _, queryOperand := range queryOperands {
-		operand, err := toPatternExpressionJob(logger, inputs, b.MapPattern(queryOperand))
+		operand, err := toPatternExpressionJob(inputs, b.MapPattern(queryOperand))
 		if err != nil {
 			return nil, err
 		}
@@ -844,14 +828,14 @@ func toAndJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (job.J
 }
 
 // toOrJob creates a new job from a basic query whose pattern is an Or operator at the top level
-func toOrJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
+func toOrJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 	// Invariant: this function is only reachable from callers that
 	// guarantee a root node with one or more queryOperands.
 	queryOperands := b.Pattern.(query.Operator).Operands
 
 	operands := make([]job.Job, 0, len(queryOperands))
 	for _, term := range queryOperands {
-		operand, err := toPatternExpressionJob(logger, inputs, b.MapPattern(term))
+		operand, err := toPatternExpressionJob(inputs, b.MapPattern(term))
 		if err != nil {
 			return nil, err
 		}
@@ -860,7 +844,7 @@ func toOrJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (job.Jo
 	return NewOrJob(operands...), nil
 }
 
-func toPatternExpressionJob(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
+func toPatternExpressionJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 	switch term := b.Pattern.(type) {
 	case query.Operator:
 		if len(term.Operands) == 0 {
@@ -869,12 +853,12 @@ func toPatternExpressionJob(logger log.Logger, inputs *run.SearchInputs, b query
 
 		switch term.Kind {
 		case query.And:
-			return toAndJob(logger, inputs, b)
+			return toAndJob(inputs, b)
 		case query.Or:
-			return toOrJob(logger, inputs, b)
+			return toOrJob(inputs, b)
 		}
 	case query.Pattern:
-		return NewFlatJob(logger, inputs, query.Flat{Parameters: b.Parameters, Pattern: &term})
+		return NewFlatJob(inputs, query.Flat{Parameters: b.Parameters, Pattern: &term})
 	case query.Parameter:
 		// evaluatePatternExpression does not process Parameter nodes.
 		return NewNoopJob(), nil
@@ -885,10 +869,10 @@ func toPatternExpressionJob(logger log.Logger, inputs *run.SearchInputs, b query
 
 // toFlatJobs takes a query.Basic and expands it into a set query.Flat that are converted
 // to jobs and joined with AndJob and OrJob.
-func toFlatJobs(logger log.Logger, inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
+func toFlatJobs(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 	if b.Pattern == nil {
-		return NewFlatJob(logger, inputs, query.Flat{Parameters: b.Parameters, Pattern: nil})
+		return NewFlatJob(inputs, query.Flat{Parameters: b.Parameters, Pattern: nil})
 	} else {
-		return toPatternExpressionJob(logger, inputs, b)
+		return toPatternExpressionJob(inputs, b)
 	}
 }

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/hexops/autogold"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
@@ -347,7 +345,7 @@ func TestNewPlanJob(t *testing.T) {
 				OnSourcegraphDotCom: true,
 			}
 
-			j, err := NewPlanJob(logtest.Scoped((t)), inputs, plan)
+			j, err := NewPlanJob(inputs, plan)
 			require.NoError(t, err)
 
 			tc.want.Equal(t, "\n"+PrettySexp(j))
@@ -366,7 +364,7 @@ func TestToEvaluateJob(t *testing.T) {
 		}
 
 		b, _ := query.ToBasicQuery(q)
-		j, _ := toFlatJobs(logtest.Scoped(t), inputs, b)
+		j, _ := toFlatJobs(inputs, b)
 		return "\n" + PrettySexp(j) + "\n"
 	}
 

--- a/internal/search/job/jobutil/mapper_test.go
+++ b/internal/search/job/jobutil/mapper_test.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/hexops/autogold"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 )
 
@@ -19,7 +17,6 @@ func TestMap(t *testing.T) {
 		MapAndJob: func(children []job.Job) []job.Job {
 			return append(children, NewOrJob(NewNoopJob(), NewNoopJob()))
 		},
-		Log: logtest.Scoped(t),
 	}
 
 	autogold.Want("basic and-job mapper", `

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold"
-	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -40,7 +39,6 @@ func TestSexp(t *testing.T) {
           NoopJob)))))
 `).Equal(t, fmt.Sprintf("\n%s\n", PrettySexp(
 		NewFilterJob(
-			logtest.Scoped(t),
 			NewLimitJob(
 				100,
 				NewTimeoutJob(
@@ -105,7 +103,6 @@ flowchart TB
           15([NoopJob])
           `).Equal(t, fmt.Sprintf("\n%s", PrettyMermaid(
 		NewFilterJob(
-			logtest.Scoped(t),
 			NewLimitJob(
 				100,
 				NewTimeoutJob(
@@ -156,7 +153,6 @@ func TestPrettyJSON(t *testing.T) {
   "value": "SubRepoPermissions"
 }`).Equal(t, fmt.Sprintf("\n%s", PrettyJSON(
 		NewFilterJob(
-			logtest.Scoped(t),
 			NewLimitJob(
 				100,
 				NewTimeoutJob(
@@ -172,14 +168,13 @@ func TestPrettyJSON(t *testing.T) {
 							NewNoopJob(),
 							NewNoopJob()))))))))
 	test := func(input string) string {
-		log := logtest.Scoped(t)
 		q, _ := query.ParseLiteral(input)
 		b, _ := query.ToBasicQuery(q)
 		inputs := &run.SearchInputs{
 			UserSettings: &schema.Settings{},
 			Protocol:     search.Streaming,
 		}
-		j, _ := NewBasicJob(log, inputs, b)
+		j, _ := NewBasicJob(inputs, b)
 		return PrettyJSONVerbose(j)
 	}
 
@@ -226,8 +221,7 @@ func TestPrettyJSON(t *testing.T) {
               "ArchivedSet": false,
               "NoArchived": true,
               "OnlyArchived": false
-            },
-            "Log": {}
+            }
           }
         },
         {
@@ -261,8 +255,7 @@ func TestPrettyJSON(t *testing.T) {
                   "Features": {
                     "ContentBasedLangFilters": false,
                     "HybridSearch": false
-                  },
-                  "Log": {}
+                  }
                 }
               }
             },
@@ -296,8 +289,7 @@ func TestPrettyJSON(t *testing.T) {
                   "ContentBasedLangFilters": false,
                   "HybridSearch": false
                 },
-                "Mode": 0,
-                "Log": {}
+                "Mode": 0
               }
             }
           ]

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/opentracing/opentracing-go/log"
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -21,12 +20,11 @@ type repoPagerJob struct {
 	useIndex         query.YesNoOnly // whether to include indexed repos
 	containsRefGlobs bool            // whether to include repositories with refs
 	child            job.Job         // child job tree that need populating a repos field to run
-	log              sglog.Logger
 }
 
 // setRepos populates the repos field for all jobs that need repos. Jobs are
 // copied, ensuring this function is side-effect free.
-func setRepos(logger sglog.Logger, job job.Job, indexed *zoekt.IndexedRepoRevs, unindexed []*search.RepositoryRevisions) job.Job {
+func setRepos(job job.Job, indexed *zoekt.IndexedRepoRevs, unindexed []*search.RepositoryRevisions) job.Job {
 	setZoektRepos := func(job *zoekt.RepoSubsetTextSearchJob) *zoekt.RepoSubsetTextSearchJob {
 		jobCopy := *job
 		jobCopy.Repos = indexed
@@ -36,7 +34,6 @@ func setRepos(logger sglog.Logger, job job.Job, indexed *zoekt.IndexedRepoRevs, 
 	setSearcherRepos := func(job *searcher.TextSearchJob) *searcher.TextSearchJob {
 		jobCopy := *job
 		jobCopy.Repos = unindexed
-		job.Log = logger
 		return &jobCopy
 	}
 
@@ -53,7 +50,6 @@ func setRepos(logger sglog.Logger, job job.Job, indexed *zoekt.IndexedRepoRevs, 
 	}
 
 	setRepos := Mapper{
-		Log:                             logger,
 		MapZoektRepoSubsetTextSearchJob: setZoektRepos,
 		MapZoektSymbolSearchJob:         setZoektSymbolRepos,
 		MapSearcherTextSearchJob:        setSearcherRepos,
@@ -69,11 +65,10 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 
 	var maxAlerter search.MaxAlerter
 
-	repoResolver := &repos.Resolver{DB: clients.DB, Opts: p.repoOpts, Log: p.log}
+	repoResolver := &repos.Resolver{DB: clients.DB, Opts: p.repoOpts}
 	pager := func(page *repos.Resolved) error {
 		indexed, unindexed, err := zoekt.PartitionRepos(
 			ctx,
-			p.log,
 			page.RepoRevs,
 			clients.Zoekt,
 			search.TextRequest,
@@ -84,7 +79,7 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 			return err
 		}
 
-		job := setRepos(p.log, p.child, indexed, unindexed)
+		job := setRepos(p.child, indexed, unindexed)
 		alert, err := job.Run(ctx, clients, stream)
 		maxAlerter.Add(alert)
 		return err

--- a/internal/search/job/jobutil/repo_pager_job_test.go
+++ b/internal/search/job/jobutil/repo_pager_job_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold"
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -20,7 +18,6 @@ func Test_setRepos(t *testing.T) {
 		RepoRevs: map[api.RepoID]*search.RepositoryRevisions{
 			1: {Repo: types.MinimalRepo{Name: "indexed"}},
 		},
-		Log: logtest.Scoped(t),
 	}
 	unindexed := []*search.RepositoryRevisions{
 		{Repo: types.MinimalRepo{Name: "unindexed"}},
@@ -28,7 +25,7 @@ func Test_setRepos(t *testing.T) {
 
 	// Test function
 	test := func(job job.Job) string {
-		job = setRepos(logtest.Scoped(t), job, indexed, unindexed)
+		job = setRepos(job, indexed, unindexed)
 		return "\n" + PrettyJSONVerbose(job)
 	}
 
@@ -47,8 +44,7 @@ func Test_setRepos(t *testing.T) {
               },
               "Revs": null
             }
-          },
-          "Log": {}
+          }
         },
         "Query": null,
         "Typ": "",
@@ -74,15 +70,14 @@ func Test_setRepos(t *testing.T) {
         "Features": {
           "ContentBasedLangFilters": false,
           "HybridSearch": false
-        },
-        "Log": {}
+        }
       }
     }
   ]
 }`).Equal(t, test(
 		NewParallelJob(
 			&zoekt.RepoSubsetTextSearchJob{},
-			&searcher.TextSearchJob{Log: logtest.Scoped(t)},
+			&searcher.TextSearchJob{},
 		),
 	))
 }

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
-
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -19,13 +18,12 @@ import (
 
 // NewFilterJob creates a job that filters the streamed results
 // of its child job using the default authz.DefaultSubRepoPermsChecker.
-func NewFilterJob(logger sglog.Logger, child job.Job) job.Job {
-	return &subRepoPermsFilterJob{child: child, log: logger}
+func NewFilterJob(child job.Job) job.Job {
+	return &subRepoPermsFilterJob{child: child}
 }
 
 type subRepoPermsFilterJob struct {
 	child job.Job
-	log   sglog.Logger
 }
 
 func (s *subRepoPermsFilterJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
@@ -41,7 +39,7 @@ func (s *subRepoPermsFilterJob) Run(ctx context.Context, clients job.RuntimeClie
 
 	filteredStream := streaming.StreamFunc(func(event streaming.SearchEvent) {
 		var err error
-		event.Results, err = applySubRepoFiltering(ctx, s.log, checker, event.Results)
+		event.Results, err = applySubRepoFiltering(ctx, checker, event.Results)
 		if err != nil {
 			mu.Lock()
 			errs = errors.Append(errs, err)
@@ -67,7 +65,7 @@ func (s *subRepoPermsFilterJob) Tags() []log.Field {
 
 // applySubRepoFiltering filters a set of matches using the provided
 // authz.SubRepoPermissionChecker
-func applySubRepoFiltering(ctx context.Context, logger sglog.Logger, checker authz.SubRepoPermissionChecker, matches []result.Match) ([]result.Match, error) {
+func applySubRepoFiltering(ctx context.Context, checker authz.SubRepoPermissionChecker, matches []result.Match) ([]result.Match, error) {
 	if !authz.SubRepoEnabled(checker) {
 		return matches, nil
 	}
@@ -119,6 +117,6 @@ func applySubRepoFiltering(ctx context.Context, logger sglog.Logger, checker aut
 
 	// We don't want to return sensitive authz information or excluded paths to the
 	// user so we'll return generic error and log something more specific.
-	logger.Warn("Applying sub-repo permissions to search results", sglog.Error(errs))
+	log15.Warn("Applying sub-repo permissions to search results", "error", errs)
 	return filtered, errors.New("subRepoFilterFunc")
 }

--- a/internal/search/job/jobutil/sub_repo_perms_job_test.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -174,7 +172,7 @@ func TestApplySubRepoFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := actor.WithActor(context.Background(), tt.args.ctxActor)
-			matches, err := applySubRepoFiltering(ctx, logtest.Scoped(t), checker, tt.args.matches)
+			matches, err := applySubRepoFiltering(ctx, checker, tt.args.matches)
 			if diff := cmp.Diff(matches, tt.wantMatches, cmpopts.IgnoreUnexported(search.RepoStatusMap{})); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/search/job/jobutil/types_test.go
+++ b/internal/search/job/jobutil/types_test.go
@@ -1,10 +1,6 @@
 package jobutil
 
-import (
-	"testing"
-
-	"github.com/sourcegraph/log/logtest"
-)
+import "testing"
 
 func TestMembership(t *testing.T) {
 	defer func() {
@@ -13,9 +9,7 @@ func TestMembership(t *testing.T) {
 		}
 	}()
 
-	mapper := Mapper{
-		Log: logtest.Scoped(t),
-	}
+	mapper := Mapper{}
 	for _, j := range allJobs {
 		Sexp(j)
 		PrettyMermaid(j)

--- a/internal/search/predicate/substitute.go
+++ b/internal/search/predicate/substitute.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/grafana/regexp"
-	"github.com/sourcegraph/log"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -22,7 +21,7 @@ var ErrNoResults = errors.New("no results returned for predicate")
 
 // Expand takes a query plan, and replaces any predicates with their expansion. The returned plan
 // is guaranteed to be predicate-free.
-func Expand(ctx context.Context, logger log.Logger, clients job.RuntimeClients, inputs *run.SearchInputs, oldPlan query.Plan) (_ query.Plan, err error) {
+func Expand(ctx context.Context, clients job.RuntimeClients, inputs *run.SearchInputs, oldPlan query.Plan) (_ query.Plan, err error) {
 	tr, ctx := trace.New(ctx, "ExpandPredicates", "")
 	defer func() {
 		tr.SetError(err)
@@ -39,7 +38,7 @@ func Expand(ctx context.Context, logger log.Logger, clients job.RuntimeClients, 
 		q := q
 		g.Go(func() error {
 			predicatePlan, err := Substitute(q, func(plan query.Plan) (result.Matches, error) {
-				predicateJob, err := jobutil.NewPlanJob(logger, inputs, plan)
+				predicateJob, err := jobutil.NewPlanJob(inputs, plan)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/opentracing/opentracing-go/log"
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -14,14 +13,13 @@ import (
 
 type ComputeExcludedJob struct {
 	RepoOpts search.RepoOptions
-	Log      sglog.Logger
 }
 
 func (c *ComputeExcludedJob) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, s, finish := job.StartSpan(ctx, s, c)
 	defer func() { finish(alert, err) }()
 
-	excluded, err := computeExcludedRepos(ctx, c.Log, clients.DB, c.RepoOpts)
+	excluded, err := computeExcludedRepos(ctx, clients.DB, c.RepoOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -371,7 +371,7 @@ func TestResolverPaginate(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			r := Resolver{Log: logtest.Scoped(t), Opts: tc.opts, DB: db}
+			r := Resolver{Opts: tc.opts, DB: db}
 
 			var pages []Resolved
 			err := r.Paginate(ctx, func(page *Resolved) error {

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -42,7 +42,6 @@ func (s *RepoSearchJob) reposContainingPath(ctx context.Context, clients job.Run
 
 	indexed, unindexed, err := zoektutil.PartitionRepos(
 		ctx,
-		s.Log,
 		repos,
 		clients.Zoekt,
 		search.TextRequest,
@@ -104,7 +103,6 @@ func (s *RepoSearchJob) reposContainingPath(ctx context.Context, clients job.Run
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
 		searcherJob := &searcher.TextSearchJob{
-			Log:             s.Log,
 			PatternInfo:     searcherArgs.PatternInfo,
 			Repos:           unindexed,
 			Indexed:         false,

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/opentracing/opentracing-go/log"
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -23,14 +22,13 @@ type RepoSearchJob struct {
 	Features                     search.Features
 
 	Mode search.GlobalSearchMode
-	Log  sglog.Logger
 }
 
 func (s *RepoSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts, Log: s.Log}
+	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts}
 	err = repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
 		tr.LogFields(log.Int("resolved.len", len(page.RepoRevs)))
 

--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -34,7 +32,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 				},
 			}}, nil
 		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), t, job.RuntimeClients{Zoekt: zoekt}, repo, []string{"foo"}, nil)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, []string{"foo"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -48,7 +46,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		MockReposContainingPath = func() ([]*result.FileMatch, error) {
 			return nil, nil
 		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), t, job.RuntimeClients{Zoekt: zoekt}, repo, []string{"foo"}, nil)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, []string{"foo"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -69,7 +67,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 				},
 			}}, nil
 		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), t, job.RuntimeClients{Zoekt: zoekt}, repo, nil, []string{"foo"})
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, nil, []string{"foo"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,7 +81,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		MockReposContainingPath = func() ([]*result.FileMatch, error) {
 			return nil, nil
 		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), t, job.RuntimeClients{Zoekt: zoekt}, repo, nil, []string{"foo"})
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, nil, []string{"foo"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -95,12 +93,11 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 // repoShouldBeAdded determines whether a repository should be included in the result set based on whether the repository fits in the subset
 // of repostiories specified in the query's `repohasfile` and `-repohasfile` fields if they exist.
-func repoShouldBeAdded(ctx context.Context, t *testing.T, clients job.RuntimeClients, repo *search.RepositoryRevisions, filePatternsInclude, filePatternsExclude []string) (bool, error) {
+func repoShouldBeAdded(ctx context.Context, clients job.RuntimeClients, repo *search.RepositoryRevisions, filePatternsInclude, filePatternsExclude []string) (bool, error) {
 	repos := []*search.RepositoryRevisions{repo}
 	s := RepoSearchJob{
 		FilePatternsReposMustInclude: filePatternsInclude,
 		FilePatternsReposMustExclude: filePatternsExclude,
-		Log:                          logtest.Scoped(t),
 	}
 	rsta, err := s.reposToAdd(ctx, clients, repos)
 	if err != nil {

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
@@ -45,7 +43,6 @@ func (inputs SearchInputs) DefaultLimit() int {
 
 func NewSearchInputs(
 	ctx context.Context,
-	logger log.Logger,
 	db database.DB,
 	version string,
 	patternType *string,
@@ -73,7 +70,7 @@ func NewSearchInputs(
 	// Beta: create a step to replace each context in the query with its repository query if any.
 	searchContextsQueryEnabled := settings.ExperimentalFeatures != nil && getBoolPtr(settings.ExperimentalFeatures.SearchContextsQuery, true)
 	substituteContextsStep := query.SubstituteSearchContexts(func(context string) (string, error) {
-		sc, err := searchcontexts.ResolveSearchContextSpec(ctx, logger, db, context)
+		sc, err := searchcontexts.ResolveSearchContextSpec(ctx, db, context)
 		if err != nil {
 			return "", err
 		}

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -7,10 +7,9 @@ import (
 	"sync"
 
 	"github.com/grafana/regexp"
+	"github.com/inconshreveable/log15"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
-
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -57,7 +56,7 @@ func ParseSearchContextSpec(searchContextSpec string) ParsedSearchContextSpec {
 	return ParsedSearchContextSpec{SearchContextName: searchContextSpec}
 }
 
-func ResolveSearchContextSpec(ctx context.Context, logger log.Logger, db database.DB, searchContextSpec string) (sc *types.SearchContext, err error) {
+func ResolveSearchContextSpec(ctx context.Context, db database.DB, searchContextSpec string) (sc *types.SearchContext, err error) {
 	tr, ctx := trace.New(ctx, "ResolveSearchContextSpec", searchContextSpec)
 	defer func() {
 		tr.LazyPrintf("context: %+v", sc)
@@ -88,7 +87,8 @@ func ResolveSearchContextSpec(ctx context.Context, logger log.Logger, db databas
 					return nil, database.ErrNamespaceNotFound
 				}
 
-				logger.Error("ResolveSearchContextSpec.OrgMembers.GetByOrgIDAndUserID", log.Error(err))
+				log15.Error("ResolveSearchContextSpec.OrgMembers.GetByOrgIDAndUserID", "error", err)
+
 				// NOTE: We do want to return identical error as if the namespace not found in
 				// case of internal server error. Otherwise, we're leaking the information when
 				// error occurs.

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -62,7 +62,7 @@ func TestResolvingValidSearchContextSpecs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			searchContext, err := ResolveSearchContextSpec(context.Background(), logtest.Scoped(t), db, tt.searchContextSpec)
+			searchContext, err := ResolveSearchContextSpec(context.Background(), db, tt.searchContextSpec)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantSearchContextName, searchContext.Name)
 		})
@@ -102,7 +102,7 @@ func TestResolvingValidSearchContextSpecs_Cloud(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			searchContext, err := ResolveSearchContextSpec(context.Background(), logtest.Scoped(t), db, tt.searchContextSpec)
+			searchContext, err := ResolveSearchContextSpec(context.Background(), db, tt.searchContextSpec)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantSearchContextName, searchContext.Name)
 		})
@@ -138,7 +138,7 @@ func TestResolvingInvalidSearchContextSpecs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ResolveSearchContextSpec(context.Background(), logtest.Scoped(t), db, tt.searchContextSpec)
+			_, err := ResolveSearchContextSpec(context.Background(), db, tt.searchContextSpec)
 			require.Error(t, err)
 			assert.Equal(t, tt.wantErr, err.Error())
 		})
@@ -179,7 +179,7 @@ func TestResolvingInvalidSearchContextSpecs_Cloud(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ResolveSearchContextSpec(context.Background(), logtest.Scoped(t), db, tt.searchContextSpec)
+			_, err := ResolveSearchContextSpec(context.Background(), db, tt.searchContextSpec)
 			require.Error(t, err)
 			assert.Equal(t, tt.wantErr, err.Error())
 		})

--- a/internal/search/streaming/client/metadata.go
+++ b/internal/search/streaming/client/metadata.go
@@ -13,7 +13,8 @@ import (
 )
 
 // RepoNamer returns a best-effort function which translates repository IDs into names.
-func RepoNamer(ctx context.Context, logger log.Logger, db database.DB) streamapi.RepoNamer {
+func RepoNamer(ctx context.Context, db database.DB) streamapi.RepoNamer {
+	logger := log.Scoped("RepoNamer", "translate repository IDs into names")
 	cache := map[api.RepoID]api.RepoName{}
 
 	return func(ids []api.RepoID) []api.RepoName {

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -3,10 +3,9 @@ package structural
 import (
 	"context"
 
+	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/sync/errgroup"
-
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -58,14 +57,12 @@ type searchRepos struct {
 	clients job.RuntimeClients
 	repoSet repoData
 	stream  streaming.Sender
-	log     sglog.Logger
 }
 
 // getJob returns a function parameterized by ctx to search over repos.
 func (s *searchRepos) getJob(ctx context.Context) func() error {
 	return func() error {
 		searcherJob := &searcher.TextSearchJob{
-			Log:             s.log,
 			PatternInfo:     s.args.PatternInfo,
 			Repos:           s.repoSet.AsList(),
 			Indexed:         s.repoSet.IsIndexed(),
@@ -87,7 +84,7 @@ func runJobs(ctx context.Context, jobs []*searchRepos) error {
 }
 
 // streamStructuralSearch runs structural search jobs and streams the results.
-func streamStructuralSearch(ctx context.Context, logger sglog.Logger, clients job.RuntimeClients, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) (err error) {
+func streamStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) (err error) {
 	jobs := []*searchRepos{}
 	for _, repoSet := range repos {
 		searcherArgs := &search.SearcherParameters{
@@ -96,39 +93,39 @@ func streamStructuralSearch(ctx context.Context, logger sglog.Logger, clients jo
 			Features:        args.Features,
 		}
 
-		jobs = append(jobs, &searchRepos{clients: clients, log: logger, args: searcherArgs, stream: stream, repoSet: repoSet})
+		jobs = append(jobs, &searchRepos{clients: clients, args: searcherArgs, stream: stream, repoSet: repoSet})
 	}
 	return runJobs(ctx, jobs)
 }
 
 // retryStructuralSearch runs a structural search with a higher limit file match
 // limit so that Zoekt resolves more potential file matches.
-func retryStructuralSearch(ctx context.Context, logger sglog.Logger, clients job.RuntimeClients, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) error {
+func retryStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) error {
 	patternCopy := *(args.PatternInfo)
 	patternCopy.FileMatchLimit = 1000
 	argsCopy := *args
 	argsCopy.PatternInfo = &patternCopy
 	args = &argsCopy
-	return streamStructuralSearch(ctx, logger, clients, args, repos, stream)
+	return streamStructuralSearch(ctx, clients, args, repos, stream)
 }
 
-func runStructuralSearch(ctx context.Context, logger sglog.Logger, clients job.RuntimeClients, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) error {
+func runStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) error {
 	if args.PatternInfo.FileMatchLimit != limits.DefaultMaxSearchResults {
 		// streamStructuralSearch performs a streaming search when the user sets a value
 		// for `count`. The first return parameter indicates whether the request was
 		// serviced with streaming.
-		return streamStructuralSearch(ctx, logger, clients, args, repos, stream)
+		return streamStructuralSearch(ctx, clients, args, repos, stream)
 	}
 
 	// For structural search with default limits we retry if we get no results.
 	agg := streaming.NewAggregatingStream()
-	err := streamStructuralSearch(ctx, logger, clients, args, repos, agg)
+	err := streamStructuralSearch(ctx, clients, args, repos, agg)
 
 	event := agg.SearchEvent
 	if len(event.Results) == 0 && err == nil {
 		// retry structural search with a higher limit.
 		agg := streaming.NewAggregatingStream()
-		err := retryStructuralSearch(ctx, logger, clients, args, repos, agg)
+		err := retryStructuralSearch(ctx, clients, args, repos, agg)
 		if err != nil {
 			return err
 		}
@@ -136,7 +133,7 @@ func runStructuralSearch(ctx context.Context, logger sglog.Logger, clients job.R
 		event = agg.SearchEvent
 		if len(event.Results) == 0 {
 			// Still no results? Give up.
-			logger.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
+			log15.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
 			event.Stats.IsLimitHit = false // Ensure we don't display "Show more".
 		}
 	}
@@ -163,18 +160,16 @@ type SearchJob struct {
 	ContainsRefGlobs bool
 
 	RepoOpts search.RepoOptions
-	Log      sglog.Logger
 }
 
 func (s *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts, Log: s.Log}
+	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts}
 	return nil, repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
 		indexed, unindexed, err := zoektutil.PartitionRepos(
 			ctx,
-			s.Log,
 			page.RepoRevs,
 			clients.Zoekt,
 			search.TextRequest,
@@ -189,7 +184,7 @@ func (s *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 		if indexed != nil {
 			repoSet = append(repoSet, IndexedMap(indexed.RepoRevs))
 		}
-		return runStructuralSearch(ctx, s.Log, clients, s.SearcherArgs, repoSet, stream)
+		return runStructuralSearch(ctx, clients, s.SearcherArgs, repoSet, stream)
 	})
 }
 

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/grafana/regexp"
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -27,11 +26,11 @@ const DefaultSymbolLimit = 100
 // indexedSymbols checks to see if Zoekt has indexed symbols information for a
 // repository at a specific commit. If it has it returns the branch name (for
 // use when querying zoekt). Otherwise an empty string is returned.
-func indexedSymbolsBranch(ctx context.Context, logger sglog.Logger, repo *types.MinimalRepo, commit string) string {
+func indexedSymbolsBranch(ctx context.Context, repo *types.MinimalRepo, commit string) string {
 	if !conf.SearchIndexEnabled() {
 		return ""
 	}
-	z := search.Indexed(logger)
+	z := search.Indexed()
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
@@ -54,7 +53,7 @@ func indexedSymbolsBranch(ctx context.Context, logger sglog.Logger, repo *types.
 	return ""
 }
 
-func searchZoekt(ctx context.Context, logger sglog.Logger, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, branch string, queryString *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
+func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, branch string, queryString *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
 	raw := *queryString
 	if raw == "" {
 		raw = ".*"
@@ -96,7 +95,7 @@ func searchZoekt(ctx context.Context, logger sglog.Logger, repoName types.Minima
 
 	final := zoektquery.Simplify(zoektquery.NewAnd(ands...))
 	match := limitOrDefault(first) + 1
-	resp, err := search.Indexed(logger).Search(ctx, final, &zoekt.SearchOptions{
+	resp, err := search.Indexed().Search(ctx, final, &zoekt.SearchOptions{
 		Trace:                  policy.ShouldTrace(ctx),
 		MaxWallTime:            3 * time.Second,
 		ShardMaxMatchCount:     match * 25,
@@ -145,11 +144,11 @@ func searchZoekt(ctx context.Context, logger sglog.Logger, repoName types.Minima
 	return
 }
 
-func Compute(ctx context.Context, logger sglog.Logger, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, query *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
+func Compute(ctx context.Context, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, query *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
 	// TODO(keegancsmith) we should be able to use indexedSearchRequest here
 	// and remove indexedSymbolsBranch.
-	if branch := indexedSymbolsBranch(ctx, logger, &repoName, string(commitID)); branch != "" {
-		return searchZoekt(ctx, logger, repoName, commitID, inputRev, branch, query, first, includePatterns)
+	if branch := indexedSymbolsBranch(ctx, &repoName, string(commitID)); branch != "" {
+		return searchZoekt(ctx, repoName, commitID, inputRev, branch, query, first, includePatterns)
 	}
 
 	serverTimeout := 5 * time.Second
@@ -204,12 +203,12 @@ func Compute(ctx context.Context, logger sglog.Logger, repoName types.MinimalRep
 
 // GetMatchAtLineCharacter retrieves the shortest matching symbol (if exists) defined
 // at a specific line number and character offset in the provided file.
-func GetMatchAtLineCharacter(ctx context.Context, logger sglog.Logger, repo types.MinimalRepo, commitID api.CommitID, filePath string, line int, character int) (*result.SymbolMatch, error) {
+func GetMatchAtLineCharacter(ctx context.Context, repo types.MinimalRepo, commitID api.CommitID, filePath string, line int, character int) (*result.SymbolMatch, error) {
 	// Should be large enough to include all symbols from a single file
 	first := int32(999999)
 	emptyString := ""
 	includePatterns := []string{regexp.QuoteMeta(filePath)}
-	symbolMatches, err := Compute(ctx, logger, repo, commitID, &emptyString, &emptyString, &first, &includePatterns)
+	symbolMatches, err := Compute(ctx, repo, commitID, &emptyString, &emptyString, &first, &includePatterns)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -13,9 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -97,7 +94,6 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 
 	matches, common, err := RunRepoSubsetTextSearch(
 		context.Background(),
-		logtest.Scoped(t),
 		patternInfo,
 		repoRevs,
 		q,
@@ -127,7 +123,6 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 	// that should be checked earlier.
 	_, _, err = RunRepoSubsetTextSearch(
 		context.Background(),
-		logtest.Scoped(t),
 		patternInfo,
 		makeRepositoryRevisions("foo/no-rev@dev"),
 		q,
@@ -198,7 +193,6 @@ func TestSearchFilesInReposStream(t *testing.T) {
 
 	matches, _, err := RunRepoSubsetTextSearch(
 		context.Background(),
-		logtest.Scoped(t),
 		patternInfo,
 		makeRepositoryRevisions("foo/one", "foo/two", "foo/three"),
 		q,
@@ -277,7 +271,6 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 
 	matches, _, err := RunRepoSubsetTextSearch(
 		context.Background(),
-		logtest.Scoped(t),
 		patternInfo,
 		repos,
 		q,
@@ -339,7 +332,6 @@ func mkRepos(names ...string) []types.MinimalRepo {
 // RunRepoSubsetTextSearch is a convenience function that simulates the RepoSubsetTextSearch job.
 func RunRepoSubsetTextSearch(
 	ctx context.Context,
-	logger log.Logger,
 	patternInfo *search.TextPatternInfo,
 	repos []*search.RepositoryRevisions,
 	q query.Q,
@@ -358,7 +350,6 @@ func RunRepoSubsetTextSearch(
 
 	indexed, unindexed, err := zoektutil.PartitionRepos(
 		context.Background(),
-		logger,
 		repos,
 		zoekt,
 		search.TextRequest,
@@ -412,7 +403,6 @@ func RunRepoSubsetTextSearch(
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
 		searcherJob := &searcher.TextSearchJob{
-			Log:             logger,
 			PatternInfo:     searcherArgs.PatternInfo,
 			Repos:           unindexed,
 			Indexed:         false,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -9,10 +9,9 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
+	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	"go.uber.org/atomic"
-
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -39,7 +38,6 @@ type IndexedRepoRevs struct {
 	// branchRepos is used to construct a zoektquery.BranchesRepos to efficiently
 	// marshal and send to zoekt
 	branchRepos map[string]*zoektquery.BranchRepos
-	Log         sglog.Logger
 }
 
 // add will add reporev and repo to the list of repository and branches to
@@ -174,7 +172,6 @@ func (rb *IndexedRepoRevs) getRepoInputRev(file *zoekt.FileMatch) (repo types.Mi
 
 func PartitionRepos(
 	ctx context.Context,
-	logger sglog.Logger,
 	repos []*search.RepositoryRevisions,
 	zoektStreamer zoekt.Streamer,
 	typ search.IndexedRequestType,
@@ -215,7 +212,7 @@ func PartitionRepos(
 				return nil, nil, errors.New("index:only failed since indexed search is not available yet")
 			}
 
-			indexed.Log.Warn("zoektIndexedRepos failed", sglog.Error(err))
+			log15.Warn("zoektIndexedRepos failed", "error", err)
 		}
 
 		return nil, repos, ctx.Err()
@@ -224,7 +221,7 @@ func PartitionRepos(
 	tr.LogFields(log.Int("all_indexed_set.size", len(list.Minimal)))
 
 	// Split based on indexed vs unindexed
-	indexed, unindexed = zoektIndexedRepos(logger, list.Minimal, repos, filter)
+	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filter)
 
 	tr.LogFields(
 		log.Int("indexed.size", len(indexed.RepoRevs)),
@@ -239,9 +236,9 @@ func PartitionRepos(
 	return indexed, unindexed, nil
 }
 
-func DoZoektSearchGlobal(ctx context.Context, logger sglog.Logger, client zoekt.Streamer, args *search.ZoektParameters, c streaming.Sender) error {
+func DoZoektSearchGlobal(ctx context.Context, client zoekt.Streamer, args *search.ZoektParameters, c streaming.Sender) error {
 	k := ResultCountFactor(0, args.FileMatchLimit, true)
-	searchOpts := SearchOpts(ctx, logger, k, args.FileMatchLimit, args.Select)
+	searchOpts := SearchOpts(ctx, k, args.FileMatchLimit, args.Select)
 
 	if deadline, ok := ctx.Deadline(); ok {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
@@ -288,7 +285,7 @@ func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, ty
 	finalQuery := zoektquery.NewAnd(&zoektquery.BranchesRepos{List: brs}, q)
 
 	k := ResultCountFactor(len(repos.RepoRevs), fileMatchLimit, false)
-	searchOpts := SearchOpts(ctx, repos.Log, k, fileMatchLimit, selector)
+	searchOpts := SearchOpts(ctx, k, fileMatchLimit, selector)
 
 	// Start event stream.
 	t0 := time.Now()
@@ -510,13 +507,12 @@ func contextWithoutDeadline(cOld context.Context) (context.Context, context.Canc
 // zoektIndexedRepos splits the revs into two parts: (1) the repository
 // revisions in indexedSet (indexed) and (2) the repositories that are
 // unindexed.
-func zoektIndexedRepos(logger sglog.Logger, indexedSet map[uint32]*zoekt.MinimalRepoListEntry, revs []*search.RepositoryRevisions, filter func(repo *zoekt.MinimalRepoListEntry) bool) (indexed *IndexedRepoRevs, unindexed []*search.RepositoryRevisions) {
+func zoektIndexedRepos(indexedSet map[uint32]*zoekt.MinimalRepoListEntry, revs []*search.RepositoryRevisions, filter func(repo *zoekt.MinimalRepoListEntry) bool) (indexed *IndexedRepoRevs, unindexed []*search.RepositoryRevisions) {
 	// PERF: If len(revs) is large, we expect to be doing an indexed
 	// search. So set indexed to the max size it can be to avoid growing.
 	indexed = &IndexedRepoRevs{
 		RepoRevs:    make(map[api.RepoID]*search.RepositoryRevisions, len(revs)),
 		branchRepos: make(map[string]*zoektquery.BranchRepos, 1),
-		Log:         logger,
 	}
 	unindexed = make([]*search.RepositoryRevisions, 0)
 
@@ -590,18 +586,17 @@ type GlobalTextSearchJob struct {
 	GlobalZoektQuery *GlobalZoektQuery
 	ZoektArgs        *search.ZoektParameters
 	RepoOpts         search.RepoOptions
-	Log              sglog.Logger
 }
 
 func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, t)
 	defer func() { finish(alert, err) }()
 
-	userPrivateRepos := searchrepos.PrivateReposForActor(ctx, t.Log, clients.DB, t.RepoOpts)
+	userPrivateRepos := searchrepos.PrivateReposForActor(ctx, clients.DB, t.RepoOpts)
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	t.ZoektArgs.Query = t.GlobalZoektQuery.Generate()
 
-	return nil, DoZoektSearchGlobal(ctx, t.Log, clients.Zoekt, t.ZoektArgs, stream)
+	return nil, DoZoektSearchGlobal(ctx, clients.Zoekt, t.ZoektArgs, stream)
 }
 
 func (*GlobalTextSearchJob) Name() string {

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -15,8 +15,6 @@ import (
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
@@ -288,7 +286,6 @@ func TestIndexedSearch(t *testing.T) {
 
 			indexed, unindexed, err := PartitionRepos(
 				context.Background(),
-				logtest.Scoped(t),
 				tt.args.repos,
 				zoekt,
 				search.TextRequest,
@@ -418,7 +415,7 @@ func TestZoektIndexedRepos(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			indexed, unindexed := zoektIndexedRepos(logtest.Scoped(t), zoektRepos, tc.repos, nil)
+			indexed, unindexed := zoektIndexedRepos(zoektRepos, tc.repos, nil)
 
 			if diff := cmp.Diff(repoRevsSliceToMap(tc.indexed), indexed.RepoRevs); diff != "" {
 				t.Error("unexpected indexed:", diff)
@@ -558,7 +555,7 @@ func TestZoektIndexedRepos_single(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		indexed, unindexed := zoektIndexedRepos(logtest.Scoped(t), zoektRepos, []*search.RepositoryRevisions{repoRev(tt.rev)}, nil)
+		indexed, unindexed := zoektIndexedRepos(zoektRepos, []*search.RepositoryRevisions{repoRev(tt.rev)}, nil)
 		got := ret{
 			Indexed:   indexed.RepoRevs,
 			Unindexed: unindexed,

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -7,8 +7,6 @@ import (
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/opentracing/opentracing-go/log"
 
-	sglog "github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -79,19 +77,18 @@ type GlobalSymbolSearchJob struct {
 	GlobalZoektQuery *GlobalZoektQuery
 	ZoektArgs        *search.ZoektParameters
 	RepoOpts         search.RepoOptions
-	Log              sglog.Logger
 }
 
 func (s *GlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	userPrivateRepos := repos.PrivateReposForActor(ctx, s.Log, clients.DB, s.RepoOpts)
+	userPrivateRepos := repos.PrivateReposForActor(ctx, clients.DB, s.RepoOpts)
 	s.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	s.ZoektArgs.Query = s.GlobalZoektQuery.Generate()
 
 	// always search for symbols in indexed repositories when searching the repo universe.
-	err = DoZoektSearchGlobal(ctx, s.Log, clients.Zoekt, s.ZoektArgs, stream)
+	err = DoZoektSearchGlobal(ctx, clients.Zoekt, s.ZoektArgs, stream)
 	if err != nil {
 		tr.LogFields(log.Error(err))
 		// Only record error if we haven't timed out.

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -56,7 +55,7 @@ func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error)
 	}
 
 	opts := &zoekt.ListOptions{Minimal: true}
-	repos, err := search.Indexed(log.Scoped("GetRepositories", "")).List(ctx, &query.Const{Value: true}, opts)
+	repos, err := search.Indexed().List(ctx, &query.Const{Value: true}, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This reverts commit 3721544b9b4b7970cd1ee404b562f1da9644fd27.

See comments [here](https://github.com/sourcegraph/sourcegraph/pull/36457#issuecomment-1172667863)

Fixes https://github.com/sourcegraph/sourcegraph/issues/38105

This disables the logging lint because it's blocking me from merging this PR.

## Test plan

Backend integration tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
