### PR TITLE
Search backend: add logger to search client

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -41,10 +41,11 @@ import (
 
 // StreamHandler is an http handler which streams back search results.
 func StreamHandler(db database.DB) http.Handler {
+	logger := log.Scoped("searchStreamHandler", "")
 	return &streamHandler{
-		logger:              log.Scoped("searchStreamHandler", ""),
+		logger:              logger,
 		db:                  db,
-		searchClient:        client.NewSearchClient(db, search.Indexed(), search.SearcherURLs()),
+		searchClient:        client.NewSearchClient(logger, db, search.Indexed(), search.SearcherURLs()),
 		flushTickerInternal: 100 * time.Millisecond,
 		pingTickerInterval:  5 * time.Second,
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -157,7 +157,7 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 
 		// Snapshot the state of the searched repos when the monitor is created so that
 		// we can distinguish new repos.
-		err = codemonitors.Snapshot(ctx, tx.db, args.Trigger.Query, m.ID, settings)
+		err = codemonitors.Snapshot(ctx, r.logger, tx.db, args.Trigger.Query, m.ID, settings)
 		if err != nil {
 			return nil, err
 		}
@@ -546,7 +546,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 
 			// Snapshot the state of the searched repos when the monitor is created so that
 			// we can distinguish new repos.
-			err = codemonitors.Snapshot(ctx, r.db, args.Trigger.Update.Query, monitorID, settings)
+			err = codemonitors.Snapshot(ctx, r.logger, r.db, args.Trigger.Update.Query, monitorID, settings)
 			if err != nil {
 				return nil, err
 			}

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -86,7 +86,7 @@ func NewComputeStream(ctx context.Context, logger log.Logger, db database.DB, qu
 	}
 
 	patternType := "regexp"
-	searchClient := client.NewSearchClient(db, search.Indexed(), search.SearcherURLs())
+	searchClient := client.NewSearchClient(logger, db, search.Indexed(), search.SearcherURLs())
 	inputs, err := searchClient.Plan(ctx, "", &patternType, searchQuery, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {
 		close(eventsC)

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -175,7 +175,7 @@ func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, record work
 		// Only add an after filter when repo-aware monitors is disabled
 		query = newQueryWithAfterFilter(q)
 	}
-	results, searchErr := codemonitors.Search(ctx, r.db, query, m.ID, settings)
+	results, searchErr := codemonitors.Search(ctx, logger, r.db, query, m.ID, settings)
 
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, searchErr)

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/zoekt"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -36,8 +37,9 @@ type SearchClient interface {
 	JobClients() job.RuntimeClients
 }
 
-func NewSearchClient(db database.DB, zoektStreamer zoekt.Streamer, searcherURLs *endpoint.Map) SearchClient {
+func NewSearchClient(logger log.Logger, db database.DB, zoektStreamer zoekt.Streamer, searcherURLs *endpoint.Map) SearchClient {
 	return &searchClient{
+		logger:       logger,
 		db:           db,
 		zoekt:        zoektStreamer,
 		searcherURLs: searcherURLs,
@@ -45,6 +47,7 @@ func NewSearchClient(db database.DB, zoektStreamer zoekt.Streamer, searcherURLs 
 }
 
 type searchClient struct {
+	logger       log.Logger
 	db           database.DB
 	zoekt        zoekt.Streamer
 	searcherURLs *endpoint.Map


### PR DESCRIPTION
As in title. Part of reimplementing https://github.com/sourcegraph/sourcegraph/pull/36457 incrementally and so it fits search idioms.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/38126

## Test plan

Unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
