### PR TITLE
batches(gitlab) handle time with numeric timezone in webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights: the commit indexer no longer errors when fetching commits from empty repositories and marks them as successfully indexed. [#39081](https://github.com/sourcegraph/sourcegraph/pull/38091)
 - The file view does not jump to the first selected line anymore when selecting multiple lines and the first selected line was out of view. [#38175](https://github.com/sourcegraph/sourcegraph/pull/38175)
 - Fixed an issue where multiple activations of the back button are required to navigate back to a previously selected line in a file [#38193](https://github.com/sourcegraph/sourcegraph/pull/38193)
+- Support timestamps with numeric timezone format from Gitlab's Webhook payload [#38250](https://github.com/sourcegraph/sourcegraph/pull/38250)
 
 ### Removed
 

--- a/internal/extsvc/gitlab/time.go
+++ b/internal/extsvc/gitlab/time.go
@@ -33,6 +33,14 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 	dec, err := time.Parse("2006-01-02 15:04:05 MST", s)
 	if err == nil {
 		t.Time = dec
+		return nil
 	}
+
+	dec, err = time.Parse("2006-01-02 15:04:05 -0700", s)
+	if err == nil {
+		t.Time = dec
+		return nil
+	}
+
 	return err
 }

--- a/internal/extsvc/gitlab/time_test.go
+++ b/internal/extsvc/gitlab/time_test.go
@@ -8,6 +8,11 @@ import (
 
 func TestTimeUnmarshal(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
+		loc, err := time.LoadLocation("Europe/Berlin")
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		for _, tc := range []struct {
 			input string
 			want  time.Time
@@ -23,6 +28,10 @@ func TestTimeUnmarshal(t *testing.T) {
 			{
 				input: "2020-06-24 00:05:18 UTC",
 				want:  time.Date(2020, 6, 24, 0, 5, 18, 0, time.UTC),
+			},
+			{
+				input: "2022-07-05 20:52:49 +0200",
+				want:  time.Date(2022, 7, 5, 20, 52, 49, 0, loc),
 			},
 		} {
 			t.Run(tc.input, func(t *testing.T) {


### PR DESCRIPTION
Closes #37842

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually triggered the webhook URL with a payload containing  a timestamp with a numeric timezone 
```json
{
    "created_at": "2022-07-05 20:52:49 +0200"
}
```

![CleanShot 2022-07-05 at 22 35 29@2x](https://user-images.githubusercontent.com/25608335/177420764-9edba0b7-9b52-429e-b3b3-0d9448e0f945.png)

![CleanShot 2022-07-05 at 22 39 06@2x](https://user-images.githubusercontent.com/25608335/177420968-87b53234-fedb-4818-bace-7e6ce877206c.png)

### Context

[The `time.Parse`  method doesn't support numeric timezones with an `MST` format string](https://github.com/golang/go/issues/30780). We currently use [a custom `unmarshalJSON`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/extsvc/gitlab/time.go?L18%3A2-38%3A3=) method that performs a bunch of checks to make sure we support all time format from Gitlab's API. However, one format that triggers the issue is that of a time string containing a numeric timezone.