### PR TITLE
Remove execution results from cache entirely

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -118,7 +118,7 @@ func TestTransformRecord(t *testing.T) {
 			SparseCheckout:      []string{"a/b/c/*"},
 			VirtualMachineFiles: map[string]string{
 				"input.json":              string(marshaledInput),
-				"cache/testcachekey.json": `{"stepIndex":0,"diff":"123","outputs":null,"stepResult":{"Files":null,"Stdout":"","Stderr":""}}`,
+				"cache/testcachekey.json": `{"changedFiles":{"modified":null,"added":null,"deleted":null,"renamed":null},"stdout":"","stderr":"","stepIndex":0,"diff":"123","outputs":null}`,
 			},
 			CliSteps: []apiclient.CliStep{
 				{

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -134,7 +134,7 @@ func (r *batchSpecWorkspaceCreator) process(
 		}
 
 		stepCacheKeys := make([]stepCacheKey, 0, len(spec.Spec.Steps))
-		// Generate cache keys for all the step results as well.
+		// Generate cache keys for all the steps.
 		for i := 0; i < len(spec.Spec.Steps); i++ {
 			if _, ok := skippedSteps[int32(i)]; ok {
 				continue

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -18,9 +18,7 @@ import (
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 	"github.com/sourcegraph/sourcegraph/lib/batches/execution/cache"
-	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // batchSpecWorkspaceCreator takes in BatchSpecs, resolves them into
@@ -135,17 +133,6 @@ func (r *batchSpecWorkspaceCreator) process(
 			return err
 		}
 
-		key := cache.KeyForWorkspace(
-			&template.BatchChangeAttributes{
-				Name:        spec.Spec.Name,
-				Description: spec.Spec.Description,
-			},
-			r,
-			w.Path,
-			w.OnlyFetchWorkspace,
-			spec.Spec.Steps,
-		)
-
 		stepCacheKeys := make([]stepCacheKey, 0, len(spec.Spec.Steps))
 		// Generate cache keys for all the step results as well.
 		for i := 0; i < len(spec.Spec.Steps); i++ {
@@ -153,7 +140,18 @@ func (r *batchSpecWorkspaceCreator) process(
 				continue
 			}
 
-			key := cache.StepsCacheKey{ExecutionKey: &key, StepIndex: i}
+			key := cache.KeyForWorkspace(
+				&template.BatchChangeAttributes{
+					Name:        spec.Spec.Name,
+					Description: spec.Spec.Description,
+				},
+				r,
+				w.Path,
+				w.OnlyFetchWorkspace,
+				spec.Spec.Steps,
+				i,
+			)
+
 			rawStepKey, err := key.Key()
 			if err != nil {
 				return nil
@@ -240,20 +238,9 @@ func (r *batchSpecWorkspaceCreator) process(
 			continue
 		}
 
-		changes, err := git.ChangesInDiff([]byte(res.Value.Diff))
-		if err != nil {
-			return errors.Wrap(err, "parsing cached step diff")
-		}
-		execResult := execution.Result{
-			Outputs:      res.Value.Outputs,
-			Diff:         res.Value.Diff,
-			ChangedFiles: &changes,
-			Path:         workspace.dbWorkspace.Path,
-		}
-
 		workspace.dbWorkspace.CachedResultFound = true
 
-		rawSpecs, err := cache.ChangesetSpecsFromCache(spec.Spec, workspace.repo, execResult)
+		rawSpecs, err := cache.ChangesetSpecsFromCache(spec.Spec, workspace.repo, *res.Value, workspace.dbWorkspace.Path)
 		if err != nil {
 			return err
 		}

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -201,14 +201,12 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	}
 
 	executionResult := &execution.AfterStepResult{
-		Diff:      testDiff,
-		StepIndex: 0,
-		StepResult: execution.StepResult{
-			Files:  &git.Changes{Modified: []string{"README.md", "urls.txt"}},
-			Stdout: "asdf2",
-			Stderr: "asdf",
-		},
-		Outputs: map[string]any{},
+		Diff:         testDiff,
+		StepIndex:    0,
+		ChangedFiles: git.Changes{Modified: []string{"README.md", "urls.txt"}},
+		Stdout:       "asdf2",
+		Stderr:       "asdf",
+		Outputs:      map[string]any{},
 	}
 
 	createBatchSpec := func(t *testing.T, noCache bool, spec string) *btypes.BatchSpec {
@@ -228,7 +226,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	createCacheEntry := func(t *testing.T, batchSpec *btypes.BatchSpec, workspace *service.RepoWorkspace, result *execution.AfterStepResult) *btypes.BatchSpecExecutionCacheEntry {
 		t.Helper()
 
-		execKey := cache.KeyForWorkspace(
+		key := cache.KeyForWorkspace(
 			&template.BatchChangeAttributes{
 				Name:        batchSpec.Spec.Name,
 				Description: batchSpec.Spec.Description,
@@ -243,11 +241,8 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 			workspace.Path,
 			workspace.OnlyFetchWorkspace,
 			batchSpec.Spec.Steps,
+			len(batchSpec.Spec.Steps)-1,
 		)
-		key := cache.StepsCacheKey{
-			ExecutionKey: &execKey,
-			StepIndex:    0,
-		}
 		rawKey, err := key.Key()
 		if err != nil {
 			t.Fatal(err)

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -241,7 +241,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 			workspace.Path,
 			workspace.OnlyFetchWorkspace,
 			batchSpec.Spec.Steps,
-			len(batchSpec.Spec.Steps)-1,
+			result.StepIndex,
 		)
 		rawKey, err := key.Key()
 		if err != nil {

--- a/lib/batches/changeset_specs.go
+++ b/lib/batches/changeset_specs.go
@@ -32,8 +32,9 @@ type ChangesetSpecInput struct {
 	BatchChangeAttributes *template.BatchChangeAttributes `json:"-"`
 	Template              *ChangesetTemplate              `json:"-"`
 	TransformChanges      *TransformChanges               `json:"-"`
+	Path                  string
 
-	Result execution.Result
+	Result execution.AfterStepResult
 }
 
 type ChangesetSpecFeatureFlags struct {
@@ -46,7 +47,7 @@ func BuildChangesetSpecs(input *ChangesetSpecInput, features ChangesetSpecFeatur
 		BatchChangeAttributes: *input.BatchChangeAttributes,
 		Steps: template.StepsContext{
 			Changes: input.Result.ChangedFiles,
-			Path:    input.Result.Path,
+			Path:    input.Path,
 		},
 		Outputs: input.Result.Outputs,
 		Repository: template.Repository{

--- a/lib/batches/changeset_specs_test.go
+++ b/lib/batches/changeset_specs_test.go
@@ -70,9 +70,9 @@ func TestCreateChangesetSpecs(t *testing.T) {
 			Published: parsePublishedFieldString(t, "false"),
 		},
 
-		Result: execution.Result{
+		Result: execution.AfterStepResult{
 			Diff: "cool diff",
-			ChangedFiles: &git.Changes{
+			ChangedFiles: git.Changes{
 				Modified: []string{"README.md"},
 			},
 			Outputs: map[string]any{},

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -16,9 +16,6 @@ import (
 )
 
 type Cache interface {
-	Get(ctx context.Context, key Keyer) (result execution.Result, found bool, err error)
-	Set(ctx context.Context, key Keyer, result execution.Result) error
-
 	GetStepResult(ctx context.Context, key Keyer) (result execution.AfterStepResult, found bool, err error)
 	SetStepResult(ctx context.Context, key Keyer, result execution.AfterStepResult) error
 
@@ -30,79 +27,24 @@ type Keyer interface {
 	Slug() string
 }
 
-// ExecutionKey implements the Keyer interface for the execution of a batch
-// spec in a repository workspace and all its Steps.
-type ExecutionKey struct {
-	Repository batches.Repository
-
-	Path               string
-	OnlyFetchWorkspace bool
-	Steps              []batches.Step
-
-	BatchChangeAttributes *template.BatchChangeAttributes
-
-	// Ignore from serialization.
-	MetadataRetriever MetadataRetriever `json:"-"`
-}
-
 // MetadataRetriever retrieves mount metadata.
 type MetadataRetriever interface {
 	// Get returns the mount metadata from the provided steps.
 	Get([]batches.Step) ([]MountMetadata, error)
 }
 
-// Key converts the key into a string form that can be used to uniquely identify
-// the cache key in a more concise form than the entire Task.
-func (key *ExecutionKey) Key() (string, error) {
-	envs, err := resolveStepsEnvironment([]string{}, key.Steps)
-	if err != nil {
-		return "", err
-	}
-	metadata, err := key.mountsMetadata()
-	if err != nil {
-		return "", err
-	}
-
-	return marshalAndHash(key, envs, metadata)
+// MountMetadata is the metadata of a file that is mounted by a Step.
+type MountMetadata struct {
+	Path     string
+	Size     int64
+	Modified time.Time
 }
 
-func (key ExecutionKey) mountsMetadata() ([]MountMetadata, error) {
+func (key StepsCacheKey) mountsMetadata() ([]MountMetadata, error) {
 	if key.MetadataRetriever != nil {
 		return key.MetadataRetriever.Get(key.Steps)
 	}
 	return nil, nil
-}
-
-func (key ExecutionKey) Slug() string {
-	return SlugForRepo(key.Repository.Name, key.Repository.BaseRev)
-}
-
-func (key *ExecutionKey) WithGlobalEnv(global []string) *ExecutionKeyWithGlobalEnv {
-	return &ExecutionKeyWithGlobalEnv{
-		ExecutionKey: key,
-		GlobalEnv:    global,
-	}
-}
-
-// ExecutionKeyWithGlobalEnv implements the Keyer interface by embedding
-// ExecutionKey but adding a global environment in which the steps could be
-// resolved.
-type ExecutionKeyWithGlobalEnv struct {
-	*ExecutionKey
-	GlobalEnv []string
-}
-
-func (key *ExecutionKeyWithGlobalEnv) Key() (string, error) {
-	envs, err := resolveStepsEnvironment(key.GlobalEnv, key.Steps)
-	if err != nil {
-		return "", err
-	}
-	metadata, err := key.mountsMetadata()
-	if err != nil {
-		return "", err
-	}
-
-	return marshalAndHash(key.ExecutionKey, envs, metadata)
 }
 
 func resolveStepsEnvironment(globalEnv []string, steps []batches.Step) ([]map[string]string, error) {
@@ -125,14 +67,14 @@ func resolveStepsEnvironment(globalEnv []string, steps []batches.Step) ([]map[st
 	return envs, nil
 }
 
-func marshalAndHash(key *ExecutionKey, envs []map[string]string, metadata []MountMetadata) (string, error) {
+func marshalAndHash(key *StepsCacheKey, envs []map[string]string, metadata []MountMetadata) (string, error) {
 	raw, err := json.Marshal(struct {
-		*ExecutionKey
+		*StepsCacheKey
 		Environments []map[string]string
 		// Omit if empty to be backwards compatible
 		MountsMetadata []MountMetadata `json:"MountsMetadata,omitempty"`
 	}{
-		ExecutionKey:   key,
+		StepsCacheKey:  key,
 		Environments:   envs,
 		MountsMetadata: metadata,
 	})
@@ -144,18 +86,21 @@ func marshalAndHash(key *ExecutionKey, envs []map[string]string, metadata []Moun
 	return base64.RawURLEncoding.EncodeToString(hash[:16]), nil
 }
 
-// MountMetadata is the metadata of a file that is mounted by a Step.
-type MountMetadata struct {
-	Path     string
-	Size     int64
-	Modified time.Time
-}
-
 // StepsCacheKey implements the Keyer interface for a batch spec execution in a
 // repository workspace and a *subset* of its Steps, up to and including the
 // step with index StepIndex in Task.Steps.
 type StepsCacheKey struct {
-	*ExecutionKey
+	Repository batches.Repository
+
+	Path               string
+	OnlyFetchWorkspace bool
+	Steps              []batches.Step
+
+	BatchChangeAttributes *template.BatchChangeAttributes
+
+	// Ignore from serialization.
+	MetadataRetriever MetadataRetriever `json:"-"`
+
 	StepIndex int
 }
 
@@ -173,24 +118,19 @@ func (key StepsCacheKey) Slug() string {
 // StepsCacheKey but adding a global environment in which the steps could be
 // resolved.
 type StepsCacheKeyWithGlobalEnv struct {
-	*StepsCacheKey
+	StepsCacheKey
 	GlobalEnv []string
 }
 
 func (key *StepsCacheKeyWithGlobalEnv) Key() (string, error) {
-	return marshalAndHashStepsCacheKey(*key.StepsCacheKey, key.GlobalEnv)
+	return marshalAndHashStepsCacheKey(key.StepsCacheKey, key.GlobalEnv)
 }
 
 func marshalAndHashStepsCacheKey(key StepsCacheKey, globalEnv []string) (string, error) {
 	// Setup a copy of the Task that only includes the Steps up to and
 	// including key.StepIndex.
-	clone := &ExecutionKey{
-		Repository:            key.ExecutionKey.Repository,
-		Path:                  key.ExecutionKey.Path,
-		OnlyFetchWorkspace:    key.ExecutionKey.OnlyFetchWorkspace,
-		Steps:                 key.ExecutionKey.Steps[0 : key.StepIndex+1],
-		BatchChangeAttributes: key.ExecutionKey.BatchChangeAttributes,
-	}
+	clone := key
+	clone.Steps = key.Steps[0 : key.StepIndex+1]
 
 	// Resolve environment only for the subset of Steps
 	envs, err := resolveStepsEnvironment(globalEnv, clone.Steps)
@@ -202,27 +142,29 @@ func marshalAndHashStepsCacheKey(key StepsCacheKey, globalEnv []string) (string,
 		return "", err
 	}
 
-	hash, err := marshalAndHash(clone, envs, metadata)
+	hash, err := marshalAndHash(&clone, envs, metadata)
 	if err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%s-step-%d", hash, key.StepIndex), err
 }
 
-func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r batches.Repository, path string, onlyFetchWorkspace bool, steps []batches.Step) ExecutionKey {
+func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r batches.Repository, path string, onlyFetchWorkspace bool, steps []batches.Step, stepIndex int) StepsCacheKey {
 	sort.Strings(r.FileMatches)
 
-	executionKey := ExecutionKey{
+	executionKey := StepsCacheKey{
 		Repository:            r,
 		Path:                  path,
 		OnlyFetchWorkspace:    onlyFetchWorkspace,
 		Steps:                 steps,
 		BatchChangeAttributes: batchChangeAttributes,
+		StepIndex:             stepIndex,
 	}
 	return executionKey
 }
 
-func ChangesetSpecsFromCache(spec *batches.BatchSpec, r batches.Repository, result execution.Result) ([]*batches.ChangesetSpec, error) {
+// ChangesetSpecsFromCache takes the execution.Result and generates all changeset specs from it.
+func ChangesetSpecsFromCache(spec *batches.BatchSpec, r batches.Repository, result execution.AfterStepResult, path string) ([]*batches.ChangesetSpec, error) {
 	if result.Diff == "" {
 		return []*batches.ChangesetSpec{}, nil
 	}
@@ -238,6 +180,7 @@ func ChangesetSpecsFromCache(spec *batches.BatchSpec, r batches.Repository, resu
 		Template:         spec.ChangesetTemplate,
 		TransformChanges: spec.TransformChanges,
 		Result:           result,
+		Path:             path,
 	}
 
 	return batches.BuildChangesetSpecs(input, batches.ChangesetSpecFeatureFlags{

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -16,8 +16,8 @@ import (
 )
 
 type Cache interface {
-	GetStepResult(ctx context.Context, key Keyer) (result execution.AfterStepResult, found bool, err error)
-	SetStepResult(ctx context.Context, key Keyer, result execution.AfterStepResult) error
+	Get(ctx context.Context, key Keyer) (result execution.AfterStepResult, found bool, err error)
+	Set(ctx context.Context, key Keyer, result execution.AfterStepResult) error
 
 	Clear(ctx context.Context, key Keyer) error
 }
@@ -40,13 +40,15 @@ type MountMetadata struct {
 	Modified time.Time
 }
 
-func (key StepsCacheKey) mountsMetadata() ([]MountMetadata, error) {
+func (key CacheKey) mountsMetadata() ([]MountMetadata, error) {
 	if key.MetadataRetriever != nil {
 		return key.MetadataRetriever.Get(key.Steps)
 	}
 	return nil, nil
 }
 
+// resolveStepsEnvironment returns a slice of environments for each of the steps,
+// containing only the env vars that are actually used.
 func resolveStepsEnvironment(globalEnv []string, steps []batches.Step) ([]map[string]string, error) {
 	// We have to resolve the step environments and include them in the cache
 	// key to ensure that the cache is properly invalidated when an environment
@@ -67,14 +69,14 @@ func resolveStepsEnvironment(globalEnv []string, steps []batches.Step) ([]map[st
 	return envs, nil
 }
 
-func marshalAndHash(key *StepsCacheKey, envs []map[string]string, metadata []MountMetadata) (string, error) {
+func marshalAndHash(key *CacheKey, envs []map[string]string, metadata []MountMetadata) (string, error) {
 	raw, err := json.Marshal(struct {
-		*StepsCacheKey
+		*CacheKey
 		Environments []map[string]string
-		// Omit if empty to be backwards compatible
+		// Omit if empty to be backwards compatible.
 		MountsMetadata []MountMetadata `json:"MountsMetadata,omitempty"`
 	}{
-		StepsCacheKey:  key,
+		CacheKey:       key,
 		Environments:   envs,
 		MountsMetadata: metadata,
 	})
@@ -86,10 +88,10 @@ func marshalAndHash(key *StepsCacheKey, envs []map[string]string, metadata []Mou
 	return base64.RawURLEncoding.EncodeToString(hash[:16]), nil
 }
 
-// StepsCacheKey implements the Keyer interface for a batch spec execution in a
+// CacheKey implements the Keyer interface for a batch spec execution in a
 // repository workspace and a *subset* of its Steps, up to and including the
 // step with index StepIndex in Task.Steps.
-type StepsCacheKey struct {
+type CacheKey struct {
 	Repository batches.Repository
 
 	Path               string
@@ -101,39 +103,21 @@ type StepsCacheKey struct {
 	// Ignore from serialization.
 	MetadataRetriever MetadataRetriever `json:"-"`
 
+	GlobalEnv []string
+
 	StepIndex int
 }
 
 // Key converts the key into a string form that can be used to uniquely identify
 // the cache key in a more concise form than the entire Task.
-func (key StepsCacheKey) Key() (string, error) {
-	return marshalAndHashStepsCacheKey(key, []string{})
-}
-
-func (key StepsCacheKey) Slug() string {
-	return SlugForRepo(key.Repository.Name, key.Repository.BaseRev)
-}
-
-// StepsCacheKeyWithGlobalEnv implements the Keyer interface by embedding
-// StepsCacheKey but adding a global environment in which the steps could be
-// resolved.
-type StepsCacheKeyWithGlobalEnv struct {
-	StepsCacheKey
-	GlobalEnv []string
-}
-
-func (key *StepsCacheKeyWithGlobalEnv) Key() (string, error) {
-	return marshalAndHashStepsCacheKey(key.StepsCacheKey, key.GlobalEnv)
-}
-
-func marshalAndHashStepsCacheKey(key StepsCacheKey, globalEnv []string) (string, error) {
-	// Setup a copy of the Task that only includes the Steps up to and
+func (key CacheKey) Key() (string, error) {
+	// Setup a copy of the cache key that only includes the Steps up to and
 	// including key.StepIndex.
 	clone := key
 	clone.Steps = key.Steps[0 : key.StepIndex+1]
 
-	// Resolve environment only for the subset of Steps
-	envs, err := resolveStepsEnvironment(globalEnv, clone.Steps)
+	// Resolve environment only for the subset of Steps.
+	envs, err := resolveStepsEnvironment(key.GlobalEnv, clone.Steps)
 	if err != nil {
 		return "", err
 	}
@@ -149,10 +133,14 @@ func marshalAndHashStepsCacheKey(key StepsCacheKey, globalEnv []string) (string,
 	return fmt.Sprintf("%s-step-%d", hash, key.StepIndex), err
 }
 
-func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r batches.Repository, path string, onlyFetchWorkspace bool, steps []batches.Step, stepIndex int) StepsCacheKey {
+func (key CacheKey) Slug() string {
+	return SlugForRepo(key.Repository.Name, key.Repository.BaseRev)
+}
+
+func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r batches.Repository, path string, onlyFetchWorkspace bool, steps []batches.Step, stepIndex int) CacheKey {
 	sort.Strings(r.FileMatches)
 
-	executionKey := StepsCacheKey{
+	return CacheKey{
 		Repository:            r,
 		Path:                  path,
 		OnlyFetchWorkspace:    onlyFetchWorkspace,
@@ -160,7 +148,6 @@ func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r ba
 		BatchChangeAttributes: batchChangeAttributes,
 		StepIndex:             stepIndex,
 	}
-	return executionKey
 }
 
 // ChangesetSpecsFromCache takes the execution.Result and generates all changeset specs from it.

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -92,18 +92,16 @@ func marshalAndHash(key *CacheKey, envs []map[string]string, metadata []MountMet
 // repository workspace and a *subset* of its Steps, up to and including the
 // step with index StepIndex in Task.Steps.
 type CacheKey struct {
-	Repository batches.Repository
-
-	Path               string
-	OnlyFetchWorkspace bool
-	Steps              []batches.Step
-
+	Repository            batches.Repository
+	Path                  string
+	OnlyFetchWorkspace    bool
+	Steps                 []batches.Step
 	BatchChangeAttributes *template.BatchChangeAttributes
 
 	// Ignore from serialization.
 	MetadataRetriever MetadataRetriever `json:"-"`
-
-	GlobalEnv []string
+	// Ignore from serialization.
+	GlobalEnv []string `json:"-"`
 
 	StepIndex int
 }
@@ -137,7 +135,7 @@ func (key CacheKey) Slug() string {
 	return SlugForRepo(key.Repository.Name, key.Repository.BaseRev)
 }
 
-func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r batches.Repository, path string, onlyFetchWorkspace bool, steps []batches.Step, stepIndex int) CacheKey {
+func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r batches.Repository, path string, onlyFetchWorkspace bool, steps []batches.Step, stepIndex int) Keyer {
 	sort.Strings(r.FileMatches)
 
 	return CacheKey{

--- a/lib/batches/execution/cache/cache_test.go
+++ b/lib/batches/execution/cache/cache_test.go
@@ -48,62 +48,62 @@ func TestKeyer_Key(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name: "ExecutionKey simple",
-			keyer: &ExecutionKey{
+			name: "simple",
+			keyer: &StepsCacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo"}},
 			},
-			expectedKey: "cu8r-xdguU4s0kn9_uxL5g",
+			expectedKey: "NxWM6tGwnsIG5EoaivFOsg-step-0",
 		},
 		{
-			name: "ExecutionKey multiple steps",
-			keyer: &ExecutionKey{
+			name: "multiple steps",
+			keyer: &StepsCacheKey{
 				Repository: repo,
 				Steps: []batches.Step{
 					{Run: "foo"},
 					{Run: "bar"},
 				},
 			},
-			expectedKey: "nXrDA5Sv3jE2wGVTrixgJw",
+			expectedKey: "NxWM6tGwnsIG5EoaivFOsg-step-0",
 		},
 		{
-			name: "ExecutionKey step env",
-			keyer: &ExecutionKey{
+			name: "step env",
+			keyer: &StepsCacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: singleStepEnv}},
 			},
-			expectedKey: "Ye3eFDmvvADzZuz-TWEA2g",
+			expectedKey: "wKBVeg3u99TBq2U0qxx6cA-step-0",
 		},
 		{
-			name: "ExecutionKey multiple step envs",
-			keyer: &ExecutionKey{
+			name: "multiple step envs",
+			keyer: &StepsCacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: multipleStepEnv}},
 			},
-			expectedKey: "mZk8q7zjJioxI2nTwrt7XQ",
+			expectedKey: "YO88Tvj7bzCjP5pRag-9bQ-step-0",
 		},
 		{
-			name: "ExecutionKey null step env",
-			keyer: &ExecutionKey{
+			name: "null step env",
+			keyer: &StepsCacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: nullStepEnv}},
 			},
-			expectedKey: "_txGuv3XrkWWVQz6hGsKhw",
+			expectedKey: "wFqInfgY7mpK9F4qpW2iew-step-0",
 		},
 		{
-			name: "ExecutionKey mount metadata",
-			keyer: &ExecutionKey{
+			name: "mount metadata",
+			keyer: &StepsCacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo"}},
 				MetadataRetriever: testM{
 					m: []MountMetadata{{Path: "/foo/bar", Size: 100, Modified: modDate}},
 				},
 			},
-			expectedKey: "DFPxThKpLG4BAqW_wMGLTQ",
+			expectedKey: "cpXzPMXfSM2ZmXYW_gAEyw-step-0",
 		},
 		{
-			name: "ExecutionKey multiple mount metadata",
-			keyer: &ExecutionKey{
+			name: "multiple mount metadata",
+			keyer: &StepsCacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo"}},
 				MetadataRetriever: testM{
@@ -113,11 +113,11 @@ func TestKeyer_Key(t *testing.T) {
 					},
 				},
 			},
-			expectedKey: "FhHlnyPvsOe9__15wfuQYQ",
+			expectedKey: "ZSeYkHFJFD0TYsbKsgVjqQ-step-0",
 		},
 		{
-			name: "ExecutionKey mount metadata error",
-			keyer: &ExecutionKey{
+			name: "mount metadata error",
+			keyer: &StepsCacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo"}},
 				MetadataRetriever: testM{
@@ -127,92 +127,48 @@ func TestKeyer_Key(t *testing.T) {
 			expectedError: errors.New("failed to get mount metadata"),
 		},
 		{
-			name: "ExecutionKeyWithGlobalEnv simple",
-			keyer: &ExecutionKeyWithGlobalEnv{
-				ExecutionKey: &ExecutionKey{
+			name: "StepsCacheKeyWithGlobalEnv simple",
+			keyer: &StepsCacheKeyWithGlobalEnv{
+				StepsCacheKey: &StepsCacheKey{
 					Repository: repo,
 					Steps:      []batches.Step{{Run: "foo"}},
 				},
 				GlobalEnv: []string{},
 			},
-			expectedKey: "cu8r-xdguU4s0kn9_uxL5g",
+			expectedKey: "NxWM6tGwnsIG5EoaivFOsg-step-0",
 		},
 		{
-			name: "ExecutionKeyWithGlobalEnv has global env",
-			keyer: &ExecutionKeyWithGlobalEnv{
-				ExecutionKey: &ExecutionKey{
+			name: "StepsCacheKeyWithGlobalEnv has global env",
+			keyer: &StepsCacheKeyWithGlobalEnv{
+				StepsCacheKey: &StepsCacheKey{
 					Repository: repo,
 					Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
 				},
 				GlobalEnv: []string{"SOME_ENV=FOO", "FAZ=BAZ"},
 			},
-			expectedKey: "UWaad_y5HkY90tPkgBO7og",
+			expectedKey: "sBrPdQ_SaeTHL5cNRtl0uA-step-0",
 		},
 		{
-			name: "ExecutionKeyWithGlobalEnv env not updated",
-			keyer: &ExecutionKeyWithGlobalEnv{
-				ExecutionKey: &ExecutionKey{
+			name: "StepsCacheKeyWithGlobalEnv env not updated",
+			keyer: &StepsCacheKeyWithGlobalEnv{
+				StepsCacheKey: &StepsCacheKey{
 					Repository: repo,
 					Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
 				},
 				GlobalEnv: []string{"FAZ=BAZ"},
 			},
-			expectedKey: "tq9NsiMdvoKqMpgxE00XGQ",
+			expectedKey: "cs52Db_-N1MfDw2_0FFulw-step-0",
 		},
 		{
-			name: "ExecutionKeyWithGlobalEnv malformed global env",
-			keyer: &ExecutionKeyWithGlobalEnv{
-				ExecutionKey: &ExecutionKey{
+			name: "StepsCacheKeyWithGlobalEnv malformed global env",
+			keyer: &StepsCacheKeyWithGlobalEnv{
+				StepsCacheKey: &StepsCacheKey{
 					Repository: repo,
 					Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
 				},
 				GlobalEnv: []string{"SOME_ENV"},
 			},
 			expectedError: errors.New("resolving environment for step 0: unable to parse environment variable \"SOME_ENV\""),
-		},
-		{
-			name: "StepsCacheKey simple",
-			keyer: StepsCacheKey{
-				ExecutionKey: &ExecutionKey{
-					Repository: repo,
-					Steps:      []batches.Step{{Run: "foo"}},
-				},
-				StepIndex: 0,
-			},
-			expectedKey: "cu8r-xdguU4s0kn9_uxL5g-step-0",
-		},
-		{
-			name: "StepsCacheKey multiple steps",
-			keyer: StepsCacheKey{
-				ExecutionKey: &ExecutionKey{
-					Repository: repo,
-					Steps: []batches.Step{
-						{Run: "foo"},
-						{Run: "bar"},
-					},
-				},
-				StepIndex: 0,
-			},
-			expectedKey: "cu8r-xdguU4s0kn9_uxL5g-step-0",
-		},
-		{
-			name: "StepsCacheKeyWithGlobalEnv env set",
-			keyer: &StepsCacheKeyWithGlobalEnv{
-				StepsCacheKey: &StepsCacheKey{
-					ExecutionKey: &ExecutionKey{
-						Repository: repo,
-						Steps: []batches.Step{
-							{
-								Run: "foo",
-								Env: stepEnv,
-							},
-						},
-					},
-					StepIndex: 0,
-				},
-				GlobalEnv: []string{"SOME_ENV=FOO", "FAZ=BAZ"},
-			},
-			expectedKey: "UWaad_y5HkY90tPkgBO7og-step-0",
 		},
 	}
 	for _, test := range tests {

--- a/lib/batches/execution/cache/cache_test.go
+++ b/lib/batches/execution/cache/cache_test.go
@@ -49,7 +49,7 @@ func TestKeyer_Key(t *testing.T) {
 	}{
 		{
 			name: "simple",
-			keyer: &StepsCacheKey{
+			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo"}},
 			},
@@ -57,7 +57,7 @@ func TestKeyer_Key(t *testing.T) {
 		},
 		{
 			name: "multiple steps",
-			keyer: &StepsCacheKey{
+			keyer: &CacheKey{
 				Repository: repo,
 				Steps: []batches.Step{
 					{Run: "foo"},
@@ -68,7 +68,7 @@ func TestKeyer_Key(t *testing.T) {
 		},
 		{
 			name: "step env",
-			keyer: &StepsCacheKey{
+			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: singleStepEnv}},
 			},
@@ -76,7 +76,7 @@ func TestKeyer_Key(t *testing.T) {
 		},
 		{
 			name: "multiple step envs",
-			keyer: &StepsCacheKey{
+			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: multipleStepEnv}},
 			},
@@ -84,7 +84,7 @@ func TestKeyer_Key(t *testing.T) {
 		},
 		{
 			name: "null step env",
-			keyer: &StepsCacheKey{
+			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: nullStepEnv}},
 			},
@@ -92,7 +92,7 @@ func TestKeyer_Key(t *testing.T) {
 		},
 		{
 			name: "mount metadata",
-			keyer: &StepsCacheKey{
+			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo"}},
 				MetadataRetriever: testM{
@@ -103,7 +103,7 @@ func TestKeyer_Key(t *testing.T) {
 		},
 		{
 			name: "multiple mount metadata",
-			keyer: &StepsCacheKey{
+			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo"}},
 				MetadataRetriever: testM{
@@ -117,7 +117,7 @@ func TestKeyer_Key(t *testing.T) {
 		},
 		{
 			name: "mount metadata error",
-			keyer: &StepsCacheKey{
+			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo"}},
 				MetadataRetriever: testM{
@@ -128,45 +128,37 @@ func TestKeyer_Key(t *testing.T) {
 		},
 		{
 			name: "StepsCacheKeyWithGlobalEnv simple",
-			keyer: &StepsCacheKeyWithGlobalEnv{
-				StepsCacheKey: &StepsCacheKey{
-					Repository: repo,
-					Steps:      []batches.Step{{Run: "foo"}},
-				},
-				GlobalEnv: []string{},
+			keyer: &CacheKey{
+				Repository: repo,
+				Steps:      []batches.Step{{Run: "foo"}},
+				GlobalEnv:  []string{},
 			},
 			expectedKey: "NxWM6tGwnsIG5EoaivFOsg-step-0",
 		},
 		{
 			name: "StepsCacheKeyWithGlobalEnv has global env",
-			keyer: &StepsCacheKeyWithGlobalEnv{
-				StepsCacheKey: &StepsCacheKey{
-					Repository: repo,
-					Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
-				},
-				GlobalEnv: []string{"SOME_ENV=FOO", "FAZ=BAZ"},
+			keyer: &CacheKey{
+				Repository: repo,
+				Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
+				GlobalEnv:  []string{"SOME_ENV=FOO", "FAZ=BAZ"},
 			},
 			expectedKey: "sBrPdQ_SaeTHL5cNRtl0uA-step-0",
 		},
 		{
 			name: "StepsCacheKeyWithGlobalEnv env not updated",
-			keyer: &StepsCacheKeyWithGlobalEnv{
-				StepsCacheKey: &StepsCacheKey{
-					Repository: repo,
-					Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
-				},
-				GlobalEnv: []string{"FAZ=BAZ"},
+			keyer: &CacheKey{
+				Repository: repo,
+				Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
+				GlobalEnv:  []string{"FAZ=BAZ"},
 			},
 			expectedKey: "cs52Db_-N1MfDw2_0FFulw-step-0",
 		},
 		{
 			name: "StepsCacheKeyWithGlobalEnv malformed global env",
-			keyer: &StepsCacheKeyWithGlobalEnv{
-				StepsCacheKey: &StepsCacheKey{
-					Repository: repo,
-					Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
-				},
-				GlobalEnv: []string{"SOME_ENV"},
+			keyer: &CacheKey{
+				Repository: repo,
+				Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
+				GlobalEnv:  []string{"SOME_ENV"},
 			},
 			expectedError: errors.New("resolving environment for step 0: unable to parse environment variable \"SOME_ENV\""),
 		},

--- a/lib/batches/execution/cache/cache_test.go
+++ b/lib/batches/execution/cache/cache_test.go
@@ -52,6 +52,7 @@ func TestKeyer_Key(t *testing.T) {
 			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo"}},
+				StepIndex:  0,
 			},
 			expectedKey: "NxWM6tGwnsIG5EoaivFOsg-step-0",
 		},
@@ -63,14 +64,16 @@ func TestKeyer_Key(t *testing.T) {
 					{Run: "foo"},
 					{Run: "bar"},
 				},
+				StepIndex: 1,
 			},
-			expectedKey: "NxWM6tGwnsIG5EoaivFOsg-step-0",
+			expectedKey: "_zR95x8sdhauCYxjtOHCbA-step-1",
 		},
 		{
 			name: "step env",
 			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: singleStepEnv}},
+				StepIndex:  0,
 			},
 			expectedKey: "wKBVeg3u99TBq2U0qxx6cA-step-0",
 		},
@@ -79,6 +82,7 @@ func TestKeyer_Key(t *testing.T) {
 			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: multipleStepEnv}},
+				StepIndex:  0,
 			},
 			expectedKey: "YO88Tvj7bzCjP5pRag-9bQ-step-0",
 		},
@@ -87,6 +91,7 @@ func TestKeyer_Key(t *testing.T) {
 			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: nullStepEnv}},
+				StepIndex:  0,
 			},
 			expectedKey: "wFqInfgY7mpK9F4qpW2iew-step-0",
 		},
@@ -98,6 +103,7 @@ func TestKeyer_Key(t *testing.T) {
 				MetadataRetriever: testM{
 					m: []MountMetadata{{Path: "/foo/bar", Size: 100, Modified: modDate}},
 				},
+				StepIndex: 0,
 			},
 			expectedKey: "cpXzPMXfSM2ZmXYW_gAEyw-step-0",
 		},
@@ -112,6 +118,7 @@ func TestKeyer_Key(t *testing.T) {
 						{Path: "/faz/baz", Size: 100, Modified: modDate},
 					},
 				},
+				StepIndex: 0,
 			},
 			expectedKey: "ZSeYkHFJFD0TYsbKsgVjqQ-step-0",
 		},
@@ -123,42 +130,46 @@ func TestKeyer_Key(t *testing.T) {
 				MetadataRetriever: testM{
 					err: errors.New("failed to get mount metadata"),
 				},
+				StepIndex: 0,
 			},
 			expectedError: errors.New("failed to get mount metadata"),
 		},
 		{
-			name: "StepsCacheKeyWithGlobalEnv simple",
-			keyer: &CacheKey{
-				Repository: repo,
-				Steps:      []batches.Step{{Run: "foo"}},
-				GlobalEnv:  []string{},
-			},
-			expectedKey: "NxWM6tGwnsIG5EoaivFOsg-step-0",
-		},
-		{
-			name: "StepsCacheKeyWithGlobalEnv has global env",
+			name: "with global env",
 			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
 				GlobalEnv:  []string{"SOME_ENV=FOO", "FAZ=BAZ"},
+				StepIndex:  0,
 			},
 			expectedKey: "sBrPdQ_SaeTHL5cNRtl0uA-step-0",
 		},
 		{
-			name: "StepsCacheKeyWithGlobalEnv env not updated",
+			name: "env var not in global env",
 			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
 				GlobalEnv:  []string{"FAZ=BAZ"},
+				StepIndex:  0,
 			},
 			expectedKey: "cs52Db_-N1MfDw2_0FFulw-step-0",
 		},
 		{
-			name: "StepsCacheKeyWithGlobalEnv malformed global env",
+			name: "no global env but forwarded",
+			keyer: &CacheKey{
+				Repository: repo,
+				Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
+				StepIndex:  0,
+			},
+			expectedKey: "cs52Db_-N1MfDw2_0FFulw-step-0",
+		},
+		{
+			name: "malformed global env",
 			keyer: &CacheKey{
 				Repository: repo,
 				Steps:      []batches.Step{{Run: "foo", Env: stepEnv}},
 				GlobalEnv:  []string{"SOME_ENV"},
+				StepIndex:  0,
 			},
 			expectedError: errors.New("resolving environment for step 0: unable to parse environment variable \"SOME_ENV\""),
 		},

--- a/lib/batches/execution/results.go
+++ b/lib/batches/execution/results.go
@@ -4,74 +4,19 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 )
 
-// StepResult represents the result of a single, previously executed step.
-type StepResult struct {
-	// Files are the changes made to Files by the step.
-	Files *git.Changes
-	// Stdout is the output produced by the step on standard out.
-	Stdout string
-	// Stderr is the output produced by the step on standard error.
-	Stderr string
-}
-
-// ModifiedFiles returns the files modified by a step.
-func (r StepResult) ModifiedFiles() []string {
-	if r.Files != nil {
-		return r.Files.Modified
-	}
-	return []string{}
-}
-
-// AddedFiles returns the files added by a step.
-func (r StepResult) AddedFiles() []string {
-	if r.Files != nil {
-		return r.Files.Added
-	}
-	return []string{}
-}
-
-// DeletedFiles returns the files deleted by a step.
-func (r StepResult) DeletedFiles() []string {
-	if r.Files != nil {
-		return r.Files.Deleted
-	}
-	return []string{}
-}
-
-// RenamedFiles returns the new name of files that have been renamed by a step.
-func (r StepResult) RenamedFiles() []string {
-	if r.Files != nil {
-		return r.Files.Renamed
-	}
-	return []string{}
-}
-
-// AfterStepResult is the ExecutionResult after executing a Step with the given
+// AfterStepResult is the execution result after executing a step with the given
 // index in Steps.
 type AfterStepResult struct {
+	// Files are the changes made to Files by the step.
+	ChangedFiles git.Changes `json:"changedFiles"`
+	// Stdout is the output produced by the step on standard out.
+	Stdout string `json:"stdout"`
+	// Stderr is the output produced by the step on standard error.
+	Stderr string `json:"stderr"`
 	// StepIndex is the index of the step in the list of steps.
 	StepIndex int `json:"stepIndex"`
 	// Diff is the cumulative `git diff` after executing the Step.
 	Diff string `json:"diff"`
 	// Outputs is a copy of the Outputs after executing the Step.
 	Outputs map[string]any `json:"outputs"`
-	// StepResult is the StepResult of this step.
-	StepResult StepResult `json:"stepResult"`
-}
-
-// Result is the result of executing all executable steps in a workspace.
-type Result struct {
-	// Diff is the produced by executing all steps.
-	Diff string `json:"diff"`
-
-	// ChangedFiles are files that have been changed by all steps.
-	ChangedFiles *git.Changes `json:"changedFiles"`
-
-	// Outputs are the outputs produced by all steps.
-	Outputs map[string]any `json:"outputs"`
-
-	// Path relative to the repository's root directory in which the steps
-	// have been executed.
-	// No leading slashes. Root directory is blank string.
-	Path string `json:"path"`
 }

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 )
 
-var testChanges = &git.Changes{
+var testChanges = git.Changes{
 	Modified: []string{"go.mod"},
 	Added:    []string{"main.go.swp"},
 	Deleted:  []string{".DS_Store"},
@@ -24,10 +24,10 @@ func TestEvalStepCondition(t *testing.T) {
 			Name:        "test-batch-change",
 			Description: "This batch change is just an experiment",
 		},
-		PreviousStep: execution.StepResult{
-			Files:  testChanges,
-			Stdout: "this is previous step's stdout",
-			Stderr: "this is previous step's stderr",
+		PreviousStep: execution.AfterStepResult{
+			ChangedFiles: testChanges,
+			Stdout:       "this is previous step's stdout",
+			Stderr:       "this is previous step's stderr",
 		},
 		Steps: StepsContext{
 			Changes: testChanges,
@@ -89,19 +89,19 @@ func TestRenderStepTemplate(t *testing.T) {
 			Name:        "test-batch-change",
 			Description: "This batch change is just an experiment",
 		},
-		PreviousStep: execution.StepResult{
-			Files:  testChanges,
-			Stdout: "this is previous step's stdout",
-			Stderr: "this is previous step's stderr",
+		PreviousStep: execution.AfterStepResult{
+			ChangedFiles: testChanges,
+			Stdout:       "this is previous step's stdout",
+			Stderr:       "this is previous step's stderr",
 		},
 		Outputs: map[string]any{
 			"lastLine": "lastLine is this",
 			"project":  parsedYaml,
 		},
-		Step: execution.StepResult{
-			Files:  testChanges,
-			Stdout: "this is current step's stdout",
-			Stderr: "this is current step's stderr",
+		Step: execution.AfterStepResult{
+			ChangedFiles: testChanges,
+			Stdout:       "this is current step's stdout",
+			Stderr:       "this is current step's stderr",
 		},
 		Steps:      StepsContext{Changes: testChanges, Path: "sub/directory/of/repo"},
 		Repository: *testRepo1,
@@ -233,10 +233,10 @@ ${{ steps.path }}
 
 func TestRenderStepMap(t *testing.T) {
 	stepCtx := &StepContext{
-		PreviousStep: execution.StepResult{
-			Files:  testChanges,
-			Stdout: "this is previous step's stdout",
-			Stderr: "this is previous step's stderr",
+		PreviousStep: execution.AfterStepResult{
+			ChangedFiles: testChanges,
+			Stdout:       "this is previous step's stdout",
+			Stderr:       "this is previous step's stderr",
 		},
 		Outputs:    map[string]any{},
 		Repository: *testRepo1,
@@ -284,7 +284,7 @@ func TestRenderChangesetTemplateField(t *testing.T) {
 		},
 		Repository: *testRepo1,
 		Steps: StepsContext{
-			Changes: &git.Changes{
+			Changes: git.Changes{
 				Modified: []string{"modified-file.txt"},
 				Added:    []string{"added-file.txt"},
 				Deleted:  []string{"deleted-file.txt"},


### PR DESCRIPTION
Server-side and lib version of https://github.com/sourcegraph/src-cli/pull/797. This PR removes execution results as a distinction to step results.

## Test plan

Test suite and manual testing of caching scenarios.