### PR TITLE
Search backend: use client logger where applicable

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -441,6 +441,7 @@ func LogSearchLatency(ctx context.Context, db database.DB, si *run.SearchInputs,
 
 func (r *searchResolver) JobClients() job.RuntimeClients {
 	return job.RuntimeClients{
+		Logger:       r.logger,
 		DB:           r.db,
 		Zoekt:        r.zoekt,
 		SearcherURLs: r.searcherURLs,

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -38,7 +38,7 @@ var Targets = []Target{
 			goEnterpriseImport,
 			noLocalHost,
 			lintGoDirectives(),
-			// lintLoggingLibraries(),
+			lintLoggingLibraries(),
 			goModGuards(),
 			lintSGExit(),
 		},

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -24,7 +24,8 @@ import (
 )
 
 type Observer struct {
-	Db database.DB
+	Logger log.Logger
+	Db     database.DB
 
 	// Inputs are used to generate alert messages based on the query.
 	*run.SearchInputs
@@ -222,7 +223,7 @@ func (o *Observer) Done() (*search.Alert, error) {
 	}
 
 	if o.HasResults && o.err != nil {
-		log15.Error("Errors during search", "error", o.err)
+		o.Logger.Warn("Errors during search", log.Error(o.err))
 		return o.alert, nil
 	}
 

--- a/internal/search/alert/observer_test.go
+++ b/internal/search/alert/observer_test.go
@@ -71,7 +71,8 @@ func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 		t.Fatal(err)
 	}
 	sr := Observer{
-		Db: db,
+		Logger: logger,
+		Db:     db,
 		SearchInputs: &run.SearchInputs{
 			OriginalQuery: searchQuery,
 			Query:         q,

--- a/internal/search/alert/observer_test.go
+++ b/internal/search/alert/observer_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -39,7 +38,9 @@ func TestErrorToAlertStructuralSearch(t *testing.T) {
 	}
 	for _, test := range cases {
 		multiErr := errors.Append(nil, test.errors...)
-		haveAlert, _ := (&Observer{}).errorToAlert(context.Background(), multiErr)
+		haveAlert, _ := (&Observer{
+			Logger: logtest.Scoped(t),
+		}).errorToAlert(context.Background(), multiErr)
 
 		if haveAlert != nil && haveAlert.Title != test.wantAlertTitle {
 			t.Fatalf("test %s, have alert: %q, want: %q", test.name, haveAlert.Title, test.wantAlertTitle)

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -75,6 +75,7 @@ func (s *searchClient) Execute(
 
 func (s *searchClient) JobClients() job.RuntimeClients {
 	return job.RuntimeClients{
+		Logger:       s.logger,
 		DB:           s.db,
 		Zoekt:        s.zoekt,
 		SearcherURLs: s.searcherURLs,

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -7,7 +7,8 @@ import (
 	"context"
 
 	"github.com/google/zoekt"
-	"github.com/opentracing/opentracing-go/log"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -23,10 +24,11 @@ import (
 type Job interface {
 	Run(context.Context, RuntimeClients, streaming.Sender) (*search.Alert, error)
 	Name() string
-	Tags() []log.Field
+	Tags() []otlog.Field
 }
 
 type RuntimeClients struct {
+	Logger       log.Logger
 	DB           database.DB
 	Zoekt        zoekt.Streamer
 	SearcherURLs *endpoint.Map

--- a/internal/search/job/jobutil/alert.go
+++ b/internal/search/job/jobutil/alert.go
@@ -43,6 +43,7 @@ func (j *alertJob) Run(ctx context.Context, clients job.RuntimeClients, stream s
 	jobAlert, err := j.child.Run(ctx, clients, statsObserver)
 
 	ao := searchalert.Observer{
+		Logger:       clients.Logger,
 		Db:           clients.DB,
 		SearchInputs: j.inputs,
 		HasResults:   countingStream.Count() > 0,

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -69,6 +69,7 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 	pager := func(page *repos.Resolved) error {
 		indexed, unindexed, err := zoekt.PartitionRepos(
 			ctx,
+			clients.Logger,
 			page.RepoRevs,
 			clients.Zoekt,
 			search.TextRequest,

--- a/internal/search/job/jobutil/sub_repo_perms_job_test.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -172,7 +173,7 @@ func TestApplySubRepoFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := actor.WithActor(context.Background(), tt.args.ctxActor)
-			matches, err := applySubRepoFiltering(ctx, checker, tt.args.matches)
+			matches, err := applySubRepoFiltering(ctx, logtest.Scoped(t), checker, tt.args.matches)
 			if diff := cmp.Diff(matches, tt.wantMatches, cmpopts.IgnoreUnexported(search.RepoStatusMap{})); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/grafana/regexp"
 	regexpsyntax "github.com/grafana/regexp/syntax"
-	"github.com/inconshreveable/log15"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/log"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
@@ -832,7 +832,7 @@ func (e MissingLockfileIndexing) Error() string {
 // Get all private repos for the the current actor. On sourcegraph.com, those are
 // only the repos directly added by the user. Otherwise it's all repos the user has
 // access to on all connected code hosts / external services.
-func PrivateReposForActor(ctx context.Context, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
+func PrivateReposForActor(ctx context.Context, logger log.Logger, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
 	tr, ctx := trace.New(ctx, "PrivateReposForActor", "")
 	defer tr.Finish()
 
@@ -862,7 +862,7 @@ func PrivateReposForActor(ctx context.Context, db database.DB, repoOptions searc
 	})
 
 	if err != nil {
-		log15.Error("doResults: failed to list user private repos", "error", err, "user-id", userID)
+		logger.Error("doResults: failed to list user private repos", log.Error(err), log.Int32("user-id", userID))
 		tr.LazyPrintf("error resolving user private repos: %v", err)
 	}
 	return userPrivateRepos

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -42,6 +42,7 @@ func (s *RepoSearchJob) reposContainingPath(ctx context.Context, clients job.Run
 
 	indexed, unindexed, err := zoektutil.PartitionRepos(
 		ctx,
+		clients.Logger,
 		repos,
 		clients.Zoekt,
 		search.TextRequest,

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -3,7 +3,6 @@ package structural
 import (
 	"context"
 
-	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/sync/errgroup"
 
@@ -133,7 +132,7 @@ func runStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *
 		event = agg.SearchEvent
 		if len(event.Results) == 0 {
 			// Still no results? Give up.
-			log15.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
+			clients.Logger.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
 			event.Stats.IsLimitHit = false // Ensure we don't display "Show more".
 		}
 	}

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -169,6 +169,7 @@ func (s *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 	return nil, repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
 		indexed, unindexed, err := zoektutil.PartitionRepos(
 			ctx,
+			clients.Logger,
 			page.RepoRevs,
 			clients.Zoekt,
 			search.TextRequest,

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -403,7 +403,10 @@ func RunRepoSubsetTextSearch(
 
 		// Run literal and regexp searches on indexed repositories.
 		g.Go(func() error {
-			_, err := zoektJob.Run(ctx, job.RuntimeClients{Zoekt: zoekt}, agg)
+			_, err := zoektJob.Run(ctx, job.RuntimeClients{
+				Logger: logger,
+				Zoekt:  zoekt,
+			}, agg)
 			return err
 		})
 	}
@@ -417,7 +420,11 @@ func RunRepoSubsetTextSearch(
 			UseFullDeadline: searcherArgs.UseFullDeadline,
 		}
 
-		_, err := searcherJob.Run(ctx, job.RuntimeClients{SearcherURLs: searcherURLs, Zoekt: zoekt}, agg)
+		_, err := searcherJob.Run(ctx, job.RuntimeClients{
+			Logger:       logger,
+			SearcherURLs: searcherURLs,
+			Zoekt:        zoekt,
+		}, agg)
 		return err
 	})
 

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -94,6 +96,7 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 
 	matches, common, err := RunRepoSubsetTextSearch(
 		context.Background(),
+		logtest.Scoped(t),
 		patternInfo,
 		repoRevs,
 		q,
@@ -123,6 +126,7 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 	// that should be checked earlier.
 	_, _, err = RunRepoSubsetTextSearch(
 		context.Background(),
+		logtest.Scoped(t),
 		patternInfo,
 		makeRepositoryRevisions("foo/no-rev@dev"),
 		q,
@@ -193,6 +197,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 
 	matches, _, err := RunRepoSubsetTextSearch(
 		context.Background(),
+		logtest.Scoped(t),
 		patternInfo,
 		makeRepositoryRevisions("foo/one", "foo/two", "foo/three"),
 		q,
@@ -271,6 +276,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 
 	matches, _, err := RunRepoSubsetTextSearch(
 		context.Background(),
+		logtest.Scoped(t),
 		patternInfo,
 		repos,
 		q,
@@ -332,6 +338,7 @@ func mkRepos(names ...string) []types.MinimalRepo {
 // RunRepoSubsetTextSearch is a convenience function that simulates the RepoSubsetTextSearch job.
 func RunRepoSubsetTextSearch(
 	ctx context.Context,
+	logger log.Logger,
 	patternInfo *search.TextPatternInfo,
 	repos []*search.RepositoryRevisions,
 	q query.Q,
@@ -350,6 +357,7 @@ func RunRepoSubsetTextSearch(
 
 	indexed, unindexed, err := zoektutil.PartitionRepos(
 		context.Background(),
+		logger,
 		repos,
 		zoekt,
 		search.TextRequest,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -9,8 +9,8 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
-	"github.com/inconshreveable/log15"
-	"github.com/opentracing/opentracing-go/log"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/log"
 	"go.uber.org/atomic"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -172,6 +172,7 @@ func (rb *IndexedRepoRevs) getRepoInputRev(file *zoekt.FileMatch) (repo types.Mi
 
 func PartitionRepos(
 	ctx context.Context,
+	logger log.Logger,
 	repos []*search.RepositoryRevisions,
 	zoektStreamer zoekt.Streamer,
 	typ search.IndexedRequestType,
@@ -212,20 +213,20 @@ func PartitionRepos(
 				return nil, nil, errors.New("index:only failed since indexed search is not available yet")
 			}
 
-			log15.Warn("zoektIndexedRepos failed", "error", err)
+			logger.Warn("zoektIndexedRepos failed", log.Error(err))
 		}
 
 		return nil, repos, ctx.Err()
 	}
 
-	tr.LogFields(log.Int("all_indexed_set.size", len(list.Minimal)))
+	tr.LogFields(otlog.Int("all_indexed_set.size", len(list.Minimal)))
 
 	// Split based on indexed vs unindexed
 	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filter)
 
 	tr.LogFields(
-		log.Int("indexed.size", len(indexed.RepoRevs)),
-		log.Int("unindexed.size", len(unindexed)),
+		otlog.Int("indexed.size", len(indexed.RepoRevs)),
+		otlog.Int("unindexed.size", len(unindexed)),
 	)
 
 	// Disable unindexed search
@@ -567,17 +568,17 @@ func (*RepoSubsetTextSearchJob) Name() string {
 	return "ZoektRepoSubsetTextSearchJob"
 }
 
-func (z *RepoSubsetTextSearchJob) Tags() []log.Field {
-	tags := []log.Field{
+func (z *RepoSubsetTextSearchJob) Tags() []otlog.Field {
+	tags := []otlog.Field{
 		trace.Stringer("query", z.Query),
-		log.String("type", string(z.Typ)),
-		log.Int32("fileMatchLimit", z.FileMatchLimit),
+		otlog.String("type", string(z.Typ)),
+		otlog.Int32("fileMatchLimit", z.FileMatchLimit),
 		trace.Stringer("select", z.Select),
 	}
 	// z.Repos is nil for un-indexed search
 	if z.Repos != nil {
-		tags = append(tags, log.Int("numRepoRevs", len(z.Repos.RepoRevs)))
-		tags = append(tags, log.Int("numBranchRepos", len(z.Repos.branchRepos)))
+		tags = append(tags, otlog.Int("numRepoRevs", len(z.Repos.RepoRevs)))
+		tags = append(tags, otlog.Int("numBranchRepos", len(z.Repos.branchRepos)))
 	}
 	return tags
 }
@@ -603,13 +604,13 @@ func (*GlobalTextSearchJob) Name() string {
 	return "ZoektGlobalTextSearchJob"
 }
 
-func (t *GlobalTextSearchJob) Tags() []log.Field {
-	return []log.Field{
+func (t *GlobalTextSearchJob) Tags() []otlog.Field {
+	return []otlog.Field{
 		trace.Stringer("query", t.GlobalZoektQuery.Query),
 		trace.Printf("repoScope", "%q", t.GlobalZoektQuery.RepoScope),
-		log.Bool("includePrivate", t.GlobalZoektQuery.IncludePrivate),
-		log.String("type", string(t.ZoektArgs.Typ)),
-		log.Int32("fileMatchLimit", t.ZoektArgs.FileMatchLimit),
+		otlog.Bool("includePrivate", t.GlobalZoektQuery.IncludePrivate),
+		otlog.String("type", string(t.ZoektArgs.Typ)),
+		otlog.Int32("fileMatchLimit", t.ZoektArgs.FileMatchLimit),
 		trace.Stringer("select", t.ZoektArgs.Select),
 		trace.Stringer("repoOpts", &t.RepoOpts),
 	}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -592,7 +592,7 @@ func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClient
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, t)
 	defer func() { finish(alert, err) }()
 
-	userPrivateRepos := searchrepos.PrivateReposForActor(ctx, clients.DB, t.RepoOpts)
+	userPrivateRepos := searchrepos.PrivateReposForActor(ctx, clients.Logger, clients.DB, t.RepoOpts)
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	t.ZoektArgs.Query = t.GlobalZoektQuery.Generate()
 

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
+	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -286,6 +287,7 @@ func TestIndexedSearch(t *testing.T) {
 
 			indexed, unindexed, err := PartitionRepos(
 				context.Background(),
+				logtest.Scoped(t),
 				tt.args.repos,
 				zoekt,
 				search.TextRequest,

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -83,7 +83,7 @@ func (s *GlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	userPrivateRepos := repos.PrivateReposForActor(ctx, clients.DB, s.RepoOpts)
+	userPrivateRepos := repos.PrivateReposForActor(ctx, clients.Logger, clients.DB, s.RepoOpts)
 	s.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	s.ZoektArgs.Query = s.GlobalZoektQuery.Generate()
 


### PR DESCRIPTION
This takes the logger from `RuntimeClients` and uses it instead of log15 where applicable. Part of reimplementing https://github.com/sourcegraph/sourcegraph/pull/36457 incrementally and so it fits search idioms.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/38129

Following this PR, there are only 5 uses of `log15` in `internal/search`. I'll probably leave it here for now because the other uses are more entrenched. 

This also re-enables the log15 lint that I disabled to get this series of PRs through.

## Test plan

Unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
