### PR TITLE
Search backend: clean up repo resolver

### DIFF
--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -44,7 +44,7 @@ type Observer struct {
 // raising NoResolvedRepos alerts with suggestions when we know the original
 // query does not contain any repos to search.
 func (o *Observer) reposExist(ctx context.Context, options search.RepoOptions) bool {
-	repositoryResolver := &searchrepos.Resolver{DB: o.Db}
+	repositoryResolver := searchrepos.NewResolver(o.Db)
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0
 }

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -94,8 +94,8 @@ func (j *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 		return doSearch(args)
 	}
 
-	repos := searchrepos.Resolver{DB: clients.DB, Opts: j.RepoOpts}
-	return nil, repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
+	repos := searchrepos.Resolver{DB: clients.DB}
+	return nil, repos.Paginate(ctx, j.RepoOpts, func(page *searchrepos.Resolved) error {
 		g := group.New().WithContext(ctx).WithMaxConcurrency(j.Concurrency).WithFirstError()
 
 		for _, repoRev := range page.RepoRevs {

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -94,7 +94,7 @@ func (j *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 		return doSearch(args)
 	}
 
-	repos := searchrepos.Resolver{DB: clients.DB}
+	repos := searchrepos.NewResolver(clients.DB)
 	return nil, repos.Paginate(ctx, j.RepoOpts, func(page *searchrepos.Resolved) error {
 		g := group.New().WithContext(ctx).WithMaxConcurrency(j.Concurrency).WithFirstError()
 

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -85,7 +85,7 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 
 	var maxAlerter search.MaxAlerter
 
-	repoResolver := &repos.Resolver{DB: clients.DB, Opts: p.repoOpts}
+	repoResolver := &repos.Resolver{DB: clients.DB}
 	pager := func(page *repos.Resolved) error {
 		indexed, unindexed, err := zoekt.PartitionRepos(
 			ctx,
@@ -106,7 +106,7 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 		return err
 	}
 
-	return maxAlerter.Alert, repoResolver.Paginate(ctx, pager)
+	return maxAlerter.Alert, repoResolver.Paginate(ctx, p.repoOpts, pager)
 }
 
 func (p *repoPagerJob) Name() string {

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -85,7 +85,7 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 
 	var maxAlerter search.MaxAlerter
 
-	repoResolver := &repos.Resolver{DB: clients.DB}
+	repoResolver := repos.NewResolver(clients.DB)
 	pager := func(page *repos.Resolved) error {
 		indexed, unindexed, err := zoekt.PartitionRepos(
 			ctx,

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -50,18 +50,16 @@ func (r *Resolved) String() string {
 }
 
 type Resolver struct {
-	DB   database.DB
-	Opts search.RepoOptions
+	DB database.DB
 }
 
-func (r *Resolver) Paginate(ctx context.Context, handle func(*Resolved) error) (err error) {
+func (r *Resolver) Paginate(ctx context.Context, opts search.RepoOptions, handle func(*Resolved) error) (err error) {
 	tr, ctx := trace.New(ctx, "searchrepos.Paginate", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
 
-	opts := r.Opts
 	if opts.Limit == 0 {
 		opts.Limit = 500
 	}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -49,6 +49,10 @@ func (r *Resolved) String() string {
 	return fmt.Sprintf("Resolved{RepoRevs=%d, MissingRepoRevs=%d, OverLimit=%v}", len(r.RepoRevs), len(r.MissingRepoRevs), r.OverLimit)
 }
 
+func NewResolver(db database.DB) *Resolver {
+	return &Resolver{DB: db}
+}
+
 type Resolver struct {
 	DB database.DB
 }

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -93,8 +93,7 @@ func (r *Resolver) Paginate(ctx context.Context, handle func(*Resolved) error) (
 	return errs
 }
 
-func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved, error) {
-	var err error
+func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolved, err error) {
 	tr, ctx := trace.New(ctx, "searchrepos.Resolve", op.String())
 	defer func() {
 		tr.SetError(err)

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -371,10 +371,10 @@ func TestResolverPaginate(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			r := Resolver{Opts: tc.opts, DB: db}
+			r := Resolver{DB: db}
 
 			var pages []Resolved
-			err := r.Paginate(ctx, func(page *Resolved) error {
+			err := r.Paginate(ctx, tc.opts, func(page *Resolved) error {
 				pages = append(pages, *page)
 				return nil
 			})

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -164,7 +164,7 @@ func TestRevisionValidation(t *testing.T) {
 			db.ReposFunc.SetDefaultReturn(repos)
 
 			op := search.RepoOptions{RepoFilters: tt.repoFilters}
-			repositoryResolver := &Resolver{DB: db}
+			repositoryResolver := NewResolver(db)
 			resolved, err := repositoryResolver.Resolve(context.Background(), op)
 
 			if diff := cmp.Diff(tt.wantRepoRevs, resolved.RepoRevs); diff != "" {
@@ -320,7 +320,7 @@ func TestResolverPaginate(t *testing.T) {
 		}
 	}
 
-	all, err := (&Resolver{DB: db}).Resolve(ctx, search.RepoOptions{})
+	all, err := NewResolver(db).Resolve(ctx, search.RepoOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +371,7 @@ func TestResolverPaginate(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			r := Resolver{DB: db}
+			r := NewResolver(db)
 
 			var pages []Resolved
 			err := r.Paginate(ctx, tc.opts, func(page *Resolved) error {
@@ -447,7 +447,7 @@ func TestResolveRepositoriesWithUserSearchContext(t *testing.T) {
 	op := search.RepoOptions{
 		SearchContextSpec: "@" + wantName,
 	}
-	repositoryResolver := &Resolver{DB: db}
+	repositoryResolver := NewResolver(db)
 	resolved, err := repositoryResolver.Resolve(context.Background(), op)
 	if err != nil {
 		t.Fatal(err)
@@ -525,7 +525,7 @@ func TestResolveRepositoriesWithSearchContext(t *testing.T) {
 	op := search.RepoOptions{
 		SearchContextSpec: "searchcontext",
 	}
-	repositoryResolver := &Resolver{DB: db}
+	repositoryResolver := NewResolver(db)
 	resolved, err := repositoryResolver.Resolve(context.Background(), op)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -28,8 +28,8 @@ func (s *RepoSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts}
-	err = repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
+	repos := &searchrepos.Resolver{DB: clients.DB}
+	err = repos.Paginate(ctx, s.RepoOpts, func(page *searchrepos.Resolved) error {
 		tr.LogFields(log.Int("resolved.len", len(page.RepoRevs)))
 
 		// Filter the repos if there is a repohasfile: or -repohasfile field.

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -28,7 +28,7 @@ func (s *RepoSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	repos := &searchrepos.Resolver{DB: clients.DB}
+	repos := searchrepos.NewResolver(clients.DB)
 	err = repos.Paginate(ctx, s.RepoOpts, func(page *searchrepos.Resolved) error {
 		tr.LogFields(log.Int("resolved.len", len(page.RepoRevs)))
 

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -165,7 +165,7 @@ func (s *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	repos := &searchrepos.Resolver{DB: clients.DB}
+	repos := searchrepos.NewResolver(clients.DB)
 	return nil, repos.Paginate(ctx, s.RepoOpts, func(page *searchrepos.Resolved) error {
 		indexed, unindexed, err := zoektutil.PartitionRepos(
 			ctx,

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -165,8 +165,8 @@ func (s *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts}
-	return nil, repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
+	repos := &searchrepos.Resolver{DB: clients.DB}
+	return nil, repos.Paginate(ctx, s.RepoOpts, func(page *searchrepos.Resolved) error {
 		indexed, unindexed, err := zoektutil.PartitionRepos(
 			ctx,
 			clients.Logger,


### PR DESCRIPTION
I'm working to move `repo:contains` operations work within the repo resolver. First up though, some cleanup.

1) Don't store options on the repo resolver. We should pass those in every time we call `Resolve` or `Paginate`, otherwise it's not really clear which we are using. Additionally, it makes a resolver re-usable for different calls.
2) Create a constructor for `Resolver` and use it
3) Make resolver fields private so it can't be constructed directly and we must go through the constructor.

## Test plan

Semantics-preserving. Depending on unit tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
