### PR TITLE
search: Refactor integration tests editor API

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -315,8 +315,8 @@ export const CodeMirrorQueryInput: React.FunctionComponent<
         return (
             <div
                 ref={setContainer}
-                className={classNames(styles.root, className)}
-                data-test-id="codemirror-query-input"
+                className={classNames(styles.root, className, 'test-query-input', 'test-editor')}
+                data-editor="codemirror6"
             />
         )
     }

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -80,6 +80,7 @@ export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBo
                 props.containerClassName,
                 props.hideHelpButton ? styles.searchBoxShadow : null
             )}
+            data-testid="searchbox"
         >
             <div
                 className={classNames(

--- a/client/shared/src/components/MonacoEditor.tsx
+++ b/client/shared/src/components/MonacoEditor.tsx
@@ -291,7 +291,12 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
                     data-placeholder={this.props.placeholder}
                     ref={this.setRef}
                     id={this.props.id}
-                    className={classNames(this.props.className, this.props.border !== false && 'border rounded')}
+                    data-editor="monaco"
+                    className={classNames(
+                        this.props.className,
+                        'test-editor',
+                        this.props.border !== false && 'border rounded'
+                    )}
                 />
                 {this.props.keyboardShortcutForFocus?.keybindings.map((keybinding, index) => (
                     <Shortcut key={index} {...keybinding} onMatch={this.focusInput} />

--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -8,7 +8,7 @@ import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing
 
 import { TimeIntervalStepUnit } from '../../graphql-operations'
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../context'
-import { percySnapshotWithVariants } from '../utils'
+import { createEditorAPI, percySnapshotWithVariants } from '../utils'
 
 import {
     SEARCH_INSIGHT_LIVE_PREVIEW_FIXTURE,
@@ -265,13 +265,10 @@ describe('Code insight create insight page', () => {
         )
 
         // Add first series query
-        await driver.page.waitForSelector('[data-testid="series-form"]:nth-child(1) #monaco-query-input')
-        await driver.replaceText({
-            selector: '[data-testid="series-form"]:nth-child(1) #monaco-query-input',
-            newText: 'test series #1 query',
-            enterTextMethod: 'type',
-            selectMethod: 'keyboard',
-        })
+        {
+            const editor = await createEditorAPI(driver, '[data-testid="series-form"]:nth-child(1) .test-query-input')
+            await editor.replace('test series #1 query')
+        }
 
         // Pick first series color
         await driver.page.click('[data-testid="series-form"]:nth-child(1) label[title="Cyan"]')
@@ -286,13 +283,10 @@ describe('Code insight create insight page', () => {
         )
 
         // Add second series query
-        await driver.page.waitForSelector('[data-testid="series-form"]:nth-child(1) #monaco-query-input')
-        await driver.replaceText({
-            selector: '[data-testid="series-form"]:nth-child(2) #monaco-query-input',
-            newText: 'test series #2 query',
-            enterTextMethod: 'type',
-            selectMethod: 'keyboard',
-        })
+        {
+            const editor = await createEditorAPI(driver, '[data-testid="series-form"]:nth-child(2) .test-query-input')
+            await editor.replace('test series #2 query')
+        }
 
         // With two filled data series our mock for live preview should work - render line chart with two lines
         await driver.page.waitForSelector('[data-testid="code-search-insight-live-preview"] circle')

--- a/client/web/src/integration/insights/edit-search-insights.test.ts
+++ b/client/web/src/integration/insights/edit-search-insights.test.ts
@@ -5,7 +5,7 @@ import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/dri
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../context'
-import { percySnapshotWithVariants } from '../utils'
+import { createEditorAPI, percySnapshotWithVariants } from '../utils'
 
 import { createJITMigrationToGQLInsightMetadataFixture } from './fixtures/insights-metadata'
 import { SEARCH_INSIGHT_LIVE_PREVIEW_FIXTURE } from './fixtures/runtime-insights'
@@ -147,13 +147,10 @@ describe('Code insight edit insight page', () => {
             'test edited series title'
         )
 
-        await driver.page.waitForSelector('[data-testid="series-form"]:nth-child(1) #monaco-query-input')
-        await driver.replaceText({
-            selector: '[data-testid="series-form"]:nth-child(1) #monaco-query-input',
-            newText: 'test edited series query',
-            enterTextMethod: 'type',
-            selectMethod: 'keyboard',
-        })
+        {
+            const editor = await createEditorAPI(driver, '[data-testid="series-form"]:nth-child(1) .test-query-input')
+            await editor.replace('test edited series query')
+        }
 
         await driver.page.click('[data-testid="series-form"]:nth-child(1) label[title="Cyan"]')
 
@@ -170,13 +167,10 @@ describe('Code insight edit insight page', () => {
             'new test series title'
         )
 
-        await driver.page.waitForSelector('[data-testid="series-form"]:nth-child(2) #monaco-query-input')
-        await driver.replaceText({
-            selector: '[data-testid="series-form"]:nth-child(2) #monaco-query-input',
-            newText: 'new test series query',
-            enterTextMethod: 'type',
-            selectMethod: 'keyboard',
-        })
+        {
+            const editor = await createEditorAPI(driver, '[data-testid="series-form"]:nth-child(2) .test-query-input')
+            await editor.replace('new test series query')
+        }
 
         // Change insight Granularity
         await driver.page.type('input[name="stepValue"]', '2')

--- a/client/web/src/integration/org.test.ts
+++ b/client/web/src/integration/org.test.ts
@@ -12,7 +12,7 @@ import { WebGraphQlOperations, OrganizationResult } from '../graphql-operations'
 
 import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults } from './graphQlResults'
-import { percySnapshotWithVariants } from './utils'
+import { createEditorAPI, percySnapshotWithVariants } from './utils'
 
 describe('Organizations', () => {
     const testOrg = subtypeOf<OrganizationResult['organization']>()({
@@ -156,13 +156,8 @@ describe('Organizations', () => {
                 })
                 await driver.page.goto(driver.sourcegraphBaseUrl + '/organizations/sourcegraph/settings')
                 const updatedSettings = '// updated'
-                await driver.page.waitForSelector('.test-settings-file .monaco-editor')
-                await driver.replaceText({
-                    selector: '.test-settings-file .monaco-editor',
-                    newText: updatedSettings,
-                    selectMethod: 'keyboard',
-                    enterTextMethod: 'paste',
-                })
+                const editor = await createEditorAPI(driver, '.test-settings-file .test-editor')
+                await editor.replace(updatedSettings, 'paste')
 
                 const variables = await testContext.waitForGraphQLRequest(async () => {
                     await driver.page.click('.test-save-toolbar-save')

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -136,9 +136,11 @@ describe('Search', () => {
 
                 await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
                 const editor = await createEditorAPI(driver, queryInputSelector)
-                await editor.replace('-repo')
-                await editor.selectSuggestion('-repo')
-                expect(await editor.getValue()).toStrictEqual('-repo:')
+                await editor.replace('-file')
+                await editor.selectSuggestion('-file')
+                // Using a regular expression here because currently the
+                // value for CodeMirror includes placeholders
+                expect(await editor.getValue()).toMatch(/^-file:/)
                 await percySnapshotWithVariants(driver.page, `Search home page (${editorName})`)
                 await accessibilityAudit(driver.page)
             })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -22,7 +22,7 @@ import { WebGraphQlOperations } from '../graphql-operations'
 
 import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
-import { createEditorAPI, EditorAPI, enableEditor, percySnapshotWithVariants, withSearchQueryInput } from './utils'
+import { createEditorAPI, enableEditor, percySnapshotWithVariants, withSearchQueryInput } from './utils'
 
 const mockDefaultStreamEvents: SearchEvent[] = [
     {
@@ -82,6 +82,8 @@ const commonSearchGraphQLResultsWithUser: Partial<
     }),
 }
 
+const queryInputSelector = '[data-testid="searchbox"] .test-query-input'
+
 describe('Search', () => {
     let driver: Driver
     before(async () => {
@@ -125,21 +127,18 @@ describe('Search', () => {
     })
 
     describe('Filter completion', () => {
-        withSearchQueryInput((editorName, editorSelector) => {
-            // skipping because it's flaky, see: https://github.com/sourcegraph/sourcegraph/issues/38633
-            test.skip(`Completing a negated filter should insert the filter with - prefix (${editorName})`, async () => {
-                const editor = createEditorAPI(driver, editorName, editorSelector)
-
+        withSearchQueryInput(editorName => {
+            test(`Completing a negated filter should insert the filter with - prefix (${editorName})`, async () => {
                 testContext.overrideGraphQL({
                     ...commonSearchGraphQLResults,
                     ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
                 })
 
                 await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                await editor.waitForIt()
-                await editor.replace('-file')
-                await editor.selectSuggestion('-file')
-                expect(await editor.getValue()).toStrictEqual('-file:')
+                const editor = await createEditorAPI(driver, queryInputSelector)
+                await editor.replace('-repo')
+                await editor.selectSuggestion('-repo')
+                expect(await editor.getValue()).toStrictEqual('-repo:')
                 await percySnapshotWithVariants(driver.page, `Search home page (${editorName})`)
                 await accessibilityAudit(driver.page)
             })
@@ -147,10 +146,8 @@ describe('Search', () => {
     })
 
     describe('Suggestions', () => {
-        withSearchQueryInput((editorName, editorSelector) => {
+        withSearchQueryInput(editorName => {
             test(`Typing in the search field shows relevant suggestions (${editorName})`, async () => {
-                const editor = createEditorAPI(driver, editorName, editorSelector)
-
                 testContext.overrideGraphQL({
                     ...commonSearchGraphQLResults,
                     ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
@@ -186,7 +183,7 @@ describe('Search', () => {
 
                 // Repo autocomplete from homepage
                 await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                await editor.waitForIt()
+                const editor = await createEditorAPI(driver, queryInputSelector)
                 await editor.focus()
                 await editor.replace('repo:go-jwt-middlew')
                 await editor.selectSuggestion('github.com/auth0/go-jwt-middleware')
@@ -217,13 +214,9 @@ describe('Search', () => {
     })
 
     describe('Search field value', () => {
-        withSearchQueryInput((editorName, editorSelector) => {
+        withSearchQueryInput(editorName => {
             describe(editorName, () => {
-                let editor: EditorAPI
-
                 beforeEach(() => {
-                    editor = createEditorAPI(driver, editorName, editorSelector)
-
                     testContext.overrideGraphQL({
                         ...commonSearchGraphQLResults,
                         ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
@@ -239,7 +232,7 @@ describe('Search', () => {
 
                 test('Is set from the URL query parameter when loading a search-related page', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=foo')
-                    await editor.waitForIt()
+                    const editor = await createEditorAPI(driver, queryInputSelector)
                     expect(await editor.getValue()).toStrictEqual('foo')
                     // Field value is cleared when navigating to a non search-related page
                     await driver.page.waitForSelector('a[href="/extensions"]')
@@ -253,6 +246,7 @@ describe('Search', () => {
 
                 test('Normalizes input with line breaks', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                    const editor = await createEditorAPI(driver, queryInputSelector)
                     await editor.focus()
                     await driver.paste('foo\n\n\n\n\nbar')
                     expect(await editor.getValue()).toBe('foo bar')
@@ -262,13 +256,9 @@ describe('Search', () => {
     })
 
     describe('Case sensitivity toggle', () => {
-        withSearchQueryInput((editorName, editorSelector) => {
+        withSearchQueryInput(editorName => {
             describe(editorName, () => {
-                let editor: EditorAPI
-
                 beforeEach(() => {
-                    editor = createEditorAPI(driver, editorName, editorSelector)
-
                     testContext.overrideGraphQL({
                         ...commonSearchGraphQLResults,
                         ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
@@ -277,7 +267,7 @@ describe('Search', () => {
 
                 test('Clicking toggle turns on case sensitivity', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                    await editor.waitForIt()
+                    const editor = await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-case-sensitivity-toggle')
                     await editor.focus()
                     await driver.page.keyboard.type('test')
@@ -287,7 +277,7 @@ describe('Search', () => {
 
                 test('Clicking toggle turns off case sensitivity and removes case= URL parameter', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=literal&case=yes')
-                    await editor.waitForIt()
+                    await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-case-sensitivity-toggle')
                     await driver.page.click('.test-case-sensitivity-toggle')
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal')
@@ -297,13 +287,9 @@ describe('Search', () => {
     })
 
     describe('Structural search toggle', () => {
-        withSearchQueryInput((editorName, editorSelector) => {
+        withSearchQueryInput(editorName => {
             describe(editorName, () => {
-                let editor: EditorAPI
-
                 beforeEach(() => {
-                    editor = createEditorAPI(driver, editorName, editorSelector)
-
                     testContext.overrideGraphQL({
                         ...commonSearchGraphQLResults,
                         ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
@@ -312,7 +298,7 @@ describe('Search', () => {
 
                 test('Clicking toggle turns on structural search', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                    await editor.waitForIt()
+                    const editor = await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await editor.focus()
                     await driver.page.keyboard.type('test')
@@ -322,6 +308,7 @@ describe('Search', () => {
 
                 test('Clicking toggle turns on structural search and removes existing patternType parameter', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
+                    const editor = await createEditorAPI(driver, queryInputSelector)
                     await editor.focus()
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
@@ -330,7 +317,7 @@ describe('Search', () => {
 
                 test('Clicking toggle turns off structural search and reverts to default pattern type', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=structural')
-                    await editor.waitForIt()
+                    await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal')
@@ -534,13 +521,9 @@ describe('Search', () => {
     })
 
     describe('Search sidebar', () => {
-        withSearchQueryInput((editorName, editorSelector) => {
+        withSearchQueryInput(editorName => {
             describe(editorName, () => {
-                let editor: EditorAPI
-
                 beforeEach(() => {
-                    editor = createEditorAPI(driver, editorName, editorSelector)
-
                     testContext.overrideGraphQL({
                         ...commonSearchGraphQLResults,
                         ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
@@ -551,6 +534,7 @@ describe('Search', () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test')
                     await driver.page.waitForSelector('[data-testid="search-type-suggest"]')
                     await driver.page.click('[data-testid="search-type-suggest"]')
+                    const editor = await createEditorAPI(driver, queryInputSelector)
                     await editor.waitForSuggestion()
                     expect(await editor.getValue()).toEqual('test repo:')
                 })

--- a/client/web/src/integration/settings.test.ts
+++ b/client/web/src/integration/settings.test.ts
@@ -8,7 +8,7 @@ import { retry } from '@sourcegraph/shared/src/testing/utils'
 
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults } from './graphQlResults'
-import { percySnapshotWithVariants } from './utils'
+import { createEditorAPI, percySnapshotWithVariants } from './utils'
 
 describe('Settings', () => {
     let driver: Driver
@@ -90,19 +90,8 @@ describe('Settings', () => {
                 }),
             })
 
-            const getSettingsEditorContent = async (): Promise<string | null | undefined> => {
-                await driver.page.waitForSelector('.test-settings-file .monaco-editor .view-lines')
-                return driver.page.evaluate(
-                    () =>
-                        document
-                            .querySelector<HTMLElement>('.test-settings-file .monaco-editor .view-lines')
-                            ?.textContent?.replace(/\u00A0/g, ' ') // Monaco replaces all spaces with &nbsp;
-                )
-            }
-
             await driver.page.goto(driver.sourcegraphBaseUrl + '/users/test/settings')
 
-            await driver.page.waitForSelector('.test-settings-file .monaco-editor')
             await driver.page.waitForSelector('.test-save-toolbar-save')
 
             assert.strictEqual(
@@ -118,14 +107,10 @@ describe('Settings', () => {
 
             // Replace with new settings
             const newSettings = '{ /* These are new settings */}'
-            await driver.replaceText({
-                selector: '.test-settings-file .monaco-editor .view-lines',
-                newText: newSettings,
-                selectMethod: 'keyboard',
-                enterTextMethod: 'type',
-            })
+            const editor = await createEditorAPI(driver, '.test-settings-file .test-editor')
+            await editor.replace(newSettings, 'paste')
             await retry(async () => {
-                const currentSettings = await getSettingsEditorContent()
+                const currentSettings = await editor.getValue()
                 assert.strictEqual(currentSettings, newSettings)
             })
 

--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -151,7 +151,7 @@ export interface EditorAPI {
     /**
      * Replaces the editor's content with the provided input.
      */
-    replace: (input: string) => Promise<void>
+    replace: (input: string, method?: 'type' | 'paste') => Promise<void>
     /**
      * Triggers application of the specified suggestion.
      */
@@ -159,7 +159,6 @@ export interface EditorAPI {
 }
 
 const editors: Record<Editor, (driver: Driver, rootSelector: string) => EditorAPI> = {
-    // Using id selector rather than `test-` classes as Monaco doesn't allow customizing classes
     monaco: (driver: Driver, rootSelector: string) => {
         const inputSelector = `${rootSelector} textarea`
         const completionSelector = `${rootSelector} .suggest-widget.visible`
@@ -180,11 +179,12 @@ const editors: Record<Editor, (driver: Driver, rootSelector: string) => EditorAP
                     inputSelector
                 )
             },
-            replace(newText: string) {
+            replace(newText: string, method = 'type') {
                 return driver.replaceText({
                     selector: rootSelector,
                     newText,
-                    enterTextMethod: 'type',
+                    enterTextMethod: method,
+                    selectMethod: 'keyboard',
                 })
             },
             async waitForSuggestion(suggestion?: string) {
@@ -227,11 +227,12 @@ const editors: Record<Editor, (driver: Driver, rootSelector: string) => EditorAP
                     inputSelector
                 )
             },
-            replace(newText: string) {
+            replace(newText: string, method = 'type') {
                 return driver.replaceText({
                     selector: rootSelector,
                     newText,
-                    enterTextMethod: 'type',
+                    enterTextMethod: method,
+                    selectMethod: 'selectall',
                 })
             },
             async waitForSuggestion(suggestion?: string) {
@@ -275,23 +276,32 @@ export function enableEditor(editor: Editor): Partial<Settings> {
 /**
  * Returns an object for accessing editor related information at `rootSelector`.
  */
-export const createEditorAPI = (driver: Driver, editor: Editor, rootSelector: string): EditorAPI =>
-    editors[editor](driver, rootSelector)
+export const createEditorAPI = async (driver: Driver, rootSelector: string): Promise<EditorAPI> => {
+    await driver.page.waitForSelector(rootSelector)
+    const editor = await driver.page.evaluate<(selector: string) => string | undefined>(
+        selector => (document.querySelector(selector) as HTMLElement).dataset.editor,
+        rootSelector
+    )
+    switch (editor) {
+        case 'monaco':
+        case 'codemirror6':
+            break
+        default:
+            throw new Error(`${editor} is not a supported editor`)
+    }
+    return editors[editor](driver, rootSelector)
+}
 
 /**
  * Helper function for abstracting away testing different search query input
- * implementations. The callback function gets passed the editor name and the
- * main search query input selector, which can be used with {@link enableEditor}
- * and {@link createEditorAPI}.
+ * implementations. The callback function gets passed the editor name which can
+ * be used with {@link enableEditor} and {@link createEditorAPI}.
  */
-export const withSearchQueryInput = (callback: (editorName: Editor, rootSelector: string) => void): void => {
-    const editorNames: [Editor, string][] = [
-        ['monaco', '#monaco-query-input'],
-        ['codemirror6', '[data-test-id="codemirror-query-input"]'],
-    ]
-    for (const [editor, selector] of editorNames) {
+export const withSearchQueryInput = (callback: (editorName: Editor) => void): void => {
+    const editorNames: Editor[] = ['monaco', 'codemirror6']
+    for (const editor of editorNames) {
         // This callback is supposed to be called multiple times
         // eslint-disable-next-line callback-return
-        callback(editor, selector)
+        callback(editor)
     }
 }

--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -46,8 +46,9 @@ type ColorScheme = 'dark' | 'light'
 export const convertImgSourceHttpToBase64 = async (page: Page): Promise<void> => {
     await page.evaluate(() => {
         // Skip images with data-skip-percy
+        // Skip images with .cm-widgetBuffer, which CodeMirror uses when using a widget decoration
         // See https://github.com/sourcegraph/sourcegraph/issues/28949
-        const imgs = document.querySelectorAll<HTMLImageElement>('img:not([data-skip-percy])')
+        const imgs = document.querySelectorAll<HTMLImageElement>('img:not([data-skip-percy]):not(.cm-widgetBuffer)')
 
         for (const img of imgs) {
             if (img.src.startsWith('data:image')) {


### PR DESCRIPTION
I split out the changes to fix the integration tests for #38584
into this PR.

This commit refactors the integration test editor helper API to be
easier to use and converts remaining tests that explicitly refer to
Monaco to use this API instead.

The problem with the current API was that you'd have to know which
editor is currently used to create an API object. But the developer
shouldn't have to know that.

This commit adds a `data-editor` attribute,  the `test-query-input`
class and `test-editor` class to the DOM elements created by the editor
implementations  (where needed).  This allows tests to target the query
input (or editor) in a generic way (via classes) and the API can figure
out which editor is used via the `data-editor` attribute.

Before:

```
const editor = createEditorAPI(driver, editorToUse, selector)
```

After:

```
const editor = await createEditorAPI(driver, selector)
```

This also removes the "default selector" provided by
`withSearchQueryInput`, which was also a bit awkward. Instead the
selector to the editor component has to be provided by the developer,
which makes it much clearer which component is tested.

Note: `test-*` classes where chosen simply because the Monaco query
input already uses `test-query-input` and it's easier to add multiple
classes than multiple `data-*` attributes.

Note 2: Because the CodeMirror *editor* doesn't produce an element on
its own, those classes and `data-editor` are added by the
CodeMirrorQueryInput component. This is not ideal but not a problem
either since it's only used for testing. Once CodeMirror is more used
(and tested) throughout the app this should be addressed somehow.



Fixes #38633 too (see comment below).


## Test plan

Integration tests pass.

## App preview:

- [Web](https://sg-web-fkling-editor-integration-test-api.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hbugxgtsey.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
