### PR TITLE
Add automatic repo permissions sync toggle

### DIFF
--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -527,7 +527,8 @@ const GITHUB_DOTCOM: AddExternalServiceOptions = {
     defaultConfig: `{
   "url": "https://github.com",
   "token": "<access token>",
-  "orgs": []
+  "orgs": [],
+  "disableAutomaticRepoPermissionsSync": true
 }`,
 }
 const GITHUB_ENTERPRISE: AddExternalServiceOptions = {
@@ -536,7 +537,8 @@ const GITHUB_ENTERPRISE: AddExternalServiceOptions = {
     defaultConfig: `{
   "url": "https://github.example.com",
   "token": "<access token>",
-  "orgs": []
+  "orgs": [],
+  "disableAutomaticRepoPermissionsSync": true
 }`,
     editorActions: githubEditorActions(true),
     instructions: githubInstructions(true),
@@ -923,7 +925,8 @@ const GITLAB_DOTCOM: AddExternalServiceOptions = {
   "token": "<access token>",
   "projectQuery": [
     "projects?membership=true&archived=no"
-  ]
+  ],
+  "disableAutomaticRepoPermissionsSync": true
 }`,
     editorActions: gitlabEditorActions(false),
     instructions: gitlabInstructions(false),
@@ -938,7 +941,8 @@ const GITLAB_SELF_MANAGED: AddExternalServiceOptions = {
   "token": "<access token>",
   "projectQuery": [
     "projects?membership=true&archived=no"
-  ]
+  ],
+  "disableAutomaticRepoPermissionsSync": true
 }`,
 }
 const SRC_SERVE_GIT: AddExternalServiceOptions = {

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1752,7 +1752,11 @@ WHERE extsvcs.deleted_at IS NULL
 
 		switch c := parsed.(type) {
 		case *schema.GitHubConnection:
-			if !c.AutomaticRepoPermissionsSync {
+			if c.DisableAutomaticRepoPermissionsSync {
+				excludedExternalServices = append(excludedExternalServices, externalService.ID)
+			}
+		case *schema.GitLabConnection:
+			if c.DisableAutomaticRepoPermissionsSync {
 				excludedExternalServices = append(excludedExternalServices, externalService.ID)
 			}
 		}

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1603,7 +1603,7 @@ func (s *permsStore) RepoIDsWithNoPerms(ctx context.Context) ([]api.RepoID, erro
 
 	excludedExternalServicesClause := sqlf.Sprintf("TRUE")
 	if len(excludedExternalServices) > 0 {
-		excludedExternalServicesList := strings.Trim(strings.Replace(fmt.Sprint(excludedExternalServices), " ", ",", -1), "[]")
+		excludedExternalServicesList := strings.Trim(strings.ReplaceAll(fmt.Sprint(excludedExternalServices), " ", ","), "[]")
 		excludedExternalServicesClause = sqlf.Sprintf(fmt.Sprintf("(extsvc_repos.external_service_id IS NULL OR extsvc_repos.external_service_id NOT IN (%s))", excludedExternalServicesList))
 	}
 
@@ -1669,7 +1669,7 @@ func (s *permsStore) ReposIDsWithOldestPerms(ctx context.Context, limit int, age
 
 	excludedExternalServicesClause := sqlf.Sprintf("TRUE")
 	if len(excludedExternalServices) > 0 {
-		excludedExternalServicesList := strings.Trim(strings.Replace(fmt.Sprint(excludedExternalServices), " ", ",", -1), "[]")
+		excludedExternalServicesList := strings.Trim(strings.ReplaceAll(fmt.Sprint(excludedExternalServices), " ", ","), "[]")
 		excludedExternalServicesClause = sqlf.Sprintf(fmt.Sprintf("(extsvc_repos.external_service_id IS NULL OR extsvc_repos.external_service_id NOT IN (%s))", excludedExternalServicesList))
 	}
 

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -2716,7 +2716,7 @@ func testPermsStore_RepoIDsWithNoPerms(db database.DB) func(*testing.T) {
 			sqlf.Sprintf(`INSERT INTO repo(name, private) VALUES('private_repo_2', TRUE)`),                    // ID=3
 			sqlf.Sprintf(`INSERT INTO repo(name, private, deleted_at) VALUES('private_repo_3', TRUE, NOW())`), // ID=4
 			sqlf.Sprintf(`INSERT INTO repo(name, private) VALUES('private_repo_4', TRUE)`),                    // ID=5
-			sqlf.Sprintf(`INSERT INTO external_services(id, display_name, kind, config) VALUES(1, 'GitHub #1', 'GITHUB', '{"automaticRepoPermissionsSync": false}')`),
+			sqlf.Sprintf(`INSERT INTO external_services(id, display_name, kind, config) VALUES(1, 'GitHub #1', 'GITHUB', '{"disableAutomaticRepoPermissionsSync": true}')`),
 			sqlf.Sprintf(`INSERT INTO external_service_repos(repo_id, external_service_id, clone_url)
                                  VALUES(5, 1, '')`),
 		}
@@ -2904,8 +2904,8 @@ func testPermsStore_ReposIDsWithOldestPerms(db database.DB) func(*testing.T) {
 			sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(2, 'private_repo_2', TRUE)`),
 			sqlf.Sprintf(`INSERT INTO repo(id, name, private, deleted_at) VALUES(3, 'private_repo_3', TRUE, NOW())`),
 			sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(4, 'private_repo_4', TRUE)`),
-			sqlf.Sprintf(`INSERT INTO external_services(id, display_name, kind, config) VALUES(1, 'GitHub #1', 'GITHUB', '{"automaticRepoPermissionsSync": true}')`),
-			sqlf.Sprintf(`INSERT INTO external_services(id, display_name, kind, config) VALUES(2, 'GitHub #2', 'GITHUB', '{"automaticRepoPermissionsSync": false}')`),
+			sqlf.Sprintf(`INSERT INTO external_services(id, display_name, kind, config) VALUES(1, 'GitHub #1', 'GITHUB', '{"disableAutomaticRepoPermissionsSync": false}')`),
+			sqlf.Sprintf(`INSERT INTO external_services(id, display_name, kind, config) VALUES(2, 'GitHub #2', 'GITHUB', '{"disableAutomaticRepoPermissionsSync": true}')`),
 			sqlf.Sprintf(`INSERT INTO external_service_repos(repo_id, external_service_id, clone_url)
                                  VALUES(1, 1, ''), (2, 1, ''), (3, 1, ''), (4, 2, '')`),
 		}

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -53,8 +53,8 @@
         "requestsPerHour": 5000
       }
     },
-    "automaticRepoPermissionsSync": {
-      "description": "Automatically schedule repository permission syncing for this connection in the background.",
+    "disableAutomaticRepoPermissionsSync": {
+      "description": "If true, repository-centric permissions syncing will not be automatically scheduled in the background.",
       "type": "boolean",
       "default": false
     },

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -53,6 +53,11 @@
         "requestsPerHour": 5000
       }
     },
+    "automaticRepoPermissionsSync": {
+      "description": "Automatically schedule repository permission syncing for this connection in the background.",
+      "type": "boolean",
+      "default": false
+    },
     "certificate": {
       "description": "TLS certificate of the GitHub Enterprise instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.",
       "type": "string",

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -61,6 +61,11 @@
         "requestsPerHour": 36000
       }
     },
+    "disableAutomaticRepoPermissionsSync": {
+      "description": "If true, repository-centric permissions syncing will not be automatically scheduled in the background.",
+      "type": "boolean",
+      "default": false
+    },
     "gitURLType": {
       "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.\n\nIf \"http\", Sourcegraph will access GitLab repositories using Git URLs of the form http(s)://gitlab.example.com/myteam/myproject.git (using https: if the GitLab instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
       "type": "string",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -747,6 +747,8 @@ type GitHubAuthorization struct {
 type GitHubConnection struct {
 	// Authorization description: If non-null, enforces GitHub repository permissions. This requires that there is an item in the [site configuration json](https://docs.sourcegraph.com/admin/config/site_config#auth-providers) `auth.providers` field, of type "github" with the same `url` field as specified in this `GitHubConnection`.
 	Authorization *GitHubAuthorization `json:"authorization,omitempty"`
+	// AutomaticRepoPermissionsSync description: Automatically schedule repository permission syncing for this connection in the background.
+	AutomaticRepoPermissionsSync bool `json:"automaticRepoPermissionsSync,omitempty"`
 	// Certificate description: TLS certificate of the GitHub Enterprise instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	Certificate string `json:"certificate,omitempty"`
 	// CloudDefault description: Only used to override the cloud_default column from a config file specified by EXTSVC_CONFIG_FILE

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -747,14 +747,14 @@ type GitHubAuthorization struct {
 type GitHubConnection struct {
 	// Authorization description: If non-null, enforces GitHub repository permissions. This requires that there is an item in the [site configuration json](https://docs.sourcegraph.com/admin/config/site_config#auth-providers) `auth.providers` field, of type "github" with the same `url` field as specified in this `GitHubConnection`.
 	Authorization *GitHubAuthorization `json:"authorization,omitempty"`
-	// AutomaticRepoPermissionsSync description: Automatically schedule repository permission syncing for this connection in the background.
-	AutomaticRepoPermissionsSync bool `json:"automaticRepoPermissionsSync,omitempty"`
 	// Certificate description: TLS certificate of the GitHub Enterprise instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	Certificate string `json:"certificate,omitempty"`
 	// CloudDefault description: Only used to override the cloud_default column from a config file specified by EXTSVC_CONFIG_FILE
 	CloudDefault bool `json:"cloudDefault,omitempty"`
 	// CloudGlobal description: When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.
 	CloudGlobal bool `json:"cloudGlobal,omitempty"`
+	// DisableAutomaticRepoPermissionsSync description: If true, repository-centric permissions syncing will not be automatically scheduled in the background.
+	DisableAutomaticRepoPermissionsSync bool `json:"disableAutomaticRepoPermissionsSync,omitempty"`
 	// Exclude description: A list of repositories to never mirror from this GitHub instance. Takes precedence over "orgs", "repos", and "repositoryQuery" configuration.
 	//
 	// Supports excluding by name ({"name": "owner/name"}) or by ID ({"id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg=="}).
@@ -860,6 +860,8 @@ type GitLabConnection struct {
 	CloudDefault bool `json:"cloudDefault,omitempty"`
 	// CloudGlobal description: When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.
 	CloudGlobal bool `json:"cloudGlobal,omitempty"`
+	// DisableAutomaticRepoPermissionsSync description: If true, repository-centric permissions syncing will not be automatically scheduled in the background.
+	DisableAutomaticRepoPermissionsSync bool `json:"disableAutomaticRepoPermissionsSync,omitempty"`
 	// Exclude description: A list of projects to never mirror from this GitLab instance. Takes precedence over "projects" and "projectQuery" configuration. Supports excluding by name ({"name": "group/name"}) or by ID ({"id": 42}).
 	Exclude []*ExcludedGitLabProject `json:"exclude,omitempty"`
 	// GitURLType description: The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.


### PR DESCRIPTION
Adds a new field to the external services config called `disableAutomaticRepoPermissionsSync`, which is `false` by default. This maintains backwards compatibility with existing configurations. However, all new configurations will have `"disableAutomaticRepoPermissionsSync": true` added to the config by default.

Any repositories added by external services with this field set to `false` will be excluded from the functions `ReposIDsWithOldestPerms` and `RepoIDsWithNoPerms`, which are used to fetch repositories that should be automatically synced.

This allows admins to still trigger a manual sync of the repositories if they want to.

Will probably have to think of some sort of a migration for existing customers so that things don't stop working the way they're used to.

Fix #25903 
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Updated unit tests to include code hosts that have `disableAutomaticRepoPermissionsSync` set to `true`, and verified that `ReposIDsWithOldestPerms` and `RepoIDsWithNoPerms` ignores those repositories.