### PR TITLE
search frontend: detect and highlight patterns in query

### DIFF
--- a/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -2,11 +2,13 @@ import React, { Fragment, useMemo } from 'react'
 
 import classNames from 'classnames'
 
+import { SearchPatternType } from '@sourcegraph/search'
 import { decorate, DecoratedToken, toCSSClassName } from '@sourcegraph/shared/src/search/query/decoratedToken'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 
 interface SyntaxHighlightedSearchQueryProps extends React.HTMLAttributes<HTMLSpanElement> {
     query: string
+    searchPatternType?: SearchPatternType
 }
 
 interface decoration {
@@ -87,7 +89,7 @@ function toDecoration(query: string, token: DecoratedToken): decoration {
 // A read-only syntax highlighted search query
 export const SyntaxHighlightedSearchQuery: React.FunctionComponent<
     React.PropsWithChildren<SyntaxHighlightedSearchQueryProps>
-> = ({ query, ...otherProps }) => {
+> = ({ query, searchPatternType = SearchPatternType.standard, ...otherProps }) => {
     const tokens = useMemo(() => {
         const tokens = scanSearchQuery(query)
         return tokens.type === 'success'

--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -252,4 +252,10 @@ describe('scanSearchQuery() with predicate', () => {
             '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":6},"kind":1,"value":"\'email","delimited":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"pattern","range":{"start":7,"end":9},"kind":1,"value":"is","delimited":false},{"type":"whitespace","range":{"start":9,"end":10}},{"type":"keyword","value":"not","range":{"start":10,"end":13},"kind":"not"},{"type":"whitespace","range":{"start":13,"end":14}},{"type":"pattern","range":{"start":14,"end":22},"kind":1,"value":"allowed\'","delimited":false}]}'
         )
     })
+
+    test('detect patterntype inside query', () => {
+        expect(scanSearchQuery('patterntype:standard /test/')).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":20},"field":{"type":"literal","value":"patterntype","range":{"start":0,"end":11}},"value":{"type":"literal","value":"standard","range":{"start":12,"end":20},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":20,"end":21}},{"type":"pattern","range":{"start":21,"end":27},"kind":2,"value":"test","delimited":true}]}'
+        )
+    })
 })

--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -504,6 +504,20 @@ const scanStandard = (query: string): ScanResult<Token[]> => {
     return scan(query, 0)
 }
 
+function detectPatternType(query: string): SearchPatternType | undefined {
+    const result = scanStandard(query)
+    const tokens =
+        result.type === 'success'
+            ? result.term.filter(
+                  token => !!(token.type === 'filter' && token.field.value.toLowerCase() === 'patterntype')
+              )
+            : undefined
+    if (tokens && tokens.length > 0) {
+        return (tokens[0] as Filter).value?.value as SearchPatternType
+    }
+    return undefined
+}
+
 /**
  * Scans a search query string.
  */
@@ -512,8 +526,9 @@ export const scanSearchQuery = (
     interpretComments?: boolean,
     searchPatternType = SearchPatternType.literal
 ): ScanResult<Token[]> => {
+    const patternType = detectPatternType(query) || searchPatternType
     let patternKind
-    switch (searchPatternType) {
+    switch (patternType) {
         case SearchPatternType.standard:
         case SearchPatternType.lucky:
             return scanStandard(query)


### PR DESCRIPTION
Patterns now highlight wherever they are used, based on `patterntype`, if set in the query string. Example Code Insights page:

Before:


![Screen Shot 2022-07-07 at 3 23 41 PM](https://user-images.githubusercontent.com/888624/177882061-05c71642-814f-4e37-a5bd-59ed96094f60.png)

After:

![Screen Shot 2022-07-07 at 3 22 01 PM](https://user-images.githubusercontent.com/888624/177882075-20c8397d-d1a5-46cd-bb1b-ee65501a2f11.png)


The query highlighter doesn't take a parameter to know how to highlight patterns (so I can't tell whether to highlight `.*` as regex or not). This PR adds an optional parameter so it can force highlighting on the patterntype if it's explicitly added. 

But that's not enough, because everything that uses the query highlight component today _doesn't_ set the patterntype (because it doesn't exist), so there's no way to just add highlighting, unless... well, if those queries happen to specify `patterntype` in the query string, then we can detect it.

So now:

- we detect `patterntype` in the query string and tokenize based on that value if it exists. it means scanning every twice is unavoidable. this is the cost of making a decision to include a value inside a string that defines how that string itself should be interpreted. bad decision and the bane of `patterntype`

- if we don't detect `patterntype` in the query string, and the query highlighter is not told how to scan/highlight the query, then it scans/highlights as literal. When https://github.com/sourcegraph/sourcegraph/pull/38141 is merged it will scan/highlight as standard.

## Test plan
Added test.

## App preview:

- [Web](https://sg-web-rvt-client-pattern-highlighting.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-miwifqvnrz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
