### PR TITLE
search: 'Expert' -> 'Advanced' mode for lucky toggle

### DIFF
--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -121,7 +121,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
         submitOnToggle({ newPatternType })
     }, [defaultPatternTypeValue, patternType, setPatternType, submitOnToggle])
 
-    const toggleExpertMode = useCallback((): void => {
+    const toggleAdvancedMode = useCallback((): void => {
         const newPatternType =
             patternType === SearchPatternType.lucky ? SearchPatternType.literal : SearchPatternType.lucky
 
@@ -150,13 +150,13 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
             {patternType === SearchPatternType.lucky ? (
                 <>
                     <QueryInputToggle
-                        title="Expert mode"
+                        title="Advanced mode"
                         isActive={false}
-                        onToggle={toggleExpertMode}
+                        onToggle={toggleAdvancedMode}
                         icon={LightningBoltIcon}
                         interactive={props.interactive}
-                        className="test-expert-mode-toggle"
-                        activeClassName="test-expert-mode-toggle--active"
+                        className="test-advanced-mode-toggle"
+                        activeClassName="test-advanced-mode-toggle--active"
                         disableOn={[]}
                     />
                     {copyQueryButton}
@@ -228,13 +228,13 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                     )}
                     {luckySearchEnabled && (
                         <QueryInputToggle
-                            title="Expert mode"
+                            title="Advanced mode"
                             isActive={true}
-                            onToggle={toggleExpertMode}
+                            onToggle={toggleAdvancedMode}
                             icon={LightningBoltIcon}
                             interactive={props.interactive}
-                            className="test-expert-mode-toggle"
-                            activeClassName="test-expert-mode-toggle--active"
+                            className="test-advanced-mode-toggle"
+                            activeClassName="test-advanced-mode-toggle--active"
                             disableOn={[]}
                         />
                     )}


### PR DESCRIPTION
Even though I'm not looking for design feedback yet, some word got out on this feature and I'll just address this design feedback so there's fewer issues when rolling out.

> With all this in mind, I suggest we change this to “Enable advanced mode,” in which the adjective unambiguously describes the mode, not the user. 

https://sourcegraph.slack.com/archives/C0HMGV90V/p1655205572654679

## Test plan
Just changes text.

## App preview:

- [Web](https://sg-web-rvt-lucky-fe-stuff.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jvspwxuvpx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
