### PR TITLE
batches: fix badge color on selected workspace

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesListItem.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesListItem.module.scss
@@ -5,6 +5,7 @@
     h4,
     small,
     svg,
+    span,
     strong {
         // !important is to override the color applied to the svg Icon and strong
         // elements, which also have !important on them.

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesListItem.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesListItem.module.scss
@@ -5,7 +5,6 @@
     h4,
     small,
     svg,
-    span,
     strong {
         // !important is to override the color applied to the svg Icon and strong
         // elements, which also have !important on them.

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
@@ -1,7 +1,27 @@
-.status {
-    width: 1.5rem;
-    flex-shrink: 0;
-    padding-right: 0.5rem;
+.container {
+    display: flex;
+    flex: 1;
+    padding: 1rem 0.5rem;
+    align-items: center;
+
+    .status {
+        width: 1.5rem;
+        flex-shrink: 0;
+        padding-right: 0.5rem;
+    }
+
+    .workspaceDetails {
+        color: var(--text-muted);
+        padding-top: 0.25rem;
+        align-items: center;
+        display: flex;
+
+        .badge {
+            margin-right: 0.625rem;
+            font-size: 0.6875rem;
+            color: var(--badge-text) !important;
+        }
+    }
 }
 
 .name {
@@ -15,9 +35,4 @@
     overflow-wrap: anywhere;
     color: var(--text-muted);
     padding-top: 0.25rem;
-}
-
-.badge {
-    margin-right: 0.625rem;
-    font-size: 0.6875rem;
 }

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.module.scss
@@ -10,7 +10,7 @@
         padding-right: 0.5rem;
     }
 
-    .workspaceDetails {
+    .workspace-details {
         color: var(--text-muted);
         padding-top: 0.25rem;
         align-items: center;

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react'
 
 import { mdiSourceBranch } from '@mdi/js'
+import classNames from 'classnames'
 
 import { Icon, H4, Badge } from '@sourcegraph/wildcard'
 
@@ -28,15 +29,15 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
     statusIndicator,
     workspace,
 }: DescriptorProps<Workspace>): ReactElement => (
-    <div className="d-flex flex-1 align-items-center pt-3 pb-3 pl-2 pr-2">
+    <div className={styles.container}>
         <div className={styles.status}>{statusIndicator}</div>
         <div className="flex-1">
             <H4 className={styles.name}>{workspace?.repository.name ?? 'Workspace in hidden repository'}</H4>
             {workspace && workspace.path !== '' && workspace.path !== '/' ? (
-                <span className={styles.path}>{workspace?.path}</span>
+                <span className={styles.path}>{workspace?.path || '/some/path'}</span>
             ) : null}
             {workspace && (
-                <div className="d-flex align-items-center text-muted text-monospace pt-1">
+                <div className={classNames(styles.workspaceDetails, '.text-monospace')}>
                     {workspace.ignored && (
                         <Badge
                             className={styles.badge}

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -34,7 +34,7 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
         <div className="flex-1">
             <H4 className={styles.name}>{workspace?.repository.name ?? 'Workspace in hidden repository'}</H4>
             {workspace && workspace.path !== '' && workspace.path !== '/' ? (
-                <span className={styles.path}>{workspace?.path || '/some/path'}</span>
+                <span className={styles.path}>{workspace?.path}</span>
             ) : null}
             {workspace && (
                 <div className={classNames(styles.workspaceDetails, '.text-monospace')}>


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

When an `unsupported` or `ignored` workspace is selected, the badge text is overridden by the [WorkspaceListItem](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@bo/handle-unsupported-badge-selected-workspace/-/blob/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesListItem.module.scss?L5-L12=) style.

For now, we don't have a `span` inside of `WorkspaceListItem` so this works without affecting any other element, however in the future we might need to revisit the use of `!important` here.

Screen | Before | After
:-------:|:------:|:-------:
ExecuteBatchSpec | <img width="521" alt="CleanShot 2022-07-12 at 15 50 43@2x" src="https://user-images.githubusercontent.com/25608335/178519256-b707944d-5832-4222-a8fa-31669cbbf4ce.png"> |  <img width="517" alt="CleanShot 2022-07-12 at 14 29 58@2x" src="https://user-images.githubusercontent.com/25608335/178501582-e39f7df8-6b6b-4d09-85a0-47c30f5e7fdc.png">


## App preview:

- [Web](https://sg-web-bo-handle-unsupported-badge.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kxiqgqroeo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
