### PR TITLE
dev/sg: fix enterprise-e2e set, fix frontend-e2e test preamble

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -747,7 +747,7 @@ commandsets:
 
   enterprise-e2e:
     <<: *enterprise_set
-    env:
+    envOverrides:
       # EXTSVC_CONFIG_FILE being set prevents the e2e test suite to add
       # additional connections.
       EXTSVC_CONFIG_FILE: ""
@@ -972,14 +972,19 @@ tests:
 
   frontend-e2e:
     preamble: |
-      'sg start enterprise-e2e' must be already running for these tests to work. You can also
-      run tests against an existing server image:
+      A Sourcegraph isntance must be already running for these tests to work, most
+      commonly with:
+
+        sg start enterprise-e2e
+
+      You can also run tests against an existing server image (note that this test must
+      be run with SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' for the following to work):
 
         TAG=insiders sg run server
 
       If you run into authentication issues, you can run the following commands to fix them:
 
-        sg db reset-pg && sg db add-user --username 'test' --password 'supersecurepassword'
+        sg db reset-pg && sg migration up && sg db add-user --username 'test' --password 'supersecurepassword'
 
       The above command resets the database and creates a user like so:
 


### PR DESCRIPTION
Fixes enterprise-e2e run set using `envOverrides` introduced in https://github.com/sourcegraph/sourcegraph/pull/38318 , and updates the `frontend-e2e` test preamble + db reset instructions

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
sg start enterprise-e2e
sg test frontend-e2e
```