### PR TITLE
core workflow: reserve temporary setting name

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -39,6 +39,7 @@ export interface TemporarySettingsSchema {
     'codeintel.referencePanel.redesign.ctaDismissed': boolean
     'codeintel.referencePanel.redesign.enabled': boolean
     'onboarding.quickStartTour': TourListState
+    'coreWorkflowImprovements.enabled': boolean
 }
 
 /**

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -13,6 +13,7 @@ export type FeatureFlagName =
     | 'ab-email-verification-alert'
     | 'hide-run-batch-spec-for-mi'
     | 'contrast-compliant-syntax-highlighting'
+    | 'core-workflow-improvements'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -13,7 +13,6 @@ export type FeatureFlagName =
     | 'ab-email-verification-alert'
     | 'hide-run-batch-spec-for-mi'
     | 'contrast-compliant-syntax-highlighting'
-    | 'core-workflow-improvements'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -48,6 +48,9 @@ export const UserSettingsSidebar: React.FunctionComponent<
     const [, setHasCancelledTour] = useTemporarySetting('search.onboarding.tourCancelled')
     const showOnboardingTour = useExperimentalFeatures(features => features.showOnboardingTour ?? false)
     const [isOpenBetaEnabled] = useFeatureFlag('open-beta-enabled')
+    const [coreWorkflowImprovementsEnabled, setCoreWorkflowImprovementsEnabled] = useTemporarySetting(
+        'coreWorkflowImprovements.enabled'
+    )
 
     if (!props.authenticatedUser) {
         return null
@@ -118,6 +121,12 @@ export const UserSettingsSidebar: React.FunctionComponent<
                         Show search tour
                     </Button>
                 )}
+                <Button
+                    className="text-left sidebar__link--inactive d-flex w-100"
+                    onClick={() => setCoreWorkflowImprovementsEnabled(!coreWorkflowImprovementsEnabled)}
+                >
+                    {coreWorkflowImprovementsEnabled ? 'Disable' : 'Enable'} workflow improvements
+                </Button>
             </SidebarGroup>
             <div>Version: {window.context.version}</div>
         </div>


### PR DESCRIPTION
Fixes #38060

As a temporary measure, I added a toggle button to enable the flag in the user settings sidebar name. Once we have more features in the new workflow, we can add the button to a more prominent place.

<img width="210" alt="Screenshot 2022-07-05 at 07 17 23" src="https://user-images.githubusercontent.com/6417322/177254971-3b7aa775-cbc3-4816-b703-6bad8757cc56.png">

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
No new functionality is added.

## App preview:

- [Web](https://sg-web-rn-core-workflow-improvements.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-acwphvwjvk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
