### PR TITLE
Backend: add scoped `log.Field` encoder

### DIFF
--- a/internal/trace/fields.go
+++ b/internal/trace/fields.go
@@ -28,6 +28,17 @@ func Stringer(key string, v fmt.Stringer) log.Field {
 	})
 }
 
+// Scoped is an opentracing log.Field which is a LazyLogger. It will log each
+// field with a key scoped by the given scope like `scope.key`.
+func Scoped(scope string, fields ...log.Field) log.Field {
+	return log.Lazy(func(fv log.Encoder) {
+		enc := &scopedEncoder{scope: scope, enc: fv}
+		for _, field := range fields {
+			field.Marshal(enc)
+		}
+	})
+}
+
 // Strings is an opentracing log.Field which is a LazyLogger. It will log each
 // string as key.$i.
 func Strings(key string, values []string) log.Field {
@@ -184,3 +195,25 @@ func (e *spanTagEncoder) EmitObject(key string, value any) {
 func (e *spanTagEncoder) EmitLazyLogger(value log.LazyLogger) {
 	value(e)
 }
+
+// scopedEncoder encodes each field with a scoped key, like `scope.key`
+type scopedEncoder struct {
+	scope string
+	enc   log.Encoder
+}
+
+func (e *scopedEncoder) scoped(key string) string {
+	return fmt.Sprintf("%s.%s", e.scope, key)
+}
+
+func (e *scopedEncoder) EmitString(k, v string)              { e.enc.EmitString(e.scoped(k), v) }
+func (e *scopedEncoder) EmitBool(k string, v bool)           { e.enc.EmitBool(e.scoped(k), v) }
+func (e *scopedEncoder) EmitInt(k string, v int)             { e.enc.EmitInt(e.scoped(k), v) }
+func (e *scopedEncoder) EmitInt32(k string, v int32)         { e.enc.EmitInt32(e.scoped(k), v) }
+func (e *scopedEncoder) EmitInt64(k string, v int64)         { e.enc.EmitInt64(e.scoped(k), v) }
+func (e *scopedEncoder) EmitUint32(k string, v uint32)       { e.enc.EmitUint32(e.scoped(k), v) }
+func (e *scopedEncoder) EmitUint64(k string, v uint64)       { e.enc.EmitUint64(e.scoped(k), v) }
+func (e *scopedEncoder) EmitFloat32(k string, v float32)     { e.enc.EmitFloat32(e.scoped(k), v) }
+func (e *scopedEncoder) EmitFloat64(k string, v float64)     { e.enc.EmitFloat64(e.scoped(k), v) }
+func (e *scopedEncoder) EmitObject(k string, v any)          { e.enc.EmitObject(e.scoped(k), v) }
+func (e *scopedEncoder) EmitLazyLogger(value log.LazyLogger) { value(e) }


### PR DESCRIPTION
This adds the function `trace.Scoped()` to the utility functions for trace fields. This returns a lazy logger that adds a scope to each of the fields so they are emitted with the key `scope.originalKey` rather than just `originalKey`. The purpose of this is so I can nest logical sub-fields in traces. 

## Test plan

Manually tested as part of https://github.com/sourcegraph/sourcegraph/pull/38350

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
