### PR TITLE
Accessibility: Codemod from `<MdiIcon />` to `<Icon svgPath={mdiPath} aria-(hidden|label) />`

### DIFF
--- a/client/branded/src/components/CodeSnippet.tsx
+++ b/client/branded/src/components/CodeSnippet.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo } from 'react'
 
+import { mdiContentCopy } from '@mdi/js'
 import classNames from 'classnames'
 import copy from 'copy-to-clipboard'
-import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
 
 import { highlightCodeSafe } from '@sourcegraph/common'
-import { Button, Code } from '@sourcegraph/wildcard'
+import { Button, Code, Icon } from '@sourcegraph/wildcard'
 
 import styles from './CodeSnippet.module.scss'
 
@@ -31,7 +31,7 @@ export const CodeSnippet: React.FunctionComponent<React.PropsWithChildren<CodeSn
         <pre className={classNames('bg-code rounded border p-3 position-relative', className)}>
             {withCopyButton && (
                 <Button className={styles.copyButton} onClick={() => copy(code)}>
-                    <ContentCopyIcon className="pr-2 pt-2" />
+                    <Icon className="pr-2 pt-2" svgPath={mdiContentCopy} inline={false} aria-label="Copy" />
                 </Button>
             )}
             <Code dangerouslySetInnerHTML={highlightedInput} />

--- a/client/branded/src/components/panel/views/ReferencePanelCta.tsx
+++ b/client/branded/src/components/panel/views/ReferencePanelCta.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
+import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
-import CloseIcon from 'mdi-react/CloseIcon'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
-import { Alert, Button } from '@sourcegraph/wildcard'
+import { Alert, Button, Icon } from '@sourcegraph/wildcard'
 
 import styles from './ReferencePanelCta.module.scss'
 
@@ -33,7 +33,7 @@ export const ReferencePanelCta: React.FunctionComponent = () => {
                         className={classNames('m-0 p-0 text-right', styles.button)}
                         onClick={() => setCtaDismissed(true)}
                     >
-                        <CloseIcon size={16} />
+                        <Icon svgPath={mdiClose} inline={false} aria-label="Close" height={16} width={16} />
                     </Button>
                 </Alert>
             )}

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -29,9 +29,11 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
             type="button"
           >
             <svg
-              class="mdi-icon "
+              aria-label="Close"
+              class="mdi-icon"
               fill="currentColor"
               height="16"
+              role="img"
               viewBox="0 0 24 24"
               width="16"
             >
@@ -296,9 +298,11 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
             type="button"
           >
             <svg
-              class="mdi-icon "
+              aria-label="Close"
+              class="mdi-icon"
               fill="currentColor"
               height="16"
+              role="img"
               viewBox="0 0 24 24"
               width="16"
             >
@@ -517,9 +521,11 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
             type="button"
           >
             <svg
-              class="mdi-icon "
+              aria-label="Close"
+              class="mdi-icon"
               fill="currentColor"
               height="16"
+              role="img"
               viewBox="0 0 24 24"
               width="16"
             >

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { mdiEarth, mdiBookOpenPageVariant, mdiCheckCircleOutline, mdiLock, mdiBlockHelper } from '@mdi/js'
+import { mdiEarth, mdiBookOpenPageVariant, mdiCheckCircleOutline, mdiLock, mdiBlockHelper, mdiOpenInNew } from '@mdi/js'
 import { Combobox, ComboboxInput, ComboboxOption, ComboboxPopover, ComboboxList } from '@reach/combobox'
 import classNames from 'classnames'
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import { Observable } from 'rxjs'
 
 import { LoaderInput } from '@sourcegraph/branded/src/components/LoaderInput'
@@ -136,7 +135,15 @@ export const OptionsPage: React.FunctionComponent<React.PropsWithChildren<Option
                     {...NEW_TAB_LINK_PROPS}
                     className="d-block mb-1"
                 >
-                    <small>How do we keep your code private?</small> <OpenInNewIcon size="0.75rem" className="ml-2" />
+                    <small>How do we keep your code private?</small>{' '}
+                    <Icon
+                        className="ml-2"
+                        svgPath={mdiOpenInNew}
+                        inline={false}
+                        aria-hidden={true}
+                        height="0.75rem"
+                        width="0.75rem"
+                    />
                 </Link>
                 <Text className="mb-0">
                     <Button

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react'
 
+import { mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import { from, Subject, Subscription } from 'rxjs'
 import { catchError, map, mapTo, mergeMap, startWith, tap } from 'rxjs/operators'
 
 import { ActionContribution, Evaluated } from '@sourcegraph/client-api'
 import { asError, ErrorLike, isErrorLike, isExternalLink } from '@sourcegraph/common'
-import { LoadingSpinner, Button, ButtonLink, ButtonLinkProps, WildcardThemeContext } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Button, ButtonLink, ButtonLinkProps, WildcardThemeContext, Icon } from '@sourcegraph/wildcard'
 
 import { ExecuteCommandParameters } from '../api/client/mainthread-api'
 import { urlForOpenPanel } from '../commands/commands'
@@ -336,7 +336,12 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
             >
                 {content}{' '}
                 {!this.props.hideExternalLinkIcon && primaryTo && isExternalLink(primaryTo) && (
-                    <OpenInNewIcon className={this.props.iconClassName} />
+                    <Icon
+                        className={this.props.iconClassName}
+                        svgPath={mdiOpenInNew}
+                        inline={false}
+                        aria-hidden={true}
+                    />
                 )}
                 {showLoadingSpinner && (
                     <div className={styles.loader} data-testid="action-item-spinner">

--- a/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -36,7 +36,19 @@ exports[`ActionItem "open" command renders as link with icon and opens a new tab
     target="_blank"
   >
      t 
-    <openinnewicon />
+    <svg
+      aria-hidden="true"
+      class="mdi-icon"
+      fill="currentColor"
+      height="24"
+      role="img"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+      />
+    </svg>
   </a>
 </DocumentFragment>
 `;

--- a/client/shared/src/hover/HoverOverlay.tsx
+++ b/client/shared/src/hover/HoverOverlay.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties, useCallback, useState } from 'react'
 
+import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
-import CloseIcon from 'mdi-react/CloseIcon'
 
 import { isErrorLike, sanitizeClass } from '@sourcegraph/common'
 // eslint-disable-next-line no-restricted-imports
@@ -176,7 +176,7 @@ export const HoverOverlay: React.FunctionComponent<React.PropsWithChildren<Hover
                             hoverOrError === LOADING && hoverOverlayStyle.closeButtonLoading
                         )}
                     >
-                        <CloseIcon className={iconClassName} />
+                        <Icon className={iconClassName} svgPath={mdiClose} inline={false} aria-label="Close" />
                     </button>
                 )}
                 <HoverOverlayContents

--- a/client/web/src/auth/ExternalsAuth.tsx
+++ b/client/web/src/auth/ExternalsAuth.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
+import { mdiGithub } from '@mdi/js'
 import classNames from 'classnames'
-import GithubIcon from 'mdi-react/GithubIcon'
 
-import { Link } from '@sourcegraph/wildcard'
+import { Link, Icon } from '@sourcegraph/wildcard'
 
 import { AuthProvider, SourcegraphContext } from '../jscontext'
 
@@ -82,7 +82,7 @@ const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<ExternalsAu
                     )}
                     onClick={() => onClick('github')}
                 >
-                    <GithubIcon className="mr-3" /> {githubLabel}
+                    <Icon className="mr-3" svgPath={mdiGithub} inline={false} aria-hidden={true} /> {githubLabel}
                 </Link>
             )}
 

--- a/client/web/src/components/ExecutionLogEntry.tsx
+++ b/client/web/src/components/ExecutionLogEntry.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
+import { mdiCheckCircle, mdiAlertCircle } from '@mdi/js'
 
 import { pluralize } from '@sourcegraph/common'
-import { LoadingSpinner, CardBody, Card } from '@sourcegraph/wildcard'
+import { LoadingSpinner, CardBody, Card, Icon } from '@sourcegraph/wildcard'
 
 import { Collapsible } from './Collapsible'
 import { LogOutput } from './LogOutput'
@@ -42,9 +41,19 @@ export const ExecutionLogEntry: React.FunctionComponent<React.PropsWithChildren<
                 {logEntry.exitCode !== null && (
                     <>
                         {logEntry.exitCode === 0 ? (
-                            <CheckCircleIcon className="text-success mr-1" />
+                            <Icon
+                                className="text-success mr-1"
+                                svgPath={mdiCheckCircle}
+                                inline={false}
+                                aria-label="Success"
+                            />
                         ) : (
-                            <AlertCircleIcon className="text-danger mr-1" />
+                            <Icon
+                                className="text-danger mr-1"
+                                svgPath={mdiAlertCircle}
+                                inline={false}
+                                aria-label="Failed"
+                            />
                         )}
                     </>
                 )}

--- a/client/web/src/components/Timeline.story.tsx
+++ b/client/web/src/components/Timeline.story.tsx
@@ -1,8 +1,6 @@
 import { mdiCheck, mdiAlertCircle } from '@mdi/js'
 import { Meta, Story, DecoratorFn } from '@storybook/react'
 import { parseISO } from 'date-fns'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckIcon from 'mdi-react/CheckIcon'
 
 import { Icon, Text } from '@sourcegraph/wildcard'
 
@@ -90,7 +88,7 @@ export const Details: Story = () => (
                         expandedByDefault: true,
                     },
                     {
-                        icon: <CheckIcon />,
+                        icon: <Icon svgPath={mdiCheck} inline={false} aria-label="Success" />,
                         className: 'bg-success',
                         text: 'Third event description',
                         date: '2020-06-15T13:25:00+00:00',
@@ -111,13 +109,13 @@ export const DetailsWithoutDurations: Story = () => (
                 showDurations={false}
                 stages={[
                     {
-                        icon: <CheckIcon />,
+                        icon: <Icon svgPath={mdiCheck} inline={false} aria-label="Success" />,
                         className: 'bg-success',
                         text: 'First event description',
                         date: '2020-06-15T11:15:00+00:00',
                     },
                     {
-                        icon: <AlertCircleIcon />,
+                        icon: <Icon svgPath={mdiAlertCircle} inline={false} aria-label="Failed" />,
                         className: 'bg-danger',
                         text: 'Second event description',
                         date: '2020-06-15T12:20:00+00:00',

--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 
-import { mdiAccount } from '@mdi/js'
+import { mdiAccount, mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
 import { Icon, Link, H3, Text } from '@sourcegraph/wildcard'
 
@@ -60,7 +59,7 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
                 </H3>
                 {shortDescription && <Text className="mb-0 text-muted">{shortDescription}</Text>}
             </div>
-            {to && <ChevronRightIcon className="align-self-center" />}
+            {to && <Icon className="align-self-center" svgPath={mdiChevronRight} inline={false} aria-hidden={true} />}
         </div>
     )
     return to ? (

--- a/client/web/src/enterprise/batches/BatchSpecsPage.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecsPage.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useMemo } from 'react'
 
+import { mdiMapSearch } from '@mdi/js'
 import classNames from 'classnames'
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { RouteComponentProps } from 'react-router'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Container, PageHeader, H5 } from '@sourcegraph/wildcard'
+import { Container, PageHeader, H5, Icon } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../components/FilteredConnection'
 import { PageTitle } from '../../components/PageTitle'
@@ -126,7 +126,7 @@ const Header: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
 
 const EmptyList: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <div className="text-muted text-center mb-3 w-100">
-        <MapSearchIcon className="icon" />
+        <Icon className="icon" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <div className="pt-2">No batch specs have been created so far.</div>
     </div>
 )

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { mdiChevronDown } from '@mdi/js'
 import VisuallyHidden from '@reach/visually-hidden'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 
 import {
     ProductStatusBadge,
@@ -16,6 +16,7 @@ import {
     H4,
     Text,
     Tooltip,
+    Icon,
 } from '@sourcegraph/wildcard'
 
 import styles from './DropdownButton.module.scss'
@@ -145,7 +146,7 @@ export const DropdownButton: React.FunctionComponent<React.PropsWithChildren<Pro
                     </Tooltip>
                     {actions.length > 1 && (
                         <MenuButton variant="primary" className={styles.dropdownButton}>
-                            <ChevronDownIcon />
+                            <Icon svgPath={mdiChevronDown} inline={false} aria-hidden={true} />
                             <VisuallyHidden>Actions</VisuallyHidden>
                         </MenuButton>
                     )}

--- a/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
+import { mdiClose } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
-import CloseIcon from 'mdi-react/CloseIcon'
 
 import { CodeSnippet } from '@sourcegraph/branded/src/components/CodeSnippet'
-import { Button, Link, Modal, H3, H4, Text } from '@sourcegraph/wildcard'
+import { Button, Link, Modal, H3, H4, Text, Icon } from '@sourcegraph/wildcard'
 
 import { BatchSpecDownloadLink, getFileName } from '../../BatchSpec'
 
@@ -46,7 +46,7 @@ export const DownloadSpecModal: React.FunctionComponent<React.PropsWithChildren<
                 }}
             >
                 <VisuallyHidden>Close</VisuallyHidden>
-                <CloseIcon className={styles.icon} />
+                <Icon className={styles.icon} svgPath={mdiClose} inline={false} aria-hidden={true} />
             </Button>
         </div>
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
 
-import { mdiInformationOutline } from '@mdi/js'
+import { mdiInformationOutline, mdiChevronDown } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import { animated } from 'react-spring'
 
 import {
@@ -60,7 +59,7 @@ export const RunBatchSpecButton: React.FunctionComponent<React.PropsWithChildren
                     type="button"
                     className={styles.executionOptionsMenuButton}
                 >
-                    <ChevronDownIcon />
+                    <Icon svgPath={mdiChevronDown} inline={false} aria-hidden={true} />
                     <VisuallyHidden>Options</VisuallyHidden>
                 </PopoverTrigger>
             </ButtonGroup>

--- a/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
+import { mdiClose } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
-import CloseIcon from 'mdi-react/CloseIcon'
 
-import { Button, Link, Modal, H3, H4, Text } from '@sourcegraph/wildcard'
+import { Button, Link, Modal, H3, H4, Text, Icon } from '@sourcegraph/wildcard'
 
 import styles from './RunServerSideModal.module.scss'
 
@@ -29,7 +29,7 @@ export const RunServerSideModal: React.FunctionComponent<RunServerSideModalProps
             }}
         >
             <VisuallyHidden>Close</VisuallyHidden>
-            <CloseIcon className={styles.icon} />
+            <Icon className={styles.icon} svgPath={mdiClose} inline={false} aria-hidden={true} />
         </Button>
 
         <div className={styles.content}>

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react'
 
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import { mdiMapSearch } from '@mdi/js'
 
 import { dataOrThrowErrors } from '@sourcegraph/http-client'
 import { BulkOperationState } from '@sourcegraph/shared/src/graphql-operations'
-import { Container } from '@sourcegraph/wildcard'
+import { Container, Icon } from '@sourcegraph/wildcard'
 
 import { dismissAlert } from '../../../components/DismissibleAlert'
 import { useConnection, UseConnectionResult } from '../../../components/FilteredConnection/hooks/useConnection'
@@ -68,7 +68,7 @@ export const BulkOperationsTab: React.FunctionComponent<React.PropsWithChildren<
 
 const EmptyBulkOperationsListElement: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <div className="text-muted text-center mb-3 w-100">
-        <MapSearchIcon className="icon" />
+        <Icon className="icon" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <div className="pt-2">No bulk operations have been run on this batch change.</div>
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
 
+import { mdiTimerSand, mdiGateArrowRight, mdiCommentOutline, mdiDelta, mdiCheckCircle } from '@mdi/js'
 import classNames from 'classnames'
-import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
-import CommentOutlineIcon from 'mdi-react/CommentOutlineIcon'
-import DeltaIcon from 'mdi-react/DeltaIcon'
-import GateArrowRightIcon from 'mdi-react/GateArrowRightIcon'
-import TimerSandIcon from 'mdi-react/TimerSandIcon'
+
+import { Icon } from '@sourcegraph/wildcard'
 
 import { ExternalChangesetFields, ChangesetReviewState } from '../../../../graphql-operations'
 
@@ -40,7 +38,7 @@ export const ChangesetReviewStatusPending: React.FunctionComponent<React.PropsWi
             className
         )}
     >
-        <TimerSandIcon />
+        <Icon svgPath={mdiTimerSand} inline={false} aria-hidden={true} />
         <span className="text-muted">Pending</span>
     </div>
 )
@@ -53,7 +51,7 @@ export const ChangesetReviewStatusDismissed: React.FunctionComponent<
             className
         )}
     >
-        <GateArrowRightIcon />
+        <Icon svgPath={mdiGateArrowRight} inline={false} aria-hidden={true} />
         <span className="text-muted">Dismissed</span>
     </div>
 )
@@ -66,7 +64,7 @@ export const ChangesetReviewStatusCommented: React.FunctionComponent<
             className
         )}
     >
-        <CommentOutlineIcon />
+        <Icon svgPath={mdiCommentOutline} inline={false} aria-hidden={true} />
         <span className="text-muted">Commented</span>
     </div>
 )
@@ -79,7 +77,7 @@ export const ChangesetReviewStatusChangesRequested: React.FunctionComponent<
             className
         )}
     >
-        <DeltaIcon />
+        <Icon svgPath={mdiDelta} inline={false} aria-hidden={true} />
         <span className="text-muted">Changes requested</span>
     </div>
 )
@@ -92,7 +90,7 @@ export const ChangesetReviewStatusApproved: React.FunctionComponent<
             className
         )}
     >
-        <CheckCircleIcon />
+        <Icon svgPath={mdiCheckCircle} inline={false} aria-hidden={true} />
         <span className="text-muted">Approved</span>
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.tsx
@@ -1,17 +1,19 @@
 import React from 'react'
 
+import {
+    mdiSourceBranch,
+    mdiSourcePull,
+    mdiSourceMerge,
+    mdiDelete,
+    mdiAlertCircle,
+    mdiAutorenew,
+    mdiTimerSand,
+    mdiArchive,
+    mdiLock,
+} from '@mdi/js'
 import classNames from 'classnames'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import ArchiveIcon from 'mdi-react/ArchiveIcon'
-import AutorenewIcon from 'mdi-react/AutorenewIcon'
-import DeleteIcon from 'mdi-react/DeleteIcon'
-import LockIcon from 'mdi-react/LockIcon'
-import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
-import SourceMergeIcon from 'mdi-react/SourceMergeIcon'
-import SourcePullIcon from 'mdi-react/SourcePullIcon'
-import TimerSandIcon from 'mdi-react/TimerSandIcon'
 
-import { Tooltip } from '@sourcegraph/wildcard'
+import { Tooltip, Icon } from '@sourcegraph/wildcard'
 
 import { ChangesetFields, ChangesetState, Scalars } from '../../../../graphql-operations'
 
@@ -67,7 +69,7 @@ export const ChangesetStatusUnpublished: React.FunctionComponent<React.PropsWith
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <SourceBranchIcon role="presentation" />
+        <Icon svgPath={mdiSourceBranch} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -77,7 +79,7 @@ export const ChangesetStatusClosed: React.FunctionComponent<React.PropsWithChild
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <SourcePullIcon className="text-danger" role="presentation" />
+        <Icon className="text-danger" svgPath={mdiSourcePull} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -87,7 +89,7 @@ export const ChangesetStatusMerged: React.FunctionComponent<React.PropsWithChild
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <SourceMergeIcon className="text-merged" role="presentation" />
+        <Icon className="text-merged" svgPath={mdiSourceMerge} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -97,7 +99,7 @@ export const ChangesetStatusOpen: React.FunctionComponent<React.PropsWithChildre
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <SourcePullIcon className="text-success" role="presentation" />
+        <Icon className="text-success" svgPath={mdiSourcePull} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -107,7 +109,7 @@ export const ChangesetStatusDraft: React.FunctionComponent<React.PropsWithChildr
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <SourcePullIcon role="presentation" />
+        <Icon svgPath={mdiSourcePull} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -117,7 +119,7 @@ export const ChangesetStatusDeleted: React.FunctionComponent<React.PropsWithChil
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <DeleteIcon role="presentation" />
+        <Icon svgPath={mdiDelete} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -127,7 +129,7 @@ export const ChangesetStatusError: React.FunctionComponent<React.PropsWithChildr
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <AlertCircleIcon className="text-danger" role="presentation" />
+        <Icon className="text-danger" svgPath={mdiAlertCircle} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -137,7 +139,7 @@ export const ChangesetStatusRetrying: React.FunctionComponent<React.PropsWithChi
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <AutorenewIcon role="presentation" />
+        <Icon svgPath={mdiAutorenew} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -148,7 +150,7 @@ export const ChangesetStatusProcessing: React.FunctionComponent<React.PropsWithC
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <TimerSandIcon role="presentation" />
+        <Icon svgPath={mdiTimerSand} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -159,7 +161,7 @@ export const ChangesetStatusArchived: React.FunctionComponent<React.PropsWithChi
     ...props
 }) => (
     <div className={classNames(iconClassNames, className)} {...props}>
-        <ArchiveIcon role="presentation" />
+        <Icon svgPath={mdiArchive} inline={false} aria-hidden={true} />
         {label}
     </div>
 )
@@ -171,7 +173,7 @@ export const ChangesetStatusReadOnly: React.FunctionComponent<React.PropsWithChi
 }) => (
     <Tooltip content="This changeset is read-only, and cannot be modified. This is usually caused by the repository being archived.">
         <div className={classNames(iconClassNames, className)} {...props}>
-            <LockIcon role="presentation" />
+            <Icon svgPath={mdiLock} inline={false} aria-hidden={true} />
             {label}
         </div>
     </Tooltip>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusScheduled.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusScheduled.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useState } from 'react'
 
+import { mdiTimerOutline } from '@mdi/js'
 import classNames from 'classnames'
 import { formatDistanceToNow, isBefore, parseISO } from 'date-fns'
-import TimerOutlineIcon from 'mdi-react/TimerOutlineIcon'
 
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
-import { Tooltip } from '@sourcegraph/wildcard'
+import { Tooltip, Icon } from '@sourcegraph/wildcard'
 
 import { getChangesetScheduleEstimate } from '../backend'
 
@@ -88,7 +88,7 @@ const DynamicChangesetStatusScheduled: React.FunctionComponent<React.PropsWithCh
     return (
         <Tooltip content={tooltip}>
             <div className={classNames(iconClassNames, className)} onMouseOver={onMouseOver} onFocus={onMouseOver}>
-                <TimerOutlineIcon />
+                <Icon svgPath={mdiTimerOutline} inline={false} aria-hidden={true} />
                 {label}
             </div>
         </Tooltip>
@@ -99,7 +99,7 @@ const StaticChangesetStatusScheduled: React.FunctionComponent<
     React.PropsWithChildren<Pick<Props, 'label' | 'className'>>
 > = ({ label, className }) => (
     <div className={classNames(iconClassNames, className)}>
-        <TimerOutlineIcon />
+        <Icon svgPath={mdiTimerOutline} inline={false} aria-hidden={true} />
         {label}
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/EmptyArchivedChangesetListElement.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/EmptyArchivedChangesetListElement.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 
-import ArchiveIcon from 'mdi-react/ArchiveIcon'
+import { mdiArchive } from '@mdi/js'
+
+import { Icon } from '@sourcegraph/wildcard'
 
 export const EmptyArchivedChangesetListElement: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <div className="text-muted mb-3 text-center w-100">
-        <ArchiveIcon className="icon" />
+        <Icon className="icon" svgPath={mdiArchive} inline={false} aria-hidden={true} />
         <div className="pt-2">This batch change does not contain archived changesets.</div>
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/EmptyChangesetSearchElement.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/EmptyChangesetSearchElement.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 
-import MagnifyIcon from 'mdi-react/MagnifyIcon'
+import { mdiMagnify } from '@mdi/js'
+
+import { Icon } from '@sourcegraph/wildcard'
 
 export const EmptyChangesetSearchElement: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <div className="text-muted row mb-3 w-100">
         <div className="col-12 text-center">
-            <MagnifyIcon className="icon" />
+            <Icon className="icon" svgPath={mdiMagnify} inline={false} aria-hidden={true} />
             <div className="pt-2">No changesets matched the search and/or filters selected.</div>
         </div>
     </div>

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { mdiExternalLink } from '@mdi/js'
+import { mdiOpenInNew } from '@mdi/js'
 
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { Icon } from '@sourcegraph/wildcard'
@@ -24,7 +24,7 @@ export const ExternalChangesetTitle: React.FunctionComponent<React.PropsWithChil
         {externalURL?.url && (
             <>
                 {' '}
-                <Icon svgPath={mdiExternalLink} inline={false} aria-hidden={true} height="1rem" width="1rem" />
+                <Icon svgPath={mdiOpenInNew} inline={false} aria-hidden={true} height="1rem" width="1rem" />
             </>
         )}
     </LinkOrSpan>

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 
-import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
+import { mdiExternalLink } from '@mdi/js'
 
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
+import { Icon } from '@sourcegraph/wildcard'
 
 import { ExternalChangesetFields } from '../../../../graphql-operations'
 
@@ -23,7 +24,7 @@ export const ExternalChangesetTitle: React.FunctionComponent<React.PropsWithChil
         {externalURL?.url && (
             <>
                 {' '}
-                <ExternalLinkIcon size="1rem" />
+                <Icon svgPath={mdiExternalLink} inline={false} aria-hidden={true} height="1rem" width="1rem" />
             </>
         )}
     </LinkOrSpan>

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from 'react'
 
+import { mdiHistory } from '@mdi/js'
 import classNames from 'classnames'
-import HistoryIcon from 'mdi-react/HistoryIcon'
 
-import { Badge, Tooltip } from '@sourcegraph/wildcard'
+import { Badge, Tooltip, Icon } from '@sourcegraph/wildcard'
 
 import { BatchChangeState, BatchSpecState, Scalars } from '../../../graphql-operations'
 
@@ -111,7 +111,7 @@ const ExecutionStatePill: React.FunctionComponent<
                     }.`}
                 >
                     <Badge variant="warning" className={styles.executionPill}>
-                        <HistoryIcon className={styles.executionIcon} />
+                        <Icon className={styles.executionIcon} svgPath={mdiHistory} inline={false} aria-hidden={true} />
                     </Badge>
                 </Tooltip>
             )
@@ -120,7 +120,7 @@ const ExecutionStatePill: React.FunctionComponent<
             return (
                 <Tooltip content="This batch change has a newer batch spec execution that is ready to be applied.">
                     <Badge variant="primary" className={styles.executionPill}>
-                        <HistoryIcon className={styles.executionIcon} />
+                        <Icon className={styles.executionIcon} svgPath={mdiHistory} inline={false} aria-hidden={true} />
                     </Badge>
                 </Tooltip>
             )
@@ -129,7 +129,7 @@ const ExecutionStatePill: React.FunctionComponent<
             return (
                 <Tooltip content="The latest batch spec execution for this batch change failed.">
                     <Badge variant="danger" className={styles.executionPill}>
-                        <HistoryIcon className={styles.executionIcon} />
+                        <Icon className={styles.executionIcon} svgPath={mdiHistory} inline={false} aria-hidden={true} />
                     </Badge>
                 </Tooltip>
             )

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
@@ -111,7 +111,16 @@ const ExecutionStatePill: React.FunctionComponent<
                     }.`}
                 >
                     <Badge variant="warning" className={styles.executionPill}>
-                        <Icon className={styles.executionIcon} svgPath={mdiHistory} inline={false} aria-hidden={true} />
+                        <Icon
+                            className={styles.executionIcon}
+                            svgPath={mdiHistory}
+                            inline={false}
+                            aria-label={`This batch change has a new spec ${
+                                latestExecutionState === BatchSpecState.QUEUED
+                                    ? 'queued for execution'
+                                    : 'in the process of executing'
+                            }.`}
+                        />
                     </Badge>
                 </Tooltip>
             )

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useContext, useState } from 'react'
 
+import { mdiMagnify } from '@mdi/js'
 import * as H from 'history'
-import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import { tap } from 'rxjs/operators'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Container } from '@sourcegraph/wildcard'
+import { Container, Icon } from '@sourcegraph/wildcard'
 
 import { DismissibleAlert } from '../../../../components/DismissibleAlert'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
@@ -179,7 +179,7 @@ export const PreviewList: React.FunctionComponent<React.PropsWithChildren<Props>
 const EmptyPreviewSearchElement: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <div className="text-muted row w-100">
         <div className="col-12 text-center">
-            <MagnifyIcon className="icon" />
+            <Icon className="icon" svgPath={mdiMagnify} inline={false} aria-hidden={true} />
             <div className="pt-2">No changesets matched the search.</div>
         </div>
     </div>

--- a/client/web/src/enterprise/batches/settings/CheckButton.tsx
+++ b/client/web/src/enterprise/batches/settings/CheckButton.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 
-import CheckIcon from 'mdi-react/CheckIcon'
-import CloseIcon from 'mdi-react/CloseIcon'
+import { mdiCheck, mdiClose } from '@mdi/js'
 
-import { Button, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Button, LoadingSpinner, Icon } from '@sourcegraph/wildcard'
 
 export interface CheckButtonProps {
     label: string
@@ -37,14 +36,14 @@ export const CheckButton: React.FunctionComponent<React.PropsWithChildren<CheckB
     if (successMessage && !failedMessage) {
         return (
             <div className="text-success">
-                <CheckIcon /> {successMessage}
+                <Icon svgPath={mdiCheck} inline={false} aria-label="Success" /> {successMessage}
             </div>
         )
     }
     if (failedMessage) {
         return (
             <div className="text-danger">
-                <CloseIcon /> {failedMessage}
+                <Icon svgPath={mdiClose} inline={false} aria-label="Failed" /> {failedMessage}
             </div>
         )
     }

--- a/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
-import { mdiAlertCircle, mdiCheckBold, mdiOpenInNew } from '@mdi/js'
+import { mdiAlertCircle, mdiCheckBold, mdiOpenInNew, mdiChevronDown, mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
 import { Button, Icon, Link, Tooltip } from '@sourcegraph/wildcard'
 
@@ -55,12 +53,21 @@ export const MonitorLogNode: React.FunctionComponent<
                 <Button
                     onClick={toggleExpanded}
                     className="btn-icon text-left pl-0 border-0 d-flex align-items-center flex-1"
-                    aria-label="Expand code monitor"
                 >
                     {expanded ? (
-                        <ChevronDownIcon className="mr-2 flex-shrink-0" />
+                        <Icon
+                            className="mr-2 flex-shrink-0"
+                            svgPath={mdiChevronDown}
+                            inline={false}
+                            aria-label="Collapse code monitor"
+                        />
                     ) : (
-                        <ChevronRightIcon className="mr-2 flex-shrink-0" />
+                        <Icon
+                            className="mr-2 flex-shrink-0"
+                            svgPath={mdiChevronRight}
+                            inline={false}
+                            aria-label="Expand code monitor"
+                        />
                     )}
                     {hasError ? (
                         <Tooltip content="One or more runs of this code monitor have an error" placement="top">

--- a/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 
+import { mdiCheck, mdiAlert } from '@mdi/js'
 import classNames from 'classnames'
-import AlertIcon from 'mdi-react/AlertIcon'
-import CheckIcon from 'mdi-react/CheckIcon'
 
 import { isDefined } from '@sourcegraph/common'
-import { Badge, Text } from '@sourcegraph/wildcard'
+import { Badge, Text, Icon } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../../components/time/Timestamp'
 import {
@@ -102,12 +101,27 @@ export const IndexerSummary: React.FunctionComponent<React.PropsWithChildren<Ind
                         <>
                             {failedUploads.length === 0 && failedIndexes.length === 0 && (
                                 <Text className="mb-1 text-muted">
-                                    <CheckIcon size={16} className="text-success" /> Looks good!
+                                    <Icon
+                                        className="text-success"
+                                        svgPath={mdiCheck}
+                                        inline={false}
+                                        aria-hidden={true}
+                                        height={16}
+                                        width={16}
+                                    />{' '}
+                                    Looks good!
                                 </Text>
                             )}
                             {failedUploads.length > 0 && (
                                 <Text className="mb-1 text-muted">
-                                    <AlertIcon size={16} className="text-danger" />{' '}
+                                    <Icon
+                                        className="text-danger"
+                                        svgPath={mdiAlert}
+                                        inline={false}
+                                        aria-hidden={true}
+                                        height={16}
+                                        width={16}
+                                    />{' '}
                                     <TelemetricLink
                                         to={`/${repoName}/-/code-intelligence/uploads?filters=errored`}
                                         label="Latest upload processing"
@@ -120,7 +134,14 @@ export const IndexerSummary: React.FunctionComponent<React.PropsWithChildren<Ind
                             )}
                             {failedIndexes.length > 0 && (
                                 <Text className="mb-1 text-muted">
-                                    <AlertIcon size={16} className="text-danger" />{' '}
+                                    <Icon
+                                        className="text-danger"
+                                        svgPath={mdiAlert}
+                                        inline={false}
+                                        aria-hidden={true}
+                                        height={16}
+                                        width={16}
+                                    />{' '}
                                     <TelemetricLink
                                         to={`/${repoName}/-/code-intelligence/indexes?filters=errored`}
                                         label="Latest indexing"

--- a/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import { mdiMapSearch } from '@mdi/js'
 
-import { Link, Text } from '@sourcegraph/wildcard'
+import { Link, Text, Icon } from '@sourcegraph/wildcard'
 
 export const EmptyPoliciesList: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <Text alignment="center" className="text-muted w-100 mb-0 mt-1" data-testid="summary">
-        <MapSearchIcon className="mb-2" />
+        <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <br />
         {'No policies have been defined.  Enable precise code intelligence by '}
         <Link to="/help/code_intelligence/how-to/configure_data_retention" target="_blank" rel="noreferrer noopener">

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -1,15 +1,15 @@
 import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
 
 import { useApolloClient } from '@apollo/client'
+import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import { RouteComponentProps, useHistory } from 'react-router'
 import { Subject } from 'rxjs'
 
 import { GitObjectType } from '@sourcegraph/shared/src/graphql-operations'
 import { TelemetryProps, TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Container, PageHeader, Link, H3, Text } from '@sourcegraph/wildcard'
+import { Container, PageHeader, Link, H3, Text, Icon } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../../auth'
 import {
@@ -209,7 +209,7 @@ export const PoliciesNode: FunctionComponent<React.PropsWithChildren<PoliciesNod
 
         <span className={classNames(styles.button, 'd-none d-md-inline')}>
             <Link to={`./configuration/${policy.id}`} className="p-0">
-                <ChevronRightIcon />
+                <Icon svgPath={mdiChevronRight} inline={false} aria-label="Configure" />
             </Link>
         </span>
     </>

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelAssociatedUpload.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelAssociatedUpload.tsx
@@ -1,9 +1,9 @@
 import { FunctionComponent } from 'react'
 
+import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
-import { Link, H3 } from '@sourcegraph/wildcard'
+import { Link, H3, Icon } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../../components/time/Timestamp'
 import { LsifIndexFields } from '../../../../graphql-operations'
@@ -55,7 +55,7 @@ export const CodeIntelAssociatedUpload: FunctionComponent<React.PropsWithChildre
                         <Link
                             to={`/${node.projectRoot.repository.name}/-/code-intelligence/uploads/${node.associatedUpload.id}`}
                         >
-                            <ChevronRightIcon />
+                            <Icon svgPath={mdiChevronRight} inline={false} aria-label="View more information" />
                         </Link>
                     </span>
                 </div>

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexNode.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexNode.tsx
@@ -1,9 +1,9 @@
 import { FunctionComponent } from 'react'
 
+import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
-import { Link, H3 } from '@sourcegraph/wildcard'
+import { Link, H3, Icon } from '@sourcegraph/wildcard'
 
 import { LsifIndexFields } from '../../../../graphql-operations'
 import { CodeIntelState } from '../../shared/components/CodeIntelState'
@@ -58,7 +58,7 @@ export const CodeIntelIndexNode: FunctionComponent<React.PropsWithChildren<CodeI
         </span>
         <span>
             <Link to={`./indexes/${node.id}`}>
-                <ChevronRightIcon />
+                <Icon svgPath={mdiChevronRight} inline={false} aria-label="View more information" />
             </Link>
         </span>
     </>

--- a/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import { mdiMapSearch } from '@mdi/js'
 
-import { Link, Text } from '@sourcegraph/wildcard'
+import { Link, Text, Icon } from '@sourcegraph/wildcard'
 
 export const EmptyAutoIndex: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <Text alignment="center" className="text-muted w-100 mb-0 mt-1" data-testid="summary">
-        <MapSearchIcon className="mb-2" />
+        <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <br />
         {'No indexes yet.  Enable precise code intelligence by '}
         <Link to="/help/code_intelligence/how-to/enable_auto_indexing" target="_blank" rel="noreferrer noopener">

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateIcon.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateIcon.tsx
@@ -1,12 +1,9 @@
 import { FunctionComponent } from 'react'
 
+import { mdiFileUpload, mdiCheckCircle, mdiTimerSand, mdiAlertCircle } from '@mdi/js'
 import classNames from 'classnames'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
-import FileUploadIcon from 'mdi-react/FileUploadIcon'
-import TimerSandIcon from 'mdi-react/TimerSandIcon'
 
-import { LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Icon } from '@sourcegraph/wildcard'
 
 import { LSIFIndexState, LSIFUploadState } from '../../../../graphql-operations'
 
@@ -20,17 +17,32 @@ export const CodeIntelStateIcon: FunctionComponent<React.PropsWithChildren<CodeI
     className,
 }) =>
     state === LSIFUploadState.UPLOADING ? (
-        <FileUploadIcon className={className} />
+        <Icon className={className} svgPath={mdiFileUpload} inline={false} aria-label="Uploading" />
     ) : state === LSIFUploadState.DELETING ? (
-        <CheckCircleIcon className={classNames('text-muted', className)} />
+        <Icon
+            className={classNames('text-muted', className)}
+            svgPath={mdiCheckCircle}
+            inline={false}
+            aria-label="Deleting"
+        />
     ) : state === LSIFUploadState.QUEUED || state === LSIFIndexState.QUEUED ? (
-        <TimerSandIcon className={className} />
+        <Icon className={className} svgPath={mdiTimerSand} inline={false} aria-label="Queued" />
     ) : state === LSIFUploadState.PROCESSING || state === LSIFIndexState.PROCESSING ? (
         <LoadingSpinner inline={false} className={className} />
     ) : state === LSIFUploadState.COMPLETED || state === LSIFIndexState.COMPLETED ? (
-        <CheckCircleIcon className={classNames('text-success', className)} />
+        <Icon
+            className={classNames('text-success', className)}
+            svgPath={mdiCheckCircle}
+            inline={false}
+            aria-label="Completed"
+        />
     ) : state === LSIFUploadState.ERRORED || state === LSIFIndexState.ERRORED ? (
-        <AlertCircleIcon className={classNames('text-danger', className)} />
+        <Icon
+            className={classNames('text-danger', className)}
+            svgPath={mdiAlertCircle}
+            inline={false}
+            aria-label="Errored"
+        />
     ) : (
         <></>
     )

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelAssociatedIndex.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelAssociatedIndex.tsx
@@ -1,9 +1,9 @@
 import { FunctionComponent } from 'react'
 
+import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
-import { Link, H3 } from '@sourcegraph/wildcard'
+import { Link, H3, Icon } from '@sourcegraph/wildcard'
 
 import { LsifUploadFields } from '../../../../graphql-operations'
 import { CodeIntelState } from '../../shared/components/CodeIntelState'
@@ -46,7 +46,7 @@ export const CodeIntelAssociatedIndex: FunctionComponent<React.PropsWithChildren
                         <Link
                             to={`/${node.projectRoot.repository.name}/-/code-intelligence/indexes/${node.associatedIndex.id}`}
                         >
-                            <ChevronRightIcon />
+                            <Icon svgPath={mdiChevronRight} inline={false} aria-label="View more information" />
                         </Link>
                     </span>
 

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadNode.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent } from 'react'
 
+import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
-import { Link, H3 } from '@sourcegraph/wildcard'
+import { Link, H3, Icon } from '@sourcegraph/wildcard'
 
 import { LsifUploadFields } from '../../../../graphql-operations'
 import { CodeIntelState } from '../../shared/components/CodeIntelState'
@@ -58,7 +58,7 @@ export const CodeIntelUploadNode: FunctionComponent<React.PropsWithChildren<Code
         </span>
         <span>
             <Link to={`./uploads/${node.id}`}>
-                <ChevronRightIcon />
+                <Icon svgPath={mdiChevronRight} inline={false} aria-label="View more information" />
             </Link>
         </span>
     </>

--- a/client/web/src/enterprise/codeintel/uploads/components/DependencyOrDependentNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/DependencyOrDependentNode.tsx
@@ -1,9 +1,9 @@
 import { FunctionComponent } from 'react'
 
+import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
-import { Link, H3 } from '@sourcegraph/wildcard'
+import { Link, H3, Icon } from '@sourcegraph/wildcard'
 
 import { LsifUploadFields } from '../../../../graphql-operations'
 import { CodeIntelState } from '../../shared/components/CodeIntelState'
@@ -45,7 +45,7 @@ export const DependencyOrDependentNode: FunctionComponent<React.PropsWithChildre
         </span>
         <span>
             <Link to={`./${node.id}`}>
-                <ChevronRightIcon />
+                <Icon svgPath={mdiChevronRight} inline={false} aria-label="View more information" />
             </Link>
         </span>
     </>

--- a/client/web/src/enterprise/codeintel/uploads/components/EmptyDependencies.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/EmptyDependencies.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import { mdiMapSearch } from '@mdi/js'
 
-import { Text } from '@sourcegraph/wildcard'
+import { Text, Icon } from '@sourcegraph/wildcard'
 
 export const EmptyDependencies: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <Text alignment="center" className="text-muted w-100 mb-0 mt-1">
-        <MapSearchIcon className="mb-2" />
+        <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <br />
         This upload has no dependencies.
     </Text>

--- a/client/web/src/enterprise/codeintel/uploads/components/EmptyDependents.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/EmptyDependents.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import { mdiMapSearch } from '@mdi/js'
 
-import { Text } from '@sourcegraph/wildcard'
+import { Text, Icon } from '@sourcegraph/wildcard'
 
 export const EmptyDependents: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <Text className="text-muted text-center w-100 mb-0 mt-1">
-        <MapSearchIcon className="mb-2" />
+        <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <br />
         This upload has no dependents.
     </Text>

--- a/client/web/src/enterprise/codeintel/uploads/components/EmptyUploadRetentionStatusNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/EmptyUploadRetentionStatusNode.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import { mdiMapSearch } from '@mdi/js'
 
-import { Text } from '@sourcegraph/wildcard'
+import { Text, Icon } from '@sourcegraph/wildcard'
 
 export const EmptyUploadRetentionMatchStatus: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <Text alignment="center" className="text-muted w-100 mb-0 mt-1">
-        <MapSearchIcon className="mb-2" />
+        <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <br />
         No retention policies matched.
     </Text>

--- a/client/web/src/enterprise/codeintel/uploads/components/EmptyUploads.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/EmptyUploads.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import { mdiMapSearch } from '@mdi/js'
 
-import { Link, Text } from '@sourcegraph/wildcard'
+import { Link, Text, Icon } from '@sourcegraph/wildcard'
 
 export const EmptyUploads: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <Text alignment="center" className="text-muted w-100 mb-0 mt-1">
-        <MapSearchIcon className="mb-2" />
+        <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <br />
         No uploads yet. Enable precise code intelligence by{' '}
         <Link

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
@@ -1,9 +1,8 @@
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useApolloClient } from '@apollo/client'
-import { mdiInformationOutline } from '@mdi/js'
+import { mdiInformationOutline, mdiMapSearch } from '@mdi/js'
 import classNames from 'classnames'
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { Redirect, RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 import { takeWhile } from 'rxjs/operators'
@@ -365,7 +364,7 @@ export const CodeIntelUploadPage: FunctionComponent<React.PropsWithChildren<Code
                                 <UploadAuditLogTimeline logs={uploadOrError.auditLogs || []} />
                             ) : (
                                 <Text alignment="center" className="text-muted w-100 mb-0 mt-1">
-                                    <MapSearchIcon className="mb-2" />
+                                    <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
                                     <br />
                                     This upload has no audit logs.
                                 </Text>


### PR DESCRIPTION
**Migration automated through codemod: https://github.com/sourcegraph/codemod/pull/148**

## Description

Migrates simple `<MdiIcon />` usage directly from `mdi-react` to the `<Icon />` Wildcard component and `@mdi/js` icon content.

Changes:
- Ran codemod to automatically update all direct usage of this  icons
- Manually added `aria-label` attributes where relevant.

**Also closes some accessibility issues**:
Closes https://github.com/sourcegraph/sourcegraph/issues/35183

## Test plan

Icon edge cases tested through https://github.com/sourcegraph/sourcegraph/pull/37387, this diff is tested through automated tests.

## App preview:

- [Web](https://sg-web-tr-icon-codemod-v3-1.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zcwtbbfqok.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
