### PR TITLE
Use 1req/s rate limit for Rust packages

### DIFF
--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -518,7 +518,7 @@ func GetLimitFromConfig(kind string, config any) (rate.Limit, error) {
 		}
 	case *schema.RustPackagesConnection:
 		// 1 request per second is default policy for crates.io
-		limit = rate.Limit(32)
+		limit = rate.Limit(1)
 		if c != nil && c.RateLimit != nil {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}


### PR DESCRIPTION
This addresses the comment here https://github.com/sourcegraph/sourcegraph/pull/36047#issuecomment-1180241992 by setting the rate limit to the actual value it should be (and that's in the docstring above).


## Test plan

- Existing tests