### PR TITLE
github-proxy: do not log fatal err message if err is expected

### DIFF
--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -128,7 +128,7 @@ func main() {
 		os.Exit(0)
 	}()
 
-	if err := s.ListenAndServe(); err != nil {
+	if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		logger.Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
I don't think it makes sense to log a fatal message if the server simply
closed. And we do the same check in other `main()` functions too.

## Test plan

- Tested manually with `sg run github-proxy` and then using `Ctrl-c` to exit it