### PR TITLE
Accessibility: Add `focus-visible` outline to menus

### DIFF
--- a/client/wildcard/src/components/Menu/MenuList.module.scss
+++ b/client/wildcard/src/components/Menu/MenuList.module.scss
@@ -1,4 +1,4 @@
-.menuList {
+.menu-list {
     &:focus-visible {
         box-shadow: var(--focus-box-shadow);
     }

--- a/client/wildcard/src/components/Menu/MenuList.module.scss
+++ b/client/wildcard/src/components/Menu/MenuList.module.scss
@@ -1,0 +1,5 @@
+.menuList {
+    &:focus-visible {
+        box-shadow: var(--focus-box-shadow);
+    }
+}

--- a/client/wildcard/src/components/Menu/MenuList.tsx
+++ b/client/wildcard/src/components/Menu/MenuList.tsx
@@ -6,14 +6,22 @@ import classNames from 'classnames'
 import { ForwardReferenceComponent } from '../../types'
 import { createRectangle, PopoverContent, PopoverContentProps, Position } from '../Popover'
 
+import styles from './MenuList.module.scss'
+
 const DEFAULT_MENU_LIST_PADDING = createRectangle(0, 0, 2, 2)
 
 export interface MenuListProps extends Omit<PopoverProps, 'popoverPosition'> {
     position?: Position
 }
 
-export const MenuList = React.forwardRef((props, reference) => {
-    const { children, position = Position.bottomStart, targetPadding = DEFAULT_MENU_LIST_PADDING, ...rest } = props
+export const MenuList = React.forwardRef(function MenuList(props, reference) {
+    const {
+        children,
+        position = Position.bottomStart,
+        targetPadding = DEFAULT_MENU_LIST_PADDING,
+        className,
+        ...rest
+    } = props
 
     return (
         <ReachMenuPopover
@@ -23,6 +31,7 @@ export const MenuList = React.forwardRef((props, reference) => {
             portal={false}
             targetPadding={targetPadding}
             popoverPosition={position}
+            className={classNames(className, styles.menuList)}
         >
             {children}
         </ReachMenuPopover>
@@ -38,14 +47,16 @@ export interface PopoverProps extends PopoverContentProps {
     popoverPosition: Position
 }
 
-const Popover = React.forwardRef(({ popoverPosition, ...props }, reference) => (
-    <PopoverContent
-        {...props}
-        as={MenuItems}
-        ref={reference}
-        position={popoverPosition}
-        focusLocked={false}
-        className={classNames('py-1', props.className)}
-        keepInDOM={true}
-    />
-)) as ForwardReferenceComponent<'div', PopoverProps>
+const Popover = React.forwardRef(function Popover({ popoverPosition, ...props }, reference) {
+    return (
+        <PopoverContent
+            {...props}
+            as={MenuItems}
+            ref={reference}
+            position={popoverPosition}
+            focusLocked={false}
+            className={classNames('py-1', props.className)}
+            keepInDOM={true}
+        />
+    )
+}) as ForwardReferenceComponent<'div', PopoverProps>

--- a/client/wildcard/src/components/NavMenu/__snapshots__/NavMenu.test.tsx.snap
+++ b/client/wildcard/src/components/NavMenu/__snapshots__/NavMenu.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<NavMenu /> Should render Menu Items Correctly 1`] = `
   <div
     aria-labelledby="menu-button-2"
     aria-modal="true"
-    class="floatingPanel popover py-1"
+    class="floatingPanel popover py-1 menuList"
     data-reach-menu-items=""
     data-reach-menu-popover=""
     id="menu-1"


### PR DESCRIPTION
## Description

Related to https://github.com/sourcegraph/sourcegraph/pull/38298

Until we have a better solution to attaching the correct focus to menu items, this works as an OK workaround to indicate to users where the focus has moved to.

**This is only shown for keyboard users**

## Screenshots
| BEFORE             |  AFTER |
:-------------------------:|:-------------------------:
<img width="247" alt="image" src="https://user-images.githubusercontent.com/9516420/177585670-54d3bc60-1df9-4b04-83c1-671df1ffdfe0.png"> | <img width="256" alt="image" src="https://user-images.githubusercontent.com/9516420/177585633-46390d92-4b94-4fc8-a4d3-40ea442ffa56.png">



## Test plan

Tested locally with keyboard navigation

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-menu-focus-outline.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qzresdrlac.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
