### PR TITLE
JetBrains: Fix encoding errors when using the standalone version

### DIFF
--- a/client/jetbrains/standalone/src/index.html
+++ b/client/jetbrains/standalone/src/index.html
@@ -101,6 +101,7 @@
             color:#4f5b66;
         }
     </style>
+    <meta charset="UTF-8">
 </head>
 <body>
 <div id="modal">

--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -1,3 +1,5 @@
+import { decode } from 'js-base64'
+
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 
 import type { PreviewRequest, Request } from '../search/js-to-java-bridge'
@@ -87,7 +89,7 @@ function handleRequest(
             if (previewContent.content === null) {
                 htmlContent = 'No preview available'
             } else {
-                const decodedContent = atob(previewContent.content || '')
+                const decodedContent = decode(previewContent.content || '')
                 htmlContent = escapeHTML(decodedContent.slice(0, start))
                 htmlContent += `<span id="code-details-highlight">${escapeHTML(
                     decodedContent.slice(start, start + length)


### PR DESCRIPTION
This PR fixes a text encoding error with the standalone version. Not urgent but this was annoying me 😐.

The issue is that the default `atob` method does not properly handle unicode characters. We can, however, use the same library that we use to encode the text. This also preserves leading [ZERO WIDTH NO-BREAK SPACE](https://www.fileformat.info/info/unicode/char/feff/index.htm) character, a property that the `TextEncoder` did not help with.

## Test plan

![Screenshot 2022-07-08 at 15 40 09](https://user-images.githubusercontent.com/458591/178003430-5fa09bb1-c910-499b-a75f-c49c5950e1c5.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-standalone-encoding.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tpjszaytcv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
