### PR TITLE
Accessibility: Fix `ButtonLink` blocking focus

### DIFF
--- a/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
@@ -10,16 +10,13 @@ import { ForwardReferenceComponent } from '@sourcegraph/wildcard'
 import { Button, ButtonProps } from '../Button'
 import { Link, AnchorLink } from '../Link'
 
-const isSelectKeyPress = (event: React.KeyboardEvent): boolean => {
-    event.preventDefault()
-    return (
-        (event.key === Key.Enter || event.key === ' ') &&
-        !event.ctrlKey &&
-        !event.shiftKey &&
-        !event.metaKey &&
-        !event.altKey
-    )
-}
+const isSelectKeyPress = (event: React.KeyboardEvent): boolean =>
+    (event.key === Key.Enter || event.key === ' ') &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.metaKey &&
+    !event.altKey
+
 export type ButtonLinkProps = Omit<ButtonProps, 'as' | 'onSelect'> &
     Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onSelect'> & {
         /** The link destination URL. */
@@ -54,7 +51,7 @@ export type ButtonLinkProps = Omit<ButtonProps, 'as' | 'onSelect'> &
  *
  * It is keyboard accessible: unlike `<Link>` or `<a>`, pressing the enter key triggers it.
  */
-export const ButtonLink = React.forwardRef((props, reference) => {
+export const ButtonLink = React.forwardRef(function ButtonLink(props, reference) {
     const {
         className,
         to,
@@ -78,6 +75,8 @@ export const ButtonLink = React.forwardRef((props, reference) => {
             return
         }
 
+        // Override the original key press and trigger the click event
+        event.preventDefault()
         buttonReference.current?.click()
     }
 
@@ -128,5 +127,3 @@ export const ButtonLink = React.forwardRef((props, reference) => {
         </Button>
     )
 }) as ForwardReferenceComponent<typeof AnchorLink, ButtonLinkProps>
-
-ButtonLink.displayName = 'ButtonLink'


### PR DESCRIPTION
## Description

Regression introduced in https://github.com/sourcegraph/sourcegraph/pull/36205/files#diff-7b82add34f7d69e33598ffbe9b19076f246d0aea3f072b9dd6a1058016eb4a6cR15

We only want to `preventDefault` if we are overriding this behavior to force a click (e.g. override `Space` behavior to click instead of jump scroll down the page)

## Test plan

Tested locally using a keyboard

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-fix-button-link-a11y.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pwmbnqygcx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
