### PR TITLE
search: when clicking a dynamic filter, only log the kind

### DIFF
--- a/client/search-ui/src/results/sidebar/FilterLink.test.tsx
+++ b/client/search-ui/src/results/sidebar/FilterLink.test.tsx
@@ -126,6 +126,6 @@ describe('FilterLink', () => {
         renderWithBrandedContext(<>{links}</>)
         userEvent.click(screen.getByTestId('filter-link'))
 
-        sinon.assert.calledWithExactly(onFilterChosen, repoFilter1.value)
+        sinon.assert.calledWithExactly(onFilterChosen, repoFilter1.value, repoFilter1.kind)
     })
 })

--- a/client/search-ui/src/results/sidebar/FilterLink.tsx
+++ b/client/search-ui/src/results/sidebar/FilterLink.tsx
@@ -21,8 +21,9 @@ export interface FilterLinkProps {
     value: string
     count?: number
     limitHit?: boolean
+    kind?: string
     labelConverter?: (label: string) => JSX.Element
-    onFilterChosen: (value: string) => void
+    onFilterChosen: (value: string, kind?: string) => void
 }
 
 export const FilterLink: React.FunctionComponent<React.PropsWithChildren<FilterLinkProps>> = ({
@@ -31,6 +32,7 @@ export const FilterLink: React.FunctionComponent<React.PropsWithChildren<FilterL
     value,
     count,
     limitHit,
+    kind,
     labelConverter = label => (label === value ? <SyntaxHighlightedSearchQuery query={label} /> : label),
     onFilterChosen,
 }) => {
@@ -41,7 +43,7 @@ export const FilterLink: React.FunctionComponent<React.PropsWithChildren<FilterL
     return (
         <Button
             className={styles.sidebarSectionListItem}
-            onClick={() => onFilterChosen(value)}
+            onClick={() => onFilterChosen(value, kind)}
             data-testid="filter-link"
             value={value}
             variant="link"
@@ -60,7 +62,7 @@ export const FilterLink: React.FunctionComponent<React.PropsWithChildren<FilterL
 
 export const getRepoFilterLinks = (
     filters: Filter[] | undefined,
-    onFilterChosen: (value: string) => void
+    onFilterChosen: (value: string, kind?: string) => void
 ): React.ReactElement[] => {
     function repoLabelConverter(label: string): JSX.Element {
         const Icon = CodeHostIcon({
@@ -96,7 +98,7 @@ export const getRepoFilterLinks = (
 
 export const getDynamicFilterLinks = (
     filters: Filter[] | undefined,
-    onFilterChosen: (value: string) => void
+    onFilterChosen: (value: string, kind?: string) => void
 ): React.ReactElement[] =>
     (filters || [])
         .filter(filter => filter.kind !== 'repo')

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -88,9 +88,9 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
     )
 
     const onDynamicFilterClicked = useCallback(
-        (value: string) => {
+        (value: string, kind?: string) => {
             props.telemetryService.log('DynamicFilterClicked', {
-                search_filter: { value },
+                search_filter: { kind },
             })
 
             submitQueryWithProps([{ type: 'toggleSubquery', value }])


### PR DESCRIPTION
When clicking dynamic filters (both repo and generic ones), the whole filter is logged. This is a potential security leak as it could reveal repo names of confidential projects to telemetry. This change makes it so only the filter kind (eg. repo, lang) is logged, not the whole filter. This is logged in the `{search_filter: kind}` argument of the `DynamicFilterClicked` event (previously, the whole filter value was logged in the `{search_filter: value}` argument).

## Test plan

Use the debugger Network tab to verify only the filter kind is logged, not the full filter value.

![image](https://user-images.githubusercontent.com/206864/177602189-7fa82892-c265-4b72-b6d9-1cd0c27f8f21.png)

## App preview:

- [Web](https://sg-web-jp-telemetryfilterclickevents.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fjqowdhcox.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
