### PR TITLE
search frontend: highlight lucky regexp patterns with test

### DIFF
--- a/client/search-ui/src/components/SyntaxHighlightedSearchQuery.story.tsx
+++ b/client/search-ui/src/components/SyntaxHighlightedSearchQuery.story.tsx
@@ -1,6 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
+import { SearchPatternType } from '@sourcegraph/search'
 import { Text } from '@sourcegraph/wildcard'
 
 import { SyntaxHighlightedSearchQuery } from './SyntaxHighlightedSearchQuery'
@@ -23,6 +24,8 @@ export const SyntaxHighlightedSearchQueryStory: Story = () => (
                 <SyntaxHighlightedSearchQuery query="test or spec repo:sourcegraph" />
                 <br />
                 <SyntaxHighlightedSearchQuery query="test -lang:ts" />
+                <br />
+                <SyntaxHighlightedSearchQuery query="/func.*parse/" searchPatternType={SearchPatternType.standard} />
             </Text>
         )}
     </BrandedStory>

--- a/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -91,7 +91,7 @@ export const SyntaxHighlightedSearchQuery: React.FunctionComponent<
     React.PropsWithChildren<SyntaxHighlightedSearchQueryProps>
 > = ({ query, searchPatternType, ...otherProps }) => {
     const tokens = useMemo(() => {
-        const tokens = searchPatternType ? scanSearchQuery(query) : scanSearchQuery(query, false, searchPatternType)
+        const tokens = searchPatternType ? scanSearchQuery(query, false, searchPatternType) : scanSearchQuery(query)
         return tokens.type === 'success'
             ? tokens.term.flatMap(token =>
                   decorate(token).map(token => {


### PR DESCRIPTION
Well I thought https://github.com/sourcegraph/sourcegraph/pull/38581 would cover this but I swapped the expression in the ternary expression 🤦. Was going to add a test anyway so here we are.

<img width="873" alt="Screen Shot 2022-07-11 at 2 56 35 PM" src="https://user-images.githubusercontent.com/888624/178365633-5c772052-6e82-4c83-a69a-faeb0464d9a6.png">



## Test plan
Adds story test

## App preview:

- [Web](https://sg-web-rvt-highlight-query-actually.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tjqdjfrbrk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
