### PR TITLE
Code Insights: Render insight that are rendered in visible viewport area

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -66,7 +66,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
     const [zeroYAxisMin, setZeroYAxisMin] = useState(false)
     const insightCardReference = useRef<HTMLDivElement>(null)
     const mergedInsightCardReference = useMergeRefs([insightCardReference, innerRef])
-    const { wasEverVisible } = useVisibility(insightCardReference)
+    const { isVisible, wasEverVisible } = useVisibility(insightCardReference)
 
     // Use deep copy check in case if a setting subject has re-created copy of
     // the insight config with same structure and values. To avoid insight data
@@ -198,7 +198,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                     </Link>
                 }
             >
-                {wasEverVisible && (
+                {isVisible && (
                     <>
                         <DrillDownFiltersPopover
                             isOpen={isFiltersOpen}
@@ -230,7 +230,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                 <InsightCardBanner>Resizing</InsightCardBanner>
             ) : error ? (
                 <BackendInsightErrorAlert error={error} />
-            ) : loading || !wasEverVisible || !insightData ? (
+            ) : loading || !isVisible || !insightData ? (
                 <InsightCardLoading>Loading code insight</InsightCardLoading>
             ) : (
                 <BackendInsightChart
@@ -244,7 +244,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
             {
                 // Passing children props explicitly to render any top-level content like
                 // resize-handler from the react-grid-layout library
-                wasEverVisible && otherProps.children
+                isVisible && otherProps.children
             }
         </InsightCard>
     )

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -101,7 +101,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
             variables: { id: insight.id, filters: filterInput, seriesDisplayOptions: displayInput },
             fetchPolicy: 'cache-and-network',
             pollInterval: pollingInterval,
-            skip: !wasEverVisible,
+            skip: !wasEverVisible || (insightData && (!insightData.isFetchingHistoricalData || !isVisible)),
             context: { concurrentRequests: { key: 'GET_INSIGHT_VIEW' } },
             onCompleted: data => {
                 const parsedData = createBackendInsightData({ ...insight, filters }, data.insightViews.nodes[0])

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -68,7 +68,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
     // configuration object, They are updated  whenever the user clicks update/save button
     const [originalInsightFilters, setOriginalInsightFilters] = useState(insight.filters)
     const insightCardReference = useRef<HTMLDivElement>(null)
-    const { wasEverVisible } = useVisibility(insightCardReference)
+    const { isVisible, wasEverVisible } = useVisibility(insightCardReference)
     // Live valid filters from filter form. They are updated whenever the user is changing
     // filter value in filters fields.
     const [filters, setFilters] = useState<InsightFilters>(originalInsightFilters)
@@ -197,7 +197,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
 
                 {error ? (
                     <BackendInsightErrorAlert error={error} />
-                ) : loading || !wasEverVisible || !insightData ? (
+                ) : loading || !isVisible || !insightData ? (
                     <InsightCardLoading>Loading code insight</InsightCardLoading>
                 ) : error ? (
                     <BackendInsightErrorAlert error={error} />


### PR DESCRIPTION
## Background 
Prior to this PR, we render all insights on the page that were ever visible. So for example, if we have 100 insights on the page and only 10 of them are visible, during user scrolling we will render more and more elements on the page (10, 12, 15, 20 ....) at the end we will render all insights. 

In this PR we use intersection observer information to track insight cards that are visible so we always will have approximately the same number of rendered insight cards on the page.

## Test plan
- Make sure that we don't skip any insight rendering on the page
- Make sure that we don't have unnecessary requests in the network tab during page scrolling

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-insight-fix-lazy-rendering.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kbgshhlsih.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
