### PR TITLE
Accessibility: Improve symbol sidebar contrast

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
@@ -48,5 +48,5 @@
 }
 
 .container-name {
-    margin-left: 0.25rem;
+    margin-left: 0.5rem;
 }

--- a/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
@@ -32,7 +32,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: var(--secondary);
+    color: var(--text-muted);
 
     &--active,
     &:hover {


### PR DESCRIPTION
Related Slack thread: https://sourcegraph.slack.com/archives/C0HMGV90V/p1657551637587399

New color is WCAG 2.1 compliant in both light and dark mode


## Screenshots
| BEFORE             |  AFTER |
:-------------------------:|:-------------------------:
<img width="531" alt="image" src="https://user-images.githubusercontent.com/9516420/178302034-206ecfe9-9979-4a27-ae1f-ed4c8336c3e7.png">  | <img width="450" alt="image" src="https://user-images.githubusercontent.com/9516420/178307024-48d6def8-4510-4a6c-af0f-b1d8a208d241.png">





## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-fix-symbol-sidebar-contrast.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hssjqpoyqv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
