### PR TITLE
search: separate static vs runtime construction in lucky search

### DIFF
--- a/internal/search/job/jobutil/feeling_lucky_search_job_test.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job_test.go
@@ -111,7 +111,7 @@ func TestNewFeelingLuckySearchJob_Run(t *testing.T) {
 	j := FeelingLuckySearchJob{
 		initialJob: mockJob,
 		generators: []next{func() (*autoQuery, next) { return mockAutoQuery, nil }},
-		createJob: func(*autoQuery) job.Job {
+		newGeneratedJob: func(*autoQuery) job.Job {
 			return mockJob
 		},
 	}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/38356

This just factors the closures created so it doesn't bloat functions as much and explains the reasoning. Again, at a later stage I might revisit to see how to remove the need for this.

## Test plan
Updated tests
