### PR TITLE
Upserting user permissions is strictly additive

### DIFF
--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -439,12 +439,12 @@ func testPermsStore_SetUserPermissions(db database.DB) func(*testing.T) {
 				},
 			},
 			expectUserPerms: map[int32][]uint32{
-				1: {2, 3},
-				2: {1, 3},
+				1: {1, 2, 3},
+				2: {1, 2, 3},
 			},
 			expectRepoPerms: map[int32][]uint32{
-				1: {2},
-				2: {1},
+				1: {1, 2},
+				2: {1, 2},
 				3: {1, 2},
 			},
 		},
@@ -462,12 +462,12 @@ func testPermsStore_SetUserPermissions(db database.DB) func(*testing.T) {
 				},
 			},
 			expectUserPerms: map[int32][]uint32{
-				1: {},
+				1: {1, 2, 3},
 			},
 			expectRepoPerms: map[int32][]uint32{
-				1: {},
-				2: {},
-				3: {},
+				1: {1},
+				2: {1},
+				3: {1},
 			},
 		},
 		{


### PR DESCRIPTION
Alternative option that makes user-centric permissions syncing purely additive. This means that user-centric permissions syncing can be used to speed up the permissions syncing process, but it cannot take permissions away that repo-centric permissions syncing has granted.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Updated unit tests