### PR TITLE
JetBrains: Open files on double click

### DIFF
--- a/client/jetbrains/webview/src/search/results/CommitSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/CommitSearchResult.tsx
@@ -19,13 +19,24 @@ interface Props {
     match: CommitMatch
     selectedResult: null | string
     selectResult: (id: string) => void
+    openResult: (id: string) => void
 }
 
-export const CommitSearchResult: React.FunctionComponent<Props> = ({ match, selectedResult, selectResult }: Props) => {
+export const CommitSearchResult: React.FunctionComponent<Props> = ({
+    match,
+    selectedResult,
+    selectResult,
+    openResult,
+}: Props) => {
     const formattedRepositoryStarCount = formatRepositoryStarCount(match.repoStars)
 
     return (
-        <SelectableSearchResult match={match} selectResult={selectResult} selectedResult={selectedResult}>
+        <SelectableSearchResult
+            match={match}
+            selectedResult={selectedResult}
+            selectResult={selectResult}
+            openResult={openResult}
+        >
             {isActive => (
                 <SearchResultLayout
                     isActive={isActive}

--- a/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
@@ -17,16 +17,11 @@ import { getResultId } from './utils'
 
 import styles from './FileSearchResult.module.scss'
 
-interface Props {
-    selectResult: (resultId: string) => void
-    selectedResult: null | string
-    match: ContentMatch | SymbolMatch
-}
-
 function renderResultElementsForContentMatch(
     match: ContentMatch,
+    selectedResult: string | null,
     selectResult: (resultId: string) => void,
-    selectedResult: string | null
+    openResult: (resultId: string) => void
 ): JSX.Element[] {
     return match.lineMatches.map(line => (
         <SelectableSearchResult
@@ -35,6 +30,7 @@ function renderResultElementsForContentMatch(
             match={match}
             selectedResult={selectedResult}
             selectResult={selectResult}
+            openResult={openResult}
         >
             {isActive => (
                 <SearchResultLayout infoColumn={line.lineNumber + 1} className={styles.code} isActive={isActive}>
@@ -45,10 +41,18 @@ function renderResultElementsForContentMatch(
     ))
 }
 
+interface Props {
+    selectResult: (resultId: string) => void
+    selectedResult: null | string
+    match: ContentMatch | SymbolMatch
+    openResult: (resultId: string) => void
+}
+
 function renderResultElementsForSymbolMatch(
     match: SymbolMatch,
+    selectedResult: string | null,
     selectResult: (resultId: string) => void,
-    selectedResult: string | null
+    openResult: (resultId: string) => void
 ): JSX.Element[] {
     return match.symbols.map(symbol => (
         <SelectableSearchResult
@@ -57,6 +61,7 @@ function renderResultElementsForSymbolMatch(
             match={match}
             selectedResult={selectedResult}
             selectResult={selectResult}
+            openResult={openResult}
         >
             {isActive => (
                 <SearchResultLayout className={styles.code} isActive={isActive}>
@@ -68,11 +73,16 @@ function renderResultElementsForSymbolMatch(
     ))
 }
 
-export const FileSearchResult: React.FunctionComponent<Props> = ({ match, selectedResult, selectResult }: Props) => {
+export const FileSearchResult: React.FunctionComponent<Props> = ({
+    match,
+    selectedResult,
+    selectResult,
+    openResult,
+}: Props) => {
     const lines =
         match.type === 'content'
-            ? renderResultElementsForContentMatch(match, selectResult, selectedResult)
-            : renderResultElementsForSymbolMatch(match, selectResult, selectedResult)
+            ? renderResultElementsForContentMatch(match, selectedResult, selectResult, openResult)
+            : renderResultElementsForSymbolMatch(match, selectedResult, selectResult, openResult)
 
     const formattedRepositoryStarCount = formatRepositoryStarCount(match.repoStars)
 

--- a/client/jetbrains/webview/src/search/results/PathSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/PathSearchResult.tsx
@@ -13,13 +13,24 @@ interface Props {
     match: PathMatch
     selectedResult: null | string
     selectResult: (id: string) => void
+    openResult: (id: string) => void
 }
 
-export const PathSearchResult: React.FunctionComponent<Props> = ({ match, selectedResult, selectResult }: Props) => {
+export const PathSearchResult: React.FunctionComponent<Props> = ({
+    match,
+    selectedResult,
+    selectResult,
+    openResult,
+}: Props) => {
     const formattedRepositoryStarCount = formatRepositoryStarCount(match.repoStars)
 
     return (
-        <SelectableSearchResult match={match} selectResult={selectResult} selectedResult={selectedResult}>
+        <SelectableSearchResult
+            match={match}
+            selectedResult={selectedResult}
+            selectResult={selectResult}
+            openResult={openResult}
+        >
             {isActive => (
                 <SearchResultLayout
                     isActive={isActive}

--- a/client/jetbrains/webview/src/search/results/RepoSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/RepoSearchResult.tsx
@@ -13,16 +13,23 @@ export interface RepoSearchResultProps {
     match: RepositoryMatch
     selectedResult: null | string
     selectResult: (id: string) => void
+    openResult: (id: string) => void
 }
 
 export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = ({
     match,
     selectedResult,
     selectResult,
+    openResult,
 }) => {
     const formattedRepositoryStarCount = formatRepositoryStarCount(match.repoStars)
     return (
-        <SelectableSearchResult match={match} selectResult={selectResult} selectedResult={selectedResult}>
+        <SelectableSearchResult
+            match={match}
+            selectedResult={selectedResult}
+            selectResult={selectResult}
+            openResult={openResult}
+        >
             {isActive => (
                 <SearchResultLayout
                     iconColumn={{ icon: SourceRepositoryIcon, repoName: match.repository }}

--- a/client/jetbrains/webview/src/search/results/SearchResultList.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.tsx
@@ -61,7 +61,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                         .then(() => {})
                         .catch(() => {})
                 } else {
-                    console.log(`No match found for result id: ${resultId}`)
+                    console.log(`No match found for result id for selection: ${resultId}`)
                 }
             } else {
                 onPreviewClear()
@@ -71,6 +71,28 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
             setSelectedResultId(resultId)
         },
         [onPreviewChange, onPreviewClear, matchIdToMatchMap]
+    )
+
+    const openResult = useCallback(
+        (resultId: null | string) => {
+            if (resultId !== null) {
+                const matchId = getMatchIdForResult(resultId)
+                const match = matchIdToMatchMap.get(matchId)
+                if (match) {
+                    onOpen(
+                        match,
+                        match.type === 'content' || match.type === 'symbol'
+                            ? getLineOrSymbolMatchIndexForFileResult(resultId)
+                            : undefined
+                    )
+                        .then(() => {})
+                        .catch(() => {})
+                } else {
+                    console.log(`No match found for result id for opening: ${resultId}`)
+                }
+            }
+        },
+        [onOpen, matchIdToMatchMap]
     )
 
     useEffect(() => {
@@ -161,6 +183,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                                 match={match}
                                 selectedResult={selectedResultId}
                                 selectResult={selectResult}
+                                openResult={openResult}
                             />
                         )
                     case 'content':
@@ -170,6 +193,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                                 match={match}
                                 selectedResult={selectedResultId}
                                 selectResult={selectResult}
+                                openResult={openResult}
                             />
                         )
                     case 'symbol':
@@ -179,6 +203,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                                 match={match}
                                 selectedResult={selectedResultId}
                                 selectResult={selectResult}
+                                openResult={openResult}
                             />
                         )
                     case 'repo':
@@ -188,6 +213,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                                 match={match}
                                 selectedResult={selectedResultId}
                                 selectResult={selectResult}
+                                openResult={openResult}
                             />
                         )
                     case 'path':
@@ -197,6 +223,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                                 match={match}
                                 selectedResult={selectedResultId}
                                 selectResult={selectResult}
+                                openResult={openResult}
                             />
                         )
                     default:

--- a/client/jetbrains/webview/src/search/results/SelectableSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/SelectableSearchResult.tsx
@@ -12,6 +12,7 @@ interface Props {
     match: SearchMatch
     selectedResult: null | string
     selectResult: (id: string) => void
+    openResult: (id: string) => void
 }
 
 export const SelectableSearchResult: React.FunctionComponent<Props> = ({
@@ -20,9 +21,11 @@ export const SelectableSearchResult: React.FunctionComponent<Props> = ({
     match,
     selectedResult,
     selectResult,
+    openResult,
 }: Props) => {
     const resultId = getResultId(match, lineOrSymbolMatch)
     const onClick = useCallback((): void => selectResult(resultId), [selectResult, resultId])
+    const onDoubleClick = useCallback((): void => openResult(resultId), [openResult, resultId])
     const isActive = resultId === selectedResult
 
     return (
@@ -33,6 +36,7 @@ export const SelectableSearchResult: React.FunctionComponent<Props> = ({
             id={`search-result-list-item-${resultId}`}
             className={styles.selectableSearchResult}
             onClick={onClick}
+            onDoubleClick={onDoubleClick}
             key={resultId}
         >
             {children(isActive)}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/38477

- JS side: Had to pass the “onOpen” callback to each search result type to trigger it on double click
- Java side: while my JS solution worked in the standalone version right away, it didn't work in the IDE. The error messages pointed at the editor opening event not being in the EDT (event dispatch thread). Then I realized the "open" event didn't work for `⌥⏎` either! 😮  Not sure what happened, but it seemed reasonable to make the call with `invokeLater` so I did, and this made it work right away. Normally, I'd have investigated the causes further, but it really makes sense to me that we should use `invokeLater` here, so I didn't go down this rabbit hole.

## Test plan

- [1-min Loom](https://www.loom.com/share/2267adbe13d249c088a5fce39a50175c) – as mentioned in the video, I didn't demo all result types, just two, but based on the code structure, I'm pretty confident that it works for all of them.
