### PR TITLE
search: change `repo:description()` predicate to `repo:has.description()`

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -225,10 +225,10 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         showSuggestions: true,
     },
     {
-        ...createQueryExampleFromString('description({regex-pattern})'),
+        ...createQueryExampleFromString('has.description({regex-pattern})'),
         field: FilterType.repo,
         description: 'Search inside repositories that have a description matched by the provided regex pattern.',
-        examples: ['repo:description(linux kernel)', 'repo:description(go.*library)'],
+        examples: ['repo:has.description(linux kernel)', 'repo:has.description(go.*library)'],
         showSuggestions: false,
     },
     {

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -408,7 +408,7 @@ describe('getCompletionItems()', () => {
               "dependencies(\${1}) ",
               "revdeps(\${1}) ",
               "dependents(\${1}) ",
-              "description(\${1}) ",
+              "has.description(\${1}) ",
               "^repo/with\\\\ a\\\\ space$ "
             ]
         `)
@@ -434,7 +434,7 @@ describe('getCompletionItems()', () => {
               "dependencies(\${1}) ",
               "revdeps(\${1}) ",
               "dependents(\${1}) ",
-              "description(\${1}) "
+              "has.description(\${1}) "
             ]
         `)
     })

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -102,7 +102,6 @@ export const repositoryInsertText = (
         // depsPredicateMatches[1] contains either `deps`, `dependencies`, `revdeps` or `dependents` based on the matched value.
         return `${depsPredicateMatches[1]}(${insertText})`
     }
-
     return insertText
 }
 

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -14,7 +14,6 @@ const filterCompletionItemKind = Monaco.languages.CompletionItemKind.Issue
 
 type PartialCompletionItem = Omit<Monaco.languages.CompletionItem, 'range'>
 
-export const REPO_DESCRIPTION_PREDICATE_REGEX = /^(description)\((.*?)\)?$/
 export const REPO_DEPS_PREDICATE_REGEX = /^(deps|dependencies|revdeps|dependents)\((.*?)\)?$/
 export const PREDICATE_REGEX = /^([.A-Za-z]+)\((.*?)\)?$/
 
@@ -102,14 +101,6 @@ export const repositoryInsertText = (
     if (depsPredicateMatches) {
         // depsPredicateMatches[1] contains either `deps`, `dependencies`, `revdeps` or `dependents` based on the matched value.
         return `${depsPredicateMatches[1]}(${insertText})`
-    }
-
-    const descriptionPredicateMatches = options.filterValue
-        ? options.filterValue.match(REPO_DESCRIPTION_PREDICATE_REGEX)
-        : null
-    if (descriptionPredicateMatches) {
-        // descriptionPredicateMatches[1] contains `description`
-        return `${descriptionPredicateMatches[1]}(${insertText})`
     }
 
     return insertText

--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1520,8 +1520,8 @@ describe('getMonacoTokens()', () => {
         `)
     })
 
-    test('highlight repo:description predicate', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:description(.*)')))).toMatchInlineSnapshot(`
+    test('highlight repo:has.description predicate', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:has.description(.*)')))).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -1533,23 +1533,31 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 5,
-                "scopes": "metaPredicateNameAccess"
+                "scopes": "identifier"
               },
               {
-                "startIndex": 16,
-                "scopes": "metaPredicateParenthesis"
-              },
-              {
-                "startIndex": 17,
+                "startIndex": 8,
                 "scopes": "metaRegexpCharacterSet"
               },
               {
-                "startIndex": 18,
+                "startIndex": 9,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 20,
+                "scopes": "metaRegexpDelimited"
+              },
+              {
+                "startIndex": 21,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 22,
                 "scopes": "metaRegexpRangeQuantifier"
               },
               {
-                "startIndex": 19,
-                "scopes": "metaPredicateParenthesis"
+                "startIndex": 23,
+                "scopes": "metaRegexpDelimited"
               }
             ]
         `)

--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1533,19 +1533,19 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 5,
-                "scopes": "identifier"
+                "scopes": "metaPredicateNameAccess"
               },
               {
                 "startIndex": 8,
-                "scopes": "metaRegexpCharacterSet"
+                "scopes": "metaPredicateDot"
               },
               {
                 "startIndex": 9,
-                "scopes": "identifier"
+                "scopes": "metaPredicateNameAccess"
               },
               {
                 "startIndex": 20,
-                "scopes": "metaRegexpDelimited"
+                "scopes": "metaPredicateParenthesis"
               },
               {
                 "startIndex": 21,
@@ -1557,7 +1557,7 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 23,
-                "scopes": "metaRegexpDelimited"
+                "scopes": "metaPredicateParenthesis"
               }
             ]
         `)

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -955,6 +955,7 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
             break
         case 'contains.file':
         case 'contains.content':
+        case 'has.description':
             return mapRegexpMetaSucceed({
                 type: 'pattern',
                 range: { start: offset, end: body.length },
@@ -965,7 +966,6 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
         case 'deps':
         case 'dependents':
         case 'revdeps':
-        case 'description':
             return mapRegexpMetaSucceed({
                 type: 'pattern',
                 range: { start: offset, end: body.length },

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -172,7 +172,7 @@ const toPredicateHover = (token: MetaPredicate): string => {
         case 'dependents':
         case 'revdeps':
             return '**Built-in predicate**. Search only repositories depending on repositories matching the regular expression'
-        case 'description':
+        case 'has.description':
             return '**Built-in predicate**. Search only inside repositories that have a **description** matching the given regular expression'
     }
     return ''

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -27,6 +27,12 @@ export const PREDICATES: Access[] = [
                 ],
             },
             {
+                name: 'has',
+                fields: [
+                    { name: 'description' },
+                ],
+            },
+            {
                 name: 'dependencies',
             },
             {
@@ -37,9 +43,6 @@ export const PREDICATES: Access[] = [
             },
             {
                 name: 'revdeps',
-            },
-            {
-                name: 'description',
             },
         ],
     },
@@ -200,8 +203,8 @@ export const predicateCompletion = (field: string): Completion[] => {
                 asSnippet: true,
             },
             {
-                label: 'description(...)',
-                insertText: 'description(${1})',
+                label: 'has.description(...)',
+                insertText: 'has.description(${1})',
                 asSnippet: true,
             },
         ]

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -28,9 +28,7 @@ export const PREDICATES: Access[] = [
             },
             {
                 name: 'has',
-                fields: [
-                    { name: 'description' },
-                ],
+                fields: [{ name: 'description' }],
             },
             {
                 name: 'dependencies',

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -5,7 +5,7 @@ import { map, delay, takeUntil, switchMap } from 'rxjs/operators'
 import { SearchPatternType } from '../../graphql-operations'
 import { isSearchMatchOfType, SearchMatch } from '../stream'
 
-import { getCompletionItems, REPO_DEPS_PREDICATE_REGEX, REPO_DESCRIPTION_PREDICATE_REGEX } from './completion'
+import { getCompletionItems, REPO_DEPS_PREDICATE_REGEX } from './completion'
 import { getMonacoTokens } from './decoratedToken'
 import { FilterType } from './filters'
 import { getHoverResult } from './hover'
@@ -67,11 +67,10 @@ export function getSuggestionQuery(tokens: Token[], tokenAtColumn: Token, sugges
     }
 
     if (suggestionType === 'repo') {
-        const predicateMatch =
-            tokenValue.match(REPO_DEPS_PREDICATE_REGEX) || tokenValue.match(REPO_DESCRIPTION_PREDICATE_REGEX)
-        const repoValue = predicateMatch ? predicateMatch[2] : tokenValue
+        const depsPredicateMatch = tokenValue.match(REPO_DEPS_PREDICATE_REGEX)
+        const repoValue = depsPredicateMatch ? depsPredicateMatch[2] : tokenValue
         const relevantFilters =
-            !hasAndOrOperators && !predicateMatch ? serializeFilters(tokens, REPO_SUGGESTION_FILTERS) : ''
+            !hasAndOrOperators && !depsPredicateMatch ? serializeFilters(tokens, REPO_SUGGESTION_FILTERS) : ''
         return `${relevantFilters} repo:${repoValue} type:repo count:${MAX_SUGGESTION_COUNT}`.trimStart()
     }
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -627,7 +627,7 @@ func toRepoOptions(b query.Basic, userSettings *schema.Settings) search.RepoOpti
 		MinusRepoFilters:    minusRepoFilters,
 		Dependencies:        b.Dependencies(),
 		Dependents:          b.Dependents(),
-		DescriptionPatterns: b.Description(),
+		DescriptionPatterns: b.RepoHasDescription(),
 		SearchContextSpec:   searchContextSpec,
 		ForkSet:             b.Fork() != nil,
 		OnlyForks:           fork == query.Only,

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -40,7 +40,7 @@ var DefaultPredicateRegistry = PredicateRegistry{
 		"deps":                  func() Predicate { return &RepoDependenciesPredicate{} },
 		"dependents":            func() Predicate { return &RepoDependentsPredicate{} },
 		"revdeps":               func() Predicate { return &RepoDependentsPredicate{} },
-		"description":           func() Predicate { return &RepoDescriptionPredicate{} },
+		"has.description":       func() Predicate { return &RepoHasDescriptionPredicate{} },
 	},
 	FieldFile: {
 		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
@@ -319,26 +319,26 @@ func (f *RepoDependentsPredicate) Plan(parent Basic) (Plan, error) {
 	return nil, nil
 }
 
-/* repo:description(...) */
+/* repo:has.description(...) */
 
-type RepoDescriptionPredicate struct {
+type RepoHasDescriptionPredicate struct {
 	Pattern string
 }
 
-func (f *RepoDescriptionPredicate) ParseParams(params string) (err error) {
+func (f *RepoHasDescriptionPredicate) ParseParams(params string) (err error) {
 	if _, err := regexp.Compile(params); err != nil {
-		return errors.Errorf("invalid repo:description argument: %w", err)
+		return errors.Errorf("invalid repo:has.description() argument: %w", err)
 	}
 	if len(params) == 0 {
-		return errors.New("empty repo:description predicate parameter")
+		return errors.New("empty repo:has.description() predicate parameter")
 	}
 	f.Pattern = params
 	return nil
 }
 
-func (f *RepoDescriptionPredicate) Field() string { return FieldRepo }
-func (f *RepoDescriptionPredicate) Name() string  { return "description" }
-func (f *RepoDescriptionPredicate) Plan(parent Basic) (Plan, error) {
+func (f *RepoHasDescriptionPredicate) Field() string { return FieldRepo }
+func (f *RepoHasDescriptionPredicate) Name() string  { return "has.description" }
+func (f *RepoHasDescriptionPredicate) Plan(parent Basic) (Plan, error) {
 	return nil, nil
 }
 

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -170,22 +170,22 @@ func TestRepoDependentsPredicate(t *testing.T) {
 	})
 }
 
-func TestRepoDescriptionPredicate(t *testing.T) {
+func TestRepoHasDescriptionPredicate(t *testing.T) {
 	t.Run("ParseParams", func(t *testing.T) {
 		type test struct {
 			name     string
 			params   string
-			expected *RepoDescriptionPredicate
+			expected *RepoHasDescriptionPredicate
 		}
 
 		valid := []test{
-			{`literal`, `test`, &RepoDescriptionPredicate{Pattern: "test"}},
-			{`regexp`, `test(.*)package`, &RepoDescriptionPredicate{Pattern: "test(.*)package"}},
+			{`literal`, `test`, &RepoHasDescriptionPredicate{Pattern: "test"}},
+			{`regexp`, `test(.*)package`, &RepoHasDescriptionPredicate{Pattern: "test(.*)package"}},
 		}
 
 		for _, tc := range valid {
 			t.Run(tc.name, func(t *testing.T) {
-				p := &RepoDescriptionPredicate{}
+				p := &RepoHasDescriptionPredicate{}
 				err := p.ParseParams(tc.params)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
@@ -204,7 +204,7 @@ func TestRepoDescriptionPredicate(t *testing.T) {
 
 		for _, tc := range invalid {
 			t.Run(tc.name, func(t *testing.T) {
-				p := &RepoDescriptionPredicate{}
+				p := &RepoHasDescriptionPredicate{}
 				err := p.ParseParams(tc.params)
 				if err == nil {
 					t.Fatal("expected error but got none")

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -393,8 +393,8 @@ func (p Parameters) Dependents() (dependents []string) {
 	return dependents
 }
 
-func (p Parameters) Description() (descriptionPatterns []string) {
-	VisitTypedPredicate(toNodes(p), func(pred *RepoDescriptionPredicate, _ bool) {
+func (p Parameters) RepoHasDescription() (descriptionPatterns []string) {
+	VisitTypedPredicate(toNodes(p), func(pred *RepoHasDescriptionPredicate, _ bool) {
 		split := strings.Split(pred.Pattern, " ")
 		descriptionPatterns = append(descriptionPatterns, "(?:"+strings.Join(split, ").*?(?:")+")")
 	})

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -25,5 +25,5 @@ func TestDescription(t *testing.T) {
 		"(?:test).*?(?:input)",
 	}
 
-	require.Equal(t, want, ps.Description())
+	require.Equal(t, want, ps.RepoHasDescription())
 }

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -6,16 +6,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDescription(t *testing.T) {
+func TestRepoHasDescription(t *testing.T) {
 	ps := Parameters{
 		Parameter{
 			Field:      FieldRepo,
-			Value:      "description(test)",
+			Value:      "has.description(test)",
 			Annotation: Annotation{Labels: IsPredicate},
 		},
 		Parameter{
 			Field:      FieldRepo,
-			Value:      "description(test input)",
+			Value:      "has.description(test input)",
 			Annotation: Annotation{Labels: IsPredicate},
 		},
 	}


### PR DESCRIPTION
Per discussion in [this thread](https://sourcegraph.slack.com/archives/C020S8AT3LN/p1657659303904099) we are going to try to move toward implementing `repo:has.X` syntax for predicates. `repo:description()` was literally just added so changing the syntax for that off the bat.

## Test plan
Unit tests, integration tests, visually verify things like predicate decoration.


https://user-images.githubusercontent.com/70350613/178629643-91c845d1-1fc2-43a1-894d-fbc3b68aa516.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
