### PR TITLE
Code Insights: Revert skip logic for the GET_INSIGHT_VIEW_GQL query

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -22,7 +22,7 @@ import { createBackendInsightData } from '../../../../core/backend/gql-backend/m
 import { insightPollingInterval } from '../../../../core/backend/gql-backend/utils/insight-polling'
 import { SeriesDisplayOptionsInputRequired } from '../../../../core/types/insight/common'
 import { getTrackingTypeByInsightType, useCodeInsightViewPings } from '../../../../pings'
-import { FORM_ERROR, SubmissionErrors } from '../../../form/hooks/useForm'
+import { FORM_ERROR, SubmissionErrors } from '../../../form'
 import { InsightCard, InsightCardBanner, InsightCardHeader, InsightCardLoading } from '../../../views'
 import { useVisibility } from '../../hooks/use-insight-data'
 import { InsightContextMenu } from '../insight-context-menu/InsightContextMenu'
@@ -101,7 +101,8 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
             variables: { id: insight.id, filters: filterInput, seriesDisplayOptions: displayInput },
             fetchPolicy: 'cache-and-network',
             pollInterval: pollingInterval,
-            skip: !wasEverVisible || (insightData && (!insightData.isFetchingHistoricalData || !isVisible)),
+            // TODO: Fix problem with offscreen pooling see https://github.com/sourcegraph/sourcegraph/issues/38425
+            skip: !wasEverVisible,
             context: { concurrentRequests: { key: 'GET_INSIGHT_VIEW' } },
             onCompleted: data => {
                 const parsedData = createBackendInsightData({ ...insight, filters }, data.insightViews.nodes[0])
@@ -111,9 +112,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                 seriesToggleState.setSelectedSeriesIds([])
                 setInsightData(parsedData)
             },
-            onError: () => {
-                stopPolling()
-            },
+            onError: () => stopPolling(),
         }
     )
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/38424

This PR reverts changes from https://github.com/sourcegraph/sourcegraph/pull/38252 [(see comment about skip logic)](https://github.com/sourcegraph/sourcegraph/pull/38252#discussion_r914202303)

The original problem with pooling state for insights that are not visible on the screen will be addressed in this issue https://github.com/sourcegraph/sourcegraph/issues/38425

## Test plan
- Make sure that the insight card is fetching its data when filters are changing 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
