### PR TITLE
search: Show placeholder for some filters (CodeMirror)

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -175,12 +175,21 @@
         repeat-x bottom left;
 }
 
+// .placeholder needs to explicilty have the same background color because it
+// appears to be placed outside of .focusedFilter rather than within it.
+.placeholder,
 .focusedFilter {
     background-color: var(--gray-02);
 
     :global(.theme-dark) & {
         background-color: var(--gray-08);
     }
+}
+
+.placeholder {
+    color: var(--text-muted);
+    font-style: italic;
+    pointer-events: none;
 }
 
 // Copied and adapted from the Wildcard LoadingSpinner component

--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -146,6 +146,9 @@ interface BaseFilterDefinition {
     alias?: keyof typeof AliasedFilterType
     description: string
     discreteValues?: (value: Literal | undefined, isSourcegraphDotCom?: boolean) => Completion[]
+    /** Placeholder value shown in the input when the filter has no value. */
+    placeholder?: string
+    /** Whether to query the server for completions of this type. */
     suggestions?: SearchMatch['type']
     default?: string
     /** Whether the filter may only be used 0 or 1 times in a query. */
@@ -185,6 +188,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     [FilterType.after]: {
         alias: 'since',
         description: 'Commits made after a certain date',
+        placeholder: '"time frame"',
     },
     [FilterType.archived]: {
         description: 'Include results from archived repositories.',
@@ -194,10 +198,12 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     [FilterType.author]: {
         negatable: true,
         description: negated => `${negated ? 'Exclude' : 'Include only'} commits or diffs authored by a user.`,
+        placeholder: '"author name/email"',
     },
     [FilterType.before]: {
         alias: 'until',
         description: 'Commits made before a certain date',
+        placeholder: '"time frame"',
     },
     [FilterType.case]: {
         description: 'Treat the search pattern as case-sensitive.',
@@ -208,12 +214,14 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     [FilterType.committer]: {
         description: (negated: boolean): string =>
             `${negated ? 'Exclude' : 'Include only'} commits and diffs committed by a user.`,
+        placeholder: '"author name/email"',
         negatable: true,
         singular: true,
     },
     [FilterType.content]: {
         description: (negated: boolean): string =>
             `${negated ? 'Exclude' : 'Include only'} results from files if their content matches the search pattern.`,
+        placeholder: 'pattern',
         negatable: true,
         singular: true,
     },
@@ -223,6 +231,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     },
     [FilterType.count]: {
         description: 'Number of results to fetch (integer) or "all"',
+        placeholder: 'number',
         singular: true,
     },
     [FilterType.file]: {
@@ -230,6 +239,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
         negatable: true,
         description: negated =>
             `${negated ? 'Exclude' : 'Include only'} results from file paths matching the given search pattern.`,
+        placeholder: 'regex',
         suggestions: 'path',
     },
     [FilterType.fork]: {
@@ -248,6 +258,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
         negatable: true,
         description: negated =>
             `${negated ? 'Exclude' : 'Include only'} Commits with messages matching a certain string`,
+        placeholder: '"content"',
     },
     [FilterType.patterntype]: {
         discreteValues: () => ['regexp', 'structural', 'literal'].map(value => ({ label: value })),
@@ -267,11 +278,13 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     },
     [FilterType.repogroup]: {
         alias: 'g',
-        description: 'group-name (include results from the named group)',
+        description: 'Include results from the named group.',
+        placeholder: 'group-name',
         singular: true,
     },
     [FilterType.repohascommitafter]: {
-        description: '"string specifying time frame" (filter out stale repositories without recent commits)',
+        description: 'Filter out stale repositories without recent commits',
+        placeholder: '"time frame"',
         singular: true,
     },
     [FilterType.repohasfile]: {
@@ -282,6 +295,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     [FilterType.rev]: {
         alias: 'revision',
         description: 'Search a revision (branch, commit hash, or tag) instead of the default branch.',
+        placeholder: 'branch/commit/tag',
         singular: true,
     },
     [FilterType.select]: {
@@ -291,6 +305,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     },
     [FilterType.timeout]: {
         description: 'Duration before timeout',
+        placeholder: 'duration-value',
         singular: true,
     },
     [FilterType.type]: {


### PR DESCRIPTION
Addresses https://github.com/sourcegraph/sourcegraph/issues/20662

This commit adds logic to render a simple placeholder when a filter has
no value. I only added placeholders to filters for which we don't
provided static suggestions. I think suggestions provide enough
information about which value can be used. This way we also avoid some
visual clutter (placeholder + suggestions visible otherwise).

Note that the filter will only be shown when the filter is currently
"active", i.e. the text cursor is "inside" the filter (and there is no
value of course).

We could also make it so that the placeholder is always shown,
regardless where the cursor is positioned.

I chose placeholder text that seem reasonable to me but please make
suggestions for improvements.

**Caveat:** Due to the placeholder not being part of the document and
because we don't do line wrapping in the main query input, the placeholder
text will be truncated at the end of the input. But I think that's an
acceptable tradeoff. 


<img width="881" alt="2022-07-11_13-24_1" src="https://user-images.githubusercontent.com/179026/178261724-48aff332-7f1f-4bca-9a0a-2b649c70a568.png">
<img width="893" alt="2022-07-11_13-24" src="https://user-images.githubusercontent.com/179026/178261727-d7cdf7a6-bff5-4326-b672-5312282bb2c4.png">



## Test plan

Type `author:`, `count:`, etc in the query input. A placeholder value should be shown as long as the filter has not value and "has focus". The placeholder value is not selectable.

## App preview:

- [Web](https://sg-web-fkling-cm-filter-placeholders.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pnsofoeksy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

