### PR TITLE
JetBrains: Bump version to 2.0.0-alpha.3

### DIFF
--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=2.0.0-alpha.2
+pluginVersion=2.0.0-alpha.3
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default


### PR DESCRIPTION
Let's release another preview build! I’m bumping the version and will ship once we merge #38707 cc @vdavid 

## Test plan

Just a version bump.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-alpha-3.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yomztqzoox.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
