### PR TITLE
fix(sg): restrict grafana link to only render on main

### DIFF
--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -18,7 +18,7 @@ generate_grafana_link() {
     # embedded as a value in other json (aka the query we send to grafana)
     expression="$(cat <<-EOF | jq -sR .
     {app="buildkite", build="$BUILDKITE_BUILD_NUMBER", branch="main", state="failed", job="$BUILDKITE_JOB_ID"} # to search the whole build remove the job id here!\n
-    |~ "(?i)failed|panic|" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
+    |~ "(?i)failed|panic|(FAIL:)" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
     EOF
     )"
     # On Darwin use gdate

--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -17,7 +17,7 @@ generate_grafana_link() {
     # -sR in the jq command below is "slurp" and "raw" tells jq to escape the json as a raw string since it will be
     # embedded as a value in other json (aka the query we send to grafana)
     expression="$(cat <<EOF | jq -sR .
-{app="buildkite", build="$BUILDKITE_BUILD_NUMBER", branch="main", state="failed", job="$BUILDKITE_JOB_ID"} # to search the whole build remove the job id here!\n
+{app="buildkite", build="$BUILDKITE_BUILD_NUMBER", branch="main", state="failed", job="$BUILDKITE_JOB_ID"} # to search the whole build remove the job id here!
 |~ "(?i)failed|panic|(FAIL:)" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
 EOF
     )"

--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -16,10 +16,10 @@ print_usage() {
 generate_grafana_link() {
     # -sR in the jq command below is "slurp" and "raw" tells jq to escape the json as a raw string since it will be
     # embedded as a value in other json (aka the query we send to grafana)
-    expression="$(cat <<-EOF | jq -sR .
-    {app="buildkite", build="$BUILDKITE_BUILD_NUMBER", branch="main", state="failed", job="$BUILDKITE_JOB_ID"} # to search the whole build remove the job id here!\n
-    |~ "(?i)failed|panic|(FAIL:)" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
-    EOF
+    expression="$(cat <<EOF | jq -sR .
+{app="buildkite", build="$BUILDKITE_BUILD_NUMBER", branch="main", state="failed", job="$BUILDKITE_JOB_ID"} # to search the whole build remove the job id here!\n
+|~ "(?i)failed|panic|(FAIL:)" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
+EOF
     )"
     # On Darwin use gdate
     begin=$(date -d '1 hour ago' "+%s")000

--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -32,9 +32,9 @@ EOF
 print_heading() {
     logs=""
     output="&bull; [View job output](#$BUILDKITE_JOB_ID)"
-    #if [[ $BUILDKITE_BRANCH == "main" ]]; then
-    logs="&bull; [View Grafana logs]($(generate_grafana_link))"
-    #fi
+    if [[ $BUILDKITE_BRANCH == "main" ]]; then
+        logs="&bull; [View Grafana logs]($(generate_grafana_link))"
+    fi
     printf "**%s** %s %s\n\n" "$BUILDKITE_LABEL" "$output" "$logs"
 }
 

--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -14,15 +14,17 @@ print_usage() {
 }
 
 generate_grafana_link() {
-    expression="$(cat <<EOF | sed '/\"/\\"/g'
-{app="buildkite", build="$BUILDKITE_BUILD_NUMBER", branch="main", state="failed", job="$BUILDKITE_JOB_ID"} # to search the whole build remove job here!\n
-|~ "(?i)failed|panic|" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
-EOF
-)"
+    # -sR in the jq command below is "slurp" and "raw" tells jq to escape the json as a raw string since it will be
+    # embedded as a value in other json (aka the query we send to grafana)
+    expression="$(cat <<-EOF | jq -sR .
+    {app="buildkite", build="$BUILDKITE_BUILD_NUMBER", branch="main", state="failed", job="$BUILDKITE_JOB_ID"} # to search the whole build remove the job id here!\n
+    |~ "(?i)failed|panic|" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
+    EOF
+    )"
     # On Darwin use gdate
     begin=$(date -d '1 hour ago' "+%s")000
     end=$(date "+%s")000
-    payload=$(printf '{"datasource":"grafanacloud-sourcegraph-logs","queries":[{"refId":"A","expr":"%s"}],"range":{"from":"%s","to":"%s"}}' "$expression" "$begin" "$end")
+    payload=$(printf '{"datasource":"grafanacloud-sourcegraph-logs","queries":[{"refId":"A","expr":%s}],"range":{"from":"%s","to":"%s"}}' "$expression" "$begin" "$end")
 
     echo "https://sourcegraph.grafana.net/explore?orgId=1&left=$(echo "$payload" | jq -s -R -r @uri)"
 }

--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -29,11 +29,11 @@ EOF
 
 print_heading() {
     logs=""
-    output="[View job output](#$BUILDKITE_JOB_ID)"
+    output="&bull; [View job output](#$BUILDKITE_JOB_ID)"
     if [[ $BUILDKITE_BRANCH == "main" ]]; then
-        logs="[View Grafana logs]($(generate_grafana_link))"
+        logs="&bull; [View Grafana logs]($(generate_grafana_link))"
     fi
-    printf "**%s** &bull; %s &bull; %s\n\n" "$BUILDKITE_LABEL" "$output" "$logs"
+    printf "**%s** %s %s\n\n" "$BUILDKITE_LABEL" "$output" "$logs"
 }
 
 if [ $# -eq 0 ]; then

--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -30,9 +30,9 @@ EOF
 print_heading() {
     logs=""
     output="&bull; [View job output](#$BUILDKITE_JOB_ID)"
-    if [[ $BUILDKITE_BRANCH == "main" ]]; then
-        logs="&bull; [View Grafana logs]($(generate_grafana_link))"
-    fi
+    #if [[ $BUILDKITE_BRANCH == "main" ]]; then
+    logs="&bull; [View Grafana logs]($(generate_grafana_link))"
+    #fi
     printf "**%s** %s %s\n\n" "$BUILDKITE_LABEL" "$output" "$logs"
 }
 


### PR DESCRIPTION
This fixes two slight issues with the grafana link generation
1. only render it when we're on the main branch, otherwise it is pointless since logs don't get uploaded on other branches
2. Add inline comments to the LogQL query and add a regex - Thanks @bobheadxi !

<img width="1568" alt="image" src="https://user-images.githubusercontent.com/1001709/177769437-0ab46630-ee49-47ea-abbb-f19c0b573586.png">

## Test plan
Tested on main-dry-run and allowing all branches
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
