### PR TITLE
search: Remove focus from search query input when pressing Escape (CodeMirror)

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -118,6 +118,20 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
             EditorView.contentAttributes.of({ 'aria-label': ariaLabel }),
             callbacksField,
             autocompletion,
+            // Pressing Escape should remove focus from the input. Note that
+            // CodeMirror also uses Escape to "simplify selections" and to close
+            // the autocompletion popover. So focus will only be removed once no
+            // popover is open and there is no selection to simplify.
+            // Relevant documentation: https://codemirror.net/docs/ref/#commands.defaultKeymap
+            keymap.of([
+                {
+                    key: 'Escape',
+                    run: view => {
+                        view.contentDOM.blur()
+                        return true
+                    },
+                },
+            ]),
         ]
 
         if (preventNewLine) {


### PR DESCRIPTION
Addresses #29937 for CodeMirror


https://user-images.githubusercontent.com/179026/177567345-c78ae39e-41ba-4a31-a95b-a4c095971a74.mp4

## Test plan

Focus main query input, press escape. Focus should be removed.

## App preview:

- [Web](https://sg-web-fkling-29937-escape-query-input.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-djigcsjhxm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
