### PR TITLE
search: add generated query constructor

### DIFF
--- a/internal/search/job/jobutil/feeling_lucky_search_job.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job.go
@@ -459,6 +459,21 @@ func typePatterns(b query.Basic) *query.Basic {
 	}
 }
 
+func NewGeneratedSearchJob(inputs *run.SearchInputs, description string, q query.Basic) (job.Job, error) {
+	child, err := NewBasicJob(inputs, q)
+	if err != nil {
+		return nil, err
+	}
+	return &generatedSearchJob{
+		Child: child,
+		ProposedQuery: &search.ProposedQuery{
+			Description: description,
+			Query:       query.StringHuman(q.ToParseTree()),
+			PatternType: query.SearchTypeLucky,
+		},
+	}, nil
+}
+
 type generatedSearchJob struct {
 	Child         job.Job
 	ProposedQuery *search.ProposedQuery


### PR DESCRIPTION
First of 4 PRs to clean up lucky search and remove mutations and stuff like https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/job/jobutil/feeling_lucky_search_job.go?L485

## Test plan
Semantics-preserving.
