### PR TITLE
Only warn on slow requests

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -273,6 +273,8 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 				// https://github.com/sourcegraph/sourcegraph/pull/29312.
 				fields = append(fields, log.Error(requestErrorCause))
 				logger.Error(msg, fields...)
+			case m.Duration >= minDuration:
+				logger.Warn(msg, fields...)
 			default:
 				logger.Error(msg, fields...)
 			}


### PR DESCRIPTION
I was a bit confused to see "slow http request" as an error message.
This changes the code to log the "slow request" messages as warning (in
case none of the other conditions before matched).

## Test plan

- N/A
