### PR TITLE
Search backend: make filename order deterministic

### DIFF
--- a/internal/search/query/helpers.go
+++ b/internal/search/query/helpers.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/go-enry/go-enry/v2"
@@ -37,6 +38,9 @@ var filenamesFromLanguage = func() map[string][]string {
 		for _, language := range languages {
 			res[language] = append(res[language], filename)
 		}
+	}
+	for _, v := range res {
+		sort.Strings(v)
 	}
 	return res
 }()


### PR DESCRIPTION
Because we construct this list of filenames by iterating over a map, the
list of filenames is nondeterministic. This is causing test failures
when writing tests that depend on this behavior.

## Test plan

Ran my in-progress tests after making this change and they no longer fail

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
