### PR TITLE
Deprecate enableGitServerCommandExecFilter and make it NOOP

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1377,15 +1377,11 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	// See https://github.com/sourcegraph/security-issues/issues/213.
 	if !gitdomain.IsAllowedGitCmd(s.Logger, req.Args) {
 		blockedCommandExecutedCounter.Inc()
-
 		s.Logger.Warn("exec: bad command", log.String("RemoteAddr", r.RemoteAddr), log.Strings("req.Args", req.Args))
 
-		// Temporary feature flag to disable this feature in case their are any regressions.
-		if conf.ExperimentalFeatures().EnableGitServerCommandExecFilter {
-			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte("invalid command"))
-			return
-		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("invalid command"))
+		return
 	}
 
 	ctx := r.Context()

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -591,7 +591,7 @@ type ExperimentalFeatures struct {
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// DependenciesSearch description: Enables support for repo:dependencies predicate queries.
 	DependenciesSearch string `json:"dependenciesSearch,omitempty"`
-	// EnableGitServerCommandExecFilter description: Enable filtering of all exec commands on gitserver based on a pre-defined allowlist
+	// EnableGitServerCommandExecFilter description: DEPRECATED: Setting any value to this flag has no effect.
 	EnableGitServerCommandExecFilter bool `json:"enableGitServerCommandExecFilter,omitempty"`
 	// EnableGithubInternalRepoVisibility description: Enable support for visilibity of internal Github repositories
 	EnableGithubInternalRepoVisibility bool `json:"enableGithubInternalRepoVisibility,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -427,7 +427,7 @@
           "default": false
         },
         "enableGitServerCommandExecFilter": {
-          "description": "Enable filtering of all exec commands on gitserver based on a pre-defined allowlist",
+          "description": "DEPRECATED: Setting any value to this flag has no effect.",
           "type": "boolean",
           "default": true
         },


### PR DESCRIPTION
Follow up on #32030 and also closes #32030.

Part of https://github.com/sourcegraph/security-issues/issues/213.

[Searching](https://sourcegraph.com/search?q=context:%40sourcegraph+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+EnableGitServerCommandExecFilter+rev:ig/deprecate-git-command-exec-filter-flag&patternType=literal) for EnableGitServerCommandExecFilter in the code now returns only the hits where it is declared in the JSON and the generated schema:

![image](https://user-images.githubusercontent.com/2682729/178486297-e451c52f-1d26-4e23-a17f-ee52b297c4a3.png)


## Test plan

Updated tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
