### PR TITLE
codeintel: coalesce null columns from partial audit logs aggregation

### DIFF
--- a/internal/codeintel/stores/dbstore/uploads.go
+++ b/internal/codeintel/stores/dbstore/uploads.go
@@ -522,14 +522,14 @@ SELECT
 	(snapshot->'started_at')::timestamptz AS started_at,
 	(snapshot->'finished_at')::timestamptz AS finished_at,
 	(snapshot->'process_after')::timestamptz AS process_after,
-	(snapshot->'num_resets')::integer AS num_resets,
-	(snapshot->'num_failures')::integer AS num_failures,
+	COALESCE((snapshot->'num_resets')::integer, -1) AS num_resets,
+	COALESCE((snapshot->'num_failures')::integer, -1) AS num_failures,
 	au.repository_id,
 	au.indexer, au.indexer_version,
 	COALESCE((snapshot->'num_parts')::integer, -1) AS num_parts,
 	NULL::integer[] as uploaded_parts,
 	au.upload_size, au.associated_index_id,
-	(snapshot->'expired')::boolean AS expired
+	COALESCE((snapshot->'expired')::boolean, false) AS expired
 FROM (
 	SELECT upload_id, snapshot_transition_columns(transition_columns ORDER BY sequence ASC) AS snapshot
 	FROM lsif_uploads_audit_logs

--- a/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/internal/codeintel/stores/dbstore/uploads_test.go
@@ -274,10 +274,27 @@ func TestGetUploads(t *testing.T) {
 
 		// to-be hard deleted
 		Upload{ID: 16, Commit: makeCommit(3333), UploadedAt: t4, FinishedAt: &t3, State: "deleted"},
+		Upload{ID: 17, Commit: makeCommit(3334), UploadedAt: t4, FinishedAt: &t5, State: "deleting"},
 	)
 	insertVisibleAtTip(t, db, 50, 2, 5, 7, 8)
 
+	updateUploads(t, db, Upload{
+		ID: 17, State: "deleted",
+	})
+
 	deleteUploads(t, db, 16)
+	deleteUploads(t, db, 17)
+
+	if err := store.Exec(ctx, sqlf.Sprintf(
+		`DELETE FROM lsif_uploads_audit_logs WHERE upload_id = %s
+			AND sequence NOT IN (
+				SELECT MAX(sequence) FROM lsif_uploads_audit_logs
+				WHERE upload_id = %s
+			)`,
+		17, 17),
+	); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
 
 	// upload 10 depends on uploads 7 and 8
 	insertPackages(t, store, []shared.Package{
@@ -337,7 +354,7 @@ func TestGetUploads(t *testing.T) {
 		{dependentOf: 10, expectedIDs: []int{}},
 		{dependencyOf: 11, expectedIDs: []int{8}},
 		{dependentOf: 11, expectedIDs: []int{}},
-		{allowDeletedRepo: true, state: "deleted", expectedIDs: []int{12, 13, 14, 15, 16}},
+		{allowDeletedRepo: true, state: "deleted", expectedIDs: []int{12, 13, 14, 15, 16, 17}},
 	}
 
 	runTest := func(testCase testCase, lo, hi int) (errors int) {

--- a/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -109,14 +109,14 @@ SELECT
 	(snapshot->'started_at')::timestamptz AS started_at,
 	(snapshot->'finished_at')::timestamptz AS finished_at,
 	(snapshot->'process_after')::timestamptz AS process_after,
-	(snapshot->'num_resets')::integer AS num_resets,
-	(snapshot->'num_failures')::integer AS num_failures,
+	COALESCE((snapshot->'num_resets')::integer, -1) AS num_resets,
+	COALESCE((snapshot->'num_failures')::integer, -1) AS num_failures,
 	au.repository_id,
 	au.indexer, au.indexer_version,
 	COALESCE((snapshot->'num_parts')::integer, -1) AS num_parts,
 	NULL::integer[] as uploaded_parts,
 	au.upload_size, au.associated_index_id,
-	(snapshot->'expired')::boolean AS expired
+	COALESCE((snapshot->'expired')::boolean, false) AS expired
 FROM (
 	SELECT upload_id, snapshot_transition_columns(transition_columns ORDER BY sequence ASC) AS snapshot
 	FROM lsif_uploads_audit_logs


### PR DESCRIPTION
For cases where only a partial set of audit logs exist for an upload (aka a full representation can't be built through the aggregation function), it is possible for columns that are expected to not contain `NULL`s to contain `NULL`s. This PR addresses this edge case by coalescing those columns to a default value

## Test plan

Unit tests expanded to cover the edge case
