### PR TITLE
Select first item on file result header click

### DIFF
--- a/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
@@ -86,8 +86,13 @@ export const FileSearchResult: React.FunctionComponent<Props> = ({
 
     const formattedRepositoryStarCount = formatRepositoryStarCount(match.repoStars)
 
+    const onClick = (): void =>
+        lines.length
+            ? selectResult(getResultId(match, match.type === 'content' ? match.lineMatches[0] : match.symbols[0]))
+            : undefined
+
     const title = (
-        <SearchResultHeader>
+        <SearchResultHeader onClick={onClick}>
             <SearchResultLayout
                 iconColumn={{
                     icon: match.type === 'content' ? FileDocumentIcon : AlphaSBoxIcon,

--- a/client/jetbrains/webview/src/search/results/SearchResultHeader.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultHeader.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
 
-interface Props {
-    children: React.ReactNode
-}
-
 import styles from './SearchResultHeader.module.scss'
 
-export const SearchResultHeader: React.FunctionComponent<Props> = ({ children }: Props) => (
-    <div className={styles.searchResultHeader}>{children}</div>
+interface Props {
+    children: React.ReactNode
+    onClick: () => void
+}
+
+export const SearchResultHeader: React.FunctionComponent<Props> = ({ children, onClick }: Props) => (
+    // The below element's accessibility is handled via a document level event listener.
+    //
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
+    <div className={styles.searchResultHeader} onClick={onClick} role="listitem">
+        {children}
+    </div>
 )

--- a/client/jetbrains/webview/src/search/results/SelectableSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/SelectableSearchResult.tsx
@@ -6,7 +6,7 @@ import { getResultId, LineMatchItem, SymbolMatchItem } from './utils'
 
 import styles from './SelectableSearchResult.module.scss'
 
-interface Props {
+export interface SelectableSearchResultProps {
     children: (isActive: boolean) => React.ReactNode
     lineOrSymbolMatch?: LineMatchItem | SymbolMatchItem
     match: SearchMatch
@@ -15,14 +15,14 @@ interface Props {
     openResult: (id: string) => void
 }
 
-export const SelectableSearchResult: React.FunctionComponent<Props> = ({
+export const SelectableSearchResult: React.FunctionComponent<SelectableSearchResultProps> = ({
     children,
     lineOrSymbolMatch,
     match,
     selectedResult,
     selectResult,
     openResult,
-}: Props) => {
+}: SelectableSearchResultProps) => {
     const resultId = getResultId(match, lineOrSymbolMatch)
     const onClick = useCallback((): void => selectResult(resultId), [selectResult, resultId])
     const onDoubleClick = useCallback((): void => openResult(resultId), [openResult, resultId])
@@ -31,13 +31,14 @@ export const SelectableSearchResult: React.FunctionComponent<Props> = ({
     return (
         // The below element's accessibility is handled via a document level event listener.
         //
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
         <div
             id={`search-result-list-item-${resultId}`}
             className={styles.selectableSearchResult}
             onClick={onClick}
             onDoubleClick={onDoubleClick}
             key={resultId}
+            role="listitem"
         >
             {children(isActive)}
         </div>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/38293

I just set up a new "click" event handler on headers, and select the first item of the match if it's present.

Unrelated change: added a missing "role" to list items. (I'm unsure whether this matters inside the IDE, but it _could_ help.)

## Test plan

- [half-minute Loom](https://www.loom.com/share/c9a9a90bf5f94f0b98cf6e9aa48c56da) where I demo both the standalone and in-IDE versions

## App preview:

- [Web](https://sg-web-dv-jetbrains-open-first-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xeahenhimg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
