### PR TITLE
search: Mark label match in dynamic filter suggestions (CodeMirror)

### DIFF
--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -347,12 +347,14 @@ export function createDefaultSuggestionSources(options: {
                     })
                     .filter(isDefined)
 
+                const insidePredicate = token.value ? PREDICATE_REGEX.test(token.value.value) : false
+
                 return {
                     from: token.value?.range.start ?? token.range.end,
                     to: token.value?.range.end,
                     filter: false,
                     options: filteredResults,
-                    getMatch: options.globbing ? undefined : createMatchFunction(token),
+                    getMatch: insidePredicate || options.globbing ? undefined : createMatchFunction(token),
                 }
             })
         )
@@ -461,8 +463,15 @@ function createMatchFunction(token: Filter): ((completion: Completion) => number
     if (!token.value?.value) {
         return undefined
     }
-    const pattern = new RegExp(token.value.value, 'ig')
-    return completion => Array.from(completion.label.matchAll(pattern), matchToIndexTupel).flat()
+    try {
+        // Creating a regular expression fails if the value contains special
+        // regex characters in invalid positions. In that case we don't
+        // highlight.
+        const pattern = new RegExp(token.value.value, 'ig')
+        return completion => Array.from(completion.label.matchAll(pattern), matchToIndexTupel).flat()
+    } catch {
+        return undefined
+    }
 }
 
 /**

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -454,7 +454,7 @@ const FILTER_SUGGESTIONS: Completion[] = createFilterSuggestions(Object.keys(FIL
 )
 
 /**
- * This helper function creates a function suitable for CodeMirro's 'getMatch'
+ * This helper function creates a function suitable for CodeMirror's 'getMatch'
  * option. This is used to allow CodeMirror to highlight the matching part of
  * the label.
  * See https://codemirror.net/docs/ref/#autocomplete.CompletionResult.getMatch
@@ -468,7 +468,7 @@ function createMatchFunction(token: Filter): ((completion: Completion) => number
         // regex characters in invalid positions. In that case we don't
         // highlight.
         const pattern = new RegExp(token.value.value, 'ig')
-        return completion => Array.from(completion.label.matchAll(pattern), matchToIndexTupel).flat()
+        return completion => Array.from(completion.label.matchAll(pattern), matchToIndexTuple).flat()
     } catch {
         return undefined
     }
@@ -478,7 +478,7 @@ function createMatchFunction(token: Filter): ((completion: Completion) => number
  * Converts a regular expression match into an (possibly empty) number tuple
  * representing the start index and the end index of the match.
  */
-function matchToIndexTupel(match: RegExpMatchArray): number[] {
+function matchToIndexTuple(match: RegExpMatchArray): number[] {
     return match.index !== undefined ? [match.index, match.index + match[0].length] : []
 }
 


### PR DESCRIPTION
For "normal" suggestions CodeMirror marks which part of the label
matches the input. This doesn't work for unfiltered suggestions such as
dynamic filter suggestions.
Recently CodeMirror introduced an option to provide a function that,
given a completion item, returns match ranges.

The filters for which we have dynamic suggestions enabled accept regex
as input, a simple solution is to take the value, convert it to a
regular expression and apply that to the label.

FWIW, Monaco does also highlight the label if the filter value is a
simple word. With CodeMirors solution we can even highlight the label
when the value is a regular expression.

Before/after video: 

https://user-images.githubusercontent.com/179026/177535774-29718000-d3a1-4ed2-ab88-6d314abf4e77.mp4



## Test plan

Add `repo:` or `file:` filter in the search input and provide a value that returns suggestions. The suggestion labels contain the highlighted value.

## App preview:

- [Web](https://sg-web-fkling-cm-dynamic-suggestions.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lsxemlaofx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
