### PR TITLE
[debug] codeintel: dump raw uploads state in codeintel-qa

### DIFF
--- a/dev/codeintel-qa/cmd/upload/state.go
+++ b/dev/codeintel-qa/cmd/upload/state.go
@@ -89,10 +89,14 @@ func monitor(ctx context.Context, repoNames []string, uploads []uploadMeta) erro
 						return errors.Newf("unexpected state '%s' for %s@%s\nAudit Logs:\n%s", uploadState.state, uploadState.upload.repoName, uploadState.upload.commit[:7], errors.Wrap(err, "error getting audit logs"))
 					}
 
+					fmt.Printf("RAW PAYLOAD DUMP:\n%+v\n", payload)
+					fmt.Println("SEARCHING FOR ID", uploadState.upload.id)
+
 					var logs auditLogs
 					for _, upload := range payload.Data.LsifUploads.Nodes {
 						if upload.ID == uploadState.upload.id {
 							logs = upload.AuditLogs
+							break
 						}
 					}
 


### PR DESCRIPTION
For debug purposes, to find out why audit logs arent being shown, we're dumping the raw graphql response payload

## Test plan

This is the test, n\a : )
