### PR TITLE
Re-enable flaky dependency search test

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1526,20 +1526,19 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 				{"repos-go", `r:deps(oklog/ulid)`, []string{
 					"/go/github.com/pborman/getopt@v0.0.0-20170112200414-7148bc3a4c30",
 				}},
-				// Flakey
-				// {"repos-python-poetry", `r:deps(^github\.com/sgtest/poetry-hw$)`, []string{
-				// 	"/python/atomicwrites@v1.4.0",
-				// 	"/python/attrs@v21.4.0",
-				// 	"/python/colorama@v0.4.4",
-				// 	"/python/more-itertools@v8.13.0",
-				// 	"/python/packaging@v21.3",
-				// 	"/python/pluggy@v0.13.1",
-				// 	"/python/py@v1.11.0",
-				// 	"/python/pyparsing@v3.0.8",
-				// 	"/python/pytest@v5.4.3",
-				// 	"/python/tqdm@v4.64.0",
-				// 	"/python/wcwidth@v0.2.5",
-				// }},
+				{"repos-python-poetry", `r:deps(^github\.com/sgtest/poetry-hw$)`, []string{
+					"/python/atomicwrites@v1.4.0",
+					"/python/attrs@v21.4.0",
+					"/python/colorama@v0.4.4",
+					"/python/more-itertools@v8.13.0",
+					"/python/packaging@v21.3",
+					"/python/pluggy@v0.13.1",
+					"/python/py@v1.11.0",
+					"/python/pyparsing@v3.0.8",
+					"/python/pytest@v5.4.3",
+					"/python/tqdm@v4.64.0",
+					"/python/wcwidth@v0.2.5",
+				}},
 				{"repos-python-pipenv", `r:deps(^github\.com/sgtest/pipenv-hw$)`, []string{
 					"/python/certifi@v2021.10.8",
 					"/python/charset-normalizer@v2.0.12",


### PR DESCRIPTION
This test was disabled in #38505 because the dependency search for
`sgtest/poetry-hw` didn't return `atomicwrites@1.4.0`. See these two
failures:

- https://buildkite.com/sourcegraph/sourcegraph/builds/159353#0181df60-0721-4b24-aa3d-8247cc21d431/278-279
- https://buildkite.com/sourcegraph/sourcegraph/builds/159359#0181df7d-3e35-433c-bd78-b758dbde3bdd/278-280

The failures don't look that flaky to me:

- why is it `atomicwrites` that's missing, every time?
- why could it be cloned (which we assert before in the test) but the rev wasn't returned in response?

I tried to reproduce it locally but couldn't. Multiple runs (with fresh
instance, warm instance) and no failure. I re-ran it in CI [20 times](https://buildkite.com/sourcegraph/sourcegraph/builds/159516) and
it didn't fail.

That made me curious about `atomicwrites@1.4.0` so I looked at its pypi
releases: https://pypi.org/project/atomicwrites/#history

Turns out a new version - 1.4.1 - was released on July 8, the same day
that these failures started to show up. And the older releases now have
July 9 (!) attached to them.

The maintainer also set the package to "unmaintained" on the same day:

https://github.com/untitaker/python-atomicwrites/commit/d18328460520e18b4f197297f962d4444c5889b6

What to make of this? Not sure. But I somehow suspect that the release
process for atomicwrites@1.4.1 got a bit mixed up on July 8 and maybe
1.4.0 was un-clone-able for some time?

Since I can't reproduce it locally and it passed 20+ times in CI, I
think it's fine to re-enable this and mark it as a "glitch".

## Test plan

- This is a test. Tested locally and [ran 20 times here](https://buildkite.com/sourcegraph/sourcegraph/builds/159516).
