### PR TITLE
debugserver: remove DB interface for debug dump

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -230,7 +230,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	globals.WatchExternalURL(nil)
 
 	debugDumpers["repos"] = updateScheduler
-	debugserverEndpoints.repoUpdaterStateEndpoint = repoUpdaterStatsHandler(db, debugDumpers)
+	debugserverEndpoints.repoUpdaterStateEndpoint = repoUpdaterStatsHandler(debugDumpers)
 	debugserverEndpoints.listAuthzProvidersEndpoint = listAuthzProvidersHandler()
 	debugserverEndpoints.gitserverReposStatusEndpoint = gitserverReposStatusHandler(db)
 	debugserverEndpoints.rateLimiterStateEndpoint = rateLimiterStateHandler
@@ -413,7 +413,7 @@ func listAuthzProvidersHandler() http.HandlerFunc {
 	}
 }
 
-func repoUpdaterStatsHandler(db database.DB, debugDumpers map[string]debugserver.Dumper) http.HandlerFunc {
+func repoUpdaterStatsHandler(debugDumpers map[string]debugserver.Dumper) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wantDumper := r.URL.Query().Get("dumper")
 		wantFormat := r.URL.Query().Get("format")
@@ -436,7 +436,7 @@ func repoUpdaterStatsHandler(db database.DB, debugDumpers map[string]debugserver
 				},
 			})
 			template.Must(tmpl.Parse(stateHTMLTemplate))
-			err := tmpl.Execute(w, reposDumper.DebugDump(r.Context(), db.ExternalServices()))
+			err := tmpl.Execute(w, reposDumper.DebugDump(r.Context()))
 			if err != nil {
 				http.Error(w, "Failed to render template: "+err.Error(), http.StatusInternalServerError)
 				return
@@ -449,7 +449,7 @@ func repoUpdaterStatsHandler(db database.DB, debugDumpers map[string]debugserver
 			if wantDumper != "" && wantDumper != name {
 				continue
 			}
-			dumps = append(dumps, dumper.DebugDump(r.Context(), db.ExternalServices()))
+			dumps = append(dumps, dumper.DebugDump(r.Context()))
 		}
 
 		p, err := json.MarshalIndent(dumps, "", "  ")

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -1324,7 +1323,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 }
 
 // DebugDump returns the state of the permissions syncer for debugging.
-func (s *PermsSyncer) DebugDump(_ context.Context, _ debugserver.ExternalServicesStore) any {
+func (s *PermsSyncer) DebugDump(_ context.Context) any {
 	type requestInfo struct {
 		Meta     *requestMeta
 		Acquired bool

--- a/internal/debugserver/debug.go
+++ b/internal/debugserver/debug.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 var addr = env.Get("SRC_PROF_HTTP", ":6060", "net/http/pprof http bind address.")
@@ -72,14 +71,10 @@ type Service struct {
 	DefaultPath string
 }
 
-type ExternalServicesStore interface {
-	GetSyncJobs(ctx context.Context) ([]*types.ExternalServiceSyncJob, error)
-}
-
 // Dumper is a service which can dump its state for debugging.
 type Dumper interface {
 	// DebugDump returns a snapshot of the current state.
-	DebugDump(ctx context.Context, esStore ExternalServicesStore) any
+	DebugDump(ctx context.Context) any
 }
 
 // NewServerRoutine returns a background routine that exposes pprof and metrics endpoints.

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	gitserverprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
@@ -398,7 +397,7 @@ func (s *UpdateScheduler) UpdateOnce(id api.RepoID, name api.RepoName) {
 }
 
 // DebugDump returns the state of the update scheduler for debugging.
-func (s *UpdateScheduler) DebugDump(ctx context.Context, esStore debugserver.ExternalServicesStore) any {
+func (s *UpdateScheduler) DebugDump(ctx context.Context) any {
 	data := struct {
 		Name        string
 		UpdateQueue []*repoUpdate
@@ -447,7 +446,7 @@ func (s *UpdateScheduler) DebugDump(ctx context.Context, esStore debugserver.Ext
 	}
 
 	var err error
-	data.SyncJobs, err = esStore.GetSyncJobs(ctx)
+	data.SyncJobs, err = s.db.ExternalServices().GetSyncJobs(ctx)
 	if err != nil {
 		s.logger.Warn("getting external service sync jobs for debug page", log.Error(err))
 	}


### PR DESCRIPTION
Turns out the `repos.UpdateScheduler` already embeds a `database.DB`, and no need to pass it through as the method argument.

## Test plan

Manually tested:

1. Add the following lines to your `sg.config.overwrite.yaml`:

```yaml
commands:
  repo-updater:
    env:
      SRC_PROF_HTTP: ':6060'
```

<img width="665" alt="CleanShot 2022-06-29 at 15 13 27@2x" src="https://user-images.githubusercontent.com/2946214/176374831-5dc24851-d0cb-49a6-a79f-d075040bb439.png">

---

Followup of https://github.com/sourcegraph/sourcegraph/pull/37915#discussion_r911758746