### PR TITLE
web: mute more irrelevant logs in integration tests

### DIFF
--- a/client/web/src/integration/nav.test.ts
+++ b/client/web/src/integration/nav.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect'
 import { test } from 'mocha'
 
 import { encodeURIPathComponent } from '@sourcegraph/common'
-import { SearchGraphQlOperations } from '@sourcegraph/search'
+import { mixedSearchStreamEvents, SearchGraphQlOperations } from '@sourcegraph/search'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
 import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
@@ -79,6 +79,7 @@ describe('GlobalNavbar', () => {
             })
 
             testContext.overrideGraphQL(commonSearchGraphQLResults)
+            testContext.overrideSearchStreamEvents(mixedSearchStreamEvents)
         })
 
         afterEachSaveScreenshotIfFailed(() => driver.page)

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -277,7 +277,6 @@ export const StreamingSearchResults: React.FunctionComponent<
             telemetryService.log('SearchResultsFetchFailed', {
                 code_search: { error_message: asError(results.error).message },
             })
-            console.error(results.error)
         }
     }, [results, telemetryService])
 

--- a/dev/ci/yarn-web-integration.sh
+++ b/dev/ci/yarn-web-integration.sh
@@ -11,7 +11,7 @@ echo "--- Yarn install in root"
 yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent
 
 echo "--- Run integration test suite"
-yarn percy exec --quiet yarn _cover-integration "$@"
+yarn percy exec --quiet -- yarn _cover-integration "$@"
 
 echo "--- Process NYC report"
 yarn nyc report -r json

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@mermaid-js/mermaid-cli": "^8.13.4",
     "@octokit/rest": "^16.36.0",
     "@peculiar/webcrypto": "^1.1.7",
-    "@percy/cli": "^1.2.1",
+    "@percy/cli": "^1.6.0",
     "@percy/puppeteer": "^2.0.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-rc.1",
     "@pollyjs/adapter": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,96 +3155,96 @@
     tslib "^2.2.0"
     webcrypto-core "^1.2.0"
 
-"@percy/cli-build@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.3.0.tgz#abfb8350cbd2c93688eb6e5340c521c346dca952"
-  integrity sha512-iq8aAE+PgQ7m8M37uOFTCj6a46c2eNZudxJLePN+qNtIwtWtoFa/UL+QyWEsxl1a+jEQ8qZZLPSvLPs8bofClw==
+"@percy/cli-build@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.6.0.tgz#4e82b081fea993ece789f102ea9cc5ad71a20edb"
+  integrity sha512-ABMnWccKENvvLX7n7xgUyNDlApxWmDLBUPq2kMrWkNNcLmpVrFFWiRu2eRCa2jFh772ceFkDLNpxueVRIq8pTw==
   dependencies:
-    "@percy/cli-command" "1.3.0"
+    "@percy/cli-command" "1.6.0"
 
-"@percy/cli-command@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.3.0.tgz#d82c190f2f0a27e9e59d30415ed5de42ca836f7c"
-  integrity sha512-0mZ0s/HdVM/sfQA0wiRPKvPoZiG59/U3+oEYLjkz/4x7OymP1cGymTRSVypHT7ZmBGg1Q928gosgjpzWrzM5AA==
+"@percy/cli-command@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.6.0.tgz#3227e5429adfaf1ff8bd170df571f72c46286beb"
+  integrity sha512-seJ3bkRKS1Nmf9GLE1K5Mqvl01MdejmWD9c6kuYcJndGGkwp6xqUDjhbtIHPxFp1UOTa7b6cb0CT6o01C7VjmQ==
   dependencies:
-    "@percy/config" "1.3.0"
-    "@percy/core" "1.3.0"
-    "@percy/logger" "1.3.0"
+    "@percy/config" "1.6.0"
+    "@percy/core" "1.6.0"
+    "@percy/logger" "1.6.0"
 
-"@percy/cli-config@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.3.0.tgz#dbd6dcbb29100e796a0c45d38ee25d037a935b80"
-  integrity sha512-Ad3XMQldyu3U6KxJPjYmROoKyadRw9c/8doDjMEkPVcFdsHoHnqyYPL0BFmLBoWwJOaDgjOrsjdp17HLbNsOqQ==
+"@percy/cli-config@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.6.0.tgz#19e65dad1385f533e577743b80c4974fdf7b2c86"
+  integrity sha512-GRj6yiL0SDC37Cg70gFibiIBQ5vDxQPeYVqTeXxT2jnGzcQokTLvI/qz9q1WrJhVxf6NZozuWCCE1XO5iisFjA==
   dependencies:
-    "@percy/cli-command" "1.3.0"
+    "@percy/cli-command" "1.6.0"
 
-"@percy/cli-exec@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.3.0.tgz#4fbbe37939c81ceadfd3f3f853df494b3f3c13dd"
-  integrity sha512-dCI1ED/WbQcYrUFGYaCI54PHfOADOkAKeKLlE7WLDCmLJvjx2JIoO+a/VJE2EVh0+j1zOUItMq20ejzoRe6a/A==
+"@percy/cli-exec@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.6.0.tgz#c9fbb67f7f0c797fb2b766ef86ade102b606a8d5"
+  integrity sha512-Tm5XosxBR48n+byOVU18H9avYKD1c1oAj0celROGoq4sE0nG0Mus7O/JlwShvEzwQLXaHemmAEqt7n4pdX8peA==
   dependencies:
-    "@percy/cli-command" "1.3.0"
+    "@percy/cli-command" "1.6.0"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.3.0.tgz#24836b2a1cc7ead2533631dce70a5e22b76cdc2f"
-  integrity sha512-t2cu4stv5th94I2eeIku4KUn3YvI+Pzu2W0S0rCwT5wEaJUo7sBB+EptXKNrPyWrrZvFnZoly7DA41z5hyQP8w==
+"@percy/cli-snapshot@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.6.0.tgz#9be14d4c5046a373d0f91ef3fe46cc83c2418984"
+  integrity sha512-sf9VdPepJEPyPDySfJXQ4WEbWZ5Dqsbh8QYRm9NOHQazmaHZ+mdtccnN9lCwNNuulm78hixA0Ahv0C6L3YiB9g==
   dependencies:
-    "@percy/cli-command" "1.3.0"
+    "@percy/cli-command" "1.6.0"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.3.0.tgz#d828f768e79e028e2a9504b54dee4279e9f1cc7d"
-  integrity sha512-4MlZMDFIyXb53Yg3GdZSR29AlGQltM3jwlG3z7lr6rueBJjo5IflvWUPsfAQ8Lu+oEqYj3y2j8PZfSimHKuE4w==
+"@percy/cli-upload@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.6.0.tgz#3ee9a3adec1b62ca9f91a647e9e323fcf8f11345"
+  integrity sha512-k1Hy/Q4W/OV5+Qqf5bzDUt2v2In0+tM6XZWfAR89GxZuxTWpIQ15tYtd3/FsSVOdPPE8sPfYbMXnBuaSjp2ooQ==
   dependencies:
-    "@percy/cli-command" "1.3.0"
+    "@percy/cli-command" "1.6.0"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.2.1":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/cli/-/cli-1.3.0.tgz#bf9807809dc1192139a61ba4799cf1b5da1a2f19"
-  integrity sha512-33u8dGTG0APVQKOSZIq/uxA77xCcR65BZ2KhxRtEZCSKDUuF5WbSzBRspCj4dpvlnSlIQrTFJv8TEt22COI5EQ==
+"@percy/cli@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/cli/-/cli-1.6.0.tgz#4c584939ff275fbb1974f69de61286777e489b1b"
+  integrity sha512-mto3ds3iRbl2nzqJQMhPX9BNARDInydfqkGlaeAZi1q+VfMAbNuSpi1AoT1OLNYWCRrbvQgcJ0NRPTMIq9Ll4Q==
   dependencies:
-    "@percy/cli-build" "1.3.0"
-    "@percy/cli-command" "1.3.0"
-    "@percy/cli-config" "1.3.0"
-    "@percy/cli-exec" "1.3.0"
-    "@percy/cli-snapshot" "1.3.0"
-    "@percy/cli-upload" "1.3.0"
-    "@percy/client" "1.3.0"
-    "@percy/logger" "1.3.0"
+    "@percy/cli-build" "1.6.0"
+    "@percy/cli-command" "1.6.0"
+    "@percy/cli-config" "1.6.0"
+    "@percy/cli-exec" "1.6.0"
+    "@percy/cli-snapshot" "1.6.0"
+    "@percy/cli-upload" "1.6.0"
+    "@percy/client" "1.6.0"
+    "@percy/logger" "1.6.0"
 
-"@percy/client@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/client/-/client-1.3.0.tgz#1cabc6787ebe7824b67dd82e710d4da84ff82598"
-  integrity sha512-qkXC183vyY9QhGrD1AbXwtYftor9D/T6I+BoO1dcxt3S4U+S4+FHhmPKFstLfGxzleEn2MhWVN3mMaMQYd0g5g==
+"@percy/client@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/client/-/client-1.6.0.tgz#33470d20891ddfcfc4a3f1a6d3c2b0c404eada75"
+  integrity sha512-pUC1ZUaCpHcKCORIOrE/Y2+7LgELGX/s0X3INCFMIiFcgQK+FyQAjV+0x4MG+FJJvtxfj5WoP4LVu1XWlbyHrg==
   dependencies:
-    "@percy/env" "1.3.0"
-    "@percy/logger" "1.3.0"
+    "@percy/env" "1.6.0"
+    "@percy/logger" "1.6.0"
 
-"@percy/config@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/config/-/config-1.3.0.tgz#62879d915915b542a795f2919e1c9da6eb34419c"
-  integrity sha512-H1nVxinIg4yjOfXovNA0pbQ78ac/xdib2XkR7EwgDPrHbBdcTqkJ2EjPNImuL9b67QHkkz7U4lqR8cUUjyDqmA==
+"@percy/config@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/config/-/config-1.6.0.tgz#5e720c76fca8cb8872257b3a6630ffad1fce4e36"
+  integrity sha512-g5wDYRqyrSxoTszLxmw/cb1DIjuc91uYQZNVjNc7TWtX8Rvlvbr1fOhaLq5/bmB8N6kLP2sXmcdz9zO4Fuw53g==
   dependencies:
-    "@percy/logger" "1.3.0"
+    "@percy/logger" "1.6.0"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/core/-/core-1.3.0.tgz#1c1503ba24d63e7678cddabc5dcbb98bb7503ddf"
-  integrity sha512-kCpJr9AT0qFOaVbrGhx14qJCZiOUvJVxejUOcqk02Vzj99Q+DGvLUyd/Cg/lw3fyJdlEhTytZzz2WuPYkNRQrg==
+"@percy/core@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/core/-/core-1.6.0.tgz#ff2c29a11883f6251a5e664dfb130a1296f69a99"
+  integrity sha512-pXqzmg84cQO39xAT90RChnh7R2Xfv7e3Tu0z1/pEO7/TbxAbMFN5xjLYEXExmbvRlBZ1aMlhjfeHMcMWodyC8A==
   dependencies:
-    "@percy/client" "1.3.0"
-    "@percy/config" "1.3.0"
-    "@percy/dom" "1.3.0"
-    "@percy/logger" "1.3.0"
+    "@percy/client" "1.6.0"
+    "@percy/config" "1.6.0"
+    "@percy/dom" "1.6.0"
+    "@percy/logger" "1.6.0"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -3255,25 +3255,25 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/dom@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/dom/-/dom-1.3.0.tgz#e928e526a5ebfc37b61c59b8409e920e6813e240"
-  integrity sha512-wY6nIXD8zhwfHXROOYYfU9qht9yWn5GgOdDWZAbcOe2qxpivfuKF4qOubKD9iwCgUZhFxRc5xUSciCGKdOm1TQ==
+"@percy/dom@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/dom/-/dom-1.6.0.tgz#15a9363ad45757b71287fa0ef982f58d69877311"
+  integrity sha512-yy5BCSTS6q0aOaA0v5kthgl/Ap8GPTJNfjmMTZxOjsxZ5WpVWWgMItkLo/sWcV77YJQG+Q343xCd/+thH393NA==
 
-"@percy/env@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/env/-/env-1.3.0.tgz#1413a1c4207d40418fbbc3f3367bc33835a2d970"
-  integrity sha512-sAOKdUGYEYPf2TRgCL8P5INqwXuqaczTWICQ2G90pLzUFV0mHo+5ih+XHGtAi5wdv1Tpz088nia+eXYXpwi4og==
+"@percy/env@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/env/-/env-1.6.0.tgz#47cc9a886a3ab1045c1bbff30831fad16abb485a"
+  integrity sha512-nQpAspFtKdU7fwyVyEY+JtWMohrRfPug6osLRV6DmZnBvT9SLJ4Fh67W06xOGL6PBGiWLuCKyS5d7tJi+WWkUw==
 
 "@percy/logger@1.0.0-beta.68":
   version "1.0.0-beta.68"
   resolved "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.68.tgz#6c42ba7d7b4350db99c3ba5fa622db7daf27e442"
   integrity sha512-PmKMLOexQUlsPASy4vQEQRYa0KHec/6xWsAg/wnWhGgmnQA4l9EKcz7ZvjDWA6H+wrErLM+FdvMsd8POf417CQ==
 
-"@percy/logger@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@percy/logger/-/logger-1.3.0.tgz#2453816f5463e9864eb0ae3c837e82d3b35bd598"
-  integrity sha512-fCuhFBXRuJruz9PNdeMZXgEhUODmhXt4hiMLBWAn1cpV8evQah3tXbHqwxEqWzLHGfbPYCKZmgk49NJvwHQKmw==
+"@percy/logger@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@percy/logger/-/logger-1.6.0.tgz#09653444013ba3bae152543c8721e6c9e025d2d5"
+  integrity sha512-4Y3dQdVDgFtEHtou2IVSNqaxGNOp0QeVWGx/4wbxchrPh8fXpBcXuYRHQRgpH+vDlb8pdx7cOFSlGJuOXN8LMw==
 
 "@percy/puppeteer@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
## Context

Removing web development builds logs to unclutter out integration test logs.
This PR is based on the previous work https://github.com/sourcegraph/sourcegraph/pull/38406 to showcase clean logs with both improvements.

Ideally, we want to use the production build of our web application for integration tests but this requires more time investment. We will be able to address this issue fully next quarter when we will look at our integration tests fundamentals.

Closes https://github.com/sourcegraph/sourcegraph/issues/37666.

## Changes

1. Muted more types of logs.
2. Upgraded `@percy/cli` to the latest version to remove warnings.
3. Added missing mocks to remove error messages from one of the tests.

| Before | After |
| -- | -- |
| <img width="1141" alt="Screen Shot 2022-07-08 at 16 06 29" src="https://user-images.githubusercontent.com/3846380/177987774-a5460485-2804-4d34-9973-9c99a388efc0.png"> | <img width="1141" alt="Screen Shot 2022-07-08 at 16 06 29" src="https://user-images.githubusercontent.com/3846380/177987974-e9b12ace-ceca-414c-92ad-c282b73d3fed.png"> |

## Test plan

Check that integration test logs are much cleaner! 🧹

## App preview:

- [Web](https://sg-web-vb-erorr-on-unexpected-console.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zpwfvlxbhu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
