### PR TITLE
repo/file page: remove repo dropdown in breadcrumbs

### DIFF
--- a/client/shared/src/settings/temporary/useTemporarySetting.ts
+++ b/client/shared/src/settings/temporary/useTemporarySetting.ts
@@ -5,7 +5,7 @@ import { ObservableStatus, useObservableWithStatus } from '@sourcegraph/wildcard
 import { TemporarySettings } from './TemporarySettings'
 import { TemporarySettingsContext } from './TemporarySettingsProvider'
 
-type UseTemporarySettingsReturnType<K extends keyof TemporarySettings> = [
+export type UseTemporarySettingsReturnType<K extends keyof TemporarySettings> = [
     TemporarySettings[K],
     (newValue: TemporarySettings[K] | ((previousValue: TemporarySettings[K]) => TemporarySettings[K])) => void,
     TemporarySettingsLoadStatus

--- a/client/shared/src/settings/useCoreWorkflowImprovementsEnabled.ts
+++ b/client/shared/src/settings/useCoreWorkflowImprovementsEnabled.ts
@@ -1,0 +1,5 @@
+import { useTemporarySetting, UseTemporarySettingsReturnType } from './temporary/useTemporarySetting'
+
+export function useCoreWorkflowImprovementsEnabled(): UseTemporarySettingsReturnType<'coreWorkflowImprovements.enabled'> {
+    return useTemporarySetting('coreWorkflowImprovements.enabled')
+}

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -26,7 +26,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { escapeSpaces } from '@sourcegraph/shared/src/search/query/filters'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { makeRepoURI } from '@sourcegraph/shared/src/util/url'
@@ -166,7 +166,7 @@ export const RepoContainer: React.FunctionComponent<React.PropsWithChildren<Repo
         location.pathname + location.search + location.hash
     )
 
-    const [coreWorkflowImprovementsEnabled] = useTemporarySetting('coreWorkflowImprovements.enabled')
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
 
     // Fetch repository upon mounting the component.
     const repoOrError = useObservable(

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -26,6 +26,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { escapeSpaces } from '@sourcegraph/shared/src/search/query/filters'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { makeRepoURI } from '@sourcegraph/shared/src/util/url'
@@ -165,6 +166,8 @@ export const RepoContainer: React.FunctionComponent<React.PropsWithChildren<Repo
         location.pathname + location.search + location.hash
     )
 
+    const [coreWorkflowImprovementsEnabled] = useTemporarySetting('coreWorkflowImprovements.enabled')
+
     // Fetch repository upon mounting the component.
     const repoOrError = useObservable(
         useMemo(
@@ -227,26 +230,31 @@ export const RepoContainer: React.FunctionComponent<React.PropsWithChildren<Repo
                 return
             }
 
+            const button = (
+                <Button
+                    to={
+                        resolvedRevisionOrError && !isErrorLike(resolvedRevisionOrError)
+                            ? resolvedRevisionOrError.rootTreeURL
+                            : repoOrError.url
+                    }
+                    className="text-nowrap test-repo-header-repo-link"
+                    variant="secondary"
+                    outline={true}
+                    size="sm"
+                    as={Link}
+                >
+                    <Icon aria-hidden={true} svgPath={mdiSourceRepository} /> {displayRepoName(repoOrError.name)}
+                </Button>
+            )
+
             return {
                 key: 'repository',
-                element: (
+                element: coreWorkflowImprovementsEnabled ? (
+                    button // Don't show the repo dropdown if core workflow improvements are enabled
+                ) : (
                     <Popover>
                         <ButtonGroup className="d-inline-flex">
-                            <Button
-                                to={
-                                    resolvedRevisionOrError && !isErrorLike(resolvedRevisionOrError)
-                                        ? resolvedRevisionOrError.rootTreeURL
-                                        : repoOrError.url
-                                }
-                                className="text-nowrap test-repo-header-repo-link"
-                                variant="secondary"
-                                outline={true}
-                                size="sm"
-                                as={Link}
-                            >
-                                <Icon aria-hidden={true} svgPath={mdiSourceRepository} />{' '}
-                                {displayRepoName(repoOrError.name)}
-                            </Button>
+                            {button}
                             <PopoverTrigger
                                 as={Button}
                                 className={styles.repoChange}
@@ -271,7 +279,7 @@ export const RepoContainer: React.FunctionComponent<React.PropsWithChildren<Repo
                     </Popover>
                 ),
             }
-        }, [repoOrError, resolvedRevisionOrError, props.telemetryService])
+        }, [repoOrError, resolvedRevisionOrError, coreWorkflowImprovementsEnabled, props.telemetryService])
     )
 
     // Update the workspace roots service to reflect the current repo / resolved revision

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { mdiPlus } from '@mdi/js'
 import { RouteComponentProps } from 'react-router-dom'
 
-import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { ProductStatusBadge, Button, Link, Icon, ProductStatusType } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
@@ -45,9 +45,7 @@ export const UserSettingsSidebar: React.FunctionComponent<
     React.PropsWithChildren<UserSettingsSidebarProps>
 > = props => {
     const [isOpenBetaEnabled] = useFeatureFlag('open-beta-enabled')
-    const [coreWorkflowImprovementsEnabled, setCoreWorkflowImprovementsEnabled] = useTemporarySetting(
-        'coreWorkflowImprovements.enabled'
-    )
+    const [coreWorkflowImprovementsEnabled, setCoreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
 
     if (!props.authenticatedUser) {
         return null


### PR DESCRIPTION
Closed #38666

If core workflow improvements are enabled, don't show the repo dropdown menu in the breadcrumbs on the file/repo pages.

### Disabled:
![image](https://user-images.githubusercontent.com/206864/178575456-22a81bd7-8873-41ed-9137-c181d63794b6.png)

### Enabled:
![image](https://user-images.githubusercontent.com/206864/178575394-e9bbe3c2-0715-40fb-bf85-5c14c29a91c4.png)

## Test plan

Test with core workflow improvements enabled and disabled.

## App preview:

- [Web](https://sg-web-jp-cwremoverepodropdown.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zucuplwybn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
