### PR TITLE
Mention software community search contexts in docs

### DIFF
--- a/doc/code_search/explanations/features.md
+++ b/doc/code_search/explanations/features.md
@@ -50,7 +50,7 @@ Every search on Sourcegraph uses a search context. Search contexts can be define
 
 **Sourcegraph.com** supports a [set of predefined search contexts](https://sourcegraph.com/contexts?order=spec-asc&visible=17&owner=all).
 
-If no search context is specified, `context:global` is used.
+If no search context is specified, then the `context:global` is used, which searches over all code connected to Sourcegraph.com
 
 **Private Sourcegraph instances** support custom search contexts:
 

--- a/doc/code_search/explanations/features.md
+++ b/doc/code_search/explanations/features.md
@@ -52,7 +52,7 @@ Every search on Sourcegraph uses a search context. Search contexts can be define
 
 - Your personal context, `context:@username`, which automatically includes all repositories you add to Sourcegraph Cloud.
 - The global context, `context:global`, which includes all repositories on Sourcegraph Cloud.
-- Search contexts for various software communities like [CNCF](https://sourcegraph.com/search?q=context:cncf), [crates.io](https://sourcegraph.com/search?q=context:crates.io), [jvm](https://sourcegraph.com/search?q=context:jvm), and more.  
+- Search contexts for various software communities like [CNCF](https://sourcegraph.com/search?q=context:CNCF), [crates.io](https://sourcegraph.com/search?q=context:crates.io), [JVM](https://sourcegraph.com/search?q=context:JVM), and more.  
 
 If no search context is specified, `context:global` is used.
 

--- a/doc/code_search/explanations/features.md
+++ b/doc/code_search/explanations/features.md
@@ -48,9 +48,13 @@ Search contexts help you search the code you care about on Sourcegraph. A search
 
 Every search on Sourcegraph uses a search context. Search contexts can be defined with the contexts selector shown in the search input, or entered directly in a search query.
 
-**Sourcegraph.com** supports a [set of predefined search contexts](https://sourcegraph.com/contexts?order=spec-asc&visible=17&owner=all).
+**Sourcegraph.com** supports a [set of predefined search contexts](https://sourcegraph.com/contexts?order=spec-asc&visible=17&owner=all) that include:
 
-If no search context is specified, then the `context:global` is used, which searches over all code connected to Sourcegraph.com
+- Your personal context, `context:@username`, which automatically includes all repositories you add to Sourcegraph Cloud.
+- The global context, `context:global`, which includes all repositories on Sourcegraph Cloud.
+- Search contexts for various software communities like [CNCF](https://sourcegraph.com/search?q=context:cncf), [crates.io](https://sourcegraph.com/search?q=context:crates.io), [jvm](https://sourcegraph.com/search?q=context:jvm), and more.  
+
+If no search context is specified, `context:global` is used.
 
 **Private Sourcegraph instances** support custom search contexts:
 

--- a/doc/code_search/explanations/features.md
+++ b/doc/code_search/explanations/features.md
@@ -48,10 +48,7 @@ Search contexts help you search the code you care about on Sourcegraph. A search
 
 Every search on Sourcegraph uses a search context. Search contexts can be defined with the contexts selector shown in the search input, or entered directly in a search query.
 
-**Sourcegraph Cloud** currently supports two pre-set search contexts: 
-
-- Your personal context, `context:@username`, which automatically includes all repositories you add to Sourcegraph Cloud.
-- The global context, `context:global`, which includes all repositories on Sourcegraph Cloud.
+**Sourcegraph.com** supports a [set of predefined search contexts](https://sourcegraph.com/contexts?order=spec-asc&visible=17&owner=all).
 
 If no search context is specified, `context:global` is used.
 


### PR DESCRIPTION
I was reading these docs and noticed that we didn't mention any of the predefined contexts that we support (like CNCF, JVM, crates.io, etc), so wanted to add this (as well a link to the dynamic page that lists all search contexts a user has access to).

## Test plan

Reviewed markdown preview in GitHub