### PR TITLE
autoinference: sort --exclude args in Python interference

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/lang_python_test.go
+++ b/internal/codeintel/autoindexing/internal/inference/lang_python_test.go
@@ -154,7 +154,7 @@ Summary:  NumPy is the fundamental package for array computing with Python.
 						"--project-version",
 						"1.22.3",
 						"--exclude",
-						"src,nested/lib",
+						"nested/lib,src",
 					},
 					Outfile: "index.scip",
 				},

--- a/internal/codeintel/autoindexing/internal/inference/lua/python.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/python.lua
@@ -148,7 +148,8 @@ return recognizers.path_recognizer {
     for _, lib in ipairs(libraries) do
       table.insert(to_exclude, lib.root)
     end
-
+    -- Sort to_exclude list so the tests are stable
+    table.sort(to_exclude)
     local exclude = table.concat(to_exclude, ",")
     if contents_by_path["PKG-INFO"] and exclude ~= "" then
       local name, version = get_name_and_version_from_content(contents_by_path["PKG-INFO"])


### PR DESCRIPTION
This fixes the test being flaky in CI.

Failure here: https://buildkite.com/sourcegraph/sourcegraph/builds/160213#0181f70b-2bee-4079-9a8e-64c3127ebbba


## Test plan

- Existing (modified) test