### PR TITLE
Searcher: reduce allocations for chunk matches

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -187,6 +187,9 @@ func (rg *readerGrep) Find(zf *zipFile, f *srcFile, limit int) (matches []protoc
 
 	// find limit+1 matches so we know whether we hit the limit
 	locs := rg.re.FindAllIndex(fileMatchBuf, limit+1)
+	if len(locs) == 0 {
+		return nil, nil // short-circuit if we have no matches
+	}
 	ranges := locsToRanges(fileBuf, locs)
 	chunks := chunkRanges(ranges, 0)
 	return chunksToMatches(fileBuf, chunks), nil

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -31,6 +31,16 @@ func BenchmarkSearchRegex_large_fixed(b *testing.B) {
 	})
 }
 
+func BenchmarkSearchRegex_rare_fixed(b *testing.B) {
+	benchSearchRegex(b, &protocol.Request{
+		Repo:   "github.com/golang/go",
+		Commit: "0ebaca6ba27534add5930a95acffa9acff182e2b",
+		PatternInfo: protocol.PatternInfo{
+			Pattern: "REBOOT_CMD",
+		},
+	})
+}
+
 func BenchmarkSearchRegex_large_fixed_casesensitive(b *testing.B) {
 	benchSearchRegex(b, &protocol.Request{
 		Repo:   "github.com/golang/go",

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -187,6 +187,9 @@ func chunksToMatches(buf []byte, chunks []rangeChunk) []protocol.ChunkMatch {
 		}
 
 		chunkMatches = append(chunkMatches, protocol.ChunkMatch{
+			// NOTE: we must copy the content here because the reference
+			// must not outlive the backing mmap, which may be cleaned
+			// up before the match is serialized for the network.
 			Content: string(buf[firstLineStart:lastLineEnd]),
 			ContentStart: protocol.Location{
 				Offset: firstLineStart,

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -148,7 +148,7 @@ func chunkRanges(ranges []protocol.Range, interChunkLines int) []rangeChunk {
 			// First iteration, there are no chunks, so create a new one
 			chunks = append(chunks, rangeChunk{
 				cover:  rr,
-				ranges: []protocol.Range{rr},
+				ranges: ranges[:1],
 			})
 			continue
 		}
@@ -156,7 +156,7 @@ func chunkRanges(ranges []protocol.Range, interChunkLines int) []rangeChunk {
 		lastChunk := &chunks[len(chunks)-1] // pointer for mutability
 		if int(lastChunk.cover.End.Line)+interChunkLines >= int(rr.Start.Line) {
 			// The current range overlaps with the current chunk, so merge them
-			lastChunk.ranges = append(lastChunk.ranges, rr)
+			lastChunk.ranges = ranges[i-len(lastChunk.ranges) : i+1]
 
 			// Expand the chunk coverRange if needed
 			if rr.End.Offset > lastChunk.cover.End.Offset {
@@ -166,7 +166,7 @@ func chunkRanges(ranges []protocol.Range, interChunkLines int) []rangeChunk {
 			// No overlap, so create a new chunk
 			chunks = append(chunks, rangeChunk{
 				cover:  rr,
-				ranges: []protocol.Range{rr},
+				ranges: ranges[i : i+1],
 			})
 		}
 	}

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -139,7 +139,10 @@ func chunkRanges(ranges []protocol.Range, interChunkLines int) []rangeChunk {
 		return ranges[i].Start.Offset < ranges[j].Start.Offset
 	})
 
-	var chunks []rangeChunk
+	// guestimate size to minimize allocations. This assumes ~2 matches per
+	// chunk. Additionally, since allocations are doubled on realloc, this
+	// should only realloc once for small ranges.
+	chunks := make([]rangeChunk, 0, len(ranges)/2)
 	for i, rr := range ranges {
 		if i == 0 {
 			// First iteration, there are no chunks, so create a new one


### PR DESCRIPTION
While investigating performance of searcher, I noticed we're doing quite a few extra allocations. 

```
❯ benchstat -alpha 0.1 /tmp/baseline.txt /tmp/ranges_slices.txt
name                                             old time/op    new time/op    delta
SearchRegex_large_fixed-10                         6.32ms ± 2%    6.18ms ± 0%   -2.06%  (p=0.008 n=5+5)
SearchRegex_rare_fixed-10                          7.96ms ± 1%    7.71ms ± 1%   -3.03%  (p=0.008 n=5+5)
SearchRegex_large_fixed_casesensitive-10           4.03ms ± 0%    3.93ms ± 1%   -2.50%  (p=0.008 n=5+5)
SearchRegex_large_re_dotstar-10                     235ms ± 1%     218ms ± 1%   -7.19%  (p=0.008 n=5+5)
SearchRegex_large_re_common-10                     6.08ms ± 1%    5.91ms ± 1%   -2.82%  (p=0.008 n=5+5)
SearchRegex_large_re_anchor-10                     69.9ms ± 2%    69.6ms ± 1%     ~     (p=0.690 n=5+5)
SearchRegex_large_path/path_only-10                 304µs ± 0%     305µs ± 1%     ~     (p=0.548 n=5+5)
SearchRegex_large_path/content_only-10             6.92ms ± 2%    6.85ms ± 1%     ~     (p=0.151 n=5+5)
SearchRegex_large_path/both_path_and_content-10    7.01ms ± 2%    6.87ms ± 1%   -1.92%  (p=0.056 n=5+5)
SearchRegex_small_fixed-10                          134µs ± 0%     133µs ± 0%   -1.10%  (p=0.008 n=5+5)
SearchRegex_small_fixed_casesensitive-10           87.5µs ± 0%    78.5µs ± 7%  -10.28%  (p=0.008 n=5+5)
SearchRegex_small_re_dotstar-10                    2.28ms ± 1%    2.27ms ± 1%     ~     (p=0.690 n=5+5)
SearchRegex_small_re_common-10                     90.7µs ± 0%    87.9µs ± 0%   -3.05%  (p=0.016 n=4+5)
SearchRegex_small_re_anchor-10                      769µs ± 1%     770µs ± 2%     ~     (p=0.841 n=5+5)

name                                             old alloc/op   new alloc/op   delta
SearchRegex_large_fixed-10                         15.8MB ± 0%    15.7MB ± 0%   -0.90%  (p=0.008 n=5+5)
SearchRegex_rare_fixed-10                          15.9MB ± 0%    15.7MB ± 0%   -0.95%  (p=0.008 n=5+5)
SearchRegex_large_fixed_casesensitive-10            167kB ± 0%      10kB ± 0%  -94.06%  (p=0.008 n=5+5)
SearchRegex_large_re_dotstar-10                     685MB ± 0%     570MB ± 0%  -16.76%  (p=0.008 n=5+5)
SearchRegex_large_re_common-10                     7.74MB ± 0%    6.40MB ± 0%  -17.31%  (p=0.008 n=5+5)
SearchRegex_large_re_anchor-10                     5.01MB ± 0%    4.27MB ± 0%  -14.79%  (p=0.008 n=5+5)
SearchRegex_large_path/path_only-10                1.03kB ± 0%    1.03kB ± 0%     ~     (all equal)
SearchRegex_large_path/content_only-10              219kB ± 1%      51kB ± 0%  -76.90%  (p=0.008 n=5+5)
SearchRegex_large_path/both_path_and_content-10     219kB ± 0%      51kB ± 0%  -76.93%  (p=0.008 n=5+5)
SearchRegex_small_fixed-10                          365kB ± 1%     361kB ± 1%   -1.02%  (p=0.008 n=5+5)
SearchRegex_small_fixed_casesensitive-10           6.46kB ± 0%    4.71kB ± 0%  -27.02%  (p=0.008 n=5+5)
SearchRegex_small_re_dotstar-10                    4.52MB ± 0%    3.75MB ± 0%  -16.95%  (p=0.008 n=5+5)
SearchRegex_small_re_common-10                     44.7kB ± 0%    38.7kB ± 0%  -13.36%  (p=0.008 n=5+5)
SearchRegex_small_re_anchor-10                     19.8kB ± 0%    18.3kB ± 1%   -7.34%  (p=0.008 n=5+5)

name                                             old allocs/op  new allocs/op  delta
SearchRegex_large_fixed-10                          6.63k ± 0%     0.19k ± 1%  -97.17%  (p=0.008 n=5+5)
SearchRegex_rare_fixed-10                           7.09k ± 0%     0.49k ± 0%  -93.08%  (p=0.008 n=5+5)
SearchRegex_large_fixed_casesensitive-10            6.59k ± 0%     0.14k ± 0%  -97.91%  (p=0.008 n=5+5)
SearchRegex_large_re_dotstar-10                     6.13M ± 0%     4.51M ± 0%  -26.52%  (p=0.008 n=5+5)
SearchRegex_large_re_common-10                      74.8k ± 0%     50.6k ± 0%  -32.32%  (p=0.008 n=5+5)
SearchRegex_large_re_anchor-10                      54.5k ± 0%     37.9k ± 0%  -30.42%  (p=0.008 n=5+5)
SearchRegex_large_path/path_only-10                  20.0 ± 0%      20.0 ± 0%     ~     (all equal)
SearchRegex_large_path/content_only-10              7.03k ± 0%     0.46k ± 0%  -93.43%  (p=0.008 n=5+5)
SearchRegex_large_path/both_path_and_content-10     7.03k ± 0%     0.46k ± 0%  -93.43%  (p=0.008 n=5+5)
SearchRegex_small_fixed-10                            154 ± 0%        82 ± 0%  -46.75%  (p=0.008 n=5+5)
SearchRegex_small_fixed_casesensitive-10              146 ± 0%        74 ± 0%  -49.32%  (p=0.008 n=5+5)
SearchRegex_small_re_dotstar-10                     40.5k ± 0%     29.6k ± 0%  -26.81%  (p=0.008 n=5+5)
SearchRegex_small_re_common-10                        537 ± 0%       387 ± 0%  -27.93%  (p=0.008 n=5+5)
SearchRegex_small_re_anchor-10                        296 ± 0%       235 ± 0%  -20.61%  (p=0.008 n=5+5)

```
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
