### PR TITLE
`lib/group`: add error to error group before canceling

### DIFF
--- a/lib/group/group.go
+++ b/lib/group/group.go
@@ -268,7 +268,12 @@ func (g *contextGroup) Go(f func(context.Context) error) {
 
 		err := f(ctx)
 		if err != nil && g.cancel != nil {
+			// Add the error directly because otherwise, canceling could cause
+			// another goroutine to exit and return an error before this error
+			// was added, which breaks the expectations of WithFirstError().
+			g.errorGroup.addErr(err)
 			g.cancel()
+			return nil
 		}
 		return err
 	})


### PR DESCRIPTION
This fixes a minor race condition where the error returned when `WithFirstError`
might not actually be the first error because we cancel the context before collecting
the error, which means another goroutine might return a context canceled error
and accumulate it before the triggering error is collected.

Flake [here](https://buildkite.com/sourcegraph/sourcegraph/builds/160030#0181f349-b1cc-4617-a431-4aadc1da340e/129-1410)

## Test plan

There are existing tests to cover this, but it is a really difficult condition to hit. I tried running tests locally 100 times and hit no failures.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
