### PR TITLE
dev/sg: add completions for 'sg generate go'

### DIFF
--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate/golang"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 )
 
 var allGenerateTargets = generateTargets{
@@ -12,6 +13,14 @@ var allGenerateTargets = generateTargets{
 		Name:   "go",
 		Help:   "Run go generate [packages...] on the codebase",
 		Runner: generateGoRunner,
+		Completer: func() (options []string) {
+			root, err := root.RepositoryRoot()
+			if err != nil {
+				return
+			}
+			options, _ = golang.FindFilesWithGenerate(root)
+			return
+		},
 	},
 }
 

--- a/dev/sg/internal/generate/generate.go
+++ b/dev/sg/internal/generate/generate.go
@@ -25,9 +25,10 @@ type Report struct {
 
 // Target denotes a generate task that can be run by `sg generate`
 type Target struct {
-	Name   string
-	Help   string
-	Runner Runner
+	Name      string
+	Help      string
+	Runner    Runner
+	Completer func() (options []string)
 }
 
 // RunScript runs the given script from the root of sourcegraph/sourcegraph.

--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -91,10 +91,15 @@ func (gt generateTargets) Commands() (cmds []*cli.Command) {
 		}
 	}
 	for _, c := range gt {
+		var completions cli.BashCompleteFunc
+		if c.Completer != nil {
+			completions = completeOptions(c.Completer)
+		}
 		cmds = append(cmds, &cli.Command{
-			Name:   c.Name,
-			Usage:  c.Help,
-			Action: actionFactory(c),
+			Name:         c.Name,
+			Usage:        c.Help,
+			Action:       actionFactory(c),
+			BashComplete: completions,
 		})
 	}
 	return cmds


### PR DESCRIPTION
Sometimes I forget the path of something I want to generate, and I don't really want to generate _everything_. This change adds (somewhat slow, unfortunately, but oh well) autocompletions to `sg generate go`.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
 go build -o ./sg ./dev/sg && ./sg install -f -p=false
```

<img width="1087" alt="Screenshot 2022-07-06 at 3 25 02 PM" src="https://user-images.githubusercontent.com/23356519/177654694-1a6df3a0-d8ad-4ba2-a263-4b415b1dc93f.png">

