### PR TITLE
[Admin Analytics] fix user stats avg dau typecasting

### DIFF
--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -163,9 +163,9 @@ var (
 			month
 	)
 	SELECT
-		ROUND(sum_total_count / total_days) AS avg_total_count,
-		ROUND(sum_unique_users / total_days) AS avg_unique_users,
-		ROUND(sum_registered_users / total_days) AS avg_registered_users
+		ROUND(sum_total_count / total_days)::int AS avg_total_count,
+		ROUND(sum_unique_users / total_days)::int AS avg_unique_users,
+		ROUND(sum_registered_users / total_days)::int AS avg_registered_users
 	FROM
 		(
 			SELECT
@@ -183,9 +183,9 @@ var (
 		) AS f
 	UNION ALL
 	SELECT
-		ROUND(sum_total_count / total_weeks) AS avg_total_count,
-		ROUND(sum_unique_users / total_weeks) AS avg_unique_users,
-		ROUND(sum_registered_users / total_weeks) AS avg_registered_users
+		ROUND(sum_total_count / total_weeks)::int AS avg_total_count,
+		ROUND(sum_unique_users / total_weeks)::int AS avg_unique_users,
+		ROUND(sum_registered_users / total_weeks)::int AS avg_registered_users
 	FROM
 		(
 			SELECT
@@ -203,9 +203,9 @@ var (
 		) AS f
 	UNION ALL
 	SELECT
-		ROUND(sum_total_count / total_months) AS avg_total_count,
-		ROUND(sum_unique_users / total_months) AS avg_unique_users,
-		ROUND(sum_registered_users / total_months) AS avg_registered_users
+		ROUND(sum_total_count / total_months)::int AS avg_total_count,
+		ROUND(sum_unique_users / total_months)::int AS avg_unique_users,
+		ROUND(sum_registered_users / total_months)::int AS avg_registered_users
 	FROM
 		(
 			SELECT


### PR DESCRIPTION

<img width="981" alt="image" src="https://user-images.githubusercontent.com/22571395/178026801-796a2446-2e1a-431e-89c6-21694926069b.png">


Type conversion issue with large numbers on admin analytics users stats page, particularly the avg DAU/WAU/MAU chart. The default type for avg is float in SQL query response, but when a large number is converted to int32 in golang, it gives a syntax error. 

Typecasting the avgs to int in SQL to fix it.
## Test plan

Check diff. 