### PR TITLE
JetBrains: Change shortcuts

### DIFF
--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -29,7 +29,6 @@
             class="com.sourcegraph.website.OpenFile"
             text="Open Selection in Sourcegraph Web"
             description="Open selection in Sourcegraph Web">
-            <keyboard-shortcut first-keystroke="alt shift a" keymap="$default"/>
         </action>
         <action
             id="sourcegraph.searchSelection"
@@ -37,7 +36,6 @@
             text="Search Selection on Sourcegraph Web"
             description="Search selection on Sourcegraph web"
             icon="/icons/icon.png">
-            <keyboard-shortcut first-keystroke="alt s" keymap="$default"/>
         </action>
         <action
             id="sourcegraph.searchRepository"
@@ -45,7 +43,6 @@
             text="Search Selection in Repository on Sourcegraph Web"
             description="Search selection in repository on Sourcegraph web"
             icon="/icons/icon.png">
-            <keyboard-shortcut first-keystroke="alt r" keymap="$default"/>
         </action>
         <action
             id="sourcegraph.copy"
@@ -53,7 +50,6 @@
             text="Copy Sourcegraph File Link"
             description="Copy Sourcegraph file link"
             icon="/icons/icon.png">
-            <keyboard-shortcut first-keystroke="alt c" keymap="$default"/>
         </action>
         <action
             id="com.sourcegraph.website.OpenRevisionAction"
@@ -70,7 +66,7 @@
             text="Find on Sourcegraph..."
             description="Search all your repos on Sourcegraph"
             icon="/icons/icon.png">
-            <keyboard-shortcut first-keystroke="alt a" keymap="$default"/>
+            <keyboard-shortcut first-keystroke="alt s" keymap="$default"/>
             <add-to-group group-id="FindMenuGroup" anchor="after" relative-to-action="ReplaceInPath"/>
         </action>
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/37998

Set the “Open popup” shortcut to `⌥S` (`Alt + S`) (as in Sourcegraph).
Remove the rest of the shortcuts.

## Test plan

The context menu looks like this:
<img width="1613" alt="CleanShot 2022-07-05 at 11 59 15@2x" src="https://user-images.githubusercontent.com/2552265/177303232-fe5547b8-760c-4b84-b817-61de165bb342.png">

✅ The popup opens when I press Option+S.

## App preview:

- [Web](https://sg-web-dv-jetbrains-change-shortcuts.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rsdvadejpp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
