### PR TITLE
fix bitbucket_projects_test.go compilation

### DIFF
--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -25,8 +25,7 @@ import (
 
 func TestStore(t *testing.T) {
 	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(dbtest.NewDB(t))
 
 	ctx := context.Background()
 	jobID, err := db.BitbucketProjectPermissions().Enqueue(ctx, "project1", 2, []types.UserPermission{
@@ -37,7 +36,7 @@ func TestStore(t *testing.T) {
 	require.NotZero(t, jobID)
 
 	store := createBitbucketProjectPermissionsStore(db, &config{})
-	count, err := store.QueuedCount(ctx, true)
+	count, err := store.QueuedCount(ctx, true, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 }
@@ -102,10 +101,9 @@ func TestSetPermissionsForUsers(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
-	db := edb.NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
+	db := edb.NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
 
 	// create 3 users
 	users := db.Users()
@@ -296,11 +294,9 @@ func TestHandleRestricted(t *testing.T) {
 	}
 	t.Parallel()
 
-	logger := logtest.Scoped(t)
-
 	ctx := context.Background()
 
-	db := edb.NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
+	db := edb.NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
 
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}
@@ -397,10 +393,9 @@ func TestHandleUnrestricted(t *testing.T) {
 	}
 	t.Parallel()
 
-	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
-	db := edb.NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
+	db := edb.NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
 
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -54,8 +54,6 @@ func mustParseTime(v string) time.Time {
 }
 
 func TestGetBitbucketClient(t *testing.T) {
-	t.Parallel()
-
 	var c schema.BitbucketServerConnection
 	c.Token = "secret"
 	c.Url = "http://some-url"
@@ -75,7 +73,6 @@ func TestGetBitbucketClient(t *testing.T) {
 }
 
 func TestHandle_UnsupportedCodeHost(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 
 	externalServices := database.NewMockExternalServiceStore()
@@ -292,7 +289,6 @@ func TestHandleRestricted(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	t.Parallel()
 
 	ctx := context.Background()
 
@@ -391,7 +387,6 @@ func TestHandleUnrestricted(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	t.Parallel()
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Unit test compilation is fixed after cherry-picking https://github.com/sourcegraph/sourcegraph/commit/1881df46d954842cb8ba828ef1e4f45431653d18 and https://github.com/sourcegraph/sourcegraph/commit/dda458ed8922cc48a10f256492ccb6550abe1381 from main to `3.40`

## Test plan
Tests should pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
