### PR TITLE
search: lucky search rules use standard interpretation

### DIFF
--- a/internal/search/job/jobutil/feeling_lucky_search_job.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job.go
@@ -303,7 +303,7 @@ func unquotePatterns(b query.Basic) *query.Basic {
 		return nil
 	}
 
-	newNodes, err := query.Sequence(query.For(query.SearchTypeLiteral))(newParseTree)
+	newNodes, err := query.Sequence(query.For(query.SearchTypeStandard))(newParseTree)
 	if err != nil {
 		return nil
 	}
@@ -322,7 +322,7 @@ func unquotePatterns(b query.Basic) *query.Basic {
 // because parsing maintains the invariant that `concat` nodes only ever have
 // pattern children.
 func unorderedPatterns(b query.Basic) *query.Basic {
-	rawParseTree, err := query.Parse(query.StringHuman(b.ToParseTree()), query.SearchTypeRegex)
+	rawParseTree, err := query.Parse(query.StringHuman(b.ToParseTree()), query.SearchTypeStandard)
 	if err != nil {
 		return nil
 	}
@@ -332,7 +332,7 @@ func unorderedPatterns(b query.Basic) *query.Basic {
 		return nil
 	}
 
-	newNodes, err := query.Sequence(query.For(query.SearchTypeLiteral))(newParseTree)
+	newNodes, err := query.Sequence(query.For(query.SearchTypeStandard))(newParseTree)
 	if err != nil {
 		return nil
 	}
@@ -374,7 +374,7 @@ func mapConcat(q []query.Node) ([]query.Node, bool) {
 }
 
 func langPatterns(b query.Basic) *query.Basic {
-	rawPatternTree, err := query.Parse(query.StringHuman([]query.Node{b.Pattern}), query.SearchTypeLiteral)
+	rawPatternTree, err := query.Parse(query.StringHuman([]query.Node{b.Pattern}), query.SearchTypeStandard)
 	if err != nil {
 		return nil
 	}
@@ -412,7 +412,7 @@ func langPatterns(b query.Basic) *query.Basic {
 	var pattern query.Node
 	if len(newPattern) > 0 {
 		// Process concat nodes
-		nodes, err := query.Sequence(query.For(query.SearchTypeLiteral))(newPattern)
+		nodes, err := query.Sequence(query.For(query.SearchTypeStandard))(newPattern)
 		if err != nil {
 			return nil
 		}
@@ -426,7 +426,7 @@ func langPatterns(b query.Basic) *query.Basic {
 }
 
 func typePatterns(b query.Basic) *query.Basic {
-	rawPatternTree, err := query.Parse(query.StringHuman([]query.Node{b.Pattern}), query.SearchTypeLiteral)
+	rawPatternTree, err := query.Parse(query.StringHuman([]query.Node{b.Pattern}), query.SearchTypeStandard)
 	if err != nil {
 		return nil
 	}
@@ -471,7 +471,7 @@ func typePatterns(b query.Basic) *query.Basic {
 	var pattern query.Node
 	if len(newPattern) > 0 {
 		// Process concat nodes
-		nodes, err := query.Sequence(query.For(query.SearchTypeLiteral))(newPattern)
+		nodes, err := query.Sequence(query.For(query.SearchTypeStandard))(newPattern)
 		if err != nil {
 			return nil
 		}

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/one_of_many_patterns_as_lang.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/one_of_many_patterns_as_lang.golden
@@ -5,6 +5,6 @@
   },
   {
     "Description": "AND patterns together",
-    "Query": "context:global (/parse/ AND /python/)"
+    "Query": "context:global (parse AND python)"
   }
 ]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type.golden
@@ -5,6 +5,6 @@
   },
   {
     "Description": "AND patterns together",
-    "Query": "context:global (/fix/ AND /commit/)"
+    "Query": "context:global (fix AND commit)"
   }
 ]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
@@ -5,10 +5,10 @@
   },
   {
     "Description": "apply search type with AND patterns",
-    "Query": "context:global type:commit (/code/ AND /monitor/)"
+    "Query": "context:global type:commit (code AND monitor)"
   },
   {
     "Description": "AND patterns together",
-    "Query": "context:global (/code/ AND /monitor/ AND /commit/)"
+    "Query": "context:global (code AND monitor AND commit)"
   }
 ]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_with_expression.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_with_expression.golden
@@ -5,6 +5,6 @@
   },
   {
     "Description": "AND patterns together",
-    "Query": "context:global (/code/ OR (/monitor/ AND /commit/))"
+    "Query": "context:global (code OR (monitor AND commit))"
   }
 ]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
@@ -1,6 +1,6 @@
 [
   {
     "Description": "AND patterns together",
-    "Query": "context:global (/parse/ AND /func/)"
+    "Query": "context:global (parse AND func)"
   }
 ]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/two_basic_jobs.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/two_basic_jobs.golden
@@ -1,10 +1,10 @@
 [
   {
     "Description": "AND patterns together",
-    "Query": "context:global type:file (/parse/ AND /func/)"
+    "Query": "context:global type:file (parse AND func)"
   },
   {
     "Description": "AND patterns together",
-    "Query": "context:global type:commit (/parse/ AND /func/)"
+    "Query": "context:global type:commit (parse AND func)"
   }
 ]

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/type_and_lang_multi_rule.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/type_and_lang_multi_rule.golden
@@ -13,18 +13,18 @@
   },
   {
     "Description": "apply search type and language filter for patterns with AND patterns",
-    "Query": "context:global type:commit lang:Go (/monitor/ AND /code/)"
+    "Query": "context:global type:commit lang:Go (monitor AND code)"
   },
   {
     "Description": "apply search type with AND patterns",
-    "Query": "context:global type:commit (/go/ AND /monitor/ AND /code/)"
+    "Query": "context:global type:commit (go AND monitor AND code)"
   },
   {
     "Description": "apply language filter with AND patterns",
-    "Query": "context:global lang:Go (/commit/ AND /monitor/ AND /code/)"
+    "Query": "context:global lang:Go (commit AND monitor AND code)"
   },
   {
     "Description": "AND patterns together",
-    "Query": "context:global (/go/ AND /commit/ AND /monitor/ AND /code/)"
+    "Query": "context:global (go AND commit AND monitor AND code)"
   }
 ]


### PR DESCRIPTION
Default to parsing and generating standard queries in lucky search (there's one exception with quoting, which I'll handle later).

There will be other rules later to guess patterns like regexp or structural.

## Test plan
Updated tests.