### PR TITLE
ci: Run with Sentry source map uploading in release build

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -142,6 +142,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **CI script tests**: test-trace-command.sh
 - **Integration tests**: Backend integration tests, Code Intel QA
 - **End-to-end tests**: Sourcegraph E2E, Sourcegraph QA, Sourcegraph Cluster (deploy-sourcegraph) QA, Sourcegraph Upgrade
+- Build and upload sourcemaps to Sentry
 - **Publish images**: alpine-3.14, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, jaeger-agent, jaeger-all-in-one, minio, postgres-12-alpine, postgres_exporter, precise-code-intel-worker, prometheus, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, symbols, syntax-highlighter, worker, migrator, executor, server, sg, Publish executor image, Publish docker registry mirror image
 - Upload build trace
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -216,6 +216,22 @@ func addWebApp(pipeline *bk.Pipeline) {
 		bk.Cmd("dev/ci/codecov.sh -c -F typescript -F unit"))
 }
 
+// Adds steps for building webapp with the Sentry Webpack plugin enabled to upload sourcemaps
+// Only builds webapp without ENTERPRISE=1, no tests are performed. Should only run on release branches.
+func buildWebAppWithSentrySourcemaps(version string) operations.Operation {
+	return func(pipeline *bk.Pipeline) {
+		// Webapp build with Sentry's webpack plugin enabled
+		pipeline.AddStep(":webpack::globe_with_meridians: Build and upload sourcemaps to Sentry",
+			withYarnCache(),
+			bk.Cmd("dev/ci/yarn-build.sh client/web"),
+			bk.Env("NODE_ENV", "production"),
+			bk.Env("ENTERPRISE", ""),
+			bk.Env("SENTRY_UPLOAD_SOURCE_MAPS", "1"),
+			bk.Env("RELEASE_CANDIDATE_VERSION", version),
+		)
+	}
+}
+
 var browsers = []string{"chrome"}
 
 func getParallelTestCount(webParallelTestCount int) int {

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -227,6 +227,8 @@ func buildWebAppWithSentrySourcemaps(version string) operations.Operation {
 			bk.Env("NODE_ENV", "production"),
 			bk.Env("ENTERPRISE", ""),
 			bk.Env("SENTRY_UPLOAD_SOURCE_MAPS", "1"),
+			bk.Env("SENTRY_ORGANIZATION", "sourcegraph"),
+			bk.Env("SENTRY_PROJECT", "sourcegraph-dot-com"),
 			bk.Env("RELEASE_CANDIDATE_VERSION", version),
 		)
 	}

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -124,6 +124,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case runtype.ReleaseNightly:
 		ops.Append(triggerReleaseBranchHealthchecks(minimumUpgradeableVersion))
 
+	case runtype.ReleaseBranch:
+		ops.Append(buildWebAppWithSentrySourcemaps(c.Version))
+
 	case runtype.BackendIntegrationTests:
 		ops.Append(
 			buildCandidateDockerImage("server", c.Version, c.candidateImageTag()),
@@ -269,10 +272,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			clusterQA(c.candidateImageTag()),
 			testUpgrade(c.candidateImageTag(), minimumUpgradeableVersion),
 		))
-
-		if c.RunType.Is(runtype.ReleaseBranch) {
-			ops.Append(buildWebAppWithSentrySourcemaps(c.Version))
-		}
 
 		// All operations before this point are required
 		ops.Append(wait)

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -124,9 +124,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case runtype.ReleaseNightly:
 		ops.Append(triggerReleaseBranchHealthchecks(minimumUpgradeableVersion))
 
-	case runtype.ReleaseBranch:
-		ops.Append(buildWebAppWithSentrySourcemaps(c.Version))
-
 	case runtype.BackendIntegrationTests:
 		ops.Append(
 			buildCandidateDockerImage("server", c.Version, c.candidateImageTag()),
@@ -272,6 +269,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			clusterQA(c.candidateImageTag()),
 			testUpgrade(c.candidateImageTag(), minimumUpgradeableVersion),
 		))
+
+		if c.RunType.Is(runtype.ReleaseBranch) {
+			ops.Append(buildWebAppWithSentrySourcemaps(c.Version))
+		}
 
 		// All operations before this point are required
 		ops.Append(wait)

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -124,9 +124,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case runtype.ReleaseNightly:
 		ops.Append(triggerReleaseBranchHealthchecks(minimumUpgradeableVersion))
 
-	case runtype.ReleaseBranch:
-		ops.Append(buildWebAppWithSentrySourcemaps(c.Version))
-
 	case runtype.BackendIntegrationTests:
 		ops.Append(
 			buildCandidateDockerImage("server", c.Version, c.candidateImageTag()),
@@ -286,6 +283,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			publishOps.Append(publishExecutor(c.Version, skipHashCompare))
 			if c.RunType.Is(runtype.ReleaseBranch) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
 				publishOps.Append(publishExecutorDockerMirror(c.Version))
+			}
+			if c.RunType.Is(runtype.ReleaseBranch) {
+				ops.Append(buildWebAppWithSentrySourcemaps(c.Version))
 			}
 		}
 		ops.Merge(publishOps)

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -124,6 +124,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case runtype.ReleaseNightly:
 		ops.Append(triggerReleaseBranchHealthchecks(minimumUpgradeableVersion))
 
+	case runtype.ReleaseBranch:
+		ops.Append(buildWebAppWithSentrySourcemaps(c.Version))
+
 	case runtype.BackendIntegrationTests:
 		ops.Append(
 			buildCandidateDockerImage("server", c.Version, c.candidateImageTag()),


### PR DESCRIPTION
To be merged after #38391. Closes #26578.

---

With this PR, we will run the build command for the webapp with Sentry source maps uploading enabled for release branches only. The step will run after the Docker images are published.

## Test plan

WIP

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
