### PR TITLE
rockskip: Add ROCKSKIP_MIN_REPO_SIZE_MB to index repos over a certain size

### DIFF
--- a/doc/code_intelligence/explanations/rockskip.md
+++ b/doc/code_intelligence/explanations/rockskip.md
@@ -22,13 +22,12 @@ For Docker Compose:
 
 ```yaml
 services:
-
   symbols-0:
     environment:
       # 👇 Enables Rockskip
       - USE_ROCKSKIP=true
-      # 👇 Uses Rockskip for the repositories in the comma separated list
-      - ROCKSKIP_REPOS=github.com/torvalds/linux,github.com/pallets/flask
+      # 👇 Uses Rockskip for all the repositories over 1GB
+      - ROCKSKIP_MIN_REPO_SIZE_MB=1000
 ```
 
 For Helm:
@@ -59,9 +58,9 @@ spec:
         # 👇 Enables Rockskip
         - name: USE_ROCKSKIP
           value: "true"
-        # 👇 Uses Rockskip for the repositories in the comma separated list
-        - name: ROCKSKIP_REPOS
-          value: "github.com/torvalds/linux,github.com/pallets/flask"
+        # 👇 Uses Rockskip for all the repositories over 1GB
+        - name: ROCKSKIP_MIN_REPO_SIZE_MB
+          value: "1000"
 ```
 
 For all deployments, make sure that:

--- a/doc/code_intelligence/explanations/search_based_code_intelligence.md
+++ b/doc/code_intelligence/explanations/search_based_code_intelligence.md
@@ -44,8 +44,9 @@ The symbols container recognizes these environment variables:
 - `REQUEST_BUFFER_SIZE`: defaults to `8192`, maximum size of buffered parser request channel
 - `PROCESSING_TIMEOUT`: defaults to `2h`, maximum time to spend processing a repository
 - `MAX_TOTAL_PATHS_LENGTH`: defaults to `100000`, maximum sum of lengths of all paths in a single call to git archive
-- `USE_ROCKSKIP`: defaults to `false`, enables [Rockskip](rockskip.md) for fast symbol searches and search-based code intelligence on big repositories specified in `ROCKSKIP_REPOS`
+- `USE_ROCKSKIP`: defaults to `false`, enables [Rockskip](rockskip.md) for fast symbol searches and search-based code intelligence on repositories specified in `ROCKSKIP_REPOS`, or respositories over `ROCKSKIP_MIN_REPO_SIZE_MB` in size
 - `ROCKSKIP_REPOS`: no default, in combination with `USE_ROCKSKIP=true` this specifies a comma separated list of repositories to index using [Rockskip](rockskip.md) (e.g. `github.com/torvalds/linux,github.com/pallets/flask`)
+- `ROCKSKIP_MIN_REPO_SIZE_MB`: no default, in combination with `USE_ROCKSKIP=true` all repos that are at least this big will be indexed using Rockskip
 - `MAX_CONCURRENTLY_INDEXING`: defaults to `4`, maximum number of repositories being indexed at a time by [Rockskip](rockskip.md) (also limits ctags processes)
 
 The defaults come from [`config.go`](https://github.com/sourcegraph/sourcegraph/blob/eea895ae1a8acef08370a5cc6f24bdc7c66cb4ed/cmd/symbols/config.go#L42-L59).

--- a/enterprise/cmd/symbols/main.go
+++ b/enterprise/cmd/symbols/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/sourcegraph/go-ctags"
 	"github.com/sourcegraph/log"
@@ -34,7 +35,11 @@ func main() {
 	reposVar := env.Get("ROCKSKIP_REPOS", "", "comma separated list of repositories to index (e.g. `github.com/torvalds/linux,github.com/pallets/flask`)")
 	repos := strings.Split(reposVar, ",")
 
-	if env.Get("USE_ROCKSKIP", "false", "use Rockskip to index the repos specified in ROCKSKIP_REPOS") == "true" {
+	minRepoSizeMb := env.MustGetInt("ROCKSKIP_MIN_REPO_SIZE_MB", -1, "all repos that are at least this big will be indexed using Rockskip")
+
+	repoToSize := map[string]int64{}
+
+	if env.Get("USE_ROCKSKIP", "false", "use Rockskip to index the repos specified in ROCKSKIP_REPOS, or repos over ROCKSKIP_MIN_REPO_SIZE_MB in size") == "true" {
 		shared.Main(func(observationContext *observation.Context, gitserverClient symbolsGitserver.GitserverClient, repositoryFetcher fetcher.RepositoryFetcher) (types.SearchFunc, func(http.ResponseWriter, *http.Request), []goroutine.BackgroundRoutine, string, error) {
 			rockskipSearchFunc, rockskipHandleStatus, rockskipBackgroundRoutines, rockskipCtagsCommand, err := SetupRockskip(observationContext, gitserverClient, repositoryFetcher)
 			if err != nil {
@@ -49,11 +54,35 @@ func main() {
 			}
 
 			searchFunc := func(ctx context.Context, args search.SymbolsParameters) (results result.Symbols, err error) {
-				if sliceContains(repos, string(args.Repo)) {
-					return rockskipSearchFunc(ctx, args)
-				} else {
-					return sqliteSearchFunc(ctx, args)
+				if reposVar != "" {
+					if sliceContains(repos, string(args.Repo)) {
+						return rockskipSearchFunc(ctx, args)
+					} else {
+						return sqliteSearchFunc(ctx, args)
+					}
 				}
+
+				if minRepoSizeMb != -1 {
+					var size int64
+					if _, ok := repoToSize[string(args.Repo)]; ok {
+						size = repoToSize[string(args.Repo)]
+					} else {
+						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+						defer cancel()
+						size, err = gitserverClient.GetRepoSize(ctx, args.Repo)
+						if err != nil {
+							return sqliteSearchFunc(ctx, args)
+						}
+					}
+
+					if size >= int64(minRepoSizeMb)*1000*1000 {
+						return rockskipSearchFunc(ctx, args)
+					} else {
+						return sqliteSearchFunc(ctx, args)
+					}
+				}
+
+				return sqliteSearchFunc(ctx, args)
 			}
 
 			return searchFunc, rockskipHandleStatus, append(rockskipBackgroundRoutines, sqliteBackgroundRoutines...), rockskipCtagsCommand, nil

--- a/enterprise/internal/rockskip/status.go
+++ b/enterprise/internal/rockskip/status.go
@@ -96,10 +96,7 @@ func (s *Service) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, "This is the symbols service status page.")
 	fmt.Fprintln(w, "")
 
-	if os.Getenv("ROCKSKIP_REPOS") == "" {
-		fmt.Fprintln(w, "⚠️ Rockskip is not enabled for any repositories. Remember to set the ROCKSKIP_REPOS environment variable and restart the symbols service.")
-		fmt.Fprintln(w, "")
-	} else {
+	if os.Getenv("ROCKSKIP_REPOS") != "" {
 		fmt.Fprintln(w, "Rockskip is enabled for these repositories:")
 		for _, repo := range strings.Split(os.Getenv("ROCKSKIP_REPOS"), ",") {
 			fmt.Fprintln(w, "  "+repo)
@@ -113,6 +110,12 @@ func (s *Service) HandleStatus(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, "⚠️ Docs: https://docs.sourcegraph.com/code_intelligence/explanations/rockskip")
 			fmt.Fprintln(w, "")
 		}
+	} else if os.Getenv("ROCKSKIP_MIN_REPO_SIZE_MB") != "" {
+		fmt.Fprintf(w, "Rockskip is enabled for repositories over %sMB in size.\n", os.Getenv("ROCKSKIP_MIN_REPO_SIZE_MB"))
+		fmt.Fprintln(w, "")
+	} else {
+		fmt.Fprintln(w, "⚠️ Rockskip is not enabled for any repositories. Remember to set either ROCKSKIP_REPOS or ROCKSKIP_MIN_REPO_SIZE_MB and restart the symbols service.")
+		fmt.Fprintln(w, "")
 	}
 
 	fmt.Fprintf(w, "Number of rows in rockskip_repos: %d\n", repositoryCount)


### PR DESCRIPTION
This adds `ROCKSKIP_MIN_REPO_SIZE_MB` (defaults to 1000, or 1GB), which tells the `symbols` service to index all repos over that size.

This makes it easier to set up Rockskip because you no longer have to explicitly list the repos in `ROCKSKIP_REPOS`.

## Test plan

Ran locally.
