### PR TITLE
Search backend: remove `PartialJob.Partial()` and extend utility functions

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -209,7 +209,7 @@ func orderSearcherJob(j job.Job) job.Job {
 	// This job will be sequentially ordered after any Zoekt jobs. We assume
 	// at most one searcher job exists.
 	var pagedSearcherJob job.Job
-	newJob := job.MapType[*repoPagerJob](j, func(pager *repoPagerJob) job.Job {
+	newJob := job.MapType(j, func(pager *repoPagerJob) job.Job {
 		if job.HasDescendent[*searcher.TextSearchJob](pager) {
 			pagedSearcherJob = pager
 			return &NoopJob{}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -209,14 +209,12 @@ func orderSearcherJob(j job.Job) job.Job {
 	// This job will be sequentially ordered after any Zoekt jobs. We assume
 	// at most one searcher job exists.
 	var pagedSearcherJob job.Job
-	newJob := job.Map(j, func(current job.Job) job.Job {
-		if pager, ok := current.(*repoPagerJob); ok {
-			if _, ok := pager.child.Partial().(*searcher.TextSearchJob); ok {
-				pagedSearcherJob = pager
-				return &NoopJob{}
-			}
+	newJob := job.MapType[*repoPagerJob](j, func(pager *repoPagerJob) job.Job {
+		if job.HasDescendent[*searcher.TextSearchJob](pager) {
+			pagedSearcherJob = pager
+			return &NoopJob{}
 		}
-		return current
+		return pager
 	})
 
 	if pagedSearcherJob == nil {
@@ -226,15 +224,18 @@ func orderSearcherJob(j job.Job) job.Job {
 
 	// Map the tree to execute paged searcher jobs after any Zoekt jobs.
 	// We assume at most one of either two Zoekt search jobs may exist.
-	seenZoektRepoSearch, seenZoektGlobalSearch := false, false
-	newJob = job.Map(newJob, func(current job.Job) job.Job {
-		if pager, ok := current.(*repoPagerJob); ok {
-			if _, ok := pager.child.Partial().(*zoekt.RepoSubsetTextSearchJob); ok && !seenZoektRepoSearch {
-				seenZoektRepoSearch = true
-				return NewSequentialJob(false, current, pagedSearcherJob)
-			}
+	seenZoektRepoSearch := false
+	newJob = job.MapType(newJob, func(pager *repoPagerJob) job.Job {
+		if job.HasDescendent[*zoekt.RepoSubsetTextSearchJob](pager) {
+			seenZoektRepoSearch = true
+			return NewSequentialJob(false, pager, pagedSearcherJob)
 		}
-		if _, ok := current.(*zoekt.GlobalTextSearchJob); ok && !seenZoektGlobalSearch {
+		return pager
+	})
+
+	seenZoektGlobalSearch := false
+	newJob = job.MapType(newJob, func(current *zoekt.GlobalTextSearchJob) job.Job {
+		if !seenZoektGlobalSearch {
 			seenZoektGlobalSearch = true
 			return NewSequentialJob(false, current, pagedSearcherJob)
 		}

--- a/internal/search/job/walk.go
+++ b/internal/search/job/walk.go
@@ -1,0 +1,51 @@
+package job
+
+type MapFunc func(Job) Job
+
+// Map applies fn to every job in tree recursively, returning a new job.
+// The provided function should return a copied job with the mutations
+// applied rather than mutating the job in-place.
+func Map(j Job, fn MapFunc) Job {
+	j = j.MapChildren(fn)
+	return fn(j)
+}
+
+// MapType works the same way as Map, except the provided function
+// is only called for jobs of the type the function accepts. This
+// is useful for when you want to modify only jobs of a certain type.
+func MapType[T Job](j Job, fn func(T) Job) Job {
+	mapFn := func(current Job) Job {
+		if t, ok := current.(T); ok {
+			return fn(t)
+		}
+		return current
+	}
+	return Map(j, mapFn)
+}
+
+// Visit iterates through each job and partial job in preorder.
+func Visit(j Describer, fn func(Describer)) {
+	fn(j)
+	for _, child := range j.Children() {
+		Visit(child, fn)
+	}
+}
+
+// VisitType works the same way as Visit, except the callback is only
+// called on describers with the type that the caller accepts. This is
+// useful when you want to visit all jobs of a certain type.
+func VisitType[T Describer](j Describer, fn func(T)) {
+	Visit(j, func(current Describer) {
+		if t, ok := current.(T); ok {
+			fn(t)
+		}
+	})
+}
+
+// HasDescendent returns whether the job has any descendents with type T.
+func HasDescendent[T Describer](j Job) (res bool) {
+	VisitType(j, func(T) {
+		res = true
+	})
+	return res
+}


### PR DESCRIPTION
This removes `PartialJob.Partial()` by replacing its uses with visitors. It also adds some utility functions like `MapType`, `Visit`, `VisitType`, and `HasDescendents`, which are used to simplify the code that was previously using `Partial()`. 

Stacked on https://github.com/sourcegraph/sourcegraph/pull/38364

## Test plan

Tested implicitly by current uses of map. It's exercised quite well by `NewPlanJob` tests. Testing explicitly is a little annoying because it turns out I can't import `mockjob` from `job`. I'll have to figure that one out.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
