### PR TITLE
Simplify blob view line highlighting logic

### DIFF
--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -442,6 +442,11 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                 row.classList.add('selected')
             }
         }
+        // It looks like `parsedHash` is updated _before_ `blobInfo` when
+        // navigating between files. That means we have to make this effect
+        // dependent on `blobInfo` even if it is not used inside the effect,
+        // otherwise the highlighting would not be updated when the new file
+        // content is available.
     }, [parsedHash, blobInfo])
 
     // EXTENSION FEATURES

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -424,36 +424,25 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
         )
     )
 
-    // Trigger line highlighting after React has finished putting new lines into the DOM via
-    // `dangerouslySetInnerHTML`.
-    useEffect(() => codeViewElements.next(codeViewReference.current))
-
     // Line highlighting when position in hash changes
-    useObservable(
-        useMemo(
-            () =>
-                combineLatest([locationPositions, codeViewElements.pipe(filter(isDefined))]).pipe(
-                    tap(([position, codeView]) => {
-                        const codeCells = getCodeElementsInRange({
-                            codeView,
-                            position,
-                            getCodeElementFromLineNumber: domFunctions.getCodeElementFromLineNumber,
-                        })
-                        // Remove existing highlighting
-                        for (const selected of codeView.querySelectorAll('.selected')) {
-                            selected.classList.remove('selected')
-                        }
-                        for (const { element } of codeCells) {
-                            // Highlight row
-                            const row = element.parentElement as HTMLTableRowElement
-                            row.classList.add('selected')
-                        }
-                    }),
-                    mapTo(undefined)
-                ),
-            [locationPositions, codeViewElements]
-        )
-    )
+    useEffect(() => {
+        if (codeViewReference.current) {
+            const codeCells = getCodeElementsInRange({
+                codeView: codeViewReference.current,
+                position: parsedHash,
+                getCodeElementFromLineNumber: domFunctions.getCodeElementFromLineNumber,
+            })
+            // Remove existing highlighting
+            for (const selected of codeViewReference.current.querySelectorAll('.selected')) {
+                selected.classList.remove('selected')
+            }
+            for (const { element } of codeCells) {
+                // Highlight row
+                const row = element.parentElement as HTMLTableRowElement
+                row.classList.add('selected')
+            }
+        }
+    }, [parsedHash, blobInfo])
 
     // EXTENSION FEATURES
 


### PR DESCRIPTION
Currently the line highlighting logic is triggered on every re-render of
the component because the `codeViewElements` observable emits unconditionally
on every render.

This was introduced to ensure that the highlighting logic runs after
React updated the DOM, otherwise React would overwrite our changes.

In that case a simpler solution which avoids updating the highlighted lines
if neither code nor position is to avoid using observables altogether and
put the highlighting logic directly in `useEffect`, conditioned on file and
position changes.

Still seems to work as expected:

https://user-images.githubusercontent.com/179026/177218893-902912e7-2cc9-4c2a-bcbe-8dee29cd1a67.mp4




## Test plan

- Open a file in Sourcegraph that imports a dependency so that you can us jump to definition.
- Select any line.
- Jump to definition in another file. The line should be highlighted.
- Press the back button. The previously highlighted line in the previous file should be highlighted.

## App preview:

- [Web](https://sg-web-fkling-blob-simplify-line.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-icbfcddlko.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
