### PR TITLE
Search backend: add logger to stream search handler

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -42,6 +42,7 @@ import (
 // StreamHandler is an http handler which streams back search results.
 func StreamHandler(db database.DB) http.Handler {
 	return &streamHandler{
+		logger:              log.Scoped("searchStreamHandler", ""),
 		db:                  db,
 		searchClient:        client.NewSearchClient(db, search.Indexed(), search.SearcherURLs()),
 		flushTickerInternal: 100 * time.Millisecond,
@@ -50,6 +51,7 @@ func StreamHandler(db database.DB) http.Handler {
 }
 
 type streamHandler struct {
+	logger              log.Logger
 	db                  database.DB
 	searchClient        client.SearchClient
 	flushTickerInternal time.Duration
@@ -144,6 +146,7 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 
 	eventHandler := newEventHandler(
 		ctx,
+		h.logger,
 		h.db,
 		eventWriter,
 		progress,
@@ -161,11 +164,11 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 	if alert != nil {
 		eventWriter.Alert(alert)
 	}
-	logSearch(ctx, alert, err, start, inputs.OriginalQuery, progress)
+	logSearch(ctx, h.logger, alert, err, start, inputs.OriginalQuery, progress)
 	return err
 }
 
-func logSearch(ctx context.Context, alert *search.Alert, err error, start time.Time, originalQuery string, progress *streamclient.ProgressAggregator) {
+func logSearch(ctx context.Context, logger log.Logger, alert *search.Alert, err error, start time.Time, originalQuery string, progress *streamclient.ProgressAggregator) {
 	status := graphqlbackend.DetermineStatusForLogs(alert, progress.Stats, err)
 
 	var alertType string
@@ -191,7 +194,7 @@ func logSearch(ctx context.Context, alert *search.Alert, err error, start time.T
 		}
 
 		if isSlow {
-			log15.Warn("streaming: slow search request", searchlogs.MapToLog15Ctx(ev.Fields())...)
+			logger.Warn("streaming: slow search request", log.String("query", originalQuery))
 		}
 	}
 }
@@ -561,6 +564,7 @@ func repoIDs(results []result.Match) []api.RepoID {
 // an HTTP stream.
 func newEventHandler(
 	ctx context.Context,
+	logger log.Logger,
 	db database.DB,
 	eventWriter *eventWriter,
 	progress *streamclient.ProgressAggregator,
@@ -579,6 +583,7 @@ func newEventHandler(
 
 	eh := &eventHandler{
 		ctx:                ctx,
+		logger:             logger,
 		db:                 db,
 		eventWriter:        eventWriter,
 		matchesBuf:         matchesBuf,
@@ -604,8 +609,9 @@ func newEventHandler(
 }
 
 type eventHandler struct {
-	ctx context.Context
-	db  database.DB
+	ctx    context.Context
+	logger log.Logger
+	db     database.DB
 
 	// Config params
 	enableChunkMatches bool
@@ -642,7 +648,7 @@ func (h *eventHandler) Send(event streaming.SearchEvent) {
 
 	repoMetadata, err := getEventRepoMetadata(h.ctx, h.db, event)
 	if err != nil {
-		log15.Error("failed to get repo metadata", "error", err)
+		h.logger.Error("failed to get repo metadata", log.Error(err))
 		return
 	}
 

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
@@ -36,6 +37,7 @@ func TestServeStream_empty(t *testing.T) {
 	mock.PlanFunc.SetDefaultReturn(&run.SearchInputs{}, nil)
 
 	ts := httptest.NewServer(&streamHandler{
+		logger:              logtest.Scoped(t),
 		flushTickerInternal: 1 * time.Millisecond,
 		pingTickerInterval:  1 * time.Millisecond,
 		searchClient:        mock,
@@ -94,6 +96,7 @@ func TestServeStream_chunkMatches(t *testing.T) {
 	db.ReposFunc.SetDefaultReturn(mockRepos)
 
 	ts := httptest.NewServer(&streamHandler{
+		logger:              logtest.Scoped(t),
 		db:                  db,
 		flushTickerInternal: 1 * time.Millisecond,
 		pingTickerInterval:  1 * time.Millisecond,
@@ -211,6 +214,7 @@ func TestDisplayLimit(t *testing.T) {
 			db.ReposFunc.SetDefaultReturn(repos)
 
 			ts := httptest.NewServer(&streamHandler{
+				logger:              logtest.Scoped(t),
 				db:                  db,
 				flushTickerInternal: 1 * time.Millisecond,
 				pingTickerInterval:  1 * time.Millisecond,

--- a/enterprise/cmd/frontend/internal/compute/init.go
+++ b/enterprise/cmd/frontend/internal/compute/init.go
@@ -15,7 +15,8 @@ import (
 )
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
-	enterpriseServices.ComputeResolver = resolvers.NewResolver(log.Scoped("computeResolver", ""), db)
-	enterpriseServices.NewComputeStreamHandler = func() http.Handler { return streaming.NewComputeStreamHandler(db) }
+	logger := log.Scoped("compute", "")
+	enterpriseServices.ComputeResolver = resolvers.NewResolver(logger, db)
+	enterpriseServices.NewComputeStreamHandler = func() http.Handler { return streaming.NewComputeStreamHandler(logger, db) }
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -3,6 +3,8 @@ package streaming
 import (
 	"context"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
@@ -33,7 +35,7 @@ func toComputeResult(ctx context.Context, db database.DB, cmd compute.Command, m
 	return out, nil
 }
 
-func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan Event, func() (*search.Alert, error)) {
+func NewComputeStream(ctx context.Context, logger log.Logger, db database.DB, query string) (<-chan Event, func() (*search.Alert, error)) {
 	computeQuery, err := compute.Parse(query)
 	if err != nil {
 		return nil, func() (*search.Alert, error) { return nil, err }

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -80,7 +80,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Log events to trace
 	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
 
-	events, getResults := NewComputeStream(ctx, h.db, args.Query)
+	events, getResults := NewComputeStream(ctx, h.logger, h.db, args.Query)
 	events = batchEvents(events, 50*time.Millisecond)
 
 	// Store marshalled matches and flush periodically or when we go over

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -23,8 +24,9 @@ import (
 const maxRequestDuration = time.Minute
 
 // NewComputeStreamHandler is an http handler which streams back compute results.
-func NewComputeStreamHandler(db database.DB) http.Handler {
+func NewComputeStreamHandler(logger log.Logger, db database.DB) http.Handler {
 	return &streamHandler{
+		logger:              logger,
 		db:                  db,
 		flushTickerInternal: 100 * time.Millisecond,
 		pingTickerInterval:  5 * time.Second,
@@ -32,6 +34,7 @@ func NewComputeStreamHandler(db database.DB) http.Handler {
 }
 
 type streamHandler struct {
+	logger              log.Logger
 	db                  database.DB
 	flushTickerInternal time.Duration
 	pingTickerInterval  time.Duration


### PR DESCRIPTION
As in title. Part of reimplementing https://github.com/sourcegraph/sourcegraph/pull/36457 incrementally and so it fits search idioms.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/38122

## Test plan

 Unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
