### PR TITLE
JetBrains: Add “login” to Find Action window

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -5,7 +5,6 @@ import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
@@ -22,12 +21,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
         // Display notification
         Notification notification = new Notification("Sourcegraph", "Sourcegraph",
             "A custom Sourcegraph URL is not set for this project. You can only access public repos. Do you want to set your custom URL?", NotificationType.INFORMATION);
-        AnAction setUrlAction = new DumbAwareAction("Set URL") {
-            @Override
-            public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-                ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class);
-            }
-        };
+        AnAction setUrlAction = new OpenPluginSettingsAction("Set URL");
         AnAction cancelAction = new DumbAwareAction("Do Not Set") {
             @Override
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/OpenPluginSettingsAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/OpenPluginSettingsAction.java
@@ -3,9 +3,19 @@ package com.sourcegraph.config;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.util.NlsActions;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class OpenPluginSettingsAction extends DumbAwareAction {
+    public OpenPluginSettingsAction() {
+        super();
+    }
+
+    public OpenPluginSettingsAction(@Nullable @NlsActions.ActionText String text) {
+        super(text);
+    }
+
     @Override
     public void actionPerformed(@NotNull AnActionEvent event) {
         ShowSettingsUtil.getInstance().showSettingsDialog(event.getProject(), SettingsConfigurable.class);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/OpenPluginSettingsAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/OpenPluginSettingsAction.java
@@ -1,0 +1,13 @@
+package com.sourcegraph.config;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.project.DumbAwareAction;
+import org.jetbrains.annotations.NotNull;
+
+public class OpenPluginSettingsAction extends DumbAwareAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        ShowSettingsUtil.getInstance().showSettingsDialog(event.getProject(), SettingsConfigurable.class);
+    }
+}

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -70,6 +70,13 @@
             <keyboard-shortcut first-keystroke="alt s" keymap="$default"/>
             <add-to-group group-id="FindMenuGroup" anchor="after" relative-to-action="ReplaceInPath"/>
         </action>
+        <action
+            id="sourcegraph.login"
+            class="com.sourcegraph.config.OpenPluginSettingsAction"
+            text="Log in to Sourcegraph"
+            description="Log in to Sourcegraph"
+            icon="/icons/sourcegraphLogo.png">
+        </action>
 
         <group id="SourcegraphEditor" icon="/icons/sourcegraphLogo.png" popup="true" text="Sourcegraph">
             <reference ref="sourcegraph.openFindPopup"/>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/37815

I’ve added a new “Log in to Sourcegraph” action to the Find Action window. It looks like this:

<img width="671" alt="CleanShot 2022-07-11 at 10 49 27@2x" src="https://user-images.githubusercontent.com/2552265/178225708-ea3a562d-81d8-4ae3-a120-daf044b9eb30.png">

This always shows because on the Java side, we currently don’t know whether the user is logged in, without the user opening the popup first.

Also reused the action in the login notification balloon.
Weirdly enough, when I tried to also reuse the action for the small cog icon at the top-right of our “Find with Sourcegraph” popup, it errored out with some weird message. Looking into that was outside the scope of this change, so I just didn’t reuse the logic there.

## Test plan

- Tested: [41-sec Loom](https://www.loom.com/share/a086fcc8c9194443a3179a3893a17844)

## App preview:

- [Web](https://sg-web-dv-jetbrains-add-login-to-find.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bbnhktskgf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
