### PR TITLE
sg: remove useless env var from sg.config.yaml

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -365,9 +365,6 @@ commands:
       docker inspect syntax-highlighter >/dev/null 2>&1 && docker rm -f syntax-highlighter || true
       # Pull syntax-highlighter latest insider image, only during install
       docker pull -q sourcegraph/syntax-highlighter:insiders
-    env:
-      # This is not needed actually
-      INSECURE_DEV: 1
 
   zoekt-indexserver-template: &zoekt_indexserver_template
     cmd: |


### PR DESCRIPTION
I was just trying out Camden's [dockerless `sg`](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1656541550515079)
and ran into this again.

Pretty sure that I can trust past-me that the comment is correct and
that it's actually useless. We use `INSECURE_DEV` in our app in some
places, but pretty sure rocket/syntect/http-server-stabilizer don't use
it.

## Test plan

- Ran it locally