### PR TITLE
Search backend: propagate logger through compute streams

### DIFF
--- a/enterprise/cmd/frontend/internal/compute/init.go
+++ b/enterprise/cmd/frontend/internal/compute/init.go
@@ -15,7 +15,8 @@ import (
 )
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
-	enterpriseServices.ComputeResolver = resolvers.NewResolver(log.Scoped("computeResolver", ""), db)
-	enterpriseServices.NewComputeStreamHandler = func() http.Handler { return streaming.NewComputeStreamHandler(db) }
+	logger := log.Scoped("compute", "")
+	enterpriseServices.ComputeResolver = resolvers.NewResolver(logger, db)
+	enterpriseServices.NewComputeStreamHandler = func() http.Handler { return streaming.NewComputeStreamHandler(logger, db) }
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -3,6 +3,8 @@ package streaming
 import (
 	"context"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
@@ -33,7 +35,7 @@ func toComputeResult(ctx context.Context, db database.DB, cmd compute.Command, m
 	return out, nil
 }
 
-func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan Event, func() (*search.Alert, error)) {
+func NewComputeStream(ctx context.Context, logger log.Logger, db database.DB, query string) (<-chan Event, func() (*search.Alert, error)) {
 	computeQuery, err := compute.Parse(query)
 	if err != nil {
 		return nil, func() (*search.Alert, error) { return nil, err }

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -80,7 +80,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Log events to trace
 	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
 
-	events, getResults := NewComputeStream(ctx, h.db, args.Query)
+	events, getResults := NewComputeStream(ctx, h.logger, h.db, args.Query)
 	events = batchEvents(events, 50*time.Millisecond)
 
 	// Store marshalled matches and flush periodically or when we go over

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -23,8 +24,9 @@ import (
 const maxRequestDuration = time.Minute
 
 // NewComputeStreamHandler is an http handler which streams back compute results.
-func NewComputeStreamHandler(db database.DB) http.Handler {
+func NewComputeStreamHandler(logger log.Logger, db database.DB) http.Handler {
 	return &streamHandler{
+		logger:              logger,
 		db:                  db,
 		flushTickerInternal: 100 * time.Millisecond,
 		pingTickerInterval:  5 * time.Second,
@@ -32,6 +34,7 @@ func NewComputeStreamHandler(db database.DB) http.Handler {
 }
 
 type streamHandler struct {
+	logger              log.Logger
 	db                  database.DB
 	flushTickerInternal time.Duration
 	pingTickerInterval  time.Duration


### PR DESCRIPTION
As in title. Part of reimplementing https://github.com/sourcegraph/sourcegraph/pull/36457 incrementally and so it fits search idioms.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/38117

## Test plan

Unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
