### PR TITLE
[SG-35195] Congratulate users on saving a form

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
@@ -6,7 +6,7 @@ import { editor } from 'monaco-editor'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner, screenReaderAnnounce } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../../auth'
 import { SaveToolbarProps, SaveToolbarPropsGenerator } from '../../../../components/SaveToolbar'
@@ -40,7 +40,10 @@ export const ConfigurationEditor: FunctionComponent<React.PropsWithChildren<Conf
             updateConfigForRepository({
                 variables: { id: repoId, content },
                 update: cache => cache.modify({ fields: { node: () => {} } }),
-            }).then(() => setDirty(false)),
+            }).then(() => {
+                screenReaderAnnounce('Saved successfully')
+                setDirty(false)
+            }),
         [updateConfigForRepository, repoId]
     )
 


### PR DESCRIPTION
### Description
Screen reader should announce `Saved Successfully` on Saving changes to repository auto-indexing configuration

### Problem description

<img width="640" alt="Screen Shot 2022-05-09 at 5 29 58 PM" src="https://user-images.githubusercontent.com/103087/167509485-e811ee5e-974e-4c84-82f3-1d0ef12f31be.png">

Saving changes to repository auto-indexing configuration does not announce success. Failure is announced properly.

### Expected behavior

Show a banner on successful save.

### Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35195)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35195)

### Test Plan
1) Change the value of `codeIntelAutoIndexingEnabled to true` on client/web/dev/utils/create-js-context.ts and run sg start web-standalone
2) Go through [this link](http://localhost:3080/github.com/sourcegraph/sourcegraph/-/code-intelligence/index-configuration)
3) On saving changes the screen reader announce `Saved Successfully` (if there is no any error)

## App preview:

- [Web](https://sg-web-contractors-sg-35195.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mdqclkmfzo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
