### PR TITLE
Revert "Search backend: use client logger where applicable"

### DIFF
--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -38,7 +38,7 @@ var Targets = []Target{
 			goEnterpriseImport,
 			noLocalHost,
 			lintGoDirectives(),
-			lintLoggingLibraries(),
+			// lintLoggingLibraries(),
 			goModGuards(),
 			lintSGExit(),
 		},

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sourcegraph/log"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -24,8 +24,7 @@ import (
 )
 
 type Observer struct {
-	Logger log.Logger
-	Db     database.DB
+	Db database.DB
 
 	// Inputs are used to generate alert messages based on the query.
 	*run.SearchInputs
@@ -223,7 +222,7 @@ func (o *Observer) Done() (*search.Alert, error) {
 	}
 
 	if o.HasResults && o.err != nil {
-		o.Logger.Warn("Errors during search", log.Error(o.err))
+		log15.Error("Errors during search", "error", o.err)
 		return o.alert, nil
 	}
 

--- a/internal/search/alert/observer_test.go
+++ b/internal/search/alert/observer_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -38,9 +39,7 @@ func TestErrorToAlertStructuralSearch(t *testing.T) {
 	}
 	for _, test := range cases {
 		multiErr := errors.Append(nil, test.errors...)
-		haveAlert, _ := (&Observer{
-			Logger: logtest.Scoped(t),
-		}).errorToAlert(context.Background(), multiErr)
+		haveAlert, _ := (&Observer{}).errorToAlert(context.Background(), multiErr)
 
 		if haveAlert != nil && haveAlert.Title != test.wantAlertTitle {
 			t.Fatalf("test %s, have alert: %q, want: %q", test.name, haveAlert.Title, test.wantAlertTitle)
@@ -72,8 +71,7 @@ func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 		t.Fatal(err)
 	}
 	sr := Observer{
-		Logger: logger,
-		Db:     db,
+		Db: db,
 		SearchInputs: &run.SearchInputs{
 			OriginalQuery: searchQuery,
 			Query:         q,

--- a/internal/search/job/jobutil/alert.go
+++ b/internal/search/job/jobutil/alert.go
@@ -43,7 +43,6 @@ func (j *alertJob) Run(ctx context.Context, clients job.RuntimeClients, stream s
 	jobAlert, err := j.child.Run(ctx, clients, statsObserver)
 
 	ao := searchalert.Observer{
-		Logger:       clients.Logger,
 		Db:           clients.DB,
 		SearchInputs: j.inputs,
 		HasResults:   countingStream.Count() > 0,

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -69,7 +69,6 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 	pager := func(page *repos.Resolved) error {
 		indexed, unindexed, err := zoekt.PartitionRepos(
 			ctx,
-			clients.Logger,
 			page.RepoRevs,
 			clients.Zoekt,
 			search.TextRequest,

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"sync"
 
-	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/log"
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -39,7 +39,7 @@ func (s *subRepoPermsFilterJob) Run(ctx context.Context, clients job.RuntimeClie
 
 	filteredStream := streaming.StreamFunc(func(event streaming.SearchEvent) {
 		var err error
-		event.Results, err = applySubRepoFiltering(ctx, clients.Logger, checker, event.Results)
+		event.Results, err = applySubRepoFiltering(ctx, checker, event.Results)
 		if err != nil {
 			mu.Lock()
 			errs = errors.Append(errs, err)
@@ -59,13 +59,13 @@ func (s *subRepoPermsFilterJob) Name() string {
 	return "SubRepoPermsFilterJob"
 }
 
-func (s *subRepoPermsFilterJob) Tags() []otlog.Field {
-	return []otlog.Field{}
+func (s *subRepoPermsFilterJob) Tags() []log.Field {
+	return []log.Field{}
 }
 
 // applySubRepoFiltering filters a set of matches using the provided
 // authz.SubRepoPermissionChecker
-func applySubRepoFiltering(ctx context.Context, logger log.Logger, checker authz.SubRepoPermissionChecker, matches []result.Match) ([]result.Match, error) {
+func applySubRepoFiltering(ctx context.Context, checker authz.SubRepoPermissionChecker, matches []result.Match) ([]result.Match, error) {
 	if !authz.SubRepoEnabled(checker) {
 		return matches, nil
 	}
@@ -117,6 +117,6 @@ func applySubRepoFiltering(ctx context.Context, logger log.Logger, checker authz
 
 	// We don't want to return sensitive authz information or excluded paths to the
 	// user so we'll return generic error and log something more specific.
-	logger.Warn("Applying sub-repo permissions to search results", log.Error(errs))
+	log15.Warn("Applying sub-repo permissions to search results", "error", errs)
 	return filtered, errors.New("subRepoFilterFunc")
 }

--- a/internal/search/job/jobutil/sub_repo_perms_job_test.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -173,7 +172,7 @@ func TestApplySubRepoFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := actor.WithActor(context.Background(), tt.args.ctxActor)
-			matches, err := applySubRepoFiltering(ctx, logtest.Scoped(t), checker, tt.args.matches)
+			matches, err := applySubRepoFiltering(ctx, checker, tt.args.matches)
 			if diff := cmp.Diff(matches, tt.wantMatches, cmpopts.IgnoreUnexported(search.RepoStatusMap{})); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/grafana/regexp"
 	regexpsyntax "github.com/grafana/regexp/syntax"
+	"github.com/inconshreveable/log15"
 	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/log"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
@@ -832,7 +832,7 @@ func (e MissingLockfileIndexing) Error() string {
 // Get all private repos for the the current actor. On sourcegraph.com, those are
 // only the repos directly added by the user. Otherwise it's all repos the user has
 // access to on all connected code hosts / external services.
-func PrivateReposForActor(ctx context.Context, logger log.Logger, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
+func PrivateReposForActor(ctx context.Context, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
 	tr, ctx := trace.New(ctx, "PrivateReposForActor", "")
 	defer tr.Finish()
 
@@ -862,7 +862,7 @@ func PrivateReposForActor(ctx context.Context, logger log.Logger, db database.DB
 	})
 
 	if err != nil {
-		logger.Error("doResults: failed to list user private repos", log.Error(err), log.Int32("user-id", userID))
+		log15.Error("doResults: failed to list user private repos", "error", err, "user-id", userID)
 		tr.LazyPrintf("error resolving user private repos: %v", err)
 	}
 	return userPrivateRepos

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -42,7 +42,6 @@ func (s *RepoSearchJob) reposContainingPath(ctx context.Context, clients job.Run
 
 	indexed, unindexed, err := zoektutil.PartitionRepos(
 		ctx,
-		clients.Logger,
 		repos,
 		clients.Zoekt,
 		search.TextRequest,

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/log"
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
@@ -69,8 +69,8 @@ func (s *TextSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 	}
 
 	tr.LogFields(
-		otlog.Int64("fetch_timeout_ms", fetchTimeout.Milliseconds()),
-		otlog.Int64("repos_count", int64(len(s.Repos))),
+		log.Int64("fetch_timeout_ms", fetchTimeout.Milliseconds()),
+		log.Int64("repos_count", int64(len(s.Repos))),
 	)
 
 	if len(s.Repos) == 0 {
@@ -112,8 +112,8 @@ func (s *TextSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 
 					repoLimitHit, err := s.searchFilesInRepo(ctx, clients.DB, clients.SearcherURLs, repo, repo.Name, rev, s.Indexed, s.PatternInfo, fetchTimeout, stream)
 					if err != nil {
-						tr.LogFields(otlog.String("repo", string(repo.Name)), otlog.Error(err), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
-						clients.Logger.Warn("searchFilesInRepo failed", log.Error(err), log.String("repo", string(repo.Name)))
+						tr.LogFields(log.String("repo", string(repo.Name)), log.Error(err), log.Bool("timeout", errcode.IsTimeout(err)), log.Bool("temporary", errcode.IsTemporary(err)))
+						log15.Warn("searchFilesInRepo failed", "error", err, "repo", repo.Name)
 					}
 					// non-diff search reports timeout through err, so pass false for timedOut
 					status, limitHit, err := search.HandleRepoSearchResult(repo.ID, []search.RevisionSpecifier{{RevSpec: rev}}, repoLimitHit, false, err)
@@ -138,12 +138,12 @@ func (s *TextSearchJob) Name() string {
 	return "SearcherTextSearchJob"
 }
 
-func (s *TextSearchJob) Tags() []otlog.Field {
-	return []otlog.Field{
+func (s *TextSearchJob) Tags() []log.Field {
+	return []log.Field{
 		trace.Stringer("patternInfo", s.PatternInfo),
-		otlog.Int("numRepos", len(s.Repos)),
-		otlog.Bool("indexed", s.Indexed),
-		otlog.Bool("useFullDeadline", s.UseFullDeadline),
+		log.Int("numRepos", len(s.Repos)),
+		log.Bool("indexed", s.Indexed),
+		log.Bool("useFullDeadline", s.UseFullDeadline),
 	}
 }
 

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -3,6 +3,7 @@ package structural
 import (
 	"context"
 
+	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/sync/errgroup"
 
@@ -132,7 +133,7 @@ func runStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *
 		event = agg.SearchEvent
 		if len(event.Results) == 0 {
 			// Still no results? Give up.
-			clients.Logger.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
+			log15.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
 			event.Stats.IsLimitHit = false // Ensure we don't display "Show more".
 		}
 	}
@@ -169,7 +170,6 @@ func (s *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 	return nil, repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
 		indexed, unindexed, err := zoektutil.PartitionRepos(
 			ctx,
-			clients.Logger,
 			page.RepoRevs,
 			clients.Zoekt,
 			search.TextRequest,

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/log/logtest"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -96,7 +94,6 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 
 	matches, common, err := RunRepoSubsetTextSearch(
 		context.Background(),
-		logtest.Scoped(t),
 		patternInfo,
 		repoRevs,
 		q,
@@ -126,7 +123,6 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 	// that should be checked earlier.
 	_, _, err = RunRepoSubsetTextSearch(
 		context.Background(),
-		logtest.Scoped(t),
 		patternInfo,
 		makeRepositoryRevisions("foo/no-rev@dev"),
 		q,
@@ -197,7 +193,6 @@ func TestSearchFilesInReposStream(t *testing.T) {
 
 	matches, _, err := RunRepoSubsetTextSearch(
 		context.Background(),
-		logtest.Scoped(t),
 		patternInfo,
 		makeRepositoryRevisions("foo/one", "foo/two", "foo/three"),
 		q,
@@ -276,7 +271,6 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 
 	matches, _, err := RunRepoSubsetTextSearch(
 		context.Background(),
-		logtest.Scoped(t),
 		patternInfo,
 		repos,
 		q,
@@ -338,7 +332,6 @@ func mkRepos(names ...string) []types.MinimalRepo {
 // RunRepoSubsetTextSearch is a convenience function that simulates the RepoSubsetTextSearch job.
 func RunRepoSubsetTextSearch(
 	ctx context.Context,
-	logger log.Logger,
 	patternInfo *search.TextPatternInfo,
 	repos []*search.RepositoryRevisions,
 	q query.Q,
@@ -357,7 +350,6 @@ func RunRepoSubsetTextSearch(
 
 	indexed, unindexed, err := zoektutil.PartitionRepos(
 		context.Background(),
-		logger,
 		repos,
 		zoekt,
 		search.TextRequest,
@@ -403,10 +395,7 @@ func RunRepoSubsetTextSearch(
 
 		// Run literal and regexp searches on indexed repositories.
 		g.Go(func() error {
-			_, err := zoektJob.Run(ctx, job.RuntimeClients{
-				Logger: logger,
-				Zoekt:  zoekt,
-			}, agg)
+			_, err := zoektJob.Run(ctx, job.RuntimeClients{Zoekt: zoekt}, agg)
 			return err
 		})
 	}
@@ -420,11 +409,7 @@ func RunRepoSubsetTextSearch(
 			UseFullDeadline: searcherArgs.UseFullDeadline,
 		}
 
-		_, err := searcherJob.Run(ctx, job.RuntimeClients{
-			Logger:       logger,
-			SearcherURLs: searcherURLs,
-			Zoekt:        zoekt,
-		}, agg)
+		_, err := searcherJob.Run(ctx, job.RuntimeClients{SearcherURLs: searcherURLs, Zoekt: zoekt}, agg)
 		return err
 	})
 

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -9,8 +9,8 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
-	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/log"
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go/log"
 	"go.uber.org/atomic"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -172,7 +172,6 @@ func (rb *IndexedRepoRevs) getRepoInputRev(file *zoekt.FileMatch) (repo types.Mi
 
 func PartitionRepos(
 	ctx context.Context,
-	logger log.Logger,
 	repos []*search.RepositoryRevisions,
 	zoektStreamer zoekt.Streamer,
 	typ search.IndexedRequestType,
@@ -213,20 +212,20 @@ func PartitionRepos(
 				return nil, nil, errors.New("index:only failed since indexed search is not available yet")
 			}
 
-			logger.Warn("zoektIndexedRepos failed", log.Error(err))
+			log15.Warn("zoektIndexedRepos failed", "error", err)
 		}
 
 		return nil, repos, ctx.Err()
 	}
 
-	tr.LogFields(otlog.Int("all_indexed_set.size", len(list.Minimal)))
+	tr.LogFields(log.Int("all_indexed_set.size", len(list.Minimal)))
 
 	// Split based on indexed vs unindexed
 	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filter)
 
 	tr.LogFields(
-		otlog.Int("indexed.size", len(indexed.RepoRevs)),
-		otlog.Int("unindexed.size", len(unindexed)),
+		log.Int("indexed.size", len(indexed.RepoRevs)),
+		log.Int("unindexed.size", len(unindexed)),
 	)
 
 	// Disable unindexed search
@@ -568,17 +567,17 @@ func (*RepoSubsetTextSearchJob) Name() string {
 	return "ZoektRepoSubsetTextSearchJob"
 }
 
-func (z *RepoSubsetTextSearchJob) Tags() []otlog.Field {
-	tags := []otlog.Field{
+func (z *RepoSubsetTextSearchJob) Tags() []log.Field {
+	tags := []log.Field{
 		trace.Stringer("query", z.Query),
-		otlog.String("type", string(z.Typ)),
-		otlog.Int32("fileMatchLimit", z.FileMatchLimit),
+		log.String("type", string(z.Typ)),
+		log.Int32("fileMatchLimit", z.FileMatchLimit),
 		trace.Stringer("select", z.Select),
 	}
 	// z.Repos is nil for un-indexed search
 	if z.Repos != nil {
-		tags = append(tags, otlog.Int("numRepoRevs", len(z.Repos.RepoRevs)))
-		tags = append(tags, otlog.Int("numBranchRepos", len(z.Repos.branchRepos)))
+		tags = append(tags, log.Int("numRepoRevs", len(z.Repos.RepoRevs)))
+		tags = append(tags, log.Int("numBranchRepos", len(z.Repos.branchRepos)))
 	}
 	return tags
 }
@@ -593,7 +592,7 @@ func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClient
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, t)
 	defer func() { finish(alert, err) }()
 
-	userPrivateRepos := searchrepos.PrivateReposForActor(ctx, clients.Logger, clients.DB, t.RepoOpts)
+	userPrivateRepos := searchrepos.PrivateReposForActor(ctx, clients.DB, t.RepoOpts)
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	t.ZoektArgs.Query = t.GlobalZoektQuery.Generate()
 
@@ -604,13 +603,13 @@ func (*GlobalTextSearchJob) Name() string {
 	return "ZoektGlobalTextSearchJob"
 }
 
-func (t *GlobalTextSearchJob) Tags() []otlog.Field {
-	return []otlog.Field{
+func (t *GlobalTextSearchJob) Tags() []log.Field {
+	return []log.Field{
 		trace.Stringer("query", t.GlobalZoektQuery.Query),
 		trace.Printf("repoScope", "%q", t.GlobalZoektQuery.RepoScope),
-		otlog.Bool("includePrivate", t.GlobalZoektQuery.IncludePrivate),
-		otlog.String("type", string(t.ZoektArgs.Typ)),
-		otlog.Int32("fileMatchLimit", t.ZoektArgs.FileMatchLimit),
+		log.Bool("includePrivate", t.GlobalZoektQuery.IncludePrivate),
+		log.String("type", string(t.ZoektArgs.Typ)),
+		log.Int32("fileMatchLimit", t.ZoektArgs.FileMatchLimit),
 		trace.Stringer("select", t.ZoektArgs.Select),
 		trace.Stringer("repoOpts", &t.RepoOpts),
 	}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
-	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -287,7 +286,6 @@ func TestIndexedSearch(t *testing.T) {
 
 			indexed, unindexed, err := PartitionRepos(
 				context.Background(),
-				logtest.Scoped(t),
 				tt.args.repos,
 				zoekt,
 				search.TextRequest,

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -83,7 +83,7 @@ func (s *GlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	userPrivateRepos := repos.PrivateReposForActor(ctx, clients.Logger, clients.DB, s.RepoOpts)
+	userPrivateRepos := repos.PrivateReposForActor(ctx, clients.DB, s.RepoOpts)
 	s.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	s.ZoektArgs.Query = s.GlobalZoektQuery.Generate()
 


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#38130 - see https://github.com/sourcegraph/sourcegraph/pull/38130#issuecomment-1174062463

tl;dr there appears to be a panic in main:

```
2022-07-04T16:14:23.456840216Z �[0;33m16:14:23                  frontend | �[0mpanic: runtime error: invalid memory address or nil pointer dereference
2022-07-04T16:14:23.456858647Z �[0;33m16:14:23                  frontend | �[0m[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x1f0281d]
2022-07-04T16:14:23.456865190Z �[0;33m16:14:23                  frontend | �[0mgoroutine 14292 [running]:
2022-07-04T16:14:23.456870463Z �[0;33m16:14:23                  frontend | �[0mgithub.com/sourcegraph/sourcegraph/internal/search/searcher.(*TextSearchJob).Run.func2.1()
2022-07-04T16:14:23.456875409Z �[0;33m16:14:23                  frontend | �[0m	github.com/sourcegraph/sourcegraph/internal/search/searcher/search.go:116 +0x75d
```

I will handle a fix and un-revert, but for now the tests are failing consistently at this point

Test plan: reverts to a known working state