### PR TITLE
Accessibility: Update other `FeedbackPrompt`

### DIFF
--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackIcons.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackIcons.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const VerySad: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
-    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden={true}>
         <path
             d="M20 10C20 15.5228 15.5228 20 10 20C4.47778 20 0 15.5228 0 10C0 4.47778 4.47778 0 10 0C15.5228 0 20 4.47778 20 10Z"
             fill="#FFCC4D"
@@ -14,7 +14,7 @@ export const VerySad: React.FunctionComponent<React.PropsWithChildren<unknown>> 
 )
 
 export const Sad: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
-    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden={true}>
         <path
             d="M20 10C20 15.5228 15.5228 20 10 20C4.47778 20 0 15.5228 0 10C0 4.47778 4.47778 0 10 0C15.5228 0 20 4.47778 20 10Z"
             fill="#FFCC4D"
@@ -35,7 +35,7 @@ export const Sad: React.FunctionComponent<React.PropsWithChildren<unknown>> = ()
 )
 
 export const Happy: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
-    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden={true}>
         <path
             d="M10 20C15.5228 20 20 15.5228 20 10C20 4.47715 15.5228 0 10 0C4.47715 0 0 4.47715 0 10C0 15.5228 4.47715 20 10 20Z"
             fill="#FFCC4D"
@@ -56,7 +56,7 @@ export const Happy: React.FunctionComponent<React.PropsWithChildren<unknown>> = 
 )
 
 export const VeryHappy: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
-    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden={true}>
         <path
             d="M20 10C20 15.5228 15.5228 20 10 20C4.47778 20 0 15.5228 0 10C0 4.47778 4.47778 0 10 0C15.5228 0 20 4.47778 20 10Z"
             fill="#FFCC4D"

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
@@ -1,10 +1,10 @@
 import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
-import CloseIcon from 'mdi-react/CloseIcon'
-import TickIcon from 'mdi-react/TickIcon'
+import { mdiClose, mdiCheck } from '@mdi/js'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
+import { Icon } from '@sourcegraph/wildcard'
 
 import { Popover, PopoverContent, Position, Button, FlexTextArea, LoadingSpinner, Link, H3, Text } from '../..'
 import { useAutoFocus, useLocalStorage } from '../../..'
@@ -105,11 +105,11 @@ const FeedbackPromptContent: React.FunctionComponent<React.PropsWithChildren<Fee
     return (
         <>
             <Button className={styles.close} onClick={onClose}>
-                <CloseIcon className={styles.icon} />
+                <Icon inline={false} svgPath={mdiClose} className={styles.icon} aria-label="Close" />
             </Button>
             {submitResponse?.isHappinessFeedback ? (
                 <div className={styles.success}>
-                    <TickIcon className={styles.successTick} />
+                    <Icon inline={false} svgPath={mdiCheck} className={styles.successTick} aria-label="Success" />
                     <H3>We‘ve received your feedback!</H3>
                     <Text className="d-inline">
                         Thank you for your help.
@@ -127,9 +127,12 @@ const FeedbackPromptContent: React.FunctionComponent<React.PropsWithChildren<Fee
                 </div>
             ) : (
                 <Form onSubmit={handleSubmit}>
-                    <H3 className="mb-3">What’s on your mind?</H3>
+                    <H3 className="mb-3" id="feedback-prompt-question">
+                        What’s on your mind?
+                    </H3>
 
                     <FlexTextArea
+                        aria-labelledby="feedback-prompt-question"
                         onChange={handleTextChange}
                         value={text}
                         minRows={3}

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
@@ -36,9 +36,11 @@ exports[`FeedbackPrompt should render correctly 1`] = `
         type="button"
       >
         <svg
+          aria-label="Close"
           class="mdi-icon icon"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -52,6 +54,7 @@ exports[`FeedbackPrompt should render correctly 1`] = `
       >
         <h3
           class="h3 mb-3"
+          id="feedback-prompt-question"
         >
           What’s on your mind?
         </h3>
@@ -59,6 +62,7 @@ exports[`FeedbackPrompt should render correctly 1`] = `
           class="label label textarea"
         >
           <textarea
+            aria-labelledby="feedback-prompt-question"
             class="textarea form-control resizeNone textarea"
             placeholder="What’s going well? What could be better?"
             rows="3"
@@ -88,6 +92,7 @@ exports[`FeedbackPrompt should render correctly 1`] = `
                 class="emoji"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
                   viewBox="0 0 20 20"
@@ -127,6 +132,7 @@ exports[`FeedbackPrompt should render correctly 1`] = `
                 class="emoji"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
                   viewBox="0 0 20 20"
@@ -174,6 +180,7 @@ exports[`FeedbackPrompt should render correctly 1`] = `
                 class="emoji"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
                   viewBox="0 0 20 20"
@@ -221,6 +228,7 @@ exports[`FeedbackPrompt should render correctly 1`] = `
                 class="emoji"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
                   viewBox="0 0 20 20"
@@ -301,9 +309,11 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
         type="button"
       >
         <svg
+          aria-label="Close"
           class="mdi-icon icon"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -317,6 +327,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
       >
         <h3
           class="h3 mb-3"
+          id="feedback-prompt-question"
         >
           What’s on your mind?
         </h3>
@@ -324,6 +335,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
           class="label label textarea"
         >
           <textarea
+            aria-labelledby="feedback-prompt-question"
             class="textarea form-control resizeNone textarea"
             placeholder="What’s going well? What could be better?"
             rows="3"
@@ -355,6 +367,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
                 class="emoji emojiInactive"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
                   viewBox="0 0 20 20"
@@ -394,6 +407,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
                 class="emoji emojiInactive"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
                   viewBox="0 0 20 20"
@@ -441,6 +455,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
                 class="emoji emojiInactive"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
                   viewBox="0 0 20 20"
@@ -488,6 +503,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
                 class="emoji emojiActive"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
                   viewBox="0 0 20 20"
@@ -581,9 +597,11 @@ exports[`FeedbackPrompt should render submit success correctly 1`] = `
         type="button"
       >
         <svg
+          aria-label="Close"
           class="mdi-icon icon"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -596,9 +614,11 @@ exports[`FeedbackPrompt should render submit success correctly 1`] = `
         class="success"
       >
         <svg
+          aria-label="Success"
           class="mdi-icon successTick"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >


### PR DESCRIPTION
## Description 

Found through a11y audit: https://github.com/sourcegraph/sourcegraph/issues/34413

Fixes:
- Aria hides unnecessary images, where we already have an `aria-label` set through our radio buttons
- Adds labels to important images, so screen readers can "Close" the prompt and can understand the "Success" state
- Labels the feedback prompt title with the text area, so users understand some context of the prompt

<img width="378" alt="image" src="https://user-images.githubusercontent.com/9516420/178494975-86a0a5b2-1773-4741-8994-ee90c487a8f2.png">


## Test plan

Tested locally with a screen reader

## App preview:

- [Web](https://sg-web-tr-feedback-prompt-accessibility.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qtrtsylbod.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
