### PR TITLE
Search backend: add logger to runtime clients

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -441,6 +441,7 @@ func LogSearchLatency(ctx context.Context, db database.DB, si *run.SearchInputs,
 
 func (r *searchResolver) JobClients() job.RuntimeClients {
 	return job.RuntimeClients{
+		Logger:       r.logger,
 		DB:           r.db,
 		Zoekt:        r.zoekt,
 		SearcherURLs: r.searcherURLs,

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -75,6 +75,7 @@ func (s *searchClient) Execute(
 
 func (s *searchClient) JobClients() job.RuntimeClients {
 	return job.RuntimeClients{
+		Logger:       s.logger,
 		DB:           s.db,
 		Zoekt:        s.zoekt,
 		SearcherURLs: s.searcherURLs,

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -7,7 +7,8 @@ import (
 	"context"
 
 	"github.com/google/zoekt"
-	"github.com/opentracing/opentracing-go/log"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -23,10 +24,11 @@ import (
 type Job interface {
 	Run(context.Context, RuntimeClients, streaming.Sender) (*search.Alert, error)
 	Name() string
-	Tags() []log.Field
+	Tags() []otlog.Field
 }
 
 type RuntimeClients struct {
+	Logger       log.Logger
 	DB           database.DB
 	Zoekt        zoekt.Streamer
 	SearcherURLs *endpoint.Map


### PR DESCRIPTION
As in title. Part of reimplementing https://github.com/sourcegraph/sourcegraph/pull/36457 incrementally and so it fits search idioms.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/38127

## Test plan

Unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
