### PR TITLE
dev/sg: fix slack integration, use PromptPassword

### DIFF
--- a/dev/sg/internal/bk/bk.go
+++ b/dev/sg/internal/bk/bk.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/open"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -38,7 +38,7 @@ type AnnotationArtifact struct {
 type JobAnnotations map[string]AnnotationArtifact
 
 // retrieveToken obtains a token either from the cached configuration or by asking the user for it.
-func retrieveToken(ctx context.Context, out *output.Output) (string, error) {
+func retrieveToken(ctx context.Context, out *std.Output) (string, error) {
 	if tok := os.Getenv("BUILDKITE_API_TOKEN"); tok != "" {
 		// If the token is provided by the environment, use that one.
 		return tok, nil
@@ -67,7 +67,7 @@ func retrieveToken(ctx context.Context, out *output.Output) (string, error) {
 }
 
 // getTokenFromUser prompts the user for a slack OAuth token.
-func getTokenFromUser(out *output.Output) (string, error) {
+func getTokenFromUser(out *std.Output) (string, error) {
 	out.WriteLine(output.Linef(output.EmojiLightbulb, output.StylePending, `Please create and copy a new token from https://buildkite.com/user/api-access-tokens with the following scopes:
 
 - Organization access to %q
@@ -79,7 +79,7 @@ func getTokenFromUser(out *output.Output) (string, error) {
 
 To use functionality that manipulates builds, you must also have the 'write_builds' scope.
 `, BuildkiteOrg))
-	return open.Prompt("Paste your token here:")
+	return out.PromptPasswordf(os.Stdin, "Paste your token here:")
 }
 
 type Client struct {
@@ -89,7 +89,7 @@ type Client struct {
 // NewClient returns an authenticated client that can perform various operation on
 // the organization assigned to buildkiteOrg.
 // If there is no token assigned yet, it will be asked to the user.
-func NewClient(ctx context.Context, out *output.Output) (*Client, error) {
+func NewClient(ctx context.Context, out *std.Output) (*Client, error) {
 	token, err := retrieveToken(ctx, out)
 	if err != nil {
 		return nil, err

--- a/dev/sg/sg_audit.go
+++ b/dev/sg/sg_audit.go
@@ -61,7 +61,7 @@ var auditCommand = &cli.Command{
 			if err != nil {
 				return err
 			}
-			slack, err := sgslack.NewClient(ctx.Context)
+			slack, err := sgslack.NewClient(ctx.Context, std.Out)
 			if err != nil {
 				return err
 			}

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -211,7 +211,7 @@ sg ci build --help
 				Usage:   "Open build page in browser",
 			}),
 		Action: func(cmd *cli.Context) error {
-			client, err := bk.NewClient(cmd.Context, std.Out.Output)
+			client, err := bk.NewClient(cmd.Context, std.Out)
 			if err != nil {
 				return err
 			}
@@ -345,7 +345,7 @@ Learn more about pipeline run types in https://docs.sourcegraph.com/dev/backgrou
 		},
 		Action: func(cmd *cli.Context) error {
 			ctx := cmd.Context
-			client, err := bk.NewClient(ctx, std.Out.Output)
+			client, err := bk.NewClient(ctx, std.Out)
 			if err != nil {
 				return err
 			}
@@ -483,7 +483,7 @@ From there, you can start exploring logs with the Grafana explore panel.
 		),
 		Action: func(cmd *cli.Context) error {
 			ctx := cmd.Context
-			client, err := bk.NewClient(ctx, std.Out.Output)
+			client, err := bk.NewClient(ctx, std.Out)
 			if err != nil {
 				return err
 			}

--- a/dev/sg/sg_teammate.go
+++ b/dev/sg/sg_teammate.go
@@ -18,7 +18,7 @@ import (
 )
 
 func getTeamResolver(ctx context.Context) (team.TeammateResolver, error) {
-	slackClient, err := slack.NewClient(ctx)
+	slackClient, err := slack.NewClient(ctx, std.Out)
 	if err != nil {
 		return nil, errors.Newf("slack.NewClient: %w", err)
 	}


### PR DESCRIPTION
`sg handbook` etc were panicking because of nill reference of incorrectly initialized output - this fixes those issues, and updates password prompts to use the secure `PromptPassword`

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="646" alt="image" src="https://user-images.githubusercontent.com/23356519/178365327-5aab1e54-d777-41bd-8147-c98fe00d7533.png">
