### PR TITLE
JetBrains: Make resize padding macOS-only and remove bottom padding

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -55,7 +55,6 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
             browserAndLoadingPanel.setBrowser(browser);
         }
 
-
         BorderLayoutPanel topPanel = new BorderLayoutPanel();
         // The border is needed on macOS because without it, window and splitter resize don't work because the JCEF
         // doesn't properly pass the mouse events to Swing.

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -11,6 +11,7 @@ import com.intellij.util.ui.components.BorderLayoutPanel;
 import com.sourcegraph.browser.BrowserAndLoadingPanel;
 import com.sourcegraph.browser.JSToJavaBridgeRequestHandler;
 import com.sourcegraph.browser.SourcegraphJBCefBrowser;
+import org.jdesktop.swingx.util.OS;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -54,11 +55,14 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
             browserAndLoadingPanel.setBrowser(browser);
         }
 
-        // The border is needed because without it, window and splitter resize don't work because the JCEF
-        // doesn't properly pass the mouse events to Swing.
-        // 4px is the minimum amount to make it work for the window resize, and 5px for the splitter.
+
         BorderLayoutPanel topPanel = new BorderLayoutPanel();
-        topPanel.setBorder(JBUI.Borders.empty(0, 4, 5, 4));
+        // The border is needed on macOS because without it, window and splitter resize don't work because the JCEF
+        // doesn't properly pass the mouse events to Swing.
+        // 4px is the minimum amount to make it work for the window resize, the splitter works without a padding.
+        if (OS.isMacOSX()) {
+            topPanel.setBorder(JBUI.Borders.empty(0, 4, 0, 4));
+        }
         topPanel.add(browserAndLoadingPanel, BorderLayout.CENTER);
         topPanel.setMinimumSize(JBUI.size(750, 200));
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -61,7 +61,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
         // doesn't properly pass the mouse events to Swing.
         // 4px is the minimum amount to make it work for the window resize, the splitter works without a padding.
         if (OS.isMacOSX()) {
-            topPanel.setBorder(JBUI.Borders.empty(0, 4, 0, 4));
+            topPanel.setBorder(JBUI.Borders.empty(0, 4, 5, 4));
         }
         topPanel.add(browserAndLoadingPanel, BorderLayout.CENTER);
         topPanel.setMinimumSize(JBUI.size(750, 200));


### PR DESCRIPTION
Closes #37669

Unfortunlaty this is the best I could do. Here are a few observations:

- On Windows and Linux, the padding is not necessarily needed. Without it, there are a few fewer pixels that show the resize cursor but I still found it usable. In addition, I was not able to reproduce the issue where resizing would suddenly "stop" on those platforms. Hence I think it makes sense to not show these paddings on that platforms.
- On macOS, the left and right paddings are still necessary. Without it, the resizing would stop during the interaction. I also tried to play around with adding custom event listeners (the same way that the `StatusText` component does internally that is used by the `JBPanelWithEmptyText` component but I was not able to make it work no matter what I tried :( I did notice, however, that the bottom padding does not seem to be necessary anymore.

## Test plan

(Put a video on Google drive since it was exceeding the 100MB limit and I already recorded it via QuickTime instead of Loom. Old habits die hard 🙈)

https://drive.google.com/file/d/1uRNCQxm6bFdHBXryNAhVuHfx5f6Hosbd/view?usp=sharing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-resize-paddings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ityajgkwrt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
