### PR TITLE
search: Add descriptions to static filter value suggestions (CodeMirror)

### DIFF
--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -281,7 +281,7 @@ export function createDefaultSuggestionSources(options: {
                     filter: !hasDynamicSuggestions,
                     options: resolvedFilter.definition
                         .discreteValues(value, options.isSourcegraphDotCom)
-                        .map(({ label, insertText, asSnippet }, index) => {
+                        .map(({ label, insertText, asSnippet, description }, index) => {
                             const apply = (insertText || label) + ' '
                             return {
                                 label,
@@ -297,6 +297,7 @@ export function createDefaultSuggestionSources(options: {
                                 // displaying matching suggestions in the same
                                 // order as they have been defined in code.
                                 boost: index * -1,
+                                detail: description,
                             }
                         }),
                 }

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-template-curly-in-string */
-import { Completion, resolveFieldAlias } from './filters'
+import { Completion, FilterType, resolveFieldAlias } from './filters'
 
 interface Access {
     name: string
@@ -153,50 +153,67 @@ export const scanPredicate = (field: string, value: string): Predicate | undefin
     return { path, parameters }
 }
 
-export const predicateCompletion = (field: string): Completion[] => {
-    if (field === 'repo') {
-        return [
-            {
-                label: 'contains.file(...)',
-                insertText: 'contains.file(${1:CHANGELOG})',
-                asSnippet: true,
-            },
-            {
-                label: 'contains.content(...)',
-                insertText: 'contains.content(${1:TODO})',
-                asSnippet: true,
-            },
-            {
-                label: 'contains(...)',
-                insertText: 'contains(file:${1:CHANGELOG} content:${2:fix})',
-                asSnippet: true,
-            },
-            {
-                label: 'contains.commit.after(...)',
-                insertText: 'contains.commit.after(${1:1 month ago})',
-                asSnippet: true,
-            },
-            {
-                label: 'deps(...)',
-                insertText: 'deps(${1})',
-                asSnippet: true,
-            },
-            {
-                label: 'dependencies(...)',
-                insertText: 'dependencies(${1})',
-                asSnippet: true,
-            },
-            {
-                label: 'revdeps(...)',
-                insertText: 'revdeps(${1})',
-                asSnippet: true,
-            },
-            {
-                label: 'dependents(...)',
-                insertText: 'dependents(${1})',
-                asSnippet: true,
-            },
-        ]
+export const predicateCompletion = (filter: FilterType): Completion[] => {
+    switch (filter) {
+        case FilterType.repo:
+            return [
+                {
+                    label: 'contains.file(...)',
+                    insertText: 'contains.file(${1:CHANGELOG})',
+                    asSnippet: true,
+                    description: 'search in repos containing specific files',
+                },
+                {
+                    label: 'contains.content(...)',
+                    insertText: 'contains.content(${1:TODO})',
+                    asSnippet: true,
+                    description: 'search in repos containing specific file content',
+                },
+                {
+                    label: 'contains(...)',
+                    insertText: 'contains(file:${1:CHANGELOG} content:${2:fix})',
+                    asSnippet: true,
+                    description: 'search in repos containing file and content',
+                },
+                {
+                    label: 'contains.commit.after(...)',
+                    insertText: 'contains.commit.after(${1:1 month ago})',
+                    asSnippet: true,
+                    description: 'search in repos with commits after a specific time',
+                },
+                {
+                    label: 'deps(...)',
+                    insertText: 'deps(${1:repo})',
+                    asSnippet: true,
+                    description: 'alias for dependencies(...)',
+                },
+                {
+                    label: 'dependencies(...)',
+                    insertText: 'dependencies(${1:repo})',
+                    asSnippet: true,
+                    description: 'search only in dependencies of matching repositories',
+                },
+                {
+                    label: 'revdeps(...)',
+                    insertText: 'revdeps(${1})',
+                    asSnippet: true,
+                },
+                {
+                    label: 'dependents(...)',
+                    insertText: 'dependents(${1})',
+                    asSnippet: true,
+                },
+            ]
+        case FilterType.file:
+            return [
+                {
+                    label: 'contains.content(...)',
+                    insertText: 'contains.content(${1:TODO})',
+                    asSnippet: true,
+                    description: 'search in files with specific content',
+                },
+            ]
+        default:
+            return []
     }
-    return []
 }


### PR DESCRIPTION
This commit adds descriptions to most static filter value suggestions to
help better better understand what those values mean.

However, I'm not really happy with the wording, especially for the repo
predicates. It's rather repetitive and doesn't look that great in the
list IMO. If you have suggestions for better wording, please let me
know.

<img width="843" alt="2022-07-11_16-22_1" src="https://user-images.githubusercontent.com/179026/178289849-3a1e4c42-502b-4b23-a449-515eeff7d10e.png">
<img width="891" alt="2022-07-11_16-22" src="https://user-images.githubusercontent.com/179026/178289854-59e0f867-d740-4ad7-b58a-3a06b5b97cb6.png">


## Test plan

Enter filter that has static suggestions (e.g. `repo:`). They should be listed with description.

## App preview:

- [Web](https://sg-web-fkling-static-suggstions.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jozsdozblc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
