### PR TITLE
dev/sg: fix enterprise-e2e set with env hackery

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -747,7 +747,7 @@ commandsets:
 
   enterprise-e2e:
     <<: *enterprise_set
-    env:
+    envOverrides:
       # EXTSVC_CONFIG_FILE being set prevents the e2e test suite to add
       # additional connections.
       EXTSVC_CONFIG_FILE: ""
@@ -972,14 +972,19 @@ tests:
 
   frontend-e2e:
     preamble: |
-      'sg start enterprise-e2e' must be already running for these tests to work. You can also
-      run tests against an existing server image:
+      A Sourcegraph isntance must be already running for these tests to work, most
+      commonly with:
+
+        sg start enterprise-e2e
+
+      You can also run tests against an existing server image (note that this test must
+      be run with SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' for the following to work):
 
         TAG=insiders sg run server
 
       If you run into authentication issues, you can run the following commands to fix them:
 
-        sg db reset-pg && sg db add-user --username 'test' --password 'supersecurepassword'
+        sg db reset-pg && sg migration up && sg db add-user --username 'test' --password 'supersecurepassword'
 
       The above command resets the database and creates a user like so:
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -145,6 +145,11 @@ commands:
     cmd: |
       # TODO: This should be fixed
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
+      # If EXTSVC_CONFIG_FILE is *unset*, set a default.
+      if [ -z ${var+x} ]; then echo "var is unset"; else echo "var is set to '$var'"; fi
+      export EXTSVC_CONFIG_FILE=${EXTSVC_CONFIG_FILE-'../dev-private/enterprise/dev/external-services-config.json'}
+      echo $EXTSVC_CONFIG_FILE
+
       .bin/enterprise-frontend
     install: |
       if [ -n "$DELVE" ]; then
@@ -157,7 +162,6 @@ commands:
       USE_ENHANCED_LANGUAGE_DETECTION: false
       ENTERPRISE: 1
       SITE_CONFIG_FILE: '../dev-private/enterprise/dev/site-config.json'
-      EXTSVC_CONFIG_FILE: '../dev-private/enterprise/dev/external-services-config.json'
       SITE_CONFIG_ESCAPE_HATCH_PATH: '$HOME/.sourcegraph/site-config.json'
       # frontend processes need this to be so that the paths to the assets are rendered correctly
       WEBPACK_DEV_SERVER: 1
@@ -747,7 +751,7 @@ commandsets:
 
   enterprise-e2e:
     <<: *enterprise_set
-    envOverrides:
+    env:
       # EXTSVC_CONFIG_FILE being set prevents the e2e test suite to add
       # additional connections.
       EXTSVC_CONFIG_FILE: ""

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -986,7 +986,7 @@ tests:
 
       If you run into authentication issues, you can run the following commands to fix them:
 
-        sg db reset-pg && sg migration up && sg db add-user --username 'test' --password 'supersecurepassword'
+        sg db reset-pg --db=all && sg db add-user --username 'test' --password 'supersecurepassword'
 
       The above command resets the database and creates a user like so:
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -146,9 +146,7 @@ commands:
       # TODO: This should be fixed
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
       # If EXTSVC_CONFIG_FILE is *unset*, set a default.
-      if [ -z ${var+x} ]; then echo "var is unset"; else echo "var is set to '$var'"; fi
       export EXTSVC_CONFIG_FILE=${EXTSVC_CONFIG_FILE-'../dev-private/enterprise/dev/external-services-config.json'}
-      echo $EXTSVC_CONFIG_FILE
 
       .bin/enterprise-frontend
     install: |


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/pull/38318 and closes https://github.com/sourcegraph/sourcegraph/pull/38319 and uses some env setting in the command itself instead.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
sg start enterprise-e2e
sg test frontend-e2e
```

no more extsvc issues