### PR TITLE
search: Workaround for CodeMirror refocus bug

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -498,7 +498,7 @@ const highlightFocusedFilter = ViewPlugin.define(
                     const position = update.state.selection.main.head
                     const focusedFilter = query.tokens.find(
                         (token): token is Filter =>
-                            // Inclusive end so that the filter is highlighed when
+                            // Inclusive end so that the filter is highlighted when
                             // the cursor is positioned directly after the value
                             token.type === 'filter' && token.range.start <= position && token.range.end >= position
                     )
@@ -520,7 +520,12 @@ const highlightFocusedFilter = ViewPlugin.define(
                     }
                     this.decorations = Decoration.set(decorations)
                 } else {
-                    this.decorations = Decoration.none
+                    // Ideally we would remove the decoration when the input
+                    // looses focus, but there is a bug that re-focuses the
+                    // input when a filter is highlighted and the menu is
+                    // clicked.
+                    // See https://github.com/sourcegraph/sourcegraph/issues/38677
+                    // this.decorations = Decoration.none
                 }
             }
         },


### PR DESCRIPTION
Workaround for #38677.



## Test plan

Enter query with valid filter at the end (e.g. `case:yes`). Filter is highlighted. Clicking the user menu opens it and doesn't re-focus the input. The filter stays highlighted.

## App preview:

- [Web](https://sg-web-fkling-codemirror-focus-bug.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nqgtmbuaax.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
