### PR TITLE
search: Add placeholder to fallback query input

### DIFF
--- a/client/search-ui/src/input/LazyMonacoQueryInput.module.scss
+++ b/client/search-ui/src/input/LazyMonacoQueryInput.module.scss
@@ -4,7 +4,7 @@
 // lazy-loading the MonacoQueryInput, to avoid unstable UI.
 .lazy-monaco-query-input--intermediate-input {
     height: 100%;
-    font-size: 0.75rem;
+    font-size: var(--code-font-size);
     border: none;
     padding-left: 0;
     padding-right: 0;

--- a/client/search-ui/src/input/LazyMonacoQueryInput.tsx
+++ b/client/search-ui/src/input/LazyMonacoQueryInput.tsx
@@ -25,8 +25,10 @@ const CodemirrorQueryInput = lazyComponent(() => import('./CodeMirrorQueryInput'
  * It has no suggestions, but still allows to type in and submit queries.
  */
 export const PlainQueryInput: React.FunctionComponent<
-    React.PropsWithChildren<Pick<MonacoQueryInputProps, 'queryState' | 'autoFocus' | 'onChange' | 'className'>>
-> = ({ queryState, autoFocus, onChange, className }) => {
+    React.PropsWithChildren<
+        Pick<MonacoQueryInputProps, 'queryState' | 'autoFocus' | 'onChange' | 'className' | 'placeholder'>
+    >
+> = ({ queryState, autoFocus, onChange, className, placeholder }) => {
     const onInputChange = React.useCallback(
         (event: React.ChangeEvent<HTMLInputElement>) => {
             onChange({ query: event.target.value })
@@ -41,6 +43,7 @@ export const PlainQueryInput: React.FunctionComponent<
             value={queryState.query}
             onChange={onInputChange}
             spellCheck={false}
+            placeholder={placeholder}
         />
     )
 }
@@ -59,10 +62,11 @@ export const LazyMonacoQueryInput: React.FunctionComponent<React.PropsWithChildr
     editorComponent,
     ...props
 }) => {
-    const QueryInput = editorComponent === 'codemirror6' ? CodemirrorQueryInput : MonacoQueryInput
+    const isCodeMirror = editorComponent === 'codemirror6'
+    const QueryInput = isCodeMirror ? CodemirrorQueryInput : MonacoQueryInput
 
     return (
-        <Suspense fallback={<PlainQueryInput {...props} />}>
+        <Suspense fallback={<PlainQueryInput {...props} placeholder={isCodeMirror ? props.placeholder : undefined} />}>
             <QueryInput {...props} />
         </Suspense>
     )

--- a/client/shared/src/components/CodeMirrorEditor.ts
+++ b/client/shared/src/components/CodeMirrorEditor.ts
@@ -21,7 +21,7 @@ export function useCodeMirror(
         }
 
         const view = new EditorView({
-            state: EditorState.create({ extensions }),
+            state: EditorState.create({ doc: value, extensions }),
             parent: container,
         })
         setView(view)


### PR DESCRIPTION
We are rendering a simple text input until CodeMirror/Monaco are loaded.
The current experience with CodeMirror is not ideal because we show an
empty input and as soon as CodeMirror loads it shows a placeholder text.

This commit adds logic to show a placeholder text in the plaintext input
if CodeMirror is selected. There might still be a noticeable difference
between the browser's builtin placeholder color and CodeMirror's
placeholder color, but that's still much better than showing no
placeholder at all.
**Note:** It's important that the placeholder is not shown when Monaco
is selected because Monaco ignores the placeholder value. If we didn't
do this we would have the inverse problem with Monaco.

I'm also adding back setting the initial editor value immediately at
creation time (instead of also using a transaction to set the
initial value). Otherwise a flash of content can happen on the result
page when we first load the fallback input (with value), then load
CodeMirror (without value) and then set the value (via transaction).

I'm changing the font size for the fallback input to the same one we use
for CodeMirror. It already doesn't match the font size for Monaco anyway
(I see a noticeable difference in font size in both Firefox and Chrome),
so it doesn't make things worse.



## Test plan

Refreshed the initial search home page and the search result page both with CodeMirror and Monaco in Firefox and Chrome a couple of times.
