### PR TITLE
JetBrains: Remove leftover console.log

### DIFF
--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -22,10 +22,8 @@ events
         bufferTime(1000),
         concatMap(events => {
             if (events.length > 0) {
-                console.log('sending events in batches bruh', events)
-
                 // For every IDESearchSubmitted, we also fire a legacy logUserEvent event. This is
-                // necessary since we only look at the latter to calculat some activity usage
+                // necessary since we only look at the latter to calculate some activity usage
                 // numbers.
                 //
                 // See sourcegraph/sourcegraph#35178


### PR DESCRIPTION
Whoa this is awkward. Sorry I missed this!

## Test plan

Removes a `console.log`, no other changes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-remove-leftover.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yzpsaonnst.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
