### PR TITLE
email: Use configuration email address in render func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The file view does not jump to the first selected line anymore when selecting multiple lines and the first selected line was out of view. [#38175](https://github.com/sourcegraph/sourcegraph/pull/38175)
 - Fixed an issue where multiple activations of the back button are required to navigate back to a previously selected line in a file [#38193](https://github.com/sourcegraph/sourcegraph/pull/38193)
 - Support timestamps with numeric timezone format from Gitlab's Webhook payload [#38250](https://github.com/sourcegraph/sourcegraph/pull/38250)
+- Fixed regression of mismatched `From` address when render emails. [#38589](https://github.com/sourcegraph/sourcegraph/pull/38589)
 
 ### Removed
 

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -40,7 +40,7 @@ var emailSendCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 func render(message Message) (*email.Email, error) {
 	m := email.Email{
 		To:      message.To,
-		From:    "Sourcegraph",
+		From:    conf.Get().EmailAddress,
 		Headers: make(textproto.MIMEHeader),
 	}
 	if message.ReplyTo != nil {


### PR DESCRIPTION
I'm disappointed Google SMTP let you send with an invalid From email address, nevertheless this should fix this.

Fixes regression in: https://github.com/sourcegraph/sourcegraph/pull/37255

---

Alternatively we could just add this back under the render:

```go
m.From = conf.EmailAddress
```

and then we should probably stop setting `From` in the `render()` func, and update the tests not to validate the value of `From` in the returned message.

Or if we don't like the render func relying on the `conf` object, we could require the render to take a specified function parameter like, default email address, provided by the conf object in the `Send()` func.

It's all entirely up to you guys and how you want to fix this.

# Test plan

Manual e2e tests:

1. For regular SMTP: use email.smtp credentials prepopulated from the "dev-private".

2. For Google SMTP relay, change the site config:

```
"email.smtp": {
"authentication": "PLAIN",
  "username": "<you>@sourcegraph.com",
  "password": "<App password>",
  "host": "smtp-relay.gmail.com",
  "port": 587,
  "domain": "sourcegraph.com"
},
```

3. Add a new valid email to your user settings.
4. Receive the verification email.
