### PR TITLE
insights: query builder to use `SearchTypeStandard` by default

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -17,7 +17,7 @@ import (
 // and the result would be generated as `repo:myrepo test archive:no`. This preserves the semantics of the original query
 // by fully parsing and reconstructing the tree, and does **not** overwrite user supplied values for the default fields.
 func withDefaults(inputQuery string, defaults searchquery.Parameters) (string, error) {
-	plan, err := searchquery.Pipeline(searchquery.Init(inputQuery, searchquery.SearchTypeRegex))
+	plan, err := searchquery.Pipeline(searchquery.Init(inputQuery, searchquery.SearchTypeLiteral))
 	if err != nil {
 		return "", errors.Wrap(err, "Pipeline")
 	}

--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -17,7 +17,7 @@ import (
 // and the result would be generated as `repo:myrepo test archive:no`. This preserves the semantics of the original query
 // by fully parsing and reconstructing the tree, and does **not** overwrite user supplied values for the default fields.
 func withDefaults(inputQuery string, defaults searchquery.Parameters) (string, error) {
-	plan, err := searchquery.Pipeline(searchquery.Init(inputQuery, searchquery.SearchTypeLiteral))
+	plan, err := searchquery.Pipeline(searchquery.Init(inputQuery, searchquery.SearchTypeStandard))
 	if err != nil {
 		return "", errors.Wrap(err, "Pipeline")
 	}

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -61,6 +61,76 @@ func TestWithDefaults(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Fatalf("%s failed (want/got): %s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestWithDefaultsPatternTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		want     string
+		defaults query.Parameters
+	}{
+		{
+			// check: does this get parsed as regexp with new client?
+			name:     "regexp query without patterntype",
+			input:    `file:go\.mod$ go\s*(\d\.\d+)`,
+			want:     `file:go\.mod$ go\s*(\d\.\d+)`,
+			defaults: []query.Parameter{},
+		},
+		{
+			name:     "regexp query with patterntype",
+			input:    `file:go\.mod$ go\s*(\d\.\d+) patterntype:regexp`,
+			want:     `file:go\.mod$ patterntype:regexp go\s*(\d\.\d+)`,
+			defaults: []query.Parameter{},
+		},
+		{
+			name:     "literal query without patterntype",
+			input:    `package search`,
+			want:     `package search`,
+			defaults: []query.Parameter{},
+		},
+		{
+			name:     "literal query with patterntype",
+			input:    `package search patterntype:literal`,
+			want:     `patterntype:literal package search`,
+			defaults: []query.Parameter{},
+		},
+		{
+			name:     "literal query with quotes without patterntype",
+			input:    `"license": "A`,
+			want:     `"license": "A`,
+			defaults: []query.Parameter{},
+		},
+		{
+			name:     "literal query with quotes with patterntype",
+			input:    `"license": "A patterntype:literal`,
+			want:     `patterntype:literal "license": "A`,
+			defaults: []query.Parameter{},
+		},
+		{
+			name:     "structural query without patterntype",
+			input:    `TODO(...)`,
+			want:     `TODO(...)`,
+			defaults: []query.Parameter{},
+		},
+		{
+			name:     "structural query with patterntype",
+			input:    `TODO(...) patterntype:structural`,
+			want:     `patterntype:structural TODO(...)`,
+			defaults: []query.Parameter{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := withDefaults(test.input, test.defaults)
+			if err != nil {
+				t.Fatal(err)
+			}
 			println(got)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Fatalf("%s failed (want/got): %s", test.name, diff)

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -76,7 +76,7 @@ func TestWithDefaultsPatternTypes(t *testing.T) {
 		defaults query.Parameters
 	}{
 		{
-			// check: does this get parsed as regexp with new client?
+			// It's worth noting that we always append patterntype:regexp to capture group queries.
 			name:     "regexp query without patterntype",
 			input:    `file:go\.mod$ go\s*(\d\.\d+)`,
 			want:     `file:go\.mod$ go\s*(\d\.\d+)`,
@@ -131,7 +131,6 @@ func TestWithDefaultsPatternTypes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			println(got)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Fatalf("%s failed (want/got): %s", test.name, diff)
 			}
@@ -191,7 +190,6 @@ func TestMultiRepoQuery(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			println(got)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Fatalf("%s failed (want/got): %s", test.name, diff)
 			}


### PR DESCRIPTION
closes #37782

note: waiting for the default to be changed to `SearchTypeStandard`

## Test plan

Added unit tests for cases of queries with/without patterntype specified.

Created capture group insights to confirm they were still working as expected.
Created a search insight with quotes in the query to confirm it wasn't being made into a non-equivalent regexp query on the backend. 