### PR TITLE
add PartialJob

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -27,6 +27,19 @@ type Job interface {
 	Tags() []otlog.Field
 }
 
+// PartialJob is a partially constructed job that needs information only
+// available at runtime to resolve a fully constructed job.
+type PartialJob[P any] interface {
+	// Partial returns the partially constructed job. This interface allows us
+	// to inspect the state of a parameterized job before resolving it, which
+	// happens at runtime.
+	Partial() Job
+
+	// Resolve returns the fully constructed job using information that is only
+	// available at runtime.
+	Resolve(P) Job
+}
+
 type RuntimeClients struct {
 	Logger       log.Logger
 	DB           database.DB

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -93,7 +93,7 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 					return nil, err
 				}
 				addJob(&repoPagerJob{
-					child:            job,
+					child:            &reposPartialJob{job},
 					repoOpts:         repoOptions,
 					useIndex:         b.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(b.ToParseTree()),
@@ -117,7 +117,7 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 					return nil, err
 				}
 				addJob(&repoPagerJob{
-					child:            job,
+					child:            &reposPartialJob{job},
 					repoOpts:         repoOptions,
 					useIndex:         b.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(b.ToParseTree()),
@@ -212,7 +212,7 @@ func orderSearcherJob(j job.Job) job.Job {
 	collector := Mapper{
 		MapJob: func(current job.Job) job.Job {
 			if pager, ok := current.(*repoPagerJob); ok {
-				if _, ok := pager.child.(*searcher.TextSearchJob); ok {
+				if _, ok := pager.child.Partial().(*searcher.TextSearchJob); ok {
 					pagedSearcherJob = pager
 					return &NoopJob{}
 				}
@@ -234,7 +234,7 @@ func orderSearcherJob(j job.Job) job.Job {
 	orderer := Mapper{
 		MapJob: func(current job.Job) job.Job {
 			if pager, ok := current.(*repoPagerJob); ok {
-				if _, ok := pager.child.(*zoekt.RepoSubsetTextSearchJob); ok && !seenZoektRepoSearch {
+				if _, ok := pager.child.Partial().(*zoekt.RepoSubsetTextSearchJob); ok && !seenZoektRepoSearch {
 					seenZoektRepoSearch = true
 					return NewSequentialJob(false, current, pagedSearcherJob)
 				}
@@ -299,7 +299,7 @@ func NewFlatJob(searchInputs *run.SearchInputs, f query.Flat) (job.Job, error) {
 				}
 
 				addJob(&repoPagerJob{
-					child:            searcherJob,
+					child:            &reposPartialJob{searcherJob},
 					repoOpts:         repoOptions,
 					useIndex:         f.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
@@ -317,7 +317,7 @@ func NewFlatJob(searchInputs *run.SearchInputs, f query.Flat) (job.Job, error) {
 				}
 
 				addJob(&repoPagerJob{
-					child:            symbolSearchJob,
+					child:            &reposPartialJob{symbolSearchJob},
 					repoOpts:         repoOptions,
 					useIndex:         f.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),

--- a/internal/search/job/jobutil/mapper.go
+++ b/internal/search/job/jobutil/mapper.go
@@ -133,10 +133,12 @@ func (m *Mapper) Map(j job.Job) job.Job {
 		return j
 
 	case *repoPagerJob:
-		child := m.Map(j.child)
-		j.child = child
-		if m.MapRepoPagerJob != nil {
-			j = m.MapRepoPagerJob(j)
+		if j.child != nil {
+			child := m.Map(j.child.Partial())
+			j.child = &reposPartialJob{child}
+			if m.MapRepoPagerJob != nil {
+				j = m.MapRepoPagerJob(j)
+			}
 		}
 		return j
 

--- a/internal/search/job/jobutil/printers.go
+++ b/internal/search/job/jobutil/printers.go
@@ -59,7 +59,9 @@ func SexpFormat(j job.Job, sep, indent string) string {
 			b.WriteString("(REPOPAGER")
 			depth++
 			writeSep(b, sep, indent, depth)
-			writeSexp(j.child)
+			if j.child != nil {
+				writeSexp(j.child.Partial())
+			}
 			b.WriteString(")")
 			depth--
 
@@ -222,7 +224,9 @@ func PrettyMermaid(j job.Job) string {
 			depth++
 			writeNode(b, depth, RoundedStyle, &id, "REPOPAGER")
 			writeEdge(b, depth, srcId, id)
-			writeMermaid(j.child)
+			if j.child != nil {
+				writeMermaid(j.child.Partial())
+			}
 			depth--
 		case *AndJob:
 			srcId := id
@@ -341,12 +345,15 @@ func toJSON(j job.Job, verbose bool) any {
 			return j.Name()
 
 		case *repoPagerJob:
-			return struct {
+			s := struct {
 				Repopager any `json:"REPOPAGER"`
 			}{
-				Repopager: emitJSON(j.child),
+				Repopager: struct{}{},
 			}
-
+			if j.child != nil {
+				s.Repopager = emitJSON(j.child.Partial())
+			}
+			return s
 		case *AndJob:
 			children := make([]any, 0, len(j.children))
 			for _, child := range j.children {


### PR DESCRIPTION
This adds PartialJob to the internal/search/job package. The goal of
this type is to represent partially constructed jobs by the type system.
Right now, the only time we do something like this is with the repo
pager job, but the goal is to use this when converting more predicates
to just be jobs.

## Test plan

Integration tests + unit tests. Should be semantics-preserving, just a change in type encoding.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
