### PR TITLE
JetBrains: Fix Windows encoding issue

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
@@ -182,7 +183,11 @@ public class PreviewContent {
             return null;
         }
         byte[] decodedBytes = Base64.getDecoder().decode(base64String);
-        return new String(decodedBytes);
+        try {
+            return new String(decodedBytes, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return "";
+        }
     }
 
     @Override


### PR DESCRIPTION
Closes #38218 

Apparently using `new String(byte[])` without specifying a charset will default to using the [default charset](https://docs.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html#defaultCharset()) which can be different across operating systems and JVM version.

To fix the issue we only have to tell the JVM that the byte array is UTF-8 encoded.

## Test plan

### Windows

![Screenshot 2022-07-05 at 16 20 26](https://user-images.githubusercontent.com/458591/177351094-90a75ab3-a21b-422d-94a4-121cf21376db.png)

### macOS

![Screenshot 2022-07-05 at 16 22 26](https://user-images.githubusercontent.com/458591/177351202-88d4e229-ac46-45cb-8869-ad78c80e8e62.png)

### Linux

![Screenshot 2022-07-05 at 16 26 12](https://user-images.githubusercontent.com/458591/177351242-ebab94f6-1206-4bb2-bf27-c45d22ddbdf5.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
