### PR TITLE
Fix duplicate history entry on selecting lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 - A bug where some complex `repo:` regexes only returned a subset of repository results. [#37925](https://github.com/sourcegraph/sourcegraph/pull/37925)
 - Fix a bug with bad code insights chart data points links. [#38102](https://github.com/sourcegraph/sourcegraph/pull/38102)
 - Code Insights: the commit indexer no longer errors when fetching commits from empty repositories and marks them as successfully indexed. [#39081](https://github.com/sourcegraph/sourcegraph/pull/38091)
+- Fixed an issue where multiple activations of the back button are required to navigate back to a previously selected line in a file [#38193](https://github.com/sourcegraph/sourcegraph/pull/38193)
 
 ### Removed
 

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -408,7 +408,6 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
 
                         const parameters = new URLSearchParams(location.search)
                         parameters.delete('popover')
-                        nextPopoverClose()
 
                         if (position && !('character' in position)) {
                             // Only change the URL when clicking on blank space on the line (not on

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -420,7 +420,7 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                     }),
                     mapTo(undefined)
                 ),
-            [codeViewElements, hoverifier.hoverState.selectedPosition, location, nextPopoverClose, props.history]
+            [codeViewElements, hoverifier.hoverState.selectedPosition, location, props.history]
         )
     )
 


### PR DESCRIPTION
It appears that we are adding the exact same history entry twice, making the
back and forward buttons behave unexpectedly: The first time the back
button is clicked nothing seems to happen:


https://user-images.githubusercontent.com/179026/177218213-8b5b2c1c-0a56-49b3-a4f5-864f0f308290.mp4



Both the function this line was delete from as well as [the observable
that gets triggered by calling `nextPopOverClose`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@9f95e3682cd4580fc7a22baffa9ec38cc40c1d4c/-/blob/client/web/src/repo/blob/Blob.tsx?L297-315) add a history entry. I believe
calling `nextPopOverClose` is unncessary here (or we leave it but remove
the call to `history.push(...)` below).



## Test plan

- Open a file in Sourcegraph and select various lines in the file
- Press the back button. Every press should jump to a different location.

## App preview:

- [Web](https://sg-web-fkling-blob-fix-duplicate-history.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lpzqmjhisl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
