### PR TITLE
build: Upload source maps to Sentry via Webpack plugin

### DIFF
--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -37,6 +37,13 @@ export const ENVIRONMENT_CONFIG = {
     // Allow overriding default Webpack naming behavior for debugging
     WEBPACK_USE_NAMED_CHUNKS: getEnvironmentBoolean('WEBPACK_USE_NAMED_CHUNKS'),
 
+    // New release candidate version.
+    RELEASE_CANDIDATE_VERSION: process.env.RELEASE_CANDIDATE_VERSION,
+    // Should sourcemaps be uploaded to Sentry.
+    SENTRY_UPLOAD_SOURCE_MAPS: getEnvironmentBoolean('SENTRY_UPLOAD_SOURCE_MAPS'),
+    // Sentry authentication token
+    SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
+
     //  Webpack is the default web build tool, and esbuild is an experimental option (see
     //  https://docs.sourcegraph.com/dev/background-information/web/build#esbuild).
     DEV_WEB_BUILDER: (process.env.DEV_WEB_BUILDER === 'esbuild' ? 'esbuild' : 'webpack') as WEB_BUILDER,

--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -43,6 +43,10 @@ export const ENVIRONMENT_CONFIG = {
     SENTRY_UPLOAD_SOURCE_MAPS: getEnvironmentBoolean('SENTRY_UPLOAD_SOURCE_MAPS'),
     // Sentry authentication token
     SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
+    // Sentry organization
+    SENTRY_ORGANIZATION: process.env.SENTRY_ORGANIZATION,
+    // Sentry project
+    SENTRY_PROJECT: process.env.SENTRY_PROJECT,
 
     //  Webpack is the default web build tool, and esbuild is an experimental option (see
     //  https://docs.sourcegraph.com/dev/background-information/web/build#esbuild).

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -3,6 +3,7 @@
 const path = require('path')
 
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
+const SentryWebpackPlugin = require('@sentry/webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
 const CssMinimizerWebpackPlugin = require('css-minimizer-webpack-plugin')
 const mapValues = require('lodash/mapValues')
@@ -41,6 +42,9 @@ const {
   WEBPACK_SERVE_INDEX,
   WEBPACK_BUNDLE_ANALYZER,
   WEBPACK_USE_NAMED_CHUNKS,
+  SENTRY_UPLOAD_SOURCE_MAPS,
+  RELEASE_CANDIDATE_VERSION,
+  SENTRY_AUTH_TOKEN,
 } = ENVIRONMENT_CONFIG
 
 const IS_PERSISTENT_CACHE_ENABLED = IS_DEVELOPMENT && !IS_CI
@@ -173,6 +177,14 @@ const config = {
          * We can fall back to dynamic gzip for these.
          */
         threshold: 10240,
+      }),
+    RELEASE_CANDIDATE_VERSION &&
+      SENTRY_UPLOAD_SOURCE_MAPS &&
+      new SentryWebpackPlugin({
+        dryRun: true,
+        authToken: SENTRY_AUTH_TOKEN,
+        release: `frontend@${RELEASE_CANDIDATE_VERSION}`,
+        include: path.join(ROOT_PATH, 'ui', 'assets', 'scripts'),
       }),
   ].filter(Boolean),
   resolve: {

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -13,6 +13,7 @@ const { WebpackManifestPlugin } = require('webpack-manifest-plugin')
 
 const {
   ROOT_PATH,
+  STATIC_ASSETS_PATH,
   getBabelLoader,
   getCacheConfig,
   getMonacoWebpackPlugin,
@@ -120,7 +121,7 @@ const config = {
     ...(IS_EMBED_ENTRY_POINT_ENABLED && { embed: path.join(enterpriseDirectory, 'embed', 'main.tsx') }),
   },
   output: {
-    path: path.join(ROOT_PATH, 'ui', 'assets'),
+    path: STATIC_ASSETS_PATH,
     // Do not [hash] for development -- see https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
     // Note: [name] will vary depending on the Webpack chunk. If specified, it will use a provided chunk name, otherwise it will fallback to a deterministic id.
     filename:
@@ -187,7 +188,7 @@ const config = {
         project: SENTRY_PROJECT,
         authToken: SENTRY_AUTH_TOKEN,
         release: `frontend@${RELEASE_CANDIDATE_VERSION}`,
-        include: path.join(ROOT_PATH, 'ui', 'assets', 'scripts'),
+        include: path.join(STATIC_ASSETS_PATH, 'scripts'),
       }),
   ].filter(Boolean),
   resolve: {

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -45,6 +45,8 @@ const {
   SENTRY_UPLOAD_SOURCE_MAPS,
   RELEASE_CANDIDATE_VERSION,
   SENTRY_AUTH_TOKEN,
+  SENTRY_ORGANIZATION,
+  SENTRY_PROJECT,
 } = ENVIRONMENT_CONFIG
 
 const IS_PERSISTENT_CACHE_ENABLED = IS_DEVELOPMENT && !IS_CI
@@ -181,6 +183,8 @@ const config = {
     RELEASE_CANDIDATE_VERSION &&
       SENTRY_UPLOAD_SOURCE_MAPS &&
       new SentryWebpackPlugin({
+        org: SENTRY_ORGANIZATION,
+        project: SENTRY_PROJECT,
         authToken: SENTRY_AUTH_TOKEN,
         release: `frontend@${RELEASE_CANDIDATE_VERSION}`,
         include: path.join(ROOT_PATH, 'ui', 'assets', 'scripts'),

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -181,7 +181,6 @@ const config = {
     RELEASE_CANDIDATE_VERSION &&
       SENTRY_UPLOAD_SOURCE_MAPS &&
       new SentryWebpackPlugin({
-        dryRun: true,
         authToken: SENTRY_AUTH_TOKEN,
         release: `frontend@${RELEASE_CANDIDATE_VERSION}`,
         include: path.join(ROOT_PATH, 'ui', 'assets', 'scripts'),

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@pollyjs/adapter": "^5.0.0",
     "@pollyjs/core": "^5.1.0",
     "@pollyjs/persister-fs": "^5.0.0",
+    "@sentry/webpack-plugin": "^1.18.9",
     "@slack/web-api": "^5.15.0",
     "@sourcegraph/eslint-config": "0.31.0",
     "@sourcegraph/eslint-plugin-sourcegraph": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3864,6 +3864,19 @@
     "@sentry/utils" "6.13.2"
     tslib "^1.9.3"
 
+"@sentry/cli@^1.74.4":
+  version "1.74.4"
+  resolved "https://registry.npmjs.org/@sentry/cli/-/cli-1.74.4.tgz#7df82f68045a155e1885bfcbb5d303e5259eb18e"
+  integrity sha512-BMfzYiedbModsNBJlKeBOLVYUtwSi99LJ8gxxE4Bp5N8hyjNIN0WVrozAVZ27mqzAuy6151Za3dpmOLO86YlGw==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.7"
+    npmlog "^4.1.2"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
+
 "@sentry/core@6.13.2":
   version "6.13.2"
   resolved "https://registry.npmjs.org/@sentry/core/-/core-6.13.2.tgz#2ce164f81667aa89cd116f807d772b4718434583"
@@ -3905,6 +3918,13 @@
   dependencies:
     "@sentry/types" "6.13.2"
     tslib "^1.9.3"
+
+"@sentry/webpack-plugin@^1.18.9":
+  version "1.18.9"
+  resolved "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.18.9.tgz#acb48c0f96fdb9e73f1e1db374ea31ded6d883a8"
+  integrity sha512-+TrenJrgFM0QTOwBnw0ZXWMvc0PiOebp6GN5EbGEx3JPCQqXOfXFzCaEjBtASKRgcNCL7zGly41S25YR6Hm+jw==
+  dependencies:
+    "@sentry/cli" "^1.74.4"
 
 "@sindresorhus/fnv1a@^1.2.0":
   version "1.2.0"
@@ -18631,7 +18651,7 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.1:
+npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==


### PR DESCRIPTION
This PR adds the `SentryWebpackPlugin` through which we will upload source maps of the generated frontend scripts and send them to Sentry.

As a next step (in a separate PR), we will exclusively run this plugin during the release branch builds.

## Test plan

Tested the success through a dry run, and altering the `yarn build` script to add `RELEASE_CANDIDATE_VERSION`, `SENTRY_UPLOAD_SOURCE_MAPS` and `SENTRY_AUTH_TOKEN` env vars.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mihir-26578-sentry-webpack-plugin.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nnmscxglxj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
