### PR TITLE
JetBrains: 2.0.0-alpha.1 release

### DIFF
--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -93,6 +93,9 @@ The publishing process is based on the [intellij-platform-plugin-template](https
 ### Publishing from your local machine
 
 1. Update `pluginVersion` in `gradle.properties`
+
+- Pre-release builds with the same version as a previous one need to append a number. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
+
 2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md`
 3. Run `PUBLISH_TOKEN=<YOUR TOKEN HERE> ./scripts/release.sh` from inside the `client/jetbrains` directory (You can [generate tokens on the JetBrains marketplace](https://plugins.jetbrains.com/author/me/tokens)).
 

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=2.0.0-alpha
+pluginVersion=2.0.0-alpha.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default


### PR DESCRIPTION
Docs change and a version bump for an alpha release.

## Test plan

Just a docs change and version bump

## App preview:

- [Web](https://sg-web-dv-jetbrains-alpha-release.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jqiucudetx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
