### PR TITLE
Search backend: bump zoekt and use chunk matches

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -308,12 +308,8 @@ func TestSearchResultsHydration(t *testing.T) {
 		RepositoryID: uint32(repoWithIDs.ID),
 		Repository:   string(repoWithIDs.Name), // Important: this needs to match a name in `repos`
 		Branches:     []string{"master"},
-		LineMatches: []zoekt.LineMatch{
-			{
-				Line: nil,
-			},
-		},
-		Checksum: []byte{0, 1, 2},
+		ChunkMatches: make([]zoekt.ChunkMatch, 1),
+		Checksum:     []byte{0, 1, 2},
 	}}
 
 	z := &searchbackend.FakeSearcher{

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -395,12 +395,8 @@ func generateZoektMatches(count int) []zoekt.FileMatch {
 			RepositoryID: uint32(i),
 			Repository:   repoName, // Important: this needs to match a name in `repos`
 			Branches:     []string{"master"},
-			LineMatches: []zoekt.LineMatch{
-				{
-					Line: nil,
-				},
-			},
-			Checksum: []byte{0, 1, 2},
+			ChunkMatches: make([]zoekt.ChunkMatch, 1),
+			Checksum:     []byte{0, 1, 2},
 		})
 	}
 	return zoektFileMatches

--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -158,6 +158,34 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 			}
 		}
 
+		for _, cm := range fm.ChunkMatches {
+			ranges := make([]protocol.Range, 0, len(cm.Ranges))
+			for _, r := range cm.Ranges {
+				ranges = append(ranges, protocol.Range{
+					Start: protocol.Location{
+						Offset: int32(r.Start.ByteOffset),
+						Line:   int32(r.Start.LineNumber - 1),
+						Column: int32(r.Start.Column - 1),
+					},
+					End: protocol.Location{
+						Offset: int32(r.End.ByteOffset),
+						Line:   int32(r.End.LineNumber - 1),
+						Column: int32(r.End.Column - 1),
+					},
+				})
+			}
+
+			cms = append(cms, protocol.ChunkMatch{
+				Content: string(cm.Content),
+				ContentStart: protocol.Location{
+					Offset: int32(cm.ContentStart.ByteOffset),
+					Line:   int32(cm.ContentStart.LineNumber) - 1,
+					Column: int32(cm.ContentStart.Column) - 1,
+				},
+				Ranges: ranges,
+			})
+		}
+
 		sender.Send(protocol.FileMatch{
 			Path:         fm.FileName,
 			ChunkMatches: cms,

--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -124,7 +124,7 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 			return false, nil
 		}
 
-		cms := make([]protocol.ChunkMatch, 0, len(fm.LineMatches))
+		cms := make([]protocol.ChunkMatch, 0, len(fm.ChunkMatches))
 		for _, l := range fm.LineMatches {
 			if l.FileName {
 				continue

--- a/go.mod
+++ b/go.mod
@@ -424,7 +424,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220705133139-3a699662f40c
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220705174942-9a93c54993fe
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -2182,8 +2182,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220705133139-3a699662f40c h1:g1YJkYN/SNo5C2bgCs6FG6X3O2UagAYjzCKfuFjjhwo=
-github.com/sourcegraph/zoekt v0.0.0-20220705133139-3a699662f40c/go.mod h1:t/uiqddLcxjbXnqccq/m+H2ZVoteTRvZUB4HDU2KlfI=
+github.com/sourcegraph/zoekt v0.0.0-20220705174942-9a93c54993fe h1:vN5MqH34k57Vez15OHjC59PmSNTz4pg7J+vaU7jT0nw=
+github.com/sourcegraph/zoekt v0.0.0-20220705174942-9a93c54993fe/go.mod h1:t/uiqddLcxjbXnqccq/m+H2ZVoteTRvZUB4HDU2KlfI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -140,6 +140,32 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 				))
 			}
 		}
+
+		for _, cm := range file.ChunkMatches {
+			if cm.FileName {
+				continue
+			}
+
+			for i, r := range cm.Ranges {
+				si := cm.SymbolInfo[i]
+				if si == nil {
+					continue
+				}
+
+				res = append(res, result.NewSymbolMatch(
+					newFile,
+					r.Start.LineNumber,
+					-1,
+					si.Sym,
+					si.Kind,
+					si.Parent,
+					si.ParentKind,
+					file.Language,
+					string(cm.Content), // TODO will symbol matches always be one line?
+					false,
+				))
+			}
+		}
 	}
 	return
 }

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -146,8 +146,8 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 				continue
 			}
 
-			for i, r := range cm.Ranges {
-				si := cm.SymbolInfo[i]
+			for _, r := range cm.Ranges {
+				si := r.SymbolInfo
 				if si == nil {
 					continue
 				}

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -103,6 +103,7 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 		ShardMaxImportantMatch: match * 25,
 		TotalMaxImportantMatch: match * 25,
 		MaxDocDisplayCount:     match,
+		ChunkMatches:           true,
 	})
 	if err != nil {
 		return nil, err
@@ -142,12 +143,12 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 		}
 
 		for _, cm := range file.ChunkMatches {
-			if cm.FileName {
+			if cm.FileName || len(cm.SymbolInfo) == 0 {
 				continue
 			}
 
-			for _, r := range cm.Ranges {
-				si := r.SymbolInfo
+			for i, r := range cm.Ranges {
+				si := cm.SymbolInfo[i]
 				if si == nil {
 					continue
 				}

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -154,7 +154,7 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 
 				res = append(res, result.NewSymbolMatch(
 					newFile,
-					r.Start.LineNumber,
+					int(r.Start.LineNumber),
 					-1,
 					si.Sym,
 					si.Kind,

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -156,13 +156,13 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 				res = append(res, result.NewSymbolMatch(
 					newFile,
 					int(r.Start.LineNumber),
-					-1,
+					int(r.Start.Column),
 					si.Sym,
 					si.Kind,
 					si.Parent,
 					si.ParentKind,
 					file.Language,
-					string(cm.Content), // TODO will symbol matches always be one line?
+					"", // unused when column is set
 					false,
 				))
 			}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/google/zoekt"

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -477,8 +477,8 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 			continue
 		}
 
-		for i, r := range cm.Ranges {
-			si := cm.SymbolInfo[i]
+		for _, r := range cm.Ranges {
+			si := r.SymbolInfo
 			if si == nil {
 				continue
 			}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -472,6 +472,32 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 		}
 	}
 
+	for _, cm := range file.ChunkMatches {
+		if cm.FileName {
+			continue
+		}
+
+		for i, r := range cm.Ranges {
+			si := cm.SymbolInfo[i]
+			if si == nil {
+				continue
+			}
+
+			symbols = append(symbols, result.NewSymbolMatch(
+				newFile,
+				r.Start.LineNumber,
+				-1,
+				si.Sym,
+				si.Kind,
+				si.Parent,
+				si.ParentKind,
+				file.Language,
+				string(cm.Content), // TODO will symbol matches always be one line?
+				false,
+			))
+		}
+	}
+
 	return symbols
 }
 

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -2,7 +2,7 @@ package zoekt
 
 import (
 	"context"
-	"encoding/utf8"
+	"unicode/utf8"
 	"strings"
 	"time"
 

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -445,7 +445,7 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 		InputRev: &inputRev,
 	}
 
-	symbols := make([]*result.SymbolMatch, 0, len(file.LineMatches))
+	symbols := make([]*result.SymbolMatch, 0, len(file.ChunkMatches))
 	for _, l := range file.LineMatches {
 		if l.FileName {
 			continue

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -485,13 +485,13 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 			symbols = append(symbols, result.NewSymbolMatch(
 				newFile,
 				int(r.Start.LineNumber),
-				-1,
+				int(r.Start.Column)-1,
 				si.Sym,
 				si.Kind,
 				si.Parent,
 				si.ParentKind,
 				file.Language,
-				string(cm.Content), // TODO will symbol matches always be one line?
+				"", // Unused when column is set
 				false,
 			))
 		}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -485,7 +485,7 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 
 			symbols = append(symbols, result.NewSymbolMatch(
 				newFile,
-				r.Start.LineNumber,
+				int(r.Start.LineNumber),
 				-1,
 				si.Sym,
 				si.Kind,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -2,9 +2,9 @@ package zoekt
 
 import (
 	"context"
-	"unicode/utf8"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/google/zoekt"

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -473,12 +473,12 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 	}
 
 	for _, cm := range file.ChunkMatches {
-		if cm.FileName {
+		if cm.FileName || len(cm.SymbolInfo) == 0 {
 			continue
 		}
 
-		for _, r := range cm.Ranges {
-			si := r.SymbolInfo
+		for i, r := range cm.Ranges {
+			si := cm.SymbolInfo[i]
 			if si == nil {
 				continue
 			}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -120,21 +120,22 @@ func TestIndexedSearch(t *testing.T) {
 						Branches:     []string{"HEAD"},
 						Version:      "1",
 						FileName:     "baz.go",
-						LineMatches: []zoekt.LineMatch{
-							{
-								Line: []byte("I'm like 1.5+ hours into writing this test :'("),
-								LineFragments: []zoekt.LineFragmentMatch{
-									{LineOffset: 0, MatchLength: 5},
-								},
-							},
-							{
-								Line: []byte("I'm ready for the rain to stop."),
-								LineFragments: []zoekt.LineFragmentMatch{
-									{LineOffset: 0, MatchLength: 5},
-									{LineOffset: 5, MatchLength: 10},
-								},
-							},
-						},
+						ChunkMatches: []zoekt.ChunkMatch{{
+							Content: []byte("I'm like 1.5+ hours into writing this test :'("),
+							Ranges: []zoekt.Range{{
+								Start: zoekt.Location{0, 1, 1},
+								End:   zoekt.Location{5, 1, 6},
+							}},
+						}, {
+							Content: []byte("I'm ready for the rain to stop."),
+							Ranges: []zoekt.Range{{
+								Start: zoekt.Location{0, 1, 1},
+								End:   zoekt.Location{5, 1, 6},
+							}, {
+								Start: zoekt.Location{5, 1, 6},
+								End:   zoekt.Location{15, 1, 16},
+							}},
+						}},
 					},
 					{
 						Repository:   "foo/foobar",
@@ -142,15 +143,16 @@ func TestIndexedSearch(t *testing.T) {
 						Branches:     []string{"HEAD"},
 						Version:      "2",
 						FileName:     "baz.go",
-						LineMatches: []zoekt.LineMatch{
-							{
-								Line: []byte("s/rain/pain"),
-								LineFragments: []zoekt.LineFragmentMatch{
-									{LineOffset: 0, MatchLength: 5},
-									{LineOffset: 5, MatchLength: 2},
-								},
-							},
-						},
+						ChunkMatches: []zoekt.ChunkMatch{{
+							Content: []byte("s/rain/pain"),
+							Ranges: []zoekt.Range{{
+								Start: zoekt.Location{0, 1, 1},
+								End:   zoekt.Location{5, 1, 6},
+							}, {
+								Start: zoekt.Location{5, 1, 6},
+								End:   zoekt.Location{7, 1, 8},
+							}},
+						}},
 					},
 				},
 				since: func(time.Time) time.Duration { return 0 },
@@ -587,31 +589,36 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		Repository: "foo",
 		Language:   "go",
 		Version:    "deadbeef",
-		LineMatches: []zoekt.LineMatch{{
+		ChunkMatches: []zoekt.ChunkMatch{{
 			// Skips missing symbol info (shouldn't happen in practice).
-			Line:          []byte(""),
-			LineNumber:    5,
-			LineFragments: []zoekt.LineFragmentMatch{{}},
+			Content:      []byte(""),
+			ContentStart: zoekt.Location{LineNumber: 5, Column: 1},
+			Ranges: []zoekt.Range{{
+				Start: zoekt.Location{LineNumber: 5},
+			}},
 		}, {
-			Line:       []byte("symbol a symbol b"),
-			LineNumber: 10,
-			LineFragments: []zoekt.LineFragmentMatch{{
-				SymbolInfo: symbolInfo("a"),
+			Content:      []byte("symbol a symbol b"),
+			ContentStart: zoekt.Location{LineNumber: 10, Column: 1},
+			Ranges: []zoekt.Range{{
+				Start: zoekt.Location{LineNumber: 10},
 			}, {
-				SymbolInfo: symbolInfo("b"),
+				Start: zoekt.Location{LineNumber: 10},
 			}},
+			SymbolInfo: []*zoekt.Symbol{symbolInfo("a"), symbolInfo("b")},
 		}, {
-			Line:       []byte("symbol c"),
-			LineNumber: 15,
-			LineFragments: []zoekt.LineFragmentMatch{{
-				SymbolInfo: symbolInfo("c"),
+			Content:      []byte("symbol c"),
+			ContentStart: zoekt.Location{LineNumber: 15, Column: 1},
+			Ranges: []zoekt.Range{{
+				Start: zoekt.Location{LineNumber: 15},
 			}},
+			SymbolInfo: []*zoekt.Symbol{symbolInfo("c")},
 		}, {
-			Line:       []byte(`bar() { var regex = /.*\//; function baz() { }  } `),
-			LineNumber: 20,
-			LineFragments: []zoekt.LineFragmentMatch{{
-				SymbolInfo: symbolInfo("baz"),
+			Content:      []byte(`bar() { var regex = /.*\//; function baz() { }  } `),
+			ContentStart: zoekt.Location{LineNumber: 20, Column: 1},
+			Ranges: []zoekt.Range{{
+				Start: zoekt.Location{LineNumber: 20},
 			}},
+			SymbolInfo: []*zoekt.Symbol{symbolInfo("baz")},
 		}},
 	}
 
@@ -819,23 +826,18 @@ func TestZoektFileMatchToMultilineMatches(t *testing.T) {
 		output result.ChunkMatches
 	}{{
 		input: &zoekt.FileMatch{
-			LineMatches: []zoekt.LineMatch{{
-				Line:       []byte("testing 1 2 3"),
-				LineNumber: 1,
-				LineStart:  0,
-				LineEnd:    len("testing 1 2 3"),
-				LineFragments: []zoekt.LineFragmentMatch{{
-					LineOffset:  8,
-					Offset:      8,
-					MatchLength: 1,
+			ChunkMatches: []zoekt.ChunkMatch{{
+				Content:      []byte("testing 1 2 3"),
+				ContentStart: zoekt.Location{ByteOffset: 0, LineNumber: 1, Column: 1},
+				Ranges: []zoekt.Range{{
+					Start: zoekt.Location{8, 1, 9},
+					End:   zoekt.Location{9, 1, 10},
 				}, {
-					LineOffset:  10,
-					Offset:      10,
-					MatchLength: 1,
+					Start: zoekt.Location{10, 1, 11},
+					End:   zoekt.Location{11, 1, 12},
 				}, {
-					LineOffset:  12,
-					Offset:      12,
-					MatchLength: 1,
+					Start: zoekt.Location{12, 1, 13},
+					End:   zoekt.Location{13, 1, 14},
 				}},
 			}},
 		},

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -594,29 +594,29 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 			Content:      []byte(""),
 			ContentStart: zoekt.Location{LineNumber: 5, Column: 1},
 			Ranges: []zoekt.Range{{
-				Start: zoekt.Location{LineNumber: 5},
+				Start: zoekt.Location{LineNumber: 5, Column: 8},
 			}},
 		}, {
 			Content:      []byte("symbol a symbol b"),
 			ContentStart: zoekt.Location{LineNumber: 10, Column: 1},
 			Ranges: []zoekt.Range{{
-				Start: zoekt.Location{LineNumber: 10},
+				Start: zoekt.Location{LineNumber: 10, Column: 8},
 			}, {
-				Start: zoekt.Location{LineNumber: 10},
+				Start: zoekt.Location{LineNumber: 10, Column: 18},
 			}},
 			SymbolInfo: []*zoekt.Symbol{symbolInfo("a"), symbolInfo("b")},
 		}, {
 			Content:      []byte("symbol c"),
 			ContentStart: zoekt.Location{LineNumber: 15, Column: 1},
 			Ranges: []zoekt.Range{{
-				Start: zoekt.Location{LineNumber: 15},
+				Start: zoekt.Location{LineNumber: 15, Column: 8},
 			}},
 			SymbolInfo: []*zoekt.Symbol{symbolInfo("c")},
 		}, {
 			Content:      []byte(`bar() { var regex = /.*\//; function baz() { }  } `),
 			ContentStart: zoekt.Location{LineNumber: 20, Column: 1},
 			Ranges: []zoekt.Range{{
-				Start: zoekt.Location{LineNumber: 20},
+				Start: zoekt.Location{LineNumber: 20, Column: 38},
 			}},
 			SymbolInfo: []*zoekt.Symbol{symbolInfo("baz")},
 		}},
@@ -635,7 +635,7 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 	}, {
 		Name:      "b",
 		Line:      10,
-		Character: 3,
+		Character: 17,
 	}, {
 		Name:      "c",
 		Line:      15,

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -76,9 +76,10 @@ func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[stri
 func SearchOpts(ctx context.Context, k int, fileMatchLimit int32, selector filter.SelectPath) zoekt.SearchOptions {
 	shouldTrace, spanContext := getSpanContext(ctx)
 	searchOpts := zoekt.SearchOptions{
-		Trace:       shouldTrace,
-		SpanContext: spanContext,
-		MaxWallTime: defaultTimeout,
+		Trace:        shouldTrace,
+		SpanContext:  spanContext,
+		MaxWallTime:  defaultTimeout,
+		ChunkMatches: true,
 	}
 
 	if userProbablyWantsToWaitLonger := fileMatchLimit > limits.DefaultMaxSearchResults; userProbablyWantsToWaitLonger {


### PR DESCRIPTION
This updates the pinned version of Zoekt and updates our calls to the Zoekt search API to request ChunkMatches.

I decided to not put this behind a feature flag because it was a huge pain to thread that state through our search backend and across APIs, which would be necessary because searcher is also a client of Zoekt. Instead, there are two booleans that are set by this PR that can safely be switched to false in case we need to disable this behavior. This should be unnecessary (I've manually tested this pretty extensively in addition to updating tests in Zoekt), but I'm documenting it here just in case.

## Test plan

Much manual testing as part of https://github.com/sourcegraph/zoekt/pull/367. Updated unit tests to work with chunk matches instead. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
