### PR TITLE
[a11y] notepad: make into a landmark

### DIFF
--- a/client/web/src/search/Notepad.test.tsx
+++ b/client/web/src/search/Notepad.test.tsx
@@ -12,7 +12,7 @@ import { addNotepadEntry, NotepadEntry } from '../stores/notepad'
 
 import { NotepadContainer, NotepadProps } from './Notepad'
 
-describe('Search Stack', () => {
+describe('Notepad', () => {
     const renderNotepad = (props?: Partial<NotepadProps>, enabled = true): RenderWithBrandedContextResult =>
         renderWithBrandedContext(
             <MockTemporarySettings settings={{ 'search.notepad.enabled': enabled }}>
@@ -21,7 +21,7 @@ describe('Search Stack', () => {
         )
 
     function open() {
-        userEvent.click(screen.getByRole('button', { name: 'Open Notepad' }))
+        userEvent.click(screen.getByRole('button', { name: /Open Notepad/ }))
     }
 
     afterEach(cleanup)
@@ -43,7 +43,7 @@ describe('Search Stack', () => {
 
             renderNotepad()
 
-            expect(screen.queryByRole('button', { name: 'Open Notepad' })).toBeInTheDocument()
+            expect(screen.queryByRole('button', { name: /Open Notepad/ })).toBeInTheDocument()
         })
     })
 
@@ -56,7 +56,7 @@ describe('Search Stack', () => {
                 addableEntry: mockEntries[0],
             })
             renderNotepad()
-            userEvent.click(screen.getByRole('button', { name: 'Open Notepad' }))
+            userEvent.click(screen.getByRole('button', { name: /Open Notepad/ }))
 
             userEvent.click(screen.getByRole('button', { name: 'Restore last session' }))
             expect(useNotepadState.getState().entries).toEqual(mockEntries)
@@ -82,10 +82,10 @@ describe('Search Stack', () => {
         it('opens and closes', () => {
             renderNotepad()
 
-            userEvent.click(screen.getByRole('button', { name: 'Open Notepad' }))
-            userEvent.click(screen.getByRole('button', { name: 'Close Notepad' }))
+            userEvent.click(screen.getByRole('button', { name: /Open Notepad/ }))
+            userEvent.click(screen.getByRole('button', { name: /Close Notepad/ }))
 
-            expect(screen.queryByRole('button', { name: 'Open Notepad' })).toBeInTheDocument()
+            expect(screen.queryByRole('button', { name: /Open Notepad/ })).toBeInTheDocument()
         })
 
         it('redirects to notes', () => {

--- a/client/web/src/search/Notepad.tsx
+++ b/client/web/src/search/Notepad.tsx
@@ -326,14 +326,18 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
     )
 
     return (
-        <section className={classNames(styles.root, className, { [styles.open]: open })} id={NOTEPAD_ID} role="dialog">
+        <aside
+            className={classNames(styles.root, className, { [styles.open]: open })}
+            id={NOTEPAD_ID}
+            aria-labelledby={`${NOTEPAD_ID}-button`}
+        >
             <Button
-                aria-label={(open ? 'Close' : 'Open') + ' Notepad'}
                 variant="icon"
                 className={classNames(styles.header, 'p-2 d-flex align-items-center justify-content-between')}
                 onClick={toggleOpen}
                 aria-controls={NOTEPAD_ID}
                 aria-expanded="true"
+                id={`${NOTEPAD_ID}-button`}
             >
                 <span>
                     <NotepadIcon />
@@ -343,7 +347,7 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
                     </small>
                 </span>
                 <span className={styles.toggleIcon}>
-                    <Icon aria-hidden={true} as={ChevronUpIcon} />
+                    <Icon aria-label={(open ? 'Close' : 'Open') + ' Notepad'} as={ChevronUpIcon} />
                 </span>
             </Button>
             {open && (
@@ -439,7 +443,7 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
                     </div>
                 </>
             )}
-        </section>
+        </aside>
     )
 }
 


### PR DESCRIPTION
Closes #35145

Turns notepad from a `<section role="dialog">` into an `<aside>` which can be navigated to via the landmarks menu. 

## Test plan

Tested with VoiceOver on macOS.

## App preview:

- [Web](https://sg-web-jp-notepadaria.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-aunjohdeac.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
