### PR TITLE
[SG-35475] Fix Branch/tag/commit: Non-interactive element that is focusable in header

### DIFF
--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
@@ -124,7 +124,7 @@ export const RevisionsPopover: React.FunctionComponent<React.PropsWithChildren<R
             </TabList>
             <TabPanels>
                 {TABS.map(tab => (
-                    <TabPanel key={tab.id}>
+                    <TabPanel key={tab.id} tabIndex={-1}>
                         {tab.type ? (
                             <RevisionsPopoverReferences
                                 noun={tab.noun}


### PR DESCRIPTION
### Audit type
Keyboard navigation

### User journey audit issue [#34417](https://github.com/sourcegraph/sourcegraph/issues/34417)

## Description
- This element is not interactive and should not be accessed via the tab key.
<img width="607" alt="Screen Shot 2022-06-24 at 10 46 34" src="https://user-images.githubusercontent.com/30657705/175505558-283c7375-7183-4e5d-b3ac-4fee3731653f.png">

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35475)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35475)

## Implementation Details
- The element should be ignored when tabbing through the page.

## Test plan
 Take a look at the issue description. It should be fixed