### PR TITLE
Search backend: add logger to searchResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -11,6 +11,7 @@ import (
 	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
+	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -342,6 +343,7 @@ func TestSearchResultsHydration(t *testing.T) {
 
 	resolver := &searchResolver{
 		db:           db,
+		logger:       logtest.Scoped(t),
 		SearchInputs: searchInputs,
 		zoekt:        z,
 	}
@@ -579,6 +581,7 @@ func TestEvaluateAnd(t *testing.T) {
 
 			resolver := &searchResolver{
 				db:           db,
+				logger:       logtest.Scoped(t),
 				SearchInputs: searchInputs,
 				zoekt:        z,
 			}
@@ -685,6 +688,7 @@ func TestSubRepoFiltering(t *testing.T) {
 				SearchInputs: searchInputs,
 				zoekt:        mockZoekt,
 				db:           db,
+				logger:       logtest.Scoped(t),
 			}
 
 			ctx := context.Background()

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/web"
 	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -338,7 +339,8 @@ func BenchmarkSearchResults(b *testing.B) {
 			b.Fatal(err)
 		}
 		resolver := &searchResolver{
-			db: db,
+			db:     db,
+			logger: logtest.Scoped(b),
 			SearchInputs: &run.SearchInputs{
 				Plan:         plan,
 				Query:        plan.ToQ(),

--- a/enterprise/cmd/frontend/internal/compute/init.go
+++ b/enterprise/cmd/frontend/internal/compute/init.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute/streaming"
@@ -13,7 +15,7 @@ import (
 )
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
-	enterpriseServices.ComputeResolver = resolvers.NewResolver(db)
+	enterpriseServices.ComputeResolver = resolvers.NewResolver(log.Scoped("computeResolver", ""), db)
 	enterpriseServices.NewComputeStreamHandler = func() http.Handler { return streaming.NewComputeStreamHandler(db) }
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -14,12 +15,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func NewResolver(db database.DB) gql.ComputeResolver {
-	return &Resolver{db: db}
+func NewResolver(logger log.Logger, db database.DB) gql.ComputeResolver {
+	return &Resolver{logger: logger, db: db}
 }
 
 type Resolver struct {
-	db database.DB
+	logger log.Logger
+	db     database.DB
 }
 
 type computeMatchContextResolver struct {
@@ -218,7 +220,7 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 
 // NewBatchComputeImplementer is a function that abstracts away the need to have a
 // handle on (*schemaResolver) Compute.
-func NewBatchComputeImplementer(ctx context.Context, db database.DB, args *gql.ComputeArgs) ([]gql.ComputeResultResolver, error) {
+func NewBatchComputeImplementer(ctx context.Context, logger log.Logger, db database.DB, args *gql.ComputeArgs) ([]gql.ComputeResultResolver, error) {
 	computeQuery, err := compute.Parse(args.Query)
 	if err != nil {
 		return nil, err
@@ -231,7 +233,7 @@ func NewBatchComputeImplementer(ctx context.Context, db database.DB, args *gql.C
 	log15.Debug("compute", "search", searchQuery)
 
 	patternType := "regexp"
-	job, err := gql.NewBatchSearchImplementer(ctx, db, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType})
+	job, err := gql.NewBatchSearchImplementer(ctx, logger, db, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType})
 	if err != nil {
 		return nil, err
 	}
@@ -244,5 +246,5 @@ func NewBatchComputeImplementer(ctx context.Context, db database.DB, args *gql.C
 }
 
 func (r *Resolver) Compute(ctx context.Context, args *gql.ComputeArgs) ([]gql.ComputeResultResolver, error) {
-	return NewBatchComputeImplementer(ctx, r.db, args)
+	return NewBatchComputeImplementer(ctx, r.logger, r.db, args)
 }


### PR DESCRIPTION
As in title. Part of reimplementing #36457 incrementally and so it fits search idioms. 

Stacked on https://github.com/sourcegraph/sourcegraph/pull/38116

## Test plan

Unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
