### PR TITLE
insights: remove Just in time conversion check on backfilled_at

### DIFF
--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -391,7 +391,6 @@ func (s *InsightStore) GetJustInTimeSearchSeriesToBackfill(ctx context.Context) 
 	preds := make([]*sqlf.Query, 0, 1)
 
 	preds = append(preds, sqlf.Sprintf("deleted_at IS NULL"))
-	preds = append(preds, sqlf.Sprintf("backfill_queued_at IS NULL"))
 	preds = append(preds, sqlf.Sprintf("CARDINALITY(repositories) > 0"))
 	preds = append(preds, sqlf.Sprintf("just_in_time = true"))
 	preds = append(preds, sqlf.Sprintf("backfill_attempts < 10"))


### PR DESCRIPTION
some environments have just in time insights with a backfill date already set, these should be migrated
## Test plan
Made a Just in time series and set a backfilled date on it.  Ran historical enquerer and validated that series converted and backfilled.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
