### PR TITLE
Update instructions for the SAML allowGroups configuration

### DIFF
--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -120,24 +120,35 @@ Use the following filters to restrict how users can create accounts and sign in 
     }
   ```
 
-  **Groups with special characters**
+  * Groups with special characters
 
-  Special characters such as the `&` (ampersand) will be encoded in the XML document, the format used by SAML. For example, if you have a group `Dogs & cats` set in your Identity Provider, it will show up as `Dogs &amp; cats` in the XML assertions. This is expected - just avoid using the encoded character when adding a group name to the `allowGroups` array. 
+  Special characters such as the `&` (ampersand) will be encoded in the XML document, the format used by SAML. For example, if you have a group `Dogs & cats` set in your Identity Provider, it will show up as `Dogs &amp; cats` in the XML assertions.
 
-  _Insted of `&amp;`_
+  This is expected - just avoid using the encoded character when adding a group name to the `allowGroups` array.
+
+  _Instead of_
   ```json
     {
-      "allowGroups": ["Dogs &amp; cats"] // wrong
+      "allowGroups":
+      [
+        "Dogs &amp; cats", // wrong
+        "Dogs &gt; cats", // wrong
+        "Cats &lt; dogs" // wrong
+      ]
     }
   ```
 
-  _Use `&`_
+  _Use_
   ```json
     {
-      "allowGroups": ["Dogs & cats"] // correct
+      "allowGroups":
+      [
+        "Dogs & cats", // correct
+        "Dogs > cats", // correct
+        "Cats < dogs" // correct
+      ]
     }
   ```
-
 
 See [SAML troubleshooting](#troubleshooting) for more tips.
 

--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -122,7 +122,7 @@ Use the following filters to restrict how users can create accounts and sign in 
 
   * Groups with special characters
 
-  Special characters such as the `&` (ampersand) will be encoded in the XML document, the format used by SAML. For example, if you have a group `Dogs & cats` set in your Identity Provider, it will show up as `Dogs &amp; cats` in the XML assertions.
+  Special characters such as the `&` (ampersand) will be encoded in the XML document, the format used by SAML. For example, if you have a group `Dogs & cats` set in your Identity Provider, it will be shown as `Dogs &amp; cats` in the XML assertions.
 
   This is expected - just avoid using the encoded character when adding a group name to the `allowGroups` array.
 

--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -120,7 +120,7 @@ Use the following filters to restrict how users can create accounts and sign in 
     }
   ```
 
-  * Groups with special characters
+  * Group names with special characters
 
   Special characters such as the `&` (ampersand) will be encoded in the XML document, the format used by SAML. For example, if you have a group `Dogs & cats` set in your Identity Provider, it will be shown as `Dogs &amp; cats` in the XML assertions.
 

--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -120,6 +120,24 @@ Use the following filters to restrict how users can create accounts and sign in 
     }
   ```
 
+  **Groups with special characters**
+
+  Special characters such as the `&` (ampersand) will be encoded in the XML document, the format used by SAML. For example, if you have a group `Dogs & cats` set in your Identity Provider, it will show up as `Dogs &amp; cats` in the XML assertions. This is expected - just avoid using the encoded character when adding a group name to the `allowGroups` array. 
+
+  _Insted of `&amp;`_
+  ```json
+    {
+      "allowGroups": ["Dogs &amp; cats"] // wrong
+    }
+  ```
+
+  _Use `&`_
+  ```json
+    {
+      "allowGroups": ["Dogs & cats"] // correct
+    }
+  ```
+
 
 See [SAML troubleshooting](#troubleshooting) for more tips.
 


### PR DESCRIPTION
This PR adds more instructions to the SAML configuration, covering the use of  special characters in the array `allowGroups`.

## Test plan

Manually tested in a local instance.
