### PR TITLE
migration: fix sg logger scope, add success messages to up and validate

### DIFF
--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -228,7 +228,7 @@ func dbResetPGExec(ctx *cli.Context) error {
 	storeFactory := func(db *sql.DB, migrationsTable string) connections.Store {
 		return connections.NewStoreShim(store.NewWithDB(db, migrationsTable, store.NewOperations(&observation.TestContext)))
 	}
-	r, err := connections.RunnerFromDSNs(log.Scoped("dbResetPGExec", ""), dsnMap, "sg", storeFactory)
+	r, err := connections.RunnerFromDSNs(log.Scoped("migrations.runner", ""), dsnMap, "sg", storeFactory)
 	if err != nil {
 		return err
 	}

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -197,7 +197,13 @@ func dbResetPGExec(ctx *cli.Context) error {
 		}
 	}
 
-	for name, dsn := range dsnMap {
+	std.Out.WriteNoticef("This will reset database(s) %s%s%s. Are you okay with this?",
+		output.StyleOrange, strings.Join(schemaNames, ", "), output.StyleReset)
+	if ok := getBool(); !ok {
+		return NewEmptyExitErr(1)
+	}
+
+	for _, dsn := range dsnMap {
 		var (
 			db  *pgx.Conn
 			err error
@@ -206,12 +212,6 @@ func dbResetPGExec(ctx *cli.Context) error {
 		db, err = pgx.Connect(ctx.Context, dsn)
 		if err != nil {
 			return errors.Wrap(err, "failed to connect to Postgres database")
-		}
-
-		std.Out.WriteNoticef("This will reset database %s%s%s. Are you okay with this?", output.StyleOrange, name, output.StyleReset)
-		ok := getBool()
-		if !ok {
-			return nil
 		}
 
 		_, err = db.Exec(ctx.Context, "DROP SCHEMA public CASCADE; CREATE SCHEMA public;")

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -241,7 +241,12 @@ func dbResetPGExec(ctx *cli.Context) error {
 		})
 	}
 
-	return r.Run(ctx.Context, runner.Options{
+	if err := r.Run(ctx.Context, runner.Options{
 		Operations: operations,
-	})
+	}); err != nil {
+		return err
+	}
+
+	std.Out.WriteSuccessf("Database(s) reset!")
+	return nil
 }

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -173,7 +173,7 @@ func makeRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, erro
 	// configuration and use process env as fallback.
 	var getEnv func(string) string
 	config, _ := sgconf.Get(configFile, configOverwriteFile)
-	logger := log.Scoped("makeRunner", "")
+	logger := log.Scoped("migrations.runner", "migration runner")
 	if config != nil {
 		getEnv = config.GetEnv
 	} else {

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -654,7 +654,7 @@ Available schemas:
 
 Flags:
 
-* `--db="<value>"`: The target `schema(s)` to modify. Comma-separated values are accepted. Supply "all" to migrate all schemas. (default: [all])
+* `--db="<value>"`: The target `schema(s)` to validate. Comma-separated values are accepted. Supply "all" to validate all schemas. (default: [all])
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 
 ### sg migration describe

--- a/internal/database/migration/cliutil/up.go
+++ b/internal/database/migration/cliutil/up.go
@@ -72,7 +72,12 @@ func Up(commandName string, factory RunnerFactory, outFactory OutputFactory, dev
 			}
 		}
 
-		return r.Run(ctx, makeOptions(cmd, schemaNames))
+		if err := r.Run(ctx, makeOptions(cmd, schemaNames)); err != nil {
+			return err
+		}
+
+		out.WriteLine(output.Emoji(output.EmojiSuccess, "migrations okay!"))
+		return nil
 	})
 
 	return &cli.Command{

--- a/internal/database/migration/cliutil/validate.go
+++ b/internal/database/migration/cliutil/validate.go
@@ -11,7 +11,7 @@ import (
 func Validate(commandName string, factory RunnerFactory, outFactory OutputFactory) *cli.Command {
 	schemaNamesFlag := &cli.StringSliceFlag{
 		Name:  "db",
-		Usage: "The target `schema(s)` to modify. Comma-separated values are accepted. Supply \"all\" to migrate all schemas.",
+		Usage: "The target `schema(s)` to validate. Comma-separated values are accepted. Supply \"all\" to validate all schemas.",
 		Value: cli.NewStringSlice("all"),
 	}
 
@@ -28,7 +28,12 @@ func Validate(commandName string, factory RunnerFactory, outFactory OutputFactor
 			return err
 		}
 
-		return r.Validate(ctx, schemaNames...)
+		if err := r.Validate(ctx, schemaNames...); err != nil {
+			return err
+		}
+
+		out.WriteLine(output.Emoji(output.EmojiSuccess, "schema okay!"))
+		return nil
 	})
 
 	return &cli.Command{


### PR DESCRIPTION
Caught this because it seems `sg db reset-pg` needs to be followed by application of migrations in https://github.com/sourcegraph/sourcegraph/pull/38319

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg db reset-pg && sg migration up && sg migration validate`