### PR TITLE
Fix popover margin on GitLab

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
@@ -44,6 +44,8 @@
         color: inherit;
     }
 
+    margin-bottom: 0;
+
     // highlight.js styles
 
     :global(.hljs) {


### PR DESCRIPTION
Fixes margin.

Before:

![CleanShot 2022-07-08 at 16 56 02](https://user-images.githubusercontent.com/1387653/178079790-bcfeab0d-c404-4404-9c93-b4c9d018e069.png)

After:

![CleanShot 2022-07-08 at 16 56 57](https://user-images.githubusercontent.com/1387653/178079851-8acef75e-3540-40ab-8e8e-d28a7f2b73cb.png)

## Test plan

Ran locally

## App preview:

- [Web](https://sg-web-fix-gitlab-popover-margin.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nelbymigzi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
