### PR TITLE
JetBrains: Bump version to 2.0.0-alpha.2

### DIFF
--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=2.0.0-alpha.1
+pluginVersion=2.0.0-alpha.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default


### PR DESCRIPTION
Bump version to 2.0.0-alpha.2

## Test plan

Just a version change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
