### PR TITLE
lint: Enable rule to ban unexplained `console.error` calls

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ const config = {
     // All other rules should go into https://github.com/sourcegraph/eslint-config
     'monorepo/no-relative-import': 'error',
     '@sourcegraph/sourcegraph/check-help-links': 'error',
+    '@sourcegraph/sourcegraph/no-unexplained-console-error': 'warn',
     'no-restricted-imports': [
       'error',
       {

--- a/client/web/src/monitoring/sentry/initSentry.ts
+++ b/client/web/src/monitoring/sentry/initSentry.ts
@@ -71,7 +71,7 @@ export function initSentry(): void {
                 beforeSend(event, hint) {
                     logErrorToConsole(hint?.originalException)
                     return null
-                }
+                },
             })
         })
     }

--- a/client/web/src/monitoring/sentry/initSentry.ts
+++ b/client/web/src/monitoring/sentry/initSentry.ts
@@ -30,6 +30,11 @@ export function initSentry(): void {
                 // tunnel: '/-/debug/sentry_tunnel',
                 release: 'frontend@' + version,
                 beforeSend(event, hint) {
+                    if (process.env.NODE_ENV === 'development' && hint?.originalException) {
+                        // Log error to console in the development environment
+                        console.error(hint.originalException)
+                    }
+
                     // Use `originalException` to check if we want to ignore the error.
                     if (!hint || shouldErrorBeReported(hint.originalException)) {
                         return event

--- a/client/web/src/monitoring/sentry/initSentry.ts
+++ b/client/web/src/monitoring/sentry/initSentry.ts
@@ -16,7 +16,7 @@ declare global {
 // Log supplied error to console if in development mode
 function logErrorToConsole(error: unknown): void {
     if (error && process.env.NODE_ENV === 'development') {
-        // eslint-disable-next-line @sourcegraph/sourcegraph/no-unexplained-console-error
+        // Log this error to the console
         console.error(error)
     }
 }


### PR DESCRIPTION
This PR is completes https://github.com/sourcegraph/sourcegraph/issues/26582 and builds upon [this PR](https://github.com/sourcegraph/codemod/pull/149) in the codemod repo.

---

This PR:
1. Enables warning for the `no-unexplained-console-error` eslint rule created [here](https://github.com/sourcegraph/codemod/pull/149)
2. Logs to console the exceptions that were passed to Sentry through `Sentry.captureException` in development mode.

## Test plan

Manually checked for warnings created by eslint VS Code extension when `console.error` calls are uncommented.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mihir-26582-enable-console-error.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tjdllwpojf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
