### PR TITLE
search: simplify query generator control flow

### DIFF
--- a/internal/search/lucky/feeling_lucky_search_job.go
+++ b/internal/search/lucky/feeling_lucky_search_job.go
@@ -89,16 +89,8 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	generated := &alertobserver.ErrLuckyQueries{ProposedQueries: []*search.ProposedQuery{}}
 	var autoQ *autoQuery
 	for _, next := range f.generators {
-		for {
+		for next != nil {
 			autoQ, next = next()
-			if autoQ == nil {
-				if next == nil {
-					// No query and generator is exhausted.
-					break
-				}
-				continue
-			}
-
 			j := f.newGeneratedJob(autoQ)
 			if j == nil {
 				// Generated an invalid job with this query, just continue.
@@ -126,10 +118,6 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 			}
 
 			maxAlerter.Add(alert)
-
-			if next == nil {
-				break
-			}
 		}
 	}
 

--- a/internal/search/lucky/feeling_lucky_search_job_test.go
+++ b/internal/search/lucky/feeling_lucky_search_job_test.go
@@ -31,20 +31,15 @@ func TestNewFeelingLuckySearchJob(t *testing.T) {
 		}
 		generated := []want{}
 
-		for {
+		for g != nil {
 			autoQ, g = g()
-			if autoQ != nil {
-				generated = append(
-					generated,
-					want{
-						Description: autoQ.description,
-						Query:       query.StringHuman(autoQ.query.ToParseTree()),
-					})
-			}
+			generated = append(
+				generated,
+				want{
+					Description: autoQ.description,
+					Query:       query.StringHuman(autoQ.query.ToParseTree()),
+				})
 
-			if g == nil {
-				break
-			}
 		}
 
 		result, _ := json.MarshalIndent(generated, "", "  ")
@@ -171,20 +166,14 @@ func TestCombinations(t *testing.T) {
 		}
 		generated := []want{}
 
-		for {
+		for g != nil {
 			autoQ, g = g()
-			if autoQ != nil {
-				generated = append(
-					generated,
-					want{
-						Description: autoQ.description,
-						Query:       query.StringHuman(autoQ.query.ToParseTree()),
-					})
-			}
-
-			if g == nil {
-				break
-			}
+			generated = append(
+				generated,
+				want{
+					Description: autoQ.description,
+					Query:       query.StringHuman(autoQ.query.ToParseTree()),
+				})
 		}
 
 		result, _ := json.MarshalIndent(generated, "", "  ")
@@ -218,21 +207,15 @@ func Test_patternsAsFilters(t *testing.T) {
 		}
 		generated := []want{}
 
-		for {
+		for g != nil {
 			autoQ, g = g()
-			if autoQ != nil {
-				generated = append(
-					generated,
-					want{
-						Description: autoQ.description,
-						Input:       input,
-						Query:       query.StringHuman(autoQ.query.ToParseTree()),
-					})
-			}
-
-			if g == nil {
-				break
-			}
+			generated = append(
+				generated,
+				want{
+					Description: autoQ.description,
+					Input:       input,
+					Query:       query.StringHuman(autoQ.query.ToParseTree()),
+				})
 		}
 
 		result, _ := json.MarshalIndent(generated, "", "  ")
@@ -289,21 +272,15 @@ func Test_regexpPatterns(t *testing.T) {
 		}
 		generated := []want{}
 
-		for {
+		for g != nil {
 			autoQ, g = g()
-			if autoQ != nil {
-				generated = append(
-					generated,
-					want{
-						Description: autoQ.description,
-						Input:       input,
-						Query:       query.StringHuman(autoQ.query.ToParseTree()),
-					})
-			}
-
-			if g == nil {
-				break
-			}
+			generated = append(
+				generated,
+				want{
+					Description: autoQ.description,
+					Input:       input,
+					Query:       query.StringHuman(autoQ.query.ToParseTree()),
+				})
 		}
 
 		result, _ := json.MarshalIndent(generated, "", "  ")

--- a/internal/search/lucky/generator.go
+++ b/internal/search/lucky/generator.go
@@ -93,7 +93,7 @@ func NewGenerator(seed query.Basic, narrow, widen []rule) next {
 				// Base case: we exhausted the set of narrow
 				// rules (if any) and we've attempted every
 				// widen rule with the sets of narrow rules.
-				return func() (*autoQuery, next) { return nil, nil }
+				return nil
 			}
 
 			transform = append(transform, widen[w].transform...)


### PR DESCRIPTION
Now that I had a minute to stare at this I finally have a nicer control flow for generation. The generator returns `nil` only when exhausted, so the pattern from now on is just:

```go
g := NewGenerator(b, rulesNarrow, rulesWiden)
for g != nil {
  autoQ, g = g()
  // stuff
}
```

## Test plan
Covered by existing tests.
