### PR TITLE
Accessibility: Update code intel wording

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/GitObjectPreview.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/GitObjectPreview.tsx
@@ -113,7 +113,7 @@ const GitObjectPreview: FunctionComponent<React.PropsWithChildren<GitObjectPrevi
                 {preview.preview.length === 0 ? (
                     <div className="mt-2 pt-2">
                         <div className={styles.empty}>
-                            <Text className="text-monospace">N/A</Text>
+                            <Text className="text-monospace">Not applicable</Text>
                         </div>
                     </div>
                 ) : (


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35189

Small copy change as "N/A" was deemed to be unreadable for screen readers.

Thought: We should probably implement a lint rule if we notice these acronyms causing us issues

## Test plan

N/A - Minimal copy change

## App preview:

- [Web](https://sg-web-tr-na-not-applicable.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-maiawiexgq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
