### PR TITLE
Correcting punctuation in test email

### DIFF
--- a/cmd/frontend/graphqlbackend/send_test_email.go
+++ b/cmd/frontend/graphqlbackend/send_test_email.go
@@ -28,14 +28,14 @@ func (r *schemaResolver) SendTestEmail(ctx context.Context, args struct{ To stri
 var emailTemplateTest = txemail.MustValidate(txtypes.Templates{
 	Subject: `TEST: email sent from Sourcegraph`,
 	Text: `
-If you're seeing this, Sourcegraph is able to send email correctly for all of it's product features!
+If you're seeing this, Sourcegraph is able to send email correctly for all of its product features!
 
 Congratulations!
 
 * Sourcegraph
 `,
 	HTML: `
-<p>Sourcegraph is able to send email correctly for all of it's product features!</p>
+<p>Sourcegraph is able to send email correctly for all of its product features!</p>
 <br>
 <p>Congratulations!</p>
 <br>


### PR DESCRIPTION
It would be sweet if we could include in the body of the email, config settings that worked, such as the SMTP server address, port number, protocol used, response time, TLS versions and ciphers used, etc., or provide this feedback in the API console when the test is run.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes
