### PR TITLE
JetBrains: Make auth more convenient

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -103,7 +103,7 @@ public class JSToJavaBridgeRequestHandler {
                     ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.indicateAuthenticationStatus(arguments.get("wasServerAccessSuccessful").getAsBoolean(), arguments.get("wasAuthenticationSuccessful").getAsBoolean()));
                     return createSuccessResponse(null);
                 case "windowClose":
-                    ApplicationManager.getApplication().invokeLater(() -> findService.hidePopup());
+                    ApplicationManager.getApplication().invokeLater(findService::hidePopup);
                     return createSuccessResponse(null);
                 default:
                     return createErrorResponse("Unknown action: '" + action + "'.", "No stack trace");

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -16,59 +16,16 @@ import javax.swing.*;
 public class SettingsComponent {
 
     private final JPanel panel;
-    private final JBTextField sourcegraphUrlTextField;
-    private final JBTextField accessTokenTextField;
-    private final JBTextField defaultBranchNameTextField;
-    private final JBTextField remoteUrlReplacementsTextField;
-    private final JBCheckBox globbingCheckBox;
-    private final JBCheckBox isUrlNotificationDismissedCheckBox;
+    private JBTextField sourcegraphUrlTextField;
+    private JBTextField accessTokenTextField;
+    private JBTextField defaultBranchNameTextField;
+    private JBTextField remoteUrlReplacementsTextField;
+    private JBCheckBox globbingCheckBox;
+    private JBCheckBox isUrlNotificationDismissedCheckBox;
 
     public SettingsComponent() {
-        // User authentication
-        JBLabel sourcegraphUrlLabel = new JBLabel("Sourcegraph URL:");
-        sourcegraphUrlTextField = new JBTextField();
-        //noinspection DialogTitleCapitalization
-        sourcegraphUrlTextField.getEmptyText().setText("https://sourcegraph.example.com");
-        sourcegraphUrlTextField.setToolTipText("If your company has your own Sourcegraph instance, set its URL here.\nThe default is \"https://sourcegraph.com\".");
-
-        JBLabel accessTokenLabel = new JBLabel("Access token:");
-        accessTokenTextField = new JBTextField();
-        accessTokenTextField.getEmptyText().setText("Paste your access token here");
-        accessTokenTextField.setToolTipText("Go to https://sourcegraph.example.com/users/{your-username}/settings/tokens to create a token.");
-
-        JPanel userAuthenticationPanel = FormBuilder.createFormBuilder()
-            .addLabeledComponent(sourcegraphUrlLabel, sourcegraphUrlTextField)
-            .addLabeledComponent(accessTokenLabel, accessTokenTextField)
-            .getPanel();
-        userAuthenticationPanel.setBorder(IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
-
-        // Navigation settings
-        JBLabel defaultBranchNameLabel = new JBLabel("Default branch name:");
-        defaultBranchNameTextField = new JBTextField();
-        //noinspection DialogTitleCapitalization
-        defaultBranchNameTextField.getEmptyText().setText("main");
-        defaultBranchNameTextField.setToolTipText("Usually \"main\" or \"master\", but can be any branch name");
-
-        JBLabel remoteUrlReplacementsLabel = new JBLabel("Remote URL replacements:");
-        remoteUrlReplacementsTextField = new JBTextField();
-        //noinspection DialogTitleCapitalization
-        remoteUrlReplacementsTextField.getEmptyText().setText("search1, replacement1, search2, replacement2, ...");
-        remoteUrlReplacementsTextField.setToolTipText("You can replace specified strings in your repo's remote URL.\n" +
-            "The format is \"search1, replacement1, search2, replacement2, ...\".\n" +
-            "Use any number of search/replacement pairs.\n" +
-            "Pairs will be replaced going from left to right.\n" +
-            "The whitespace before and after the commas doesn't matter.");
-
-        globbingCheckBox = new JBCheckBox("Enable globbing");
-        isUrlNotificationDismissedCheckBox = new JBCheckBox("Never show the \"No Sourcegraph URL set\" notification for this project");
-
-        JPanel navigationSettingsPanel = FormBuilder.createFormBuilder()
-            .addLabeledComponent(defaultBranchNameLabel, defaultBranchNameTextField)
-            .addLabeledComponent(remoteUrlReplacementsLabel, remoteUrlReplacementsTextField)
-            .addComponent(globbingCheckBox)
-            .addComponent(isUrlNotificationDismissedCheckBox, 10)
-            .getPanel();
-        navigationSettingsPanel.setBorder(IdeBorderFactory.createTitledBorder("Navigation Settings", true, JBUI.insetsTop(8)));
+        JPanel userAuthenticationPanel = createAuthenticationPanel();
+        JPanel navigationSettingsPanel = createNavigationSettingsPanel();
 
         panel = FormBuilder.createFormBuilder()
             .addComponent(userAuthenticationPanel)
@@ -135,5 +92,57 @@ public class SettingsComponent {
 
     public void setUrlNotificationDismissedEnabled(boolean value) {
         isUrlNotificationDismissedCheckBox.setSelected(value);
+    }
+
+    @NotNull
+    private JPanel createAuthenticationPanel() {
+        JBLabel sourcegraphUrlLabel = new JBLabel("Sourcegraph URL:");
+        sourcegraphUrlTextField = new JBTextField();
+        //noinspection DialogTitleCapitalization
+        sourcegraphUrlTextField.getEmptyText().setText("https://sourcegraph.example.com");
+        sourcegraphUrlTextField.setToolTipText("If your company has your own Sourcegraph instance, set its URL here.\nThe default is \"https://sourcegraph.com\".");
+
+        JBLabel accessTokenLabel = new JBLabel("Access token:");
+        accessTokenTextField = new JBTextField();
+        accessTokenTextField.getEmptyText().setText("Paste your access token here");
+        accessTokenTextField.setToolTipText("Go to https://sourcegraph.example.com/users/{your-username}/settings/tokens to create a token.");
+
+        JPanel userAuthenticationPanel = FormBuilder.createFormBuilder()
+            .addLabeledComponent(sourcegraphUrlLabel, sourcegraphUrlTextField)
+            .addLabeledComponent(accessTokenLabel, accessTokenTextField)
+            .getPanel();
+        userAuthenticationPanel.setBorder(IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
+        return userAuthenticationPanel;
+    }
+
+    @NotNull
+    private JPanel createNavigationSettingsPanel() {
+        JBLabel defaultBranchNameLabel = new JBLabel("Default branch name:");
+        defaultBranchNameTextField = new JBTextField();
+        //noinspection DialogTitleCapitalization
+        defaultBranchNameTextField.getEmptyText().setText("main");
+        defaultBranchNameTextField.setToolTipText("Usually \"main\" or \"master\", but can be any branch name");
+
+        JBLabel remoteUrlReplacementsLabel = new JBLabel("Remote URL replacements:");
+        remoteUrlReplacementsTextField = new JBTextField();
+        //noinspection DialogTitleCapitalization
+        remoteUrlReplacementsTextField.getEmptyText().setText("search1, replacement1, search2, replacement2, ...");
+        remoteUrlReplacementsTextField.setToolTipText("You can replace specified strings in your repo's remote URL.\n" +
+            "The format is \"search1, replacement1, search2, replacement2, ...\".\n" +
+            "Use any number of search/replacement pairs.\n" +
+            "Pairs will be replaced going from left to right.\n" +
+            "The whitespace before and after the commas doesn't matter.");
+
+        globbingCheckBox = new JBCheckBox("Enable globbing");
+        isUrlNotificationDismissedCheckBox = new JBCheckBox("Never show the \"No Sourcegraph URL set\" notification for this project");
+
+        JPanel navigationSettingsPanel = FormBuilder.createFormBuilder()
+            .addLabeledComponent(defaultBranchNameLabel, defaultBranchNameTextField)
+            .addLabeledComponent(remoteUrlReplacementsLabel, remoteUrlReplacementsTextField)
+            .addComponent(globbingCheckBox)
+            .addComponent(isUrlNotificationDismissedCheckBox, 10)
+            .getPanel();
+        navigationSettingsPanel.setBorder(IdeBorderFactory.createTitledBorder("Navigation Settings", true, JBUI.insetsTop(8)));
+        return navigationSettingsPanel;
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -199,7 +199,6 @@ public class SettingsComponent {
             (remoteUrlReplacementsTextField.getText().length() > 0 && remoteUrlReplacementsTextField.getText().split(",").length % 2 != 0)
                 ? new ValidationInfo("Must be a comma-separated list of pairs", remoteUrlReplacementsTextField)
                 : null);
-        //remoteUrlReplacementsTextField.setToolTipText();
 
         globbingCheckBox = new JBCheckBox("Enable globbing");
         isUrlNotificationDismissedCheckBox = new JBCheckBox("Never show the \"No Sourcegraph URL set\" notification for this project");

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -1,9 +1,11 @@
 package com.sourcegraph.config;
 
+import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -22,6 +24,7 @@ public class SettingsComponent {
     private final JBCheckBox isUrlNotificationDismissedCheckBox;
 
     public SettingsComponent() {
+        // User authentication
         JBLabel sourcegraphUrlLabel = new JBLabel("Sourcegraph URL:");
         sourcegraphUrlTextField = new JBTextField();
         //noinspection DialogTitleCapitalization
@@ -33,6 +36,13 @@ public class SettingsComponent {
         accessTokenTextField.getEmptyText().setText("Paste your access token here");
         accessTokenTextField.setToolTipText("Go to https://sourcegraph.example.com/users/{your-username}/settings/tokens to create a token.");
 
+        JPanel userAuthenticationPanel = FormBuilder.createFormBuilder()
+            .addLabeledComponent(sourcegraphUrlLabel, sourcegraphUrlTextField)
+            .addLabeledComponent(accessTokenLabel, accessTokenTextField)
+            .getPanel();
+        userAuthenticationPanel.setBorder(IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
+
+        // Navigation settings
         JBLabel defaultBranchNameLabel = new JBLabel("Default branch name:");
         defaultBranchNameTextField = new JBTextField();
         //noinspection DialogTitleCapitalization
@@ -50,16 +60,19 @@ public class SettingsComponent {
             "The whitespace before and after the commas doesn't matter.");
 
         globbingCheckBox = new JBCheckBox("Enable globbing");
-
         isUrlNotificationDismissedCheckBox = new JBCheckBox("Never show the \"No Sourcegraph URL set\" notification for this project");
 
+        JPanel navigationSettingsPanel = FormBuilder.createFormBuilder()
+            .addLabeledComponent(defaultBranchNameLabel, defaultBranchNameTextField)
+            .addLabeledComponent(remoteUrlReplacementsLabel, remoteUrlReplacementsTextField)
+            .addComponent(globbingCheckBox)
+            .addComponent(isUrlNotificationDismissedCheckBox, 10)
+            .getPanel();
+        navigationSettingsPanel.setBorder(IdeBorderFactory.createTitledBorder("Navigation Settings", true, JBUI.insetsTop(8)));
+
         panel = FormBuilder.createFormBuilder()
-            .addLabeledComponent(sourcegraphUrlLabel, sourcegraphUrlTextField, 1, false)
-            .addLabeledComponent(accessTokenLabel, accessTokenTextField, 1, false)
-            .addLabeledComponent(defaultBranchNameLabel, defaultBranchNameTextField, 1, false)
-            .addLabeledComponent(remoteUrlReplacementsLabel, remoteUrlReplacementsTextField, 1, false)
-            .addComponent(globbingCheckBox, 1)
-            .addComponent(isUrlNotificationDismissedCheckBox, 1)
+            .addComponent(userAuthenticationPanel)
+            .addComponent(navigationSettingsPanel)
             .addComponentFillVertically(new JPanel(), 0)
             .getPanel();
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -201,7 +201,7 @@ public class SettingsComponent {
                 : null);
 
         globbingCheckBox = new JBCheckBox("Enable globbing");
-        isUrlNotificationDismissedCheckBox = new JBCheckBox("Never show the \"No Sourcegraph URL set\" notification for this project");
+        isUrlNotificationDismissedCheckBox = new JBCheckBox("Do not show the \"No Sourcegraph URL set\" notification for this project");
 
         JPanel navigationSettingsPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent(defaultBranchNameLabel, defaultBranchNameTextField)

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -100,16 +100,18 @@ public class SettingsComponent {
         sourcegraphUrlTextField = new JBTextField();
         //noinspection DialogTitleCapitalization
         sourcegraphUrlTextField.getEmptyText().setText("https://sourcegraph.example.com");
-        sourcegraphUrlTextField.setToolTipText("If your company has your own Sourcegraph instance, set its URL here.\nThe default is \"https://sourcegraph.com\".");
+        sourcegraphUrlTextField.setToolTipText("The default is \"https://sourcegraph.com\".");
 
         JBLabel accessTokenLabel = new JBLabel("Access token:");
         accessTokenTextField = new JBTextField();
         accessTokenTextField.getEmptyText().setText("Paste your access token here");
-        accessTokenTextField.setToolTipText("Go to https://sourcegraph.example.com/users/{your-username}/settings/tokens to create a token.");
+        accessTokenTextField.setToolTipText("");
 
         JPanel userAuthenticationPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent(sourcegraphUrlLabel, sourcegraphUrlTextField)
+            .addTooltip("If your company has your own Sourcegraph instance, set its URL here")
             .addLabeledComponent(accessTokenLabel, accessTokenTextField)
+            .addTooltip("Go to https://sourcegraph.example.com/settings | \"Access tokens\" to create a token")
             .getPanel();
         userAuthenticationPanel.setBorder(IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
         return userAuthenticationPanel;
@@ -121,24 +123,25 @@ public class SettingsComponent {
         defaultBranchNameTextField = new JBTextField();
         //noinspection DialogTitleCapitalization
         defaultBranchNameTextField.getEmptyText().setText("main");
-        defaultBranchNameTextField.setToolTipText("Usually \"main\" or \"master\", but can be any branch name");
+        defaultBranchNameTextField.setToolTipText("Usually \"main\" or \"master\", but can be any name");
 
         JBLabel remoteUrlReplacementsLabel = new JBLabel("Remote URL replacements:");
         remoteUrlReplacementsTextField = new JBTextField();
         //noinspection DialogTitleCapitalization
         remoteUrlReplacementsTextField.getEmptyText().setText("search1, replacement1, search2, replacement2, ...");
-        remoteUrlReplacementsTextField.setToolTipText("You can replace specified strings in your repo's remote URL.\n" +
-            "The format is \"search1, replacement1, search2, replacement2, ...\".\n" +
-            "Use any number of search/replacement pairs.\n" +
-            "Pairs will be replaced going from left to right.\n" +
-            "The whitespace before and after the commas doesn't matter.");
+        //remoteUrlReplacementsTextField.setToolTipText();
 
         globbingCheckBox = new JBCheckBox("Enable globbing");
         isUrlNotificationDismissedCheckBox = new JBCheckBox("Never show the \"No Sourcegraph URL set\" notification for this project");
 
         JPanel navigationSettingsPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent(defaultBranchNameLabel, defaultBranchNameTextField)
+            .addTooltip("The branch to use if the current branch is not yet pushed")
             .addLabeledComponent(remoteUrlReplacementsLabel, remoteUrlReplacementsTextField)
+            .addTooltip("You can replace specified strings in your repo's remote URL.")
+            .addTooltip("The format is \"search1, replacement1, search2, replacement2, ...\".")
+            .addTooltip("Use any number of search/replacement pairs. Pairs will be replaced going from left to right.")
+            .addTooltip("The whitespace before and after the commas doesn't matter.")
             .addComponent(globbingCheckBox)
             .addComponent(isUrlNotificationDismissedCheckBox, 10)
             .getPanel();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -1,20 +1,30 @@
 package com.sourcegraph.config;
 
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComponentValidator;
+import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import com.jetbrains.jsonSchema.settings.mappings.JsonSchemaConfigurable;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.JTextComponent;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Supports creating and managing a {@link JPanel} for the Settings Dialog.
  */
 public class SettingsComponent {
-
+    private final Project project;
     private final JPanel panel;
     private JBTextField sourcegraphUrlTextField;
     private JBTextField accessTokenTextField;
@@ -22,8 +32,10 @@ public class SettingsComponent {
     private JBTextField remoteUrlReplacementsTextField;
     private JBCheckBox globbingCheckBox;
     private JBCheckBox isUrlNotificationDismissedCheckBox;
+    private JBLabel accessTokenLinkComment;
 
-    public SettingsComponent() {
+    public SettingsComponent(@NotNull Project project) {
+        this.project = project;
         JPanel userAuthenticationPanel = createAuthenticationPanel();
         JPanel navigationSettingsPanel = createNavigationSettingsPanel();
 
@@ -96,25 +108,79 @@ public class SettingsComponent {
 
     @NotNull
     private JPanel createAuthenticationPanel() {
-        JBLabel sourcegraphUrlLabel = new JBLabel("Sourcegraph URL:");
+        JBLabel urlLabel = new JBLabel("Sourcegraph URL:");
         sourcegraphUrlTextField = new JBTextField();
         //noinspection DialogTitleCapitalization
         sourcegraphUrlTextField.getEmptyText().setText("https://sourcegraph.example.com");
         sourcegraphUrlTextField.setToolTipText("The default is \"https://sourcegraph.com\".");
 
+        addValidation(sourcegraphUrlTextField, () ->
+            sourcegraphUrlTextField.getText().length() == 0 ? new ValidationInfo("Missing URL", sourcegraphUrlTextField)
+                : (!JsonSchemaConfigurable.isValidURL(sourcegraphUrlTextField.getText()) ? new ValidationInfo("This is an invalid URL", sourcegraphUrlTextField)
+                : null));
+        addDocumentListener(sourcegraphUrlTextField, e -> updateAccessTokenLinkCommentText());
+
         JBLabel accessTokenLabel = new JBLabel("Access token:");
         accessTokenTextField = new JBTextField();
         accessTokenTextField.getEmptyText().setText("Paste your access token here");
-        accessTokenTextField.setToolTipText("");
+        addValidation(accessTokenTextField, () ->
+            (accessTokenTextField.getText().length() > 0 && accessTokenTextField.getText().length() != 40)
+                ? new ValidationInfo("Invalid access token", accessTokenTextField)
+                : null);
+
+        JBLabel userDocsLinkComment = new JBLabel("<html><body>You might need an access token to sign in. See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> for a video guide,</body></html>", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
+        userDocsLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
+        userDocsLinkComment.setCopyable(true);
+        accessTokenLinkComment = new JBLabel("", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
+        accessTokenLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
+        accessTokenLinkComment.setCopyable(true);
 
         JPanel userAuthenticationPanel = FormBuilder.createFormBuilder()
-            .addLabeledComponent(sourcegraphUrlLabel, sourcegraphUrlTextField)
+            .addLabeledComponent(urlLabel, sourcegraphUrlTextField)
             .addTooltip("If your company has your own Sourcegraph instance, set its URL here")
             .addLabeledComponent(accessTokenLabel, accessTokenTextField)
-            .addTooltip("Go to https://sourcegraph.example.com/settings | \"Access tokens\" to create a token")
+            .addComponentToRightColumn(userDocsLinkComment, 1)
+            .addComponentToRightColumn(accessTokenLinkComment, 1)
             .getPanel();
         userAuthenticationPanel.setBorder(IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
+
         return userAuthenticationPanel;
+    }
+
+    private void addValidation(@NotNull JTextComponent component, @NotNull Supplier<ValidationInfo> validator) {
+        new ComponentValidator(project).withValidator(validator).installOn(component);
+        addDocumentListener(component, e -> ComponentValidator.getInstance(component).ifPresent(ComponentValidator::revalidate));
+    }
+
+    private void addDocumentListener(@NotNull JTextComponent textComponent, @NotNull Consumer<ComponentValidator> function) {
+        textComponent.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                ComponentValidator.getInstance(textComponent).ifPresent(function);
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                ComponentValidator.getInstance(textComponent).ifPresent(function);
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                ComponentValidator.getInstance(textComponent).ifPresent(function);
+            }
+        });
+    }
+
+    private void updateAccessTokenLinkCommentText() {
+        String baseUrl = sourcegraphUrlTextField.getText();
+        String settingsUrl = (baseUrl.endsWith("/") ? baseUrl : baseUrl + "/") + "settings";
+        accessTokenLinkComment.setText(isUrlValid(baseUrl)
+            ? "<html><body>or go to <a href=\"" + settingsUrl + "\">" + settingsUrl + "</a> | \"Access tokens\" to create one.</body></html>"
+            : "");
+    }
+
+    private boolean isUrlValid(@NotNull String url) {
+        return JsonSchemaConfigurable.isValidURL(url);
     }
 
     @NotNull
@@ -129,6 +195,10 @@ public class SettingsComponent {
         remoteUrlReplacementsTextField = new JBTextField();
         //noinspection DialogTitleCapitalization
         remoteUrlReplacementsTextField.getEmptyText().setText("search1, replacement1, search2, replacement2, ...");
+        addValidation(remoteUrlReplacementsTextField, () ->
+            (remoteUrlReplacementsTextField.getText().length() > 0 && remoteUrlReplacementsTextField.getText().split(",").length % 2 != 0)
+                ? new ValidationInfo("Must be a comma-separated list of pairs", remoteUrlReplacementsTextField)
+                : null);
         //remoteUrlReplacementsTextField.setToolTipText();
 
         globbingCheckBox = new JBCheckBox("Enable globbing");
@@ -139,9 +209,8 @@ public class SettingsComponent {
             .addTooltip("The branch to use if the current branch is not yet pushed")
             .addLabeledComponent(remoteUrlReplacementsLabel, remoteUrlReplacementsTextField)
             .addTooltip("You can replace specified strings in your repo's remote URL.")
-            .addTooltip("The format is \"search1, replacement1, search2, replacement2, ...\".")
-            .addTooltip("Use any number of search/replacement pairs. Pairs will be replaced going from left to right.")
-            .addTooltip("The whitespace before and after the commas doesn't matter.")
+            .addTooltip("Use any number of pairs: \"search1, replacement1, search2, replacement2, ...\".")
+            .addTooltip("Pairs are replaced from left to right. Whitespace around commas doesn't matter.")
             .addComponent(globbingCheckBox)
             .addComponent(isUrlNotificationDismissedCheckBox, 10)
             .getPanel();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -33,7 +33,7 @@ public class SettingsConfigurable implements Configurable {
     @Nullable
     @Override
     public JComponent createComponent() {
-        mySettingsComponent = new SettingsComponent();
+        mySettingsComponent = new SettingsComponent(project);
         return mySettingsComponent.getPanel();
     }
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36783

The work items here were these:
1. Add "User authentication" and "Navigation settings" groups
2. Add help texts
3. Set up URL syntax validation
4. Set up automatic access token validation after an access token change or URL change

--- 

Details on each:

**1. Grouping:** It was a pain. It was rather difficult to figure it out without the UI Inspector, which I couldn't make work at first. But then today morning I managed to pop it up: I still don't have a menu item for it, but `⌃⌥click` brings it up in my sandboxed instance! So that made it somewhat quicker, and I've added the two groups and the indentation to make the two groups of settings look somewhat like JetBrains' UI guidelines.

**2. Help texts:** I've added many of them. They don't closely follow the [figma](https://www.figma.com/file/nmNPZGYCoGIUN0YMylmPTT/JetBrains-plugin-MLP?node-id=246%3A11) but we discussed with @jjinnii that even the figma versions are not final and let's not get blocked by the final copy, as it's something that's relatively easy to change later.

**3. URL validation:** Turns out that JetBrains has pretty good [guidelines](https://jetbrains.design/intellij/principles/validation_errors/) for this, that even includes some code! The code is somewhat obsolete and it didn't really work for me out of the box, but I found a way and now it's very stable. I also extracted the most verbose parts to private methods, so now we can add validations with lambda functions in a much more concise way. The validation itself is not my custom one but one that's part of `JsonSchemaConfigurable`, as this seemed to be the most standard one. TBH, it's cr*p, it basically notices if a URL doesn't start with "http", but accepts pretty much everything else. I think this is a good baseline of defense, though.

**4. Token validation:** I only implemented a simplistic version. I think this is acceptable, but I'm also interested in other opinions. Currently, the validation only considers the field valid if it's either exactly 40 characters long, or empty. This should cover most honest mistakes. The next step here would be to implement remote validation, but:
 - Currently, we only have the access token validation code on the JS side, and adding it to the Java side would result in some duplication of functionality, and would take time.
 - I already took so long with this because of the lack of documentation on Swing and IntelliJ components that I'd prefer to cut this effort short and go with this more simplistic validation. I honestly think it helps users with the most common mistakes like not copying the first/last character of the token.

## Test plan

- Here is the UI demo: [3-min Loom](https://www.loom.com/share/a52b6566f88b4a1a8e0f6e9ae53c493a)
- Check the code

## App preview:

- [Web](https://sg-web-dv-jetbrains-make-auth-more.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-appvhjimib.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
