### PR TITLE
search: fix lucky search icon and tighten text

### DIFF
--- a/client/web/src/search/suggestion/LuckySearch.tsx
+++ b/client/web/src/search/suggestion/LuckySearch.tsx
@@ -15,15 +15,9 @@ export const LuckySearch: React.FunctionComponent<React.PropsWithChildren<LuckyS
     alert?.kind && alert.kind !== 'lucky-search-queries' ? null : (
         <div className={styles.root}>
             <H3>
-                Also showing results for:
-                <Tooltip content="We returned all the results for your query. We also added results you might be interested in for similar queries. Below are similar queries we ran.">
-                    <Icon
-                        size="sm"
-                        className="ml-1"
-                        tabIndex={0}
-                        aria-label="More information"
-                        svgPath={mdiInformationOutline}
-                    />
+                Also showing additional results
+                <Tooltip content="We returned all the results for your query. We also added results for similar queries that might interest you.">
+                    <Icon className="ml-1" tabIndex={0} aria-label="More information" svgPath={mdiInformationOutline} />
                 </Tooltip>
             </H3>
             <ul className={styles.container}>


### PR DESCRIPTION
Icon got broken in the crossfire with https://github.com/sourcegraph/sourcegraph/pull/37417. This fixes it and I'm tightening the text.

## Test plan
Manually tested for experimental feature.

## App preview:

- [Web](https://sg-web-rvt-lucky-icon.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fpedqdptdh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
