### PR TITLE
JetBrains: Prepare for an alpha release

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added a new UI to search with Sourcegraph from inside your JetBrains product.
+
 ## [1.2.4]
 
 - Fixed an issue that prevent the latest version of the plugin to work with JetBrains 2022.1 products.

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -2,6 +2,7 @@
 
 # Sourcegraph for JetBrains IDEs
 
+- **New:** Search with Sourcegraph directly from inside your JetBrains product.
 - Instantly search in all open source repos and your private code.
 - Peek into any remote repo in the IDE, without checking it out.
 - Create URLs to specific code blocks to share them with your teammates.

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -90,13 +90,11 @@ If you have any questions, feedback, or bug report, we appreciate if you [open a
 
 The publishing process is based on the [intellij-platform-plugin-template](https://github.com/JetBrains/intellij-platform-plugin-template).
 
-1. Update `pluginVersion` in `gradle.properties`.
-2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md`.
-3. **TODO: The following steps are obsolete now that we merged the project in the monorepo. Figure out a new process!**
-4. ~~Create a [new release](https://github.com/sourcegraph/sourcegraph/releases/new) on GitHub.~~
-5. ~~Pick the new version number as the git tag (e.g. `v1.2.3`).~~
-6. ~~Copy/paste the `[Unreleased]` section of [`CHANGELOG.md`](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/CHANGELOG.md) into the GitHub release text.~~
-7. ~~Once published, a GitHub action is triggered that will publish the release automatically and create a PR to update the changelog and version text. You may need to manually fix the content.~~
+### Publishing from your local machine
+
+1. Update `pluginVersion` in `gradle.properties`
+2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md`
+3. Run `PUBLISH_TOKEN=<YOUR TOKEN HERE> ./scripts/release.sh` from inside the `client/jetbrains` directory (You can [generate tokens on the JetBrains marketplace](https://plugins.jetbrains.com/author/me/tokens)).
 
 ## Version History
 

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=1.2.4
+pluginVersion=2.0.0-alpha
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default

--- a/client/jetbrains/scripts/release.sh
+++ b/client/jetbrains/scripts/release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+[ -z "$PUBLISH_TOKEN" ] && echo "You must set a \$PUBLISH_TOKEN before running this script. You can generate a token in the JetBrains marketplace." && exit 1
+
+# Ensure we have a clean git checkout
+git diff-index --quiet HEAD || (echo "Please commit your changes before releasing" && exit 1)
+
+# Make sure we have all dependencies
+pushd "../.." > /dev/null
+yarn && yarn generate
+popd > /dev/null || exit
+
+# Build the JavaScript artifacts
+yarn build
+
+# Build the release candidate and publish it onto the registry
+./gradlew publishPlugin
+
+# The release script automatically changes the README and moves the unreleased
+# section into a version numbered one. We don't care about this while we are
+# creating pre-release versions.
+if grep -q "alpha\|beta" "gradle.properties"; then
+  git restore CHANGELOG.md
+fi


### PR DESCRIPTION
Fixes #38143 

I decided to draw up a quick script as well so that we have a single point to run when we publish a release from our devices that makes sure all dependencies are build properly.

It can be run via `./scripts/build.sh` inside the JetBrains folder and will prompt you at how to set up the required token.

## Test plan

🤞 

![Screenshot 2022-07-04 at 12 02 23](https://user-images.githubusercontent.com/458591/177132514-0e40622f-9382-4e74-b7b3-02310fd6d48b.png)
![Screenshot 2022-07-04 at 12 02 19](https://user-images.githubusercontent.com/458591/177132522-5945bfd4-0453-4c2a-9595-f0c8ebcf9896.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-prepare-alpha-release.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pvoqenxtsc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
