### PR TITLE
Searcher: make hot loop lock free

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -307,7 +307,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatche
 	}
 
 	var (
-		nextFileIdx   = atomic.NewInt32(-1)
+		lastFileIdx   = atomic.NewInt32(-1)
 		filesSkipped  atomic.Uint32
 		filesSearched atomic.Uint32
 	)
@@ -326,7 +326,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatche
 		rg := rg.Copy()
 		g.Go(func() error {
 			for !contextCanceled.Load() {
-				idx := int(nextFileIdx.Inc())
+				idx := int(lastFileIdx.Inc())
 				if idx >= len(files) {
 					cancel()
 					return nil

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -319,9 +319,9 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatche
 	go func() {
 		<-ctx.Done()
 		contextCanceled.Store(true)
-		return nil
+		close(done)
 	}()
-	defer func() { <-done }()
+	defer func() { cancel(); <-done }()
 
 	// Start workers. They read from files and write to matches.
 	for i := 0; i < numWorkers; i++ {

--- a/cmd/searcher/internal/search/sender.go
+++ b/cmd/searcher/internal/search/sender.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 
+	"go.uber.org/atomic"
+
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 )
 
@@ -16,10 +18,9 @@ type matchSender interface {
 
 type limitedStream struct {
 	cb        func(protocol.FileMatch)
-	mux       sync.Mutex
-	sentCount int
-	remaining int
-	limitHit  bool
+	limit     int
+	remaining *atomic.Int64
+	limitHit  *atomic.Bool
 	cancel    context.CancelFunc
 }
 
@@ -32,74 +33,64 @@ func newLimitedStream(ctx context.Context, limit int, cb func(protocol.FileMatch
 	s := &limitedStream{
 		cb:        cb,
 		cancel:    cancel,
-		remaining: limit,
+		limit:     limit,
+		remaining: atomic.NewInt64(int64(limit)),
+		limitHit:  atomic.NewBool(false),
 	}
 	return ctx, cancel, s
 }
 
 func (m *limitedStream) Send(match protocol.FileMatch) {
-	m.mux.Lock()
-	matchCount := match.MatchCount()
-	if matchCount <= m.remaining {
-		m.remaining -= matchCount
-		m.sentCount += matchCount
+	count := int64(match.MatchCount())
+
+	after := m.remaining.Sub(count)
+	before := after + count
+
+	if after > 0 {
+		// Remaining was large enough to send the full match
 		m.cb(match)
-		m.mux.Unlock()
+	} else if before <= 0 {
+		// We had already hit the limit, so just ignore this event
 		return
+	} else if after == 0 {
+		// We hit the limit exactly.
+		m.cancel()
+		m.limitHit.Store(true)
+		m.cb(match)
+	} else {
+		// We crossed the limit threshold, so we need to truncate the
+		// event before sending.
+		m.cancel()
+		m.limitHit.Store(true)
+		match.Limit(int(before))
+		m.cb(match)
 	}
-
-	m.limitHit = true
-	m.cancel()
-
-	// Can't truncate a path match
-	if len(match.ChunkMatches) == 0 {
-		m.mux.Unlock()
-		return
-	}
-
-	for i, cm := range match.ChunkMatches {
-		if l := len(cm.Ranges); l >= m.remaining {
-			match.ChunkMatches[i].Ranges = cm.Ranges[:m.remaining]
-			match.ChunkMatches = match.ChunkMatches[:i+1]
-			break
-		} else {
-			m.remaining -= l
-		}
-	}
-	match.LimitHit = true
-	m.sentCount += m.remaining
-	m.remaining = 0
-	m.cb(match)
-	m.mux.Unlock()
 }
 
 func (m *limitedStream) SentCount() int {
-	m.mux.Lock()
-	defer m.mux.Unlock()
-	return m.sentCount
+	return m.limit - int(m.remaining.Load())
 }
 
 func (m *limitedStream) Remaining() int {
-	m.mux.Lock()
-	defer m.mux.Unlock()
-	return m.remaining
+	return int(m.remaining.Load())
 }
 
 func (m *limitedStream) LimitHit() bool {
-	m.mux.Lock()
-	defer m.mux.Unlock()
-	return m.limitHit
+	return m.limitHit.Load()
 }
 
 type limitedStreamCollector struct {
 	collected []protocol.FileMatch
+	mux       sync.Mutex
 	*limitedStream
 }
 
 func newLimitedStreamCollector(ctx context.Context, limit int) (context.Context, context.CancelFunc, *limitedStreamCollector) {
 	s := &limitedStreamCollector{}
 	ctx, cancel, ls := newLimitedStream(ctx, limit, func(fm protocol.FileMatch) {
+		s.mux.Lock()
 		s.collected = append(s.collected, fm)
+		s.mux.Unlock()
 	})
 	s.limitedStream = ls
 	return ctx, cancel, s

--- a/cmd/searcher/internal/search/sender.go
+++ b/cmd/searcher/internal/search/sender.go
@@ -68,11 +68,19 @@ func (m *limitedStream) Send(match protocol.FileMatch) {
 }
 
 func (m *limitedStream) SentCount() int {
-	return m.limit - int(m.remaining.Load())
+	remaining := int(m.remaining.Load())
+	if remaining < 0 {
+		remaining = 0
+	}
+	return m.limit - remaining
 }
 
 func (m *limitedStream) Remaining() int {
-	return int(m.remaining.Load())
+	remaining := int(m.remaining.Load())
+	if remaining < 0 {
+		remaining = 0
+	}
+	return remaining
 }
 
 func (m *limitedStream) LimitHit() bool {

--- a/cmd/searcher/internal/search/sender_test.go
+++ b/cmd/searcher/internal/search/sender_test.go
@@ -1,0 +1,155 @@
+package search
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/quick"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
+	"github.com/sourcegraph/sourcegraph/lib/group"
+)
+
+func TestLimitedStream(t *testing.T) {
+	cases := []struct {
+		limit   int
+		inputs  []protocol.FileMatch
+		outputs []protocol.FileMatch
+	}{{
+		limit: 1,
+		inputs: []protocol.FileMatch{{
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 1),
+			}},
+		}},
+		outputs: []protocol.FileMatch{{
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 1),
+			}},
+		}},
+	}, {
+		limit: 1,
+		inputs: []protocol.FileMatch{{
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 2),
+			}},
+		}},
+		outputs: []protocol.FileMatch{{
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 1),
+			}},
+			LimitHit: true,
+		}},
+	}, {
+		limit: 2,
+		inputs: []protocol.FileMatch{{
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 1),
+			}},
+		}, {
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 2),
+			}},
+		}},
+		outputs: []protocol.FileMatch{{
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 1),
+			}},
+		}, {
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 1),
+			}},
+			LimitHit: true,
+		}},
+	}, {
+		limit: 2,
+		inputs: []protocol.FileMatch{{
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 1),
+			}, {
+				Ranges: make([]protocol.Range, 2),
+			}},
+		}},
+		outputs: []protocol.FileMatch{{
+			ChunkMatches: []protocol.ChunkMatch{{
+				Ranges: make([]protocol.Range, 1),
+			}, {
+				Ranges: make([]protocol.Range, 1),
+			}},
+			LimitHit: true,
+		}},
+	}, {
+		limit:   1,
+		inputs:  make([]protocol.FileMatch, 2),
+		outputs: make([]protocol.FileMatch, 1),
+	}}
+
+	for _, tt := range cases {
+		t.Run("", func(t *testing.T) {
+			ctx := context.Background()
+			var got []protocol.FileMatch
+			_, _, s := newLimitedStream(ctx, tt.limit, func(m protocol.FileMatch) {
+				got = append(got, m)
+			})
+
+			for _, input := range tt.inputs {
+				s.Send(input)
+			}
+
+			require.Equal(t, tt.outputs, got)
+		})
+	}
+
+	t.Run("parallel", func(t *testing.T) {
+		quick.Check(func(matchSizes [][]uint16, limit uint16) bool {
+			inputs := make([]protocol.FileMatch, 0, len(matchSizes))
+			totalSize := 0
+			for _, chunkSizes := range matchSizes {
+				chunks := make([]protocol.ChunkMatch, 0, len(chunkSizes))
+				for _, chunkSize := range chunkSizes {
+					chunks = append(chunks, protocol.ChunkMatch{
+						Ranges: make([]protocol.Range, chunkSize),
+					})
+					totalSize += int(chunkSize)
+				}
+				if len(chunks) == 0 {
+					totalSize += 1
+				}
+				inputs = append(inputs, protocol.FileMatch{})
+			}
+
+			var (
+				ctx           = context.Background()
+				mux           sync.Mutex
+				outputMatches []protocol.FileMatch
+			)
+			_, _, s := newLimitedStream(ctx, int(limit), func(m protocol.FileMatch) {
+				mux.Lock()
+				outputMatches = append(outputMatches, m)
+				mux.Unlock()
+			})
+
+			g := group.New()
+			for _, input := range inputs {
+				input := input
+				g.Go(func() {
+					s.Send(input)
+				})
+			}
+			g.Wait()
+
+			outputSize := 0
+			for _, outputMatch := range outputMatches {
+				outputSize += outputMatch.MatchCount()
+			}
+			if totalSize < int(limit) && outputSize != totalSize {
+				return false
+			} else if totalSize >= int(limit) && outputSize != int(limit) {
+				return false
+			}
+			return true
+		}, nil)
+	})
+}

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -217,14 +217,14 @@ func (fm FileMatch) MatchCount() int {
 }
 
 func (fm *FileMatch) Limit(limit int) {
-	for i, cm := range fm.ChunkMatches {
-		l := len(cm.Ranges)
+	for i := range fm.ChunkMatches {
+		l := len(fm.ChunkMatches[i].Ranges)
 		if l <= limit {
 			limit -= l
 			continue
 		}
 
-		cm.Ranges = cm.Ranges[:limit]
+		fm.ChunkMatches[i].Ranges = fm.ChunkMatches[i].Ranges[:limit]
 		if limit > 0 {
 			fm.ChunkMatches = fm.ChunkMatches[:i+1]
 		} else {

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -216,6 +216,25 @@ func (fm FileMatch) MatchCount() int {
 	return count
 }
 
+func (fm *FileMatch) Limit(limit int) {
+	for i, cm := range fm.ChunkMatches {
+		l := len(cm.Ranges)
+		if l <= limit {
+			limit -= l
+			continue
+		}
+
+		cm.Ranges = cm.Ranges[:limit]
+		if limit > 0 {
+			fm.ChunkMatches = fm.ChunkMatches[:i+1]
+		} else {
+			fm.ChunkMatches = fm.ChunkMatches[:i]
+		}
+		fm.LimitHit = true
+		return
+	}
+}
+
 type ChunkMatch struct {
 	Content      string
 	ContentStart Location

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -224,6 +224,7 @@ func (fm *FileMatch) Limit(limit int) {
 			continue
 		}
 
+		// invariant: limit < l
 		fm.ChunkMatches[i].Ranges = fm.ChunkMatches[i].Ranges[:limit]
 		if limit > 0 {
 			fm.ChunkMatches = fm.ChunkMatches[:i+1]


### PR DESCRIPTION
So, I took another pass at optimizing the hot file iteration loop in searcher, and found a few modest gains. Basically, this takes all the operations in the worker goroutines and makes them lockfree. This has the most visible effect on cheap searches (e.g. literal, case sensitive) because iterating over files is a much larger proportion of the work done, so lock contention is meaningful. 

The first commit makes iterating over the list of files lockfree by atomically incrementing an index variable and exiting when the index is outside the range of the list of files.

The second commit makes sender lockfree using the same techniques as we do [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@b55d7c3a905436059c4f5481aa6c2e434a7a9f49/-/blob/internal/search/job/jobutil/limit.go?L86-86). We still require the callback to hold a mutex (both for the benchmarks and in real life), so sending results isn't lockfree, but the important part is that `sender.Remaining()` no longer requires holding a mutex because that is called on every file searched.

The third commit uses an atomic boolean instead of checking `ctx.Err()` each iteration, which requires a mutex lock. This does require creating a new goroutine, but the benchmarks seemed to indicate that the overhead pays off. An alternative here would be to only check the context every `n` iterations, but that means we could end up searching extra (maybe very large) files, so I think this is a better tradeoff from a worst-case perspective. 

I had previously tried some of these out, but the effects are far less visible before the memory optimizations I made in https://github.com/sourcegraph/sourcegraph/pull/38507. 

## Test plan

Added tests for the limiting stream, which apparently didn't exist.

Benchmark results:

```
❯ benchstat -alpha 0.1 /tmp/baseline.txt /tmp/lockfree_ctx.txt
name                                             old time/op    new time/op    delta
SearchRegex_large_fixed-10                         6.20ms ± 0%    5.37ms ± 6%  -13.30%  (p=0.008 n=5+5)
SearchRegex_rare_fixed-10                          7.76ms ± 4%    6.92ms ± 1%  -10.85%  (p=0.008 n=5+5)
SearchRegex_large_fixed_casesensitive-10           3.92ms ± 1%    2.68ms ± 4%  -31.54%  (p=0.008 n=5+5)
SearchRegex_large_re_dotstar-10                     217ms ± 2%     214ms ± 2%     ~     (p=0.310 n=5+5)
SearchRegex_large_re_common-10                     6.01ms ± 7%    4.83ms ± 1%  -19.61%  (p=0.008 n=5+5)
SearchRegex_large_re_anchor-10                     70.0ms ± 1%    68.7ms ± 1%   -1.86%  (p=0.032 n=5+5)
SearchRegex_large_path/path_only-10                 301µs ± 1%     302µs ± 0%     ~     (p=0.222 n=5+5)
SearchRegex_large_path/content_only-10             6.84ms ± 1%    6.81ms ± 1%     ~     (p=0.548 n=5+5)
SearchRegex_large_path/both_path_and_content-10    6.86ms ± 2%    6.73ms ± 1%   -1.90%  (p=0.016 n=5+5)
SearchRegex_small_fixed-10                          132µs ± 0%     130µs ± 0%   -1.81%  (p=0.008 n=5+5)
SearchRegex_small_fixed_casesensitive-10           86.1µs ± 0%    85.4µs ± 0%   -0.74%  (p=0.016 n=4+5)
SearchRegex_small_re_dotstar-10                    2.23ms ± 0%    2.30ms ± 4%     ~     (p=0.310 n=5+5)
SearchRegex_small_re_common-10                     87.4µs ± 1%    85.0µs ± 0%   -2.71%  (p=0.016 n=5+4)
SearchRegex_small_re_anchor-10                      769µs ± 0%     767µs ± 1%     ~     (p=0.222 n=5+5)

name                                             old alloc/op   new alloc/op   delta
SearchRegex_large_fixed-10                         15.7MB ± 0%    15.7MB ± 0%     ~     (p=0.421 n=5+5)
SearchRegex_rare_fixed-10                          15.7MB ± 0%    15.7MB ± 0%     ~     (p=0.222 n=5+5)
SearchRegex_large_fixed_casesensitive-10           9.89kB ± 0%   10.26kB ± 0%   +3.66%  (p=0.016 n=4+5)
SearchRegex_large_re_dotstar-10                     570MB ± 0%     570MB ± 0%     ~     (p=0.310 n=5+5)
SearchRegex_large_re_common-10                     6.40MB ± 0%    6.40MB ± 0%   -0.04%  (p=0.095 n=5+5)
SearchRegex_large_re_anchor-10                     4.27MB ± 0%    4.26MB ± 1%     ~     (p=0.841 n=5+5)
SearchRegex_large_path/path_only-10                1.03kB ± 1%    1.01kB ± 1%   -1.55%  (p=0.008 n=5+5)
SearchRegex_large_path/content_only-10             50.6kB ± 0%    51.4kB ± 1%   +1.59%  (p=0.016 n=4+5)
SearchRegex_large_path/both_path_and_content-10    50.6kB ± 0%    51.2kB ± 1%   +1.25%  (p=0.008 n=5+5)
SearchRegex_small_fixed-10                          360kB ± 0%     348kB ± 0%   -3.24%  (p=0.008 n=5+5)
SearchRegex_small_fixed_casesensitive-10           4.71kB ± 0%    5.08kB ± 0%   +7.87%  (p=0.008 n=5+5)
SearchRegex_small_re_dotstar-10                    3.75MB ± 0%    3.75MB ± 0%   -0.08%  (p=0.032 n=5+5)
SearchRegex_small_re_common-10                     38.7kB ± 0%    39.1kB ± 0%   +1.00%  (p=0.008 n=5+5)
SearchRegex_small_re_anchor-10                     18.3kB ± 0%    18.7kB ± 0%   +2.33%  (p=0.008 n=5+5)

name                                             old allocs/op  new allocs/op  delta
SearchRegex_large_fixed-10                            186 ± 1%       188 ± 1%     ~     (p=0.111 n=5+5)
SearchRegex_rare_fixed-10                             492 ± 0%       493 ± 0%     ~     (p=0.246 n=5+5)
SearchRegex_large_fixed_casesensitive-10              138 ± 0%       142 ± 0%   +2.90%  (p=0.008 n=5+5)
SearchRegex_large_re_dotstar-10                     4.51M ± 0%     4.51M ± 0%     ~     (p=0.841 n=5+5)
SearchRegex_large_re_common-10                      50.6k ± 0%     50.6k ± 0%     ~     (p=0.333 n=5+5)
SearchRegex_large_re_anchor-10                      37.9k ± 0%     37.9k ± 0%     ~     (p=0.190 n=5+5)
SearchRegex_large_path/path_only-10                  20.0 ± 0%      19.0 ± 0%   -5.00%  (p=0.008 n=5+5)
SearchRegex_large_path/content_only-10                462 ± 0%       466 ± 0%   +0.87%  (p=0.008 n=5+5)
SearchRegex_large_path/both_path_and_content-10       462 ± 0%       466 ± 0%   +0.87%  (p=0.008 n=5+5)
SearchRegex_small_fixed-10                           82.0 ± 0%      85.6 ± 1%   +4.39%  (p=0.008 n=5+5)
SearchRegex_small_fixed_casesensitive-10             74.0 ± 0%      78.0 ± 0%   +5.41%  (p=0.008 n=5+5)
SearchRegex_small_re_dotstar-10                     29.6k ± 0%     29.6k ± 0%   +0.01%  (p=0.008 n=5+5)
SearchRegex_small_re_common-10                        387 ± 0%       391 ± 0%   +1.03%  (p=0.008 n=5+5)
SearchRegex_small_re_anchor-10                        235 ± 0%       239 ± 0%   +1.70%  (p=0.008 n=5+5)
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
