### PR TITLE
Accessibility: Improve Fuzzy Finder UX for small / zoomed screens

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -1,3 +1,5 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .modal {
     height: 80vh;
     width: 80vw;
@@ -23,7 +25,7 @@
 }
 
 .results {
-    overflow: hidden auto;
+    overflow: auto;
     flex: 1;
     text-align: left;
     list-style-type: none;
@@ -38,6 +40,11 @@
 .summary {
     display: flex;
     margin-bottom: 0.5rem;
+
+    @media (--xs-breakpoint-down) {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
 }
 
 .result-count {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35251

## Description

- Breaks result count onto a new line on small screens
- Removes `overflow: hidden` which blocks horizontal scroll
  - Unsure if we intended to do this, horizontal scroll will only show when the text overflows, in which case we definitely want to allow users to be able to view all of the file path

## Screenshots
(Note "After" includes scrolling the list horizontally, which wasn't possible before) 
| BEFORE             |  AFTER |
:-------------------------:|:-------------------------:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/9516420/178455899-ee1f71c8-85e8-4566-abe1-f553a13e46fb.png"> | <img width="419" alt="image" src="https://user-images.githubusercontent.com/9516420/178455973-8052e80e-a1dd-4b16-9e6d-45d83557f956.png">



## Test plan

Tested locally using a responsive screen

## App preview:

- [Web](https://sg-web-tr-fuzzy-finder-mobile.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-auqditefrs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
