### PR TITLE
docs: link to package host docs from dep search & extend pkg host docs

### DIFF
--- a/doc/code_search/how-to/dependencies_search.md
+++ b/doc/code_search/how-to/dependencies_search.md
@@ -2,16 +2,19 @@
 
 Dependencies search is a code search feature that lets you search through the dependencies of your repositories.
 
-
 <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code_search/dependencies-search-usage.png" style="margin-left:0;margin-right:0;"/>
 
 ### Setup
 
-1. Configure a package host connection for each kind of dependency you want to search over.
+1. Configure a package host connection for each kind of dependency you want to search over:
+  - [JVM](../../integration/jvm.md)
+  - [npm and Yarn](../../integration/npm.md)
+  - [Go](../../integration/go.md)
+  - [Python dependencies](../../integration/python.md)
 1. Add `"codeIntelLockfileIndexing.enabled": true` to your [site configuration](../../admin/config/site_config.md) to enable the lockfile-indexing feature.
-1. Add `"codeIntelAutoIndexing.allowGlobalPolicies": true` to your [site configuration](../../admin/config/site_config.md) to allow a lockfile-indexing policy to match multiple repositories.
-1. Go to **Site admin > Code intelligence > Configuration** and click on **Create new policy** to create a policy with **Lockfile-indexing** enabled to index the repositories matching this policy. Example: lock-file index all repositories matching the name `go-*` and `go/`.
-1. Wait until lockfile indexing has finished and then run a dependency search.
+1. Add `"codeIntelAutoIndexing.allowGlobalPolicies": true` to your [site configuration](../../admin/config/site_config.md) to allow a lockfile-indexing policy to match multiple repositories. This is **optional** if you want to lockfile-index only single repositories.
+1. Go to **Site admin > Code intelligence > Configuration** and click on **Create new policy** to create a policy with **Lockfile-indexing** enabled to index the repositories matching this policy. Example: lockfile-index all repositories matching the name `go-*` and `go/`.
+1. Wait until the indexing of lockfiles has finished and then run a dependency search.
 
 ### Use cases
 

--- a/doc/integration/go-modules.schema.json
+++ b/doc/integration/go-modules.schema.json
@@ -1,0 +1,1 @@
+../../schema/go-modules.schema.json

--- a/doc/integration/go.md
+++ b/doc/integration/go.md
@@ -10,6 +10,15 @@ Feature | Supported?
 [Rate limiting](#rate-limiting) | ✅
 [Repository permissions](#repository-syncing) | ❌
 
+## Setup
+
+To add Go dependencies to Sourcegraph you need to setup a Go dependencies code host:
+
+1. As *site admin*: go to **Site admin > Manage code hosts**
+1. Select **JVM Dependencies**.
+1. Configure the connection by following the instructions above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
+1. Press **Add repositories**.
+
 ## Repository syncing
 
 There are currently two ways to sync Go dependency repositories.
@@ -48,3 +57,9 @@ This increases the risk of overloading the proxy.
 ## Repository permissions
 
 ⚠️ Go dependency repositories are visible by all users of the Sourcegraph instance.
+
+## Configuration
+
+Go dependencies code host connections support the following configuration options, which are specified in the JSON editor in the site admin "Manage code hosts" area.
+
+<div markdown-func=jsonschemadoc jsonschemadoc:path="integration/go-modules.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/integration/go) to see rendered content.</div>

--- a/doc/integration/jvm-packages.schema.json
+++ b/doc/integration/jvm-packages.schema.json
@@ -1,0 +1,1 @@
+../../schema/jvm-packages.schema.json

--- a/doc/integration/jvm.md
+++ b/doc/integration/jvm.md
@@ -11,6 +11,15 @@ Feature | Supported?
 [Repository permissions](#repository-syncing) | ❌
 [Multiple JVM dependencies code hosts](#multiple-jvm-dependency-code-hosts) | ❌
 
+## Setup
+
+To add JVM dependencies to Sourcegraph you need to setup a JVM Dependencies code host:
+
+1. As *site admin*: go to **Site admin > Manage code hosts**
+1. Select **JVM Dependencies**.
+1. Configure the connection by following the instructions above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
+1. Press **Add repositories**.
+
 ## Repository syncing
 
 There are two ways to sync JVM dependency repositories.
@@ -55,3 +64,9 @@ This increases the risk of overloading the code host.
 
 ⚠️ It's only possible to create one JVM dependency code host for each Sourcegraph instance.
 See the issue [sourcegraph#32461](https://github.com/sourcegraph/sourcegraph/issues/32461) for more details about this limitation. In most situations, it's possible to work around this limitation by configurating multiple Maven repositories to the same JVM dependency code host.
+
+## Configuration
+
+JVM dependencies code host connections support the following configuration options, which are specified in the JSON editor in the site admin "Manage code hosts" area.
+
+<div markdown-func=jsonschemadoc jsonschemadoc:path="integration/jvm-packages.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/integration/jvm) to see rendered content.</div>

--- a/doc/integration/npm-packages.schema.json
+++ b/doc/integration/npm-packages.schema.json
@@ -1,0 +1,1 @@
+../../schema/npm-packages.schema.json

--- a/doc/integration/npm.md
+++ b/doc/integration/npm.md
@@ -11,6 +11,15 @@ Feature | Supported?
 [Repository permissions](#repository-syncing) | ❌
 [Multiple npm dependencies code hosts](#multiple-npm-dependency-code-hosts) | ❌
 
+## Setup
+
+To add npm dependencies to Sourcegraph you need to setup an npm dependencies code host:
+
+1. As *site admin*: go to **Site admin > Manage code hosts**
+1. Select **npm Dependencies**.
+1. Configure the connection by following the instructions above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
+1. Press **Add repositories**.
+
 ## Repository syncing
 
 There are three ways to sync npm dependency repositories.
@@ -52,3 +61,9 @@ This increases the risk of overloading the code host.
 
 ⚠️ It's only possible to create one npm dependency code host for each Sourcegraph instance.
 See the issue [sourcegraph#32499](https://github.com/sourcegraph/sourcegraph/issues/32499) for more details about this limitation. In most situations, it's possible to work around this limitation by configurating a single private npm registry to proxy multiple underlying registries.
+
+## Configuration
+
+npm dependencies code host connections support the following configuration options, which are specified in the JSON editor in the site admin "Manage code hosts" area.
+
+<div markdown-func=jsonschemadoc jsonschemadoc:path="integration/npm-packages.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/integration/npm) to see rendered content.</div>

--- a/doc/integration/python-packages.schema.json
+++ b/doc/integration/python-packages.schema.json
@@ -1,0 +1,1 @@
+../../schema/python-packages.schema.json

--- a/doc/integration/python.md
+++ b/doc/integration/python.md
@@ -10,6 +10,15 @@ Feature | Supported?
 [Rate limiting](#rate-limiting) | ✅
 Repository permissions | ❌
 
+## Setup
+
+To add Python dependencies to Sourcegraph you need to setup a Python dependencies code host:
+
+1. As *site admin*: go to **Site admin > Manage code hosts**
+1. Select **Python Dependencies**.
+1. Configure the connection by following the instructions above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
+1. Press **Add repositories**.
+
 ## Repository syncing
 
 There are currently two ways to sync Python dependency repositories.
@@ -47,3 +56,9 @@ This increases the risk of overloading the proxy.
 ## Repository permissions
 
 ⚠️ Python dependency repositories are visible by all users of the Sourcegraph instance.
+
+## Configuration
+
+Python dependencies code host connections support the following configuration options, which are specified in the JSON editor in the site admin "Manage code hosts" area.
+
+<div markdown-func=jsonschemadoc jsonschemadoc:path="integration/python-packages.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/integration/python) to see rendered content.</div>


### PR DESCRIPTION
This links to the relevant integration pages from the dependency search
page, based on [this feedback](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1653001195872489). (cc @emchap @maaaaaaaax)

It also extends the separate integration pages to include explicit
"Setup" steps and to also include the schema:

<img width="1030" alt="screenshot_2022-07-12_13 54 13@2x" src="https://user-images.githubusercontent.com/1185253/178484092-6bc8de39-176c-4c6f-b3ab-8fec0f66ef4c.png">

<img width="1067" alt="screenshot_2022-07-12_13 54 27@2x" src="https://user-images.githubusercontent.com/1185253/178484144-63c32b0a-0fdd-4e0d-b6c4-e71782651b77.png">

That makes them really similar to the standard code host doc pages we
have: https://docs.sourcegraph.com/admin/external_service

Next step should probably be to migrate these pages to
`admin/external_service` and link to them from the integration page.
Didn't want to do it all in one PR though.

## Test plan

- Tested locally with `sg run docsite` and looking at pages.
