### PR TITLE
Avoid duplicate history entries for the same line position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Updated minimum required veresion of `git` to 2.35.2 in `gitserver` and `server` Docker image. This addresses a few vulnerabilities disclosed in https://github.blog/2022-04-12-git-security-vulnerability-announced/.
 - Search: Pasting a query with line breaks into the main search query input will now replace them with spaces instead of removing them. [#37674](https://github.com/sourcegraph/sourcegraph/pull/37674)
 - Rewrite resource estimator using the latest metrics [#37869](https://github.com/sourcegraph/sourcegraph/pull/37869)
+- Selecting a line multiple times in the file view will only add a single browser history entry [#38193](https://github.com/sourcegraph/sourcegraph/pull/38193)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Updated minimum required veresion of `git` to 2.35.2 in `gitserver` and `server` Docker image. This addresses a few vulnerabilities disclosed in https://github.blog/2022-04-12-git-security-vulnerability-announced/.
 - Search: Pasting a query with line breaks into the main search query input will now replace them with spaces instead of removing them. [#37674](https://github.com/sourcegraph/sourcegraph/pull/37674)
 - Rewrite resource estimator using the latest metrics [#37869](https://github.com/sourcegraph/sourcegraph/pull/37869)
-- Selecting a line multiple times in the file view will only add a single browser history entry [#38193](https://github.com/sourcegraph/sourcegraph/pull/38193)
+- Selecting a line multiple times in the file view will only add a single browser history entry [#38204](https://github.com/sourcegraph/sourcegraph/pull/38204)
 
 ### Fixed
 

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -861,9 +861,9 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
 function updateBrowserHistoryIfNecessary(
     history: H.History,
     location: H.Location,
-    newSearchParams: URLSearchParams
+    newSearchParameters: URLSearchParams
 ): void {
-    const currentSearchParams = [...new URLSearchParams(location.search).entries()]
+    const currentSearchParameters = [...new URLSearchParams(location.search).entries()]
 
     // Update history if the number of search params changes or if any parameter
     // value changes. This will also work for file position changes, which are
@@ -871,13 +871,13 @@ function updateBrowserHistoryIfNecessary(
     // non-existing key in the new search parameters and thus return `null`
     // (whereas it returns an empty string in the current search parameters).
     const needsUpdate =
-        currentSearchParams.length !== [...newSearchParams.keys()].length ||
-        currentSearchParams.some(([key, value]) => newSearchParams.get(key) !== value)
+        currentSearchParameters.length !== [...newSearchParameters.keys()].length ||
+        currentSearchParameters.some(([key, value]) => newSearchParameters.get(key) !== value)
 
     if (needsUpdate) {
         history.push({
             ...location,
-            search: formatSearchParameters(newSearchParams),
+            search: formatSearchParameters(newSearchParameters),
         })
     }
 }

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -858,22 +858,26 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
  * from the current ones. This prevents adding a new entry when e.g. the user
  * clicks the same line multiple times.
  */
-function updateBrowserHistoryIfNecessary(history: H.History, location: H.Location, newSearch: URLSearchParams): void {
-    const currentSearch = new URLSearchParams(location.search)
-    let updateHistory = [...currentSearch.keys()].length !== [...newSearch.keys()].length
-    if (!updateHistory) {
-        for (const [key, value] of currentSearch) {
-            if (newSearch.get(key) !== value) {
-                updateHistory = true
-                break
-            }
-        }
-    }
+function updateBrowserHistoryIfNecessary(
+    history: H.History,
+    location: H.Location,
+    newSearchParams: URLSearchParams
+): void {
+    const currentSearchParams = [...new URLSearchParams(location.search).entries()]
 
-    if (updateHistory) {
+    // Update history if the number of search params changes or if any parameter
+    // value changes. This will also work for file position changes, which are
+    // encoded as parameter without a value. The old file position will be a
+    // non-existing key in the new search parameters and thus return `null`
+    // (whereas it returns an empty string in the current search parameters).
+    const needsUpdate =
+        currentSearchParams.length !== [...newSearchParams.keys()].length ||
+        currentSearchParams.some(([key, value]) => newSearchParams.get(key) !== value)
+
+    if (needsUpdate) {
         history.push({
             ...location,
-            search: formatSearchParameters(newSearch),
+            search: formatSearchParameters(newSearchParams),
         })
     }
 }


### PR DESCRIPTION
In a way this is a continuation of #38193.

In noticed that clicking the same line multiple times adds a separate
history entry for every click. That's not a great experience wrt
navigating back and forth.

This is done by comparing the URL query parameters and their values.
Location is encoded as a query parameter without a value, so if the
location changed then trying to look up the same paremeter in the new
URL will return `null` (and therefore be different from an empty
string).

Before/after video: I wanted to add overlay text to indicate where the version begins but I hope it's clear without it. Also note that mouse clicks are not visible in the video. I'm moving the mouse before clicking to make it clearer when I click.

https://user-images.githubusercontent.com/179026/177300042-b7403d95-16e6-4330-a651-2560df3bf8e8.mp4


## Test plan

Click on a couple of lines in a file multiple times. Clicking the back button directly goes to the previous line, no matter how often a line was clicked.

## App preview:

- [Web](https://sg-web-fkling-blob-prevent-duplicate.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-caymdmogpq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
