### PR TITLE
Disable flaky dep search test

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -97,7 +97,9 @@ func TestSearch(t *testing.T) {
 	// Adding and deleting the dependency repos external services in between all other tests is
 	// flaky since deleting an external service doesn't cancel a running external
 	// service sync job for it.
-	t.Run("repo:deps", testDependenciesSearch(client, streamClient))
+	//
+	// DISABLED because flaky
+	// t.Run("repo:deps", testDependenciesSearch(client, streamClient))
 }
 
 // searchClient is an interface so we can swap out a streaming vs graphql


### PR DESCRIPTION
Started failing again: https://buildkite.com/sourcegraph/sourcegraph/builds/159910#0181f248-61fd-43f2-a6c8-1fcc9d8e6d54

## Test plan

- N/A