### PR TITLE
[SG-35262] Upload/Index timeline time between states is not explained as such

### DIFF
--- a/client/web/src/components/Timeline.tsx
+++ b/client/web/src/components/Timeline.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, ReactNode, useState } from 'react'
 
 import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { formatDistance } from 'date-fns/esm'
 
@@ -41,6 +42,7 @@ export const Timeline: FunctionComponent<React.PropsWithChildren<TimelineProps>>
                         <div className={styles.separator} />
                         {showDurations && (
                             <span className="flex-1 text-muted ml-4">
+                                <VisuallyHidden>Step took</VisuallyHidden>
                                 {formatDistance(new Date(stage.date), new Date(stages[stageIndex - 1]?.date))}
                             </span>
                         )}


### PR DESCRIPTION
## Problem description
The timeline view lists the amount of time between each state "about 5 hours" etc, but it is not clear via screen reader (and also visually) what this time duration represents.

![image](https://user-images.githubusercontent.com/18282288/167705517-2e230b0e-098f-4e82-b1c5-ab32fdfa8779.png)

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35262)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35262)

### Expected behavior
Reword so the meaning of the time duration is clear both visually and from the screen reader.

## Test Plan
https://www.loom.com/share/f029416853b6405885adeb364c0a8baf

## App preview:

- [Web](https://sg-web-contractors-sg-35262.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hklwudeyhi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

