### PR TITLE
codeintel: ignore blocked repos from dirty commit graph age

### DIFF
--- a/internal/codeintel/stores/dbstore/commits.go
+++ b/internal/codeintel/stores/dbstore/commits.go
@@ -151,6 +151,7 @@ SELECT ldr.repository_id, ldr.dirty_token
     INNER JOIN repo ON repo.id = ldr.repository_id
   WHERE ldr.dirty_token > ldr.update_token
     AND repo.deleted_at IS NULL
+	AND repo.blocked IS NULL
 `
 
 // MaxStaleAge returns the longest duration that a repository has been (currently) stale for. This method considers

--- a/internal/codeintel/uploads/internal/store/store_repositories.go
+++ b/internal/codeintel/uploads/internal/store/store_repositories.go
@@ -58,6 +58,7 @@ SELECT ldr.repository_id, ldr.dirty_token
     INNER JOIN repo ON repo.id = ldr.repository_id
   WHERE ldr.dirty_token > ldr.update_token
     AND repo.deleted_at IS NULL
+	AND repo.blocked IS NULL
 `
 
 // GetRepositoriesMaxStaleAge returns the longest duration that a repository has been (currently) stale for. This method considers


### PR DESCRIPTION
Skips blocked repositories with a dirty commit graph. Ideally these repos shouldnt be able to have any uploads (failing at an earlier stage), what Im assuming happened is that the repo became blocked between the upload being processed and the commit graph updater running for the repository (not sure how).

Closes https://github.com/sourcegraph/sourcegraph/issues/37996

## Test plan

Only affects a single metrics counter
