### PR TITLE
[Admin Analytics] update stat items data types to float

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5905,16 +5905,16 @@ type AnalyticsStatItemNode {
     """
     Total number of events.
     """
-    count: Int!
+    count: Float!
     """
     Unique number of users who triggered event.
     This counts deleted users as well as anonymous users.
     """
-    uniqueUsers: Int!
+    uniqueUsers: Float!
     """
     Unique number of currently registered users who triggered event.
     """
-    registeredUsers: Int!
+    registeredUsers: Float!
 }
 
 """
@@ -5924,16 +5924,16 @@ type AnalyticsStatItemSummary {
     """
     Total number of events.
     """
-    totalCount: Int!
+    totalCount: Float!
     """
     Total unique number of users who triggered event.
     This counts deleted users as well as anonymous users.
     """
-    totalUniqueUsers: Int!
+    totalUniqueUsers: Float!
     """
     Total unique number of currently registered users who triggered event.
     """
-    totalRegisteredUsers: Int!
+    totalRegisteredUsers: Float!
 }
 
 """
@@ -5997,11 +5997,11 @@ type AnalyticsUsersFrequencyItem {
     """
     Number of days used
     """
-    daysUsed: Int!
+    daysUsed: Float!
     """
     Number of users.
     """
-    frequency: Int!
+    frequency: Float!
     """
     Percentage of users from total frequencies.
     """
@@ -6081,11 +6081,11 @@ type AnalyticsReposSummartResult {
     """
     Total number of repositories.
     """
-    count: Int!
+    count: Float!
     """
     Total number of repositories with precise code-intel.
     """
-    preciseCodeIntelCount: Int!
+    preciseCodeIntelCount: Float!
 }
 
 """

--- a/internal/adminanalytics/fetcher.go
+++ b/internal/adminanalytics/fetcher.go
@@ -21,9 +21,9 @@ type AnalyticsFetcher struct {
 
 type AnalyticsNodeData struct {
 	Date            time.Time
-	Count           int32
-	UniqueUsers     int32
-	RegisteredUsers int32
+	Count           float64
+	UniqueUsers     float64
+	RegisteredUsers float64
 }
 
 type AnalyticsNode struct {
@@ -32,11 +32,11 @@ type AnalyticsNode struct {
 
 func (n *AnalyticsNode) Date() string { return n.Data.Date.Format(time.RFC3339) }
 
-func (n *AnalyticsNode) Count() int32 { return n.Data.Count }
+func (n *AnalyticsNode) Count() float64 { return n.Data.Count }
 
-func (n *AnalyticsNode) UniqueUsers() int32 { return n.Data.UniqueUsers }
+func (n *AnalyticsNode) UniqueUsers() float64 { return n.Data.UniqueUsers }
 
-func (n *AnalyticsNode) RegisteredUsers() int32 { return n.Data.RegisteredUsers }
+func (n *AnalyticsNode) RegisteredUsers() float64 { return n.Data.RegisteredUsers }
 
 func (f *AnalyticsFetcher) Nodes(ctx context.Context) ([]*AnalyticsNode, error) {
 	cacheKey := fmt.Sprintf(`%s:%s:%s`, f.group, f.dateRange, "nodes")
@@ -73,20 +73,20 @@ func (f *AnalyticsFetcher) Nodes(ctx context.Context) ([]*AnalyticsNode, error) 
 }
 
 type AnalyticsSummaryData struct {
-	TotalCount           int32
-	TotalUniqueUsers     int32
-	TotalRegisteredUsers int32
+	TotalCount           float64
+	TotalUniqueUsers     float64
+	TotalRegisteredUsers float64
 }
 
 type AnalyticsSummary struct {
 	Data AnalyticsSummaryData
 }
 
-func (s *AnalyticsSummary) TotalCount() int32 { return s.Data.TotalCount }
+func (s *AnalyticsSummary) TotalCount() float64 { return s.Data.TotalCount }
 
-func (s *AnalyticsSummary) TotalUniqueUsers() int32 { return s.Data.TotalUniqueUsers }
+func (s *AnalyticsSummary) TotalUniqueUsers() float64 { return s.Data.TotalUniqueUsers }
 
-func (s *AnalyticsSummary) TotalRegisteredUsers() int32 { return s.Data.TotalRegisteredUsers }
+func (s *AnalyticsSummary) TotalRegisteredUsers() float64 { return s.Data.TotalRegisteredUsers }
 
 func (f *AnalyticsFetcher) Summary(ctx context.Context) (*AnalyticsSummary, error) {
 	cacheKey := fmt.Sprintf(`%s:%s:%s`, f.group, f.dateRange, "summary")

--- a/internal/adminanalytics/repos.go
+++ b/internal/adminanalytics/repos.go
@@ -49,13 +49,13 @@ type ReposSummary struct {
 }
 
 type ReposSummaryData struct {
-	Count                 int32
-	PreciseCodeIntelCount int32
+	Count                 float64
+	PreciseCodeIntelCount float64
 }
 
-func (s *ReposSummary) Count() int32 { return s.Data.Count }
+func (s *ReposSummary) Count() float64 { return s.Data.Count }
 
-func (s *ReposSummary) PreciseCodeIntelCount() int32 { return s.Data.PreciseCodeIntelCount }
+func (s *ReposSummary) PreciseCodeIntelCount() float64 { return s.Data.PreciseCodeIntelCount }
 
 func (s *Repos) CacheAll(ctx context.Context) error {
 	if _, err := s.Summary(ctx); err != nil {

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -100,8 +100,8 @@ func (f *Users) Frequencies(ctx context.Context) ([]*UsersFrequencyNode, error) 
 }
 
 type UsersFrequencyNodeData struct {
-	DaysUsed   int32
-	Frequency  int32
+	DaysUsed   float64
+	Frequency  float64
 	Percentage float64
 }
 
@@ -109,9 +109,9 @@ type UsersFrequencyNode struct {
 	Data UsersFrequencyNodeData
 }
 
-func (n *UsersFrequencyNode) DaysUsed() int32 { return n.Data.DaysUsed }
+func (n *UsersFrequencyNode) DaysUsed() float64 { return n.Data.DaysUsed }
 
-func (n *UsersFrequencyNode) Frequency() int32 { return n.Data.Frequency }
+func (n *UsersFrequencyNode) Frequency() float64 { return n.Data.Frequency }
 
 func (n *UsersFrequencyNode) Percentage() float64 { return n.Data.Percentage }
 
@@ -120,7 +120,7 @@ var (
 	WITH daus AS (
 		SELECT
 			DATE_TRUNC('day', timestamp) AS day,
-			COUNT(*) AS total_count,
+			0 AS total_count,
 			COUNT(DISTINCT anonymous_user_id) AS unique_users,
 			COUNT(DISTINCT user_id) FILTER (
 				WHERE
@@ -135,7 +135,7 @@ var (
 	waus AS (
 		SELECT
 			DATE_TRUNC('week', timestamp) AS week,
-			COUNT(*) AS total_count,
+			0 AS total_count,
 			COUNT(DISTINCT anonymous_user_id) AS unique_users,
 			COUNT(DISTINCT user_id) FILTER (
 				WHERE
@@ -150,7 +150,7 @@ var (
 	maus AS (
 		SELECT
 			DATE_TRUNC('month', timestamp) AS month,
-			COUNT(*) AS total_count,
+			0 AS total_count,
 			COUNT(DISTINCT anonymous_user_id) AS unique_users,
 			COUNT(DISTINCT user_id) FILTER (
 				WHERE


### PR DESCRIPTION
Graphql `Int` type only interfaces with `int32` in go. For large-scale sg instances, the counts for some stat items can be > 2^32. 


The `BigInt` data type in Graphql works with `int64` in go but returns count as a string which has to be always typecasted to `Number` before operating on in JS.

The better solution is to use `Float` in graphql and `float64` in go which will handle numbers up to 2^64 easily. 


This PR converts all the admin analytics stat items data types from `Int` to `Float` in graphql and from `int32` to `float64` in go.

## Test plan

- Enable feature flag: `admin-analytics-enabled`
- Go to `/site-admin/analytics/users` and check if the stats are loading. 