### PR TITLE
authz: Allow directory read access for sub repo permissions

### DIFF
--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -137,7 +137,7 @@ write user alice * //TestDepot/.../spec/...
 
 #### File-level permissions
 
-> NOTE: See [below](#experimental-support-for-path-level-permissions) for details on experimental support for file level permissions
+> NOTE: See [below](#experimental-support-for-file-level-permissions) for details on experimental support for file level permissions
 
 Sourcegraph does not support file-level permissions, as allowed in [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html). That means if a user has access to a directory and also has exclusions to some subdirectories, _those exclusions will not be enforced in Sourcegraph_ because Sourcegraph does not support file-level permissions.
 

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -333,8 +333,17 @@ func (s *SubRepoPermsClient) EnabledForRepo(ctx context.Context, repo api.RepoNa
 	return s.permissionsGetter.RepoSupported(ctx, repo)
 }
 
+// expandDirs will return rules that match all parent directories of the given
+// rule.
 func expandDirs(rule string) []string {
 	dirs := make([]string, 0)
+
+	// We can't support rules that start with a wildcard because we can only
+	// see one level of the tree at a time so we have no way of knowing which path leads
+	// to a file the user is allowed to see.
+	if strings.HasPrefix(rule, "*") {
+		return dirs
+	}
 
 	for {
 		lastSlash := strings.LastIndex(rule, "/")
@@ -343,6 +352,7 @@ func expandDirs(rule string) []string {
 		}
 		// Drop anything after the last slash
 		rule = rule[:lastSlash]
+
 		dirs = append(dirs, rule+"/")
 	}
 

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/fs"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gobwas/glob"
@@ -104,8 +105,9 @@ type cachedRules struct {
 }
 
 type compiledRules struct {
-	includes []glob.Glob
-	excludes []glob.Glob
+	includes    []glob.Glob
+	excludes    []glob.Glob
+	dirIncludes []glob.Glob
 }
 
 // NewSubRepoPermsClient instantiates an instance of authz.SubRepoPermsClient
@@ -221,6 +223,16 @@ func (s *SubRepoPermsClient) Permissions(ctx context.Context, userID int32, cont
 		}
 	}
 
+	// We also want to match any directories above paths that we include so that we
+	// can browse down the file hierarchy.
+	if strings.HasSuffix(content.Path, "/") {
+		for _, rule := range rules.dirIncludes {
+			if rule.Match(content.Path) {
+				return Read, nil
+			}
+		}
+	}
+
 	// Return None if no rule matches to be safe
 	return None, nil
 }
@@ -256,13 +268,30 @@ func (s *SubRepoPermsClient) getCompiledRules(ctx context.Context, userID int32)
 		}
 		for repo, perms := range repoPerms {
 			includes := make([]glob.Glob, 0, len(perms.PathIncludes))
+			dirIncludes := make([]glob.Glob, 0)
+			dirSeen := make(map[string]struct{})
 			for _, rule := range perms.PathIncludes {
 				g, err := glob.Compile(rule, '/')
 				if err != nil {
 					return nil, errors.Wrap(err, "building include matcher")
 				}
 				includes = append(includes, g)
+
+				// We should include all directories above an include rule
+				dirs := expandDirs(rule)
+				for _, dir := range dirs {
+					if _, ok := dirSeen[dir]; ok {
+						continue
+					}
+					g, err := glob.Compile(dir, '/')
+					if err != nil {
+						return nil, errors.Wrap(err, "building include matcher for dir")
+					}
+					dirIncludes = append(dirIncludes, g)
+					dirSeen[dir] = struct{}{}
+				}
 			}
+
 			excludes := make([]glob.Glob, 0, len(perms.PathExcludes))
 			for _, rule := range perms.PathExcludes {
 				g, err := glob.Compile(rule, '/')
@@ -272,8 +301,9 @@ func (s *SubRepoPermsClient) getCompiledRules(ctx context.Context, userID int32)
 				excludes = append(excludes, g)
 			}
 			toCache.rules[repo] = compiledRules{
-				includes: includes,
-				excludes: excludes,
+				includes:    includes,
+				excludes:    excludes,
+				dirIncludes: dirIncludes,
 			}
 		}
 		toCache.timestamp = s.clock()
@@ -301,6 +331,22 @@ func (s *SubRepoPermsClient) EnabledForRepoId(ctx context.Context, id api.RepoID
 
 func (s *SubRepoPermsClient) EnabledForRepo(ctx context.Context, repo api.RepoName) (bool, error) {
 	return s.permissionsGetter.RepoSupported(ctx, repo)
+}
+
+func expandDirs(rule string) []string {
+	dirs := make([]string, 0)
+
+	for {
+		lastSlash := strings.LastIndex(rule, "/")
+		if lastSlash == -1 {
+			break
+		}
+		// Drop anything after the last slash
+		rule = rule[:lastSlash]
+		dirs = append(dirs, rule+"/")
+	}
+
+	return dirs
 }
 
 // NewSimpleChecker is exposed for testing and allows creation of a simple

--- a/internal/authz/sub_repo_perms_test.go
+++ b/internal/authz/sub_repo_perms_test.go
@@ -222,6 +222,95 @@ func TestCanReadAllPaths(t *testing.T) {
 	}
 }
 
+func TestSubRepoPermissionsCanReadDirectoriesInPath(t *testing.T) {
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				SubRepoPermissions: &schema.SubRepoPermissions{
+					Enabled: true,
+				},
+			},
+		},
+	})
+	t.Cleanup(func() { conf.Mock(nil) })
+	repoName := api.RepoName("repo")
+
+	for _, tc := range []struct {
+		pathIncludes  []string
+		canReadAll    []string
+		cannotReadAny []string
+	}{
+		{
+			pathIncludes:  []string{"foo/bar/thing.txt"},
+			canReadAll:    []string{"foo/", "foo/bar/"},
+			cannotReadAny: []string{"foo/thing.txt", "foo/bar/other.txt"},
+		},
+		{
+			pathIncludes: []string{"foo/bar/**"},
+			canReadAll:   []string{"foo/", "foo/bar/"},
+		},
+		{
+			pathIncludes:  []string{"foo/bar/"},
+			canReadAll:    []string{"foo/", "foo/bar/"},
+			cannotReadAny: []string{"foo/thing.txt", "foo/bar/thing.txt"},
+		},
+		{
+			pathIncludes: []string{"**/foo/bar/thing.txt"},
+			canReadAll:   []string{"a/b/foo/bar/", "foo/", "foo/bar/"},
+		},
+		{
+			pathIncludes:  []string{"baz/*/foo/bar/thing.txt"},
+			canReadAll:    []string{"baz/", "baz/x/", "baz/x/foo/bar/"},
+			cannotReadAny: []string{"baz/thing.txt"},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			getter := NewMockSubRepoPermissionsGetter()
+			getter.GetByUserFunc.SetDefaultHook(func(ctx context.Context, i int32) (map[api.RepoName]SubRepoPermissions, error) {
+				return map[api.RepoName]SubRepoPermissions{
+					repoName: {
+						PathIncludes: tc.pathIncludes,
+					},
+				}, nil
+			})
+			client, err := NewSubRepoPermsClient(getter)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.Background()
+
+			for _, path := range tc.canReadAll {
+				content := RepoContent{
+					Repo: repoName,
+					Path: path,
+				}
+				perm, err := client.Permissions(ctx, 1, content)
+				if err != nil {
+					t.Error(err)
+				}
+				if !perm.Include(Read) {
+					t.Errorf("Should be able to read %q, cannot", path)
+				}
+			}
+
+			for _, path := range tc.cannotReadAny {
+				content := RepoContent{
+					Repo: repoName,
+					Path: path,
+				}
+				perm, err := client.Permissions(ctx, 1, content)
+				if err != nil {
+					t.Error(err)
+				}
+				if perm.Include(Read) {
+					t.Errorf("Should not be able to read %q, can", path)
+				}
+			}
+		})
+	}
+}
+
 func TestSubRepoPermsPermissionsCache(t *testing.T) {
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{

--- a/internal/authz/sub_repo_perms_test.go
+++ b/internal/authz/sub_repo_perms_test.go
@@ -255,8 +255,9 @@ func TestSubRepoPermissionsCanReadDirectoriesInPath(t *testing.T) {
 			cannotReadAny: []string{"foo/thing.txt", "foo/bar/thing.txt"},
 		},
 		{
-			pathIncludes: []string{"**/foo/bar/thing.txt"},
-			canReadAll:   []string{"a/b/foo/bar/", "foo/", "foo/bar/"},
+			pathIncludes:  []string{"**/foo/bar/thing.txt"},
+			canReadAll:    []string{"a/b/foo/bar/", "a/foo/", "a/foo/bar/"},
+			cannotReadAny: []string{"foo/", "foo/bar/"},
 		},
 		{
 			pathIncludes:  []string{"baz/*/foo/bar/thing.txt"},

--- a/internal/authz/sub_repo_perms_test.go
+++ b/internal/authz/sub_repo_perms_test.go
@@ -247,7 +247,7 @@ func TestSubRepoPermissionsCanReadDirectoriesInPath(t *testing.T) {
 		},
 		{
 			pathIncludes: []string{"foo/bar/**"},
-			canReadAll:   []string{"foo/", "foo/bar/"},
+			canReadAll:   []string{"foo/", "foo/bar/", "foo/bar/baz/"},
 		},
 		{
 			pathIncludes:  []string{"foo/bar/"},


### PR DESCRIPTION
If a path is allowed by sub repo permissions, we should also allow read
access to any directories the lie above that path in the tree.

For example, if we allow access to "foo/bar/data.txt" we should also
allow the path "foo/" and "foo/bar/" so that we can navigate down the
tree.

This does NOT imply access to all items living under "foo/" or
"foo/bar/"

**Caveat**: The logic above cannot be applied to rules that start with a wildcard
because it can lead to allowing read access to *any* directory.

## Test plan

More test cases added
Tested manually