### PR TITLE
dev/pr-auditor: run on pull_request_target

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -1,7 +1,7 @@
 # See https://docs.sourcegraph.com/dev/background-information/ci#pr-auditor
 name: pr-auditor
 on:
-  pull_request:
+  pull_request_target:
     types: [ closed, edited, opened, synchronize, ready_for_review ]
 
 jobs:

--- a/dev/pr-auditor/batch-changes/pr-auditor-patch.yml
+++ b/dev/pr-auditor/batch-changes/pr-auditor-patch.yml
@@ -27,7 +27,7 @@ steps:
       # See https://docs.sourcegraph.com/dev/background-information/ci#pr-auditor
       name: pr-auditor
       on:
-        pull_request:
+        pull_request_target:
           types: [ closed, edited, opened, synchronize, ready_for_review ]
 
       jobs:

--- a/dev/pr-auditor/batch-changes/pr-auditor-rollout.yml
+++ b/dev/pr-auditor/batch-changes/pr-auditor-rollout.yml
@@ -48,7 +48,7 @@ steps:
       # See https://docs.sourcegraph.com/dev/background-information/ci#pr-auditor
       name: pr-auditor
       on:
-        pull_request:
+        pull_request_target:
           types: [ closed, edited, opened, synchronize, ready_for_review ]
 
       jobs:


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/35675, which fixes pr-auditor's ability to set commit statuses on PRs coming from forks, was mistakenly reverted in https://github.com/sourcegraph/sourcegraph/pull/36798 

I'll update https://k8s.sgdev.org/users/robert/batch-changes/pr-auditor-patch-06-16 with this change

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

was previously tested