### PR TITLE
gitserver: move repo_count metrics to worker

### DIFF
--- a/cmd/worker/internal/gitserver/servermetrics.go
+++ b/cmd/worker/internal/gitserver/servermetrics.go
@@ -14,10 +14,13 @@ import (
 )
 
 type metricsJob struct {
+	Logger log.Logger
 }
 
 func NewMetricsJob() job.Job {
-	return &metricsJob{}
+	return &metricsJob{
+		Logger: log.Scoped("gitserver-metrics", ""),
+	}
 }
 
 func (j *metricsJob) Description() string {
@@ -48,7 +51,7 @@ func (j *metricsJob) Routines(ctx context.Context, logger log.Logger) ([]gorouti
 			WHERE g.last_error IS NOT NULL AND r.deleted_at IS NULL
 		`).Scan(&count)
 		if err != nil {
-			// s.Logger.Error("failed to count repository errors", log.Error(err))
+			j.Logger.Error("failed to count repository errors", log.Error(err))
 			return 0
 		}
 		return float64(count)
@@ -68,7 +71,7 @@ func (j *metricsJob) Routines(ctx context.Context, logger log.Logger) ([]gorouti
 			WHERE r.deleted_at IS NULL
 		`).Scan(&count)
 		if err != nil {
-			// s.Logger.Error("failed to count repositories", log.Error(err))
+			j.Logger.Error("failed to count repositories", log.Error(err))
 			return 0
 		}
 		return float64(count)

--- a/cmd/worker/internal/gitserver/servermetrics.go
+++ b/cmd/worker/internal/gitserver/servermetrics.go
@@ -1,0 +1,79 @@
+package gitserver
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+type metricsJob struct {
+}
+
+func NewMetricsJob() job.Job {
+	return &metricsJob{}
+}
+
+func (j *metricsJob) Description() string {
+	return ""
+}
+
+func (j *metricsJob) Config() []env.Config {
+	return nil
+}
+
+func (j *metricsJob) Routines(ctx context.Context, logger log.Logger) ([]goroutine.BackgroundRoutine, error) {
+	db, err := workerdb.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	c := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "src_gitserver_repo_last_error_total",
+		Help: "Number of repositories whose last_error column is not empty.",
+	}, func() float64 {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		var count int64
+		err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM gitserver_repos AS g
+			INNER JOIN repo AS r ON g.repo_id = r.id
+			WHERE g.last_error IS NOT NULL AND r.deleted_at IS NULL
+		`).Scan(&count)
+		if err != nil {
+			// s.Logger.Error("failed to count repository errors", log.Error(err))
+			return 0
+		}
+		return float64(count)
+	})
+	prometheus.MustRegister(c)
+
+	c = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "src_gitserver_repo_count",
+		Help: "Number of repos.",
+	}, func() float64 {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		var count int64
+		err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM repo AS r
+			WHERE r.deleted_at IS NULL
+		`).Scan(&count)
+		if err != nil {
+			// s.Logger.Error("failed to count repositories", log.Error(err))
+			return 0
+		}
+		return float64(count)
+	})
+	prometheus.MustRegister(c)
+
+	return nil, nil
+}

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/codeintel"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/migrations"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/migrations/migrators"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/webhooks"
@@ -45,6 +46,7 @@ func Start(logger log.Logger, additionalJobs map[string]job.Job, registerEnterpr
 		"codeintel-documents-indexer":           codeintel.NewDocumentsIndexerJob(),
 		"codeintel-dependencies":                codeintel.NewDependenciesJob(),
 		"codeintel-policies-repository-matcher": codeintel.NewPoliciesRepositoryMatcherJob(),
+		"gitserver-metrics":                     gitserver.NewMetricsJob(),
 	}
 
 	jobs := map[string]job.Job{}

--- a/doc/admin/workers.md
+++ b/doc/admin/workers.md
@@ -103,6 +103,10 @@ This job executes the bulk operations in the background.
 
 This job runs the workspace resolutions for batch specs. Used for batch changes that are running server-side.
 
+#### `gitserver-metrics`
+
+This job runs queries against the database pertaining to generate `gitserver` metrics. These queries are generally expensive to run and do not need to be run per-instance of `gitserver` so the worker allows them to only be run once per scrape.
+
 ## Deploying workers
 
 By default, all of the jobs listed above are registered to a single instance of the `worker` service. For Sourcegraph instances operating over large data (e.g., a high number of repositories, large monorepos, high commit frequency, or regular precise code intelligence index uploads), a single `worker` instance may experience low throughput or stability issues.


### PR DESCRIPTION
Moves the `src_gitserver_repo_count` and `src_gitserver_repo_last_error_total` metrics out of `gitserver` metrics and to the worker. This query takes over 2.5s to resolve on DotCom and could cause performance issues as it runs once per replica of `gitserver`. This solution is probably a stop-gap, there's some [Slack discussion](https://sourcegraph.slack.com/archives/C018CJQ5YBB/p1657276718654509) about creating a stats table reliant on triggers to move statistics like this into. 

## Test plan

1. `sg start` and `sg start monitoring`
2. Visit http://localhost:6089/metrics and check that `src_gitserver_repo_count` is present.
3. Verify the metric value matches the result of this query:
```sql

SELECT COUNT(*) FROM repo WHERE deleted_at IS NULL;
```