### PR TITLE
squirrel: Remove usage of raw GitCommand

### DIFF
--- a/cmd/symbols/squirrel/service.go
+++ b/cmd/symbols/squirrel/service.go
@@ -126,12 +126,11 @@ func (squirrel *SquirrelService) symbolInfo(ctx context.Context, point types.Rep
 
 // How to read a file from gitserver.
 func readFileFromGitserver(ctx context.Context, repoCommitPath types.RepoCommitPath) ([]byte, error) {
-	cmd := gitserver.NewClient(nil).GitCommand(api.RepoName(repoCommitPath.Repo), "cat-file", "blob", repoCommitPath.Commit+":"+repoCommitPath.Path)
-	stdout, stderr, err := cmd.DividedOutput(ctx)
+	data, err := gitserver.NewClient(nil).ReadFile(ctx, api.RepoName(repoCommitPath.Repo), api.CommitID(repoCommitPath.Commit), repoCommitPath.Path, nil)
 	if err != nil {
-		return nil, errors.Newf("failed to get file contents: %s\n\nstdout:\n\n%s\n\nstderr:\n\n%s", err, stdout, stderr)
+		return nil, errors.Newf("failed to get file contents: %s", err)
 	}
-	return stdout, nil
+	return data, nil
 }
 
 // DirOrNode is a union type that can either be a directory or a node. It's returned by getDef().

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -184,7 +184,8 @@ type Client interface {
 	// BlameFile returns Git blame information about a file.
 	BlameFile(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, path string, opt *BlameOptions) ([]*Hunk, error)
 
-	// GitCommand creates a new GitCommand.
+	// GitCommand is deprecated. You should use one of the other methods provided
+	// here or add a new one if what you need doesn't exist.
 	GitCommand(repo api.RepoName, args ...string) GitCommand
 
 	// CreateCommitFromPatch will attempt to create a commit from a patch


### PR DESCRIPTION
This method is deprecated and will be removed once all usages are
removed.

Part of https://github.com/sourcegraph/sourcegraph/issues/38235

## Test plan

All tests pass