### PR TITLE
repos: add SetSyncJobsState method

### DIFF
--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -37,6 +37,7 @@ func TestIntegration(t *testing.T) {
 		{"ListExternalServiceUserIDsByRepoID", testStoreListExternalServiceUserIDsByRepoID},
 		{"ListExternalServicePrivateRepoIDsByUserID", testStoreListExternalServicePrivateRepoIDsByUserID},
 		{"ListSyncJobs", testStoreListSyncJobs},
+		{"SetSyncJobState", testStoreSetSyncJobState},
 		{"Syncer/SyncWorker", testSyncWorkerPlumbing},
 		{"Syncer/Sync", testSyncerSync},
 		{"Syncer/SyncRepo", testSyncRepo},

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -523,9 +523,10 @@ func testStoreSetSyncJobState(store repos.Store) func(*testing.T) {
 		}
 
 		// list them, they should be all in queued state
-		require.Len(t, list("queued"), 10)
+		jobs := list("queued")
+		require.Len(t, jobs, 10)
 
-		err = store.SetSyncJobState(ctx, "processing", services[0].ID, services[1].ID, services[2].ID)
+		err = store.SetSyncJobState(ctx, "processing", int64(jobs[0].ID), int64(jobs[1].ID), int64(jobs[2].ID))
 		require.NoError(t, err)
 
 		require.Len(t, list("queued"), 7)


### PR DESCRIPTION
This adds a method to manually set repo update sync jobs state in the database.

Related to https://github.com/sourcegraph/sourcegraph/issues/37377

## Test plan

- Unit test