### PR TITLE
[SG-35007] Accessibility Changeset sync button is not an actual button

### DIFF
--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetLastSynced.module.scss
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetLastSynced.module.scss
@@ -1,0 +1,6 @@
+// This class is for preventing layout changes while switching between loading and loaded state
+.update-loader-wrapper {
+    display: inline-flex;
+    align-items: center;
+    height: 1rem;
+}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetLastSynced.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetLastSynced.tsx
@@ -4,10 +4,12 @@ import { mdiAlertCircle, mdiSync, mdiInformationOutline } from '@mdi/js'
 import { formatDistance, isBefore, parseISO } from 'date-fns'
 
 import { isErrorLike } from '@sourcegraph/common'
-import { LoadingSpinner, Icon, Tooltip } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Icon, Tooltip, Button } from '@sourcegraph/wildcard'
 
 import { ExternalChangesetFields, HiddenExternalChangesetFields } from '../../../../graphql-operations'
 import { syncChangeset } from '../backend'
+
+import styles from './ChangesetLastSynced.module.scss'
 
 interface Props {
     changeset:
@@ -87,7 +89,7 @@ export const ChangesetLastSynced: React.FunctionComponent<React.PropsWithChildre
                 </Tooltip>
             )}
             <Tooltip content={tooltipText}>
-                <span>
+                <span className={styles.updateLoaderWrapper}>
                     <UpdateLoaderIcon
                         changesetUpdatedAt={changeset.updatedAt}
                         lastUpdatedAt={lastUpdatedAt}
@@ -114,13 +116,9 @@ const UpdateLoaderIcon: React.FunctionComponent<
 
     if (viewerCanAdminister) {
         return (
-            <Icon
-                aria-label="Refresh"
-                className="cursor-pointer"
-                onClick={onEnqueueChangeset}
-                role="button"
-                svgPath={mdiSync}
-            />
+            <Button aria-label="Refresh" variant="icon" className="d-inline" onClick={onEnqueueChangeset}>
+                <Icon className="text-muted" svgPath={mdiSync} aria-hidden={true} />
+            </Button>
         )
     }
 


### PR DESCRIPTION
### Description
The sync button is not addressable using keyboard navigation
### Problem description
The sync icon next to "Last synced X minutes ago." is not addressable using keyboard navigation, as it's not a proper button.

Also, it's too small for mobile probably.
### Expected behavior
It can be focussed using keyboard navigation and clicked on accordingly.
### Refs
- [Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/35007)
- [Gitstart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35007)
### Test plan
- Click “Batch Changes” in the top navigation bar
- Scan the list to find the open batch change
- Click the name of the batch change on the list item
- Check sync icon next to "Last synced X minutes ago."  and ensure that it is addressable using keyboard navigation

## App preview:

- [Web](https://sg-web-contractors-sg-35007.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wesohqxxwq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
