### PR TITLE
JetBrains: Decrease popup default size

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -32,7 +32,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
     public FindPopupPanel(@NotNull Project project, @NotNull FindService findService) {
         super();
 
-        setPreferredSize(JBUI.size(1200, 800));
+        setPreferredSize(JBUI.size(1000, 700));
         setBorder(PopupBorder.Factory.create(true, true));
         setFocusCycleRoot(true);
 


### PR DESCRIPTION
"Find in Files" doesn't seem to have a default size. Its' initial size depends on things like font size and other factors that I didn't even trace all the way to their source.
The previous size was pretty arbitrary (either Philipp or I came up with the previous numbers).
This new size is pretty arbitrary too, just it seems to me that it matches the default size of "Find in Files" closer.

## Test plan

The popup should be a bit smaller at the first load.

## App preview:

- [Web](https://sg-web-dv-jetbrains-decrease-popup.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bwmsqaxlps.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
