### PR TITLE
Fix auto index config accepted syntax

### DIFF
--- a/doc/code_intelligence/references/auto_indexing_configuration.md
+++ b/doc/code_intelligence/references/auto_indexing_configuration.md
@@ -8,7 +8,7 @@
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
 </aside>
 
-This document details the expected contents of [explicit index job configuration](../how-to/configure_auto_indexing.md#explicit-index-job-configuration) for a particular repository. Depending on how this configuration is supplied, it may be encoded as YAML or JSON.
+This document details the expected contents of [explicit index job configuration](../how-to/configure_auto_indexing.md#explicit-index-job-configuration) for a particular repository. Depending on how this configuration is supplied, it may be encoded as JSON.
 
 ## Keys
 


### PR DESCRIPTION
YAML is not accepted, it will return

```
Error saving index configuration: Invalid JSON: failed to parse JSON: [InvalidSymbol ValueExpected]
```



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```sh
sg run docsite
```