### PR TITLE
Search backend: add logger to code monitor resolver

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/init.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/init.go
@@ -3,6 +3,8 @@ package codemonitors
 import (
 	"context"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors/resolvers"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
@@ -12,6 +14,6 @@ import (
 )
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
-	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(edb.NewEnterpriseDB(db))
+	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(log.Scoped("codeMonitorResolver", ""), edb.NewEnterpriseDB(db))
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -140,14 +142,14 @@ func newTestResolver(t *testing.T, db database.DB) *Resolver {
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	clock := func() time.Time { return now }
-	return newResolverWithClock(db, clock)
+	return newResolverWithClock(logtest.Scoped(t), db, clock)
 }
 
 // newResolverWithClock is used in tests to set the clock manually.
-func newResolverWithClock(db database.DB, clock func() time.Time) *Resolver {
+func newResolverWithClock(logger log.Logger, db database.DB, clock func() time.Time) *Resolver {
 	mockDB := edb.NewMockEnterpriseDBFrom(edb.NewEnterpriseDB(db))
 	mockDB.CodeMonitorsFunc.SetDefaultReturn(edb.CodeMonitorsWithClock(db, clock))
-	return &Resolver{db: mockDB}
+	return &Resolver{logger: logger, db: mockDB}
 }
 
 func marshalDateTime(t testing.TB, ts time.Time) string {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -20,12 +21,13 @@ import (
 )
 
 // NewResolver returns a new Resolver that uses the given database
-func NewResolver(db edb.EnterpriseDB) graphqlbackend.CodeMonitorsResolver {
-	return &Resolver{db: db}
+func NewResolver(logger log.Logger, db edb.EnterpriseDB) graphqlbackend.CodeMonitorsResolver {
+	return &Resolver{logger: logger, db: db}
 }
 
 type Resolver struct {
-	db edb.EnterpriseDB
+	logger log.Logger
+	db     edb.EnterpriseDB
 }
 
 func (r *Resolver) Now() time.Time {
@@ -638,7 +640,8 @@ func (r *Resolver) transact(ctx context.Context) (*Resolver, error) {
 		return nil, err
 	}
 	return &Resolver{
-		db: edb.NewEnterpriseDB(tx),
+		logger: r.logger,
+		db:     edb.NewEnterpriseDB(tx),
 	}, nil
 }
 


### PR DESCRIPTION
As in title. Part of reimplementing https://github.com/sourcegraph/sourcegraph/pull/36457 incrementally and so it fits search idioms.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/38123

## Test plan

Unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
