### PR TITLE
[SG-35180] Accessibility: Screen reader navigation for notebooks

### DIFF
--- a/client/web/src/notebooks/notebookPage/NotebookTitle.module.scss
+++ b/client/web/src/notebooks/notebookPage/NotebookTitle.module.scss
@@ -6,16 +6,21 @@
     background-color: transparent;
     border: 1px solid transparent;
     color: var(--body-color);
+
+    // Allow the edit icon to be visible when navigating using the keyboard.
+    &:focus,
+    &:active,
+    &:hover {
+        .title-edit-icon {
+            visibility: visible;
+        }
+    }
 }
 
 .title-edit-icon {
     visibility: hidden;
     font-size: 1rem;
     margin-left: 0.25rem;
-}
-
-.title-button:hover .title-edit-icon {
-    visibility: visible;
 }
 
 .title-input {

--- a/client/web/src/notebooks/notebookPage/NotebookTitle.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookTitle.tsx
@@ -67,7 +67,8 @@ export const NotebookTitle: React.FunctionComponent<React.PropsWithChildren<Note
             >
                 <span>{title}</span>
                 <span className={styles.titleEditIcon}>
-                    <Icon aria-hidden={true} as={PencilOutlineIcon} />
+                    {/* Dot prefix in aria-label to ensure vocal differentiation from notebook title, when read by screen reader */}
+                    <Icon aria-label=". Click to edit title" as={PencilOutlineIcon} />
                 </span>
             </button>
         )


### PR DESCRIPTION
### Audit type
Screen reader navigation

### User journey audit issue[
#34197](https://github.com/sourcegraph/sourcegraph/issues/34197)

### Problem description
**On the notebook edit page:**
- The edit button should announce what it does.

### Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35180)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35180)

### Test Plan
https://www.loom.com/share/e9ac078cf6fa497c85f035c4eb94ed9d

### ET
1 hour


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-contractors-sg-35180.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qxeeamfarv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
