### PR TITLE
search: Show token information for operators (CodeMirror)

### DIFF
--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -55,7 +55,7 @@ import { getSuggestionQuery } from '@sourcegraph/shared/src/search/query/provide
 import { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
 import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
-import { parsedQuery } from './parsedQuery'
+import { queryTokens } from './parsedQuery'
 
 import styles from '../CodeMirrorQueryInput.module.scss'
 
@@ -134,7 +134,7 @@ export function searchQueryAutocompletion(
 ): Extension {
     const override: CompletionSource[] = sources.map(source => context => {
         const position = context.pos
-        const query = context.state.facet(parsedQuery)
+        const query = context.state.facet(queryTokens)
         const token = query.tokens.find(token => isTokenInRange(token, position))
         return source(
             { position, onAbort: listener => context.addEventListener('abort', listener) },
@@ -173,7 +173,7 @@ export function searchQueryAutocompletion(
             // If a filter was completed, show the completion list again for
             // filter values.
             if (update.transactions.some(transaction => transaction.isUserEvent('input.complete'))) {
-                const query = update.state.facet(parsedQuery)
+                const query = update.state.facet(queryTokens)
                 const token = query.tokens.find(token => isTokenInRange(token, update.state.selection.main.anchor - 1))
                 if (token) {
                     startCompletion(update.view)

--- a/client/shared/src/search/query/parser.ts
+++ b/client/shared/src/search/query/parser.ts
@@ -205,8 +205,8 @@ export const parseOr = (tokens: Token[]): State => {
 /**
  * Produces a parse tree from a search query.
  */
-export const parseSearchQuery = (input: string): ParseResult => {
-    const result = scanSearchQuery(input)
+export const parseSearchQuery = (input: string | ScanResult<Token[]>): ParseResult => {
+    const result = typeof input === 'string' ? scanSearchQuery(input) : input
     if (result.type === 'error') {
         return {
             type: 'error',

--- a/client/shared/src/search/query/parser.ts
+++ b/client/shared/src/search/query/parser.ts
@@ -1,4 +1,4 @@
-import { scanSearchQuery } from './scanner'
+import { ScanResult, scanSearchQuery } from './scanner'
 import { PatternKind, Token, KeywordKind, CharacterRange } from './token'
 
 export interface Pattern {


### PR DESCRIPTION
Stacking on top of #38335, this commit extends the token info extension to
highlight and show tooltip information for AND and OR operators.

To do this I updated the editor state to also compute a parse tree from
the current query tokens in a new facet. If an operator is hovered
I'm locating the corresponding node in the parse tree and use that nodes
range information to highlight the operator and its operands.

If the query cannot be parsed as a parse tree it falls back to just
highlighting the operator.

I guess highlighting operands in a different color would be even
better but it's a start?

Also if you have a better idea for the tooltip text, please let me know!

Demo video: 

https://user-images.githubusercontent.com/179026/177644906-ee659f41-3323-4067-8248-20d89048aee7.mp4


## Test plan

Enter query containing `and` and `or` operators and parenthesis into query input and hover over operators.

## App preview:

- [Web](https://sg-web-fkling-highlight-operators.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mkzpdnflvd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
