### PR TITLE
Search backend: clean up repo resolver pt.3

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -300,10 +300,6 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolv
 
 					if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 						// The revspec does not exist, so don't include it, and report that it's missing.
-						if rev.RevSpec == "" {
-							// Report as HEAD not "" (empty string) to avoid user confusion.
-							rev.RevSpec = "HEAD"
-						}
 						res.Lock()
 						res.MissingRepoRevs = append(res.MissingRepoRevs, &search.RepositoryRevisions{
 							Repo: repo,


### PR DESCRIPTION
Builds off https://github.com/sourcegraph/sourcegraph/pull/38602

- Removes a redundant empty string -> `HEAD` 
- Constructs `Resolved` at the end rather than mutating its fields concurrently

## Test plan

Backend integration tests. Should be semantics-preserving. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
