### PR TITLE
Remove "nuke" wording for user deletion

### DIFF
--- a/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { mdiCog, mdiDelete, mdiRadioactive, mdiPlus } from '@mdi/js'
+import { mdiCog, mdiPlus } from '@mdi/js'
 import * as H from 'history'
 import { isEqual } from 'lodash'
 import { RouteComponentProps } from 'react-router'
@@ -56,8 +56,8 @@ interface UserNodeState {
 }
 
 const nukeDetails = `
-- By deleting a user, the user and ALL associated data is marked as deleted in the DB and never served again. You could undo this by running DB commands manually.
-- By nuking a user, the user and ALL associated data is deleted forever (you CANNOT undo this). When deleting data at a user's request, nuking is used.
+- When deleting a user normally, the user and ALL associated data is marked as deleted in the DB and never served again. You could undo this by running DB commands manually.
+- By deleting a user forever, the user and ALL associated data will be permanently removed from the DB (you CANNOT undo this). When deleting data at a user's request, "Delete forever" is used.
 
 Beware this includes e.g. deleting extensions authored by the user, deleting ANY settings authored or updated by the user, etc.
 
@@ -196,15 +196,8 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                                 </Button>
                             ))}{' '}
                         {this.props.node.id !== this.props.authenticatedUser.id && (
-                            <Button
-                                onClick={this.deleteUser}
-                                disabled={this.state.loading}
-                                data-tooltip="Delete user"
-                                variant="danger"
-                                size="sm"
-                                aria-label="Delete User"
-                            >
-                                <Icon aria-hidden={true} svgPath={mdiDelete} />
+                            <Button onClick={this.deleteUser} disabled={this.state.loading} variant="danger" size="sm">
+                                Delete
                             </Button>
                         )}
                         {this.props.node.id !== this.props.authenticatedUser.id && (
@@ -212,12 +205,10 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                                 className="ml-1"
                                 onClick={this.nukeUser}
                                 disabled={this.state.loading}
-                                data-tooltip="Nuke user (click for more information)"
                                 variant="danger"
                                 size="sm"
-                                aria-label="Nuke user (click for more information)"
                             >
-                                <Icon aria-hidden={true} svgPath={mdiRadioactive} />
+                                Delete forever
                             </Button>
                         )}
                     </div>
@@ -330,7 +321,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
     private doDeleteUser = (hard: boolean): void => {
         let message = `Delete the user ${this.props.node.username}?`
         if (hard) {
-            message = `Nuke the user ${this.props.node.username}?${nukeDetails}`
+            message = `Delete the user ${this.props.node.username} forever?${nukeDetails}`
         }
         if (!window.confirm(message)) {
             return

--- a/doc/admin/user_data_deletion.md
+++ b/doc/admin/user_data_deletion.md
@@ -4,10 +4,10 @@ As a site administrator, you have the ability to delete users and their associat
 
 On this page, you are presented two options:
 
-- Deleting a user: the user and ALL associated data is marked as deleted in the DB and never served again. You could undo this by running DB commands manually.
-- Nuking a user, the user and ALL associated data is deleted forever (you CANNOT undo this).
+- "Delete": the user and ALL associated data is marked as deleted in the DB and never served again. You could undo this by running DB commands manually.
+- "Delete forever": the user and ALL associated data is permanently removed from the DB (you CANNOT undo this).
 
-When deleting or nuking a user, the following information is removed:
+When deleting a user with either option, the following information is removed:
 
 - All user data (access tokens, email addresses, external account info, survey responses, etc)
 - Organization membership information (which organizations the user is a part of, any invitations created by or targeting the user).


### PR DESCRIPTION
Brought up in both #35823 and #16035, I was confronted with editing this wording during other work. [With the help](https://sourcegraph.slack.com/archives/C0HMGV90V/p1657560863602519?thread_ts=1657559932.257299&cid=C0HMGV90V) of @quinnkeast, we decided to make some small adjustments that can enable use to remove the verb "nuke" without waiting on bigger decisions for #16035.

Pulled just these changes into their own PR to keep it simple.

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lrh-remove-nuke-wording.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fegofmbpbq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
