### PR TITLE
search: Hide notepad on small screens

### DIFF
--- a/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
@@ -19,6 +19,7 @@ import {
     Input,
     Modal,
     Icon,
+    useMatchMedia,
 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
@@ -50,6 +51,8 @@ export const NotebooksListPageHeader: React.FunctionComponent<
     React.PropsWithChildren<NotebooksListPageHeaderProps>
 > = ({ authenticatedUser, telemetryService, setImportState, importNotebook }) => {
     const fileInputReference = useRef<HTMLInputElement>(null)
+    // Taken from global-styles/breakpoints.css , $viewport-md
+    const isWideScreen = useMatchMedia('(min-width: 768px)')
 
     const onImportMenuItemSelect = useCallback(() => {
         telemetryService.log('SearchNotebookImportMarkdownNotebookButtonClick')
@@ -96,7 +99,7 @@ export const NotebooksListPageHeader: React.FunctionComponent<
 
     return (
         <>
-            <ToggleNotepadButton telemetryService={telemetryService} />
+            {isWideScreen && <ToggleNotepadButton telemetryService={telemetryService} className="mr-2" />}
             {/* The file upload input has to always be present in the DOM, otherwise the upload process
             does not complete when the menu below closes.  */}
             <Input
@@ -108,7 +111,7 @@ export const NotebooksListPageHeader: React.FunctionComponent<
                 data-testid="import-markdown-notebook-file-input"
             />
             <Menu>
-                <ButtonGroup className="ml-2">
+                <ButtonGroup>
                     <Button to={PageRoutes.NotebookCreate} variant="primary" as={Link}>
                         Create notebook
                     </Button>
@@ -130,9 +133,9 @@ export const NotebooksListPageHeader: React.FunctionComponent<
 export const NOTEPAD_ENABLED_EVENT = 'SearchNotepadEnabled'
 const NOTEPAD_DISABLED_EVENT = 'SearchNotepadDisabled'
 
-const ToggleNotepadButton: React.FunctionComponent<React.PropsWithChildren<TelemetryProps>> = ({
-    telemetryService,
-}) => {
+const ToggleNotepadButton: React.FunctionComponent<
+    React.PropsWithChildren<TelemetryProps & { className?: string }>
+> = ({ telemetryService, className }) => {
     const [notepadEnabled, setNotepadEnabled] = useTemporarySetting('search.notepad.enabled')
     const [ctaSeen, setCTASeen] = useTemporarySetting('search.notepad.ctaSeen')
     const [showCTA, setShowCTA] = useState(false)
@@ -164,7 +167,7 @@ const ToggleNotepadButton: React.FunctionComponent<React.PropsWithChildren<Telem
 
     return (
         <>
-            <Button variant="secondary" type="button" onClick={onClick}>
+            <Button variant="secondary" type="button" onClick={onClick} className={className}>
                 <NotepadIcon /> {notepadEnabled ? 'Disable' : 'Enable'} notepad
             </Button>
             {showCTA && (

--- a/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
@@ -19,7 +19,6 @@ import {
     Input,
     Modal,
     Icon,
-    useMatchMedia,
 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
@@ -52,7 +51,6 @@ export const NotebooksListPageHeader: React.FunctionComponent<
 > = ({ authenticatedUser, telemetryService, setImportState, importNotebook }) => {
     const fileInputReference = useRef<HTMLInputElement>(null)
     // Taken from global-styles/breakpoints.css , $viewport-md
-    const isWideScreen = useMatchMedia('(min-width: 768px)')
 
     const onImportMenuItemSelect = useCallback(() => {
         telemetryService.log('SearchNotebookImportMarkdownNotebookButtonClick')
@@ -99,7 +97,7 @@ export const NotebooksListPageHeader: React.FunctionComponent<
 
     return (
         <>
-            {isWideScreen && <ToggleNotepadButton telemetryService={telemetryService} className="mr-2" />}
+            <ToggleNotepadButton telemetryService={telemetryService} className="mr-2 d-none d-md-inline" />
             {/* The file upload input has to always be present in the DOM, otherwise the upload process
             does not complete when the menu below closes.  */}
             <Input

--- a/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
@@ -50,7 +50,6 @@ export const NotebooksListPageHeader: React.FunctionComponent<
     React.PropsWithChildren<NotebooksListPageHeaderProps>
 > = ({ authenticatedUser, telemetryService, setImportState, importNotebook }) => {
     const fileInputReference = useRef<HTMLInputElement>(null)
-    // Taken from global-styles/breakpoints.css , $viewport-md
 
     const onImportMenuItemSelect = useCallback(() => {
         telemetryService.log('SearchNotebookImportMarkdownNotebookButtonClick')

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -24,7 +24,6 @@ import {
     Icon,
     H3,
     Text,
-    useMatchMedia,
 } from '@sourcegraph/wildcard'
 
 import { Block } from '..'
@@ -110,8 +109,6 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
     const outlineContainerElement = useRef<HTMLDivElement | null>(null)
     const [notepadCTASeen, setNotepadCTASeen] = useTemporarySetting('search.notepad.ctaSeen')
     const [notepadEnabled, setNotepadEnabled] = useTemporarySetting('search.notepad.enabled')
-    // Taken from global-styles/breakpoints.css , $viewport-md
-    const isWideScreen = useMatchMedia('(min-width: 768px)')
 
     const exportedFileName = useMemo(
         () => `${notebookTitle ? convertNotebookTitleToFileName(notebookTitle) : 'notebook'}.snb.md`,
@@ -194,8 +191,12 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
     )
 
     const showNotepadCTA = useMemo(
-        () => isNotebookLoaded(latestNotebook) && latestNotebook.blocks.length === 0 && isWideScreen,
-        [latestNotebook, notepadCTASeen, notepadEnabled, isWideScreen]
+        () =>
+            !notepadEnabled &&
+            !notepadCTASeen &&
+            isNotebookLoaded(latestNotebook) &&
+            latestNotebook.blocks.length === 0,
+        [latestNotebook, notepadCTASeen, notepadEnabled]
     )
 
     return (
@@ -350,7 +351,7 @@ const NotepadCTA: React.FunctionComponent<React.PropsWithChildren<NotepadCTAProp
     const isLightTheme = useTheme().enhancedThemePreference === ThemePreference.Light
 
     return (
-        <MarketingBlock wrapperClassName={styles.notepadCta}>
+        <MarketingBlock wrapperClassName={classNames(styles.notepadCta, 'd-none d-md-block')}>
             <aside className={styles.notepadCtaContent}>
                 <Button
                     aria-label="Hide"

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -24,6 +24,7 @@ import {
     Icon,
     H3,
     Text,
+    useMatchMedia,
 } from '@sourcegraph/wildcard'
 
 import { Block } from '..'
@@ -109,6 +110,8 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
     const outlineContainerElement = useRef<HTMLDivElement | null>(null)
     const [notepadCTASeen, setNotepadCTASeen] = useTemporarySetting('search.notepad.ctaSeen')
     const [notepadEnabled, setNotepadEnabled] = useTemporarySetting('search.notepad.enabled')
+    // Taken from global-styles/breakpoints.css , $viewport-md
+    const isWideScreen = useMatchMedia('(min-width: 768px)')
 
     const exportedFileName = useMemo(
         () => `${notebookTitle ? convertNotebookTitleToFileName(notebookTitle) : 'notebook'}.snb.md`,
@@ -191,12 +194,8 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
     )
 
     const showNotepadCTA = useMemo(
-        () =>
-            !notepadEnabled &&
-            !notepadCTASeen &&
-            isNotebookLoaded(latestNotebook) &&
-            latestNotebook.blocks.length === 0,
-        [latestNotebook, notepadCTASeen, notepadEnabled]
+        () => isNotebookLoaded(latestNotebook) && latestNotebook.blocks.length === 0 && isWideScreen,
+        [latestNotebook, notepadCTASeen, notepadEnabled, isWideScreen]
     )
 
     return (

--- a/client/web/src/search/Notepad.test.tsx
+++ b/client/web/src/search/Notepad.test.tsx
@@ -24,6 +24,22 @@ describe('Notepad', () => {
         userEvent.click(screen.getByRole('button', { name: /Open Notepad/ }))
     }
 
+    // Notepad is hidden by default on small screens. jest-dom has no concept of
+    // screen size, so this needs to be explicitly overriden to ensure that the
+    // component renders.
+    window.matchMedia = sinon.spy(
+        (media: string): MediaQueryList => ({
+            matches: true,
+            media,
+            addListener: () => {},
+            removeListener: () => {},
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            dispatchEvent: () => false,
+            onchange: null,
+        })
+    )
+
     afterEach(cleanup)
 
     const mockEntries: NotepadEntry[] = [

--- a/client/web/src/search/Notepad.tsx
+++ b/client/web/src/search/Notepad.tsx
@@ -30,7 +30,7 @@ import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { appendContextFilter, updateFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { buildSearchURLQuery, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
-import { Button, Link, TextArea, Icon, H2, H3, Text, createLinkUrl } from '@sourcegraph/wildcard'
+import { Button, Link, TextArea, Icon, H2, H3, Text, createLinkUrl, useMatchMedia } from '@sourcegraph/wildcard'
 
 import { BlockInput } from '../notebooks'
 import {
@@ -100,8 +100,10 @@ export const NotepadContainer: React.FunctionComponent<React.PropsWithChildren<N
     const entries = useNotepadState(state => state.entries)
     const canRestore = useNotepadState(state => state.canRestoreSession)
     const [enableNotepad] = useTemporarySetting('search.notepad.enabled')
+    // Taken from global-styles/breakpoints.css , $viewport-md
+    const isWideScreen = useMatchMedia('(min-width: 768px)')
 
-    if (enableNotepad) {
+    if (enableNotepad && isWideScreen) {
         return (
             <Notepad
                 className={styles.fixed}


### PR DESCRIPTION
Closes #36125

This only shows the notepad, the buttons to enable/disable it, and the CTA on screens wider than 768px. I first tried 576px but that still felt too small.

Demo: (note that I modified the code to show the CTA regardless of status)


https://user-images.githubusercontent.com/179026/178514723-58a5d137-4f93-4bbd-838c-6786775febd2.mp4



## Test plan

- Go to https://sourcegraph.test:3443/notebooks
- Enable notepad (if necessary)
- Enable responsive design mode
- Resize window. Below 768px the notepad and the enable/disable notepad button should be hidden.

## App preview:

- [Web](https://sg-web-fkling-36125-disable-notepad-on.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-aqxdgvijay.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
