### PR TITLE
rockskip: Update CHANGELOG for ROCKSKIP_MIN_REPO_SIZE_MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Changesets that are not associated with any batch changes can have a retention period set using the site configuration `batchChanges.changesetsRetention`. [#36188](https://github.com/sourcegraph/sourcegraph/pull/36188)
+- Added experimental support for exporting traces to an OpenTelemetry collector with `"observability.tracing": { "type": "opentelemetry" }` [#37984](https://github.com/sourcegraph/sourcegraph/pull/37984)
+- Code Insights over some repos now get 12 historic data points in addition to a current daily value and future points that align with the defined interval. [#37756](https://github.com/sourcegraph/sourcegraph/pull/37756)
+- Added `ROCKSKIP_MIN_REPO_SIZE_MB` to automatically use [Rockskip](https://docs.sourcegraph.com/code_intelligence/explanations/rockskip) for repositories over a certain size. [#38192](https://github.com/sourcegraph/sourcegraph/pull/38192)
 
 ### Changed
 

--- a/doc/code_intelligence/explanations/rockskip.md
+++ b/doc/code_intelligence/explanations/rockskip.md
@@ -26,7 +26,7 @@ services:
     environment:
       # 👇 Enables Rockskip
       - USE_ROCKSKIP=true
-      # 👇 Uses Rockskip for all the repositories over 1GB
+      # 👇 Uses Rockskip for all repositories over 1GB
       - ROCKSKIP_MIN_REPO_SIZE_MB=1000
 ```
 
@@ -40,9 +40,9 @@ symbols:
     # 👇 Enables Rockskip
     USE_ROCKSHIP:
       value: "true"
-    # 👇 Uses Rockskip for the repositories in the comma separated list
-    ROCKSKIP_REPOS:
-      value: "github.com/crossplane/crossplane,github.com/sgtest/megarepo"
+    # 👇 Uses Rockskip for all repositories over 1GB
+    ROCKSKIP_MIN_REPO_SIZE_MB:
+      value: "1000"
 ```
 
 For Kubernetes:
@@ -58,7 +58,7 @@ spec:
         # 👇 Enables Rockskip
         - name: USE_ROCKSKIP
           value: "true"
-        # 👇 Uses Rockskip for all the repositories over 1GB
+        # 👇 Uses Rockskip for all repositories over 1GB
         - name: ROCKSKIP_MIN_REPO_SIZE_MB
           value: "1000"
 ```


### PR DESCRIPTION
Updates the CHANGELOG and one more part of the docs.

## Test plan

N/A
