### PR TITLE
Download crates from CDN instead of crates.io API

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_rust_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_rust_packages.go
@@ -70,7 +70,7 @@ func (s *rustDependencySource) Get(ctx context.Context, name, version string) (r
 }
 
 func (s *rustDependencySource) Download(ctx context.Context, dir string, dep reposource.PackageVersion) error {
-	packageURL := fmt.Sprintf("https://crates.io/api/v1/crates/%s/%s/%s", dep.PackageSyntax(), dep.PackageVersion(), "download")
+	packageURL := fmt.Sprintf("https://static.crates.io/crates/%s/%s-%s.crate", dep.PackageSyntax(), dep.PackageSyntax(), dep.PackageVersion())
 
 	pkg, err := s.client.Get(ctx, packageURL)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/38559

Previously, we downloaded crate contents from the crates.io API, which
has a rate limit of 1 request/second that we were exceeding. This commit
changes the download URL to use the CDN, which has no rate limit. See
this post https://www.pietroalbini.org/blog/downloading-crates-io/ for
more details.

## Test plan

See the CI go green. I also manually tested the change locally to verify it works as expected using the site config

```
❯ cat ../dev-private/enterprise/dev/external-services-config.json
{
  "RUSTPACKAGES": [
    {
      "dependencies": ["serde@1.0.139"]
    }
  ]
}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
