### PR TITLE
Use computed style to set viewport constants in JS

### DIFF
--- a/client/wildcard/src/global-styles/breakpoints.scss
+++ b/client/wildcard/src/global-styles/breakpoints.scss
@@ -1,11 +1,17 @@
 // To use breakpoints mixins in CSS modules import this file via:
 // @import 'wildcard/src/global-styles/breakpoints';
 
-// These should match the viewpoint variables defined in viewports.ts
 $viewport-sm: 576px;
 $viewport-md: 768px;
 $viewport-lg: 992px;
 $viewport-xl: 1200px;
+
+:root {
+    --viewport-sm: #{$viewport-sm};
+    --viewport-md: #{$viewport-md};
+    --viewport-lg: #{$viewport-lg};
+    --viewport-xl: #{$viewport-xl};
+}
 
 /* stylelint-disable unknownAtRules */
 @custom-media --xs-breakpoint-up (min-width: none);

--- a/client/wildcard/src/viewports.ts
+++ b/client/wildcard/src/viewports.ts
@@ -1,8 +1,9 @@
-// These should match the viewpoint variables defined in global-styles/breakpoints.scss
-export const VIEWPORT_SM = 576
-export const VIEWPORT_MD = 768
-export const VIEWPORT_LG = 992
-export const VIEWPORT_XL = 1200
+const styles = getComputedStyle(document.documentElement)
+
+export const VIEWPORT_SM = parseInt(styles.getPropertyValue('--viewport-sm'), 10)
+export const VIEWPORT_MD = parseInt(styles.getPropertyValue('--viewport-md'), 10)
+export const VIEWPORT_LG = parseInt(styles.getPropertyValue('--viewport-lg'), 10)
+export const VIEWPORT_XL = parseInt(styles.getPropertyValue('--viewport-xl'), 10)
 
 export const VIEWPORTS = {
     sm: VIEWPORT_SM,


### PR DESCRIPTION
Following [some conversation in Slack](https://sourcegraph.slack.com/archives/C01LTKUHRL3/p1657633929002769), I took a brief look into what this would entail.

Is this a good idea? Maybe! Is this more effective than just hard-coding the values? In theory!

There appear to be [lots of ways](https://www.falldowngoboone.com/blog/share-variables-between-javascript-and-css/) of doing this. Most ways involve changes to the webpack config, so this is the most lightweight way.

## Test plan

Verified breakpoint values are respected when used in JS.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-pull-viewport-values-from-css.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nuwnsygzao.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
