### PR TITLE
migration: Add `-noop-privileged` flag

### DIFF
--- a/doc/cli/references/batch/exec.md
+++ b/doc/cli/references/batch/exec.md
@@ -5,10 +5,8 @@
 
 | Name | Description | Default Value |
 |------|-------------|---------------|
-| `-cache` | Directory to read cached results from. |  |
 | `-f` | The workspace execution input file to read. |  |
 | `-repo` | Path of the checked out repo on disk. |  |
-| `-sourcegraphVersion` | Sourcegraph backend version. |  |
 | `-timeout` | The maximum duration a single batch spec step can take. | `1h0m0s` |
 | `-tmp` | Directory for storing temporary data. |  |
 
@@ -17,14 +15,10 @@
 
 ```
 Usage of 'src batch exec':
-  -cache string
-    	Directory to read cached results from.
   -f string
     	The workspace execution input file to read.
   -repo string
     	Path of the checked out repo on disk.
-  -sourcegraphVersion string
-    	Sourcegraph backend version.
   -timeout duration
     	The maximum duration a single batch spec step can take. (default 1h0m0s)
   -tmp string

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -574,8 +574,9 @@ Flags:
 * `--db="<value>"`: The target `schema(s)` to modify. Comma-separated values are accepted. Supply "all" to migrate all schemas. (default: [all])
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 * `--ignore-single-dirty-log`: Ignore a previously failed attempt if it will be immediately retried by this operation.
+* `--noop-privileged`: Skip application of privileged migrations, but record that they have been applied. This assumes the user has already applied the required privileged migrations with elevated permissions.
 * `--skip-upgrade-validation`: Do not attempt to compare the previous instance version with the target instance version for upgrade compatibility. Please refer to https://docs.sourcegraph.com/admin/updates#update-policy for our instance upgrade compatibility policy.
-* `--unprivileged-only`: Do not apply privileged migrations.
+* `--unprivileged-only`: Refuse to apply privileged migrations.
 
 ### sg migration upto
 
@@ -596,8 +597,9 @@ Flags:
 * `--db="<value>"`: The target `schema` to modify.
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 * `--ignore-single-dirty-log`: Ignore a previously failed attempt if it will be immediately retried by this operation.
+* `--noop-privileged`: Skip application of privileged migrations, but record that they have been applied. This assumes the user has already applied the required privileged migrations with elevated permissions.
 * `--target="<value>"`: The `migration` to apply. Comma-separated values are accepted.
-* `--unprivileged-only`: Do not apply privileged migrations.
+* `--unprivileged-only`: Refuse to apply privileged migrations.
 
 ### sg migration undo
 
@@ -638,8 +640,9 @@ Flags:
 * `--db="<value>"`: The target `schema` to modify.
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 * `--ignore-single-dirty-log`: Ignore a previously failed attempt if it will be immediately retried by this operation.
+* `--noop-privileged`: Skip application of privileged migrations, but record that they have been applied. This assumes the user has already applied the required privileged migrations with elevated permissions.
 * `--target="<value>"`: The migration to apply. Comma-separated values are accepted.
-* `--unprivileged-only`: Do not apply privileged migrations.
+* `--unprivileged-only`: Refuse to apply privileged migrations.
 
 ### sg migration validate
 

--- a/internal/database/migration/cliutil/upto.go
+++ b/internal/database/migration/cliutil/upto.go
@@ -23,7 +23,12 @@ func UpTo(commandName string, factory RunnerFactory, outFactory OutputFactory, d
 	}
 	unprivilegedOnlyFlag := &cli.BoolFlag{
 		Name:  "unprivileged-only",
-		Usage: "Do not apply privileged migrations.",
+		Usage: "Refuse to apply privileged migrations.",
+		Value: false,
+	}
+	noopPrivilegedFlag := &cli.BoolFlag{
+		Name:  "noop-privileged",
+		Usage: "Skip application of privileged migrations, but record that they have been applied. This assumes the user has already applied the required privileged migrations with elevated permissions.",
 		Value: false,
 	}
 	ignoreSingleDirtyLogFlag := &cli.BoolFlag{
@@ -32,7 +37,12 @@ func UpTo(commandName string, factory RunnerFactory, outFactory OutputFactory, d
 		Value: development,
 	}
 
-	makeOptions := func(cmd *cli.Context, versions []int) runner.Options {
+	makeOptions := func(cmd *cli.Context, out *output.Output, versions []int) (runner.Options, error) {
+		privilegedMode, err := getPivilegedModeFromFlags(cmd, out, unprivilegedOnlyFlag, noopPrivilegedFlag)
+		if err != nil {
+			return runner.Options{}, err
+		}
+
 		return runner.Options{
 			Operations: []runner.MigrationOperation{
 				{
@@ -41,9 +51,9 @@ func UpTo(commandName string, factory RunnerFactory, outFactory OutputFactory, d
 					TargetVersions: versions,
 				},
 			},
-			UnprivilegedOnly:     unprivilegedOnlyFlag.Get(cmd),
+			PrivilegedMode:       privilegedMode,
 			IgnoreSingleDirtyLog: ignoreSingleDirtyLogFlag.Get(cmd),
-		}
+		}, nil
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
@@ -59,7 +69,13 @@ func UpTo(commandName string, factory RunnerFactory, outFactory OutputFactory, d
 		if err != nil {
 			return err
 		}
-		return r.Run(ctx, makeOptions(cmd, versions))
+
+		options, err := makeOptions(cmd, out, versions)
+		if err != nil {
+			return err
+		}
+
+		return r.Run(ctx, options)
 	})
 
 	return &cli.Command{
@@ -72,6 +88,7 @@ func UpTo(commandName string, factory RunnerFactory, outFactory OutputFactory, d
 			schemaNameFlag,
 			targetFlag,
 			unprivilegedOnlyFlag,
+			noopPrivilegedFlag,
 			ignoreSingleDirtyLogFlag,
 		},
 	}

--- a/internal/database/migration/runner/options.go
+++ b/internal/database/migration/runner/options.go
@@ -30,6 +30,10 @@ type Options struct {
 
 type PrivilegedMode uint
 
+func (m PrivilegedMode) Valid() bool {
+	return m < InvalidPrivilegedMode
+}
+
 const (
 	// ApplyPrivilegedMigrations, the default privileged mode, indicates to the runner that any
 	// privileged migrations should be applied along with unprivileged migrations.

--- a/internal/database/migration/runner/options.go
+++ b/internal/database/migration/runner/options.go
@@ -18,10 +18,8 @@ type Options struct {
 	// when trying to install Postgres extensions concurrently (which do not seem txn-safe).
 	Parallel bool
 
-	// UnprivilegedOnly controls whether privileged migrations can run with the current user
-	// credentials, or if an error should be printed so the site admin can apply manulaly the
-	// privileged migration file with a superuser.
-	UnprivilegedOnly bool
+	// PrivilegedMode controls how privileged migrations are applied.
+	PrivilegedMode PrivilegedMode
 
 	// IgnoreSingleDirtyLog controls whether or not to ignore a dirty database in the specific
 	// case when the _next_ migration application is the only failure. This is meant to enable
@@ -29,6 +27,28 @@ type Options struct {
 	// create a dummy migration log to proceed.
 	IgnoreSingleDirtyLog bool
 }
+
+type PrivilegedMode uint
+
+const (
+	// ApplyPrivilegedMigrations, the default privileged mode, indicates to the runner that any
+	// privileged migrations should be applied along with unprivileged migrations.
+	ApplyPrivilegedMigrations PrivilegedMode = iota
+
+	// NoopPrivilegedMigrations, enabled via the -noop-privileged flag, indicates to the runner
+	// that any privileged migrations should be skipped, but an entry in the migration logs table
+	// should be added. This mode assumes that the user has already applied these migrations by hand.
+	NoopPrivilegedMigrations
+
+	// RefusePrivilegedMigrations, enabled via the -unprivileged-only flag, indicates to the runner
+	// that any privileged migrations should result in an error. This indicates to the user that
+	// these migrations need to be run by hand with elevated permissions before the migration can
+	// succeed.
+	RefusePrivilegedMigrations
+
+	// InvalidPrivilegedMode indicates an unsupported privileged mode state.
+	InvalidPrivilegedMode
+)
 
 type MigrationOperation struct {
 	SchemaName     string

--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (r *Runner) Run(ctx context.Context, options Options) error {
-	if options.PrivilegedMode >= InvalidPrivilegedMode {
+	if !options.PrivilegedMode.Valid() {
 		return errors.Newf("invalid privileged mode")
 	}
 

--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (r *Runner) Run(ctx context.Context, options Options) error {
+	if options.PrivilegedMode >= InvalidPrivilegedMode {
+		return errors.Newf("invalid privileged mode")
+	}
+
 	schemaNames := make([]string, 0, len(options.Operations))
 	for _, operation := range options.Operations {
 		schemaNames = append(schemaNames, operation.SchemaName)
@@ -44,7 +48,7 @@ func (r *Runner) Run(ctx context.Context, options Options) error {
 			ctx,
 			operationMap[schemaName],
 			schemaContext,
-			options.UnprivilegedOnly,
+			options.PrivilegedMode,
 			options.IgnoreSingleDirtyLog,
 		); err != nil {
 			return errors.Wrapf(err, "failed to run migration for schema %q", schemaName)
@@ -62,7 +66,7 @@ func (r *Runner) runSchema(
 	ctx context.Context,
 	operation MigrationOperation,
 	schemaContext schemaContext,
-	unprivilegedOnly bool,
+	privilegedMode PrivilegedMode,
 	ignoreSingleDirtyLog bool,
 ) error {
 	// First, rewrite operations into a smaller set of operations we'll handle below. This call converts
@@ -102,13 +106,11 @@ func (r *Runner) runSchema(
 	if len(byState.pending)+len(byState.failed) == 0 {
 		if operation.Type == MigrationOperationTypeTargetedUp && len(byState.applied) == len(definitions) {
 			logger.Info("Schema is in the expected state")
-
 			return nil
 		}
 
 		if operation.Type == MigrationOperationTypeTargetedDown && len(byState.applied) == 0 {
 			logger.Info("Schema is in the expected state")
-
 			return nil
 		}
 	}
@@ -133,7 +135,7 @@ func (r *Runner) runSchema(
 			operation,
 			schemaContext,
 			definitions,
-			unprivilegedOnly,
+			privilegedMode,
 			ignoreSingleDirtyLog,
 		); err != nil {
 			return err
@@ -143,7 +145,6 @@ func (r *Runner) runSchema(
 	}
 
 	logger.Info("Schema is in the expected state")
-
 	return nil
 }
 
@@ -156,7 +157,7 @@ func (r *Runner) applyMigrations(
 	operation MigrationOperation,
 	schemaContext schemaContext,
 	definitions []definition.Definition,
-	unprivilegedOnly bool,
+	privilegedMode PrivilegedMode,
 	ignoreSingleDirtyLog bool,
 ) (retry bool, _ error) {
 	var (
@@ -192,7 +193,7 @@ func (r *Runner) applyMigrations(
 				}
 			} else {
 				// Apply all other types of migrations uniformly
-				if err := r.applyMigration(ctx, schemaContext, operation, definition, unprivilegedOnly); err != nil {
+				if err := r.applyMigration(ctx, schemaContext, operation, definition, privilegedMode); err != nil {
 					return err
 				}
 			}
@@ -221,13 +222,30 @@ func (r *Runner) applyMigration(
 	schemaContext schemaContext,
 	operation MigrationOperation,
 	definition definition.Definition,
-	unprivilegedOnly bool,
+	privilegedMode PrivilegedMode,
 ) error {
-	if definition.Privileged && unprivilegedOnly {
-		return newPrivilegedMigrationError(operation.SchemaName, definition)
-	}
-
 	up := operation.Type == MigrationOperationTypeTargetedUp
+
+	if definition.Privileged {
+		if privilegedMode == RefusePrivilegedMigrations {
+			return newPrivilegedMigrationError(operation.SchemaName, definition)
+		}
+
+		if privilegedMode == NoopPrivilegedMigrations {
+			if err := schemaContext.store.WithMigrationLog(ctx, definition, up, func() error { return nil }); err != nil {
+				return errors.Wrapf(err, "failed to apply migration %d", definition.ID)
+			}
+
+			r.logger.Warn(
+				"Adding migrating log for privileged migration, but not applying its changes",
+				log.String("schema", schemaContext.schema.Name),
+				log.Int("migrationID", definition.ID),
+				log.Bool("up", up),
+			)
+
+			return nil
+		}
+	}
 
 	r.logger.Info(
 		"Applying migration",


### PR DESCRIPTION
This PR adds a `-noop-privileged` flag to the migrator subcommands `up`, `upto`, and `downto`. this flag is a sibling to the `-unprivileged-only` flag, which controls how to behave in the presence of a privileged migration.

There are now three behaviors:

- Apply privileged migrations as if they were unprivileged (the default)
- Fail when privileged migrations are encountered, prompting the user to apply a migration manually (enabled via the `-unprivileged-only` flag)
- Warn when privileged migrations are applied; mark them as applied but do not actually apply them (enabled via the `-noop-privileged` flag)

Fixes #38046.

## Test plan

Tested manually with new local privileged migrations.