### PR TITLE
search: Use @codemirror/lint and add support for actions

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -178,16 +178,6 @@
     }
 }
 
-.diagnosticError {
-    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23e51400'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
-        repeat-x bottom left;
-}
-
-.diagnosticWarning {
-    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23bf8803'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
-        repeat-x bottom left;
-}
-
 // .placeholder needs to explicilty have the same background color because it
 // appears to be placed outside of .focusedFilter rather than within it.
 .placeholder,

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -2,10 +2,10 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { closeCompletion, startCompletion } from '@codemirror/autocomplete'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
+import { Diagnostic as CMDiagnostic, linter } from '@codemirror/lint'
 import {
     EditorSelection,
     Extension,
-    Facet,
     StateEffect,
     StateField,
     Prec,
@@ -27,14 +27,13 @@ import {
 } from '@codemirror/view'
 import { Shortcut } from '@slimsag/react-shortcuts'
 import classNames from 'classnames'
-import { editor as Monaco, MarkerSeverity } from 'monaco-editor'
 
 import { renderMarkdown } from '@sourcegraph/common'
 import { EditorHint, QueryChangeSource, SearchPatternTypeProps } from '@sourcegraph/search'
 import { useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
 import { DecoratedToken, toCSSClassName } from '@sourcegraph/shared/src/search/query/decoratedToken'
-import { getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
+import { Diagnostic, getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
 import { resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { toHover } from '@sourcegraph/shared/src/search/query/hover'
 import { Node } from '@sourcegraph/shared/src/search/query/parser'
@@ -272,13 +271,16 @@ export const CodeMirrorQueryInput: React.FunctionComponent<
                     themeExtension.of(EditorView.darkTheme.of(isLightTheme === false)),
                     parseInputAsQuery({ patternType, interpretComments }),
                     queryDiagnostic,
-                    tokenInfo(),
-                    highlightFocusedFilter,
                     // It baffels me but the syntax highlighting extension has
                     // to come after the highlight current filter extension,
                     // otherwise CodeMirror keeps steeling the focus.
                     // See https://github.com/sourcegraph/sourcegraph/issues/38677
                     querySyntaxHighlighting,
+                    // The precedence of the next two extensions needs to be
+                    // decreased explicitly, otherwise the diagnostic indicators
+                    // will be hidden behind the highlight background color
+                    Prec.low(tokenInfo()),
+                    Prec.low(highlightFocusedFilter),
                     externalExtensions.of(extensions),
                 ],
                 // patternType and interpretComments are updated via a
@@ -449,7 +451,6 @@ const [callbacksField, setCallbacks] = createUpdateableField<
 
 // Defines decorators for syntax highlighting
 const tokenDecorators: { [key: string]: Decoration } = {}
-const emptyDecorator = Decoration.mark({})
 const focusedFilterDeco = Decoration.mark({ class: styles.focusedFilter })
 
 // Chooses the correct decorator for the decorated token
@@ -726,61 +727,44 @@ function getTokensTooltipInformation(
 // Hooks query diagnostics into the editor.
 // The facet stores the diagnostics data which is used by the text decoration
 // and the tooltip extensions.
-const diagnostics = Facet.define<Monaco.IMarkerData[], Monaco.IMarkerData[]>({
-    combine: markerData => markerData.flat(),
-})
-const diagnosticDecos: { [key in MarkerSeverity]: Decoration } = {
-    [MarkerSeverity.Hint]: emptyDecorator,
-    [MarkerSeverity.Info]: emptyDecorator,
-    [MarkerSeverity.Warning]: Decoration.mark({ class: styles.diagnosticWarning }),
-    [MarkerSeverity.Error]: Decoration.mark({ class: styles.diagnosticError }),
-}
 const queryDiagnostic: Extension = [
-    // Compute diagnostics when query changes
-    diagnostics.compute([queryTokens], state => {
-        const query = state.facet(queryTokens)
-        return query.tokens.length > 0 ? getDiagnostics(query.tokens, query.patternType) : []
-    }),
-    // Generate diagnostic markers
-    EditorView.decorations.compute([diagnostics], state =>
-        Decoration.set(
-            state
-                .facet(diagnostics)
-                .map(marker => diagnosticDecos[marker.severity].range(marker.startColumn - 1, marker.endColumn - 1)),
-            true
-        )
-    ),
-    // Show diagnostic message on hover
-    hoverTooltip(
-        (view, position) => {
-            const markersAtCursor = view.state
-                .facet(diagnostics)
-                .filter(({ startColumn, endColumn }) => startColumn - 1 <= position && endColumn > position)
-            if (markersAtCursor?.length === 0) {
-                return null
-            }
-
-            return {
-                // TODO: Properly compute range for multiple markers
-                pos: markersAtCursor[0].startColumn - 1,
-                end: markersAtCursor[0].endColumn - 1,
-                create(): TooltipView {
-                    const dom = document.createElement('div')
-                    dom.innerHTML = renderMarkdown(markersAtCursor.map(marker => marker.message).join('\n\n'))
-                    return { dom }
-                },
-            }
+    linter(
+        view => {
+            const query = view.state.facet(queryTokens)
+            return query.tokens.length > 0 ? getDiagnostics(query.tokens, query.patternType).map(toCMDiagnostic) : []
         },
         {
-            hoverTime: 100,
-            // Making changes elsewhere in the query might invalidate a specific
-            // diagnostic (e.g. adding type:commit to a query that contains
-            // author:...), so generally hiding them on any change seems
-            // reasonable.
-            hideOnChange: true,
+            delay: 200,
         }
     ),
 ]
+
+function renderMarkdownNode(message: string): Element {
+    const div = document.createElement('div')
+    div.innerHTML = renderMarkdown(message)
+    return div.firstElementChild || div
+}
+
+function toCMDiagnostic(diagnostic: Diagnostic): CMDiagnostic {
+    return {
+        from: diagnostic.range.start,
+        to: diagnostic.range.end,
+        message: diagnostic.message,
+        renderMessage() {
+            return renderMarkdownNode(diagnostic.message)
+        },
+        severity: diagnostic.severity,
+        actions: diagnostic.actions?.map(action => ({
+            name: action.label,
+            apply(view) {
+                view.dispatch({ changes: action.change, selection: action.selection })
+                if (action.selection && !view.hasFocus) {
+                    view.focus()
+                }
+            },
+        })),
+    }
+}
 
 function findOperatorNode(position: number, node: Node | null): Extract<Node, { type: 'operator' }> | null {
     if (!node || node.type !== 'operator' || node.range.start >= position || node.range.end <= position) {

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -737,6 +737,24 @@ const queryDiagnostic: Extension = [
             delay: 200,
         }
     ),
+    EditorView.theme({
+        '.cm-diagnosticText': {
+            display: 'block',
+        },
+        '.cm-diagnosticAction': {
+            color: 'var(--body-color)',
+            borderColor: 'var(--secondary)',
+            backgroundColor: 'var(--secondary)',
+            borderRadius: 'var(--border-radius)',
+            padding: 'var(--btn-padding-y-sm) .5rem',
+            fontSize: 'calc(min(0.75rem, 0.9166666667em))',
+            lineHeight: '1rem',
+            margin: '0.5rem 0 0 0',
+        },
+        '.cm-diagnosticAction + .cm-diagnosticAction': {
+            marginLeft: '1rem',
+        },
+    }),
 ]
 
 function renderMarkdownNode(message: string): Element {

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -271,16 +271,18 @@ export const CodeMirrorQueryInput: React.FunctionComponent<
                     themeExtension.of(EditorView.darkTheme.of(isLightTheme === false)),
                     parseInputAsQuery({ patternType, interpretComments }),
                     queryDiagnostic,
-                    // It baffels me but the syntax highlighting extension has
-                    // to come after the highlight current filter extension,
-                    // otherwise CodeMirror keeps steeling the focus.
-                    // See https://github.com/sourcegraph/sourcegraph/issues/38677
-                    querySyntaxHighlighting,
-                    // The precedence of the next two extensions needs to be
-                    // decreased explicitly, otherwise the diagnostic indicators
-                    // will be hidden behind the highlight background color
-                    Prec.low(tokenInfo()),
-                    Prec.low(highlightFocusedFilter),
+                    // The precedence of these extensions needs to be decreased
+                    // explicitly, otherwise the diagnostic indicators will be
+                    // hidden behind the highlight background color
+                    Prec.low([
+                        tokenInfo(),
+                        highlightFocusedFilter,
+                        // It baffels me but the syntax highlighting extension has
+                        // to come after the highlight current filter extension,
+                        // otherwise CodeMirror keeps steeling the focus.
+                        // See https://github.com/sourcegraph/sourcegraph/issues/38677
+                        querySyntaxHighlighting,
+                    ]),
                     externalExtensions.of(extensions),
                 ],
                 // patternType and interpretComments are updated via a

--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -28,7 +28,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: Invalid filter value, expected one of: yes, no.",
+                    "message": "Invalid filter value, expected one of: yes, no.",
                     "range": {
                       "start": 0,
                       "end": 10
@@ -59,7 +59,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "warning",
-                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`file:\\" a term\\"\`.",
+                    "message": "This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`file:\\" a term\\"\`.",
                     "range": {
                       "start": 10,
                       "end": 15
@@ -74,7 +74,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: Invalid filter value, expected one of: diff, commit, symbol, repo, path, file.",
+                    "message": "Invalid filter value, expected one of: diff, commit, symbol, repo, path, file.",
                     "range": {
                       "start": 10,
                       "end": 15
@@ -91,7 +91,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
+                    "message": "This filter requires \`type:commit\` or \`type:diff\` in the query",
                     "range": {
                       "start": 0,
                       "end": 9
@@ -119,7 +119,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
+                    "message": "This filter requires \`type:commit\` or \`type:diff\` in the query",
                     "range": {
                       "start": 0,
                       "end": 9
@@ -149,7 +149,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
+                    "message": "This filter requires \`type:commit\` or \`type:diff\` in the query",
                     "range": {
                       "start": 0,
                       "end": 9
@@ -173,7 +173,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
+                    "message": "This filter requires \`type:commit\` or \`type:diff\` in the query",
                     "range": {
                       "start": 10,
                       "end": 26
@@ -197,7 +197,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
+                    "message": "This filter requires \`type:commit\` or \`type:diff\` in the query",
                     "range": {
                       "start": 27,
                       "end": 44
@@ -221,7 +221,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
+                    "message": "This filter requires \`type:commit\` or \`type:diff\` in the query",
                     "range": {
                       "start": 45,
                       "end": 57
@@ -250,7 +250,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
+                    "message": "This filter requires \`type:commit\` or \`type:diff\` in the query",
                     "range": {
                       "start": 0,
                       "end": 15
@@ -274,7 +274,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
+                    "message": "This filter requires \`type:commit\` or \`type:diff\` in the query",
                     "range": {
                       "start": 16,
                       "end": 33
@@ -298,7 +298,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
+                    "message": "This filter requires \`type:commit\` or \`type:diff\` in the query",
                     "range": {
                       "start": 34,
                       "end": 40
@@ -349,7 +349,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: query contains \`rev:\` without \`repo:\`. Add a \`repo:\` filter.",
+                    "message": "Query contains \`rev:\` without \`repo:\`. Add a \`repo:\` filter.",
                     "range": {
                       "start": 0,
                       "end": 8
@@ -373,7 +373,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: query contains \`rev:\` without \`repo:\`. Add a \`repo:\` filter.",
+                    "message": "Query contains \`rev:\` without \`repo:\`. Add a \`repo:\` filter.",
                     "range": {
                       "start": 0,
                       "end": 13
@@ -400,7 +400,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
+                    "message": "You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
                     "range": {
                       "start": 9,
                       "end": 22
@@ -424,7 +424,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
+                    "message": "You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
                     "range": {
                       "start": 0,
                       "end": 8
@@ -452,7 +452,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
+                    "message": "You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
                     "range": {
                       "start": 9,
                       "end": 19
@@ -476,7 +476,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
+                    "message": "You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
                     "range": {
                       "start": 0,
                       "end": 8
@@ -507,7 +507,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "warning",
-                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`repo:\\" a term\\"\`.",
+                    "message": "This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`repo:\\" a term\\"\`.",
                     "range": {
                       "start": 9,
                       "end": 14
@@ -515,7 +515,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
+                    "message": "Query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
                     "range": {
                       "start": 9,
                       "end": 14
@@ -531,7 +531,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
+                    "message": "Query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
                     "range": {
                       "start": 0,
                       "end": 8
@@ -551,7 +551,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
+                    "message": "Query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
                     "range": {
                       "start": 9,
                       "end": 14
@@ -567,7 +567,7 @@ describe('getDiagnostics()', () => {
                   },
                   {
                     "severity": "error",
-                    "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
+                    "message": "Query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
                     "range": {
                       "start": 0,
                       "end": 8
@@ -591,7 +591,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "warning",
-                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`repo:\\" a term\\"\`.",
+                    "message": "This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`repo:\\" a term\\"\`.",
                     "range": {
                       "start": 19,
                       "end": 24
@@ -608,7 +608,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \`type:\`. Remove this filter or switch to a different search type.",
+                    "message": "Structural search syntax only applies to searching file contents and is not compatible with \`type:\`. Remove this filter or switch to a different search type.",
                     "range": {
                       "start": 0,
                       "end": 11
@@ -621,7 +621,7 @@ describe('getDiagnostics()', () => {
                 [
                   {
                     "severity": "error",
-                    "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \`type:\`. Remove this filter or switch to a different search type.",
+                    "message": "Structural search syntax only applies to searching file contents and is not compatible with \`type:\`. Remove this filter or switch to a different search type.",
                     "range": {
                       "start": 0,
                       "end": 11

--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -27,12 +27,12 @@ describe('getDiagnostics()', () => {
             expect(parseAndDiagnose('case:maybe', SearchPatternType.literal)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: Invalid filter value, expected one of: yes, no.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 5
+                    "range": {
+                      "start": 0,
+                      "end": 10
+                    }
                   }
                 ]
             `)
@@ -58,12 +58,12 @@ describe('getDiagnostics()', () => {
             expect(parseAndDiagnose('meatadata file: ', SearchPatternType.regexp)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 4,
-                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g., file:\\" a term\\".",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 11,
-                    "endColumn": 15
+                    "severity": "warning",
+                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`file:\\" a term\\"\`.",
+                    "range": {
+                      "start": 10,
+                      "end": 15
+                    }
                   }
                 ]
             `)
@@ -73,12 +73,12 @@ describe('getDiagnostics()', () => {
             expect(parseAndDiagnose('meatadata type: ', SearchPatternType.regexp)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: Invalid filter value, expected one of: diff, commit, symbol, repo, path, file.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 11,
-                    "endColumn": 15
+                    "range": {
+                      "start": 10,
+                      "end": 15
+                    }
                   }
                 ]
             `)
@@ -90,24 +90,56 @@ describe('getDiagnostics()', () => {
             expect(parseAndDiagnose('author:me', SearchPatternType.literal)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 7
+                    "range": {
+                      "start": 0,
+                      "end": 9
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"type:commit\\"",
+                        "change": {
+                          "from": 0,
+                          "insert": "type:commit "
+                        }
+                      },
+                      {
+                        "label": "Add \\"type:diff\\"",
+                        "change": {
+                          "from": 0,
+                          "insert": "type:diff "
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
             expect(parseAndDiagnose('author:me test', SearchPatternType.literal)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 7
+                    "range": {
+                      "start": 0,
+                      "end": 9
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"type:commit\\"",
+                        "change": {
+                          "from": 0,
+                          "insert": "type:commit "
+                        }
+                      },
+                      {
+                        "label": "Add \\"type:diff\\"",
+                        "change": {
+                          "from": 0,
+                          "insert": "type:diff "
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
@@ -116,36 +148,100 @@ describe('getDiagnostics()', () => {
             ).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 7
+                    "range": {
+                      "start": 0,
+                      "end": 9
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"type:commit\\"",
+                        "change": {
+                          "from": 0,
+                          "insert": "type:commit "
+                        }
+                      },
+                      {
+                        "label": "Add \\"type:diff\\"",
+                        "change": {
+                          "from": 0,
+                          "insert": "type:diff "
+                        }
+                      }
+                    ]
                   },
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 11,
-                    "endColumn": 17
+                    "range": {
+                      "start": 10,
+                      "end": 26
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"type:commit\\"",
+                        "change": {
+                          "from": 10,
+                          "insert": "type:commit "
+                        }
+                      },
+                      {
+                        "label": "Add \\"type:diff\\"",
+                        "change": {
+                          "from": 10,
+                          "insert": "type:diff "
+                        }
+                      }
+                    ]
                   },
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 28,
-                    "endColumn": 33
+                    "range": {
+                      "start": 27,
+                      "end": 44
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"type:commit\\"",
+                        "change": {
+                          "from": 27,
+                          "insert": "type:commit "
+                        }
+                      },
+                      {
+                        "label": "Add \\"type:diff\\"",
+                        "change": {
+                          "from": 27,
+                          "insert": "type:diff "
+                        }
+                      }
+                    ]
                   },
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 46,
-                    "endColumn": 53
+                    "range": {
+                      "start": 45,
+                      "end": 57
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"type:commit\\"",
+                        "change": {
+                          "from": 45,
+                          "insert": "type:commit "
+                        }
+                      },
+                      {
+                        "label": "Add \\"type:diff\\"",
+                        "change": {
+                          "from": 45,
+                          "insert": "type:diff "
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
@@ -153,28 +249,76 @@ describe('getDiagnostics()', () => {
                 .toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 6
+                    "range": {
+                      "start": 0,
+                      "end": 15
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"type:commit\\"",
+                        "change": {
+                          "from": 0,
+                          "insert": "type:commit "
+                        }
+                      },
+                      {
+                        "label": "Add \\"type:diff\\"",
+                        "change": {
+                          "from": 0,
+                          "insert": "type:diff "
+                        }
+                      }
+                    ]
                   },
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 17,
-                    "endColumn": 22
+                    "range": {
+                      "start": 16,
+                      "end": 33
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"type:commit\\"",
+                        "change": {
+                          "from": 16,
+                          "insert": "type:commit "
+                        }
+                      },
+                      {
+                        "label": "Add \\"type:diff\\"",
+                        "change": {
+                          "from": 16,
+                          "insert": "type:diff "
+                        }
+                      }
+                    ]
                   },
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: this filter requires \`type:commit\` or \`type:diff\` in the query",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 35,
-                    "endColumn": 36
+                    "range": {
+                      "start": 34,
+                      "end": 40
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"type:commit\\"",
+                        "change": {
+                          "from": 34,
+                          "insert": "type:commit "
+                        }
+                      },
+                      {
+                        "label": "Add \\"type:diff\\"",
+                        "change": {
+                          "from": 34,
+                          "insert": "type:diff "
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
@@ -204,24 +348,48 @@ describe('getDiagnostics()', () => {
             expect(parseAndDiagnose('rev:main test', SearchPatternType.literal)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: query contains \`rev:\` without \`repo:\`. Add a \`repo:\` filter.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 4
+                    "range": {
+                      "start": 0,
+                      "end": 8
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"repo:\\"",
+                        "change": {
+                          "from": 8,
+                          "insert": " repo:"
+                        },
+                        "selection": {
+                          "anchor": 14
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
             expect(parseAndDiagnose('revision:main test', SearchPatternType.literal)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: query contains \`rev:\` without \`repo:\`. Add a \`repo:\` filter.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 9
+                    "range": {
+                      "start": 0,
+                      "end": 13
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"repo:\\"",
+                        "change": {
+                          "from": 13,
+                          "insert": " repo:"
+                        },
+                        "selection": {
+                          "anchor": 19
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
@@ -231,40 +399,104 @@ describe('getDiagnostics()', () => {
             expect(parseAndDiagnose('rev:main repo:test@dev test', SearchPatternType.literal)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
-                    "message": "Error: You have specified both \`@\` and \`rev:\` for a repo filter and I don\`t know how to interpret this. Remove either \`@\` or \`rev:\`",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 10,
-                    "endColumn": 14
+                    "severity": "error",
+                    "message": "Error: You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
+                    "range": {
+                      "start": 9,
+                      "end": 22
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove @<rev>",
+                        "change": {
+                          "from": 18,
+                          "to": 22
+                        }
+                      },
+                      {
+                        "label": "Remove \\"rev:\\" filter",
+                        "change": {
+                          "from": 0,
+                          "to": 8
+                        }
+                      }
+                    ]
                   },
                   {
-                    "severity": 8,
-                    "message": "Error: You have specified both \`@\` and \`rev:\` for a repo filter and I don\`t know how to interpret this. Remove either \`@\` or \`rev:\`",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 4
+                    "severity": "error",
+                    "message": "Error: You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
+                    "range": {
+                      "start": 0,
+                      "end": 8
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove @<rev>",
+                        "change": {
+                          "from": 18,
+                          "to": 22
+                        }
+                      },
+                      {
+                        "label": "Remove \\"rev:\\" filter",
+                        "change": {
+                          "from": 0,
+                          "to": 8
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
             expect(parseAndDiagnose('rev:main r:test@dev test', SearchPatternType.literal)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
-                    "message": "Error: You have specified both \`@\` and \`rev:\` for a repo filter and I don\`t know how to interpret this. Remove either \`@\` or \`rev:\`",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 10,
-                    "endColumn": 11
+                    "severity": "error",
+                    "message": "Error: You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
+                    "range": {
+                      "start": 9,
+                      "end": 19
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove @<rev>",
+                        "change": {
+                          "from": 15,
+                          "to": 19
+                        }
+                      },
+                      {
+                        "label": "Remove \\"rev:\\" filter",
+                        "change": {
+                          "from": 0,
+                          "to": 8
+                        }
+                      }
+                    ]
                   },
                   {
-                    "severity": 8,
-                    "message": "Error: You have specified both \`@\` and \`rev:\` for a repo filter and I don\`t know how to interpret this. Remove either \`@\` or \`rev:\`",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 4
+                    "severity": "error",
+                    "message": "Error: You have specified both \`@<rev>\` and \`rev:\` for a repo filter and I don't know how to interpret this. Remove either \`@<rev>\` or \`rev:\`",
+                    "range": {
+                      "start": 0,
+                      "end": 8
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove @<rev>",
+                        "change": {
+                          "from": 15,
+                          "to": 19
+                        }
+                      },
+                      {
+                        "label": "Remove \\"rev:\\" filter",
+                        "change": {
+                          "from": 0,
+                          "to": 8
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
@@ -274,48 +506,80 @@ describe('getDiagnostics()', () => {
             expect(parseAndDiagnose('rev:main repo: test', SearchPatternType.literal)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 4,
-                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g., repo:\\" a term\\".",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 10,
-                    "endColumn": 14
+                    "severity": "warning",
+                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`repo:\\" a term\\"\`.",
+                    "range": {
+                      "start": 9,
+                      "end": 14
+                    }
                   },
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 10,
-                    "endColumn": 14
+                    "range": {
+                      "start": 9,
+                      "end": 14
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"repo:\\" value",
+                        "selection": {
+                          "anchor": 14
+                        }
+                      }
+                    ]
                   },
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 4
+                    "range": {
+                      "start": 0,
+                      "end": 8
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"repo:\\" value",
+                        "selection": {
+                          "anchor": 14
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
             expect(parseAndDiagnose('rev:main repo:', SearchPatternType.literal)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 10,
-                    "endColumn": 14
+                    "range": {
+                      "start": 9,
+                      "end": 14
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"repo:\\" value",
+                        "selection": {
+                          "anchor": 14
+                        }
+                      }
+                    ]
                   },
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: query contains \`rev:\` with an empty \`repo:\` filter. Add a non-empty \`repo:\` filter.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 4
+                    "range": {
+                      "start": 0,
+                      "end": 8
+                    },
+                    "actions": [
+                      {
+                        "label": "Add \\"repo:\\" value",
+                        "selection": {
+                          "anchor": 14
+                        }
+                      }
+                    ]
                   }
                 ]
             `)
@@ -326,12 +590,12 @@ describe('getDiagnostics()', () => {
                 .toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 4,
-                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g., repo:\\" a term\\".",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 20,
-                    "endColumn": 24
+                    "severity": "warning",
+                    "message": "Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`repo:\\" a term\\"\`.",
+                    "range": {
+                      "start": 19,
+                      "end": 24
+                    }
                   }
                 ]
             `)
@@ -343,12 +607,12 @@ describe('getDiagnostics()', () => {
             expect(parseAndDiagnose('type:symbol test', SearchPatternType.structural)).toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \`type:\`. Remove this filter or switch to a different search type.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 5
+                    "range": {
+                      "start": 0,
+                      "end": 11
+                    }
                   }
                 ]
             `)
@@ -356,12 +620,12 @@ describe('getDiagnostics()', () => {
                 .toMatchInlineSnapshot(`
                 [
                   {
-                    "severity": 8,
+                    "severity": "error",
                     "message": "Error: Structural search syntax only applies to searching file contents and is not compatible with \`type:\`. Remove this filter or switch to a different search type.",
-                    "startLineNumber": 1,
-                    "endLineNumber": 1,
-                    "startColumn": 1,
-                    "endColumn": 5
+                    "range": {
+                      "start": 0,
+                      "end": 11
+                    }
                   }
                 ]
             `)

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -59,7 +59,7 @@ export function validFilterValue(filter: Filter): Diagnostic[] {
     if (validationResult.valid) {
         return []
     }
-    return [createDiagnostic(`Error: ${validationResult.reason}`, filter)]
+    return [createDiagnostic(validationResult.reason, filter)]
 }
 
 export function emptyFilterValue(filter: Filter): Diagnostic[] {
@@ -68,7 +68,7 @@ export function emptyFilterValue(filter: Filter): Diagnostic[] {
     }
     return [
         createDiagnostic(
-            `Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`${filter.field.value}:" a term"\`.`,
+            `This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`${filter.field.value}:" a term"\`.`,
             filter,
             'warning'
         ),
@@ -128,21 +128,16 @@ const rules: PatternOf<Token[], PatternData>[] = [
         each({
             field: { value: oneOf('author', 'before', 'until', 'after', 'since', 'message', 'msg', 'm') },
             $data: addDiagnostic(token => [
-                createDiagnostic(
-                    'Error: this filter requires `type:commit` or `type:diff` in the query',
-                    token,
-                    'error',
-                    [
-                        {
-                            label: 'Add "type:commit"',
-                            change: { from: token.range.start, insert: 'type:commit ' },
-                        },
-                        {
-                            label: 'Add "type:diff"',
-                            change: { from: token.range.start, insert: 'type:diff ' },
-                        },
-                    ]
-                ),
+                createDiagnostic('This filter requires `type:commit` or `type:diff` in the query', token, 'error', [
+                    {
+                        label: 'Add "type:commit"',
+                        change: { from: token.range.start, insert: 'type:commit ' },
+                    },
+                    {
+                        label: 'Add "type:diff"',
+                        change: { from: token.range.start, insert: 'type:diff ' },
+                    },
+                ]),
             ]),
         })
     ),
@@ -163,7 +158,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
 
                     return [
                         createDiagnostic(
-                            'Error: query contains `rev:` without `repo:`. Add a `repo:` filter.',
+                            'Query contains `rev:` without `repo:`. Add a `repo:` filter.',
                             revisionFilter,
                             'error',
                             [
@@ -185,7 +180,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
                     value: oneOf(undefined, { value: '' }),
                     $data: addDiagnostic((token, context) => {
                         const errorMessage =
-                            'Error: query contains `rev:` with an empty `repo:` filter. Add a non-empty `repo:` filter.'
+                            'Query contains `rev:` with an empty `repo:` filter. Add a non-empty `repo:` filter.'
                         const actions: Action[] = [
                             {
                                 label: 'Add "repo:" value',
@@ -206,7 +201,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
                 $data: addDiagnostic((token, context) => {
                     const repoFilter = token as Filter
                     const errorMessage =
-                        "Error: You have specified both `@<rev>` and `rev:` for a repo filter and I don't know how to interpret this. Remove either `@<rev>` or `rev:`"
+                        "You have specified both `@<rev>` and `rev:` for a repo filter and I don't know how to interpret this. Remove either `@<rev>` or `rev:`"
                     const start = repoFilter.value!.range.start
                     const actions: Action[] = [
                         {
@@ -246,7 +241,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
             field: { value: 'type' },
             $data: addDiagnostic(
                 filterDiagnosticCreator(
-                    'Error: Structural search syntax only applies to searching file contents and is not compatible with `type:`. Remove this filter or switch to a different search type.'
+                    'Structural search syntax only applies to searching file contents and is not compatible with `type:`. Remove this filter or switch to a different search type.'
                 )
             ),
         })

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -1,9 +1,6 @@
-import * as Monaco from 'monaco-editor'
-
 import { SearchPatternType } from '../../graphql-operations'
 
 import { validateFilter } from './filters'
-import { toMonacoSingleLineRange } from './monaco'
 import {
     PatternOf,
     each,
@@ -16,23 +13,44 @@ import {
     DataMapper,
     MatchContext,
 } from './patternMatcher'
-import { Filter, Token } from './token'
+import { CharacterRange, Filter, Token } from './token'
 
-type FilterCheck = (f: Filter) => Monaco.editor.IMarkerData[]
+export interface ChangeSpec {
+    from: number
+    to?: number
+    insert?: string
+}
 
-function createMarker(
+export interface Action {
+    label: string
+    change?: ChangeSpec
+    selection?: { head?: number; anchor: number }
+}
+
+export interface Diagnostic {
+    range: CharacterRange
+    message: string
+    severity: 'info' | 'warning' | 'error'
+    actions?: Action[]
+}
+
+type FilterCheck = (f: Filter) => Diagnostic[]
+
+function createDiagnostic(
     message: string,
-    filter: Filter,
-    severity = Monaco.MarkerSeverity.Error
-): Monaco.editor.IMarkerData {
+    token: Token,
+    severity: Diagnostic['severity'] = 'error',
+    actions?: Action[]
+): Diagnostic {
     return {
         severity,
         message,
-        ...toMonacoSingleLineRange(filter.field.range),
+        range: token.range,
+        actions,
     }
 }
 
-export function validFilterValue(filter: Filter): Monaco.editor.IMarkerData[] {
+export function validFilterValue(filter: Filter): Diagnostic[] {
     if (!filter.value) {
         return []
     }
@@ -41,18 +59,18 @@ export function validFilterValue(filter: Filter): Monaco.editor.IMarkerData[] {
     if (validationResult.valid) {
         return []
     }
-    return [createMarker(`Error: ${validationResult.reason}`, filter)]
+    return [createDiagnostic(`Error: ${validationResult.reason}`, filter)]
 }
 
-export function emptyFilterValue(filter: Filter): Monaco.editor.IMarkerData[] {
+export function emptyFilterValue(filter: Filter): Diagnostic[] {
     if (filter.value?.value !== '') {
         return []
     }
     return [
-        createMarker(
-            `Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g., ${filter.field.value}:" a term".`,
+        createDiagnostic(
+            `Warning: This filter is empty. Remove the space between the filter and value or quote the value to include the space. E.g. \`${filter.field.value}:" a term"\`.`,
             filter,
-            Monaco.MarkerSeverity.Warning
+            'warning'
         ),
     ]
 }
@@ -60,7 +78,7 @@ export function emptyFilterValue(filter: Filter): Monaco.editor.IMarkerData[] {
 // Returns the first nonempty diagnostic for a filter, or nothing otherwise. We return
 // the only the first so that we don't overwhelm the the user with multiple diagnostics
 // for a single filter.
-export function checkFilter(filter: Filter): Monaco.editor.IMarkerData[] {
+export function checkFilter(filter: Filter): Diagnostic[] {
     const checks: FilterCheck[] = [validFilterValue, emptyFilterValue]
     return checks.map(check => check(filter)).find(value => value.length !== 0) || []
 }
@@ -70,14 +88,23 @@ interface PatternData {
     // Used to make the search pattern type available to patterns
     searchPatternType: SearchPatternType
     // Used by patterns to "export" markers
-    marker: Monaco.editor.IMarkerData[]
+    diagnostics: Diagnostic[]
     // Used by the rev+repo patterns to keep track of the rev filter
     revFilter?: Filter
 }
 
-function addFilterDiagnostic(message: string, severity = Monaco.MarkerSeverity.Error): DataMapper<Token, PatternData> {
-    return (token, context) => {
-        context.data.marker.push(createMarker(message, token as Filter, severity))
+function filterDiagnosticCreator(
+    message: string,
+    severity: Diagnostic['severity'] = 'error'
+): (token: Token) => Diagnostic[] {
+    return token => [createDiagnostic(message, token as Filter, severity)]
+}
+
+function addDiagnostic<T>(
+    provider: (value: T, context: MatchContext<PatternData>) => Diagnostic[]
+): DataMapper<T, PatternData> {
+    return (value, context) => {
+        context.data.diagnostics.push(...provider(value, context))
     }
 }
 
@@ -90,7 +117,7 @@ const rules: PatternOf<Token[], PatternData>[] = [
     each({
         type: 'filter',
         $data: (token: Token, context: MatchContext<PatternData>) => {
-            context.data.marker.push(...checkFilter(token as Filter))
+            context.data.diagnostics.push(...checkFilter(token as Filter))
         },
     }),
 
@@ -100,7 +127,23 @@ const rules: PatternOf<Token[], PatternData>[] = [
         not(some({ field: { value: 'type' }, value: { value: oneOf('diff', 'commit') } })),
         each({
             field: { value: oneOf('author', 'before', 'until', 'after', 'since', 'message', 'msg', 'm') },
-            $data: addFilterDiagnostic('Error: this filter requires `type:commit` or `type:diff` in the query'),
+            $data: addDiagnostic(token => [
+                createDiagnostic(
+                    'Error: this filter requires `type:commit` or `type:diff` in the query',
+                    token,
+                    'error',
+                    [
+                        {
+                            label: 'Add "type:commit"',
+                            change: { from: token.range.start, insert: 'type:commit ' },
+                        },
+                        {
+                            label: 'Add "type:diff"',
+                            change: { from: token.range.start, insert: 'type:diff ' },
+                        },
+                    ]
+                ),
+            ]),
         })
     ),
 
@@ -115,14 +158,24 @@ const rules: PatternOf<Token[], PatternData>[] = [
             // No repo: filter
             {
                 $pattern: not(some(repoFilterPattern)),
-                $data: (_tokens, context) => {
-                    context.data.marker.push(
-                        createMarker(
+                $data: addDiagnostic((_tokens, context) => {
+                    const revisionFilter = context.data.revFilter!
+
+                    return [
+                        createDiagnostic(
                             'Error: query contains `rev:` without `repo:`. Add a `repo:` filter.',
-                            context.data.revFilter!
-                        )
-                    )
-                },
+                            revisionFilter,
+                            'error',
+                            [
+                                {
+                                    label: 'Add "repo:"',
+                                    change: { from: revisionFilter.range.end, insert: ' repo:' },
+                                    selection: { anchor: revisionFilter.range.end + 6 },
+                                },
+                            ]
+                        ),
+                    ]
+                }),
             },
             // Only empty repo: filter
             allOf(
@@ -130,28 +183,52 @@ const rules: PatternOf<Token[], PatternData>[] = [
                 some({
                     ...repoFilterPattern,
                     value: oneOf(undefined, { value: '' }),
-                    $data: (token: Token, context: MatchContext<PatternData>) => {
+                    $data: addDiagnostic((token, context) => {
                         const errorMessage =
                             'Error: query contains `rev:` with an empty `repo:` filter. Add a non-empty `repo:` filter.'
-                        context.data.marker.push(
-                            createMarker(errorMessage, token as Filter),
-                            createMarker(errorMessage, context.data.revFilter!)
-                        )
-                    },
+                        const actions: Action[] = [
+                            {
+                                label: 'Add "repo:" value',
+                                selection: { anchor: token.range.end },
+                            },
+                        ]
+                        return [
+                            createDiagnostic(errorMessage, token as Filter, 'error', actions),
+                            createDiagnostic(errorMessage, context.data.revFilter!, 'error', actions),
+                        ]
+                    }),
                 })
             ),
             // Repo filter that contains a revision "tag"
             some({
                 ...repoFilterPattern,
                 value: { value: value => value.includes('@') },
-                $data: (token: Token, context: MatchContext<PatternData>) => {
+                $data: addDiagnostic((token, context) => {
+                    const repoFilter = token as Filter
                     const errorMessage =
-                        'Error: You have specified both `@` and `rev:` for a repo filter and I don`t know how to interpret this. Remove either `@` or `rev:`'
-                    context.data.marker.push(
-                        createMarker(errorMessage, token as Filter),
-                        createMarker(errorMessage, context.data.revFilter!)
-                    )
-                },
+                        "Error: You have specified both `@<rev>` and `rev:` for a repo filter and I don't know how to interpret this. Remove either `@<rev>` or `rev:`"
+                    const start = repoFilter.value!.range.start
+                    const actions: Action[] = [
+                        {
+                            label: 'Remove @<rev>',
+                            change: {
+                                from: start + repoFilter.value!.value.indexOf('@'),
+                                to: start + repoFilter.value!.value.length,
+                            },
+                        },
+                        {
+                            label: 'Remove "rev:" filter',
+                            change: {
+                                from: context.data.revFilter!.range.start,
+                                to: context.data.revFilter!.range.end,
+                            },
+                        },
+                    ]
+                    return [
+                        createDiagnostic(errorMessage, token as Filter, 'error', actions),
+                        createDiagnostic(errorMessage, context.data.revFilter!, 'error', actions),
+                    ]
+                }),
             })
         )
     ),
@@ -167,20 +244,22 @@ const rules: PatternOf<Token[], PatternData>[] = [
         ),
         some({
             field: { value: 'type' },
-            $data: addFilterDiagnostic(
-                'Error: Structural search syntax only applies to searching file contents and is not compatible with `type:`. Remove this filter or switch to a different search type.'
+            $data: addDiagnostic(
+                filterDiagnosticCreator(
+                    'Error: Structural search syntax only applies to searching file contents and is not compatible with `type:`. Remove this filter or switch to a different search type.'
+                )
             ),
         })
     ),
 ]
 
 /**
- * Returns the diagnostics for a scanned search query to be displayed in the Monaco query input.
+ * Returns the diagnostics for a scanned search query to be displayed in the query input.
  */
-export function getDiagnostics(tokens: Token[], searchPatternType: SearchPatternType): Monaco.editor.IMarkerData[] {
-    const result = matchesValue<Token[], PatternData>(tokens, eachOf(...rules), { searchPatternType, marker: [] })
+export function getDiagnostics(tokens: Token[], searchPatternType: SearchPatternType): Diagnostic[] {
+    const result = matchesValue<Token[], PatternData>(tokens, eachOf(...rules), { searchPatternType, diagnostics: [] })
     if (result.success) {
-        return result.data.marker
+        return result.data.diagnostics
     }
     return []
 }

--- a/package.json
+++ b/package.json
@@ -364,6 +364,7 @@
     "@codemirror/lang-json": "^6.0.0",
     "@codemirror/lang-markdown": "^6.0.0",
     "@codemirror/language": "^6.2.0",
+    "@codemirror/lint": "^6.0.0",
     "@codemirror/state": "^6.1.0",
     "@codemirror/view": "^6.0.2",
     "@lezer/highlight": "^1.0.0",


### PR DESCRIPTION
This commit switches our CodeMirror diagnostics implementation from a
custom extension to the one provided by CodeMirror. It provides
diagnostic markers and the hovers show a colored bar (matching severity
type) next to the text.

I also took the opportunity to refactor our diagnostics implementation
to be less Monaco specific. Instead there is now an intermediate layer
(which is inspired by CodeMirror) and the editors themselves convert
those objects to something appropriate for them. A subtle change is marking
the whole filter + value, not just the filter field.

I also added support for actions, which can be seen in the video. We can
change the default style of the buttons if necessary (I do think they look
a bit janky so I'm happy to tweak this).
Or if this feels too much I'm also happy to remove the actions part.

Demo: (sorry for the pauses in between I had to look up which filters to showcase)

https://user-images.githubusercontent.com/179026/178018955-9a741dba-8fb2-4389-b99d-d76b4f2b6731.mp4

After button style and message update:

<img width="557" alt="2022-07-08_22-26" src="https://user-images.githubusercontent.com/179026/178065826-291f0142-75a8-4e19-8b4c-afff1aff289a.png">



## Test plan

Tested filters for which we have validation in CodeMirror and Monaco.

## App preview:

- [Web](https://sg-web-fkling-query-input-lint.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ucsdomddam.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
