### PR TITLE
search: make lucky generator return autoQuery type

### DIFF
--- a/internal/search/job/jobutil/feeling_lucky_search_job.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job.go
@@ -29,15 +29,31 @@ func NewFeelingLuckySearchJob(initialJob job.Job, inputs *run.SearchInputs, plan
 	for _, b := range plan {
 		generators = append(generators, NewGenerator(inputs, b, rules))
 	}
+
+	createJob := func(autoQ *autoQuery) job.Job {
+		j, err := NewGeneratedSearchJob(inputs, autoQ.description, autoQ.query)
+		if err != nil {
+			return nil
+		}
+		return j
+	}
+
 	return &FeelingLuckySearchJob{
 		initialJob: initialJob,
 		generators: generators,
+		createJob:  createJob,
 	}
 }
 
+// FeelingLuckySearchJob represents a lucky search. Note `createJob` returns a
+// job given an autoQuery. It is a function so that generated queries can be
+// composed at runtime with static inputs, while abstracting away the details of
+// those static inputs.
 type FeelingLuckySearchJob struct {
 	initialJob job.Job
 	generators []next
+
+	createJob func(*autoQuery) job.Job
 }
 
 func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClients, parentStream streaming.Sender) (alert *search.Alert, err error) {
@@ -74,19 +90,19 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	maxAlerter.Add(alert)
 
 	generated := &alertobserver.ErrLuckyQueries{ProposedQueries: []*search.ProposedQuery{}}
-	var j job.Job
+	var autoQ *autoQuery
 	for _, next := range f.generators {
 		for {
-			j, next = next()
-			if j == nil {
+			autoQ, next = next()
+			if autoQ == nil {
 				if next == nil {
-					// No job and generator is exhausted.
+					// No query and generator is exhausted.
 					break
 				}
 				continue
 			}
 
-			alert, err = j.Run(ctx, clients, stream)
+			alert, err = f.createJob(autoQ).Run(ctx, clients, stream)
 			if ctx.Err() != nil {
 				// Cancellation or Deadline hit implies it's time to stop running jobs.
 				errs = errors.Append(errs, generated)
@@ -123,8 +139,14 @@ func (f *FeelingLuckySearchJob) Tags() []log.Field {
 	return []log.Field{}
 }
 
+// autoQuery is an automatically generated query with associated data (e.g., description).
+type autoQuery struct {
+	description string
+	query       query.Basic
+}
+
 // next is the continuation for the query generator.
-type next func() (job.Job, next)
+type next func() (*autoQuery, next)
 
 // NewGenerator creates a new generator using rules and a seed Basic query. It
 // returns a `next` function which, when called, returns the next job
@@ -136,32 +158,22 @@ func NewGenerator(inputs *run.SearchInputs, seed query.Basic, rules []rule) next
 	var n func(i int) next // i keeps track of rule index in the continuation
 	n = func(i int) next {
 		if i >= len(rules) {
-			return func() (job.Job, next) { return nil, nil }
+			return func() (*autoQuery, next) { return nil, nil }
 		}
 
-		return func() (job.Job, next) {
+		return func() (*autoQuery, next) {
 			generated := applyTransformation(seed, rules[i].transform)
 			if generated == nil {
 				// Rule doesn't apply, go to next rule.
 				return nil, n(i + 1)
 			}
 
-			child, err := NewBasicJob(inputs, *generated)
-			if err != nil {
-				// Generated invalid job, go to next rule.
-				return nil, n(i + 1)
+			q := autoQuery{
+				description: rules[i].description,
+				query:       *generated,
 			}
 
-			j := &generatedSearchJob{
-				Child: child,
-				ProposedQuery: &search.ProposedQuery{
-					Description: rules[i].description,
-					Query:       query.StringHuman(generated.ToParseTree()),
-					PatternType: query.SearchTypeLucky,
-				},
-			}
-
-			return j, n(i + 1)
+			return &q, n(i + 1)
 		}
 	}
 

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/one_of_many_patterns_as_lang.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/one_of_many_patterns_as_lang.golden
@@ -1,24 +1,10 @@
-{
-  "OR": [
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply language filter for pattern",
-          "Query": "context:global lang:Python parse",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "AND patterns together",
-          "Query": "context:global (parse AND python)",
-          "PatternType": 3
-        }
-      }
-    }
-  ]
-}
+[
+  {
+    "Description": "apply language filter for pattern",
+    "Query": "context:global lang:Python parse"
+  },
+  {
+    "Description": "AND patterns together",
+    "Query": "context:global (parse AND python)"
+  }
+]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type.golden
@@ -1,24 +1,10 @@
-{
-  "OR": [
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply search type for pattern",
-          "Query": "context:global type:commit fix",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "AND patterns together",
-          "Query": "context:global (fix AND commit)",
-          "PatternType": 3
-        }
-      }
-    }
-  ]
-}
+[
+  {
+    "Description": "apply search type for pattern",
+    "Query": "context:global type:commit fix"
+  },
+  {
+    "Description": "AND patterns together",
+    "Query": "context:global (fix AND commit)"
+  }
+]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
@@ -1,34 +1,14 @@
-{
-  "OR": [
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply search type for pattern",
-          "Query": "context:global type:commit code monitor",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply search type with AND patterns",
-          "Query": "context:global type:commit (code AND monitor)",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "AND patterns together",
-          "Query": "context:global (code AND monitor AND commit)",
-          "PatternType": 3
-        }
-      }
-    }
-  ]
-}
+[
+  {
+    "Description": "apply search type for pattern",
+    "Query": "context:global type:commit code monitor"
+  },
+  {
+    "Description": "apply search type with AND patterns",
+    "Query": "context:global type:commit (code AND monitor)"
+  },
+  {
+    "Description": "AND patterns together",
+    "Query": "context:global (code AND monitor AND commit)"
+  }
+]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_with_expression.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_with_expression.golden
@@ -1,24 +1,10 @@
-{
-  "OR": [
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply search type for pattern",
-          "Query": "context:global type:commit (code OR monitor)",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "AND patterns together",
-          "Query": "context:global (code OR (monitor AND commit))",
-          "PatternType": 3
-        }
-      }
-    }
-  ]
-}
+[
+  {
+    "Description": "apply search type for pattern",
+    "Query": "context:global type:commit (code OR monitor)"
+  },
+  {
+    "Description": "AND patterns together",
+    "Query": "context:global (code OR (monitor AND commit))"
+  }
+]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/single_pattern_as_lang.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/single_pattern_as_lang.golden
@@ -1,10 +1,6 @@
-{
-  "GeneratedSearchJob": {
-    "Child": {},
-    "ProposedQuery": {
-      "Description": "apply language filter for pattern",
-      "Query": "context:global lang:Python",
-      "PatternType": 3
-    }
+[
+  {
+    "Description": "apply language filter for pattern",
+    "Query": "context:global lang:Python"
   }
-}
+]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
@@ -1,10 +1,6 @@
-{
-  "GeneratedSearchJob": {
-    "Child": {},
-    "ProposedQuery": {
-      "Description": "AND patterns together",
-      "Query": "context:global (parse AND func)",
-      "PatternType": 3
-    }
+[
+  {
+    "Description": "AND patterns together",
+    "Query": "context:global (parse AND func)"
   }
-}
+]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unquoted_rule.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unquoted_rule.golden
@@ -1,24 +1,10 @@
-{
-  "OR": [
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "unquote patterns",
-          "Query": "repo:^github\\.com/sourcegraph/sourcegraph$ monitor *Monitor",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "AND patterns together",
-          "Query": "repo:^github\\.com/sourcegraph/sourcegraph$ (\"monitor\" AND \"*Monitor\")",
-          "PatternType": 3
-        }
-      }
-    }
-  ]
-}
+[
+  {
+    "Description": "unquote patterns",
+    "Query": "repo:^github\\.com/sourcegraph/sourcegraph$ monitor *Monitor"
+  },
+  {
+    "Description": "AND patterns together",
+    "Query": "repo:^github\\.com/sourcegraph/sourcegraph$ (\"monitor\" AND \"*Monitor\")"
+  }
+]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/two_basic_jobs.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/two_basic_jobs.golden
@@ -1,24 +1,10 @@
-{
-  "OR": [
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "AND patterns together",
-          "Query": "context:global type:file (parse AND func)",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "AND patterns together",
-          "Query": "context:global type:commit (parse AND func)",
-          "PatternType": 3
-        }
-      }
-    }
-  ]
-}
+[
+  {
+    "Description": "AND patterns together",
+    "Query": "context:global type:file (parse AND func)"
+  },
+  {
+    "Description": "AND patterns together",
+    "Query": "context:global type:commit (parse AND func)"
+  }
+]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/type_and_lang_multi_rule.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/type_and_lang_multi_rule.golden
@@ -1,74 +1,30 @@
-{
-  "OR": [
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply search type and language filter for patterns",
-          "Query": "context:global type:commit lang:Go monitor code",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply search type for pattern",
-          "Query": "context:global type:commit go monitor code",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply language filter for pattern",
-          "Query": "context:global lang:Go commit monitor code",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply search type and language filter for patterns with AND patterns",
-          "Query": "context:global type:commit lang:Go (monitor AND code)",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply search type with AND patterns",
-          "Query": "context:global type:commit (go AND monitor AND code)",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "apply language filter with AND patterns",
-          "Query": "context:global lang:Go (commit AND monitor AND code)",
-          "PatternType": 3
-        }
-      }
-    },
-    {
-      "GeneratedSearchJob": {
-        "Child": {},
-        "ProposedQuery": {
-          "Description": "AND patterns together",
-          "Query": "context:global (go AND commit AND monitor AND code)",
-          "PatternType": 3
-        }
-      }
-    }
-  ]
-}
+[
+  {
+    "Description": "apply search type and language filter for patterns",
+    "Query": "context:global type:commit lang:Go monitor code"
+  },
+  {
+    "Description": "apply search type for pattern",
+    "Query": "context:global type:commit go monitor code"
+  },
+  {
+    "Description": "apply language filter for pattern",
+    "Query": "context:global lang:Go commit monitor code"
+  },
+  {
+    "Description": "apply search type and language filter for patterns with AND patterns",
+    "Query": "context:global type:commit lang:Go (monitor AND code)"
+  },
+  {
+    "Description": "apply search type with AND patterns",
+    "Query": "context:global type:commit (go AND monitor AND code)"
+  },
+  {
+    "Description": "apply language filter with AND patterns",
+    "Query": "context:global lang:Go (commit AND monitor AND code)"
+  },
+  {
+    "Description": "AND patterns together",
+    "Query": "context:global (go AND commit AND monitor AND code)"
+  }
+]


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/38354.

This makes the query generator return a new type

```go
type autoQuery struct {
	description string
	query       query.Basic
}
```

instead of jobs. This to avoid propagating notification values/descriptions to jobs by the generator.

The test output changes to print this struct rather than serialized jobs, which is a bit smaller.

## Test plan
Updated tests