### PR TITLE
Search backend: clean up repo resolver pt. 2

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -260,7 +260,7 @@ func StructuralSearchEnabled() bool {
 	return val == "enabled"
 }
 
-func DependeciesSearchEnabled() bool {
+func DependenciesSearchEnabled() bool {
 	val := ExperimentalFeatures().DependenciesSearch
 	if val == "" {
 		return true

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -534,7 +534,7 @@ func (r *Resolver) dependencies(ctx context.Context, op *search.RepoOptions) (_ 
 		tr.Finish()
 	}()
 
-	if !conf.DependeciesSearchEnabled() {
+	if !conf.DependenciesSearchEnabled() {
 		return nil, nil, nil, errors.Errorf("support for `repo:dependencies()` is disabled in site config (`experimentalFeatures.dependenciesSearch`)")
 	}
 
@@ -619,7 +619,7 @@ func (r *Resolver) dependents(ctx context.Context, op *search.RepoOptions) (_ []
 		tr.Finish()
 	}()
 
-	if !conf.DependeciesSearchEnabled() {
+	if !conf.DependenciesSearchEnabled() {
 		return nil, nil, errors.Errorf("support for `repo:dependents()` is disabled in site config (`experimentalFeatures.dependenciesSearch`)")
 	}
 

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -229,11 +229,8 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolv
 		repo, i := repo, i // avoid race
 
 		g.Go(func(ctx context.Context) error {
-
-			var (
-				repoRev = search.RepositoryRevisions{Repo: repo}
-				revs    []search.RevisionSpecifier
-			)
+			repoRev := search.RepositoryRevisions{Repo: repo}
+			revs := []search.RevisionSpecifier(nil)
 
 			if len(dependencyRevs) > 0 {
 				revs = dependencyRevs[repo.Name]

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -319,7 +319,6 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolv
 				}
 
 				if op.CommitAfter != "" {
-
 					if hasCommitAfter, err := client.HasCommitAfter(ctx, repo.Name, op.CommitAfter, string(commitID), authz.DefaultSubRepoPermsChecker); err != nil {
 						if !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) && !gitdomain.IsRepoNotExist(err) {
 							res.Lock()


### PR DESCRIPTION
Builds off of https://github.com/sourcegraph/sourcegraph/pull/38598

1) Fix a typo `Dependecies`
2) Move dependency fetching logic into another method
3) Refactor goroutine group to use `lib/group` to avoid bad behavior when returning early from semaphore error
4) Make variable declarations more consise
5) Refactor to avoid mutating fields of a struct, preferring to build the fields then construct the struct with all the parts
6) Avoid constructing a gitserver client for every rev, instead preferring to store the client on the resolver, which also makes it possible to pass in a mock client.

## Test plan

Semantics-preserving, unit tests. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
