### PR TITLE
search frontend: highlight queries accurately everywhere

### DIFF
--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -50,3 +50,107 @@ kbd {
 .search-filter-separator {
     color: var(--search-filter-separator-color);
 }
+
+.search-path-separator {
+    color: var(--search-filter-separator-color);
+}
+
+.search-regexp-meta-assertion {
+    color: var(--search-regexp-meta-assertion-color);
+}
+
+.search-regexp-meta-alternative {
+    color: var(--search-regexp-meta-alternative-color);
+}
+
+.search-regexp-meta-delimited {
+    color: var(--search-regexp-meta-delimited-color);
+}
+
+.search-regexp-meta-escaped-character {
+    color: var(--search-regexp-meta-escaped-character-color);
+}
+
+.search-regexp-meta-character-set {
+    color: var(--search-regexp-meta-character-set-color);
+}
+
+.search-regexp-meta-character-class {
+    color: var(--search-regexp-meta-character-class-color);
+}
+
+.search-regexp-meta-character-class-range {
+    color: var(--search-regexp-meta-character-class-range-color);
+}
+
+.search-regexp-meta-character-class-range-hyphen {
+    color: var(--search-regexp-meta-character-class-range-hyphen-color);
+}
+
+.search-regexp-meta-character-class-member {
+    color: var(--search-regexp-meta-character-class-member-color);
+}
+
+.search-regexp-meta-lazy-quantifier {
+    color: var(--search-regexp-meta-character-lazy-quantifier-color);
+}
+
+.search-regexp-meta-range-quantifier {
+    color: var(--search-regexp-meta-range-quantifier-color);
+}
+
+.search-revision-separator {
+    color: var(--search-revision-separator-color);
+}
+
+.search-revision-include-glob-marker {
+    color: var(--search-revision-include-glob-marker-color);
+}
+
+.search-revision-exclude-glob-marker {
+    color: var(--search-revision-exclude-glob-marker-color);
+}
+
+.search-revision-commit-hash {
+    color: var(--search-revision-commit-hash-color);
+}
+
+.search-revision-label {
+    color: var(--search-revision-label-color);
+}
+
+.search-revision-reference-path {
+    color: var(--search-revision-reference-path-color);
+}
+
+.search-revision-wildcard {
+    color: var(--search-revision-wildcard-color);
+}
+
+.search-predicate-name-access {
+    color: var(--search-predicate-name-access-color);
+}
+
+.search-predicate-dot {
+    color: var(--search-predicate-dot-color);
+}
+
+.search-predicate-parenthesis {
+    color: var(--search-predicate-parenthesis-color);
+}
+
+.search-structural-hole {
+    color: var(--search-structural-hole-color);
+}
+
+.search-structural-regexp-hole {
+    color: var(--search-structural-regexp-hole-color);
+}
+
+.search-structural-variable {
+    color: var(--search-structural-variable-color);
+}
+
+.search-structural-regexp-separator {
+    color: var(--search-structural-regexp-separator-color);
+}

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -145,10 +145,38 @@ $theme-colors: (
     --border-color-2: var(--gray-04);
     --border-active-color: var(--primary);
     --border-primary-color: #0f59aa; // = dark variant of primary-2
+    // Start query highlighting
     --search-query-text-color: var(--gray-12);
     --search-filter-keyword-color: var(--primary);
     --search-filter-separator-color: var(--oc-gray-6);
+    --search-path-separator-color: var(--oc-gray-6);
     --search-keyword-color: var(--purple);
+    --search-regexp-meta-assertion-color: var(--oc-red-9);
+    --search-regexp-meta-delimited-color: var(--oc-red-9);
+    --search-regexp-meta-lazy-quantifier-color: var(--oc-red-9);
+    --search-regexp-meta-escaped-character-color: var(--oc-red-9);
+    --search-regexp-meta-character-set-color: var(--purple);
+    --search-regexp-meta-character-class-color: var(--purple);
+    --search-regexp-meta-character-class-member-color: var(--search-query-text-color);
+    --search-regexp-meta-character-class-range-color: var(--search-query-text-color);
+    --search-regexp-meta-character-class-range-hyphen-color: var(--search-query-text-color);
+    --search-regexp-meta-range-quantifier-color: var(--oc-cyan-7);
+    --search-regexp-meta-alternative-color: var(--oc-cyan-7);
+    --search-revision-separator-color: var(--oc-orange-9);
+    --search-revision-include-glob-marker-color: var(--oc-red-9);
+    --search-revision-exclude-glob-marker-color: var(--oc-red-9);
+    --search-revision-commit-hash-color: var(--search-query-text-color);
+    --search-revision-label-color: var(--search-query-text-color);
+    --search-revision-reference-path-color: var(--search-query-text-color);
+    --search-revision-wildcard-color: var(--oc-cyan-7);
+    --search-predicate-name-access-color: var(--search-keyword-color);
+    --search-predicate-dot-color: var(--search-query-text-color);
+    --search-predicate-parenthesis-color: var(--oc-orange-9);
+    --search-structural-hole-color: var(--oc-red-9);
+    --search-structural-regexp-hole-color: var(--oc-red-9);
+    --search-structural-variable-color: var(--search-query-text-color);
+    --search-structural-regexp-separator-color: var(--oc-orange-9);
+    // End query highlighting
     --infobar-warning-color: var(--oc-red-8);
     --icon-color: var(--gray-06);
     --icon-muted: var(--gray-05);
@@ -209,10 +237,38 @@ $theme-colors: (
     --border-color-2: var(--gray-08);
     --border-active-color: #4393e7;
     --border-primary-color: #0f59aa; // = dark variant of primary-2
+    // Start query highlighting
     --search-query-text-color: var(--gray-04);
     --search-filter-keyword-color: #4393e7;
     --search-filter-separator-color: var(--oc-gray-6);
+    --search-path-separator-color: var(--oc-gray-6);
     --search-keyword-color: var(--pink);
+    --search-regexp-meta-assertion-color: var(--oc-red-5);
+    --search-regexp-meta-delimited-color: var(--oc-red-5);
+    --search-regexp-meta-lazy-quantifier-color: var(--oc-red-5);
+    --search-regexp-meta-escaped-character-color: var(--oc-red-3);
+    --search-regexp-meta-character-set-color: var(--pink);
+    --search-regexp-meta-character-class-color: var(--oc-grape-4);
+    --search-regexp-meta-character-class-member-color: var(--search-query-text-color);
+    --search-regexp-meta-character-class-range-color: var(--search-query-text-color);
+    --search-regexp-meta-character-class-range-hyphen-color: var(--search-query-text-color);
+    --search-regexp-meta-range-quantifier-color: var(--oc-cyan-4);
+    --search-regexp-meta-alternative-color: var(--oc-cyan-4);
+    --search-revision-separator-color: var(--oc-orange-4);
+    --search-revision-include-glob-marker-color: var(--oc-red-5);
+    --search-revision-exclude-glob-marker-color: var(--oc-red-5);
+    --search-revision-commit-hash-color: var(--search-query-text-color);
+    --search-revision-label-color: var(--search-query-text-color);
+    --search-revision-reference-path-color: var(--search-query-text-color);
+    --search-revision-wildcard-color: var(--oc-cyan-4);
+    --search-predicate-name-access-color: var(--search-keyword-color);
+    --search-predicate-dot-color: var(--search-query-text-color);
+    --search-predicate-parenthesis-color: var(--oc-orange-4);
+    --search-structural-hole-color: var(--oc-red-5);
+    --search-structural-regexp-hole-color: var(--oc-red-5);
+    --search-structural-variable-color: var(--search-query-text-color);
+    --search-structural-regexp-separator-color: var(--oc-orange-4);
+    // End query highlighting
     --infobar-warning-color: #f05151;
     --icon-color: var(--gray-05);
     --icon-muted: var(--gray-07);

--- a/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -2,10 +2,194 @@ import React, { Fragment, useMemo } from 'react'
 
 import classNames from 'classnames'
 
+import { decorate, DecoratedToken } from '@sourcegraph/shared/src/search/query/decoratedToken'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 
 interface SyntaxHighlightedSearchQueryProps extends React.HTMLAttributes<HTMLSpanElement> {
     query: string
+}
+
+interface decoration {
+    value: string
+    key: number
+    className: string
+}
+
+function toDecoration(query: string, token: DecoratedToken): decoration {
+    switch (token.type) {
+        case 'field':
+            return {
+                value: token.value,
+                key: token.range.start,
+                className: 'search-filter-keyword',
+            }
+        case 'keyword':
+            return {
+                value: token.value,
+                key: token.range.start,
+                className: 'search-keyword',
+            }
+        case 'openingParen':
+            return {
+                value: '(',
+                key: token.range.start,
+                className: 'search-keyword',
+            }
+        case 'closingParen':
+            return {
+                value: ')',
+                key: token.range.start,
+                className: 'search-keyword',
+            }
+
+        case 'metaFilterSeparator':
+            return {
+                value: ':',
+                key: token.range.start,
+                className: 'search-filter-separator',
+            }
+        case 'metaRepoRevisionSeparator':
+        case 'metaContextPrefix':
+            return {
+                value: '@',
+                key: token.range.start,
+                className: 'search-keyword',
+            }
+        case 'metaPath':
+            return {
+                value: token.value,
+                key: token.range.start,
+                className: 'search-path-separator',
+            }
+
+        case 'metaRevision': {
+            let kind = ''
+            switch (token.kind) {
+                case 'Separator':
+                    kind = 'separator'
+                    break
+                case 'IncludeGlobMarker':
+                    kind = 'include-glob-marker'
+                    break
+                case 'ExcludeGlobMarker':
+                    kind = 'exclude-glob-marker'
+                    break
+                case 'CommitHash':
+                    kind = 'commit-hash'
+                    break
+                case 'Label':
+                    kind = 'label'
+                    break
+                case 'ReferencePath':
+                    kind = 'reference-path'
+                    break
+                case 'Wildcard':
+                    kind = 'wildcard'
+                    break
+            }
+            return {
+                value: token.value,
+                key: token.range.start,
+                className: `search-revision-${kind}`,
+            }
+        }
+
+        case 'metaRegexp': {
+            let kind = ''
+            switch (token.kind) {
+                case 'Assertion':
+                    kind = 'assertion'
+                    break
+                case 'Alternative':
+                    kind = 'alternative'
+                    break
+                case 'Delimited':
+                    kind = 'delimited'
+                    break
+                case 'EscapedCharacter':
+                    kind = 'escaped-character'
+                    break
+                case 'CharacterSet':
+                    kind = 'character-set'
+                    break
+                case 'CharacterClass':
+                    kind = 'character-class'
+                    break
+                case 'CharacterClassRange':
+                    kind = 'character-class-range'
+                    break
+                case 'CharacterClassRangeHyphen':
+                    kind = 'character-class-range-hyphen'
+                    break
+                case 'CharacterClassMember':
+                    kind = 'character-class-member'
+                    break
+                case 'LazyQuantifier':
+                    kind = 'lazy-quantifier'
+                    break
+                case 'RangeQuantifier':
+                    kind = 'range-quantifier'
+                    break
+            }
+            return {
+                value: token.value,
+                key: token.range.start,
+                className: `search-regexp-meta-${kind}`,
+            }
+        }
+
+        case 'metaPredicate': {
+            let kind = ''
+            let value = ''
+            switch (token.kind) {
+                case 'NameAccess':
+                    kind = 'name-access'
+                    value = query.slice(token.range.start, token.range.end)
+                    break
+                case 'Dot':
+                    kind = 'dot'
+                    value = '.'
+                    break
+                case 'Parenthesis':
+                    kind = 'parenthesis'
+                    value = query.slice(token.range.start, token.range.end)
+                    break
+            }
+            return {
+                value,
+                key: token.range.start,
+                className: `search-predicate-${kind}`,
+            }
+        }
+
+        case 'metaStructural': {
+            let kind = ''
+            switch (token.kind) {
+                case 'Hole':
+                    kind = 'hole'
+                    break
+                case 'RegexpHole':
+                    kind = 'regexp-hole'
+                    break
+                case 'Variable':
+                    kind = 'variable'
+                    break
+                case 'RegexpSeparator':
+                    kind = 'regexp-separator'
+                    break
+            }
+            return {
+                value: token.value,
+                key: token.range.start,
+                className: `search-structural-${kind}`,
+            }
+        }
+    }
+    return {
+        value: query.slice(token.range.start, token.range.end),
+        key: token.range.start,
+        className: 'search-query-text',
+    }
 }
 
 // A read-only syntax highlighted search query
@@ -13,29 +197,18 @@ export const SyntaxHighlightedSearchQuery: React.FunctionComponent<
     React.PropsWithChildren<SyntaxHighlightedSearchQueryProps>
 > = ({ query, ...otherProps }) => {
     const tokens = useMemo(() => {
-        const scannedQuery = scanSearchQuery(query)
-        return scannedQuery.type === 'success'
-            ? scannedQuery.term.map(token => {
-                  if (token.type === 'filter') {
+        const tokens = scanSearchQuery(query)
+        return tokens.type === 'success'
+            ? tokens.term.flatMap(token =>
+                  decorate(token).map(token => {
+                      const { value, key, className } = toDecoration(query, token)
                       return (
-                          <Fragment key={token.range.start}>
-                              <span className="search-filter-keyword">
-                                  {query.slice(token.field.range.start, token.field.range.end)}
-                              </span>
-                              <span className="search-filter-separator">:</span>
-                              {token.value ? <>{query.slice(token.value.range.start, token.value.range.end)}</> : null}
-                          </Fragment>
-                      )
-                  }
-                  if (token.type === 'keyword') {
-                      return (
-                          <span className="search-keyword" key={token.range.start}>
-                              {query.slice(token.range.start, token.range.end)}
+                          <span className={className} key={key}>
+                              {value}
                           </span>
                       )
-                  }
-                  return <Fragment key={token.range.start}>{query.slice(token.range.start, token.range.end)}</Fragment>
-              })
+                  })
+              )
             : [<Fragment key="0">{query}</Fragment>]
     }, [query])
 

--- a/client/search-ui/src/components/__snapshots__/SyntaxHighlightedSearchQuery.test.tsx.snap
+++ b/client/search-ui/src/components/__snapshots__/SyntaxHighlightedSearchQuery.test.tsx.snap
@@ -15,7 +15,16 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight filter 1`] = `
     >
       :
     </span>
-    sourcegraph 
+    <span
+      class="search-query-text"
+    >
+      sourcegraph
+    </span>
+    <span
+      class="search-query-text"
+    >
+       
+    </span>
     <span
       class="search-filter-keyword"
     >
@@ -26,7 +35,11 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight filter 1`] = `
     >
       :
     </span>
-    go
+    <span
+      class="search-query-text"
+    >
+      go
+    </span>
   </span>
 </DocumentFragment>
 `;
@@ -46,13 +59,41 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight filter and operato
     >
       :
     </span>
-    sourcegraph test 
+    <span
+      class="search-query-text"
+    >
+      sourcegraph
+    </span>
+    <span
+      class="search-query-text"
+    >
+       
+    </span>
+    <span
+      class="search-query-text"
+    >
+      test
+    </span>
+    <span
+      class="search-query-text"
+    >
+       
+    </span>
     <span
       class="search-keyword"
     >
       and
     </span>
-     spec
+    <span
+      class="search-query-text"
+    >
+       
+    </span>
+    <span
+      class="search-query-text"
+    >
+      spec
+    </span>
   </span>
 </DocumentFragment>
 `;
@@ -72,7 +113,21 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight negated filter 1`]
     >
       :
     </span>
-    ts test
+    <span
+      class="search-query-text"
+    >
+      ts
+    </span>
+    <span
+      class="search-query-text"
+    >
+       
+    </span>
+    <span
+      class="search-query-text"
+    >
+      test
+    </span>
   </span>
 </DocumentFragment>
 `;
@@ -82,13 +137,31 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight operator 1`] = `
   <span
     class="text-monospace search-query-link"
   >
-    test 
+    <span
+      class="search-query-text"
+    >
+      test
+    </span>
+    <span
+      class="search-query-text"
+    >
+       
+    </span>
     <span
       class="search-keyword"
     >
       or
     </span>
-     spec
+    <span
+      class="search-query-text"
+    >
+       
+    </span>
+    <span
+      class="search-query-text"
+    >
+      spec
+    </span>
   </span>
 </DocumentFragment>
 `;

--- a/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -357,7 +357,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
             >
               :
             </span>
-            2m
+            <span
+              class="search-query-text"
+            >
+              2m
+            </span>
           </span>
           )
         </label>
@@ -381,7 +385,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           <span
             class="text-monospace search-query-link"
           >
-            forked:yes
+            <span
+              class="search-query-text"
+            >
+              forked:yes
+            </span>
           </span>
           )
         </label>
@@ -415,7 +423,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
             >
               :
             </span>
-            yes
+            <span
+              class="search-query-text"
+            >
+              yes
+            </span>
           </span>
           )
         </label>
@@ -449,7 +461,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
             >
               :
             </span>
-            yes
+            <span
+              class="search-query-text"
+            >
+              yes
+            </span>
           </span>
           )
         </label>

--- a/client/search-ui/src/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
+++ b/client/search-ui/src/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
@@ -25,7 +25,11 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
         >
           :
         </span>
-        go
+        <span
+          class="search-query-text"
+        >
+          go
+        </span>
       </span>
     </span>
     <span
@@ -58,7 +62,11 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
         >
           :
         </span>
-        typescript
+        <span
+          class="search-query-text"
+        >
+          typescript
+        </span>
       </span>
     </span>
     <span
@@ -91,7 +99,26 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
         >
           :
         </span>
-        _test\\.go$
+        <span
+          class="search-query-text"
+        >
+          _test
+        </span>
+        <span
+          class="search-regexp-meta-escaped-character"
+        >
+          \\.
+        </span>
+        <span
+          class="search-query-text"
+        >
+          go
+        </span>
+        <span
+          class="search-regexp-meta-assertion"
+        >
+          $
+        </span>
       </span>
     </span>
     <span

--- a/client/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
+++ b/client/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
@@ -51,7 +51,11 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
                   <span
                     class="text-monospace search-query-link"
                   >
-                    test
+                    <span
+                      class="search-query-text"
+                    >
+                      test
+                    </span>
                   </span>
                 </a>
               </small>
@@ -91,7 +95,11 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
                     >
                       :
                     </span>
-                    sourcegraph
+                    <span
+                      class="search-query-text"
+                    >
+                      sourcegraph
+                    </span>
                   </span>
                 </a>
               </small>
@@ -175,7 +183,11 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                   <span
                     class="text-monospace search-query-link"
                   >
-                    test
+                    <span
+                      class="search-query-text"
+                    >
+                      test
+                    </span>
                   </span>
                 </a>
               </small>
@@ -215,7 +227,11 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                     >
                       :
                     </span>
-                    sourcegraph
+                    <span
+                      class="search-query-text"
+                    >
+                      sourcegraph
+                    </span>
                   </span>
                 </a>
               </small>
@@ -305,7 +321,11 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
                   <span
                     class="text-monospace search-query-link"
                   >
-                    test
+                    <span
+                      class="search-query-text"
+                    >
+                      test
+                    </span>
                   </span>
                 </a>
               </small>
@@ -345,7 +365,11 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
                     >
                       :
                     </span>
-                    sourcegraph
+                    <span
+                      class="search-query-text"
+                    >
+                      sourcegraph
+                    </span>
                   </span>
                 </a>
               </small>
@@ -419,7 +443,11 @@ exports[`RecentSearchesPanel searches with no argument are skipped 1`] = `
                   <span
                     class="text-monospace search-query-link"
                   >
-                    test
+                    <span
+                      class="search-query-text"
+                    >
+                      test
+                    </span>
                   </span>
                 </a>
               </small>
@@ -459,7 +487,11 @@ exports[`RecentSearchesPanel searches with no argument are skipped 1`] = `
                     >
                       :
                     </span>
-                    sourcegraph
+                    <span
+                      class="search-query-text"
+                    >
+                      sourcegraph
+                    </span>
                   </span>
                 </a>
               </small>

--- a/client/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
+++ b/client/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
@@ -54,7 +54,11 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
                     >
                       :
                     </span>
-                    sourcegraph
+                    <span
+                      class="search-query-text"
+                    >
+                      sourcegraph
+                    </span>
                   </span>
                 </a>
               </small>
@@ -82,7 +86,11 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
                     >
                       :
                     </span>
-                    test
+                    <span
+                      class="search-query-text"
+                    >
+                      test
+                    </span>
                   </span>
                 </a>
               </small>
@@ -149,7 +157,11 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
                     >
                       :
                     </span>
-                    test
+                    <span
+                      class="search-query-text"
+                    >
+                      test
+                    </span>
                   </span>
                 </a>
               </small>
@@ -177,7 +189,11 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
                     >
                       :
                     </span>
-                    sourcegraph
+                    <span
+                      class="search-query-text"
+                    >
+                      sourcegraph
+                    </span>
                   </span>
                 </a>
               </small>
@@ -205,7 +221,11 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
                     >
                       :
                     </span>
-                    test-two
+                    <span
+                      class="search-query-text"
+                    >
+                      test-two
+                    </span>
                   </span>
                 </a>
               </small>
@@ -282,7 +302,11 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                     >
                       :
                     </span>
-                    test
+                    <span
+                      class="search-query-text"
+                    >
+                      test
+                    </span>
                   </span>
                 </a>
               </small>
@@ -310,7 +334,11 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                     >
                       :
                     </span>
-                    sourcegraph
+                    <span
+                      class="search-query-text"
+                    >
+                      sourcegraph
+                    </span>
                   </span>
                 </a>
               </small>
@@ -338,7 +366,11 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                     >
                       :
                     </span>
-                    test-two
+                    <span
+                      class="search-query-text"
+                    >
+                      test-two
+                    </span>
                   </span>
                 </a>
               </small>
@@ -421,7 +453,11 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
                     >
                       :
                     </span>
-                    test
+                    <span
+                      class="search-query-text"
+                    >
+                      test
+                    </span>
                   </span>
                 </a>
               </small>
@@ -449,7 +485,11 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
                     >
                       :
                     </span>
-                    sourcegraph
+                    <span
+                      class="search-query-text"
+                    >
+                      sourcegraph
+                    </span>
                   </span>
                 </a>
               </small>


### PR DESCRIPTION
We use this other query highlighting stuff in a lot of places and its incomplete:

- recent searches
- query suggestions
- side panel
- code insights
- ???

Why work on this now? I want lucky search suggestions to look good and communicate context about regular expression patterns with `/.../`. Honestly there are so many places that benefit from better contextual highlighting this is a no-brainer. Now the highlighting is mostly complete. It needs additions to handle patterns that I will add in follow up PR.

![Screen Shot 2022-07-06 at 1 35 59 PM](https://user-images.githubusercontent.com/888624/177638819-38ded1e7-66c0-4391-aee1-2dd9de72e5c9.png)

Don't be intimidated by the size of the PR, it's just mechanical changes and mapping everything for light/dark theme stuff. You should feel good about even just stamping because I can correct anything in follow up and it leaves things no worse than before :-)

Separately: the order of definitions is a bit out of place across the monaco code, SCSS, and logic case statements. I will make a separate PR to order things consistently in follow up (it's tricky to keep track of adding the additions int his PR alone, I have like 8 windows open to make sure I copy the right definitions :-))

## Test plan
updated

## App preview:

- [Web](https://sg-web-rvt-highlight-query-everywhere-x.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fmbqogyrcc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

