### PR TITLE
Search backend: add `Tags()` method to `RepoOpts`

### DIFF
--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -116,7 +116,7 @@ func (p *repoPagerJob) Name() string {
 
 func (p *repoPagerJob) Tags() []log.Field {
 	return []log.Field{
-		trace.Stringer("repoOpts", &p.repoOpts),
+		trace.Scoped("repoOpts", p.repoOpts.Tags()...),
 		log.String("useIndex", string(p.useIndex)),
 		log.Bool("containsRefGlobs", p.containsRefGlobs),
 	}

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -40,6 +40,6 @@ func (c *ComputeExcludedJob) Name() string {
 
 func (c *ComputeExcludedJob) Tags() []log.Field {
 	return []log.Field{
-		trace.Stringer("repoOpts", &c.RepoOpts),
+		trace.Scoped("repoOpts", c.RepoOpts.Tags()...),
 	}
 }

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -60,7 +60,7 @@ func (*RepoSearchJob) Name() string {
 
 func (s *RepoSearchJob) Tags() []log.Field {
 	return []log.Field{
-		trace.Stringer("repoOpts", &s.RepoOpts),
+		trace.Scoped("repoOpts", s.RepoOpts.Tags()...),
 		trace.Printf("filePatternsReposMustInclude", "%q", s.FilePatternsReposMustInclude),
 		trace.Printf("filePatternsReposMustExclude", "%q", s.FilePatternsReposMustExclude),
 		log.Bool("contentBasedLangFilters", s.Features.ContentBasedLangFilters),

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -202,6 +202,6 @@ func (s *SearchJob) Tags() []log.Field {
 		log.Bool("useFullDeadline", s.SearcherArgs.UseFullDeadline),
 		log.String("useIndex", string(s.UseIndex)),
 		log.Bool("containsRefGlobs", s.ContainsRefGlobs),
-		trace.Stringer("repoOpts", &s.RepoOpts),
+		trace.Scoped("repoOpts", s.RepoOpts.Tags()...),
 	}
 }

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -612,6 +612,6 @@ func (t *GlobalTextSearchJob) Tags() []otlog.Field {
 		otlog.String("type", string(t.ZoektArgs.Typ)),
 		otlog.Int32("fileMatchLimit", t.ZoektArgs.FileMatchLimit),
 		trace.Stringer("select", t.ZoektArgs.Select),
-		trace.Stringer("repoOpts", &t.RepoOpts),
+		trace.Scoped("repoOpts", t.RepoOpts.Tags()...),
 	}
 }

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -112,6 +112,6 @@ func (s *GlobalSymbolSearchJob) Tags() []log.Field {
 		log.String("type", string(s.ZoektArgs.Typ)),
 		log.Int32("fileMatchLimit", s.ZoektArgs.FileMatchLimit),
 		trace.Stringer("select", s.ZoektArgs.Select),
-		trace.Stringer("repoOpts", &s.RepoOpts),
+		trace.Scoped("repoOpts", s.RepoOpts.Tags()...),
 	}
 }

--- a/internal/trace/fields.go
+++ b/internal/trace/fields.go
@@ -28,6 +28,17 @@ func Stringer(key string, v fmt.Stringer) log.Field {
 	})
 }
 
+// Scoped is an opentracing log.Field which is a LazyLogger. It will log each
+// field with a key scoped by the given scope like `scope.key`.
+func Scoped(scope string, fields ...log.Field) log.Field {
+	return log.Lazy(func(fv log.Encoder) {
+		enc := &scopedEncoder{scope: scope, enc: fv}
+		for _, field := range fields {
+			field.Marshal(enc)
+		}
+	})
+}
+
 // Strings is an opentracing log.Field which is a LazyLogger. It will log each
 // string as key.$i.
 func Strings(key string, values []string) log.Field {
@@ -184,3 +195,25 @@ func (e *spanTagEncoder) EmitObject(key string, value any) {
 func (e *spanTagEncoder) EmitLazyLogger(value log.LazyLogger) {
 	value(e)
 }
+
+// scopedEncoder encodes each field with a scoped key, like `scope.key`
+type scopedEncoder struct {
+	scope string
+	enc   log.Encoder
+}
+
+func (e *scopedEncoder) scoped(key string) string {
+	return fmt.Sprintf("%s.%s", e.scope, key)
+}
+
+func (e *scopedEncoder) EmitString(k, v string)              { e.enc.EmitString(e.scoped(k), v) }
+func (e *scopedEncoder) EmitBool(k string, v bool)           { e.enc.EmitBool(e.scoped(k), v) }
+func (e *scopedEncoder) EmitInt(k string, v int)             { e.enc.EmitInt(e.scoped(k), v) }
+func (e *scopedEncoder) EmitInt32(k string, v int32)         { e.enc.EmitInt32(e.scoped(k), v) }
+func (e *scopedEncoder) EmitInt64(k string, v int64)         { e.enc.EmitInt64(e.scoped(k), v) }
+func (e *scopedEncoder) EmitUint32(k string, v uint32)       { e.enc.EmitUint32(e.scoped(k), v) }
+func (e *scopedEncoder) EmitUint64(k string, v uint64)       { e.enc.EmitUint64(e.scoped(k), v) }
+func (e *scopedEncoder) EmitFloat32(k string, v float32)     { e.enc.EmitFloat32(e.scoped(k), v) }
+func (e *scopedEncoder) EmitFloat64(k string, v float64)     { e.enc.EmitFloat64(e.scoped(k), v) }
+func (e *scopedEncoder) EmitObject(k string, v any)          { e.enc.EmitObject(e.scoped(k), v) }
+func (e *scopedEncoder) EmitLazyLogger(value log.LazyLogger) { value(e) }


### PR DESCRIPTION
This adds a `Tags()` method to repo opts and takes advantage of the new `trace.Scoped` to make the emitted fields more readable.  Additionally, I'd like to start using this information for serializing with our pretty printers, and more granular fields works better for that.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/38349

## Test plan

Manually tested that the generated trace tags are readable and correct.

Before:
<img width="502" alt="Screen Shot 2022-07-06 at 18 37 45" src="https://user-images.githubusercontent.com/12631702/177665458-ccb9168e-bf96-453f-adc0-20984024376a.png">

After:
<img width="283" alt="Screen Shot 2022-07-06 at 18 36 03" src="https://user-images.githubusercontent.com/12631702/177665302-0028a218-01d9-4ee1-9d3e-c59523755f3d.png">



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
