### PR TITLE
[SG-35263] Collapsible sections in code-intel index pages don't explain what they contain

### DIFF
--- a/client/web/src/components/ExecutionLogEntry.tsx
+++ b/client/web/src/components/ExecutionLogEntry.tsx
@@ -30,7 +30,7 @@ export const ExecutionLogEntry: React.FunctionComponent<React.PropsWithChildren<
     <Card className="mb-3">
         <CardBody>
             {logEntry.command.length > 0 ? (
-                <LogOutput text={logEntry.command.join(' ')} className="mb-3" />
+                <LogOutput text={logEntry.command.join(' ')} className="mb-3" logDescription="Executed command:" />
             ) : (
                 <div className="mb-3">
                     <span className="text-muted">Internal step {logEntry.key}.</span>
@@ -63,7 +63,7 @@ export const ExecutionLogEntry: React.FunctionComponent<React.PropsWithChildren<
         <div className="p-2">
             {logEntry.out ? (
                 <Collapsible title="Log output" titleAtStart={true} buttonClassName="p-2">
-                    <LogOutput text={logEntry.out} />
+                    <LogOutput text={logEntry.out} logDescription="Log output:" />
                 </Collapsible>
             ) : (
                 <div className="p-2">

--- a/client/web/src/components/LogOutput.tsx
+++ b/client/web/src/components/LogOutput.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { Code } from '@sourcegraph/wildcard'
@@ -9,25 +10,32 @@ import styles from './LogOutput.module.scss'
 export interface LogOutputProps {
     text: string
     className?: string
+    /**
+     * Descriptive prefix text, visible only to screen reader.
+     */
+    logDescription?: string
 }
 
 export const LogOutput: React.FunctionComponent<React.PropsWithChildren<LogOutputProps>> = React.memo(
-    ({ text, className }) => (
-        <pre className={classNames(styles.logs, 'rounded p-3 mb-0', className)}>
-            {
-                // Use index as key because log lines may not be unique. This is OK
-                // here because this list will not be updated during this component's
-                // lifetime (note: it's also memoized).
-                /* eslint-disable react/no-array-index-key */
-                text.split('\n').map((line, index) => (
-                    <Code
-                        key={index}
-                        className={classNames('d-block', line.startsWith('stderr:') ? 'text-danger' : '')}
-                    >
-                        {line.replace(/^std(out|err): /, '')}
-                    </Code>
-                ))
-            }
-        </pre>
+    ({ text, className, logDescription }) => (
+        <>
+            {logDescription && <VisuallyHidden>{logDescription}</VisuallyHidden>}
+            <pre className={classNames(styles.logs, 'rounded p-3 mb-0', className)}>
+                {
+                    // Use index as key because log lines may not be unique. This is OK
+                    // here because this list will not be updated during this component's
+                    // lifetime (note: it's also memoized).
+                    /* eslint-disable react/no-array-index-key */
+                    text.split('\n').map((line, index) => (
+                        <Code
+                            key={index}
+                            className={classNames('d-block', line.startsWith('stderr:') ? 'text-danger' : '')}
+                        >
+                            {line.replace(/^std(out|err): /, '')}
+                        </Code>
+                    ))
+                }
+            </pre>
+        </>
     )
 )


### PR DESCRIPTION
### Audit type
Screen reader navigation

### User journey audit issue
https://github.com/sourcegraph/sourcegraph/issues/33513

### Problem description
Upon expanding the below collapsible, the screen reader instantly starts reading the `ignite exec executor-f7ceeb6b-8973-4d54-98a3-ef86ed9f09a3...` section, with no indication as to this being the command that was run for this step.

The "log output" section is preceeded by a text element indicating as such, but without it being directly linked to being part of the following section as opposed to the previous.

### Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35263)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35263)

### Test Plan
- Run storybook `yarn storybook`
- Look for `CodeIntelIndexPage` story

## App preview:

- [Web](https://sg-web-contractors-sg-35263.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hojtmrrwev.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
