### PR TITLE
VSCE: Add open-vsx release step

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 
 ### Changes
 
+- `Internal:` Automate release step for Open-VSX registry [issues/37704](https://github.com/sourcegraph/sourcegraph/issues/37704)
+
 ### Fixes
 
 ## 2.2.7

--- a/client/vscode/CONTRIBUTING.md
+++ b/client/vscode/CONTRIBUTING.md
@@ -202,14 +202,22 @@ The release process for the VS Code Extension for Sourcegraph is currently autom
 1. Create a new branch when the main branch is ready for release, or use your current working branch if it is ready for release
 2. Run `yarn --cwd client/vscode release:$RELEASE_TYPE` in the root directory
    - $RELEASE_TYPE: major, minor, patch, pre
+     - Example: `yarn --cwd client/vscode release:patch`
    - This command will:
-     - Update the package.json with the next version number
+     - Update the package.json file with the next version number
      - Update the changelog format by listing everything under `Unreleased` to the updated version number
      - Make a commit for the release and push to the current branch
-3. Merge the current branch into main
+3. Open a PR to merge the current branch into main
 4. Once the main branch has the updated version number and changelog, run `git push origin main:vsce/release`
    - This will trigger the build pipeline for publishing the extension using the `yarn release` command
+   - Publish release to [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.sourcegraph)
+   - Publish release to [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/sourcegraph)
    - The extension will be published with the correct package name via the [vsce CLI tool](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#vsce)
 5. Visit the [buildkite page for the vsce/release pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=vsce%2Frelease) to watch the build process
 
-Once the build is completed with no error, you should see the new version being verified for the Sourcegraph extension in your [Marketplace Publisher Dashboard](https://marketplace.visualstudio.com/manage/publishers)
+Once the build is completed with no error, you should see the new version being verified for the Sourcegraph extension in:
+
+- VS Code Marketplace: [Marketplace Publisher Dashboard](https://marketplace.visualstudio.com/manage/publishers)
+- Open VSX Registry: [Namespaces Tab in User Settings](https://open-vsx.org/user-settings/namespaces)
+
+> NOTE: It might take up to 10 minutes before the new release is published.

--- a/client/vscode/scripts/publish.ts
+++ b/client/vscode/scripts/publish.ts
@@ -9,29 +9,38 @@ import { version } from '../package.json'
 /**
  * This script is used by the CI to publish the extension to the VS Code Marketplace
  * It is triggered when a commit has been made to the vsce release branch
+ * Refer to our CONTRIBUTION docs to learn more about our release process
  */
 // Get current package.json
 const originalPackageJson = fs.readFileSync('package.json').toString()
 /**
  * Build and publish the extension with the updated package name
- * using the token stored in the pipeline to run commands in yarn
+ * using the tokens stored in the pipeline to run commands in yarn
  * and allows all events to activate the extension
  */
-const isPreRelease = semver.minor(version) % 2 !== 0
-const publishToken = process.env.VSCODE_MARKETPLACE_TOKEN
-// Assume this is for testing purpose if publishToken cannot be found
-// Use vsce package command instead without publishing the extension for testing
-const publishCommand = publishToken
-    ? `yarn vsce publish ${
-          isPreRelease ? '--pre-release' : ''
-      } --pat $VSCODE_MARKETPLACE_TOKEN --yarn --allow-star-activation`
-    : 'yarn vsce package --yarn --allow-star-activation'
+const isPreRelease = semver.minor(version) % 2 !== 0 ? '--pre-release' : ''
+// Tokens are stored in CI pipeline
+const tokens = {
+    vscode: process.env.VSCODE_MARKETPLACE_TOKEN,
+    openvsx: process.env.VSCODE_OPENVSX_TOKEN,
+}
+// Assume this is for testing purpose if tokens are not found
+const hasTokens = tokens.vscode !== undefined && tokens.openvsx !== undefined
+const commands = {
+    vscode_info: 'yarn vsce show sourcegraph.sourcegraph --json',
+    // To publish to VS Code Marketplace
+    vscode_publish: `yarn vsce publish ${isPreRelease} --pat $VSCODE_MARKETPLACE_TOKEN --yarn --allow-star-activation`,
+    // To package the extension without publishing
+    vscode_pacakage: `yarn vsce package ${isPreRelease} --yarn --allow-star-activation`,
+    // To publish to the open-vsx registry
+    openvsx_publish: 'yarn npx --yes ovsx publish --yarn -p $VSCODE_OPENVSX_TOKEN',
+}
 // Publish the extension with the correct extension name "sourcegraph"
 try {
     // Get the latest release version nubmer of the last release from VS Code Marketplace using the vsce cli tool
-    const response = childProcess.execSync('vsce show sourcegraph.sourcegraph --json').toString()
+    const response = childProcess.execSync(commands.vscode_info).toString()
     const latestVersion: string = JSON.parse(response).versions[0].version
-    if (publishToken && (version === latestVersion || !semver.valid(latestVersion) || !semver.valid(version))) {
+    if (hasTokens && (version === latestVersion || !semver.valid(latestVersion) || !semver.valid(version))) {
         throw new Error(
             version === latestVersion
                 ? 'Cannot release extension with the same version number.'
@@ -41,14 +50,18 @@ try {
     // Update package name from @sourcegraph/vscode to sourcegraph in package.json
     const packageJson = originalPackageJson.replace('@sourcegraph/vscode', 'sourcegraph')
     fs.writeFileSync('package.json', packageJson)
-    // Run the publish command
-    childProcess.execSync(publishCommand, {
-        stdio: 'inherit',
-    })
-    console.log(`The extension has been ${publishToken ? 'published' : 'packaged'} successfully`)
+    if (hasTokens) {
+        // Run the publish commands
+        childProcess.execSync(commands.vscode_publish, { stdio: 'inherit' })
+        childProcess.execSync(commands.openvsx_publish, { stdio: 'inherit' })
+        console.log(`The extension has been ${hasTokens ? 'published' : 'packaged'} successfully`)
+    } else {
+        // Use vsce package command instead without publishing the extension for testing
+        childProcess.execSync(commands.vscode_pacakage, { stdio: 'inherit' })
+    }
 } catch (error) {
     console.error('Failed to publish VSCE:', error)
-    console.error('Do not run this script locally to publish the extension.')
+    console.error('You may not run this script locally to publish the extension.')
 } finally {
     // Revert changes made to package.json
     fs.writeFileSync('package.json', originalPackageJson)

--- a/client/vscode/scripts/publish.ts
+++ b/client/vscode/scripts/publish.ts
@@ -31,7 +31,7 @@ const commands = {
     // To publish to VS Code Marketplace
     vscode_publish: `yarn vsce publish ${isPreRelease} --pat $VSCODE_MARKETPLACE_TOKEN --yarn --allow-star-activation`,
     // To package the extension without publishing
-    vscode_pacakage: `yarn vsce package ${isPreRelease} --yarn --allow-star-activation`,
+    vscode_package: `yarn vsce package ${isPreRelease} --yarn --allow-star-activation`,
     // To publish to the open-vsx registry
     openvsx_publish: 'yarn npx --yes ovsx publish --yarn -p $VSCODE_OPENVSX_TOKEN',
 }

--- a/client/vscode/scripts/publish.ts
+++ b/client/vscode/scripts/publish.ts
@@ -57,7 +57,7 @@ try {
         console.log(`The extension has been ${hasTokens ? 'published' : 'packaged'} successfully`)
     } else {
         // Use vsce package command instead without publishing the extension for testing
-        childProcess.execSync(commands.vscode_pacakage, { stdio: 'inherit' })
+        childProcess.execSync(commands.vscode_package, { stdio: 'inherit' })
     }
 } catch (error) {
     console.error('Failed to publish VSCE:', error)

--- a/client/vscode/scripts/release.ts
+++ b/client/vscode/scripts/release.ts
@@ -25,12 +25,16 @@ if (isValidType) {
      */
     const releaseType: semver.ReleaseType = vsceReleaseType === 'prerelease' ? 'minor' : vsceReleaseType
     // Get the latest release version nubmer of the last release from VS Code Marketplace using the vsce cli tool
+    // We use this to compare the current package version number with the current release version number - they should be the same
     const response = childProcess.execSync('vsce show sourcegraph.sourcegraph --json').toString()
     const latestVersion: string = JSON.parse(response).versions[0].version
-    if (!semver.valid(latestVersion) || version !== latestVersion) {
+    if (!semver.valid(latestVersion)) {
         throw new Error(
-            'The current version number is not align with the version number of the latest release. Make sure you have the vsce cli tool installed.'
+            'Failed to connect to VSCE to retreive the latest extension version number. Make sure you have vsce cli tool installed.'
         )
+    }
+    if (version !== latestVersion) {
+        throw new Error('The current version number is not align with the version number of the latest release.')
     }
     // Increase minor version number by twice for minor release because ODD minor number is for pre-release
     const nextVersion =


### PR DESCRIPTION
Add open-vsx release step to release pipeline

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally.

Passing integration test - 7/6:

```
VSCode started in debug mode on http://127.0.0.1:29378
    ✓ works (10063ms)


  1 passing (27s)

✨  Done in 33.78s.
```

## App preview:

- [Web](https://sg-web-bee-vsce-release.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fkemjkkhdj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
