### PR TITLE
Search backend: update zoekt and use chunk matches

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -158,6 +158,34 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 			}
 		}
 
+		for _, cm := range fm.ChunkMatches {
+			ranges := make([]protocol.Range, 0, len(cm.Ranges))
+			for _, r := range cm.Ranges {
+				ranges = append(ranges, protocol.Range{
+					Start: protocol.Location{
+						Offset: int32(r.Start.ByteOffset),
+						Line:   int32(r.Start.LineNumber - 1),
+						Column: int32(r.Start.Column - 1),
+					},
+					End: protocol.Location{
+						Offset: int32(r.End.ByteOffset),
+						Line:   int32(r.End.LineNumber - 1),
+						Column: int32(r.End.Column - 1),
+					},
+				})
+			}
+
+			cms = append(cms, protocol.ChunkMatch{
+				Content: string(cm.Content),
+				ContentStart: protocol.Location{
+					Offset: int32(cm.ContentStart.ByteOffset),
+					Line:   int32(cm.ContentStart.LineNumber) - 1,
+					Column: int32(cm.ContentStart.Column) - 1,
+				},
+				Ranges: ranges,
+			})
+		}
+
 		sender.Send(protocol.FileMatch{
 			Path:         fm.FileName,
 			ChunkMatches: cms,

--- a/go.mod
+++ b/go.mod
@@ -409,7 +409,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220705133139-3a699662f40c
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220705174942-9a93c54993fe
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -2175,8 +2175,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220705133139-3a699662f40c h1:g1YJkYN/SNo5C2bgCs6FG6X3O2UagAYjzCKfuFjjhwo=
-github.com/sourcegraph/zoekt v0.0.0-20220705133139-3a699662f40c/go.mod h1:t/uiqddLcxjbXnqccq/m+H2ZVoteTRvZUB4HDU2KlfI=
+github.com/sourcegraph/zoekt v0.0.0-20220705174942-9a93c54993fe h1:vN5MqH34k57Vez15OHjC59PmSNTz4pg7J+vaU7jT0nw=
+github.com/sourcegraph/zoekt v0.0.0-20220705174942-9a93c54993fe/go.mod h1:t/uiqddLcxjbXnqccq/m+H2ZVoteTRvZUB4HDU2KlfI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -140,6 +140,32 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 				))
 			}
 		}
+
+		for _, cm := range file.ChunkMatches {
+			if cm.FileName {
+				continue
+			}
+
+			for i, r := range cm.Ranges {
+				si := cm.SymbolInfo[i]
+				if si == nil {
+					continue
+				}
+
+				res = append(res, result.NewSymbolMatch(
+					newFile,
+					r.Start.LineNumber,
+					-1,
+					si.Sym,
+					si.Kind,
+					si.Parent,
+					si.ParentKind,
+					file.Language,
+					string(cm.Content), // TODO will symbol matches always be one line?
+					false,
+				))
+			}
+		}
 	}
 	return
 }

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -146,8 +146,8 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 				continue
 			}
 
-			for i, r := range cm.Ranges {
-				si := cm.SymbolInfo[i]
+			for _, r := range cm.Ranges {
+				si := r.SymbolInfo
 				if si == nil {
 					continue
 				}

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -103,6 +103,7 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 		ShardMaxImportantMatch: match * 25,
 		TotalMaxImportantMatch: match * 25,
 		MaxDocDisplayCount:     match,
+		ChunkMatches:           true,
 	})
 	if err != nil {
 		return nil, err
@@ -142,12 +143,12 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 		}
 
 		for _, cm := range file.ChunkMatches {
-			if cm.FileName {
+			if cm.FileName || len(cm.SymbolInfo) == 0 {
 				continue
 			}
 
-			for _, r := range cm.Ranges {
-				si := r.SymbolInfo
+			for i, r := range cm.Ranges {
+				si := cm.SymbolInfo[i]
 				if si == nil {
 					continue
 				}

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -154,7 +154,7 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 
 				res = append(res, result.NewSymbolMatch(
 					newFile,
-					r.Start.LineNumber,
+					int(r.Start.LineNumber),
 					-1,
 					si.Sym,
 					si.Kind,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/google/zoekt"

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -477,8 +477,8 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 			continue
 		}
 
-		for i, r := range cm.Ranges {
-			si := cm.SymbolInfo[i]
+		for _, r := range cm.Ranges {
+			si := r.SymbolInfo
 			if si == nil {
 				continue
 			}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -472,6 +472,32 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 		}
 	}
 
+	for _, cm := range file.ChunkMatches {
+		if cm.FileName {
+			continue
+		}
+
+		for i, r := range cm.Ranges {
+			si := cm.SymbolInfo[i]
+			if si == nil {
+				continue
+			}
+
+			symbols = append(symbols, result.NewSymbolMatch(
+				newFile,
+				r.Start.LineNumber,
+				-1,
+				si.Sym,
+				si.Kind,
+				si.Parent,
+				si.ParentKind,
+				file.Language,
+				string(cm.Content), // TODO will symbol matches always be one line?
+				false,
+			))
+		}
+	}
+
 	return symbols
 }
 

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -485,7 +485,7 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 
 			symbols = append(symbols, result.NewSymbolMatch(
 				newFile,
-				r.Start.LineNumber,
+				int(r.Start.LineNumber),
 				-1,
 				si.Sym,
 				si.Kind,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -473,12 +473,12 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 	}
 
 	for _, cm := range file.ChunkMatches {
-		if cm.FileName {
+		if cm.FileName || len(cm.SymbolInfo) == 0 {
 			continue
 		}
 
-		for _, r := range cm.Ranges {
-			si := r.SymbolInfo
+		for i, r := range cm.Ranges {
+			si := cm.SymbolInfo[i]
 			if si == nil {
 				continue
 			}

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -76,9 +76,10 @@ func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[stri
 func SearchOpts(ctx context.Context, k int, fileMatchLimit int32, selector filter.SelectPath) zoekt.SearchOptions {
 	shouldTrace, spanContext := getSpanContext(ctx)
 	searchOpts := zoekt.SearchOptions{
-		Trace:       shouldTrace,
-		SpanContext: spanContext,
-		MaxWallTime: defaultTimeout,
+		Trace:        shouldTrace,
+		SpanContext:  spanContext,
+		MaxWallTime:  defaultTimeout,
+		ChunkMatches: true,
 	}
 
 	if userProbablyWantsToWaitLonger := fileMatchLimit > limits.DefaultMaxSearchResults; userProbablyWantsToWaitLonger {


### PR DESCRIPTION
This updates the pinned version of Zoekt and updates our calls to the Zoekt search API to request `ChunkMatches`. 

I decided to not put this behind a feature flag because it was a huge pain to thread that state through our search backend and across APIs, which would be necessary because `searcher` is also a client of Zoekt. Instead, there are two booleans that are set by this PR that can safely be switched to `false` in case we need to disable this behavior. This should be unnecessary (I've manually tested this pretty extensively in addition to updating tests in Zoekt), but I'm documenting it here just in case.

## Test plan



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
