### PR TITLE
batches: add read only external state

### DIFF
--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetFileDiff.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetFileDiff.tsx
@@ -149,7 +149,7 @@ function commitOIDForGitRevision(revision: GitRefSpecFields): string {
 
 const DiffRenderingNotSupportedAlert: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <Alert className="mb-0" variant="info">
-        Diffs for processing, merged, closed, read only, and deleted changesets are currently only available on the code
+        Diffs for processing, merged, closed, read-only, and deleted changesets are currently only available on the code
         host.
     </Alert>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetFileDiff.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetFileDiff.tsx
@@ -149,6 +149,7 @@ function commitOIDForGitRevision(revision: GitRefSpecFields): string {
 
 const DiffRenderingNotSupportedAlert: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <Alert className="mb-0" variant="info">
-        Diffs for processing, merged, closed and deleted changesets are currently only available on the code host.
+        Diffs for processing, merged, closed, read only, and deleted changesets are currently only available on the code
+        host.
     </Alert>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.tsx
@@ -165,11 +165,11 @@ export const ChangesetStatusArchived: React.FunctionComponent<React.PropsWithChi
 )
 
 export const ChangesetStatusReadOnly: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Read only</span>,
+    label = <span>Read-only</span>,
     className,
     ...props
 }) => (
-    <Tooltip content="This changeset is read only, and cannot be modified. This is usually caused by the repository being archived.">
+    <Tooltip content="This changeset is read-only, and cannot be modified. This is usually caused by the repository being archived.">
         <div className={classNames(iconClassNames, className)} {...props}>
             <LockIcon role="presentation" />
             {label}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.tsx
@@ -5,10 +5,13 @@ import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import ArchiveIcon from 'mdi-react/ArchiveIcon'
 import AutorenewIcon from 'mdi-react/AutorenewIcon'
 import DeleteIcon from 'mdi-react/DeleteIcon'
+import LockIcon from 'mdi-react/LockIcon'
 import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 import SourceMergeIcon from 'mdi-react/SourceMergeIcon'
 import SourcePullIcon from 'mdi-react/SourcePullIcon'
 import TimerSandIcon from 'mdi-react/TimerSandIcon'
+
+import { Tooltip } from '@sourcegraph/wildcard'
 
 import { ChangesetFields, ChangesetState, Scalars } from '../../../../graphql-operations'
 
@@ -44,6 +47,8 @@ export const ChangesetStatusCell: React.FunctionComponent<React.PropsWithChildre
             return <ChangesetStatusClosed className={className} />
         case ChangesetState.MERGED:
             return <ChangesetStatusMerged className={className} />
+        case ChangesetState.READONLY:
+            return <ChangesetStatusReadOnly className={className} />
         case ChangesetState.DELETED:
             return <ChangesetStatusDeleted className={className} />
     }
@@ -157,4 +162,17 @@ export const ChangesetStatusArchived: React.FunctionComponent<React.PropsWithChi
         <ArchiveIcon role="presentation" />
         {label}
     </div>
+)
+
+export const ChangesetStatusReadOnly: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
+    label = <span>Read only</span>,
+    className,
+    ...props
+}) => (
+    <Tooltip content="This changeset is read only, and cannot be modified. This is usually caused by the repository being archived.">
+        <div className={classNames(iconClassNames, className)} {...props}>
+            <LockIcon role="presentation" />
+            {label}
+        </div>
+    </Tooltip>
 )

--- a/client/web/src/enterprise/batches/preview/utils.ts
+++ b/client/web/src/enterprise/batches/preview/utils.ts
@@ -71,9 +71,13 @@ export const checkPublishability = (
     if (node.targets.__typename === 'VisibleApplyPreviewTargetsUpdate') {
         // The changeset is already published
         if (
-            [ChangesetState.CLOSED, ChangesetState.DELETED, ChangesetState.MERGED, ChangesetState.OPEN].includes(
-                node.targets.changeset.state
-            )
+            [
+                ChangesetState.CLOSED,
+                ChangesetState.DELETED,
+                ChangesetState.MERGED,
+                ChangesetState.OPEN,
+                ChangesetState.READONLY,
+            ].includes(node.targets.changeset.state)
         ) {
             return { publishable: false, reason: 'This changeset has already been published.' }
         }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -99,6 +99,7 @@ enum ChangesetExternalState {
     OPEN
     CLOSED
     MERGED
+    READONLY
     DELETED
 }
 
@@ -184,6 +185,11 @@ enum ChangesetState {
     The changeset is published, not being reconciled and merged on the code host.
     """
     MERGED
+    """
+    The changeset is published, and is now read only, most likely due to the
+    repository being archived.
+    """
+    READONLY
     """
     The changeset is published, not being reconciled and has been deleted on the code host.
     """

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -186,7 +186,7 @@ enum ChangesetState {
     """
     MERGED
     """
-    The changeset is published, and is now read only, most likely due to the
+    The changeset is published, and is now read-only, most likely due to the
     repository being archived.
     """
     READONLY

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -347,6 +347,8 @@ func (r *changesetResolver) State() (string, error) {
 		return string(btypes.ChangesetStateMerged), nil
 	case btypes.ChangesetExternalStateDeleted:
 		return string(btypes.ChangesetStateDeleted), nil
+	case btypes.ChangesetExternalStateReadOnly:
+		return string(btypes.ChangesetStateReadOnly), nil
 	default:
 		return "", errors.Errorf("invalid ExternalState %q for state calculation", r.changeset.ExternalState)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -323,7 +323,7 @@ func TestChangesetResolver(t *testing.T) {
 			},
 		},
 		{
-			name:      "read only github changeset",
+			name:      "read-only github changeset",
 			changeset: readOnlyGitHubChangeset,
 			want: apitest.Changeset{
 				Typename:           "ExternalChangeset",

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -168,6 +168,30 @@ func TestChangesetResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	readOnlyGitHubChangeset := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+		Repo:                repo.ID,
+		ExternalServiceType: "github",
+		ExternalID:          "123456",
+		ExternalBranch:      "read-only-pr",
+		ExternalState:       btypes.ChangesetExternalStateReadOnly,
+		ExternalCheckState:  btypes.ChangesetCheckStatePending,
+		ExternalReviewState: btypes.ChangesetReviewStateChangesRequested,
+		PublicationState:    btypes.ChangesetPublicationStatePublished,
+		ReconcilerState:     btypes.ReconcilerStateCompleted,
+		Metadata: &github.PullRequest{
+			ID:          "123456",
+			Title:       "GitHub PR Title",
+			Body:        "GitHub PR Body",
+			Number:      123456,
+			State:       "OPEN",
+			URL:         "https://github.com/sourcegraph/archived/pull/123456",
+			HeadRefName: "read-only-pr",
+			HeadRefOid:  headRev,
+			BaseRefOid:  baseRev,
+			BaseRefName: "master",
+		},
+	})
+
 	unsyncedChangeset := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
 		Repo:                repo.ID,
 		ExternalServiceType: "github",
@@ -296,6 +320,27 @@ func TestChangesetResolver(t *testing.T) {
 					Typename:  "RepositoryComparison",
 					FileDiffs: testDiffGraphQL,
 				},
+			},
+		},
+		{
+			name:      "read only github changeset",
+			changeset: readOnlyGitHubChangeset,
+			want: apitest.Changeset{
+				Typename:           "ExternalChangeset",
+				Title:              "GitHub PR Title",
+				Body:               "GitHub PR Body",
+				ExternalID:         "123456",
+				CheckState:         "PENDING",
+				ReviewState:        "CHANGES_REQUESTED",
+				ScheduleEstimateAt: "",
+				Repository:         apitest.Repository{Name: string(repo.Name)},
+				ExternalURL: apitest.ExternalURL{
+					URL:         "https://github.com/sourcegraph/archived/pull/123456",
+					ServiceKind: "GITHUB",
+					ServiceType: "github",
+				},
+				Labels: []apitest.Label{},
+				State:  string(btypes.ChangesetStateReadOnly),
 			},
 		},
 		{

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -870,6 +870,12 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
 			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
 			opts.PublicationState = &publicationState
+		case btypes.ChangesetStateReadOnly:
+			externalState := btypes.ChangesetExternalStateReadOnly
+			publicationState := btypes.ChangesetPublicationStatePublished
+			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
+			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
+			opts.PublicationState = &publicationState
 		case btypes.ChangesetStateUnpublished:
 			publicationState := btypes.ChangesetPublicationStateUnpublished
 			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -185,7 +185,10 @@ func (e *executor) pushChangesetPatch(ctx context.Context) (err error) {
 	if errors.As(err, &pce) {
 		if acss, ok := css.(sources.ArchivableChangesetSource); ok {
 			if acss.IsArchivedPushError(pce.CombinedOutput) {
-				return e.handleArchivedRepo(ctx)
+				if err := e.handleArchivedRepo(ctx); err != nil {
+					return errors.Wrap(err, "handling archived repo")
+				}
+				return errcode.MakeNonRetryable(errors.New("cannot push to an archived repo"))
 			}
 		}
 	}

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -221,9 +221,8 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 			isRepoArchived: true,
 			sourcerErr:     repoArchivedErr,
 
-			wantCreateOnCodeHost: true,
-			wantGitserverCommit:  true,
-			wantNonRetryableErr:  true,
+			wantGitserverCommit: true,
+			wantNonRetryableErr: true,
 
 			wantChangeset: ct.ChangesetAssertions{
 				PublicationState: btypes.ChangesetPublicationStateUnpublished,

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -586,6 +587,13 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 
 			tc.plan.Changeset = changeset
 			tc.plan.ChangesetSpec = changesetSpec
+
+			// Ensure we reset the state of the repo after executing the plan.
+			t.Cleanup(func() {
+				repo.Archived = false
+				_, err := repos.NewStore(logtest.Scoped(t), cstore.DatabaseDB()).UpdateRepo(ctx, repo)
+				require.NoError(t, err)
+			})
 
 			// Execute the plan
 			err := executePlan(

--- a/enterprise/internal/batches/reconciler/plan.go
+++ b/enterprise/internal/batches/reconciler/plan.go
@@ -139,7 +139,9 @@ func DeterminePlan(previousSpec, currentSpec *btypes.ChangesetSpec, ch *btypes.C
 	}
 
 	if ch.Closing {
-		pl.AddOp(btypes.ReconcilerOperationClose)
+		if ch.ExternalState != btypes.ChangesetExternalStateReadOnly {
+			pl.AddOp(btypes.ReconcilerOperationClose)
+		}
 		// Close is a final operation, nothing else should overwrite it.
 		return pl, nil
 	} else if wantDetachFromOwnerBatchChange || wantArchive || isArchived {

--- a/enterprise/internal/batches/reconciler/plan.go
+++ b/enterprise/internal/batches/reconciler/plan.go
@@ -188,7 +188,7 @@ func DeterminePlan(previousSpec, currentSpec *btypes.ChangesetSpec, ch *btypes.C
 		// the same as being unpublished.
 
 	case btypes.ChangesetPublicationStatePublished:
-		// Don't take any actions for merged or read only changesets.
+		// Don't take any actions for merged or read-only changesets.
 		if ch.ExternalState == btypes.ChangesetExternalStateMerged ||
 			ch.ExternalState == btypes.ChangesetExternalStateReadOnly {
 			return pl, nil

--- a/enterprise/internal/batches/reconciler/plan.go
+++ b/enterprise/internal/batches/reconciler/plan.go
@@ -186,8 +186,9 @@ func DeterminePlan(previousSpec, currentSpec *btypes.ChangesetSpec, ch *btypes.C
 		// the same as being unpublished.
 
 	case btypes.ChangesetPublicationStatePublished:
-		// Don't take any actions for merged changesets.
-		if ch.ExternalState == btypes.ChangesetExternalStateMerged {
+		// Don't take any actions for merged or read only changesets.
+		if ch.ExternalState == btypes.ChangesetExternalStateMerged ||
+			ch.ExternalState == btypes.ChangesetExternalStateReadOnly {
 			return pl, nil
 		}
 		if reopenAfterDetach(ch) {
@@ -242,7 +243,8 @@ func DeterminePlan(previousSpec, currentSpec *btypes.ChangesetSpec, ch *btypes.C
 }
 
 func reopenAfterDetach(ch *btypes.Changeset) bool {
-	closed := ch.ExternalState == btypes.ChangesetExternalStateClosed
+	closed := ch.ExternalState == btypes.ChangesetExternalStateClosed ||
+		ch.ExternalState == btypes.ChangesetExternalStateReadOnly
 	if !closed {
 		return false
 	}

--- a/enterprise/internal/batches/reconciler/plan_test.go
+++ b/enterprise/internal/batches/reconciler/plan_test.go
@@ -198,7 +198,7 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 			wantOperations: Operations{},
 		},
 		{
-			name:         "publishing read only changeset",
+			name:         "publishing read-only changeset",
 			previousSpec: &ct.TestSpecOpts{Published: true},
 			currentSpec:  &ct.TestSpecOpts{Published: true},
 			changeset: ct.TestChangesetOpts{
@@ -219,7 +219,7 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 			wantOperations: Operations{btypes.ReconcilerOperationUpdate},
 		},
 		{
-			name:         "title changed on read only changeset",
+			name:         "title changed on read-only changeset",
 			previousSpec: &ct.TestSpecOpts{Published: true, Title: "Before"},
 			currentSpec:  &ct.TestSpecOpts{Published: true, Title: "After"},
 			changeset: ct.TestChangesetOpts{
@@ -314,7 +314,7 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 			},
 		},
 		{
-			name:         "closing read only changeset",
+			name:         "closing read-only changeset",
 			previousSpec: &ct.TestSpecOpts{Published: true},
 			currentSpec:  &ct.TestSpecOpts{Published: true},
 			changeset: ct.TestChangesetOpts{

--- a/enterprise/internal/batches/reconciler/plan_test.go
+++ b/enterprise/internal/batches/reconciler/plan_test.go
@@ -198,6 +198,18 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 			wantOperations: Operations{},
 		},
 		{
+			name:         "publishing read only changeset",
+			previousSpec: &ct.TestSpecOpts{Published: true},
+			currentSpec:  &ct.TestSpecOpts{Published: true},
+			changeset: ct.TestChangesetOpts{
+				PublicationState:   btypes.ChangesetPublicationStatePublished,
+				ExternalState:      btypes.ChangesetExternalStateReadOnly,
+				UiPublicationState: &btypes.ChangesetUiPublicationStateDraft,
+			},
+			// We expect a no-op here.
+			wantOperations: Operations{},
+		},
+		{
 			name:         "title changed on published changeset",
 			previousSpec: &ct.TestSpecOpts{Published: true, Title: "Before"},
 			currentSpec:  &ct.TestSpecOpts{Published: true, Title: "After"},
@@ -205,6 +217,17 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 				PublicationState: btypes.ChangesetPublicationStatePublished,
 			},
 			wantOperations: Operations{btypes.ReconcilerOperationUpdate},
+		},
+		{
+			name:         "title changed on read only changeset",
+			previousSpec: &ct.TestSpecOpts{Published: true, Title: "Before"},
+			currentSpec:  &ct.TestSpecOpts{Published: true, Title: "After"},
+			changeset: ct.TestChangesetOpts{
+				PublicationState: btypes.ChangesetPublicationStatePublished,
+				ExternalState:    btypes.ChangesetExternalStateReadOnly,
+			},
+			// We expect a no-op here.
+			wantOperations: Operations{},
 		},
 		{
 			name:         "commit diff changed on published changeset",
@@ -289,6 +312,21 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 				// TODO: This should probably be a noop in the future
 				btypes.ReconcilerOperationClose,
 			},
+		},
+		{
+			name:         "closing read only changeset",
+			previousSpec: &ct.TestSpecOpts{Published: true},
+			currentSpec:  &ct.TestSpecOpts{Published: true},
+			changeset: ct.TestChangesetOpts{
+				PublicationState:   btypes.ChangesetPublicationStatePublished,
+				ExternalState:      btypes.ChangesetExternalStateReadOnly,
+				OwnedByBatchChange: 1234,
+				BatchChanges:       []btypes.BatchChangeAssoc{{BatchChangeID: 1234}},
+				// Important bit:
+				Closing: true,
+			},
+			// should be a noop
+			wantOperations: Operations{},
 		},
 		{
 			name:         "detaching",

--- a/enterprise/internal/batches/reconciler/reconciler.go
+++ b/enterprise/internal/batches/reconciler/reconciler.go
@@ -84,6 +84,7 @@ func (r *Reconciler) process(ctx context.Context, logger log.Logger, tx *store.S
 
 	return executePlan(
 		ctx,
+		logger,
 		r.gitserverClient,
 		r.sourcer,
 		r.noSleepBeforeSync,

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -1576,14 +1576,20 @@ func (s *Service) GetAvailableBulkOperations(ctx context.Context, opts GetAvaila
 		isChangesetOpen := changeset.ExternalState == btypes.ChangesetExternalStateOpen
 		isChangesetClosed := changeset.ExternalState == btypes.ChangesetExternalStateClosed
 		isChangesetMerged := changeset.ExternalState == btypes.ChangesetExternalStateMerged
-		isChangsetJobFailed := changeset.ReconcilerState == btypes.ReconcilerStateFailed
+		isChangesetReadOnly := changeset.ExternalState == btypes.ChangesetExternalStateReadOnly
+		isChangesetJobFailed := changeset.ReconcilerState == btypes.ReconcilerStateFailed
 
 		// can changeset be published
 		isChangesetCommentable := isChangesetOpen || isChangesetDraft || isChangesetMerged || isChangesetClosed
-		isChangesetClosable := isChangesetOpen || isChangesetDraft || isChangsetJobFailed
+		isChangesetClosable := isChangesetOpen || isChangesetDraft || isChangesetJobFailed
 
 		// check what operations this changeset support, most likely from the state
 		// so get the changeset then derive the operations from it's state.
+
+		// No operations are available for read only changesets.
+		if isChangesetReadOnly {
+			continue
+		}
 
 		// DETACH
 		if isChangesetArchived {
@@ -1591,7 +1597,7 @@ func (s *Service) GetAvailableBulkOperations(ctx context.Context, opts GetAvaila
 		}
 
 		// REENQUEUE
-		if !isChangesetArchived && isChangsetJobFailed {
+		if !isChangesetArchived && isChangesetJobFailed {
 			bulkOperationsCounter[btypes.ChangesetJobTypeReenqueue] += 1
 		}
 
@@ -1606,7 +1612,7 @@ func (s *Service) GetAvailableBulkOperations(ctx context.Context, opts GetAvaila
 		}
 
 		// MERGE
-		if !isChangesetArchived && !isChangsetJobFailed && isChangesetOpen {
+		if !isChangesetArchived && !isChangesetJobFailed && isChangesetOpen {
 			bulkOperationsCounter[btypes.ChangesetJobTypeMerge] += 1
 		}
 

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -1586,7 +1586,7 @@ func (s *Service) GetAvailableBulkOperations(ctx context.Context, opts GetAvaila
 		// check what operations this changeset support, most likely from the state
 		// so get the changeset then derive the operations from it's state.
 
-		// No operations are available for read only changesets.
+		// No operations are available for read-only changesets.
 		if isChangesetReadOnly {
 			continue
 		}

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -2428,7 +2428,7 @@ changesetTemplate:
 			}
 		})
 
-		t.Run("read only changesets", func(t *testing.T) {
+		t.Run("read-only changesets", func(t *testing.T) {
 			changeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
 				Repo:             rs[0].ID,
 				PublicationState: btypes.ChangesetPublicationStatePublished,

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -2428,6 +2428,25 @@ changesetTemplate:
 			}
 		})
 
+		t.Run("read only changesets", func(t *testing.T) {
+			changeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
+				Repo:             rs[0].ID,
+				PublicationState: btypes.ChangesetPublicationStatePublished,
+				ExternalState:    btypes.ChangesetExternalStateReadOnly,
+				BatchChange:      batchChange.ID,
+			})
+
+			bulkOperations, err := svc.GetAvailableBulkOperations(ctx, GetAvailableBulkOperationsOpts{
+				Changesets: []int64{
+					changeset.ID,
+				},
+				BatchChange: batchChange.ID,
+			})
+
+			assert.NoError(t, err)
+			assert.Empty(t, bulkOperations)
+		})
+
 		t.Run("draft, archived and failed changesets with no common bulk operation", func(t *testing.T) {
 			failedChangeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
 				Repo:             rs[0].ID,

--- a/enterprise/internal/batches/sources/common.go
+++ b/enterprise/internal/batches/sources/common.go
@@ -27,7 +27,7 @@ func (e ChangesetNotFoundError) Error() string {
 
 func (e ChangesetNotFoundError) NonRetryable() bool { return true }
 
-// An ArchivableChangesetSource represents a changeset source that has a
+// ArchivableChangesetSource represents a changeset source that has a
 // concept of archived repositories.
 type ArchivableChangesetSource interface {
 	ChangesetSource

--- a/enterprise/internal/batches/sources/common.go
+++ b/enterprise/internal/batches/sources/common.go
@@ -27,6 +27,16 @@ func (e ChangesetNotFoundError) Error() string {
 
 func (e ChangesetNotFoundError) NonRetryable() bool { return true }
 
+// An ArchivableChangesetSource represents a changeset source that has a
+// concept of archived repositories.
+type ArchivableChangesetSource interface {
+	ChangesetSource
+
+	// IsArchivedPushError parses the given error output from `git push` to
+	// detect whether the error was caused by the repository being archived.
+	IsArchivedPushError(output string) bool
+}
+
 // A DraftChangesetSource can create draft changesets and undraft them.
 type DraftChangesetSource interface {
 	ChangesetSource

--- a/enterprise/internal/batches/sources/testing/fake.go
+++ b/enterprise/internal/batches/sources/testing/fake.go
@@ -59,6 +59,7 @@ type FakeChangesetSource struct {
 	AuthenticatedUsernameCalled bool
 	ValidateAuthenticatorCalled bool
 	MergeChangesetCalled        bool
+	IsArchivedPushErrorCalled   bool
 
 	// The Changeset.HeadRef to be expected in CreateChangeset/UpdateChangeset calls.
 	WantHeadRef string
@@ -101,10 +102,16 @@ type FakeChangesetSource struct {
 
 	// Username is the username returned by AuthenticatedUsername
 	Username string
+
+	// IsArchivedPushErrorTrue is returned when IsArchivedPushError is invoked.
+	IsArchivedPushErrorTrue bool
 }
 
-var _ sources.ChangesetSource = &FakeChangesetSource{}
-var _ sources.DraftChangesetSource = &FakeChangesetSource{}
+var (
+	_ sources.ChangesetSource           = &FakeChangesetSource{}
+	_ sources.ArchivableChangesetSource = &FakeChangesetSource{}
+	_ sources.DraftChangesetSource      = &FakeChangesetSource{}
+)
 
 func (s *FakeChangesetSource) CreateDraftChangeset(ctx context.Context, c *sources.Changeset) (bool, error) {
 	s.CreateDraftChangesetCalled = true
@@ -315,4 +322,9 @@ func (s *FakeChangesetSource) AuthenticatedUsername(ctx context.Context) (string
 func (s *FakeChangesetSource) MergeChangeset(ctx context.Context, c *sources.Changeset, squash bool) error {
 	s.MergeChangesetCalled = true
 	return s.Err
+}
+
+func (s *FakeChangesetSource) IsArchivedPushError(output string) bool {
+	s.IsArchivedPushErrorCalled = true
+	return s.IsArchivedPushErrorTrue
 }

--- a/enterprise/internal/batches/state/changeset_history.go
+++ b/enterprise/internal/batches/state/changeset_history.go
@@ -144,8 +144,9 @@ func computeHistory(ch *btypes.Changeset, ce ChangesetEvents) (changesetHistory,
 			btypes.ChangesetEventKindBitbucketServerDeclined,
 			btypes.ChangesetEventKindGitLabClosed,
 			btypes.ChangesetEventKindBitbucketCloudPullRequestRejected:
-			// Merged is a final state. We can ignore everything after.
-			if currentExtState != btypes.ChangesetExternalStateMerged {
+			// Merged and ReadOnly are final states. We can ignore everything after.
+			if currentExtState != btypes.ChangesetExternalStateMerged &&
+				currentExtState != btypes.ChangesetExternalStateReadOnly {
 				currentExtState = btypes.ChangesetExternalStateClosed
 				pushStates(et)
 			}
@@ -167,8 +168,9 @@ func computeHistory(ch *btypes.Changeset, ce ChangesetEvents) (changesetHistory,
 
 		case btypes.ChangesetEventKindGitHubConvertToDraft:
 			isDraft = true
-			// Merged is a final state. We can ignore everything after.
-			if currentExtState != btypes.ChangesetExternalStateMerged {
+			// Merged and ReadOnly are final states. We can ignore everything after.
+			if currentExtState != btypes.ChangesetExternalStateMerged &&
+				currentExtState != btypes.ChangesetExternalStateReadOnly {
 				currentExtState = btypes.ChangesetExternalStateDraft
 				pushStates(et)
 			}
@@ -185,8 +187,9 @@ func computeHistory(ch *btypes.Changeset, ce ChangesetEvents) (changesetHistory,
 		case btypes.ChangesetEventKindGitHubReopened,
 			btypes.ChangesetEventKindBitbucketServerReopened,
 			btypes.ChangesetEventKindGitLabReopened:
-			// Merged is a final state. We can ignore everything after.
-			if currentExtState != btypes.ChangesetExternalStateMerged {
+			// Merged and ReadOnly are final states. We can ignore everything after.
+			if currentExtState != btypes.ChangesetExternalStateMerged &&
+				currentExtState != btypes.ChangesetExternalStateReadOnly {
 				if isDraft {
 					currentExtState = btypes.ChangesetExternalStateDraft
 				} else {

--- a/enterprise/internal/batches/state/counts.go
+++ b/enterprise/internal/batches/state/counts.go
@@ -96,7 +96,10 @@ func CalcCounts(start, end time.Time, cs []*btypes.Changeset, es ...*btypes.Chan
 
 			case btypes.ChangesetExternalStateMerged:
 				c.Merged++
-			case btypes.ChangesetExternalStateClosed:
+			case btypes.ChangesetExternalStateClosed,
+				btypes.ChangesetExternalStateReadOnly:
+				// We'll lump read only into closed, rather than trying to add another
+				// state.
 				c.Closed++
 			}
 		}

--- a/enterprise/internal/batches/state/counts.go
+++ b/enterprise/internal/batches/state/counts.go
@@ -98,7 +98,7 @@ func CalcCounts(start, end time.Time, cs []*btypes.Changeset, es ...*btypes.Chan
 				c.Merged++
 			case btypes.ChangesetExternalStateClosed,
 				btypes.ChangesetExternalStateReadOnly:
-				// We'll lump read only into closed, rather than trying to add another
+				// We'll lump read-only into closed, rather than trying to add another
 				// state.
 				c.Closed++
 			}

--- a/enterprise/internal/batches/state/state.go
+++ b/enterprise/internal/batches/state/state.go
@@ -36,8 +36,9 @@ func SetDerivedState(ctx context.Context, repoStore database.RepoStore, c *btype
 
 	logger := log.Scoped("SetDerivedState", "")
 
-	// We need to use an internal actor here as the repo-updater otherwise has no
-	// access to the repo.
+	// We need to ensure we're using an internal actor here, since we need to
+	// have access to the repo to set the derived state regardless of the actor
+	// that initiated whatever process led us here.
 	repo, err := repoStore.Get(actor.WithInternalActor(ctx), c.RepoID)
 	if err != nil {
 		logger.Warn("Getting repo to compute derived state", log.Error(err))

--- a/enterprise/internal/batches/state/state_test.go
+++ b/enterprise/internal/batches/state/state_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestComputeGithubCheckState(t *testing.T) {
@@ -559,9 +560,12 @@ func TestComputeExternalState(t *testing.T) {
 	now := timeutil.Now()
 	daysAgo := func(days int) time.Time { return now.AddDate(0, 0, -days) }
 
+	archivedRepo := &types.Repo{Archived: true}
+
 	tests := []struct {
 		name      string
 		changeset *btypes.Changeset
+		repo      *types.Repo
 		history   []changesetStatesAtTime
 		want      btypes.ChangesetExternalState
 	}{
@@ -715,13 +719,43 @@ func TestComputeExternalState(t *testing.T) {
 			},
 			want: btypes.ChangesetExternalStateDraft,
 		},
+		{
+			name:      "gitlab read only - no events",
+			changeset: setDraft(gitLabChangeset(daysAgo(10), gitlab.MergeRequestStateOpened, nil)),
+			repo:      archivedRepo,
+			history:   []changesetStatesAtTime{},
+			want:      btypes.ChangesetExternalStateReadOnly,
+		},
+		{
+			name:      "gitlab read only - changeset older than events",
+			changeset: gitLabChangeset(daysAgo(10), gitlab.MergeRequestStateOpened, nil),
+			repo:      archivedRepo,
+			history: []changesetStatesAtTime{
+				{t: daysAgo(0), externalState: btypes.ChangesetExternalStateDraft},
+			},
+			want: btypes.ChangesetExternalStateReadOnly,
+		},
+		{
+			name:      "gitlab read only - changeset newer than events",
+			changeset: setDraft(gitLabChangeset(daysAgo(0), gitlab.MergeRequestStateOpened, nil)),
+			repo:      archivedRepo,
+			history: []changesetStatesAtTime{
+				{t: daysAgo(10), externalState: btypes.ChangesetExternalStateClosed},
+			},
+			want: btypes.ChangesetExternalStateReadOnly,
+		},
 	}
 
 	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			changeset := tc.changeset
 
-			have, err := computeExternalState(changeset, tc.history)
+			repo := tc.repo
+			if repo == nil {
+				repo = &types.Repo{Archived: false}
+			}
+
+			have, err := computeExternalState(changeset, tc.history, repo)
 			if err != nil {
 				t.Fatalf("got error: %s", err)
 			}

--- a/enterprise/internal/batches/state/state_test.go
+++ b/enterprise/internal/batches/state/state_test.go
@@ -720,14 +720,14 @@ func TestComputeExternalState(t *testing.T) {
 			want: btypes.ChangesetExternalStateDraft,
 		},
 		{
-			name:      "gitlab read only - no events",
+			name:      "gitlab read-only - no events",
 			changeset: setDraft(gitLabChangeset(daysAgo(10), gitlab.MergeRequestStateOpened, nil)),
 			repo:      archivedRepo,
 			history:   []changesetStatesAtTime{},
 			want:      btypes.ChangesetExternalStateReadOnly,
 		},
 		{
-			name:      "gitlab read only - changeset older than events",
+			name:      "gitlab read-only - changeset older than events",
 			changeset: gitLabChangeset(daysAgo(10), gitlab.MergeRequestStateOpened, nil),
 			repo:      archivedRepo,
 			history: []changesetStatesAtTime{
@@ -736,7 +736,7 @@ func TestComputeExternalState(t *testing.T) {
 			want: btypes.ChangesetExternalStateReadOnly,
 		},
 		{
-			name:      "gitlab read only - changeset newer than events",
+			name:      "gitlab read-only - changeset newer than events",
 			changeset: setDraft(gitLabChangeset(daysAgo(0), gitlab.MergeRequestStateOpened, nil)),
 			repo:      archivedRepo,
 			history: []changesetStatesAtTime{

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -753,6 +753,8 @@ func getRewirerMappingCurrentState(state *btypes.ChangesetState) (*sqlf.Query, e
 		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateClosed)
 	case btypes.ChangesetStateMerged:
 		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateMerged)
+	case btypes.ChangesetStateReadOnly:
+		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateReadOnly)
 	case btypes.ChangesetStateDeleted:
 		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateDeleted)
 	default:

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -946,6 +946,7 @@ func testStoreChangesetSpecsCurrentState(t *testing.T, ctx context.Context, s *S
 			btypes.ChangesetStateClosed:      {ExternalState: btypes.ChangesetExternalStateClosed},
 			btypes.ChangesetStateMerged:      {ExternalState: btypes.ChangesetExternalStateMerged},
 			btypes.ChangesetStateDeleted:     {ExternalState: btypes.ChangesetExternalStateDeleted},
+			btypes.ChangesetStateReadOnly:    {ExternalState: btypes.ChangesetExternalStateReadOnly},
 		}
 	)
 	for state, opts := range states {

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -35,6 +35,7 @@ const (
 	ChangesetStateClosed      ChangesetState = "CLOSED"
 	ChangesetStateMerged      ChangesetState = "MERGED"
 	ChangesetStateDeleted     ChangesetState = "DELETED"
+	ChangesetStateReadOnly    ChangesetState = "READONLY"
 	ChangesetStateRetrying    ChangesetState = "RETRYING"
 	ChangesetStateFailed      ChangesetState = "FAILED"
 )
@@ -50,6 +51,7 @@ func (s ChangesetState) Valid() bool {
 		ChangesetStateClosed,
 		ChangesetStateMerged,
 		ChangesetStateDeleted,
+		ChangesetStateReadOnly,
 		ChangesetStateRetrying,
 		ChangesetStateFailed:
 		return true
@@ -154,11 +156,12 @@ type ChangesetExternalState string
 
 // ChangesetExternalState constants.
 const (
-	ChangesetExternalStateDraft   ChangesetExternalState = "DRAFT"
-	ChangesetExternalStateOpen    ChangesetExternalState = "OPEN"
-	ChangesetExternalStateClosed  ChangesetExternalState = "CLOSED"
-	ChangesetExternalStateMerged  ChangesetExternalState = "MERGED"
-	ChangesetExternalStateDeleted ChangesetExternalState = "DELETED"
+	ChangesetExternalStateDraft    ChangesetExternalState = "DRAFT"
+	ChangesetExternalStateOpen     ChangesetExternalState = "OPEN"
+	ChangesetExternalStateClosed   ChangesetExternalState = "CLOSED"
+	ChangesetExternalStateMerged   ChangesetExternalState = "MERGED"
+	ChangesetExternalStateDeleted  ChangesetExternalState = "DELETED"
+	ChangesetExternalStateReadOnly ChangesetExternalState = "READONLY"
 )
 
 // Valid returns true if the given ChangesetExternalState is valid.
@@ -168,7 +171,8 @@ func (s ChangesetExternalState) Valid() bool {
 		ChangesetExternalStateDraft,
 		ChangesetExternalStateClosed,
 		ChangesetExternalStateMerged,
-		ChangesetExternalStateDeleted:
+		ChangesetExternalStateDeleted,
+		ChangesetExternalStateReadOnly:
 		return true
 	default:
 		return false
@@ -304,7 +308,8 @@ func (c *Changeset) Clone() *Changeset {
 // Closeable returns whether the Changeset is already closed or merged.
 func (c *Changeset) Closeable() bool {
 	return c.ExternalState != ChangesetExternalStateClosed &&
-		c.ExternalState != ChangesetExternalStateMerged
+		c.ExternalState != ChangesetExternalStateMerged &&
+		c.ExternalState != ChangesetExternalStateReadOnly
 }
 
 // Complete returns whether the Changeset has been published and its

--- a/internal/errcode/code.go
+++ b/internal/errcode/code.go
@@ -147,6 +147,14 @@ func IsTemporary(err error) bool {
 	return errors.As(err, &e) && e.Temporary()
 }
 
+// IsArchived will check if err or one of its causes is an archived error.
+// (This is generally going to be in the context of repositories being
+// archived.)
+func IsArchived(err error) bool {
+	var e interface{ Archived() bool }
+	return errors.As(err, &e) && e.Archived()
+}
+
 // IsBlocked will check if err or one of its causes is a blocked error.
 func IsBlocked(err error) bool {
 	var e interface{ Blocked() bool }

--- a/internal/repos/mocks_temp.go
+++ b/internal/repos/mocks_temp.go
@@ -81,6 +81,9 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// UpdateExternalServiceRepo.
 	UpdateExternalServiceRepoFunc *StoreUpdateExternalServiceRepoFunc
+	// UpdateRepoFunc is an instance of a mock function object controlling
+	// the behavior of the method UpdateRepo.
+	UpdateRepoFunc *StoreUpdateRepoFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *StoreWithFunc
@@ -177,6 +180,11 @@ func NewMockStore() *MockStore {
 		},
 		UpdateExternalServiceRepoFunc: &StoreUpdateExternalServiceRepoFunc{
 			defaultHook: func(context.Context, *types.ExternalService, *types.Repo) (r0 error) {
+				return
+			},
+		},
+		UpdateRepoFunc: &StoreUpdateRepoFunc{
+			defaultHook: func(context.Context, *types.Repo) (r0 *types.Repo, r1 error) {
 				return
 			},
 		},
@@ -282,6 +290,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.UpdateExternalServiceRepo")
 			},
 		},
+		UpdateRepoFunc: &StoreUpdateRepoFunc{
+			defaultHook: func(context.Context, *types.Repo) (*types.Repo, error) {
+				panic("unexpected invocation of MockStore.UpdateRepo")
+			},
+		},
 		WithFunc: &StoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) Store {
 				panic("unexpected invocation of MockStore.With")
@@ -347,6 +360,9 @@ func NewMockStoreFrom(i Store) *MockStore {
 		},
 		UpdateExternalServiceRepoFunc: &StoreUpdateExternalServiceRepoFunc{
 			defaultHook: i.UpdateExternalServiceRepo,
+		},
+		UpdateRepoFunc: &StoreUpdateRepoFunc{
+			defaultHook: i.UpdateRepo,
 		},
 		WithFunc: &StoreWithFunc{
 			defaultHook: i.With,
@@ -2242,6 +2258,113 @@ func (c StoreUpdateExternalServiceRepoFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreUpdateExternalServiceRepoFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// StoreUpdateRepoFunc describes the behavior when the UpdateRepo method of
+// the parent MockStore instance is invoked.
+type StoreUpdateRepoFunc struct {
+	defaultHook func(context.Context, *types.Repo) (*types.Repo, error)
+	hooks       []func(context.Context, *types.Repo) (*types.Repo, error)
+	history     []StoreUpdateRepoFuncCall
+	mutex       sync.Mutex
+}
+
+// UpdateRepo delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockStore) UpdateRepo(v0 context.Context, v1 *types.Repo) (*types.Repo, error) {
+	r0, r1 := m.UpdateRepoFunc.nextHook()(v0, v1)
+	m.UpdateRepoFunc.appendCall(StoreUpdateRepoFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the UpdateRepo method of
+// the parent MockStore instance is invoked and the hook queue is empty.
+func (f *StoreUpdateRepoFunc) SetDefaultHook(hook func(context.Context, *types.Repo) (*types.Repo, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpdateRepo method of the parent MockStore instance invokes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *StoreUpdateRepoFunc) PushHook(hook func(context.Context, *types.Repo) (*types.Repo, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreUpdateRepoFunc) SetDefaultReturn(r0 *types.Repo, r1 error) {
+	f.SetDefaultHook(func(context.Context, *types.Repo) (*types.Repo, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreUpdateRepoFunc) PushReturn(r0 *types.Repo, r1 error) {
+	f.PushHook(func(context.Context, *types.Repo) (*types.Repo, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreUpdateRepoFunc) nextHook() func(context.Context, *types.Repo) (*types.Repo, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreUpdateRepoFunc) appendCall(r0 StoreUpdateRepoFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreUpdateRepoFuncCall objects describing
+// the invocations of this function.
+func (f *StoreUpdateRepoFunc) History() []StoreUpdateRepoFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreUpdateRepoFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreUpdateRepoFuncCall is an object that describes an invocation of
+// method UpdateRepo on an instance of MockStore.
+type StoreUpdateRepoFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 *types.Repo
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *types.Repo
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreUpdateRepoFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreUpdateRepoFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreWithFunc describes the behavior when the With method of the parent

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -145,6 +145,7 @@ type StoreMetrics struct {
 	UpdateExternalServiceRepo          *metrics.REDMetrics
 	DeleteExternalServiceRepo          *metrics.REDMetrics
 	DeleteExternalServiceReposNotIn    *metrics.REDMetrics
+	UpdateRepo                         *metrics.REDMetrics
 	UpsertRepos                        *metrics.REDMetrics
 	UpsertSources                      *metrics.REDMetrics
 	ListExternalRepoSpecs              *metrics.REDMetrics

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -579,7 +579,7 @@ func (s *store) UpdateRepo(ctx context.Context, r *types.Repo) (saved *types.Rep
 
 	metadata, err := metadataColumn(r.Metadata)
 	if err != nil {
-		return nil, errors.Wrapf(err, "metadata marshalling failed")
+		return nil, errors.Wrap(err, "metadata marshalling failed")
 	}
 
 	q := sqlf.Sprintf(updateRepoQuery,

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -77,6 +77,10 @@ type Store interface {
 	// external service, respectively in the repo and external_service_repos table.
 	// The associated external service must already exist.
 	UpdateExternalServiceRepo(ctx context.Context, svc *types.ExternalService, r *types.Repo) (err error)
+	// UpdateRepo updates a single repo without updating its association to an
+	// external service. This must only be used when updating metadata on a repo
+	// that cannot affect its associations.
+	UpdateRepo(ctx context.Context, r *types.Repo) (saved *types.Repo, err error)
 	// EnqueueSingleSyncJob enqueues a single sync job for the given external service
 	// if it is not already queued or processing. Additionally, it also skips
 	// queueing up a sync job for cloud_default external services. This is done to
@@ -545,6 +549,59 @@ WHERE
 	external_service_repos.user_id   != excluded.user_id OR
 	external_service_repos.org_id    != excluded.org_id
 `
+
+func (s *store) UpdateRepo(ctx context.Context, r *types.Repo) (saved *types.Repo, err error) {
+	tr, ctx := s.trace(ctx, "Store.UpdateRepo")
+	tr.LogFields(
+		otlog.String("name", string(r.Name)),
+		otlog.Int32("id", int32(r.ID)),
+	)
+	logger := trace.Logger(ctx, s.Logger).With(
+		log.Int32("id", int32(r.ID)),
+		log.String("name", string(r.Name)),
+	)
+
+	defer func(began time.Time) {
+		secs := time.Since(began).Seconds()
+
+		s.Metrics.UpdateRepo.Observe(secs, 1, &err)
+		if err != nil {
+			logger.Error("store.update-repo", log.Error(err))
+		}
+
+		tr.SetError(err)
+		tr.Finish()
+	}(time.Now())
+
+	if r.ID == 0 {
+		return nil, errors.New("empty repo id in update")
+	}
+
+	metadata, err := metadataColumn(r.Metadata)
+	if err != nil {
+		return nil, errors.Wrapf(err, "metadata marshalling failed")
+	}
+
+	q := sqlf.Sprintf(updateRepoQuery,
+		r.Name,
+		r.URI,
+		r.Description,
+		r.ExternalRepo.ServiceType,
+		r.ExternalRepo.ServiceID,
+		r.ExternalRepo.ID,
+		r.Archived,
+		r.Fork,
+		r.Stars,
+		r.Private,
+		metadata,
+		r.ID,
+	)
+
+	if err = s.QueryRow(ctx, q).Scan(&r.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
 
 func (s *store) UpdateExternalServiceRepo(ctx context.Context, svc *types.ExternalService, r *types.Repo) (err error) {
 	tr, ctx := s.trace(ctx, "Store.UpdateExternalServiceRepo")


### PR DESCRIPTION
### Note for Repo Management (hello!)

I've requested a review from you because this is adding a new place that mutates the `repo` table, specifically to flip the `archived` column if Batch Changes notices that a repo is archived before `repo-updater`. Let me know how you feel about that, please!

### Actual description

This PR adds a new "read only" external state that is mostly terminal[^1] and used when the repository a changeset is open on is archived. No bulk operations can be performed on those changesets, and re-applying the batch spec will not result in any operations.

When reconciling a changeset, we will detect archived repos based on the response from the code host when updating or pushing changesets. (We can also detect this when creating changesets, and the underlying code host calls will return the right error here so the user gets a good error message, but we obviously then won't have a changeset to enter the read-only state!) This PR adds the plumbing for this with a new `errcode.IsArchived` function, but does not actually add the code host support, which are in #38332 and #38333 for GitLab and GitHub, respectively. (The Bitbuckets do not support archiving repos, and are hence out of scope for this project.)

There are a couple of interesting quirks to this implementation:

1. We ultimately have to rely on the `archived` field of the `repo` table to determine the behaviour, since the only alternative would be to burn code host quota by pinging the code host each time we want to touch a repo. This means that we're at the mercy of how often the external service syncer updates repo metadata, particularly when unarchiving.
2. It's possible that the reconciler will be the first part of Sourcegraph to learn that a repository has been archived. Because of the previous point, we need to update `repo` so that we can calculate the derived state correctly — this has been implemented, but definitely feels a little weird, since normally the only thing that will update `repo` is `repo-updater`. The other option was to force an immediate sync, but `repo-updater` doesn't support only syncing one repository on an external service, and the underlying operations are intentionally asynchronous. Performing a direct `UPDATE` felt like the lesser of the two possible evils.

Related to #26820, but the actual fix will be a subsequent PR.

### Future work

* Hook changes to the `repo.archived` field to more efficiently update the external state of changesets, since right now there's going to be a non-trivial delay between a repo being (un)archived and changesets being updated. The major problem here is that it crosses the FOSS/enterprise boundary the "wrong" way, which requires either a nullable callback or some sort of broader solution for notifying disparate parts of the codebase when an event occurs.

## Test plan

Added unit tests for basically everything that was changed or added.

Additionally:

* Attempted to publish changesets to archived repos, and ensured that we got a sensible error.
* Attempted to update changesets on repos that had been archived, and ensured that the changesets entered the read only state.
* Attempted to push a commit to repos that had been archived, and ensured that the changesets entered the read only state.
* Synced read only changesets on repos that had been unarchived, and ensured that the changesets entered the correct, non read only state.

---

[^1]: Why isn't it actually terminal? The main reason is that repositories can be unarchived, so we need to be able to revive changesets. The way this has been implemented is by allowing syncs to proceed for read only changesets only to the point where we check if the repo is archived — if it is, then that's the end of the sync; otherwise we perform a full sync, which will reset the changeset's external state.