### PR TITLE
Set the right generation method for compute

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1114,6 +1114,10 @@ func searchGenerationMethod(series graphqlbackend.LineChartSearchInsightDataSeri
 	if series.GeneratedFromCaptureGroups != nil && *series.GeneratedFromCaptureGroups {
 		return types.SearchCompute
 	}
+	if series.GroupBy != nil {
+		return types.MappingCompute
+	}
+
 	return types.Search
 }
 

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1117,7 +1117,6 @@ func searchGenerationMethod(series graphqlbackend.LineChartSearchInsightDataSeri
 	if series.GroupBy != nil {
 		return types.MappingCompute
 	}
-
 	return types.Search
 }
 


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/38352

## Description

This just makes sure that the `mapping-compute` type is set for compute insights that are created.

## Test plan

Try creating a new compute insight and verify that the `generation_method` for the new series is `mapping-compute`. You can use the same query in the test plan here: https://github.com/sourcegraph/sourcegraph/pull/37951