### PR TITLE
CODENOTIFY: re-route distribution subscriptions to delivery

### DIFF
--- a/docker-images/postgres-12-alpine/CODENOTIFY
+++ b/docker-images/postgres-12-alpine/CODENOTIFY
@@ -1,3 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-**/* @sourcegraph/distribution
+**/* @sourcegraph/delivery

--- a/monitoring/CODENOTIFY
+++ b/monitoring/CODENOTIFY
@@ -2,7 +2,7 @@
 
 **/* @bobheadxi
 **/* @slimsag
-**/* @sourcegraph/distribution
+**/* @sourcegraph/delivery
 
 frontend.go @efritz
 precise_code_intel_* @efritz


### PR DESCRIPTION
`sourcegraph/distribution` is no longer a valid team, and re-route to `sourcegraph/delivery` per [discussion in Slack](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1657077216861299).

## Test plan

n/a
