### PR TITLE
dev/sg: add envOverrides option for sets to override command env

### DIFF
--- a/dev/sg/internal/sgconf/config.go
+++ b/dev/sg/internal/sgconf/config.go
@@ -50,10 +50,11 @@ func parseConfig(data []byte) (*Config, error) {
 }
 
 type Commandset struct {
-	Name     string            `yaml:"-"`
-	Commands []string          `yaml:"commands"`
-	Checks   []string          `yaml:"checks"`
-	Env      map[string]string `yaml:"env"`
+	Name         string            `yaml:"-"`
+	Commands     []string          `yaml:"commands"`
+	Checks       []string          `yaml:"checks"`
+	Env          map[string]string `yaml:"env"`
+	EnvOverrides map[string]string `yaml:"envOverrides"`
 
 	// If this is set to true, then the commandset requires the dev-private
 	// repository to be cloned at the same level as the sourcegraph repository.
@@ -97,6 +98,9 @@ func (c *Commandset) Merge(other *Commandset) *Commandset {
 
 	for k, v := range other.Env {
 		merged.Env[k] = v
+	}
+	for k, v := range other.EnvOverrides {
+		merged.EnvOverrides[k] = v
 	}
 
 	merged.RequiresDevPrivate = other.RequiresDevPrivate

--- a/dev/sg/sg_run.go
+++ b/dev/sg/sg_run.go
@@ -73,7 +73,7 @@ func runExec(ctx *cli.Context) error {
 		cmds = append(cmds, cmd)
 	}
 
-	return run.Commands(ctx.Context, config.Env, verbose, cmds...)
+	return run.Commands(ctx.Context, config.Env, nil, verbose, cmds...)
 }
 
 func constructRunCmdLongHelp() string {

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -227,7 +227,7 @@ func startCommandSet(ctx context.Context, set *sgconf.Commandset, conf *sgconf.C
 		env[k] = v
 	}
 
-	return run.Commands(ctx, env, verbose, cmds...)
+	return run.Commands(ctx, env, set.EnvOverrides, verbose, cmds...)
 }
 
 // logLevelOverrides builds a map of commands -> log level that should be overridden in the environment.


### PR DESCRIPTION
Right now, command env takes precedence over set env. I'm scared to change this, so instead I added `envOverrides` and prop-drilled it to override whatever env is set on the command.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

See stack