### PR TITLE
JetBrains: Fix Linux focus issues

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -32,12 +32,6 @@ public class FindService implements Disposable {
 
     synchronized public void showPopup() {
         createOrShowPopup();
-
-        // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
-        // feature and focus the search field.
-        if (mainPanel.getBrowser() != null) {
-            mainPanel.getBrowser().focus();
-        }
     }
 
     public void hidePopup() {


### PR DESCRIPTION
Closes #38276

When playing around with this issue, we noticed a few things:

- This was happening sporadically, so it seemed to be a race condition
- You can recover from it by moving the focus to a different window and back to the SG window

That led me to believe that this has something to do with how we manually transfer the focus to the web view. To my surprise, removing this line would still lead to the behavior we want to an all platforms and also fix the bug on Linux.

Here's what we think went wrong:

- The manual focus change was likely always broken but the issue was masked by the fact that the `autofocus` inside the web view was already working as expected.
- On Windows and macOS, it seems that the web view will always run events _after_ the Java thread finishes. Which means that the `autofocus` inside the web view will properly focus the right thing, making the manual focus management unnecessary.
- On Linux, however, there seems to be a race between the Java manual focus management and whatever the web view does under the hood. If the Java one runs _after_ the web view, it will cause this broken state. 

## Test plan

- A lot of manual tests where we press `esc` `alt+a` `asdf` on repeat. It's not worth sharing a video of that but we tested on: Windows, Ubuntu Linux, and macOS.
- We've also sent a preview to the customer that reported the issue, the'll test it in the next hour or so. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-fix-focus-issues.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mrmaljebtz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
