### PR TITLE
batches: fix missing mocks for batch change not found story

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
@@ -152,17 +152,32 @@ export const EditLatestBatchSpec: Story = () => (
 
 EditLatestBatchSpec.storyName = 'editing the latest batch spec'
 
+const NOT_FOUND_MOCKS = new WildcardMockLink([
+    {
+        request: {
+            query: getDocumentNode(GET_BATCH_CHANGE_TO_EDIT),
+            variables: MATCH_ANY_PARAMETERS,
+        },
+        result: { data: { batchChange: null } },
+        nMatches: Number.POSITIVE_INFINITY,
+    },
+    ACTIVE_EXECUTORS_MOCK,
+    ...UNSTARTED_CONNECTION_MOCKS,
+])
+
 export const BatchChangeNotFound: Story = () => (
     <WebStory>
         {props => (
-            <EditBatchSpecPage
-                {...props}
-                batchChange={{
-                    name: 'doesnt-exist',
-                    namespace: 'test1234',
-                }}
-                settingsCascade={SETTINGS_CASCADE}
-            />
+            <MockedTestProvider link={NOT_FOUND_MOCKS}>
+                <EditBatchSpecPage
+                    {...props}
+                    batchChange={{
+                        name: 'doesnt-exist',
+                        namespace: 'test1234',
+                    }}
+                    settingsCascade={SETTINGS_CASCADE}
+                />
+            </MockedTestProvider>
         )}
     </WebStory>
 )


### PR DESCRIPTION
At some point (probably in the week before beta launch when EVERYTHING was happening 🙂) the mock data requirements for the `EditBatchSpecPage` storybook stories changed, and the story for when the batch change is not found broke. This just supplies mock data for the missing request.

## Test plan

Verified storybook story no longer throws error.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-fix-story-data.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dbmpjbagpn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
