### PR TITLE
lib/output: forcibly disable dark background detection in Buildkite

### DIFF
--- a/lib/output/capabilities.go
+++ b/lib/output/capabilities.go
@@ -30,6 +30,13 @@ type capabilities struct {
 // that if an override is indicated in opts, no inference of the relevant capabilities
 // is done at all.
 func detectCapabilities(opts OutputOpts) (caps capabilities, err error) {
+	// Workaround: For some reason the dark background detection hangs indefinitely in
+	// Buildkite, so ForceDarkBackground being set is a required (Buildkite output is
+	// always against a dark background anyway, so for the user this should be fine)
+	if os.Getenv("BUILDKITE") == "true" {
+		opts.ForceDarkBackground = true
+	}
+
 	// Set atty
 	caps.Isatty = opts.ForceTTY
 	if !opts.ForceTTY {

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -69,6 +69,10 @@ type OutputOpts struct {
 
 	// ForceDarkBackground ignores all terminal detection and sets whether the terminal
 	// background is dark to this value.
+	//
+	// Workaround: For some reason the dark background detection hangs indefinitely in
+	// Buildkite, so ForceDarkBackground being set is a required (Buildkite output is
+	// always against a dark background anyway, so for the user this should be fine)
 	ForceDarkBackground bool
 
 	Verbose bool


### PR DESCRIPTION
A customer reported:

> So it looks like [github.com/sourcegraph/sourcegraph/lib/output.NewOutput](http://github.com/sourcegraph/sourcegraph/lib/output.NewOutput)  hangs when run by our Buildkite agent [see line of code here](https://github.com/sourcegraph/sourcegraph/blob/main/lib/output/output.go#L96)
I patched src-cli and use fmt.Print to isolate the problem to there. (I am unsure I can get a debugger here)

We ran into the same issue with `sg` usage in Buildkite, which we patched in https://github.com/sourcegraph/sourcegraph/pull/36193. We can't easily apply a similar patch for `src` because there are many points where output is initialized ([query](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/src-cli$+output.OutputOpts%7B...%7D+-f:_test.go&patternType=structural)) but at the end of the day I think it makes sense for `detectCapabilities` to house this logic, since all users of this package will run into this issue and it fits in with the need to "detect capabilities"

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a