### PR TITLE
codemirror: Fix suggestions snippet behavior

### DIFF
--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -234,7 +234,7 @@ export function createDefaultSuggestionSources(options: {
 
     if (options.disableFilterCompletion !== true) {
         sources.push(
-            // Static suggestions shown if the the current position is outside a
+            // Static suggestions shown if the current position is outside a
             // filter value
             createDefaultSource((context, _tokens, token) => {
                 // Default to the current cursor position (e.g. if the token is a
@@ -274,7 +274,7 @@ export function createDefaultSuggestionSources(options: {
                             return {
                                 label,
                                 // See issue https://github.com/sourcegraph/sourcegraph/issues/38254
-                                // Per CodeMirrors documentation (https://codemirror.net/docs/ref/#autocomplete.snippet)
+                                // Per CodeMirror's documentation (https://codemirror.net/docs/ref/#autocomplete.snippet)
                                 // "The user can move between fields with Tab and Shift-Tab as long as the fields are
                                 // active. Moving to the last field or moving the cursor out of the current field
                                 // deactivates the fields."

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -273,7 +273,14 @@ export function createDefaultSuggestionSources(options: {
                             const apply = (insertText || label) + ' '
                             return {
                                 label,
-                                apply: asSnippet ? snippet(apply) : apply,
+                                // See issue https://github.com/sourcegraph/sourcegraph/issues/38254
+                                // Per CodeMirrors documentation (https://codemirror.net/docs/ref/#autocomplete.snippet)
+                                // "The user can move between fields with Tab and Shift-Tab as long as the fields are
+                                // active. Moving to the last field or moving the cursor out of the current field
+                                // deactivates the fields."
+                                // This means we need to append a field at the end so that pressing Tab when at the last
+                                // field will move the cursor after the filter value and not move focus outside the input
+                                apply: asSnippet ? snippet(apply + '${}') : apply,
                             }
                         }),
                 }


### PR DESCRIPTION
Fixes #38254 

Tabbing from the last field in a snippet causes the input to loose
focus. CodeMirror only overwrites the Tab key behavior for any but the
last placeholder field in the snippet.
The simple solution is to always append an empty placeholder field at
the end of the snippet. This replicates Monaco's behavior.

Behavior after the fix (see issue for before behavior):

https://user-images.githubusercontent.com/179026/177419522-7252d8a9-100e-4631-bd37-6b7572806d34.mp4



## Test plan

- Trigger suggestions for `repo:` filter (no filter value)
- Select a predicate with a single placeholder field (e.g. `contains.commit.before(...)`)
- Pressing the <kbd>Tab</kbd> key should move focus after the filter, not outside the query input

## App preview:

- [Web](https://sg-web-fkling-cm-38254-fix-suggestion.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ypovxklaxh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
