### PR TITLE
web: disable flaky E2E test

### DIFF
--- a/client/web/src/end-to-end/frontend-platform/theme-switcher.test.ts
+++ b/client/web/src/end-to-end/frontend-platform/theme-switcher.test.ts
@@ -33,7 +33,8 @@ describe('Theme switcher', () => {
             return []
         })
 
-    test('changes the theme', async () => {
+    // Disabled as flaky
+    test.skip('changes the theme', async () => {
         await driver.page.goto(sourcegraphBaseUrl + '/github.com/gorilla/mux/-/blob/mux.go')
         await driver.page.waitForSelector('.theme.theme-dark, .theme.theme-light', { visible: true })
 


### PR DESCRIPTION
## Context

[Failure example](https://buildkite.com/sourcegraph/sourcegraph/builds/158869#0181d685-2ddd-48e9-84b0-2a3e16ed7f1f).
Issue to re-enable test: https://github.com/sourcegraph/sourcegraph/issues/38370

## Test plan

n/a – disabled flaky test

## App preview:

- [Web](https://sg-web-vb-disable-flaky-theme-switcher.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ijmhrhdsog.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

