### PR TITLE
Add rem unit to fix hover tooltip line-height when rendering on GitHub

### DIFF
--- a/client/shared/src/hover/HoverOverlayContents.module.scss
+++ b/client/shared/src/hover/HoverOverlayContents.module.scss
@@ -25,7 +25,7 @@
         margin-top: var(--hover-overlay-content-margin-top);
         margin-bottom: 0.5rem;
         // Required for the correct line-height of the `<code>` element.
-        line-height: 1;
+        line-height: 1rem;
     }
 
     code {


### PR DESCRIPTION
## Test plan

Manually tested in browser 

On GitHub (before)
<img width="551" alt="Screen Shot 2022-07-11 at 3 22 34 PM" src="https://user-images.githubusercontent.com/754768/178342042-85919323-e597-4f98-b896-5ec375716466.png">

On GitHub (after)
<img width="552" alt="Screen Shot 2022-07-11 at 3 23 15 PM" src="https://user-images.githubusercontent.com/754768/178342167-14037b4d-9f33-414e-a339-0129ef3eeb81.png">

## App preview:

- [Web](https://sg-web-ns-hoverlineheight.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-agdnnlrscj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
