### PR TITLE
search ui: disable homepage panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Search: Pasting a query with line breaks into the main search query input will now replace them with spaces instead of removing them. [#37674](https://github.com/sourcegraph/sourcegraph/pull/37674)
 - Rewrite resource estimator using the latest metrics [#37869](https://github.com/sourcegraph/sourcegraph/pull/37869)
 - Selecting a line multiple times in the file view will only add a single browser history entry [#38204](https://github.com/sourcegraph/sourcegraph/pull/38204)
-- The homepage panels are now turned off by default. They can be re-enabled by setting `experimentalFeatures.showEnterpriseHomePanels` to true. []()
+- The panels on the homepage (recent searches, etc) are now turned off by default. They can be re-enabled by setting `experimentalFeatures.showEnterpriseHomePanels` to true. [#38431](https://github.com/sourcegraph/sourcegraph/pull/38431)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Search: Pasting a query with line breaks into the main search query input will now replace them with spaces instead of removing them. [#37674](https://github.com/sourcegraph/sourcegraph/pull/37674)
 - Rewrite resource estimator using the latest metrics [#37869](https://github.com/sourcegraph/sourcegraph/pull/37869)
 - Selecting a line multiple times in the file view will only add a single browser history entry [#38204](https://github.com/sourcegraph/sourcegraph/pull/38204)
+- The homepage panels are now turned off by default. They can be re-enabled by setting `experimentalFeatures.showEnterpriseHomePanels` to true. []()
 
 ### Fixed
 

--- a/client/web/src/search/home/SearchPageFooter.tsx
+++ b/client/web/src/search/home/SearchPageFooter.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Link, H2, H3, H4 } from '@sourcegraph/wildcard'
+import { Link, H2, H4 } from '@sourcegraph/wildcard'
 
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { PageRoutes } from '../../routes.constants'
@@ -120,7 +120,7 @@ export const SearchPageFooter: React.FunctionComponent<
         </footer>
     ) : (
         <footer className={classNames(styles.serverFooter, 'd-flex flex-column flex-lg-row align-items-center')}>
-            <H4 as={H3} className="mb-2 mb-lg-0">
+            <H4 as={H2} className="mb-2 mb-lg-0">
                 Explore and extend
             </H4>
             <span className="d-flex flex-column flex-md-row align-items-center">

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -6,7 +6,7 @@ import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/setting
 
 const defaultSettings: SettingsExperimentalFeatures = {
     codeMonitoring: true,
-    showEnterpriseHomePanels: true,
+    showEnterpriseHomePanels: false,
     /**
      * Whether we show the mulitiline editor at /search/console
      */

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -144,7 +144,7 @@
         "showEnterpriseHomePanels": {
           "description": "Enabled the homepage panels in the Enterprise homepage",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "!go": {
             "pointer": true
           }


### PR DESCRIPTION
Closes #38417

Set experimental feature flag `experimentalFeatures.showEnterpriseHomePanels` to false by default. It can still be overridden in user/org/global settings.

## Test plan

- Test with feature flag on and off that panels are correctly displayed/hidden.