### PR TITLE
db: Improve performance of external service sync failure message

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7797,12 +7797,12 @@
       ],
       "Indexes": [
         {
-          "Name": "external_service_sync_jobs_state_idx",
+          "Name": "external_service_sync_jobs_state_external_service_id",
           "IsPrimaryKey": false,
           "IsUnique": false,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX external_service_sync_jobs_state_idx ON external_service_sync_jobs USING btree (state)",
+          "IndexDefinition": "CREATE INDEX external_service_sync_jobs_state_external_service_id ON external_service_sync_jobs USING btree (state, external_service_id) INCLUDE (finished_at)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1024,7 +1024,7 @@ Foreign-key constraints:
  last_heartbeat_at   | timestamp with time zone |           |          | 
  queued_at           | timestamp with time zone |           |          | now()
 Indexes:
-    "external_service_sync_jobs_state_idx" btree (state)
+    "external_service_sync_jobs_state_external_service_id" btree (state, external_service_id) INCLUDE (finished_at)
 Foreign-key constraints:
     "external_services_id_fk" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE
 

--- a/migrations/frontend/1657106983_faster_failure_msg_query/down.sql
+++ b/migrations/frontend/1657106983_faster_failure_msg_query/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS external_service_sync_jobs_state_external_service_id;

--- a/migrations/frontend/1657106983_faster_failure_msg_query/metadata.yaml
+++ b/migrations/frontend/1657106983_faster_failure_msg_query/metadata.yaml
@@ -1,0 +1,3 @@
+name: faster_failure_msg_query
+parents: [1653472246, 1655226733, 1655843069, 1655157509, 1655454264]
+createIndexConcurrently: true

--- a/migrations/frontend/1657106983_faster_failure_msg_query/up.sql
+++ b/migrations/frontend/1657106983_faster_failure_msg_query/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS external_service_sync_jobs_state_external_service_id ON external_service_sync_jobs (state, external_service_id) INCLUDE (finished_at);

--- a/migrations/frontend/1657107627_drop_duplicate_index_sync_jobs_state/down.sql
+++ b/migrations/frontend/1657107627_drop_duplicate_index_sync_jobs_state/down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS external_service_sync_jobs_state_idx ON external_service_sync_jobs (state);

--- a/migrations/frontend/1657107627_drop_duplicate_index_sync_jobs_state/metadata.yaml
+++ b/migrations/frontend/1657107627_drop_duplicate_index_sync_jobs_state/metadata.yaml
@@ -1,0 +1,2 @@
+name: drop_duplicate_index_sync_jobs_state
+parents: [1657106983]

--- a/migrations/frontend/1657107627_drop_duplicate_index_sync_jobs_state/up.sql
+++ b/migrations/frontend/1657107627_drop_duplicate_index_sync_jobs_state/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS external_service_sync_jobs_state_idx;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3611,7 +3611,7 @@ CREATE INDEX external_service_repos_idx ON external_service_repos USING btree (e
 
 CREATE INDEX external_service_repos_org_id_idx ON external_service_repos USING btree (org_id) WHERE (org_id IS NOT NULL);
 
-CREATE INDEX external_service_sync_jobs_state_idx ON external_service_sync_jobs USING btree (state);
+CREATE INDEX external_service_sync_jobs_state_external_service_id ON external_service_sync_jobs USING btree (state, external_service_id) INCLUDE (finished_at);
 
 CREATE INDEX external_service_user_repos_idx ON external_service_repos USING btree (user_id, repo_id) WHERE (user_id IS NOT NULL);
 


### PR DESCRIPTION
This was one of the bad queries that we had in prod.

Before:

```
QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=59604.02..59604.14 rows=1 width=231) (actual time=95.943..98.616 rows=1 loops=1)
   ->  Gather Merge  (cost=59604.02..59619.66 rows=134 width=231) (actual time=95.942..98.613 rows=1 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=58604.00..58604.17 rows=67 width=231) (actual time=92.085..92.086 rows=1 loops=3)
               Sort Key: finished_at DESC
               Sort Method: top-N heapsort  Memory: 26kB
               Worker 0:  Sort Method: quicksort  Memory: 25kB
               Worker 1:  Sort Method: quicksort  Memory: 25kB
               ->  Parallel Seq Scan on external_service_sync_jobs  (cost=0.00..58603.66 rows=67 width=231) (actual time=57.860..92.018 rows=17 loops=3)
                     Filter: ((external_service_id = 4129) AND (state = ANY ('{completed,errored,failed}'::text[])))
                     Rows Removed by Filter: 370732
 Planning Time: 0.202 ms
 Execution Time: 98.642 ms
(14 rows)
```

After:

```
QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=122.82..122.82 rows=1 width=231) (actual time=0.134..0.135 rows=1 loops=1)
   ->  Sort  (cost=122.82..123.22 rows=161 width=231) (actual time=0.134..0.134 rows=1 loops=1)
         Sort Key: finished_at DESC
         Sort Method: top-N heapsort  Memory: 25kB
         ->  Index Scan using erik_test_123 on external_service_sync_jobs  (cost=0.43..122.02 rows=161 width=231) (actual time=0.022..0.114 rows=52 loops=1)
               Index Cond: ((state = ANY ('{completed,errored,failed}'::text[])) AND (external_service_id = 4129))
 Planning Time: 0.100 ms
 Execution Time: 0.151 ms
(8 rows)
```



## Test plan

Tested above, see query plans.