### PR TITLE
JetBrains: Open Sourcegraph files in the browser

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/URLBuilder.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/URLBuilder.java
@@ -30,9 +30,11 @@ public class URLBuilder {
             + "?" + buildMarketingParams()
             + "&search=" + URLEncoder.encode(search, StandardCharsets.UTF_8);
 
-        if (remoteUrl != null && branchName != null) {
-            url += "&search_remote_url=" + URLEncoder.encode(remoteUrl, StandardCharsets.UTF_8)
-                + "&search_branch=" + URLEncoder.encode(branchName, StandardCharsets.UTF_8);
+        if (remoteUrl != null) {
+            url += "&search_remote_url=" + URLEncoder.encode(remoteUrl, StandardCharsets.UTF_8);
+            if (branchName != null) {
+                url += "&search_branch=" + URLEncoder.encode(branchName, StandardCharsets.UTF_8);
+            }
         }
 
         return url;

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
@@ -183,11 +183,7 @@ public class PreviewContent {
             return null;
         }
         byte[] decodedBytes = Base64.getDecoder().decode(base64String);
-        try {
-            return new String(decodedBytes, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            return "";
-        }
+        return new String(decodedBytes, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
@@ -17,9 +17,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -172,7 +172,9 @@ public class PreviewContent {
     @NotNull
     public VirtualFile getVirtualFile() {
         if (virtualFile == null) {
-            virtualFile = new LightVirtualFile(fileName != null ? fileName : "", content != null ? Objects.requireNonNull(getContent()) : "");
+            assert fileName != null;
+            assert content != null;
+            virtualFile = new LightVirtualFile(fileName, Objects.requireNonNull(getContent()));
         }
         return virtualFile;
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
@@ -171,7 +171,7 @@ public class PreviewContent {
     @NotNull
     public VirtualFile getVirtualFile() {
         if (virtualFile == null) {
-            assert fileName != null;
+            assert fileName != null; // We should always have a non-null file name and content when we call getVirtualFile()
             assert content != null;
             virtualFile = new SourcegraphVirtualFile(fileName, Objects.requireNonNull(getContent()), getRepoUrl(), getCommit(), getPath());
         }
@@ -218,7 +218,7 @@ public class PreviewContent {
     }
 
     private void openInEditor() {
-        assert fileName != null;
+        assert fileName != null; // We should always have a non-null file name when we call openInEditor()
         // Open file in editor
         virtualFile = getVirtualFile();
         OpenFileDescriptor openFileDescriptor = new OpenFileDescriptor(project, virtualFile, 0);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
-import com.intellij.testFramework.LightVirtualFile;
 import com.sourcegraph.config.ConfigUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -174,7 +173,7 @@ public class PreviewContent {
         if (virtualFile == null) {
             assert fileName != null;
             assert content != null;
-            virtualFile = new LightVirtualFile(fileName, Objects.requireNonNull(getContent()));
+            virtualFile = new SourcegraphVirtualFile(fileName, Objects.requireNonNull(getContent()), getRepoUrl(), getCommit(), getPath());
         }
         return virtualFile;
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
@@ -15,7 +15,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.JBPanelWithEmptyText;
 import com.sourcegraph.Icons;
 import com.sourcegraph.website.Copy;
-import com.sourcegraph.website.FileAction;
+import com.sourcegraph.website.FileActionBase;
 import com.sourcegraph.website.OpenFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -148,10 +148,10 @@ public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
     }
 
     class SimpleEditorFileAction extends DumbAwareAction {
-        FileAction action;
+        FileActionBase action;
         Editor editor;
 
-        SimpleEditorFileAction(String text, FileAction action, Editor editor) {
+        SimpleEditorFileAction(String text, FileActionBase action, Editor editor) {
             super(text, text, Icons.SourcegraphLogo);
             this.action = action;
             this.editor = editor;

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphVirtualFile.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphVirtualFile.java
@@ -28,4 +28,10 @@ public class SourcegraphVirtualFile extends LightVirtualFile {
     public String getRelativePath() {
         return path;
     }
+
+    @NotNull
+    @Override
+    public String getPath() {
+        return repoUrl + " > " + path;
+    }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphVirtualFile.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphVirtualFile.java
@@ -1,0 +1,31 @@
+package com.sourcegraph.find;
+
+import com.intellij.testFramework.LightVirtualFile;
+import com.intellij.util.LocalTimeCounter;
+import org.jetbrains.annotations.NotNull;
+
+public class SourcegraphVirtualFile extends LightVirtualFile {
+    private final String repoUrl;
+    private final String commit;
+    private final String path;
+
+    public SourcegraphVirtualFile(@NotNull String name, @NotNull CharSequence content, String repoUrl, String commit, String path) {
+        super(name, null, content, LocalTimeCounter.currentTime());
+        this.repoUrl = repoUrl;
+        this.commit = commit;
+        this.path = path;
+    }
+
+    public String getRepoUrl() {
+        return repoUrl;
+    }
+
+    public String getCommit() {
+        return commit;
+    }
+
+    @NotNull
+    public String getRelativePath() {
+        return path;
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/git/CommitViewUriBuilder.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/git/CommitViewUriBuilder.java
@@ -2,18 +2,20 @@ package com.sourcegraph.git;
 
 import com.google.common.base.Strings;
 import com.sourcegraph.config.ConfigUtil;
+import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 public class CommitViewUriBuilder {
-    public URI build(String sourcegraphBase, String revisionNumber, RepoInfo repoInfo, String productName, String productVersion) {
+    @NotNull
+    public URI build(@NotNull String sourcegraphBase, @NotNull String revisionNumber, @NotNull RepoInfo repoInfo, @NotNull String productName, @NotNull String productVersion) {
         if (Strings.isNullOrEmpty(sourcegraphBase)) {
             throw new RuntimeException("Missing sourcegraph URI for commit uri.");
         } else if (Strings.isNullOrEmpty(revisionNumber)) {
             throw new RuntimeException("Missing revision number for commit uri.");
-        } else if (repoInfo == null || Strings.isNullOrEmpty(repoInfo.remoteUrl)) {
+        } else if (repoInfo.remoteUrl.equals("")) {
             throw new RuntimeException("Missing remote URL for commit uri.");
         }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
@@ -15,7 +15,7 @@ public class GitUtil {
     // relative to the repository root. If the repository URI cannot be
     // determined, a RepoInfo with empty strings is returned.
     @NotNull
-    public static RepoInfo getRepoInfo(String filePath, Project project) {
+    public static RepoInfo getRepoInfo(@NotNull String filePath, @NotNull Project project) {
         String relativePath = "";
         String remoteUrl = "";
         String branchName = "";
@@ -50,7 +50,7 @@ public class GitUtil {
      * E.g. "origin" -> "git@github.com:foo/bar"
      */
     @NotNull
-    private static String getRemoteUrl(String repoDirectoryPath, String remoteName) throws Exception {
+    private static String getRemoteUrl(@NotNull String repoDirectoryPath, @NotNull String remoteName) throws Exception {
         String result = exec("git remote get-url " + remoteName, repoDirectoryPath).trim();
         if (result.isEmpty()) {
             throw new Exception("There is no such remote: \"" + remoteName + "\".");
@@ -59,12 +59,12 @@ public class GitUtil {
     }
 
     /**
-     * Returns the URL of the "sourcegraph" remote.
+     * Returns the URL of the "sourcegraph" remote. E.g. "git@github.com:foo/bar"
      * Falls back to the "origin" remote.
      * An exception is thrown if neither exists.
      */
     @NotNull
-    private static String getConfiguredRemoteUrl(String repoDirectoryPath) throws Exception {
+    private static String getConfiguredRemoteUrl(@NotNull String repoDirectoryPath) throws Exception {
         try {
             return getRemoteUrl(repoDirectoryPath, "sourcegraph");
         } catch (Exception e) {
@@ -80,7 +80,7 @@ public class GitUtil {
      * Returns the repository root directory for any path within a repository.
      */
     @NotNull
-    private static String getRepoRootPath(String path) throws IOException {
+    private static String getRepoRootPath(@NotNull String path) throws IOException {
         return exec("git rev-parse --show-toplevel", path).trim();
     }
 
@@ -89,26 +89,26 @@ public class GitUtil {
      * In detached HEAD state and other exceptional cases it returns "HEAD".
      */
     @NotNull
-    private static String getCurrentBranchName(String path) throws IOException {
+    private static String getCurrentBranchName(@NotNull String path) throws IOException {
         return exec("git rev-parse --abbrev-ref HEAD", path).trim();
     }
 
     /**
      * @param branchName E.g. "main"
      */
-    private static boolean doesRemoteBranchExist(String branchName, String repoDirectoryPath) throws IOException {
+    private static boolean doesRemoteBranchExist(@NotNull String branchName, @NotNull String repoDirectoryPath) throws IOException {
         return exec("git show-branch remotes/origin/" + branchName, repoDirectoryPath).length() > 0;
     }
 
     // exec executes the given command in the specified directory and returns
     // its stdout. Any stderr output is logged.
-    private static String exec(String command, String directoryPath) throws IOException {
+    private static String exec(@NotNull String command, @NotNull String directoryPath) throws IOException {
         Logger.getInstance(GitUtil.class).debug("exec cmd='" + command + "' dir=" + directoryPath);
 
         // Create the process.
-        Process p = Runtime.getRuntime().exec(command, null, new File(directoryPath));
-        BufferedReader stdout = new BufferedReader(new InputStreamReader(p.getInputStream()));
-        BufferedReader stderr = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+        Process process = Runtime.getRuntime().exec(command, null, new File(directoryPath));
+        BufferedReader stdout = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        BufferedReader stderr = new BufferedReader(new InputStreamReader(process.getErrorStream()));
 
         // Log any stderr output.
         Logger logger = Logger.getInstance(GitUtil.class);
@@ -119,7 +119,7 @@ public class GitUtil {
 
         String out = "";
         //noinspection StatementWithEmptyBody
-        for (String l; (l = stdout.readLine()) != null; out += l + "\n") ;
+        for (String line; (line = stdout.readLine()) != null; out += line + "\n") ;
         return out;
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/git/RepoInfo.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/git/RepoInfo.java
@@ -1,11 +1,16 @@
 package com.sourcegraph.git;
 
-public class RepoInfo {
-    public final String relativePath;
-    public final String remoteUrl;
-    public final String branchName;
+import org.jetbrains.annotations.NotNull;
 
-    public RepoInfo(String relativePath, String remoteUrl, String branchName) {
+public class RepoInfo {
+    @NotNull
+    public final String relativePath; // E.g. "/client/jetbrains/package.json"
+    @NotNull
+    public final String remoteUrl; // E.g. "git@github.com:sourcegraph/sourcegraph"
+    @NotNull
+    public final String branchName; // E.g. "main"
+
+    public RepoInfo(@NotNull String relativePath, @NotNull String remoteUrl, @NotNull String branchName) {
         this.relativePath = relativePath;
         this.remoteUrl = remoteUrl;
         this.branchName = branchName;

--- a/client/jetbrains/src/main/java/com/sourcegraph/git/RevisionContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/git/RevisionContext.java
@@ -1,20 +1,23 @@
 package com.sourcegraph.git;
 
 import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
 
 public class RevisionContext {
     private final Project project;
-    private final String revisionNumber;
+    private final String revisionNumber; // Revision number or commit hash
 
-    public RevisionContext(Project project, String revisionNumber) {
+    public RevisionContext(@NotNull Project project, @NotNull String revisionNumber) {
         this.project = project;
         this.revisionNumber = revisionNumber;
     }
 
+    @NotNull
     public Project getProject() {
         return project;
     }
 
+    @NotNull
     public String getRevisionNumber() {
         return revisionNumber;
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/Copy.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/Copy.java
@@ -8,10 +8,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.awt.datatransfer.StringSelection;
 
-public class Copy extends FileAction {
-
+public class Copy extends FileActionBase {
     @Override
-    void handleFileUri(@NotNull String uri) {
+    protected void handleFileUri(@NotNull String uri) {
         // Remove utm tags for sharing
         String urlWithoutUtm = uri.replaceAll("(&utm_product_name=)(.*)", "");
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/FileAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/FileAction.java
@@ -35,7 +35,6 @@ public abstract class FileAction extends DumbAwareAction {
         if (currentFile == null) {
             return;
         }
-        SelectionModel sel = editor.getSelectionModel();
 
         // Get repo information.
         RepoInfo repoInfo = GitUtil.getRepoInfo(currentFile.getPath(), project);
@@ -43,14 +42,23 @@ public abstract class FileAction extends DumbAwareAction {
             return;
         }
 
-        VisualPosition selectionStartPosition = sel.getSelectionStartPosition();
-        VisualPosition selectionEndPosition = sel.getSelectionEndPosition();
-        LogicalPosition start = selectionStartPosition != null ? editor.visualToLogicalPosition(selectionStartPosition) : null;
-        LogicalPosition end = selectionEndPosition != null ? editor.visualToLogicalPosition(selectionEndPosition) : null;
-
-        String uri = URLBuilder.buildEditorFileUrl(project, repoInfo.remoteUrl, repoInfo.branchName, repoInfo.relativePath, start, end);
+        String uri = URLBuilder.buildEditorFileUrl(project, repoInfo.remoteUrl, repoInfo.branchName, repoInfo.relativePath, getSelectionStartPosition(editor), getSelectionEndPosition(editor));
 
         handleFileUri(uri);
+    }
+
+    @Nullable
+    private LogicalPosition getSelectionStartPosition(@NotNull Editor editor) {
+        SelectionModel sel = editor.getSelectionModel();
+        VisualPosition position = sel.getSelectionStartPosition();
+        return position != null ? editor.visualToLogicalPosition(position) : null;
+    }
+
+    @Nullable
+    private LogicalPosition getSelectionEndPosition(@NotNull Editor editor) {
+        SelectionModel sel = editor.getSelectionModel();
+        VisualPosition position = sel.getSelectionEndPosition();
+        return position != null ? editor.visualToLogicalPosition(position) : null;
     }
 
     public void actionPerformedFromPreviewContent(@NotNull Project project, @Nullable PreviewContent previewContent, @Nullable LogicalPosition start, @Nullable LogicalPosition end) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.browser.URLBuilder;
 import com.sourcegraph.find.PreviewContent;
+import com.sourcegraph.find.SourcegraphVirtualFile;
 import com.sourcegraph.git.GitUtil;
 import com.sourcegraph.git.RepoInfo;
 import org.jetbrains.annotations.NotNull;
@@ -35,12 +36,17 @@ public abstract class FileActionBase extends DumbAwareAction {
             return;
         }
 
-        RepoInfo repoInfo = GitUtil.getRepoInfo(currentFile.getPath(), project);
-        if (repoInfo.remoteUrl.equals("")) {
-            return;
-        }
+        if (currentFile instanceof SourcegraphVirtualFile) {
+            SourcegraphVirtualFile sourcegraphFile = (SourcegraphVirtualFile) currentFile;
+            handleFileUri(URLBuilder.buildSourcegraphBlobUrl(project, sourcegraphFile.getRepoUrl(), sourcegraphFile.getCommit(), sourcegraphFile.getRelativePath(), getSelectionStartPosition(editor), getSelectionEndPosition(editor)));
+        } else {
+            RepoInfo repoInfo = GitUtil.getRepoInfo(currentFile.getPath(), project);
+            if (repoInfo.remoteUrl.equals("")) {
+                return;
+            }
 
-        handleFileUri(URLBuilder.buildEditorFileUrl(project, repoInfo.remoteUrl, repoInfo.branchName, repoInfo.relativePath, getSelectionStartPosition(editor), getSelectionEndPosition(editor)));
+            handleFileUri(URLBuilder.buildEditorFileUrl(project, repoInfo.remoteUrl, repoInfo.branchName, repoInfo.relativePath, getSelectionStartPosition(editor), getSelectionEndPosition(editor)));
+        }
     }
 
     public void actionPerformedFromPreviewContent(@NotNull Project project, @Nullable PreviewContent previewContent, @Nullable LogicalPosition start, @Nullable LogicalPosition end) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenFile.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenFile.java
@@ -7,9 +7,9 @@ import java.awt.*;
 import java.io.IOException;
 import java.net.URI;
 
-public class OpenFile extends FileAction {
+public class OpenFile extends FileActionBase {
     @Override
-    void handleFileUri(@NotNull String uri) {
+    protected void handleFileUri(@NotNull String uri) {
         Logger logger = Logger.getInstance(this.getClass());
 
         // Open the URL in the browser.

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -30,18 +30,18 @@ public class OpenRevisionAction extends AnAction implements DumbAware {
 
     @NotNull
     private Optional<RevisionContext> getHistoryRevision(@NotNull AnActionEvent event) {
-        VcsFileRevision revision = event.getDataContext().getData(VcsDataKeys.VCS_FILE_REVISION);
+        VcsFileRevision revisionObject = event.getDataContext().getData(VcsDataKeys.VCS_FILE_REVISION);
         Project project = event.getProject();
 
         if (project == null) {
             return Optional.empty();
         }
-        if (revision == null) {
+        if (revisionObject == null) {
             return Optional.empty();
         }
 
-        String rev = revision.getRevisionNumber().toString();
-        return Optional.of(new RevisionContext(project, rev));
+        String revision = revisionObject.getRevisionNumber().toString();
+        return Optional.of(new RevisionContext(project, revision));
     }
 
     @NotNull
@@ -57,8 +57,8 @@ public class OpenRevisionAction extends AnAction implements DumbAware {
         }
 
 
-        String rev = log.getSelectedCommits().get(0).getHash().asString();
-        return Optional.of(new RevisionContext(project, rev));
+        String revision = log.getSelectedCommits().get(0).getHash().asString();
+        return Optional.of(new RevisionContext(project, revision));
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -67,10 +67,16 @@ public class OpenRevisionAction extends AnAction implements DumbAware {
         RevisionContext context = getHistoryRevision(event).or(() -> getLogRevision(event))
             .orElseThrow(() -> new RuntimeException("Unable to determine revision from history or log."));
 
+        Project project = context.getProject();
+
+        if (project.getProjectFilePath() == null) {
+            logger.warn("No project file path found (project: " + project.getName() + ")");
+            return;
+        }
+
         try {
             String productName = ApplicationInfo.getInstance().getVersionName();
             String productVersion = ApplicationInfo.getInstance().getFullVersion();
-            Project project = context.getProject();
             RepoInfo repoInfo = GitUtil.getRepoInfo(project.getProjectFilePath(), project);
 
             CommitViewUriBuilder builder = new CommitViewUriBuilder();

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -1,10 +1,9 @@
 package com.sourcegraph.website;
 
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.VcsDataKeys;
 import com.intellij.openapi.vcs.history.VcsFileRevision;
@@ -25,7 +24,7 @@ import java.util.Optional;
 /**
  * Jetbrains IDE action to open a selected revision in Sourcegraph.
  */
-public class OpenRevisionAction extends AnAction implements DumbAware {
+public class OpenRevisionAction extends DumbAwareAction {
     private final Logger logger = Logger.getInstance(this.getClass());
 
     @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -28,7 +28,8 @@ import java.util.Optional;
 public class OpenRevisionAction extends AnAction implements DumbAware {
     private final Logger logger = Logger.getInstance(this.getClass());
 
-    private Optional<RevisionContext> getHistoryRevision(AnActionEvent e) {
+    @NotNull
+    private Optional<RevisionContext> getHistoryRevision(@NotNull AnActionEvent e) {
         VcsFileRevision revision = e.getDataContext().getData(VcsDataKeys.VCS_FILE_REVISION);
         Project project = e.getProject();
 
@@ -43,7 +44,8 @@ public class OpenRevisionAction extends AnAction implements DumbAware {
         return Optional.of(new RevisionContext(project, rev));
     }
 
-    private Optional<RevisionContext> getLogRevision(AnActionEvent e) {
+    @NotNull
+    private Optional<RevisionContext> getLogRevision(@NotNull AnActionEvent e) {
         VcsLog log = e.getDataContext().getData(VcsLogDataKeys.VCS_LOG);
         Project project = e.getProject();
 
@@ -60,18 +62,19 @@ public class OpenRevisionAction extends AnAction implements DumbAware {
     }
 
     @Override
-    public void actionPerformed(@NotNull AnActionEvent e) {
+    public void actionPerformed(@NotNull AnActionEvent event) {
         // This action handles events for both log and history views, so attempt to load from any possible option.
-        RevisionContext context = getHistoryRevision(e).or(() -> getLogRevision(e))
+        RevisionContext context = getHistoryRevision(event).or(() -> getLogRevision(event))
             .orElseThrow(() -> new RuntimeException("Unable to determine revision from history or log."));
 
         try {
             String productName = ApplicationInfo.getInstance().getVersionName();
             String productVersion = ApplicationInfo.getInstance().getFullVersion();
-            RepoInfo repoInfo = GitUtil.getRepoInfo(context.getProject().getProjectFilePath(), context.getProject());
+            Project project = context.getProject();
+            RepoInfo repoInfo = GitUtil.getRepoInfo(project.getProjectFilePath(), project);
 
             CommitViewUriBuilder builder = new CommitViewUriBuilder();
-            URI uri = builder.build(ConfigUtil.getSourcegraphUrl(context.getProject()), context.getRevisionNumber(), repoInfo, productName, productVersion);
+            URI uri = builder.build(ConfigUtil.getSourcegraphUrl(project), context.getRevisionNumber(), repoInfo, productName, productVersion);
 
             // Open the URL in the browser.
             Desktop.getDesktop().browse(uri);

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -29,9 +29,9 @@ public class OpenRevisionAction extends AnAction implements DumbAware {
     private final Logger logger = Logger.getInstance(this.getClass());
 
     @NotNull
-    private Optional<RevisionContext> getHistoryRevision(@NotNull AnActionEvent e) {
-        VcsFileRevision revision = e.getDataContext().getData(VcsDataKeys.VCS_FILE_REVISION);
-        Project project = e.getProject();
+    private Optional<RevisionContext> getHistoryRevision(@NotNull AnActionEvent event) {
+        VcsFileRevision revision = event.getDataContext().getData(VcsDataKeys.VCS_FILE_REVISION);
+        Project project = event.getProject();
 
         if (project == null) {
             return Optional.empty();
@@ -45,9 +45,9 @@ public class OpenRevisionAction extends AnAction implements DumbAware {
     }
 
     @NotNull
-    private Optional<RevisionContext> getLogRevision(@NotNull AnActionEvent e) {
-        VcsLog log = e.getDataContext().getData(VcsLogDataKeys.VCS_LOG);
-        Project project = e.getProject();
+    private Optional<RevisionContext> getLogRevision(@NotNull AnActionEvent event) {
+        VcsLog log = event.getDataContext().getData(VcsLogDataKeys.VCS_LOG);
+        Project project = event.getProject();
 
         if (project == null) {
             return Optional.empty();
@@ -85,7 +85,7 @@ public class OpenRevisionAction extends AnAction implements DumbAware {
     }
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        e.getPresentation().setEnabledAndVisible(true);
+    public void update(@NotNull AnActionEvent event) {
+        event.getPresentation().setEnabledAndVisible(true);
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -21,11 +21,11 @@ import java.io.IOException;
 import java.net.URI;
 
 public abstract class SearchActionBase extends DumbAwareAction {
-    public void actionPerformedMode(AnActionEvent e, @NotNull Scope scope) {
+    public void actionPerformedMode(AnActionEvent event, @NotNull Scope scope) {
         Logger logger = Logger.getInstance(this.getClass());
 
         // Get project, editor, document, file, and position information.
-        final Project project = e.getProject();
+        final Project project = event.getProject();
         if (project == null) {
             return;
         }
@@ -54,11 +54,11 @@ public abstract class SearchActionBase extends DumbAwareAction {
             branchName = repoInfo.branchName;
         }
 
-        String uri = URLBuilder.buildEditorSearchUrl(project, selectedText, remoteUrl, branchName);
+        String url = URLBuilder.buildEditorSearchUrl(project, selectedText, remoteUrl, branchName);
 
         // Open the URL in the browser.
         try {
-            Desktop.getDesktop().browse(URI.create(uri));
+            Desktop.getDesktop().browse(URI.create(url));
         } catch (IOException err) {
             logger.debug("failed to open browser");
             err.printStackTrace();

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -33,18 +33,17 @@ public abstract class SearchActionBase extends DumbAwareAction {
         if (editor == null) {
             return;
         }
-        Document currentDoc = editor.getDocument();
-        VirtualFile currentFile = FileDocumentManager.getInstance().getFile(currentDoc);
+        Document currentDocument = editor.getDocument();
+        VirtualFile currentFile = FileDocumentManager.getInstance().getFile(currentDocument);
         if (currentFile == null) {
             return;
         }
-        SelectionModel sel = editor.getSelectionModel();
 
-        // Get repo information.
         RepoInfo repoInfo = GitUtil.getRepoInfo(currentFile.getPath(), project);
 
-        String q = sel.getSelectedText();
-        if (q == null || q.equals("")) {
+        SelectionModel selection = editor.getSelectionModel();
+        String selectedText = selection.getSelectedText();
+        if (selectedText == null || selectedText.equals("")) {
             return; // nothing to query
         }
 
@@ -55,7 +54,7 @@ public abstract class SearchActionBase extends DumbAwareAction {
             branchName = repoInfo.remoteUrl;
         }
 
-        String uri = URLBuilder.buildEditorSearchUrl(project, q, remoteUrl, branchName);
+        String uri = URLBuilder.buildEditorSearchUrl(project, selectedText, remoteUrl, branchName);
 
         // Open the URL in the browser.
         try {

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.browser.URLBuilder;
 import com.sourcegraph.git.GitUtil;
 import com.sourcegraph.git.RepoInfo;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
@@ -20,7 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 
 public abstract class SearchActionBase extends DumbAwareAction {
-    public void actionPerformedMode(AnActionEvent e, String mode) {
+    public void actionPerformedMode(@NotNull AnActionEvent e, @NotNull String mode) {
         Logger logger = Logger.getInstance(this.getClass());
 
         // Get project, editor, document, file, and position information.
@@ -66,7 +67,7 @@ public abstract class SearchActionBase extends DumbAwareAction {
     }
 
     @Override
-    public void update(AnActionEvent e) {
+    public void update(@NotNull AnActionEvent e) {
         final Project project = e.getProject();
         if (project == null) {
             return;
@@ -76,7 +77,7 @@ public abstract class SearchActionBase extends DumbAwareAction {
     }
 
     @Nullable
-    private String getSelectedText(Project project) {
+    private String getSelectedText(@NotNull Project project) {
         Editor editor = FileEditorManager.getInstance(project).getSelectedTextEditor();
         if (editor == null) {
             return null;

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -50,8 +50,8 @@ public abstract class SearchActionBase extends DumbAwareAction {
         String remoteUrl = null;
         String branchName = null;
         if (mode.equals("search.repository")) {
-            remoteUrl = repoInfo.branchName;
-            branchName = repoInfo.remoteUrl;
+            remoteUrl = repoInfo.remoteUrl;
+            branchName = repoInfo.branchName;
         }
 
         String uri = URLBuilder.buildEditorSearchUrl(project, selectedText, remoteUrl, branchName);

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.net.URI;
 
 public abstract class SearchActionBase extends DumbAwareAction {
-    public void actionPerformedMode(AnActionEvent event, @NotNull Scope scope) {
+    public void actionPerformedMode(@NotNull AnActionEvent event, @NotNull Scope scope) {
         Logger logger = Logger.getInstance(this.getClass());
 
         // Get project, editor, document, file, and position information.

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 
 public abstract class SearchActionBase extends DumbAwareAction {
-    public void actionPerformedMode(@NotNull AnActionEvent e, @NotNull String mode) {
+    public void actionPerformedMode(AnActionEvent e, @NotNull Scope scope) {
         Logger logger = Logger.getInstance(this.getClass());
 
         // Get project, editor, document, file, and position information.
@@ -49,7 +49,7 @@ public abstract class SearchActionBase extends DumbAwareAction {
 
         String remoteUrl = null;
         String branchName = null;
-        if (mode.equals("search.repository")) {
+        if (scope == Scope.REPOSITORY) {
             remoteUrl = repoInfo.remoteUrl;
             branchName = repoInfo.branchName;
         }
@@ -63,6 +63,11 @@ public abstract class SearchActionBase extends DumbAwareAction {
             logger.debug("failed to open browser");
             err.printStackTrace();
         }
+    }
+
+    enum Scope {
+        REPOSITORY,
+        ANYWHERE
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchRepository.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchRepository.java
@@ -7,6 +7,6 @@ import org.jetbrains.annotations.NotNull;
 public class SearchRepository extends SearchActionBase {
     @Override
     public void actionPerformed(@NotNull AnActionEvent event) {
-        super.actionPerformedMode(event, "search.repository");
+        super.actionPerformedMode(event, Scope.REPOSITORY);
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchSelection.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchSelection.java
@@ -6,6 +6,6 @@ import org.jetbrains.annotations.NotNull;
 public class SearchSelection extends SearchActionBase {
     @Override
     public void actionPerformed(@NotNull AnActionEvent event) {
-        super.actionPerformedMode(event, "search");
+        super.actionPerformedMode(event, Scope.ANYWHERE);
     }
 }

--- a/client/jetbrains/src/test/java/CommitViewUriBuilderTest.java
+++ b/client/jetbrains/src/test/java/CommitViewUriBuilderTest.java
@@ -3,7 +3,6 @@ import com.sourcegraph.git.RepoInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
-import org.junit.jupiter.params.provider.NullSource;
 
 import java.net.URI;
 
@@ -19,7 +18,7 @@ public class CommitViewUriBuilderTest {
     RepoInfo repoInfo = new RepoInfo("", "https://github.com/sourcegraph/sourcegraph-jetbrains.git", "main");
 
     URI got = builder.build("https://www.sourcegraph.com",
-        "1fa8d5d6286c24924b55c15ed4d1a0b85ccab4d5",
+        "1fa8d5d6286c24924b55c15ed4d1a0b85c44b4d5",
         repoInfo,
         "intellij",
         "1.1");
@@ -29,7 +28,6 @@ public class CommitViewUriBuilderTest {
   }
 
   @ParameterizedTest
-  @NullSource
   @EmptySource
   public void testBuild_MissingRevision(String revision) {
     CommitViewUriBuilder builder = new CommitViewUriBuilder();
@@ -43,33 +41,26 @@ public class CommitViewUriBuilderTest {
   }
 
   @ParameterizedTest
-  @NullSource
   @EmptySource
   public void testBuild_MissingBaseUri(String baseUri) {
     CommitViewUriBuilder builder = new CommitViewUriBuilder();
     RepoInfo repoInfo = new RepoInfo("", "https://github.com/sourcegraph/sourcegraph-jetbrains.git", "main");
 
     assertThrows(RuntimeException.class, () -> builder.build(baseUri,
-        "1fa8d5d6286c24924b55c15ed4d1a0b85ccab4d5",
+        "1fa8d5d6286c24924b55c15ed4d1a0b85c44b4d5",
         repoInfo,
         "intellij",
         "1.1"));
   }
   @Test
   public void testBuild_MissingRemoteUrl() {
-    CommitViewUriBuilder builder = new CommitViewUriBuilder();
-    RepoInfo repoInfo = new RepoInfo("", "", "main");
+      CommitViewUriBuilder builder = new CommitViewUriBuilder();
+      RepoInfo repoInfo = new RepoInfo("", "", "main");
 
-    assertThrows(RuntimeException.class, () -> builder.build("https://www.sourcegraph.com",
-        "1fa8d5d6286c24924b55c15ed4d1a0b85ccab4d5",
-        repoInfo,
-        "intellij",
-        "1.1"));
-
-    assertThrows(RuntimeException.class, () -> builder.build("https://www.sourcegraph.com",
-        "1fa8d5d6286c24924b55c15ed4d1a0b85ccab4d5",
-        null,
-        "intellij",
-        "1.1"));
+      assertThrows(RuntimeException.class, () -> builder.build("https://www.sourcegraph.com",
+          "1fa8d5d6286c24924b55c15ed4d1a0b85c44b4d5",
+          repoInfo,
+          "intellij",
+          "1.1"));
   }
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/38002

Also:
- removed a bunch of code smells like missing null safety.
- added repo URL to file path (which was made possible by the new `SourcegraphVirtualFile` class. This is not really part of the issue and might be controversial, so I'm happy to remove this if it's too out of the path of this PR :)

I've left some comments in the diff to explain my changes, to avoid the reviewer having to go commit by commit.

## Test plan

- I _think_ I've tested all possible cases: [3-min Loom](https://www.loom.com/share/d4456935d9a849f1a1cf139080fdc26b)

## App preview:

- [Web](https://sg-web-dv-jetbrains-open-local-files.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wqdjbtefwd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
