### PR TITLE
Add missing index on code monitor worker tables

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -4212,6 +4212,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX cm_action_jobs_pkey ON cm_action_jobs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "cm_action_jobs_state_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX cm_action_jobs_state_idx ON cm_action_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [
@@ -5310,6 +5320,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX cm_trigger_jobs_pkey ON cm_trigger_jobs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "cm_trigger_jobs_state_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX cm_trigger_jobs_state_idx ON cm_trigger_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -415,6 +415,7 @@ Referenced by:
  queued_at         | timestamp with time zone |           |          | now()
 Indexes:
     "cm_action_jobs_pkey" PRIMARY KEY, btree (id)
+    "cm_action_jobs_state_idx" btree (state)
 Check constraints:
     "cm_action_jobs_only_one_action_type" CHECK ((
 CASE
@@ -613,6 +614,7 @@ Slack webhook actions configured on code monitors
  queued_at         | timestamp with time zone |           |          | now()
 Indexes:
     "cm_trigger_jobs_pkey" PRIMARY KEY, btree (id)
+    "cm_trigger_jobs_state_idx" btree (state)
 Check constraints:
     "search_results_is_array" CHECK (jsonb_typeof(search_results) = 'array'::text)
 Foreign-key constraints:

--- a/migrations/frontend/1657279116_faster_dequeues_cm_action_jobs/down.sql
+++ b/migrations/frontend/1657279116_faster_dequeues_cm_action_jobs/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS cm_action_jobs_state_idx;

--- a/migrations/frontend/1657279116_faster_dequeues_cm_action_jobs/metadata.yaml
+++ b/migrations/frontend/1657279116_faster_dequeues_cm_action_jobs/metadata.yaml
@@ -1,0 +1,3 @@
+name: faster_dequeues_cm_action_jobs
+parents: [1656447205, 1657107627]
+createIndexConcurrently: true

--- a/migrations/frontend/1657279116_faster_dequeues_cm_action_jobs/up.sql
+++ b/migrations/frontend/1657279116_faster_dequeues_cm_action_jobs/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS cm_action_jobs_state_idx ON cm_action_jobs (state);

--- a/migrations/frontend/1657279170_faster_dequeues_cm_trigger_jobs/down.sql
+++ b/migrations/frontend/1657279170_faster_dequeues_cm_trigger_jobs/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS cm_trigger_jobs_state_idx;

--- a/migrations/frontend/1657279170_faster_dequeues_cm_trigger_jobs/metadata.yaml
+++ b/migrations/frontend/1657279170_faster_dequeues_cm_trigger_jobs/metadata.yaml
@@ -1,0 +1,3 @@
+name: faster_dequeues_cm_trigger_jobs
+parents: [1657279116]
+createIndexConcurrently: true

--- a/migrations/frontend/1657279170_faster_dequeues_cm_trigger_jobs/up.sql
+++ b/migrations/frontend/1657279170_faster_dequeues_cm_trigger_jobs/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS cm_trigger_jobs_state_idx ON cm_trigger_jobs (state);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3551,7 +3551,11 @@ CREATE INDEX changesets_publication_state_idx ON changesets USING btree (publica
 
 CREATE INDEX changesets_reconciler_state_idx ON changesets USING btree (reconciler_state);
 
+CREATE INDEX cm_action_jobs_state_idx ON cm_action_jobs USING btree (state);
+
 CREATE INDEX cm_slack_webhooks_monitor ON cm_slack_webhooks USING btree (monitor);
+
+CREATE INDEX cm_trigger_jobs_state_idx ON cm_trigger_jobs USING btree (state);
 
 CREATE INDEX cm_webhooks_monitor ON cm_webhooks USING btree (monitor);
 


### PR DESCRIPTION
All worker tables should have an index on state. Spotted in query insights on our demo instance, where these queries were among the dominating ones.

## Test plan

Just a new index, test suite covers migrations.