### PR TITLE
JetBrains: Fix highlight offsets for lines containing emojis in the search result list

### DIFF
--- a/client/jetbrains/webview/src/search/results/TrimmedCodeLineWithHighlights.tsx
+++ b/client/jetbrains/webview/src/search/results/TrimmedCodeLineWithHighlights.tsx
@@ -20,7 +20,7 @@ export const TrimmedCodeLineWithHighlights: React.FunctionComponent<Props> = Rea
         // The indices that we receive from the Sourcegraph API are unicode code pointer offsets
         // rather than byte lengths.
         //
-        // We use the spread syntax to properly split a string based into it's unicode code points.
+        // We use the spread syntax to properly split a string based into its unicode code points.
         //
         //   "🚀".length      // => 2
         //   [..."🚀"].length // => 1

--- a/client/jetbrains/webview/src/search/results/TrimmedCodeLineWithHighlights.tsx
+++ b/client/jetbrains/webview/src/search/results/TrimmedCodeLineWithHighlights.tsx
@@ -17,24 +17,38 @@ export const TrimmedCodeLineWithHighlights: React.FunctionComponent<Props> = Rea
         // remember our progress.
         const highlightRanges = [...line.offsetAndLengths]
 
+        // The indices that we receive from the Sourcegraph API are unicode code pointer offsets
+        // rather than byte lengths.
+        //
+        // We use the spread syntax to properly split a string based into it's unicode code points.
+        //
+        //   "🚀".length      // => 2
+        //   [..."🚀"].length // => 1
+        const contentArray = [...content]
+
         const segments = []
-        for (let index = trimLeft; index <= content.length; ) {
+        for (let index = trimLeft; index <= contentArray.length; ) {
             const nextPointOfInterest = highlightRanges.shift()
 
             // There are no more highlight segments, so we can render the remaining text
             if (nextPointOfInterest === undefined) {
-                segments.push(content.slice(index))
+                segments.push(contentArray.slice(index).join(''))
                 break
             } else {
-                // There are highlight segments, so we need to render the text before the next highlight
-                // and then render the highlight.
+                // There are highlight segments, so we need to render the text before the next
+                // highlight and then render the highlight.
                 const [offset, length] = nextPointOfInterest
-                if (content.slice(index, offset) !== '') {
-                    segments.push(content.slice(index, offset))
+                const rest = contentArray.slice(index, offset).join('')
+                if (rest !== '') {
+                    segments.push(rest)
                 }
+
+                // Note: The <span> might cut-off a joined emoji sequence in-between a &zwj;. For
+                // example if the content contains "👨‍👩‍👧‍👧" but we search for "👨‍👩‍👧", we will highlight
+                // only a section of the joined sequence, e.g.: "<span>👨‍👩‍👧</span>&zwj;‍👧".
                 segments.push(
                     <span key={`highlight-${index}`} className={styles.codeHighlight}>
-                        {content.slice(offset, offset + length)}
+                        {contentArray.slice(offset, offset + length).join('')}
                     </span>
                 )
                 index = offset + length


### PR DESCRIPTION
Part of #38222

Since a fix for the native code preview block is more complex than I immediately thought, I decided to split off this first part into a separate PR.

The indices that we receive from the Sourcegraph API are unicode code pointer offsets rather than byte lengths so our highlighting logic needs to account for that rather than use `String#length`.

There's one known issue remaining after this change which is out of scope to be fixed now:

The `<span>` might cut-off a joined emoji sequence in-between a &zwj;. For example if the content contains `"👨‍👩‍👧‍👧"` but we search for `"👨‍👩‍👧"`, we will highlight only a section of the joined sequence, e.g.: `"<span>👨‍👩‍👧</span>&zwj;‍👧"`. 

## Test plan

![Screenshot 2022-07-08 at 17 17 59](https://user-images.githubusercontent.com/458591/178021612-377071a0-620c-430d-abb2-0143311c77d7.png)
![Screenshot 2022-07-08 at 17 17 45](https://user-images.githubusercontent.com/458591/178021617-b64fb25c-fb22-4152-9e2f-e2c16c4249b1.png)
![Screenshot 2022-07-08 at 17 17 33](https://user-images.githubusercontent.com/458591/178021618-ed4068b3-724e-4967-a538-fbb6550b48ce.png)



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-fix-highlight.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jdkzowtbyn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

