### PR TITLE
client/web: make relative date always the same

### DIFF
--- a/client/web/src/integration/profile.test.ts
+++ b/client/web/src/integration/profile.test.ts
@@ -1,5 +1,7 @@
 import assert from 'assert'
 
+import { subDays } from 'date-fns'
+
 import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
 import { testUserID } from '@sourcegraph/shared/src/testing/integration/graphQlResults'
@@ -10,6 +12,8 @@ import { UserSettingsAreaUserFields } from '../graphql-operations'
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults } from './graphQlResults'
 import { percySnapshotWithVariants } from './utils'
+
+const now = new Date()
 
 const USER: UserSettingsAreaUserFields = {
     __typename: 'User',
@@ -23,7 +27,7 @@ const USER: UserSettingsAreaUserFields = {
     viewerCanChangeUsername: true,
     siteAdmin: true,
     builtinAuth: true,
-    createdAt: '2020-04-10T21:11:42Z',
+    createdAt: subDays(now, 730).toISOString(),
     emails: [{ email: 'test@example.com', verified: true }],
     organizations: { nodes: [] },
     tags: [],

--- a/client/web/src/integration/profile.test.ts
+++ b/client/web/src/integration/profile.test.ts
@@ -27,7 +27,7 @@ const USER: UserSettingsAreaUserFields = {
     viewerCanChangeUsername: true,
     siteAdmin: true,
     builtinAuth: true,
-    createdAt: subDays(now, 730).toISOString(),
+    createdAt: subDays(now, 732).toISOString(),
     emails: [{ email: 'test@example.com', verified: true }],
     organizations: { nodes: [] },
     tags: [],


### PR DESCRIPTION
This caused [a Percy flake][1], since we're now "about 2 years" instead of "over 2 years", apparently.

[1]: https://percy.io/Sourcegraph/Sourcegraph/builds/19516021/changed/1096011838?browser=chrome&browser_ids=23&subcategories=approved&viewLayout=overlay&viewMode=new&width=1920&widths=1920

## Test plan

Test change only.

## App preview:

- [Web](https://sg-web-aharvey-affix-date.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hikeygzkqf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
