### PR TITLE
fix(buildchecker): do not consider cron builds

### DIFF
--- a/dev/buildchecker/checker.go
+++ b/dev/buildchecker/checker.go
@@ -44,6 +44,11 @@ func CheckBuilds(ctx context.Context, branch BranchLocker, teammates team.Teamma
 	// Scan for first build with a meaningful state
 	var firstFailedBuildIndex int
 	for i, b := range builds {
+		if isBuildScheduled(b) {
+			// a Scheduled build like Healtcheck should not be considered as part of the set that determines whether
+			// main is locked
+			continue
+		}
 		if isBuildPassed(b) {
 			fmt.Printf("most recent finished build %d passed\n", *b.Number)
 			results.Action, err = branch.Unlock(ctx)
@@ -101,6 +106,10 @@ func CheckBuilds(ctx context.Context, branch BranchLocker, teammates team.Teamma
 		return nil, errors.Newf("lockBranch: %w", err)
 	}
 	return
+}
+
+func isBuildScheduled(build buildkite.Build) bool {
+	return build.Source != nil && *build.Source == "scheduled"
 }
 
 func isBuildPassed(build buildkite.Build) bool {

--- a/dev/buildchecker/checker.go
+++ b/dev/buildchecker/checker.go
@@ -45,8 +45,10 @@ func CheckBuilds(ctx context.Context, branch BranchLocker, teammates team.Teamma
 	var firstFailedBuildIndex int
 	for i, b := range builds {
 		if isBuildScheduled(b) {
-			// a Scheduled build like Healtcheck should not be considered as part of the set that determines whether
-			// main is locked
+			// a Scheduled build should not be considered as part of the set that determines whether
+			// main is locked.
+			// An exmaple of a scheduled build is the nightly release healthcheck build at:
+			// https://buildkite.com/sourcegraph/sourcegraph/settings/schedules/d0b2e4ea-e2df-4fb5-b90e-db88fddb1b76
 			continue
 		}
 		if isBuildPassed(b) {

--- a/dev/buildchecker/checker_test.go
+++ b/dev/buildchecker/checker_test.go
@@ -57,6 +57,13 @@ func TestCheckBuilds(t *testing.T) {
 		State:     buildkite.String("running"),
 		StartedAt: buildkite.NewTimestamp(time.Now()),
 	}
+	scheduledBuild := buildkite.Build{
+		Number:    buildkite.Int(5),
+		Commit:    buildkite.String("a"),
+		State:     buildkite.String("failed"),
+		StartedAt: buildkite.NewTimestamp(time.Now()),
+		Source:    buildkite.String("scheduled"),
+	}
 
 	tests := []struct {
 		name       string
@@ -82,6 +89,10 @@ func TestCheckBuilds(t *testing.T) {
 		name:       "should skip leading running builds to lock",
 		builds:     append([]buildkite.Build{runningBuild}, failSet...),
 		wantLocked: true,
+	}, {
+		name:       "should not locked because of scheduled build",
+		builds:     []buildkite.Build{failSet[0], scheduledBuild},
+		wantLocked: false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dev/buildchecker/failures.go
+++ b/dev/buildchecker/failures.go
@@ -23,6 +23,10 @@ func findConsecutiveFailures(
 	var consecutiveFailures int
 	var build buildkite.Build
 	for buildsScanned, build = range builds {
+		if isBuildScheduled(build) {
+			// we do not consider scheduled builds like Healthcheck
+			continue
+		}
 		if isBuildPassed(build) {
 			// If we find a passed build we are done
 			return

--- a/dev/buildchecker/failures.go
+++ b/dev/buildchecker/failures.go
@@ -24,7 +24,10 @@ func findConsecutiveFailures(
 	var build buildkite.Build
 	for buildsScanned, build = range builds {
 		if isBuildScheduled(build) {
-			// we do not consider scheduled builds like Healthcheck
+			// a Scheduled build should not be considered as part of the set that determines whether
+			// main is locked.
+			// An exmaple of a scheduled build is the nightly release healthcheck build at:
+			// https://buildkite.com/sourcegraph/sourcegraph/settings/schedules/d0b2e4ea-e2df-4fb5-b90e-db88fddb1b76
 			continue
 		}
 		if isBuildPassed(build) {


### PR DESCRIPTION
Builchecker should not lock the main branch when scheduled/cron builds failed consequtively

Closes  #34470
## Test plan
Ran unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
