### PR TITLE
repos: list sync jobs by state

### DIFF
--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -36,6 +36,7 @@ func TestIntegration(t *testing.T) {
 		{"EnqueueSingleSyncJob", testStoreEnqueueSingleSyncJob},
 		{"ListExternalServiceUserIDsByRepoID", testStoreListExternalServiceUserIDsByRepoID},
 		{"ListExternalServicePrivateRepoIDsByUserID", testStoreListExternalServicePrivateRepoIDsByUserID},
+		{"ListSyncJobs", testStoreListSyncJobs},
 		{"Syncer/SyncWorker", testSyncWorkerPlumbing},
 		{"Syncer/Sync", testSyncerSync},
 		{"Syncer/SyncRepo", testSyncRepo},

--- a/internal/repos/mocks_temp.go
+++ b/internal/repos/mocks_temp.go
@@ -151,7 +151,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		ListSyncJobsFunc: &StoreListSyncJobsFunc{
-			defaultHook: func(context.Context) (r0 []SyncJob, r1 error) {
+			defaultHook: func(context.Context, SyncJobsListOptions) (r0 []SyncJob, r1 error) {
 				return
 			},
 		},
@@ -253,7 +253,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		ListSyncJobsFunc: &StoreListSyncJobsFunc{
-			defaultHook: func(context.Context) ([]SyncJob, error) {
+			defaultHook: func(context.Context, SyncJobsListOptions) ([]SyncJob, error) {
 				panic("unexpected invocation of MockStore.ListSyncJobs")
 			},
 		},
@@ -1635,23 +1635,23 @@ func (c StoreListExternalServiceUserIDsByRepoIDFuncCall) Results() []interface{}
 // StoreListSyncJobsFunc describes the behavior when the ListSyncJobs method
 // of the parent MockStore instance is invoked.
 type StoreListSyncJobsFunc struct {
-	defaultHook func(context.Context) ([]SyncJob, error)
-	hooks       []func(context.Context) ([]SyncJob, error)
+	defaultHook func(context.Context, SyncJobsListOptions) ([]SyncJob, error)
+	hooks       []func(context.Context, SyncJobsListOptions) ([]SyncJob, error)
 	history     []StoreListSyncJobsFuncCall
 	mutex       sync.Mutex
 }
 
 // ListSyncJobs delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) ListSyncJobs(v0 context.Context) ([]SyncJob, error) {
-	r0, r1 := m.ListSyncJobsFunc.nextHook()(v0)
-	m.ListSyncJobsFunc.appendCall(StoreListSyncJobsFuncCall{v0, r0, r1})
+func (m *MockStore) ListSyncJobs(v0 context.Context, v1 SyncJobsListOptions) ([]SyncJob, error) {
+	r0, r1 := m.ListSyncJobsFunc.nextHook()(v0, v1)
+	m.ListSyncJobsFunc.appendCall(StoreListSyncJobsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the ListSyncJobs method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreListSyncJobsFunc) SetDefaultHook(hook func(context.Context) ([]SyncJob, error)) {
+func (f *StoreListSyncJobsFunc) SetDefaultHook(hook func(context.Context, SyncJobsListOptions) ([]SyncJob, error)) {
 	f.defaultHook = hook
 }
 
@@ -1659,7 +1659,7 @@ func (f *StoreListSyncJobsFunc) SetDefaultHook(hook func(context.Context) ([]Syn
 // ListSyncJobs method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreListSyncJobsFunc) PushHook(hook func(context.Context) ([]SyncJob, error)) {
+func (f *StoreListSyncJobsFunc) PushHook(hook func(context.Context, SyncJobsListOptions) ([]SyncJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1668,19 +1668,19 @@ func (f *StoreListSyncJobsFunc) PushHook(hook func(context.Context) ([]SyncJob, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreListSyncJobsFunc) SetDefaultReturn(r0 []SyncJob, r1 error) {
-	f.SetDefaultHook(func(context.Context) ([]SyncJob, error) {
+	f.SetDefaultHook(func(context.Context, SyncJobsListOptions) ([]SyncJob, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreListSyncJobsFunc) PushReturn(r0 []SyncJob, r1 error) {
-	f.PushHook(func(context.Context) ([]SyncJob, error) {
+	f.PushHook(func(context.Context, SyncJobsListOptions) ([]SyncJob, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreListSyncJobsFunc) nextHook() func(context.Context) ([]SyncJob, error) {
+func (f *StoreListSyncJobsFunc) nextHook() func(context.Context, SyncJobsListOptions) ([]SyncJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1716,6 +1716,9 @@ type StoreListSyncJobsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 SyncJobsListOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []SyncJob
@@ -1727,7 +1730,7 @@ type StoreListSyncJobsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreListSyncJobsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -731,7 +731,7 @@ func (s *store) ListSyncJobs(ctx context.Context, opt SyncJobsListOptions) ([]Sy
 	if opt.State != "" {
 		query = sqlf.Sprintf(q, sqlf.Sprintf("state = %s", opt.State))
 	} else {
-		query = sqlf.Sprintf(q, "1")
+		query = sqlf.Sprintf(q, "TRUE")
 	}
 
 	rows, err := s.Query(ctx, query)

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -479,7 +479,7 @@ func testStoreListSyncJobs(store repos.Store) func(*testing.T) {
 		require.Len(t, list(""), 10)
 
 		// start processing a few of them
-		_, err = store.Handle().ExecContext(ctx, "UPDATE external_service_sync_jobs SET state = 'processing' WHERE id IN ($1, $2, $3)",
+		_, err = store.Handle().ExecContext(ctx, "UPDATE external_service_sync_jobs SET state = 'processing' WHERE external_service_id IN ($1, $2, $3)",
 			services[0].ID,
 			services[1].ID,
 			services[2].ID,


### PR DESCRIPTION
This adds an option to the repo update `ListSyncJobs` method to filter jobs by state.

## Test plan

- Added unit test

Related to #37377