### PR TITLE
Add yarn generate to sg start web-standalone

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -321,7 +321,9 @@ commands:
 
   web-standalone-http:
     cmd: yarn workspace @sourcegraph/web serve:dev --color
-    install: yarn --no-progress
+    install: |
+      yarn --no-progress
+      yarn generate
     env:
       WEBPACK_SERVE_INDEX: true
       SOURCEGRAPH_API_URL: https://k8s.sgdev.org


### PR DESCRIPTION
## Issue
1. Remove `client/shared/src/graphql-operations.ts`, which may be as well obsolete alongside with other files generated by `yarn generate` comand - which is usually the case
2. Run `sg start web-standalone`
3. See it complaining about the absense of this file

## Test plan
1. Pull the branch
2. Remove the `graphql-operations.ts` file
3. Run `sg start web-standalone`
4. Ensure it works