### PR TITLE
dependencies: Remove curl dependency from image

### DIFF
--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -27,7 +27,6 @@ RUN apk update && apk add --no-cache \
     bind-tools \
     busybox \
     ca-certificates \
-    'curl>=7.79.1-r2' \
     mailcap \
     tini \
     wget


### PR DESCRIPTION
Removing the `curl` dependency as it causes a lot of docker updates due to vulnerabilities. It's recommended to install it locally when required for debugging. The install time is lower than the amount of time it takes to build new docker images for each CVE.

## Test plan

CI checks

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
