### PR TITLE
search: scaffolding for combinatorial query generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -181,6 +181,7 @@ require (
 	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306
 	golang.org/x/tools v0.1.10
+	gonum.org/v1/gonum v0.11.0
 	google.golang.org/api v0.77.0
 	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21
 	google.golang.org/protobuf v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -3005,6 +3005,8 @@ golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df h1:5Pf6pFKu98ODmgnpvkJ3kFUOQGGLIzLIkbzUHp47618=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
+gonum.org/v1/gonum v0.11.0 h1:f1IJhK4Km5tBJmaiJXtk/PkL4cdVX6J+tGiM187uT5E=
+gonum.org/v1/gonum v0.11.0/go.mod h1:fSG4YDCxxUZQJ7rKsQrj0gMOg00Il0Z96/qMA4bVQhA=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/internal/search/job/jobutil/feeling_lucky_search_job_test.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job_test.go
@@ -169,3 +169,38 @@ func TestGeneratedSearchJob(t *testing.T) {
 	autogold.Want("1 result", autogold.Raw("test (1 result)")).Equal(t, autogold.Raw(test(1)))
 	autogold.Want("limit results", autogold.Raw("test (500+ results)")).Equal(t, autogold.Raw(test(limits.DefaultMaxSearchResultsStreaming)))
 }
+
+func TestCombinations(t *testing.T) {
+	q, _ := query.ParseStandard(`go commit`)
+	b, _ := query.ToBasicQuery(q)
+	g := NewComboGenerator(b, rulesMaxSet)
+
+	var autoQ *autoQuery
+	type want struct {
+		Description string
+		Query       string
+	}
+	generated := []want{}
+
+	for {
+		autoQ, g = g()
+		if autoQ != nil {
+			generated = append(
+				generated,
+				want{
+					Description: autoQ.description,
+					Query:       query.StringHuman(autoQ.query.ToParseTree()),
+				})
+		}
+
+		if g == nil {
+			break
+		}
+	}
+
+	result, _ := json.MarshalIndent(generated, "", "  ")
+
+	t.Run("ok", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(result))
+	})
+}

--- a/internal/search/job/jobutil/testdata/TestCombinations/ok.golden
+++ b/internal/search/job/jobutil/testdata/TestCombinations/ok.golden
@@ -1,0 +1,14 @@
+[
+  {
+    "Description": "apply search type for pattern and apply language filter for pattern",
+    "Query": "type:commit lang:Go"
+  },
+  {
+    "Description": "apply search type for pattern",
+    "Query": "type:commit go"
+  },
+  {
+    "Description": "apply language filter for pattern",
+    "Query": "lang:Go commit"
+  }
+]


### PR DESCRIPTION
Hokay started hacking on this because I'm trying to rush to the end MVP state.

This adds a generator that only takes a flat set of individual rules and tries combinations of `n choose k` on the rule set, for decreasing values of `k`. See the test and docstring for how this works.

This is unused, but it will replace the current `Generator` code which only tries to apply the list of rules, not combinations of individual ones. When the code uses the new generator, it should turn out that we can just add individual rules and leave the iteration to try combinations that apply on the query. This'll make it much easier for me to add rules that, e.g., interpret `https://github.com/repo/repo` as a repo filter without having to meddle with composition of rules. This isn't the only strategy we have to use, it's just one that will work well for me right now.

This still needs some other tweaking to incorporate the unordered patterns rule. More on that to come later.

## Test plan
Unused, adds test.

