### PR TITLE
JetBrains: Expire cached content requests after a set timeout

### DIFF
--- a/client/jetbrains/webview/src/search/lib/ExpirationCache.ts
+++ b/client/jetbrains/webview/src/search/lib/ExpirationCache.ts
@@ -1,0 +1,50 @@
+/**
+ * This class implements a Map like interface. However for every item that is
+ * stored it also stores the time on when this item was last accessed. Whenever
+ * new items are added, we check if the cache contains items that are not
+ * accessed for a certain amount of time. If so, we remove them from the cache.
+ */
+export class ExpirationCache<K, V> {
+    private expirationTime: number
+    private map: Map<K, { value: V; lastAccessAt: number }>
+
+    constructor(expirationTime: number) {
+        this.expirationTime = expirationTime
+        this.map = new Map()
+    }
+
+    public set(key: K, value: V): void {
+        this.map.set(key, { value, lastAccessAt: Date.now() })
+        this.clean()
+    }
+
+    public has(key: K): boolean {
+        const entry = this.map.get(key)
+        if (entry !== undefined) {
+            entry.lastAccessAt = Date.now()
+        }
+        return entry !== undefined
+    }
+
+    public get(key: K): V | undefined {
+        const entry = this.map.get(key)
+        if (entry === undefined) {
+            return undefined
+        }
+        entry.lastAccessAt = Date.now()
+        return entry.value
+    }
+
+    public delete(key: K): void {
+        this.map.delete(key)
+    }
+
+    private clean(): void {
+        const now = Date.now()
+        for (const [key, entry] of this.map) {
+            if (now - entry.lastAccessAt > this.expirationTime) {
+                this.map.delete(key)
+            }
+        }
+    }
+}

--- a/client/jetbrains/webview/src/search/lib/blob.ts
+++ b/client/jetbrains/webview/src/search/lib/blob.ts
@@ -4,9 +4,12 @@ import { ContentMatch, PathMatch, SymbolMatch } from '@sourcegraph/shared/src/se
 import { BlobContentResult, BlobContentVariables } from '../../graphql-operations'
 import { getMatchId } from '../results/utils'
 
+import { ExpirationCache } from './ExpirationCache'
 import { requestGraphQL } from './requestGraphQl'
 
-const cachedContentRequests = new Map<string, Promise<string | null>>()
+const THIRTY_MINUTES = 30 * 60 * 1000
+
+const cachedContentRequests = new ExpirationCache<string, Promise<string | null>>(THIRTY_MINUTES)
 
 export async function loadContent(match: ContentMatch | PathMatch | SymbolMatch): Promise<string | null> {
     const cacheKey = getMatchId(match)


### PR DESCRIPTION
Closes #37373

This PR adds a new class that implements a Map like interface. However for every item that is stored, it also stores the time on when this item was last accessed.

Whenever new items are added, we check if the cache contains items that are not accessed for a certain amount of time. If so, we remove them from the cache.

We use this in conjunction to our blob content cache to make sure we don't allocate items forever. For now, I've set a 30 inactivity expiration for the cache. This value is randomly picked and definitely up for debate. 

## Test plan

I validated the behavior manually by adding extensive logging and a reduced expiration time. You can see that items are removed from the cache in the console screenshot below:

![Screenshot 2022-07-08 at 12 40 36](https://user-images.githubusercontent.com/458591/177977730-50ee459f-29d2-4ae7-bfc6-ff5192cc981c.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-cache-expiration.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nqfozgweri.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
