### PR TITLE
cmd/gitserver/server: Remove redundant log

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2390,7 +2390,6 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 
 	err = syncer.Fetch(ctx, remoteURL, dir)
 	if err != nil {
-		s.Logger.Error("Failed to fetch", log.String("repo", string(repo)), log.Error(err))
 		return errors.Wrap(err, "failed to fetch")
 	}
 


### PR DESCRIPTION
This error is already logged in the callsite of
doBackgroundRepoUpdate. Logging it before returning is unnecessary.



## Test plan

Not applicable. Removed a log statement only.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
