### PR TITLE
search: lucky search highlights suggestions as standard queries

### DIFF
--- a/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -89,9 +89,9 @@ function toDecoration(query: string, token: DecoratedToken): decoration {
 // A read-only syntax highlighted search query
 export const SyntaxHighlightedSearchQuery: React.FunctionComponent<
     React.PropsWithChildren<SyntaxHighlightedSearchQueryProps>
-> = ({ query, searchPatternType = SearchPatternType.standard, ...otherProps }) => {
+> = ({ query, searchPatternType, ...otherProps }) => {
     const tokens = useMemo(() => {
-        const tokens = scanSearchQuery(query)
+        const tokens = searchPatternType ? scanSearchQuery(query) : scanSearchQuery(query, false, searchPatternType)
         return tokens.type === 'success'
             ? tokens.term.flatMap(token =>
                   decorate(token).map(token => {
@@ -104,7 +104,7 @@ export const SyntaxHighlightedSearchQuery: React.FunctionComponent<
                   })
               )
             : [<Fragment key="0">{query}</Fragment>]
-    }, [query])
+    }, [query, searchPatternType])
 
     return (
         <span {...otherProps} className={classNames('text-monospace search-query-link', otherProps.className)}>

--- a/client/web/src/search/suggestion/LuckySearch.tsx
+++ b/client/web/src/search/suggestion/LuckySearch.tsx
@@ -5,6 +5,8 @@ import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
 import { Link, H3, createLinkUrl, Tooltip, Icon } from '@sourcegraph/wildcard'
 
+import { SearchPatternType } from '../../graphql-operations'
+
 import styles from './QuerySuggestion.module.scss'
 
 interface LuckySearchProps {
@@ -30,7 +32,10 @@ export const LuckySearch: React.FunctionComponent<React.PropsWithChildren<LuckyS
                             })}
                         >
                             <span className={styles.suggestion}>
-                                <SyntaxHighlightedSearchQuery query={entry.query} />
+                                <SyntaxHighlightedSearchQuery
+                                    query={entry.query}
+                                    searchPatternType={SearchPatternType.standard}
+                                />
                             </span>
                             <i>{`— ${entry.description}`}</i>
                         </Link>


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/38580.

This just explicitly highlights other queries in lucky search as standard (so suggestions with `/.../` will be highlighted as regexp). The backend doesn't return such queries yet, but will soon.

## Test plan
Not active yet (lucky search doesn't return queries that would be highlighted this way yet). Will test when changes affecting this is merged.

## App preview:

- [Web](https://sg-web-rvt-lucky-highlight.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ouhamwnajm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
