### PR TITLE
dependencies: add fidelity column to codeintel_lockfiles and populate

### DIFF
--- a/internal/codeintel/dependencies/internal/lockfiles/dependency_graph_test.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/dependency_graph_test.go
@@ -42,6 +42,11 @@ func TestDependencyGraph(t *testing.T) {
 		dg.addDependency(c, e)
 		dg.addDependency(e, f)
 
+		_, undeterminable := dg.Roots()
+		if undeterminable {
+			t.Errorf("graph with non-root cycle has undeterminable roots")
+		}
+
 		gold.AssertJson(t, "normal", dg.AsMap())
 	})
 
@@ -68,6 +73,11 @@ func TestDependencyGraph(t *testing.T) {
 		dg.addDependency(e, f)
 		dg.addDependency(f, c)
 
+		_, undeterminable := dg.Roots()
+		if undeterminable {
+			t.Errorf("graph with non-root cycle has undeterminable roots")
+		}
+
 		gold.AssertJson(t, "circular", dg.AsMap())
 	})
 
@@ -93,6 +103,11 @@ func TestDependencyGraph(t *testing.T) {
 		dg.addDependency(c, e)
 		dg.addDependency(e, f)
 		dg.addDependency(f, a)
+
+		_, undeterminable := dg.Roots()
+		if !undeterminable {
+			t.Errorf("graph with root cycle is not undeterminable")
+		}
 
 		gold.AssertJson(t, "circular-root", dg.AsMap())
 	})

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -319,6 +319,7 @@ func (s *store) UpsertLockfileGraph(ctx context.Context, repoName, commit, lockf
 			dbutil.CommitBytea(commit),
 			idsArray,
 			lockfile,
+			shared.IndexFidelityFlat,
 			repoName,
 			idsArray,
 		))
@@ -364,25 +365,34 @@ func (s *store) UpsertLockfileGraph(ctx context.Context, repoName, commit, lockf
 	}
 
 	//
-	// Step 3: Insert codeintel_lockfile entry, pointing to the roots of the
+	// Step 3: Insert codeintel_lockfile entry, pointing to the rootIDs of the
 	//         graph (i.e. direct dependencies)
 	//
-	var roots []int
-	for _, r := range graph.Roots() {
+	var (
+		roots, rootsUndeterminable = graph.Roots()
+		rootIDs                    = make([]int, len(roots))
+	)
+	for i, r := range roots {
 		name := r.PackageSyntax()
 		id, ok := nameIDs[name]
 		if !ok {
 			return errors.Newf("id for root %s not found", name)
 		}
-		roots = append(roots, id)
+		rootIDs[i] = id
 	}
 
-	idsArray := pq.Array(roots)
+	fidelity := shared.IndexFidelityGraph
+	if rootsUndeterminable {
+		fidelity = shared.IndexFidelityCircular
+	}
+
+	idsArray := pq.Array(rootIDs)
 	return tx.db.Exec(ctx, sqlf.Sprintf(
 		insertLockfilesQuery,
 		dbutil.CommitBytea(commit),
 		idsArray,
 		lockfile,
+		fidelity,
 		repoName,
 		idsArray,
 	))
@@ -437,9 +447,10 @@ INSERT INTO codeintel_lockfiles (
 	repository_id,
 	commit_bytea,
 	codeintel_lockfile_reference_ids,
-	lockfile
+	lockfile,
+	fidelity
 )
-SELECT id, %s, %s, %s
+SELECT id, %s, %s, %s, %s
 FROM repo
 WHERE name = %s
 -- Last write wins

--- a/internal/codeintel/dependencies/shared/types.go
+++ b/internal/codeintel/dependencies/shared/types.go
@@ -6,6 +6,26 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 )
 
+// IndexFidelity describes the fidelity of the indexed dependency graph we
+// could get by parsing a lockfile.
+type IndexFidelity string
+
+const (
+	// IndexFidelityFlat is the default fidelity if we couldn't build a graph
+	// and create a flat list of all dependencies found in a lockfile.
+	IndexFidelityFlat IndexFidelity = "flat"
+
+	// IndexFidelityCircular is the fidelity if we couldn't determine the roots
+	// of the dependency, since it's circular, and create a forest of
+	// dependencies.
+	// That means we can't say what's a direct dependency and what not, but we
+	// can tell which dependency depends on which other dependency.
+	IndexFidelityCircular IndexFidelity = "circular"
+
+	// IndexFidelityGraph is the fidelity of a full graph.
+	IndexFidelityGraph IndexFidelity = "graph"
+)
+
 type Repo struct {
 	ID      int
 	Scheme  string
@@ -71,25 +91,29 @@ func SerializePackageDependency(dep reposource.VersionedPackage) PackageDependen
 }
 
 type DependencyGraph interface {
-	Roots() []PackageDependency
+	Roots() ([]PackageDependency, bool)
 	AllEdges() [][]PackageDependency
 	Empty() bool
 }
 
 var _ DependencyGraph = DependencyGraphLiteral{}
 
-func TestDependencyGraphLiteral(roots []PackageDependency, edges [][]PackageDependency) DependencyGraph {
-	return DependencyGraphLiteral{Edges: edges, RootPkgs: roots}
+func TestDependencyGraphLiteral(roots []PackageDependency, rootsUndeterminable bool, edges [][]PackageDependency) DependencyGraph {
+	return DependencyGraphLiteral{Edges: edges, RootPkgs: roots, RootsUndeterminable: rootsUndeterminable}
 }
 
 type DependencyGraphLiteral struct {
-	RootPkgs []PackageDependency
-	Edges    [][]PackageDependency
+	RootPkgs            []PackageDependency
+	RootsUndeterminable bool
+
+	Edges [][]PackageDependency
 }
 
 func (dg DependencyGraphLiteral) AllEdges() [][]PackageDependency { return dg.Edges }
-func (dg DependencyGraphLiteral) Roots() []PackageDependency      { return dg.RootPkgs }
-func (dg DependencyGraphLiteral) Empty() bool                     { return len(dg.RootPkgs) == 0 }
+func (dg DependencyGraphLiteral) Roots() ([]PackageDependency, bool) {
+	return dg.RootPkgs, dg.RootsUndeterminable
+}
+func (dg DependencyGraphLiteral) Empty() bool { return len(dg.RootPkgs) == 0 }
 
 func SerializeDependencyGraph(graph *lockfiles.DependencyGraph) DependencyGraph {
 	if graph == nil {
@@ -100,8 +124,8 @@ func SerializeDependencyGraph(graph *lockfiles.DependencyGraph) DependencyGraph 
 		edges           = graph.AllEdges()
 		serializedEdges = make([][]PackageDependency, len(edges))
 
-		roots           = graph.Roots()
-		serializedRoots = make([]PackageDependency, len(roots))
+		roots, rootsUndeterminable = graph.Roots()
+		serializedRoots            = make([]PackageDependency, len(roots))
 	)
 
 	for i, edge := range edges {
@@ -115,5 +139,9 @@ func SerializeDependencyGraph(graph *lockfiles.DependencyGraph) DependencyGraph 
 		serializedRoots[i] = SerializePackageDependency(root)
 	}
 
-	return DependencyGraphLiteral{RootPkgs: serializedRoots, Edges: serializedEdges}
+	return DependencyGraphLiteral{
+		RootPkgs:            serializedRoots,
+		RootsUndeterminable: rootsUndeterminable,
+		Edges:               serializedEdges,
+	}
 }

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -5838,6 +5838,19 @@
           "Comment": "A 40-char revhash. Note that this commit may not be resolvable in the future."
         },
         {
+          "Name": "fidelity",
+          "Index": 6,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "'flat'::text",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Fidelity of the dependency graph thats persisted, whether it is a flat list, a whole graph, circular graph, ..."
+        },
+        {
           "Name": "id",
           "Index": 1,
           "TypeName": "integer",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -730,6 +730,7 @@ Tracks a lockfile dependency that might be resolvable to a specific repository-c
  commit_bytea                     | bytea     |           | not null | 
  codeintel_lockfile_reference_ids | integer[] |           | not null | 
  lockfile                         | text      |           |          | 
+ fidelity                         | text      |           | not null | 'flat'::text
 Indexes:
     "codeintel_lockfiles_pkey" PRIMARY KEY, btree (id)
     "codeintel_lockfiles_repository_id_commit_bytea_lockfile" UNIQUE, btree (repository_id, commit_bytea, lockfile)
@@ -742,6 +743,8 @@ Associates a repository-commit pair with the set of repository-level dependencie
 **codeintel_lockfile_reference_ids**: A key to a resolved repository name-revspec pair. Not all repository names and revspecs are resolvable.
 
 **commit_bytea**: A 40-char revhash. Note that this commit may not be resolvable in the future.
+
+**fidelity**: Fidelity of the dependency graph thats persisted, whether it is a flat list, a whole graph, circular graph, ...
 
 **lockfile**: Relative path of a lockfile in the given repository and the given commit.
 

--- a/migrations/frontend/1657635365_add_fidelity_to_lockfiles/down.sql
+++ b/migrations/frontend/1657635365_add_fidelity_to_lockfiles/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE codeintel_lockfiles DROP COLUMN IF EXISTS fidelity;

--- a/migrations/frontend/1657635365_add_fidelity_to_lockfiles/metadata.yaml
+++ b/migrations/frontend/1657635365_add_fidelity_to_lockfiles/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_fidelity_to_lockfiles
+parents: [1657279170]

--- a/migrations/frontend/1657635365_add_fidelity_to_lockfiles/up.sql
+++ b/migrations/frontend/1657635365_add_fidelity_to_lockfiles/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE codeintel_lockfiles
+  ADD COLUMN IF NOT EXISTS fidelity text NOT NULL DEFAULT 'flat';
+
+COMMENT ON COLUMN codeintel_lockfiles.fidelity IS 'Fidelity of the dependency graph thats persisted, whether it is a flat list, a whole graph, circular graph, ...';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1219,7 +1219,8 @@ CREATE TABLE codeintel_lockfiles (
     repository_id integer NOT NULL,
     commit_bytea bytea NOT NULL,
     codeintel_lockfile_reference_ids integer[] NOT NULL,
-    lockfile text
+    lockfile text,
+    fidelity text DEFAULT 'flat'::text NOT NULL
 );
 
 COMMENT ON TABLE codeintel_lockfiles IS 'Associates a repository-commit pair with the set of repository-level dependencies parsed from lockfiles.';
@@ -1229,6 +1230,8 @@ COMMENT ON COLUMN codeintel_lockfiles.commit_bytea IS 'A 40-char revhash. Note t
 COMMENT ON COLUMN codeintel_lockfiles.codeintel_lockfile_reference_ids IS 'A key to a resolved repository name-revspec pair. Not all repository names and revspecs are resolvable.';
 
 COMMENT ON COLUMN codeintel_lockfiles.lockfile IS 'Relative path of a lockfile in the given repository and the given commit.';
+
+COMMENT ON COLUMN codeintel_lockfiles.fidelity IS 'Fidelity of the dependency graph thats persisted, whether it is a flat list, a whole graph, circular graph, ...';
 
 CREATE SEQUENCE codeintel_lockfiles_id_seq
     AS integer


### PR DESCRIPTION
As discussed with @efritz yesterday: this adds the `fidelity` column to the `codeintel_lockfiles` table and populates it when upserting a graph.

The values will likely change in the next few weeks (since we might be able to get rid of `circle` if we use more files to determine full graph) so it's not a database enum.

## Test plan

- Existing unit tests
- New unit tests
