### PR TITLE
appropriately set the generation method of the compute grouping type

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1112,6 +1112,9 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, scopedBa
 
 func searchGenerationMethod(series graphqlbackend.LineChartSearchInsightDataSeriesInput) types.GenerationMethod {
 	if series.GeneratedFromCaptureGroups != nil && *series.GeneratedFromCaptureGroups {
+		if series.GroupBy != nil {
+			return types.MappingCompute
+		}
 		return types.SearchCompute
 	}
 	return types.Search


### PR DESCRIPTION
Setting the appropriate `generation_method` when a grouping type insight comes through.


## Test plan

Created an insight with the following input:

``` json
{
  "input": 
  {
    "dataSeries":
      {
        "groupBy": "LANG",
        "generatedFromCaptureGroups": true,
        "query": "Messages",
        "label": "abc",
        "repositoryScope": {
          "repositories": ["github.com/sourcegraph/sourcegraph"]
    		},
        "timeScope": {
          "stepInterval": {
            "unit": "MONTH",
            "value": 1
          }
        },
        "options": {
          "label": "label me",
					"lineColor": "blue"
        }
      },
    "options": {
      "title": "testing compute group insight 2"
    }, 
    "viewControls": {
      "filters": {
        
      },
      "seriesDisplayOptions": {
        
      }
    }
  }
}
```

<img width="617" alt="CleanShot 2022-07-07 at 11 46 42@2x" src="https://user-images.githubusercontent.com/5090588/177849788-6c7cf61f-044a-4394-ae7c-e8614ad24d46.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
