### PR TITLE
Code Insights: Fetch only needed fields in insight view data (chart content query)

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -8,11 +8,16 @@ import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { H2 } from '@sourcegraph/wildcard'
 
 import { WebStory } from '../../../../../../components/WebStory'
-import { GetInsightViewResult, SeriesSortDirection, SeriesSortMode } from '../../../../../../graphql-operations'
-import { SeriesChartContent, SearchBasedInsight } from '../../../../core'
-import { GET_INSIGHT_VIEW_GQL } from '../../../../core/backend/gql-backend/gql/GetInsightView'
+import { GetInsightViewResult } from '../../../../../../graphql-operations'
+import {
+    SeriesChartContent,
+    SearchBasedInsight,
+    CaptureGroupInsight,
+    InsightExecutionType,
+    InsightType,
+} from '../../../../core'
+import { GET_INSIGHT_VIEW_GQL } from '../../../../core/backend/gql-backend'
 import { InsightInProcessError } from '../../../../core/backend/utils/errors'
-import { CaptureGroupInsight, InsightExecutionType, InsightType } from '../../../../core/types'
 
 import { BackendInsightView } from './BackendInsight'
 
@@ -287,24 +292,6 @@ const BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK: MockedResponse<GetInsightViewRes
                 nodes: [
                     {
                         id: 'aW5zaWdodF92aWV3OiIyNU9aNFFpTERPMGRQVUZSQWNtYnBvZ1hhWnMi',
-                        defaultSeriesDisplayOptions: {
-                            __typename: 'SeriesDisplayOptions',
-                            limit: 20,
-                            sortOptions: {
-                                __typename: 'SeriesSortOptions',
-                                mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC,
-                            },
-                        },
-                        appliedSeriesDisplayOptions: {
-                            __typename: 'SeriesDisplayOptions',
-                            limit: 20,
-                            sortOptions: {
-                                __typename: 'SeriesSortOptions',
-                                mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC,
-                            },
-                        },
                         dataSeries: [
                             {
                                 seriesId: '001',
@@ -571,24 +558,6 @@ const BACKEND_INSIGHT_DATA_FETCHING_MOCK: MockedResponse<GetInsightViewResult> =
                 nodes: [
                     {
                         id: 'aW5zaWdodF92aWV3OiIyNU9ZY1VQdThxeXpvcnR1WmJXZE9qdVh2Y2Yi',
-                        defaultSeriesDisplayOptions: {
-                            __typename: 'SeriesDisplayOptions',
-                            limit: 20,
-                            sortOptions: {
-                                __typename: 'SeriesSortOptions',
-                                mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC,
-                            },
-                        },
-                        appliedSeriesDisplayOptions: {
-                            __typename: 'SeriesDisplayOptions',
-                            limit: 20,
-                            sortOptions: {
-                                __typename: 'SeriesSortOptions',
-                                mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC,
-                            },
-                        },
                         dataSeries: [
                             {
                                 seriesId: '001',
@@ -855,24 +824,6 @@ const BACKEND_INSIGHT_TERRAFORM_AWS_VERSIONS_MOCK: MockedResponse<GetInsightView
                 nodes: [
                     {
                         id: 'aW5zaWdodF92aWV3OiIyNU9lSm8xcTZub05nUkh3aG9MWEdCdUdtN3Yi',
-                        defaultSeriesDisplayOptions: {
-                            __typename: 'SeriesDisplayOptions',
-                            limit: 20,
-                            sortOptions: {
-                                __typename: 'SeriesSortOptions',
-                                mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC,
-                            },
-                        },
-                        appliedSeriesDisplayOptions: {
-                            __typename: 'SeriesDisplayOptions',
-                            limit: 20,
-                            sortOptions: {
-                                __typename: 'SeriesSortOptions',
-                                mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC,
-                            },
-                        },
                         dataSeries: [
                             {
                                 seriesId: '25OeJqBD4dOacJDmOA1cXY97Iyb',

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsightView.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsightView.ts
@@ -20,20 +20,6 @@ const INSIGHT_DATA_SERIES_FRAGMENT = gql`
 const INSIGHT_DATA_NODE_FRAGMENT = gql`
     fragment InsightDataNode on InsightView {
         id
-        defaultSeriesDisplayOptions {
-            limit
-            sortOptions {
-                mode
-                direction
-            }
-        }
-        appliedSeriesDisplayOptions {
-            limit
-            sortOptions {
-                mode
-                direction
-            }
-        }
         dataSeries {
             ...InsightDataSeries
         }

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -5,7 +5,7 @@ import { LoadingSpinner, PageHeader, useObservable } from '@sourcegraph/wildcard
 
 import { PageTitle } from '../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../../../insights/Icons'
-import { CodeInsightsPage } from '../../../components/code-insights-page/CodeInsightsPage'
+import { CodeInsightsPage } from '../../../components'
 import { CodeInsightsBackendContext } from '../../../core'
 
 import { CodeInsightIndependentPageActions } from './components/actions/CodeInsightIndependentPageActions'

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef, useState } from 'react'
+import React, { useContext, useState } from 'react'
 
 import classNames from 'classnames'
 import { useHistory } from 'react-router'
@@ -16,8 +16,14 @@ import {
     SeriesDisplayOptionsInput,
 } from '../../../../../../../graphql-operations'
 import { useSeriesToggle } from '../../../../../../../insights/utils/use-series-toggle'
-import { InsightCard, InsightCardHeader, InsightCardLoading } from '../../../../../components'
-import { FORM_ERROR, FormChangeEvent, SubmissionErrors } from '../../../../../components/form/hooks/useForm'
+import {
+    InsightCard,
+    InsightCardHeader,
+    InsightCardLoading,
+    FORM_ERROR,
+    FormChangeEvent,
+    SubmissionErrors,
+} from '../../../../../components'
 import {
     DrillDownInsightFilters,
     FilterSectionVisualMode,
@@ -28,7 +34,6 @@ import {
     DrillDownFiltersFormValues,
     DrillDownInsightCreationFormValues,
 } from '../../../../../components/insights-view-grid/components/backend-insight/components'
-import { useVisibility } from '../../../../../components/insights-view-grid/hooks/use-insight-data'
 import {
     BackendInsightData,
     ALL_INSIGHTS_DASHBOARD,
@@ -67,8 +72,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
     // Original insight filters values that are stored in setting subject with insight
     // configuration object, They are updated  whenever the user clicks update/save button
     const [originalInsightFilters, setOriginalInsightFilters] = useState(insight.filters)
-    const insightCardReference = useRef<HTMLDivElement>(null)
-    const { isVisible, wasEverVisible } = useVisibility(insightCardReference)
+
     // Live valid filters from filter form. They are updated whenever the user is changing
     // filter value in filters fields.
     const [filters, setFilters] = useState<InsightFilters>(originalInsightFilters)
@@ -94,7 +98,6 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
             fetchPolicy: 'cache-and-network',
             pollInterval: pollingInterval,
             context: { concurrentRequests: { key: 'GET_INSIGHT_VIEW' } },
-            skip: !wasEverVisible,
             onCompleted: data => {
                 const parsedData = createBackendInsightData({ ...insight, filters }, data.insightViews.nodes[0])
                 if (!parsedData.isFetchingHistoricalData) {
@@ -181,7 +184,6 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
             </Card>
 
             <InsightCard
-                ref={insightCardReference}
                 data-testid={`insight-standalone-card.${insight.id}`}
                 className={styles.chart}
                 onMouseEnter={trackMouseEnter}
@@ -197,7 +199,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
 
                 {error ? (
                     <BackendInsightErrorAlert error={error} />
-                ) : loading || !isVisible || !insightData ? (
+                ) : loading || !insightData ? (
                     <InsightCardLoading>Loading code insight</InsightCardLoading>
                 ) : error ? (
                     <BackendInsightErrorAlert error={error} />

--- a/client/web/src/integration/insights/fixtures/calculated-insights.ts
+++ b/client/web/src/integration/insights/fixtures/calculated-insights.ts
@@ -1,18 +1,8 @@
-import { InsightDataNode, SeriesSortDirection, SeriesSortMode } from '../../../graphql-operations'
-
-const DEFAULT_SERIES_DISPLAY_OPTIONS = {
-    limit: 20,
-    sortOptions: {
-        direction: SeriesSortDirection.DESC,
-        mode: SeriesSortMode.RESULT_COUNT,
-    },
-}
+import { InsightDataNode } from '../../../graphql-operations'
 
 export const MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE: InsightDataNode = {
     __typename: 'InsightView',
     id: '001',
-    appliedSeriesDisplayOptions: DEFAULT_SERIES_DISPLAY_OPTIONS,
-    defaultSeriesDisplayOptions: DEFAULT_SERIES_DISPLAY_OPTIONS,
     dataSeries: [
         {
             __typename: 'InsightsSeries',


### PR DESCRIPTION
## Background

This PR just removes unused fields from the insight data view GQL query.  This though has a few important implications that I want to highlight here
- We do not load unnecessary data (this is obviously a good thing)
- This PR insight view query does not re-trigger the insight configuration query. Prior to this PR if you open the insight standalone insight page you could notice that we have two requests to the backend to fetch insight configuration info (`GetInsights` query). This was happening because `GetInsights` fetches info about applied filters and they usually have a default value (null values) and then `GetInsightView` also queries applied filters info but in this time API returns applied filters that are not null values because we passed some filters in this. And this retriggers the FE cache and we have two network requests for the same data that we already have on the FE. 

<img width="562" alt="Screenshot 2022-07-06 at 13 17 39" src="https://user-images.githubusercontent.com/18492575/177607240-77d7bf7f-d1da-4cd3-b677-2505e10c7598.png">


## Test plan
- Make sure that we don't have extra network requests around insight configuration and insight data on the dashboard and standalone insight pages.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-get-insight-view-fetching.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nxvqbxcser.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
