### PR TITLE
[SG-35254] Accessibility: Auto-indexing page "enqueue" bar doesn't indicate intent or purpose of any components

### DIFF
--- a/client/web/src/enterprise/codeintel/indexes/components/EnqueueForm.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EnqueueForm.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, useCallback, useState } from 'react'
 
+import { VisuallyHidden } from '@reach/visually-hidden'
 import { Subject } from 'rxjs'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
@@ -53,7 +54,10 @@ export const EnqueueForm: FunctionComponent<React.PropsWithChildren<EnqueueFormP
             {enqueueError && <ErrorAlert prefix="Error enqueueing index job" error={enqueueError} />}
 
             <div className="form-inline">
-                <Label htmlFor="revlike">Git revlike</Label>
+                <VisuallyHidden>Provide a Git rev-like to enqueue a new auto-indexing job</VisuallyHidden>
+                <Label htmlFor="revlike">
+                    <span aria-hidden={true}>Git revlike</span>
+                </Label>
 
                 <Input
                     id="revlike"


### PR DESCRIPTION
### Audit type
Screen reader navigation

### User journey audit issue
[#33513](https://github.com/sourcegraph/sourcegraph/issues/33513)

### Problem description
After the heading for the auto-indexing jobs page, the user is presented with a bar from which they can paste a "git rev-like" string with a button for enqueuing an auto-indexing job for that rev-like.

The screen-reader announces the bar with "git revlike" ("revlike" pronounced more like "rivlike"), followed by the text field announced as "head, insertion at end of text, git revlike, edit text". This doesn't indicate the purpose of the text field, and the purpose of the button is at a stretch somewhat implied.
![notes marker](https://user-images.githubusercontent.com/18282288/167682598-57908c76-4106-4334-abab-3df276fc5040.png)

### Ref
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35254)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35254)
### Expected behavior
The purpose of the entire bar should be explained outside of a vaguely correlated text element, text field and button.

### Test Plan
1. You will need to comment out line [88](https://github.com/GitStartHQ/client-sourcegrapph-gitslice-test/blob/1ab1fd50c3b263f303f6942c104b0dfde57cb7e5/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx#L88), [94](https://github.com/GitStartHQ/client-sourcegrapph-gitslice-test/blob/1ab1fd50c3b263f303f6942c104b0dfde57cb7e5/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx#L94), and [145](https://github.com/GitStartHQ/client-sourcegrapph-gitslice-test/blob/1ab1fd50c3b263f303f6942c104b0dfde57cb7e5/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx#L145) in order to have the `Auto-Index` button visible during testing.
2. Run the `screen reader` and hear it announce `Provide a Git revspec to enqueue a new auto-indexing job` while on the `text label`