### PR TITLE
search: Implement `repo:description(...)` predicate

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -225,6 +225,14 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         showSuggestions: true,
     },
     {
+        ...createQueryExampleFromString('description({regex-pattern})'),
+        field: FilterType.repo,
+        description:
+            'Search inside repositories that have a description matched by the provided regex pattern.',
+        examples: ['repo:description(linux kernel)', 'repo:description(go.*library)'],
+        showSuggestions: false,
+    },
+    {
         ...createQueryExampleFromString('{revision}'),
         field: FilterType.rev,
         commonRank: 20,

--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -227,8 +227,7 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
     {
         ...createQueryExampleFromString('description({regex-pattern})'),
         field: FilterType.repo,
-        description:
-            'Search inside repositories that have a description matched by the provided regex pattern.',
+        description: 'Search inside repositories that have a description matched by the provided regex pattern.',
         examples: ['repo:description(linux kernel)', 'repo:description(go.*library)'],
         showSuggestions: false,
     },

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -408,6 +408,7 @@ describe('getCompletionItems()', () => {
               "dependencies(\${1}) ",
               "revdeps(\${1}) ",
               "dependents(\${1}) ",
+              "description(\${1}) ",
               "^repo/with\\\\ a\\\\ space$ "
             ]
         `)
@@ -432,7 +433,8 @@ describe('getCompletionItems()', () => {
               "deps(\${1}) ",
               "dependencies(\${1}) ",
               "revdeps(\${1}) ",
-              "dependents(\${1}) "
+              "dependents(\${1}) ",
+              "description(\${1}) "
             ]
         `)
     })

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -14,6 +14,7 @@ const filterCompletionItemKind = Monaco.languages.CompletionItemKind.Issue
 
 type PartialCompletionItem = Omit<Monaco.languages.CompletionItem, 'range'>
 
+export const REPO_DESCRIPTION_PREDICATE_REGEX = /^(description)\((.*?)\)?$/
 export const REPO_DEPS_PREDICATE_REGEX = /^(deps|dependencies|revdeps|dependents)\((.*?)\)?$/
 export const PREDICATE_REGEX = /^([.A-Za-z]+)\((.*?)\)?$/
 
@@ -101,6 +102,12 @@ export const repositoryInsertText = (
     if (depsPredicateMatches) {
         // depsPredicateMatches[1] contains either `deps`, `dependencies`, `revdeps` or `dependents` based on the matched value.
         return `${depsPredicateMatches[1]}(${insertText})`
+    }
+
+    const descriptionPredicateMatches = options.filterValue ? options.filterValue.match(REPO_DESCRIPTION_PREDICATE_REGEX): null
+    if (descriptionPredicateMatches) {
+        // descriptionPredicateMatches[1] contains `description`
+        return `${descriptionPredicateMatches[1]}(${insertText})`
     }
 
     return insertText

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -104,7 +104,9 @@ export const repositoryInsertText = (
         return `${depsPredicateMatches[1]}(${insertText})`
     }
 
-    const descriptionPredicateMatches = options.filterValue ? options.filterValue.match(REPO_DESCRIPTION_PREDICATE_REGEX): null
+    const descriptionPredicateMatches = options.filterValue
+        ? options.filterValue.match(REPO_DESCRIPTION_PREDICATE_REGEX)
+        : null
     if (descriptionPredicateMatches) {
         // descriptionPredicateMatches[1] contains `description`
         return `${descriptionPredicateMatches[1]}(${insertText})`

--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1520,6 +1520,41 @@ describe('getMonacoTokens()', () => {
         `)
     })
 
+    test('highlight repo:description predicate', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:description(.*)')))).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 16,
+                "scopes": "metaPredicateParenthesis"
+              },
+              {
+                "startIndex": 17,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "metaRegexpRangeQuantifier"
+              },
+              {
+                "startIndex": 19,
+                "scopes": "metaPredicateParenthesis"
+              }
+            ]
+        `)
+    })
+
     test('highlight regex delimited pattern for standard search', () => {
         expect(getMonacoTokens(toSuccess(scanSearchQuery('/f.*/ x', false, SearchPatternType.standard))))
             .toMatchInlineSnapshot(`

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -965,6 +965,7 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
         case 'deps':
         case 'dependents':
         case 'revdeps':
+        case 'description':
             return mapRegexpMetaSucceed({
                 type: 'pattern',
                 range: { start: offset, end: body.length },

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -172,6 +172,8 @@ const toPredicateHover = (token: MetaPredicate): string => {
         case 'dependents':
         case 'revdeps':
             return '**Built-in predicate**. Search only repositories depending on repositories matching the regular expression'
+        case 'description':
+            return '**Built-in predicate**. Search only inside repositories that have a **description** matching the given regular expression'
     }
     return ''
 }

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -38,6 +38,9 @@ export const PREDICATES: Access[] = [
             {
                 name: 'revdeps',
             },
+            {
+                name: 'description',
+            }
         ],
     },
     {
@@ -196,6 +199,11 @@ export const predicateCompletion = (field: string): Completion[] => {
                 insertText: 'dependents(${1})',
                 asSnippet: true,
             },
+            {
+                label: 'description(...)',
+                insertText: 'description(${1})',
+                asSnippet: true,
+            }
         ]
     }
     return []

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -40,7 +40,7 @@ export const PREDICATES: Access[] = [
             },
             {
                 name: 'description',
-            }
+            },
         ],
     },
     {
@@ -203,7 +203,7 @@ export const predicateCompletion = (field: string): Completion[] => {
                 label: 'description(...)',
                 insertText: 'description(${1})',
                 asSnippet: true,
-            }
+            },
         ]
     }
     return []

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -5,7 +5,7 @@ import { map, delay, takeUntil, switchMap } from 'rxjs/operators'
 import { SearchPatternType } from '../../graphql-operations'
 import { isSearchMatchOfType, SearchMatch } from '../stream'
 
-import { getCompletionItems, REPO_DEPS_PREDICATE_REGEX } from './completion'
+import {getCompletionItems, REPO_DEPS_PREDICATE_REGEX, REPO_DESCRIPTION_PREDICATE_REGEX} from './completion'
 import { getMonacoTokens } from './decoratedToken'
 import { FilterType } from './filters'
 import { getHoverResult } from './hover'
@@ -67,10 +67,10 @@ export function getSuggestionQuery(tokens: Token[], tokenAtColumn: Token, sugges
     }
 
     if (suggestionType === 'repo') {
-        const depsPredicateMatch = tokenValue.match(REPO_DEPS_PREDICATE_REGEX)
-        const repoValue = depsPredicateMatch ? depsPredicateMatch[2] : tokenValue
+        const predicateMatch = tokenValue.match(REPO_DEPS_PREDICATE_REGEX) || tokenValue.match(REPO_DESCRIPTION_PREDICATE_REGEX)
+        const repoValue = predicateMatch ? predicateMatch[2] : tokenValue
         const relevantFilters =
-            !hasAndOrOperators && !depsPredicateMatch ? serializeFilters(tokens, REPO_SUGGESTION_FILTERS) : ''
+            !hasAndOrOperators && !predicateMatch ? serializeFilters(tokens, REPO_SUGGESTION_FILTERS) : ''
         return `${relevantFilters} repo:${repoValue} type:repo count:${MAX_SUGGESTION_COUNT}`.trimStart()
     }
 

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -5,7 +5,7 @@ import { map, delay, takeUntil, switchMap } from 'rxjs/operators'
 import { SearchPatternType } from '../../graphql-operations'
 import { isSearchMatchOfType, SearchMatch } from '../stream'
 
-import {getCompletionItems, REPO_DEPS_PREDICATE_REGEX, REPO_DESCRIPTION_PREDICATE_REGEX} from './completion'
+import { getCompletionItems, REPO_DEPS_PREDICATE_REGEX, REPO_DESCRIPTION_PREDICATE_REGEX } from './completion'
 import { getMonacoTokens } from './decoratedToken'
 import { FilterType } from './filters'
 import { getHoverResult } from './hover'
@@ -67,7 +67,8 @@ export function getSuggestionQuery(tokens: Token[], tokenAtColumn: Token, sugges
     }
 
     if (suggestionType === 'repo') {
-        const predicateMatch = tokenValue.match(REPO_DEPS_PREDICATE_REGEX) || tokenValue.match(REPO_DESCRIPTION_PREDICATE_REGEX)
+        const predicateMatch =
+            tokenValue.match(REPO_DEPS_PREDICATE_REGEX) || tokenValue.match(REPO_DESCRIPTION_PREDICATE_REGEX)
         const repoValue = predicateMatch ? predicateMatch[2] : tokenValue
         const relevantFilters =
             !hasAndOrOperators && !predicateMatch ? serializeFilters(tokens, REPO_SUGGESTION_FILTERS) : ''

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1639,7 +1639,7 @@ func parseCursorConds(cs types.MultiCursor) (cond *sqlf.Query, err error) {
 
 // parseIncludePattern either (1) parses the pattern into a list of exact possible
 // string values and LIKE patterns if such a list can be determined from the pattern,
-// and (2) returns the original regexp if those patterns are not equivalent to the
+// or (2) returns the original regexp if those patterns are not equivalent to the
 // regexp.
 //
 // It allows Repos.List to optimize for the common case where a pattern like

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -623,6 +623,7 @@ func toRepoOptions(b query.Basic, userSettings *schema.Settings) search.RepoOpti
 		MinusRepoFilters:  minusRepoFilters,
 		Dependencies:      b.Dependencies(),
 		Dependents:        b.Dependents(),
+		Description:       b.Description(),
 		SearchContextSpec: searchContextSpec,
 		ForkSet:           b.Fork() != nil,
 		OnlyForks:         fork == query.Only,

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -619,20 +619,20 @@ func toRepoOptions(b query.Basic, userSettings *schema.Settings) search.RepoOpti
 	searchContextSpec := b.FindValue(query.FieldContext)
 
 	return search.RepoOptions{
-		RepoFilters:       repoFilters,
-		MinusRepoFilters:  minusRepoFilters,
-		Dependencies:      b.Dependencies(),
-		Dependents:        b.Dependents(),
-		Description:       b.Description(),
-		SearchContextSpec: searchContextSpec,
-		ForkSet:           b.Fork() != nil,
-		OnlyForks:         fork == query.Only,
-		NoForks:           fork == query.No,
-		ArchivedSet:       b.Archived() != nil,
-		OnlyArchived:      archived == query.Only,
-		NoArchived:        archived == query.No,
-		Visibility:        visibility,
-		CommitAfter:       b.RepoContainsCommitAfter(),
+		RepoFilters:         repoFilters,
+		MinusRepoFilters:    minusRepoFilters,
+		Dependencies:        b.Dependencies(),
+		Dependents:          b.Dependents(),
+		DescriptionPatterns: b.Description(),
+		SearchContextSpec:   searchContextSpec,
+		ForkSet:             b.Fork() != nil,
+		OnlyForks:           fork == query.Only,
+		NoForks:             fork == query.No,
+		ArchivedSet:         b.Archived() != nil,
+		OnlyArchived:        archived == query.Only,
+		NoArchived:          archived == query.No,
+		Visibility:          visibility,
+		CommitAfter:         b.RepoContainsCommitAfter(),
 	}
 }
 

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -325,7 +325,7 @@ type RepoDescriptionPredicate struct{}
 
 func (f *RepoDescriptionPredicate) ParseParams(params string) (err error) {
 	if _, err := regexp.Compile(params); err != nil {
-		return errors.Errorf("repo:description argument: %w", err)
+		return errors.Errorf("invalid repo:description argument: %w", err)
 	}
 	if len(params) == 0 {
 		return errors.New("empty repo:description predicate parameter")

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -40,6 +40,7 @@ var DefaultPredicateRegistry = PredicateRegistry{
 		"deps":                  func() Predicate { return &RepoDependenciesPredicate{} },
 		"dependents":            func() Predicate { return &RepoDependentsPredicate{} },
 		"revdeps":               func() Predicate { return &RepoDependentsPredicate{} },
+		"description":           func() Predicate { return &RepoDescriptionPredicate{} },
 	},
 	FieldFile: {
 		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
@@ -315,6 +316,26 @@ func (f *RepoDependentsPredicate) ParseParams(params string) (err error) {
 func (f *RepoDependentsPredicate) Field() string { return FieldRepo }
 func (f *RepoDependentsPredicate) Name() string  { return "dependents" }
 func (f *RepoDependentsPredicate) Plan(parent Basic) (Plan, error) {
+	return nil, nil
+}
+
+/* repo:description(...) */
+
+type RepoDescriptionPredicate struct{}
+
+func (f *RepoDescriptionPredicate) ParseParams(params string) (err error) {
+	if _, err := regexp.Compile(params); err != nil {
+		return errors.Errorf("repo:description argument: %w", err)
+	}
+	if len(params) == 0 {
+		return errors.New("empty repo:description predicate parameter")
+	}
+	return nil
+}
+
+func (f *RepoDescriptionPredicate) Field() string { return FieldRepo }
+func (f *RepoDescriptionPredicate) Name() string  { return "description" }
+func (f *RepoDescriptionPredicate) Plan(parent Basic) (Plan, error) {
 	return nil, nil
 }
 

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -321,7 +321,9 @@ func (f *RepoDependentsPredicate) Plan(parent Basic) (Plan, error) {
 
 /* repo:description(...) */
 
-type RepoDescriptionPredicate struct{}
+type RepoDescriptionPredicate struct {
+	Pattern string
+}
 
 func (f *RepoDescriptionPredicate) ParseParams(params string) (err error) {
 	if _, err := regexp.Compile(params); err != nil {
@@ -330,6 +332,7 @@ func (f *RepoDescriptionPredicate) ParseParams(params string) (err error) {
 	if len(params) == 0 {
 		return errors.New("empty repo:description predicate parameter")
 	}
+	f.Pattern = params
 	return nil
 }
 

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -169,3 +169,47 @@ func TestRepoDependentsPredicate(t *testing.T) {
 		}
 	})
 }
+
+func TestRepoDescriptionPredicate(t *testing.T) {
+	t.Run("ParseParams", func(t *testing.T) {
+		type test struct {
+			name     string
+			params   string
+			expected *RepoDescriptionPredicate
+		}
+
+		valid := []test{
+			{`literal`, `test`, &RepoDescriptionPredicate{}},
+			{`regexp`, `test(.*)package`, &RepoDescriptionPredicate{}},
+		}
+
+		for _, tc := range valid {
+			t.Run(tc.name, func(t *testing.T) {
+				p := &RepoDescriptionPredicate{}
+				err := p.ParseParams(tc.params)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+
+				if !reflect.DeepEqual(tc.expected, p) {
+					t.Fatalf("expected %#v, got %#v", tc.expected, p)
+				}
+			})
+		}
+
+		invalid := []test{
+			{`empty`, ``, nil},
+			{`catch invalid regexp`, `([)`, nil},
+		}
+
+		for _, tc := range invalid {
+			t.Run(tc.name, func(t *testing.T) {
+				p := &RepoDescriptionPredicate{}
+				err := p.ParseParams(tc.params)
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+			})
+		}
+	})
+}

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -179,8 +179,8 @@ func TestRepoDescriptionPredicate(t *testing.T) {
 		}
 
 		valid := []test{
-			{`literal`, `test`, &RepoDescriptionPredicate{}},
-			{`regexp`, `test(.*)package`, &RepoDescriptionPredicate{}},
+			{`literal`, `test`, &RepoDescriptionPredicate{Pattern: "test"}},
+			{`regexp`, `test(.*)package`, &RepoDescriptionPredicate{Pattern: "test(.*)package"}},
 		}
 
 		for _, tc := range valid {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -3,6 +3,7 @@ package query
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/grafana/regexp"
@@ -390,6 +391,16 @@ func (p Parameters) Dependents() (dependents []string) {
 		}
 	})
 	return dependents
+}
+
+func (p Parameters) Description() (descriptionPatterns []string) {
+	VisitPredicate(toNodes(p), func(field, name, value string) {
+		if field == FieldRepo && name == "description" {
+			split := strings.Split(value, " ")
+			descriptionPatterns = append(descriptionPatterns, "(?:"+strings.Join(split, ").*?(?:")+")")
+		}
+	})
+	return descriptionPatterns
 }
 
 func (p Parameters) MaxResults(defaultLimit int) int {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -394,7 +394,7 @@ func (p Parameters) Dependents() (dependents []string) {
 }
 
 func (p Parameters) Description() (descriptionPatterns []string) {
-	VisitTypedPredicate(toNodes(p), func(pred *RepoDescriptionPredicate, negated bool) {
+	VisitTypedPredicate(toNodes(p), func(pred *RepoDescriptionPredicate, _ bool) {
 		split := strings.Split(pred.Pattern, " ")
 		descriptionPatterns = append(descriptionPatterns, "(?:"+strings.Join(split, ").*?(?:")+")")
 	})

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -394,11 +394,9 @@ func (p Parameters) Dependents() (dependents []string) {
 }
 
 func (p Parameters) Description() (descriptionPatterns []string) {
-	VisitPredicate(toNodes(p), func(field, name, value string) {
-		if field == FieldRepo && name == "description" {
-			split := strings.Split(value, " ")
-			descriptionPatterns = append(descriptionPatterns, "(?:"+strings.Join(split, ").*?(?:")+")")
-		}
+	VisitTypedPredicate(toNodes(p), func(pred *RepoDescriptionPredicate, negated bool) {
+		split := strings.Split(pred.Pattern, " ")
+		descriptionPatterns = append(descriptionPatterns, "(?:"+strings.Join(split, ").*?(?:")+")")
 	})
 	return descriptionPatterns
 }

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -1,8 +1,9 @@
 package query
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDescription(t *testing.T) {

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -1,0 +1,28 @@
+package query
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestDescription(t *testing.T) {
+	ps := Parameters{
+		Parameter{
+			Field:      FieldRepo,
+			Value:      "description(test)",
+			Annotation: Annotation{Labels: IsPredicate},
+		},
+		Parameter{
+			Field:      FieldRepo,
+			Value:      "description(test input)",
+			Annotation: Annotation{Labels: IsPredicate},
+		},
+	}
+
+	want := []string{
+		"(?:test)",
+		"(?:test).*?(?:input)",
+	}
+
+	require.Equal(t, want, ps.Description())
+}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -165,6 +165,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 		IncludePatterns:       includePatterns,
 		Names:                 dependencyNames,
 		ExcludePattern:        query.UnionRegExps(excludePatterns),
+		DescriptionPatterns:   op.Description,
 		CaseSensitivePatterns: op.CaseSensitiveRepoFilters,
 		Cursors:               op.Cursors,
 		// List N+1 repos so we can see if there are repos omitted due to our repo limit.

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -165,7 +165,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 		IncludePatterns:       includePatterns,
 		Names:                 dependencyNames,
 		ExcludePattern:        query.UnionRegExps(excludePatterns),
-		DescriptionPatterns:   op.Description,
+		DescriptionPatterns:   op.DescriptionPatterns,
 		CaseSensitivePatterns: op.CaseSensitiveRepoFilters,
 		Cursors:               op.Cursors,
 		// List N+1 repos so we can see if there are repos omitted due to our repo limit.

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -316,6 +316,7 @@ type RepoOptions struct {
 	MinusRepoFilters []string
 	Dependencies     []string
 	Dependents       []string
+	Description      []string
 
 	CaseSensitiveRepoFilters bool
 	SearchContextSpec        string
@@ -412,6 +413,10 @@ func (op *RepoOptions) String() string {
 		fmt.Fprintf(&b, "MinusRepoFilters: %q\n", op.MinusRepoFilters)
 	} else {
 		b.WriteString("MinusRepoFilters: []\n")
+	}
+
+	if len(op.Description) > 0 {
+		fmt.Fprintf(&b, "Description: %q\n", op.Description)
 	}
 
 	fmt.Fprintf(&b, "CommitAfter: %s\n", op.CommitAfter)

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -312,11 +312,11 @@ type Features struct {
 }
 
 type RepoOptions struct {
-	RepoFilters      []string
-	MinusRepoFilters []string
-	Dependencies     []string
-	Dependents       []string
-	Description      []string
+	RepoFilters         []string
+	MinusRepoFilters    []string
+	Dependencies        []string
+	Dependents          []string
+	DescriptionPatterns []string
 
 	CaseSensitiveRepoFilters bool
 	SearchContextSpec        string
@@ -415,8 +415,8 @@ func (op *RepoOptions) String() string {
 		b.WriteString("MinusRepoFilters: []\n")
 	}
 
-	if len(op.Description) > 0 {
-		fmt.Fprintf(&b, "Description: %q\n", op.Description)
+	if len(op.DescriptionPatterns) > 0 {
+		fmt.Fprintf(&b, "DescriptionPatterns: %q\n", op.DescriptionPatterns)
 	}
 
 	fmt.Fprintf(&b, "CommitAfter: %s\n", op.CommitAfter)

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -359,6 +359,9 @@ func (op *RepoOptions) Tags() []otlog.Field {
 	if len(op.Dependents) > 0 {
 		add(trace.Strings("dependents", op.Dependents))
 	}
+	if len(op.DescriptionPatterns) > 0 {
+		add(trace.Strings("descriptionPatterns", op.DescriptionPatterns))
+	}
 	if op.CaseSensitiveRepoFilters {
 		add(otlog.Bool("caseSensitiveRepoFilters", true))
 	}


### PR DESCRIPTION
Implements https://github.com/sourcegraph/sourcegraph/issues/30733

This PR introduces the `repo:description(...)` predicate. This predicate accepts a valid regular expression as an argument and will filter the list of repos returned from the database to only those that match the given regular expression.

The regex passed to the predicate is transformed into a "fuzzy" regex during job creation, e.g. in `repo:description(go package)`, `go package` is transformed to `(?:go).*?(?:package)` before being added to the database query. I anticipate that in practice, a user searching for `repo:description(go package)` probably wants their result set to be broader than only repos that contain the exact string `go package` in their description. For example, the repo `github.com/hashicorp/go-multierror` has the description `A Go (golang) package for representing a list of errors as a single error.`. The regex `go package` will not match this description, but I imagine a user would expect `repo:description(go package)` to match that repo.

The added filter on the database query uses either the case-insensitive regex operator `~*` or the `LIKE` operator to filter on the `repo.description` column, both of which can make use of the trigram index on that column. The index also supports a similarity operator `%` which only returns rows with a similarity score higher than a given threshold (I believe the default is `0.3`), but when running test queries against the cloud database I found that the performance of `%` was far slower than `~*` or `LIKE`, and (subjectively) the results were not as close to what I think real-life users would expect. I'm happy to share the outputs of those test queries if people are curious.

I mainly used https://github.com/sourcegraph/sourcegraph/pull/31577 and https://github.com/sourcegraph/sourcegraph/pull/35374 as references for implementing the front end client changes. Would appreciate a close look at those files!

## Test plan
Unit tests, integration tests, manual end-to-end tests.

Example screenshot:
![Screen Shot 2022-07-08 at 4 16 44 PM](https://user-images.githubusercontent.com/70350613/178071501-45a016ff-2745-4540-8f74-c1c7e90f2514.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
