### PR TITLE
search: limit lucky search activity after enough results

### DIFF
--- a/internal/search/job/jobutil/feeling_lucky_search_job.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job.go
@@ -76,6 +76,9 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	}
 	maxAlerter.Add(alert)
 
+	// Now start counting how many additional results we get from generated queries
+	countedStream := streaming.NewResultCountingStream(stream)
+
 	generated := &alertobserver.ErrLuckyQueries{ProposedQueries: []*search.ProposedQuery{}}
 	var autoQ *autoQuery
 	for _, next := range f.generators {
@@ -94,10 +97,16 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 				// Generated an invalid job with this query, just continue.
 				continue
 			}
-			alert, err = j.Run(ctx, clients, stream)
-			if ctx.Err() != nil {
-				// Cancellation or Deadline hit implies it's time to stop running jobs.
-				errs = errors.Append(errs, generated)
+			alert, err = j.Run(ctx, clients, countedStream)
+			if countedStream.Count() >= limits.DefaultMaxSearchResultsStreaming {
+				// We've sent additional results up to the maximum bound. Let's stop here.
+				var lErr *alertobserver.ErrLuckyQueries
+				if errors.As(err, &lErr) {
+					generated.ProposedQueries = append(generated.ProposedQueries, lErr.ProposedQueries...)
+				}
+				if len(generated.ProposedQueries) > 0 {
+					errs = errors.Append(errs, generated)
+				}
 				return maxAlerter.Alert, errs
 			}
 
@@ -501,7 +510,7 @@ func (n *notifier) New(count int) error {
 	} else if count == 1 {
 		resultCountString = fmt.Sprintf("1 result")
 	} else {
-		resultCountString = fmt.Sprintf("%d results", count)
+		resultCountString = fmt.Sprintf("%d additional results", count)
 	}
 
 	return &alertobserver.ErrLuckyQueries{
@@ -519,6 +528,11 @@ func (g *generatedSearchJob) Run(ctx context.Context, clients job.RuntimeClients
 	resultCount := stream.Count()
 	if resultCount == 0 {
 		return nil, nil
+	}
+
+	if ctx.Err() != nil {
+		notification := g.NewNotification(resultCount)
+		return alert, errors.Append(err, notification)
 	}
 
 	notification := g.NewNotification(resultCount)


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/38448

This fixes one of the major issues I had before I want to share lucky search more broadly. 

- Problem: we would continue running generated queries indefinitely, there wasn't an upper bound

- Follow on problem: I tried earlier to bound this by using `LimitJob` and cancelling on context. This turned out not to play well with what I was doing, especially when the user enters `count`, and difficult applying `LimitJob` to any of (a) the initial query (b) generated queries. I ran into trouble because it's not possible to wrap all generated queries in a limit job because they are generated on-demand in a loop, and this would need more stuff with job machinery that I don't want to deal with.

So the solution I'm happy with right now:

- Run initial query to completion, given any users `count`, as before.

- Start running generated queries after that, and count the results. When we've reached max limit streaming in aggregate (`500` currently), just stop generating and running queries. If the user does apply `count`, `count` will be honored within in each generated query, but we will still stop running after `500` total.

## Test plan
Covered by existing test, manual testing, and we'll test the rest in prod.
