### PR TITLE
repo-updater: queue changeset syncs when the archived flag changes

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/batches"
 	livedependencies "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/live"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -39,11 +40,8 @@ type Server struct {
 	GitserverClient interface {
 		ListCloned(context.Context) ([]string, error)
 	}
-	ChangesetSyncRegistry interface {
-		// EnqueueChangesetSyncs will queue the supplied changesets to sync ASAP.
-		EnqueueChangesetSyncs(ctx context.Context, ids []int64) error
-	}
-	RateLimitSyncer interface {
+	ChangesetSyncRegistry batches.ChangesetSyncRegistry
+	RateLimitSyncer       interface {
 		// SyncRateLimiters should be called when an external service changes so that
 		// our internal rate limiters are kept in sync
 		SyncRateLimiters(ctx context.Context, ids ...int64) error

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection.go
@@ -74,7 +74,7 @@ func (r *changesetsConnectionResolver) TotalCount(ctx context.Context) (int32, e
 		EnforceAuthz:         !r.optsSafe,
 		OnlyArchived:         r.opts.OnlyArchived,
 		IncludeArchived:      r.opts.IncludeArchived,
-		RepoID:               r.opts.RepoID,
+		RepoIDs:              r.opts.RepoIDs,
 	})
 	return int32(count), err
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -17,6 +17,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/deviceid"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
@@ -938,7 +939,7 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 		if err != nil {
 			return opts, false, errors.Wrap(err, "unmarshalling repo id")
 		}
-		opts.RepoID = repoID
+		opts.RepoIDs = []api.RepoID{repoID}
 	}
 
 	return opts, safe, nil

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -1195,7 +1195,7 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 			},
 			wantSafe: true,
 			wantParsed: store.ListChangesetsOpts{
-				RepoID: repoID,
+				RepoIDs: []api.RepoID{repoID},
 			},
 		},
 		// onlyClosable changesets

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
@@ -204,7 +204,7 @@ func bitbucketCloudRepoCommitStatusEventPRs(
 	// Now we can look up the changeset(s).
 	changesets, _, err := bstore.ListChangesets(ctx, store.ListChangesetsOpts{
 		BitbucketCloudCommit: e.CommitStatus.Commit.Hash,
-		RepoID:               repo.ID,
+		RepoIDs:              []api.RepoID{repo.ID},
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "listing changesets matched to repo ID=%d", repo.ID)

--- a/enterprise/internal/batches/background.go
+++ b/enterprise/internal/batches/background.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/syncer"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/batches"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -26,10 +27,7 @@ func InitBackgroundJobs(
 	db database.DB,
 	key encryption.Key,
 	cf *httpcli.Factory,
-) interface {
-	// EnqueueChangesetSyncs will queue the supplied changesets to sync ASAP.
-	EnqueueChangesetSyncs(ctx context.Context, ids []int64) error
-} {
+) batches.ChangesetSyncRegistry {
 	// We use an internal actor so that we can freely load dependencies from
 	// the database without repository permissions being enforced.
 	// We do check for repository permissions consciously in the Rewirer when

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -263,7 +263,7 @@ type CountChangesetsOpts struct {
 	PublicationState     *btypes.ChangesetPublicationState
 	TextSearch           []search.TextSearchTerm
 	EnforceAuthz         bool
-	RepoID               api.RepoID
+	RepoIDs              []api.RepoID
 }
 
 // CountChangesets returns the number of changesets in the database.
@@ -326,8 +326,8 @@ func countChangesetsQuery(opts *CountChangesetsOpts, authzConds *sqlf.Query) *sq
 	if opts.EnforceAuthz {
 		preds = append(preds, authzConds)
 	}
-	if opts.RepoID != 0 {
-		preds = append(preds, sqlf.Sprintf("repo.id = %s", opts.RepoID))
+	if len(opts.RepoIDs) > 0 {
+		preds = append(preds, sqlf.Sprintf("repo.id = ANY (%s)", pq.Array(opts.RepoIDs)))
 	}
 
 	join := sqlf.Sprintf("")
@@ -524,7 +524,7 @@ type ListChangesetsOpts struct {
 	OwnedByBatchChangeID int64
 	TextSearch           []search.TextSearchTerm
 	EnforceAuthz         bool
-	RepoID               api.RepoID
+	RepoIDs              []api.RepoID
 	BitbucketCloudCommit string
 }
 
@@ -612,8 +612,8 @@ func listChangesetsQuery(opts *ListChangesetsOpts, authzConds *sqlf.Query) *sqlf
 	if opts.EnforceAuthz {
 		preds = append(preds, authzConds)
 	}
-	if opts.RepoID != 0 {
-		preds = append(preds, sqlf.Sprintf("repo.id = %s", opts.RepoID))
+	if len(opts.RepoIDs) > 0 {
+		preds = append(preds, sqlf.Sprintf("repo.id = ANY (%s)", pq.Array(opts.RepoIDs)))
 	}
 	if len(opts.BitbucketCloudCommit) >= 12 {
 		// Bitbucket Cloud commit hashes in PR objects are generally truncated

--- a/enterprise/internal/batches/syncer/store.go
+++ b/enterprise/internal/batches/syncer/store.go
@@ -11,6 +11,7 @@ import (
 
 type SyncStore interface {
 	ListCodeHosts(ctx context.Context, opts store.ListCodeHostsOpts) ([]*btypes.CodeHost, error)
+	ListChangesets(ctx context.Context, opts store.ListChangesetsOpts) (btypes.Changesets, int64, error)
 	ListChangesetSyncData(context.Context, store.ListChangesetSyncDataOpts) ([]*btypes.ChangesetSyncData, error)
 	GetChangeset(context.Context, store.GetChangesetOpts) (*btypes.Changeset, error)
 	UpdateChangesetCodeHostState(ctx context.Context, cs *btypes.Changeset) error

--- a/internal/batches/syncer.go
+++ b/internal/batches/syncer.go
@@ -1,0 +1,23 @@
+// Package batches specifies interfaces that are called by Sourcegraph OSS, but
+// implemented in enterprise code in enterprise builds.
+//
+// No actual Batch Changes functionality is provided in this package.
+package batches
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+type ChangesetSyncRegistry interface {
+	UnarchivedChangesetSyncRegistry
+	// EnqueueChangesetSyncs will queue the supplied changesets to sync ASAP.
+	EnqueueChangesetSyncs(ctx context.Context, ids []int64) error
+}
+
+type UnarchivedChangesetSyncRegistry interface {
+	// EnqueueChangesetSyncsForRepos will queue a sync for every changeset in
+	// every given repo ASAP.
+	EnqueueChangesetSyncsForRepos(ctx context.Context, repoIDs []api.RepoID) error
+}

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -210,6 +210,15 @@ type Diff struct {
 	Deleted    types.Repos
 	Modified   types.Repos
 	Unmodified types.Repos
+
+	// Archived contains repositories that have been archived or unarchived on
+	// the code host between the previous sync and the current one. This is
+	// required for Batch Changes to migrate changesets on those repositories in
+	// and out of the read-only state.
+	//
+	// This field is always a strict subset of Modified, and is therefore not
+	// counted in Len() or iterated over in Repos().
+	Archived types.Repos
 }
 
 // Sort sorts all Diff elements by Repo.IDs.
@@ -219,6 +228,7 @@ func (d *Diff) Sort() {
 		d.Deleted,
 		d.Modified,
 		d.Unmodified,
+		d.Archived,
 	} {
 		sort.Sort(ds)
 	}
@@ -720,6 +730,8 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		stored = types.Repos{existing}
 		fallthrough
 	case 1: // Existing repo, update.
+		wasArchived := stored[0].Archived
+
 		if !stored[0].Update(sourced) {
 			d.Unmodified = append(d.Unmodified, stored[0])
 			break
@@ -731,6 +743,11 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 
 		*sourced = *stored[0]
 		d.Modified = append(d.Modified, stored[0])
+
+		if (wasArchived == true && stored[0].Archived == false) ||
+			(wasArchived == false && stored[0].Archived == true) {
+			d.Archived = append(d.Archived, stored[0])
+		}
 	case 0: // New repo, create.
 		if !svc.IsSiteOwned() { // enforce user and org repo limits
 			siteAdded, err := tx.CountNamespacedRepos(ctx, 0, 0)

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -647,10 +647,10 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 			},
 		}
 
-		clock := timeutil.NewFakeClock(time.Now(), 0)
+		now := time.Now().UTC()
 		oldRepo := repo.With(func(r *types.Repo) {
-			r.CreatedAt = clock.Now()
-			r.UpdatedAt = clock.Now()
+			r.UpdatedAt = now.Add(-time.Hour)
+			r.CreatedAt = r.UpdatedAt.Add(-time.Hour)
 			r.Stars = 0
 		})
 
@@ -774,14 +774,9 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 					}
 				}
 
-				// The clock has to advance a minute on each step to prevent SyncRepo
-				// from short circuiting because the last repo update was less than a
-				// minute ago.
-				clock := timeutil.NewFakeClock(time.Now(), 1*time.Minute)
-
 				syncer := &repos.Syncer{
 					Logger: logtest.Scoped(t),
-					Now:    clock.Now,
+					Now:    time.Now,
 					Store:  s,
 					Synced: make(chan repos.Diff, 1),
 					Sourcer: repos.NewFakeSourcer(nil,

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -601,7 +601,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				}
 
 				var want, have types.Repos
-				want.Concat(tc.diff.Added, tc.diff.Modified, tc.diff.Unmodified)
+				want.Concat(tc.diff.Added, tc.diff.Modified, tc.diff.Unmodified, tc.diff.Archived)
 				have, _ = st.RepoStore().List(ctx, database.ReposListOptions{})
 
 				want = want.With(typestest.Opt.RepoID(0))
@@ -647,53 +647,100 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 			},
 		}
 
-		now := time.Now().UTC()
+		clock := timeutil.NewFakeClock(time.Now(), 0)
 		oldRepo := repo.With(func(r *types.Repo) {
-			r.UpdatedAt = now.Add(-time.Hour)
-			r.CreatedAt = r.UpdatedAt.Add(-time.Hour)
+			r.CreatedAt = clock.Now()
+			r.UpdatedAt = clock.Now()
 			r.Stars = 0
 		})
 
 		testCases := []struct {
-			name          string
-			repo          api.RepoName
-			background    bool
-			before, after types.Repos
-			returned      *types.Repo
+			name       string
+			repo       api.RepoName
+			background bool        // whether to run SyncRepo in the background
+			before     types.Repos // the repos to insert into the database before syncing
+			sourced    *types.Repo // the repo that is returned by the fake sourcer
+			returned   *types.Repo // the expected return value from SyncRepo (which changes meaning depending on background)
+			after      types.Repos // the expected database repos after syncing
+			diff       repos.Diff  // the expected repos.Diff sent by the syncer
 		}{{
 			name:       "insert",
 			repo:       repo.Name,
 			background: true,
+			sourced:    repo.Clone(),
 			returned:   repo,
 			after:      types.Repos{repo},
+			diff: repos.Diff{
+				Added: types.Repos{repo},
+			},
 		}, {
 			name:       "update",
 			repo:       repo.Name,
 			background: true,
 			before:     types.Repos{oldRepo},
+			sourced:    repo.Clone(),
 			returned:   oldRepo,
 			after:      types.Repos{repo},
+			diff: repos.Diff{
+				Modified: types.Repos{repo},
+			},
 		}, {
 			name:       "blocking update",
 			repo:       repo.Name,
 			background: false,
 			before:     types.Repos{oldRepo},
+			sourced:    repo.Clone(),
 			returned:   repo,
 			after:      types.Repos{repo},
+			diff: repos.Diff{
+				Modified: types.Repos{repo},
+			},
 		}, {
 			name:       "update name",
 			repo:       repo.Name,
 			background: true,
 			before:     types.Repos{repo.With(typestest.Opt.RepoName("old/name"))},
+			sourced:    repo.Clone(),
 			returned:   repo,
 			after:      types.Repos{repo},
+			diff: repos.Diff{
+				Modified: types.Repos{repo},
+			},
+		}, {
+			name:       "archived",
+			repo:       repo.Name,
+			background: true,
+			before:     types.Repos{repo},
+			sourced:    repo.With(typestest.Opt.RepoArchived(true)),
+			returned:   repo,
+			after:      types.Repos{repo.With(typestest.Opt.RepoArchived(true))},
+			diff: repos.Diff{
+				Modified: types.Repos{repo.With(typestest.Opt.RepoArchived(true))},
+				Archived: types.Repos{repo.With(typestest.Opt.RepoArchived(true))},
+			},
+		}, {
+			name:       "unarchived",
+			repo:       repo.Name,
+			background: true,
+			before:     types.Repos{repo.With(typestest.Opt.RepoArchived(true))},
+			sourced:    repo.Clone(),
+			returned:   repo.With(typestest.Opt.RepoArchived(true)),
+			after:      types.Repos{repo},
+			diff: repos.Diff{
+				Modified: types.Repos{repo},
+				Archived: types.Repos{repo},
+			},
 		}, {
 			name:       "delete conflicting name",
 			repo:       repo.Name,
 			background: true,
 			before:     types.Repos{repo.With(typestest.Opt.RepoExternalID("old id"))},
+			sourced:    repo.Clone(),
 			returned:   repo.With(typestest.Opt.RepoExternalID("old id")),
 			after:      types.Repos{repo},
+			diff: repos.Diff{
+				Modified: types.Repos{repo},
+			},
 		}, {
 			name:       "rename and delete conflicting name",
 			repo:       repo.Name,
@@ -702,8 +749,12 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 				repo.With(typestest.Opt.RepoExternalID("old id")),
 				repo.With(typestest.Opt.RepoName("old name")),
 			},
+			sourced:  repo.Clone(),
 			returned: repo.With(typestest.Opt.RepoExternalID("old id")),
 			after:    types.Repos{repo},
+			diff: repos.Diff{
+				Modified: types.Repos{repo},
+			},
 		}}
 
 		for _, tc := range testCases {
@@ -723,13 +774,18 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 					}
 				}
 
+				// The clock has to advance a minute on each step to prevent SyncRepo
+				// from short circuiting because the last repo update was less than a
+				// minute ago.
+				clock := timeutil.NewFakeClock(time.Now(), 1*time.Minute)
+
 				syncer := &repos.Syncer{
 					Logger: logtest.Scoped(t),
-					Now:    time.Now,
+					Now:    clock.Now,
 					Store:  s,
 					Synced: make(chan repos.Diff, 1),
 					Sourcer: repos.NewFakeSourcer(nil,
-						repos.NewFakeSource(servicesPerKind[extsvc.KindGitHub], nil, repo.Clone()),
+						repos.NewFakeSource(servicesPerKind[extsvc.KindGitHub], nil, tc.sourced),
 					),
 				}
 
@@ -747,7 +803,9 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 					t.Errorf("returned mismatch: (-have, +want):\n%s", diff)
 				}
 
-				<-syncer.Synced
+				if diff := cmp.Diff(<-syncer.Synced, tc.diff, opt); diff != "" {
+					t.Errorf("diff mismatch: (-have, +want):\n%s", diff)
+				}
 
 				after, err := s.RepoStore().List(ctx, database.ReposListOptions{})
 				if err != nil {
@@ -1000,6 +1058,9 @@ func testSyncerMultipleServices(store repos.Store) func(t *testing.T) {
 			}
 			if len(diff.Unmodified) != 0 {
 				t.Fatalf("Expected 0 Unmodified repos. got %d", len(diff.Added))
+			}
+			if len(diff.Archived) != 0 {
+				t.Fatalf("Expected 0 Archived repos. got %d", len(diff.Added))
 			}
 		}
 

--- a/internal/types/typestest/typestest.go
+++ b/internal/types/typestest/typestest.go
@@ -265,6 +265,7 @@ var Opt = struct {
 	RepoDeletedAt             func(time.Time) func(*types.Repo)
 	RepoSources               func(...string) func(*types.Repo)
 	RepoMetadata              func(any) func(*types.Repo)
+	RepoArchived              func(bool) func(*types.Repo)
 	RepoExternalID            func(string) func(*types.Repo)
 }{
 	ExternalServiceID: func(n int64) func(*types.ExternalService) {
@@ -325,6 +326,11 @@ var Opt = struct {
 	RepoMetadata: func(md any) func(*types.Repo) {
 		return func(r *types.Repo) {
 			r.Metadata = md
+		}
+	},
+	RepoArchived: func(b bool) func(*types.Repo) {
+		return func(r *types.Repo) {
+			r.Archived = b
 		}
 	},
 	RepoExternalID: func(id string) func(*types.Repo) {


### PR DESCRIPTION
This PR adds functionality to `repo-updater` that enqueues a sync of each changeset on a repo that has been archived or unarchived. This is modelled heavily after the existing notification for the permission syncer.

This is technically not actually required — all published changesets on open batch changes will eventually be synced, even if they're in an otherwise terminal state — but implementing this reduces the lag time to update the changeset states. (We don't have any possibility of using webhooks here, so this is our only real bet to improve the latency on this process.)

This is PR 4 of 6 addressing #26820. (Originally it would have been 4 of 4, but I decided to split it up.)

## Review notes

### Repo Management

Thanks for looking at this!

I don't think there's anything too hairy here. There's some `interface` cheese moving to help with the injection of the changeset syncer into `watchSyncer`, but the interesting part is probably the addition of an `Archived` field to `repos.Diff` to signal the relevant repos back, since we can't tell from `repos.Diff.Modified` whether the archived field changed or not.

There's a synchronous query to list the affected changesets on the hot path at the end of `watchSyncer` that I _think_ is OK, since the syncer doesn't run that frequently, but if you have concerns on that speak up and I'll make it a goroutine or something. It doesn't _really_ need to be synchronous.

Feel free to ignore the Batch Changes specific parts. (Or don't, if you're interested. I can't tell you what to do.)

### Batch Changes

The main concern I have here is that we'll overwhelm the priority queue for changeset syncs. This error gets swallowed and turned into a log message, rather than being anything that bubbles back into `repo-updater`, but it does feel a bit like this is abusing the priority system. Of course, if we do #26922 in the next sprint, this won't matter for very long, since we can just enqueue the syncs that way.

I'm also happy to hear feedback if people think this is just unnecessary from a user experience perspective.

## Future work

The next PR will be to enqueue syncs from the reconciler when _it_ notices that a repo has become archived. That one's spicy.

## Test plan

Tested manually with a whole bunch of flipping repos in and out of archived states, and added what I think is pretty good test coverage, if I do say so myself.