### PR TITLE
batches: improve keyboard navigation for server-side execution flow

### DIFF
--- a/client/shared/src/components/MonacoEditor.tsx
+++ b/client/shared/src/components/MonacoEditor.tsx
@@ -197,6 +197,9 @@ interface Props extends ThemeProps {
      * Issue to improve this: https://github.com/sourcegraph/sourcegraph/issues/29438
      */
     placeholder?: string
+
+    /** Whether to autofocus the Monaco editor when it mounts. Default: false. */
+    autoFocus?: boolean
 }
 
 interface State {
@@ -256,6 +259,10 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
     }
 
     public componentDidMount(): void {
+        if (this.props.autoFocus) {
+            this.focusInput()
+        }
+
         this.subscriptions.add(
             this.componentUpdates
                 .pipe(

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -277,6 +277,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                         <H4 className={styles.header}>Batch spec</H4>
                         {executionAlert}
                         <MonacoBatchSpecEditor
+                            autoFocus={true}
                             batchChangeName={batchChange.name}
                             className={styles.editor}
                             isLightTheme={isLightTheme}

--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.tsx
@@ -30,6 +30,7 @@ export interface Props extends ThemeProps {
     value: string | undefined
     onChange?: (newValue: string) => void
     readOnly?: boolean | undefined
+    autoFocus?: boolean
 }
 
 interface State {}
@@ -86,6 +87,7 @@ export class MonacoBatchSpecEditor extends React.PureComponent<Props, State> {
                 isLightTheme={this.props.isLightTheme}
                 value={this.props.value}
                 editorWillMount={this.editorWillMount}
+                autoFocus={this.props.autoFocus}
                 options={{
                     lineNumbers: 'on',
                     minimap: { enabled: false },

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.module.scss
@@ -49,13 +49,15 @@
     overflow-y: hidden;
 }
 
+.toggle-example-button-container {
+    display: inline-block;
+    width: 6rem;
+}
+
 .toggle-example-button {
-    line-height: 0.75rem;
     font-size: 0.75rem;
     padding: 0;
     border: none;
-    vertical-align: baseline;
-    width: 6rem;
 }
 
 .on-example {

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -197,7 +197,13 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<
             </H4>
             <animated.div style={exampleStyle} className={styles.onExample}>
                 <div ref={exampleReference} className="pt-2 pb-3">
-                    <CodeSnippet className="w-100 m-0" code={ON_STATEMENT} language="yaml" withCopyButton={true} />
+                    {/* Hide the copy button while the example is closed so that it's not focusable. */}
+                    <CodeSnippet
+                        className="w-100 m-0"
+                        code={ON_STATEMENT}
+                        language="yaml"
+                        withCopyButton={exampleOpen}
+                    />
                 </div>
             </animated.div>
         </>

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -133,22 +133,32 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<
         }
     }, [isWorkspacesPreviewInProgress, start, stop])
 
-    const ctaButton = isWorkspacesPreviewInProgress ? (
-        <Button className="mt-2 mb-2" variant="secondary" onClick={cancel}>
-            Cancel
-        </Button>
-    ) : (
-        <Tooltip content={typeof isPreviewDisabled === 'string' ? isPreviewDisabled : undefined}>
-            <Button
-                className="mt-2 mb-2"
-                variant="success"
-                disabled={!!isPreviewDisabled}
-                onClick={() => preview(debouncedCode)}
+    // We use the same `<Button />` and just swap props so that we keep the same element
+    // hierarchy when the preview is in progress as when it is not. We do this in order to
+    // maintain focus on the button between state changes.
+    const ctaButton = useMemo(
+        () => (
+            <Tooltip
+                content={
+                    !isWorkspacesPreviewInProgress && typeof isPreviewDisabled === 'string'
+                        ? isPreviewDisabled
+                        : undefined
+                }
             >
-                <Icon aria-hidden={true} className="mr-1" svgPath={mdiMagnify} />
-                {error ? 'Retry preview' : 'Preview workspaces'}
-            </Button>
-        </Tooltip>
+                <Button
+                    variant={isWorkspacesPreviewInProgress ? 'secondary' : 'success'}
+                    onClick={isWorkspacesPreviewInProgress ? cancel : () => preview(debouncedCode)}
+                    // The "Cancel" button is always enabled while the preview is in progress
+                    disabled={!isWorkspacesPreviewInProgress && !!isPreviewDisabled}
+                >
+                    {!isWorkspacesPreviewInProgress && (
+                        <Icon aria-hidden={true} className="mr-1" svgPath={mdiMagnify} />
+                    )}
+                    {isWorkspacesPreviewInProgress ? 'Cancel' : error ? 'Retry preview' : 'Preview workspaces'}
+                </Button>
+            </Tooltip>
+        ),
+        [isWorkspacesPreviewInProgress, isPreviewDisabled, cancel, preview, debouncedCode, error]
     )
 
     const [exampleReference, exampleOpen, setExampleOpen, exampleStyle] = useAccordion()

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -182,17 +182,15 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<
         <H4 className={styles.instruction}>Finish editing your batch spec, then manually preview repositories.</H4>
     ) : (
         <>
-            <H4 className={styles.instruction}>
-                {hasPreviewed ? 'Modify your' : 'Add an'} <span className="text-monospace">on:</span> statement to
-                preview repositories.
+            <H4 className={classNames(styles.instruction, 'd-flex align-items-center')}>
+                {hasPreviewed ? 'Modify your' : 'Add an'}
+                <span className="text-monospace mx-1">on:</span> statement to preview repositories.
                 {!hasPreviewed && (
-                    <Button
-                        className={styles.toggleExampleButton}
-                        display="inline"
-                        onClick={() => setExampleOpen(!exampleOpen)}
-                    >
-                        {exampleOpen ? 'Close example' : 'See example'}
-                    </Button>
+                    <div className={styles.toggleExampleButtonContainer}>
+                        <Button className={styles.toggleExampleButton} onClick={() => setExampleOpen(!exampleOpen)}>
+                            {exampleOpen ? 'Close example' : 'See example'}
+                        </Button>
+                    </div>
                 )}
             </H4>
             <animated.div style={exampleStyle} className={styles.onExample}>

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -150,6 +150,7 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                     disabled={true}
                 />
                 <Input
+                    autoFocus={true}
                     label="Batch change name"
                     value={nameInput}
                     onChange={onNameChange}


### PR DESCRIPTION
This PR features several changes that improve the keyboard navigational experience for users of the new server-side execution workflows:

- Autofocusing of batch change name field on configuration (step 1) form
- Autofocusing of Monaco editor on edit (step 2)
- Improved focus indicator on "See example" button that opens `on:` example code snippet
- Maintained focus on primary CTA in workspaces preview when transitioning between in progress an finished/canceled state
- Fixed ability to focus on hidden elements

## Test plan

All fixes tested manually in accordance with keyboard navigation [auditing guidelines](https://docs.sourcegraph.com/dev/background-information/web/accessibility/how-to-audit#auditing-a-user-journey).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-ssbc-keyboard-navigation.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uiazagulfx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
