### PR TITLE
JetBrains: Decrease display limit 1500→200

### DIFF
--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -156,6 +156,7 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                     trace: undefined,
                     sourcegraphURL: instanceURL + '.api',
                     decorationContextLines: 0,
+                    displayLimit: 200,
                 }
             ).subscribe(searchResults => {
                 setMatches(searchResults.results)

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -416,6 +416,7 @@ export interface StreamSearchOptions {
     sourcegraphURL?: string
     decorationKinds?: string[]
     decorationContextLines?: number
+    displayLimit?: number
 }
 
 function initiateSearchStream(
@@ -427,6 +428,7 @@ function initiateSearchStream(
         trace,
         decorationKinds,
         decorationContextLines,
+        displayLimit = 1500,
         sourcegraphURL = '',
     }: StreamSearchOptions,
     messageHandlers: MessageHandlers
@@ -441,7 +443,7 @@ function initiateSearchStream(
             ['dl', '0'],
             ['dk', (decorationKinds || ['html']).join('|')],
             ['dc', (decorationContextLines || '1').toString()],
-            ['display', '1500'],
+            ['display', displayLimit.toString()],
         ]
         if (trace) {
             parameters.push(['trace', trace])


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/37818

Context:
- Our streaming search back-end API provides [display-limit](https://docs.sourcegraph.com/api/stream_api) to customize the total number of search results returned.
- Our streaming search front-end API did not provide such a setting, however. It was a fixed 1500.

Change:
I've created an optional setting in our front-end API to customize this (with a default of 1500), and set the JetBrains plugin to use 200 for it.

Why 200? → "Find in Files" limits its matches to 100, so I think 200 will be sufficient for our users.
Caveat: "Find in Files" allows opening _all_ search results in a panel, which we don't at the moment, so after the change, the rest of the results won't be accessible. I think we can live with this, though. We can increase it on-demand if we're getting feedback on this. Right now, this should help with performance issues that one of our testers experienced.



## Test plan

Same stuff, just fewer results:

![CleanShot 2022-07-08 at 14 02 06@2x](https://user-images.githubusercontent.com/2552265/177988419-fdac99a4-e82e-400d-bd70-a1e5d2f6fa32.png)
