### PR TITLE
search: fix missing repository ID in streaming search commit events

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -479,17 +479,18 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 	}
 
 	commitEvent := &streamhttp.EventCommitMatch{
-		Type:       streamhttp.CommitMatchType,
-		Label:      commit.Label(),
-		URL:        commit.URL().String(),
-		Detail:     commit.Detail(),
-		Repository: string(commit.Repo.Name),
-		OID:        string(commit.Commit.ID),
-		Message:    string(commit.Commit.Message),
-		AuthorName: commit.Commit.Author.Name,
-		AuthorDate: commit.Commit.Author.Date,
-		Content:    hls.Value,
-		Ranges:     ranges,
+		Type:         streamhttp.CommitMatchType,
+		Label:        commit.Label(),
+		URL:          commit.URL().String(),
+		Detail:       commit.Detail(),
+		Repository:   string(commit.Repo.Name),
+		RepositoryID: int32(commit.Repo.ID),
+		OID:          string(commit.Commit.ID),
+		Message:      string(commit.Commit.Message),
+		AuthorName:   commit.Commit.Author.Name,
+		AuthorDate:   commit.Commit.Author.Date,
+		Content:      hls.Value,
+		Ranges:       ranges,
 	}
 
 	if r, ok := repoCache[commit.Repo.ID]; ok {


### PR DESCRIPTION
Close #38676

Our commit search events were not populating the repository ID field. This PR simply adds the repository ID from the commit to the event. I also spot checked some other event types and it appears they are all including the repository ID.

## Test plan

Before:
```
event: matches
data: [{"type":"commit","label":"[jwasham/coding-interview-university](/github.com/jwasham/coding-interview-university) › [Antoine Cotten](/github.com/jwasham/coding-interview-university/-/commit/fe1ec60459cb8ef2d502af581b536e5bbcd4375b): [Update links to Topcoder community articles](/github.com/jwasham/coding-interview-university/-/commit/fe1ec60459cb8ef2d502af581b536e5bbcd4375b)","url":"/github.com/jwasham/coding-interview-university/-/commit/fe1ec60459cb8ef2d502af581b536e5bbcd4375b","detail":"[`fe1ec60` 5 days ago](/github.com/jwasham/coding-interview-university/-/commit/fe1ec60459cb8ef2d502af581b536e5bbcd4375b)","repositoryID":0,"repository":"github.com/jwasham/coding-interview-university","oid":"fe1ec60459cb8ef2d502af581b536e5bbcd4375b","message":"Update links to Topcoder community articles","authorName":"Antoine Cotten","authorDate":"2022-07-07T15:39:53Z","repoStars":221168,"repoLastFetched":"2022-07-11T07:07:14.462742Z","content":"```COMMIT_EDITMSG\nUpdate links to Topcoder community articles\n```","ranges":[]}]
```

After:
```
event: matches
data: [{"type":"commit","label":"[hashicorp/go-multierror](/github.com/hashicorp/go-multierror) âº [Seth Vargo](/github.com/hashicorp/go-multierror/-/commit/0023bb0ab1225a10509dca08627b42bed25d74a5): [Check if multierror is nil in WrappedErrors](/github.com/hashicorp/go-multierror/-/commit/0023bb0ab1225a10509dca08627b42bed25d74a5)","url":"/github.com/hashicorp/go-multierror/-/commit/0023bb0ab1225a10509dca08627b42bed25d74a5","detail":"[`0023bb0` one year ago](/github.com/hashicorp/go-multierror/-/commit/0023bb0ab1225a10509dca08627b42bed25d74a5)","repositoryID":4,"repository":"github.com/hashicorp/go-multierror","oid":"0023bb0ab1225a10509dca08627b42bed25d74a5","message":"Check if multierror is nil in WrappedErrors\n\nThis adds a check similar to `ErrorsOrNil` that ensures the multierror pointer is not nil before returning the Errors field. I believe this is fully backwards-compatible, because the former behavior is a runtime panic.","authorName":"Seth Vargo","authorDate":"2021-03-11T20:06:12Z","repoStars":1631,"repoLastFetched":"2022-07-12T16:45:39.186154Z","content":"```COMMIT_EDITMSG\nCheck if multierror is nil in WrappedErrors\n\nThis adds a check similar to `ErrorsOrNil` that ensures the multierror pointer is not nil before returning the Errors field. I believe this is fully backwards-compatible, because the former behavior is a runtime panic.\n```","ranges":[]}]
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
