### PR TITLE
Use `api.RepoName` and `reposource.PackageName` type aliases

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_go_modules.go
+++ b/cmd/gitserver/server/vcs_syncer_go_modules.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"golang.org/x/mod/module"
 	modzip "golang.org/x/mod/zip"
 
@@ -46,19 +47,19 @@ type goModulesSyncer struct {
 	client *gomodproxy.Client
 }
 
-func (s goModulesSyncer) ParseVersionedPackageFromNameAndVersion(name, version string) (reposource.VersionedPackage, error) {
-	return reposource.ParseGoVersionedPackage(name + "@" + version)
+func (s goModulesSyncer) ParseVersionedPackageFromNameAndVersion(name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
+	return reposource.ParseGoVersionedPackage(string(name) + "@" + version)
 }
 
 func (goModulesSyncer) ParseVersionedPackageFromConfiguration(dep string) (reposource.VersionedPackage, error) {
 	return reposource.ParseGoVersionedPackage(dep)
 }
 
-func (goModulesSyncer) ParsePackageFromName(name string) (reposource.Package, error) {
+func (goModulesSyncer) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return reposource.ParseGoDependencyFromName(name)
 }
 
-func (goModulesSyncer) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (goModulesSyncer) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	return reposource.ParseGoDependencyFromRepoName(repoName)
 }
 

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -60,19 +61,19 @@ type jvmPackagesSyncer struct {
 	fetch  func(ctx context.Context, config *schema.JVMPackagesConnection, dependency *reposource.MavenVersionedPackage) (sourceCodeJarPath string, err error)
 }
 
-func (jvmPackagesSyncer) ParseVersionedPackageFromNameAndVersion(name, version string) (reposource.VersionedPackage, error) {
-	return reposource.ParseMavenVersionedPackage(name + ":" + version)
+func (jvmPackagesSyncer) ParseVersionedPackageFromNameAndVersion(name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
+	return reposource.ParseMavenVersionedPackage(string(name) + ":" + version)
 }
 
 func (jvmPackagesSyncer) ParseVersionedPackageFromConfiguration(dep string) (reposource.VersionedPackage, error) {
 	return reposource.ParseMavenVersionedPackage(dep)
 }
 
-func (jvmPackagesSyncer) ParsePackageFromName(name string) (reposource.Package, error) {
+func (jvmPackagesSyncer) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return reposource.ParseMavenPackageFromName(name)
 }
 
-func (jvmPackagesSyncer) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (jvmPackagesSyncer) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	return reposource.ParseMavenPackageFromRepoName(repoName)
 }
 

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -50,18 +51,18 @@ type npmPackagesSyncer struct {
 var _ packagesSource = &npmPackagesSyncer{}
 var _ packagesDownloadSource = &npmPackagesSyncer{}
 
-func (npmPackagesSyncer) ParseVersionedPackageFromNameAndVersion(name, version string) (reposource.VersionedPackage, error) {
-	return reposource.ParseNpmVersionedPackage(name + "@" + version)
+func (npmPackagesSyncer) ParseVersionedPackageFromNameAndVersion(name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
+	return reposource.ParseNpmVersionedPackage(string(name) + "@" + version)
 }
 
 func (npmPackagesSyncer) ParseVersionedPackageFromConfiguration(dep string) (reposource.VersionedPackage, error) {
 	return reposource.ParseNpmVersionedPackage(dep)
 }
 
-func (s *npmPackagesSyncer) ParsePackageFromName(name string) (reposource.Package, error) {
-	return s.ParsePackageFromRepoName("npm/" + strings.TrimPrefix(name, "@"))
+func (s *npmPackagesSyncer) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
+	return s.ParsePackageFromRepoName(api.RepoName("npm/" + strings.TrimPrefix(string(name), "@")))
 }
-func (npmPackagesSyncer) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (npmPackagesSyncer) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	pkg, err := reposource.ParseNpmPackageFromRepoURL(repoName)
 	if err != nil {
 		return nil, err
@@ -69,8 +70,8 @@ func (npmPackagesSyncer) ParsePackageFromRepoName(repoName string) (reposource.P
 	return &reposource.NpmVersionedPackage{NpmPackageName: pkg}, nil
 }
 
-func (s npmPackagesSyncer) GetPackage(ctx context.Context, name string) (reposource.Package, error) {
-	dep, err := reposource.ParseNpmVersionedPackage(name + "@")
+func (s npmPackagesSyncer) GetPackage(ctx context.Context, name reposource.PackageName) (reposource.Package, error) {
+	dep, err := reposource.ParseNpmVersionedPackage(string(name) + "@")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -85,7 +86,7 @@ func TestNpmCloneCommand(t *testing.T) {
 	tgz2 := createTgz(t, []fileInfo{{exampleTSFilepath, []byte(exampleTSFileContents)}})
 
 	client := npmtest.MockClient{
-		Packages: map[string]*npm.PackageInfo{
+		Packages: map[reposource.PackageName]*npm.PackageInfo{
 			"example": {
 				Versions: map[string]*npm.DependencyInfo{
 					exampleNpmVersion: {

--- a/cmd/gitserver/server/vcs_syncer_python_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -51,19 +52,19 @@ type pythonPackagesSyncer struct {
 	client *pypi.Client
 }
 
-func (pythonPackagesSyncer) ParseVersionedPackageFromNameAndVersion(name, version string) (reposource.VersionedPackage, error) {
-	return reposource.ParseVersionedPackage(name + "==" + version)
+func (pythonPackagesSyncer) ParseVersionedPackageFromNameAndVersion(name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
+	return reposource.ParseVersionedPackage(string(name) + "==" + version)
 }
 
 func (pythonPackagesSyncer) ParseVersionedPackageFromConfiguration(dep string) (reposource.VersionedPackage, error) {
 	return reposource.ParseVersionedPackage(dep)
 }
 
-func (pythonPackagesSyncer) ParsePackageFromName(name string) (reposource.Package, error) {
+func (pythonPackagesSyncer) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return reposource.ParsePythonPackageFromName(name)
 }
 
-func (pythonPackagesSyncer) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (pythonPackagesSyncer) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	return reposource.ParsePythonPackageFromRepoName(repoName)
 }
 

--- a/cmd/gitserver/server/vcs_syncer_rust_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_rust_packages.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/crates"
 
 	"github.com/sourcegraph/log"
@@ -49,19 +50,19 @@ type rustDependencySource struct {
 	client *crates.Client
 }
 
-func (rustDependencySource) ParseVersionedPackageFromNameAndVersion(name, version string) (reposource.VersionedPackage, error) {
-	return reposource.ParseRustVersionedPackage(name + "@" + version)
+func (rustDependencySource) ParseVersionedPackageFromNameAndVersion(name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
+	return reposource.ParseRustVersionedPackage(string(name) + "@" + version)
 }
 
 func (rustDependencySource) ParseVersionedPackageFromConfiguration(dep string) (reposource.VersionedPackage, error) {
 	return reposource.ParseRustVersionedPackage(dep)
 }
 
-func (rustDependencySource) ParsePackageFromName(name string) (reposource.Package, error) {
+func (rustDependencySource) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return reposource.ParseRustPackageFromName(name)
 
 }
-func (rustDependencySource) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (rustDependencySource) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	return reposource.ParseRustPackageFromRepoName(repoName)
 }
 

--- a/internal/codeintel/autoindexing/infer.go
+++ b/internal/codeintel/autoindexing/infer.go
@@ -61,7 +61,7 @@ func inferNpmRepositoryAndRevision(pkg precise.Package) (api.RepoName, string, b
 	if pkg.Scheme != dependencies.NpmPackagesScheme {
 		return "", "", false
 	}
-	npmPkg, err := reposource.ParseNpmPackageFromPackageSyntax(pkg.Name)
+	npmPkg, err := reposource.ParseNpmPackageFromPackageSyntax(reposource.PackageName(pkg.Name))
 	if err != nil {
 		log15.Error("invalid npm package name in database", "error", err)
 		return "", "", false
@@ -88,12 +88,11 @@ func inferPythonRepositoryAndRevision(pkg precise.Package) (api.RepoName, string
 		return "", "", false
 	}
 
-	pythonPkg, err := reposource.ParsePythonPackageFromRepoName(pkg.Name)
+	pythonPkg, err := reposource.ParsePythonPackageFromName(reposource.PackageName(pkg.Name))
 	if err != nil {
 		log15.Error("invalid python package name in database", "error", err, "pkg", pkg.Name)
 		return "", "", false
 	}
 
 	return pythonPkg.RepoName(), pkg.Version, true
-
 }

--- a/internal/codeintel/dependencies/internal/lockfiles/dependency_graph_test.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/dependency_graph_test.go
@@ -120,7 +120,7 @@ type testPkg struct {
 	version string
 }
 
-func (t *testPkg) VersionedPackageSyntax() string        { return string(t.name) + ":" + t.version }
+func (t *testPkg) VersionedPackageSyntax() string        { return string(t.name) }
 func (t *testPkg) PackageSyntax() reposource.PackageName { return t.name }
 func (t *testPkg) RepoName() api.RepoName                { return api.RepoName("test/" + t.name) }
 func (t *testPkg) PackageVersion() string                { return t.version }

--- a/internal/codeintel/dependencies/internal/lockfiles/dependency_graph_test.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/dependency_graph_test.go
@@ -116,17 +116,17 @@ func TestDependencyGraph(t *testing.T) {
 var _ reposource.VersionedPackage = &testPkg{}
 
 type testPkg struct {
-	name    string
+	name    reposource.PackageName
 	version string
 }
 
-func (t *testPkg) VersionedPackageSyntax() string { return t.name }
-func (t *testPkg) PackageSyntax() string          { return t.name }
-func (t *testPkg) RepoName() api.RepoName         { return api.RepoName("test/" + t.name) }
-func (t *testPkg) PackageVersion() string         { return t.version }
-func (t *testPkg) Scheme() string                 { return "test" }
-func (t *testPkg) Description() string            { return "" }
-func (t *testPkg) GitTagFromVersion() string      { return t.version }
+func (t *testPkg) VersionedPackageSyntax() string        { return string(t.name) + ":" + t.version }
+func (t *testPkg) PackageSyntax() reposource.PackageName { return t.name }
+func (t *testPkg) RepoName() api.RepoName                { return api.RepoName("test/" + t.name) }
+func (t *testPkg) PackageVersion() string                { return t.version }
+func (t *testPkg) Scheme() string                        { return "test" }
+func (t *testPkg) Description() string                   { return "" }
+func (t *testPkg) GitTagFromVersion() string             { return t.version }
 func (t *testPkg) Less(other reposource.VersionedPackage) bool {
-	return t.PackageSyntax() < other.VersionedPackageSyntax()
+	return t.VersionedPackageSyntax() < other.VersionedPackageSyntax()
 }

--- a/internal/codeintel/dependencies/internal/lockfiles/pipfile.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/pipfile.go
@@ -44,10 +44,10 @@ func parsePipfileLockFile(r io.Reader) ([]reposource.VersionedPackage, error) {
 
 	libs := make([]reposource.VersionedPackage, 0, len(lockfile.Default)+len(lockfile.Develop))
 	for pkgName, info := range lockfile.Default {
-		libs = append(libs, reposource.NewPythonVersionedPackage(pkgName, strings.TrimPrefix(info.Version, "==")))
+		libs = append(libs, reposource.NewPythonVersionedPackage(reposource.PackageName(pkgName), strings.TrimPrefix(info.Version, "==")))
 	}
 	for pkgName, info := range lockfile.Develop {
-		libs = append(libs, reposource.NewPythonVersionedPackage(pkgName, strings.TrimPrefix(info.Version, "==")))
+		libs = append(libs, reposource.NewPythonVersionedPackage(reposource.PackageName(pkgName), strings.TrimPrefix(info.Version, "==")))
 	}
 	return libs, nil
 }

--- a/internal/codeintel/dependencies/internal/lockfiles/poetry.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/poetry.go
@@ -27,7 +27,7 @@ func parsePoetryLockFile(r io.Reader) ([]reposource.VersionedPackage, error) {
 
 	libs := make([]reposource.VersionedPackage, 0, len(lockfile.Packages))
 	for _, pkg := range lockfile.Packages {
-		libs = append(libs, reposource.NewPythonVersionedPackage(pkg.Name, pkg.Version))
+		libs = append(libs, reposource.NewPythonVersionedPackage(reposource.PackageName(pkg.Name), pkg.Version))
 	}
 
 	return libs, nil

--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
@@ -105,13 +106,13 @@ func scanIntString(s dbutil.Scanner) (int, string, error) {
 	return i, str, nil
 }
 
-func scanIdNames(rows *sql.Rows, queryErr error) (nameIDs map[string]int, ids []int, err error) {
+func scanIdNames(rows *sql.Rows, queryErr error) (nameIDs map[reposource.PackageName]int, ids []int, err error) {
 	if queryErr != nil {
 		return nil, nil, queryErr
 	}
 	defer func() { err = basestore.CloseRows(rows, err) }()
 
-	nameIDs = make(map[string]int)
+	nameIDs = make(map[reposource.PackageName]int)
 	ids = []int{}
 
 	for rows.Next() {
@@ -120,7 +121,7 @@ func scanIdNames(rows *sql.Rows, queryErr error) (nameIDs map[string]int, ids []
 			return nil, nil, err
 		}
 
-		nameIDs[name] = id
+		nameIDs[reposource.PackageName(name)] = id
 		ids = append(ids, id)
 	}
 

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
@@ -596,7 +597,7 @@ ORDER BY r.name, lf.commit_bytea
 // ListDependencyReposOpts are options for listing dependency repositories.
 type ListDependencyReposOpts struct {
 	Scheme          string
-	Name            string
+	Name            reposource.PackageName
 	After           any
 	Limit           int
 	NewestFirst     bool

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -667,7 +667,7 @@ func makeListDependencyReposConds(opts ListDependencyReposOpts) []*sqlf.Query {
 		case !opts.NewestFirst && after > 0:
 			conds = append(conds, sqlf.Sprintf("id > %s", opts.After))
 		}
-	case string:
+	case string, reposource.PackageName:
 		switch {
 		case opts.NewestFirst:
 			panic("cannot set NewestFirst and pass name-based offset")

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -830,7 +831,8 @@ func TestListDependencyRepos(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lastName := ""
+	var lastName reposource.PackageName
+	lastName = ""
 	for _, test := range [][]shared.Repo{
 		{{Scheme: "npm", Name: "banana"}, {Scheme: "npm", Name: "bar"}, {Scheme: "npm", Name: "foo"}},
 		{{Scheme: "npm", Name: "turtle"}},

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -183,12 +183,12 @@ func TestUpsertLockfileGraph(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "1", "2", "pkg-A", "4")
-	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "2", "3", "pkg-B", "5")
-	packageC := shared.TestPackageDependencyLiteral(api.RepoName("C"), "3", "4", "pkg-C", "6")
-	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "4", "5", "pkg-D", "7")
-	packageE := shared.TestPackageDependencyLiteral(api.RepoName("E"), "5", "6", "pkg-E", "8")
-	packageF := shared.TestPackageDependencyLiteral(api.RepoName("F"), "6", "7", "pkg-F", "9")
+	packageA := shared.TestPackageDependencyLiteral("A", "1", "2", "pkg-A", "4")
+	packageB := shared.TestPackageDependencyLiteral("B", "2", "3", "pkg-B", "5")
+	packageC := shared.TestPackageDependencyLiteral("C", "3", "4", "pkg-C", "6")
+	packageD := shared.TestPackageDependencyLiteral("D", "4", "5", "pkg-D", "7")
+	packageE := shared.TestPackageDependencyLiteral("E", "5", "6", "pkg-E", "8")
+	packageF := shared.TestPackageDependencyLiteral("F", "6", "7", "pkg-F", "9")
 
 	t.Run("with graph", func(t *testing.T) {
 		deps := []shared.PackageDependency{packageA, packageB, packageC, packageD, packageE, packageF}
@@ -223,7 +223,7 @@ func TestUpsertLockfileGraph(t *testing.T) {
 			t.Fatalf("database query error: %s", err)
 		}
 
-		wantNames := []string{packageA.PackageSyntax()}
+		wantNames := []string{string(packageA.PackageSyntax())}
 		if diff := cmp.Diff(wantNames, names); diff != "" {
 			t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
 		}
@@ -235,7 +235,7 @@ func TestUpsertLockfileGraph(t *testing.T) {
 		}
 		wantNames = []string{}
 		for _, pkg := range deps {
-			wantNames = append(wantNames, pkg.PackageSyntax())
+			wantNames = append(wantNames, string(pkg.PackageSyntax()))
 		}
 		if diff := cmp.Diff(wantNames, names); diff != "" {
 			t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
@@ -287,7 +287,7 @@ func TestUpsertLockfileGraph(t *testing.T) {
 			t.Fatalf("database query error: %s", err)
 		}
 
-		wantNames := []string{packageA.PackageSyntax()}
+		wantNames := []string{string(packageA.PackageSyntax())}
 		if diff := cmp.Diff(wantNames, names); diff != "" {
 			t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
 		}
@@ -299,7 +299,7 @@ func TestUpsertLockfileGraph(t *testing.T) {
 		}
 		wantNames = []string{}
 		for _, pkg := range deps {
-			wantNames = append(wantNames, pkg.PackageSyntax())
+			wantNames = append(wantNames, string(pkg.PackageSyntax()))
 		}
 		if diff := cmp.Diff(wantNames, names); diff != "" {
 			t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
@@ -335,7 +335,7 @@ func TestUpsertLockfileGraph(t *testing.T) {
 
 		wantNames := make([]string, 0, len(deps))
 		for _, d := range deps {
-			wantNames = append(wantNames, d.PackageSyntax())
+			wantNames = append(wantNames, string(d.PackageSyntax()))
 		}
 		if diff := cmp.Diff(wantNames, names); diff != "" {
 			t.Errorf("unexpected direct dependencies (-want +got):\n%s", diff)
@@ -402,7 +402,7 @@ func TestUpsertLockfileGraph(t *testing.T) {
 		wantNames := []string{}
 		for _, res := range results {
 			for _, pkg := range res.deps {
-				wantNames = append(wantNames, pkg.PackageSyntax())
+				wantNames = append(wantNames, string(pkg.PackageSyntax()))
 			}
 		}
 		if diff := cmp.Diff(wantNames, names); diff != "" {
@@ -420,7 +420,7 @@ func TestUpsertLockfileGraph(t *testing.T) {
 			wantNames := []string{}
 			roots, _ := res.graph.Roots()
 			for _, r := range roots {
-				wantNames = append(wantNames, r.PackageSyntax())
+				wantNames = append(wantNames, string(r.PackageSyntax()))
 			}
 			if diff := cmp.Diff(wantNames, names); diff != "" {
 				t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
@@ -433,7 +433,7 @@ func TestUpsertLockfileGraph(t *testing.T) {
 			}
 			wantNames = []string{}
 			for _, pkg := range res.deps {
-				wantNames = append(wantNames, pkg.PackageSyntax())
+				wantNames = append(wantNames, string(pkg.PackageSyntax()))
 			}
 			if diff := cmp.Diff(wantNames, names); diff != "" {
 				t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
@@ -499,12 +499,12 @@ func TestLockfileDependencies_SingleLockfile(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "1", "2", "pkg-A", "4")
-	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "2", "3", "pkg-B", "5")
-	packageC := shared.TestPackageDependencyLiteral(api.RepoName("C"), "3", "4", "pkg-C", "6")
-	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "4", "5", "pkg-D", "7")
-	packageE := shared.TestPackageDependencyLiteral(api.RepoName("E"), "5", "6", "pkg-E", "8")
-	packageF := shared.TestPackageDependencyLiteral(api.RepoName("F"), "6", "7", "pkg-F", "9")
+	packageA := shared.TestPackageDependencyLiteral("A", "1", "2", "pkg-A", "4")
+	packageB := shared.TestPackageDependencyLiteral("B", "2", "3", "pkg-B", "5")
+	packageC := shared.TestPackageDependencyLiteral("C", "3", "4", "pkg-C", "6")
+	packageD := shared.TestPackageDependencyLiteral("D", "4", "5", "pkg-D", "7")
+	packageE := shared.TestPackageDependencyLiteral("E", "5", "6", "pkg-E", "8")
+	packageF := shared.TestPackageDependencyLiteral("F", "6", "7", "pkg-F", "9")
 
 	lockfile := "lock.file"
 
@@ -649,12 +649,12 @@ func TestLockfileDependencies_MultipleLockfiles(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "1", "2", "pkg-A", "4")
-	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "2", "3", "pkg-B", "5")
-	packageC := shared.TestPackageDependencyLiteral(api.RepoName("C"), "3", "4", "pkg-C", "6")
-	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "4", "5", "pkg-D", "7")
-	packageE := shared.TestPackageDependencyLiteral(api.RepoName("E"), "5", "6", "pkg-E", "8")
-	packageF := shared.TestPackageDependencyLiteral(api.RepoName("F"), "6", "7", "pkg-F", "9")
+	packageA := shared.TestPackageDependencyLiteral("A", "1", "2", "pkg-A", "4")
+	packageB := shared.TestPackageDependencyLiteral("B", "2", "3", "pkg-B", "5")
+	packageC := shared.TestPackageDependencyLiteral("C", "3", "4", "pkg-C", "6")
+	packageD := shared.TestPackageDependencyLiteral("D", "4", "5", "pkg-D", "7")
+	packageE := shared.TestPackageDependencyLiteral("E", "5", "6", "pkg-E", "8")
+	packageF := shared.TestPackageDependencyLiteral("F", "6", "7", "pkg-F", "9")
 
 	depsInLockfile := map[string]struct {
 		deps  []shared.PackageDependency
@@ -912,11 +912,11 @@ func TestSelectRepoRevisionsToResolve(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "v1", "2", "3", "4")
-	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "v2", "3", "4", "5")
-	packageC := shared.TestPackageDependencyLiteral(api.RepoName("C"), "v3", "4", "5", "6")
-	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "v4", "5", "6", "7")
-	packageE := shared.TestPackageDependencyLiteral(api.RepoName("E"), "v5", "6", "7", "8")
+	packageA := shared.TestPackageDependencyLiteral("A", "v1", "2", "3", "4")
+	packageB := shared.TestPackageDependencyLiteral("B", "v2", "3", "4", "5")
+	packageC := shared.TestPackageDependencyLiteral("C", "v3", "4", "5", "6")
+	packageD := shared.TestPackageDependencyLiteral("D", "v4", "5", "6", "7")
+	packageE := shared.TestPackageDependencyLiteral("E", "v5", "6", "7", "8")
 
 	commit := "d34df00d"
 	repoName := "repo-1"
@@ -1003,10 +1003,10 @@ func TestUpdateResolvedRevisions(t *testing.T) {
 	}
 
 	var (
-		packageA = shared.TestPackageDependencyLiteral(api.RepoName("pkg-1"), "v1", "2", "3", "4")
-		packageB = shared.TestPackageDependencyLiteral(api.RepoName("pkg-2"), "v2", "3", "4", "5")
-		packageC = shared.TestPackageDependencyLiteral(api.RepoName("pkg-3"), "v3", "4", "5", "6")
-		packageD = shared.TestPackageDependencyLiteral(api.RepoName("pkg-4"), "v4", "5", "6", "7")
+		packageA = shared.TestPackageDependencyLiteral("pkg-1", "v1", "2", "3", "4")
+		packageB = shared.TestPackageDependencyLiteral("pkg-2", "v2", "3", "4", "5")
+		packageC = shared.TestPackageDependencyLiteral("pkg-3", "v3", "4", "5", "6")
+		packageD = shared.TestPackageDependencyLiteral("pkg-4", "v4", "5", "6", "7")
 	)
 
 	if err := store.UpsertLockfileGraph(ctx, "repo-1", "cafebabe", "lock.file", []shared.PackageDependency{packageA, packageB, packageC, packageD}, nil); err != nil {
@@ -1062,10 +1062,10 @@ func TestLockfileDependents(t *testing.T) {
 	}
 
 	var (
-		packageA = shared.TestPackageDependencyLiteral(api.RepoName("pkg-1"), "v1", "2", "3", "4")
-		packageB = shared.TestPackageDependencyLiteral(api.RepoName("pkg-2"), "v2", "3", "4", "5")
-		packageC = shared.TestPackageDependencyLiteral(api.RepoName("pkg-3"), "v3", "4", "5", "6")
-		packageD = shared.TestPackageDependencyLiteral(api.RepoName("pkg-4"), "v4", "5", "6", "7")
+		packageA = shared.TestPackageDependencyLiteral("pkg-1", "v1", "2", "3", "4")
+		packageB = shared.TestPackageDependencyLiteral("pkg-2", "v2", "3", "4", "5")
+		packageC = shared.TestPackageDependencyLiteral("pkg-3", "v3", "4", "5", "6")
+		packageD = shared.TestPackageDependencyLiteral("pkg-4", "v4", "5", "6", "7")
 	)
 
 	if err := store.UpsertLockfileGraph(ctx, "repo-1", "cafebabe", "lock.file", []shared.PackageDependency{packageA, packageB, packageC, packageD}, nil); err != nil {
@@ -1114,8 +1114,8 @@ func TestLockfileDependents(t *testing.T) {
 		t.Fatalf("unexpected error listing lockfile dependents: %s", err)
 	}
 	expectedDeps = []api.RepoCommit{
-		{Repo: api.RepoName("repo-1"), CommitID: api.CommitID("cafebabe")},
-		{Repo: api.RepoName("repo-3"), CommitID: api.CommitID("d00dd00d")},
+		{Repo: "repo-1", CommitID: "cafebabe"},
+		{Repo: "repo-3", CommitID: "d00dd00d"},
 	}
 	if diff := cmp.Diff(expectedDeps, deps); diff != "" {
 		t.Errorf("unexpected lockfile dependents (-want +got):\n%s", diff)

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -2,6 +2,7 @@ package dependencies
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -257,7 +258,7 @@ func (s *Service) listAndPersistLockfileDependencies(ctx context.Context, repoCo
 		}
 
 		for _, d := range serializableRepoDeps {
-			k := d.PackageSyntax() + d.PackageVersion()
+			k := fmt.Sprintf("%s%s", d.PackageSyntax(), d.PackageVersion())
 			if _, ok := set[k]; !ok {
 				set[k] = struct{}{}
 				allDeps = append(allDeps, d)
@@ -330,7 +331,7 @@ func (s *Service) IndexLockfiles(ctx context.Context, repoRevs map[api.RepoName]
 
 func (s *Service) upsertAndSyncDependencies(ctx context.Context, deps []shared.PackageDependency) error {
 	hash := func(dep Repo) string {
-		return strings.Join([]string{dep.Scheme, dep.Name, dep.Version}, ":")
+		return strings.Join([]string{dep.Scheme, string(dep.Name), dep.Version}, ":")
 	}
 
 	dependencies := make([]Repo, 0, len(deps))
@@ -459,7 +460,7 @@ type ListDependencyReposOpts struct {
 	// Scheme is the moniker scheme to filter for e.g. 'gomod', 'npm' etc.
 	Scheme string
 	// Name is the package name to filter for e.g. '@types/node' etc.
-	Name string
+	Name reposource.PackageName
 	// After is the value predominantly used for pagination. When sorting by
 	// newest first, this should be the ID of the last element in the previous
 	// page, when excluding versions it should be the last package name in the

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -316,7 +316,7 @@ func TestIndexLockfiles(t *testing.T) {
 		for _, dependencyRepo := range dependencyRepos {
 			// repo is even + commit is odd, or
 			// repo is odd + commit is even
-			if endsWithEvenDigit(dependencyRepo.Name) != endsWithEvenDigit(dependencyRepo.Version) {
+			if endsWithEvenDigit(string(dependencyRepo.Name)) != endsWithEvenDigit(dependencyRepo.Version) {
 				continue
 			}
 

--- a/internal/codeintel/dependencies/shared/types.go
+++ b/internal/codeintel/dependencies/shared/types.go
@@ -38,7 +38,7 @@ type LockfileIndex struct {
 type Repo struct {
 	ID      int
 	Scheme  string
-	Name    string
+	Name    reposource.PackageName
 	Version string
 }
 
@@ -46,7 +46,7 @@ type PackageDependency interface {
 	RepoName() api.RepoName
 	GitTagFromVersion() string
 	Scheme() string
-	PackageSyntax() string
+	PackageSyntax() reposource.PackageName
 	PackageVersion() string
 }
 
@@ -54,7 +54,7 @@ type PackageDependencyLiteral struct {
 	RepoNameValue          api.RepoName
 	GitTagFromVersionValue string
 	SchemeValue            string
-	PackageSyntaxValue     string
+	PackageSyntaxValue     reposource.PackageName
 	PackageVersionValue    string
 }
 
@@ -62,7 +62,7 @@ func TestPackageDependencyLiteral(
 	repoNameValue api.RepoName,
 	gitTagFromVersionValue string,
 	schemeValue string,
-	packageSyntaxValue string,
+	packageSyntaxValue reposource.PackageName,
 	packageVersionValue string,
 ) PackageDependency {
 	return PackageDependencyLiteral{
@@ -74,11 +74,11 @@ func TestPackageDependencyLiteral(
 	}
 }
 
-func (d PackageDependencyLiteral) RepoName() api.RepoName    { return d.RepoNameValue }
-func (d PackageDependencyLiteral) GitTagFromVersion() string { return d.GitTagFromVersionValue }
-func (d PackageDependencyLiteral) Scheme() string            { return d.SchemeValue }
-func (d PackageDependencyLiteral) PackageSyntax() string     { return d.PackageSyntaxValue }
-func (d PackageDependencyLiteral) PackageVersion() string    { return d.PackageVersionValue }
+func (d PackageDependencyLiteral) RepoName() api.RepoName                { return d.RepoNameValue }
+func (d PackageDependencyLiteral) GitTagFromVersion() string             { return d.GitTagFromVersionValue }
+func (d PackageDependencyLiteral) Scheme() string                        { return d.SchemeValue }
+func (d PackageDependencyLiteral) PackageSyntax() reposource.PackageName { return d.PackageSyntaxValue }
+func (d PackageDependencyLiteral) PackageVersion() string                { return d.PackageVersionValue }
 
 func SerializePackageDependencies(deps []reposource.VersionedPackage) []PackageDependency {
 	serializableRepoDeps := make([]PackageDependency, 0, len(deps))

--- a/internal/conf/reposource/go_modules.go
+++ b/internal/conf/reposource/go_modules.go
@@ -48,14 +48,14 @@ func ParseGoVersionedPackage(dependency string) (*GoVersionedPackage, error) {
 	return &GoVersionedPackage{Module: mod}, nil
 }
 
-func ParseGoDependencyFromName(name string) (*GoVersionedPackage, error) {
-	return ParseGoVersionedPackage(name)
+func ParseGoDependencyFromName(name PackageName) (*GoVersionedPackage, error) {
+	return ParseGoVersionedPackage(string(name))
 }
 
 // ParseGoDependencyFromRepoName is a convenience function to parse a repo name in a
 // 'go/<name>(@<version>)?' format into a GoVersionedPackage.
-func ParseGoDependencyFromRepoName(name string) (*GoVersionedPackage, error) {
-	dependency := strings.TrimPrefix(name, "go/")
+func ParseGoDependencyFromRepoName(name api.RepoName) (*GoVersionedPackage, error) {
+	dependency := strings.TrimPrefix(string(name), "go/")
 	if len(dependency) == len(name) {
 		return nil, errors.New("invalid go dependency repo name, missing go/ prefix")
 	}
@@ -67,11 +67,11 @@ func (d *GoVersionedPackage) Scheme() string {
 }
 
 // PackageSyntax returns the name of the Go module.
-func (d *GoVersionedPackage) PackageSyntax() string {
-	return d.Module.Path
+func (d *GoVersionedPackage) PackageSyntax() PackageName {
+	return PackageName(d.Module.Path)
 }
 
-// PackageManagerSyntax returns the dependency in Go syntax. The returned string
+// VersionedPackageSyntax returns the dependency in Go syntax. The returned string
 // can (for example) be passed to `go get`.
 func (d *GoVersionedPackage) VersionedPackageSyntax() string {
 	return d.Module.String()

--- a/internal/conf/reposource/go_modules_test.go
+++ b/internal/conf/reposource/go_modules_test.go
@@ -71,7 +71,7 @@ func TestParseGoDependencyFromRepoName(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dep, err := ParseGoDependencyFromRepoName(test.name)
+			dep, err := ParseGoDependencyFromRepoName(api.RepoName(test.name))
 
 			assert.Equal(t, test.dep, dep)
 			if test.err == "" {

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -30,8 +30,8 @@ func (m *MavenModule) CoursierSyntax() string {
 	return fmt.Sprintf("%s:%s", m.GroupID, m.ArtifactID)
 }
 
-func (m *MavenModule) PackageSyntax() string {
-	return m.CoursierSyntax()
+func (m *MavenModule) PackageSyntax() PackageName {
+	return PackageName(m.CoursierSyntax())
 }
 
 func (m *MavenModule) SortText() string {
@@ -132,18 +132,18 @@ func ParseMavenVersionedPackage(dependency string) (*MavenVersionedPackage, erro
 	return dep, nil
 }
 
-func ParseMavenPackageFromRepoName(name string) (*MavenVersionedPackage, error) {
-	return ParseMavenPackageFromName(strings.ReplaceAll(strings.TrimPrefix(name, "maven/"), "/", ":"))
+func ParseMavenPackageFromRepoName(name api.RepoName) (*MavenVersionedPackage, error) {
+	return ParseMavenPackageFromName(PackageName(strings.ReplaceAll(strings.TrimPrefix(string(name), "maven/"), "/", ":")))
 }
 
 // ParseMavenPackageFromRepoName is a convenience function to parse a repo name in a
 // 'maven/<name>' format into a MavenVersionedPackage.
-func ParseMavenPackageFromName(name string) (*MavenVersionedPackage, error) {
+func ParseMavenPackageFromName(name PackageName) (*MavenVersionedPackage, error) {
 	if name == "jdk" {
 		return &MavenVersionedPackage{MavenModule: jdkModule()}, nil
 	}
 
-	return ParseMavenVersionedPackage(name)
+	return ParseMavenVersionedPackage(string(name))
 }
 
 // jdkModule returns the module for the Java standard library (JDK). This module

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -76,10 +76,10 @@ func ParseNpmPackageNameWithoutVersion(input string) (NpmPackageName, error) {
 
 // ParseNpmPackageFromRepoURL is a convenience function to parse a string in a
 // 'npm/(scope/)?name' format into an NpmPackageName.
-func ParseNpmPackageFromRepoURL(urlPath string) (*NpmPackageName, error) {
-	match := npmURLRegex.FindStringSubmatch(urlPath)
+func ParseNpmPackageFromRepoURL(repoName api.RepoName) (*NpmPackageName, error) {
+	match := npmURLRegex.FindStringSubmatch(string(repoName))
 	if match == nil {
-		return nil, errors.Errorf("expected path in npm/(scope/)?name format but found %s", urlPath)
+		return nil, errors.Errorf("expected path in npm/(scope/)?name format but found %s", repoName)
 	}
 	result := make(map[string]string)
 	for i, groupName := range npmURLRegex.SubexpNames() {
@@ -93,7 +93,7 @@ func ParseNpmPackageFromRepoURL(urlPath string) (*NpmPackageName, error) {
 
 // ParseNpmPackageFromPackageSyntax is a convenience function to parse a
 // string in a '(@scope/)?name' format into an NpmPackageName.
-func ParseNpmPackageFromPackageSyntax(pkg string) (*NpmPackageName, error) {
+func ParseNpmPackageFromPackageSyntax(pkg PackageName) (*NpmPackageName, error) {
 	dep, err := ParseNpmVersionedPackage(fmt.Sprintf("%s@0", pkg))
 	if err != nil {
 		return nil, err
@@ -147,11 +147,11 @@ func (pkg *NpmPackageName) CloneURL() string {
 // This is largely for "lower-level" code interacting with the npm API.
 //
 // In most cases, you want to use NpmVersionedPackage's VersionedPackageSyntax() instead.
-func (pkg *NpmPackageName) PackageSyntax() string {
+func (pkg *NpmPackageName) PackageSyntax() PackageName {
 	if pkg.scope != "" {
-		return fmt.Sprintf("@%s/%s", pkg.scope, pkg.name)
+		return PackageName(fmt.Sprintf("@%s/%s", pkg.scope, pkg.name))
 	}
-	return pkg.name
+	return PackageName(pkg.name)
 }
 
 // NpmVersionedPackage is a "versioned package" for use by npm commands, such as

--- a/internal/conf/reposource/package.go
+++ b/internal/conf/reposource/package.go
@@ -2,6 +2,8 @@ package reposource
 
 import "github.com/sourcegraph/sourcegraph/internal/api"
 
+type PackageName string
+
 // Package encodes the abstract notion of a publishable artifact from different languages ecosystems.
 // For example, Package refers to:
 // - an npm package in the JS/TS ecosystem.
@@ -17,7 +19,7 @@ type Package interface {
 
 	// PackageSyntax is the string-formatted encoding of this Package, as accepted by the ecosystem's package manager.
 	// Notably, the version is not included.
-	PackageSyntax() string
+	PackageSyntax() PackageName
 
 	// RepoName provides a name that is "globally unique" for a Sourcegraph instance.
 	// The returned value is used for repo:... in queries.

--- a/internal/conf/reposource/rust_packages.go
+++ b/internal/conf/reposource/rust_packages.go
@@ -8,11 +8,11 @@ import (
 )
 
 type RustVersionedPackage struct {
-	Name    string
+	Name    PackageName
 	Version string
 }
 
-func NewRustVersionedPackage(name, version string) *RustVersionedPackage {
+func NewRustVersionedPackage(name PackageName, version string) *RustVersionedPackage {
 	return &RustVersionedPackage{
 		Name:    name,
 		Version: version,
@@ -24,22 +24,22 @@ func NewRustVersionedPackage(name, version string) *RustVersionedPackage {
 func ParseRustVersionedPackage(dependency string) (*RustVersionedPackage, error) {
 	var dep RustVersionedPackage
 	if i := strings.LastIndex(dependency, "@"); i == -1 {
-		dep.Name = dependency
+		dep.Name = PackageName(dependency)
 	} else {
-		dep.Name = strings.TrimSpace(dependency[:i])
+		dep.Name = PackageName(strings.TrimSpace(dependency[:i]))
 		dep.Version = strings.TrimSpace(dependency[i+1:])
 	}
 	return &dep, nil
 }
 
-func ParseRustPackageFromName(name string) (*RustVersionedPackage, error) {
-	return ParseRustVersionedPackage(name)
+func ParseRustPackageFromName(name PackageName) (*RustVersionedPackage, error) {
+	return ParseRustVersionedPackage(string(name))
 }
 
 // ParseRustPackageFromRepoName is a convenience function to parse a repo name in a
 // 'crates/<name>(@<version>)?' format into a RustVersionedPackage.
-func ParseRustPackageFromRepoName(name string) (*RustVersionedPackage, error) {
-	dependency := strings.TrimPrefix(name, "crates/")
+func ParseRustPackageFromRepoName(name api.RepoName) (*RustVersionedPackage, error) {
+	dependency := strings.TrimPrefix(string(name), "crates/")
 	if len(dependency) == len(name) {
 		return nil, errors.Newf("invalid Rust dependency repo name, missing crates/ prefix '%s'", name)
 	}
@@ -50,15 +50,15 @@ func (p *RustVersionedPackage) Scheme() string {
 	return "rust-analyzer"
 }
 
-func (p *RustVersionedPackage) PackageSyntax() string {
+func (p *RustVersionedPackage) PackageSyntax() PackageName {
 	return p.Name
 }
 
 func (p *RustVersionedPackage) VersionedPackageSyntax() string {
 	if p.Version == "" {
-		return p.Name
+		return string(p.Name)
 	}
-	return p.Name + "@" + p.Version
+	return string(p.Name) + "@" + p.Version
 }
 
 func (p *RustVersionedPackage) PackageVersion() string {

--- a/internal/extsvc/gomodproxy/client.go
+++ b/internal/extsvc/gomodproxy/client.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"golang.org/x/mod/module"
 
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -36,7 +37,7 @@ func NewClient(urn string, urls []string, cli httpcli.Doer) *Client {
 }
 
 // GetVersion gets a single version of the given module if it exists.
-func (c *Client) GetVersion(ctx context.Context, mod, version string) (*module.Version, error) {
+func (c *Client) GetVersion(ctx context.Context, mod reposource.PackageName, version string) (*module.Version, error) {
 	var paths []string
 	if version != "" {
 		escapedVersion, err := module.EscapeVersion(version)
@@ -58,11 +59,11 @@ func (c *Client) GetVersion(ctx context.Context, mod, version string) (*module.V
 		return nil, err
 	}
 
-	return &module.Version{Path: mod, Version: v.Version}, nil
+	return &module.Version{Path: string(mod), Version: v.Version}, nil
 }
 
 // GetZip returns the zip archive bytes of the given module and version.
-func (c *Client) GetZip(ctx context.Context, mod, version string) ([]byte, error) {
+func (c *Client) GetZip(ctx context.Context, mod reposource.PackageName, version string) ([]byte, error) {
 	escapedVersion, err := module.EscapeVersion(version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to escape version")
@@ -81,8 +82,8 @@ func (c *Client) GetZip(ctx context.Context, mod, version string) ([]byte, error
 // longer than expected.
 const rateLimitingWaitThreshold = 200 * time.Millisecond
 
-func (c *Client) get(ctx context.Context, mod string, paths ...string) (respBody []byte, err error) {
-	escapedMod, err := module.EscapePath(mod)
+func (c *Client) get(ctx context.Context, mod reposource.PackageName, paths ...string) (respBody []byte, err error) {
+	escapedMod, err := module.EscapePath(string(mod))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to escape module path")
 	}

--- a/internal/extsvc/gomodproxy/client_test.go
+++ b/internal/extsvc/gomodproxy/client_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"golang.org/x/mod/module"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -45,7 +46,7 @@ func TestClient_GetVersion(t *testing.T) {
 		} else {
 			mod = ps[0]
 		}
-		v, err := cli.GetVersion(ctx, mod, version)
+		v, err := cli.GetVersion(ctx, reposource.PackageName(mod), version)
 		results = append(results, result{v, fmt.Sprint(err)})
 	}
 
@@ -74,7 +75,7 @@ func TestClient_GetZip(t *testing.T) {
 			mod = ps[0]
 		}
 
-		zipBytes, err := cli.GetZip(ctx, mod, version)
+		zipBytes, err := cli.GetZip(ctx, reposource.PackageName(mod), version)
 
 		r := result{Error: fmt.Sprint(err)}
 

--- a/internal/extsvc/npm/npmtest/npmtest.go
+++ b/internal/extsvc/npm/npmtest/npmtest.go
@@ -12,14 +12,14 @@ import (
 )
 
 type MockClient struct {
-	Packages map[string]*npm.PackageInfo
+	Packages map[reposource.PackageName]*npm.PackageInfo
 	Tarballs map[string][]byte
 }
 
 func NewMockClient(t testing.TB, deps ...string) *MockClient {
 	t.Helper()
 
-	packages := map[string]*npm.PackageInfo{}
+	packages := map[reposource.PackageName]*npm.PackageInfo{}
 	for _, dep := range deps {
 		d, err := reposource.ParseNpmVersionedPackage(dep)
 		if err != nil {
@@ -34,7 +34,7 @@ func NewMockClient(t testing.TB, deps ...string) *MockClient {
 			packages[name] = info
 		}
 
-		info.Description = name + " description"
+		info.Description = string(name) + " description"
 		version := info.Versions[d.Version]
 		if version == nil {
 			version = &npm.DependencyInfo{}

--- a/internal/repos/go_packages.go
+++ b/internal/repos/go_packages.go
@@ -1,8 +1,7 @@
 package repos
 
 import (
-	"context"
-
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gomodproxy"
@@ -41,22 +40,14 @@ type goPackagesSource struct {
 
 var _ packagesSource = &goPackagesSource{}
 
-func (s *goPackagesSource) Get(ctx context.Context, name, version string) (reposource.VersionedPackage, error) {
-	mod, err := s.client.GetVersion(ctx, name, version)
-	if err != nil {
-		return nil, err
-	}
-	return reposource.NewGoVersionedPackage(*mod), nil
-}
-
 func (goPackagesSource) ParseVersionedPackageFromConfiguration(dep string) (reposource.VersionedPackage, error) {
 	return reposource.ParseGoVersionedPackage(dep)
 }
 
-func (goPackagesSource) ParsePackageFromName(name string) (reposource.Package, error) {
+func (goPackagesSource) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return reposource.ParseGoDependencyFromName(name)
 }
 
-func (goPackagesSource) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (goPackagesSource) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	return reposource.ParseGoDependencyFromRepoName(repoName)
 }

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -3,6 +3,7 @@ package repos
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages/coursier"
@@ -58,10 +59,10 @@ func (jvmPackagesSource) ParseVersionedPackageFromConfiguration(dep string) (rep
 	return reposource.ParseMavenVersionedPackage(dep)
 }
 
-func (jvmPackagesSource) ParsePackageFromName(name string) (reposource.Package, error) {
+func (jvmPackagesSource) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return reposource.ParseMavenPackageFromName(name)
 }
 
-func (jvmPackagesSource) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (jvmPackagesSource) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	return reposource.ParseMavenPackageFromRepoName(repoName)
 }

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm"
@@ -45,7 +46,7 @@ type npmPackagesSource struct {
 	client npm.Client
 }
 
-func (s npmPackagesSource) GetPackage(ctx context.Context, name string) (reposource.Package, error) {
+func (s npmPackagesSource) GetPackage(ctx context.Context, name reposource.PackageName) (reposource.Package, error) {
 	// By using the empty string "" for the version, the request URL becomes "NPM_REGISTRY_URL/PACKAGE_NAME/",
 	// which returns metadata about the package instead a specific version. For example, compare:
 	// - https://registry.npmjs.org/react/
@@ -57,11 +58,11 @@ func (npmPackagesSource) ParseVersionedPackageFromConfiguration(dep string) (rep
 	return reposource.ParseNpmVersionedPackage(dep)
 }
 
-func (s *npmPackagesSource) ParsePackageFromName(name string) (reposource.Package, error) {
-	return s.ParsePackageFromRepoName("npm/" + strings.TrimPrefix(name, "@"))
+func (s *npmPackagesSource) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
+	return s.ParsePackageFromRepoName(api.RepoName("npm/" + strings.TrimPrefix(string(name), "@")))
 }
 
-func (npmPackagesSource) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (npmPackagesSource) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	pkg, err := reposource.ParseNpmPackageFromRepoURL(repoName)
 	if err != nil {
 		return nil, err
@@ -69,7 +70,7 @@ func (npmPackagesSource) ParsePackageFromRepoName(repoName string) (reposource.P
 	return &reposource.NpmVersionedPackage{NpmPackageName: pkg}, nil
 }
 
-func (s *npmPackagesSource) Get(ctx context.Context, name, version string) (reposource.VersionedPackage, error) {
+func (s *npmPackagesSource) Get(ctx context.Context, name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
 	parsedDbPackage, err := reposource.ParseNpmPackageFromPackageSyntax(name)
 	if err != nil {
 		return nil, err

--- a/internal/repos/npm_packages_test.go
+++ b/internal/repos/npm_packages_test.go
@@ -39,7 +39,7 @@ func TestGetNpmDependencyRepos(t *testing.T) {
 	for _, testCase := range testCases {
 		deps, err := depsSvc.ListDependencyRepos(ctx, dependencies.ListDependencyReposOpts{
 			Scheme: dependencies.NpmPackagesScheme,
-			Name:   testCase.pkgName,
+			Name:   reposource.PackageName(testCase.pkgName),
 		})
 		require.Nil(t, err)
 		depStrs := []string{}
@@ -61,7 +61,7 @@ func TestGetNpmDependencyRepos(t *testing.T) {
 		for i := 0; i < len(testCase.matches); i++ {
 			deps, err := depsSvc.ListDependencyRepos(ctx, dependencies.ListDependencyReposOpts{
 				Scheme: dependencies.NpmPackagesScheme,
-				Name:   testCase.pkgName,
+				Name:   reposource.PackageName(testCase.pkgName),
 				After:  lastID,
 				Limit:  1,
 			})

--- a/internal/repos/packages.go
+++ b/internal/repos/packages.go
@@ -30,10 +30,10 @@ type packagesSource interface {
 	ParseVersionedPackageFromConfiguration(dep string) (reposource.VersionedPackage, error)
 	// ParsePackageFromRepoName parses a Sourcegraph repository name of the package.
 	// For example: "npm/react" or "maven/com.google.guava/guava".
-	ParsePackageFromRepoName(repoName string) (reposource.Package, error)
+	ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error)
 	// ParsePackageFromName parses a package from the name of the package, as accepted by the ecosystem's package manager.
 	// For example: "react" or "com.google.guava:guava".
-	ParsePackageFromName(name string) (reposource.Package, error)
+	ParsePackageFromName(name reposource.PackageName) (reposource.Package, error)
 	// functions in this file that switch against concrete implementations of this interface:
 	// getPackage(): to fetch the description of this package, only supported by a few implementations.
 	// metadata(): to store gob-encoded structs with implementation-specific metadata.
@@ -41,7 +41,7 @@ type packagesSource interface {
 
 type packagesDownloadSource interface {
 	// GetPackage sends a request to the package host to get metadata about this package, like the description.
-	GetPackage(ctx context.Context, name string) (reposource.Package, error)
+	GetPackage(ctx context.Context, name reposource.PackageName) (reposource.Package, error)
 }
 
 var _ Source = &PackagesSource{}
@@ -53,7 +53,7 @@ func (s *PackagesSource) ListRepos(ctx context.Context, results chan SourceResul
 		return
 	}
 
-	handledPackages := make(map[string]struct{})
+	handledPackages := make(map[reposource.PackageName]struct{})
 
 	for _, dep := range deps {
 		if _, ok := handledPackages[dep.PackageSyntax()]; !ok {
@@ -134,7 +134,7 @@ func (s *PackagesSource) ListRepos(ctx context.Context, results chan SourceResul
 }
 
 func (s *PackagesSource) GetRepo(ctx context.Context, repoName string) (*types.Repo, error) {
-	parsedPkg, err := s.src.ParsePackageFromRepoName(repoName)
+	parsedPkg, err := s.src.ParsePackageFromRepoName(api.RepoName(repoName))
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (s *PackagesSource) makeRepo(dep reposource.Package) *types.Repo {
 	}
 }
 
-func getPackage(ctx context.Context, s packagesSource, name string) (reposource.Package, error) {
+func getPackage(ctx context.Context, s packagesSource, name reposource.PackageName) (reposource.Package, error) {
 	switch d := s.(type) {
 	case packagesDownloadSource:
 		return d.GetPackage(ctx, name)

--- a/internal/repos/packages.go
+++ b/internal/repos/packages.go
@@ -81,7 +81,8 @@ func (s *PackagesSource) ListRepos(ctx context.Context, results chan SourceResul
 	}()
 
 	const batchLimit = 100
-	lastName := ""
+	var lastName reposource.PackageName
+	lastName = ""
 	for {
 		depRepos, err := s.depsSvc.ListDependencyRepos(ctx, dependencies.ListDependencyReposOpts{
 			Scheme:          s.scheme,

--- a/internal/repos/packages_test.go
+++ b/internal/repos/packages_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -38,7 +39,7 @@ type dummyPackagesSource struct {
 }
 
 // GetPackage implements packagesDownloadSource
-func (d *dummyPackagesSource) GetPackage(ctx context.Context, name string) (reposource.Package, error) {
+func (d *dummyPackagesSource) GetPackage(ctx context.Context, name reposource.PackageName) (reposource.Package, error) {
 	d.getPackageCalled = true
 	return reposource.ParseGoDependencyFromName(name)
 }
@@ -48,12 +49,12 @@ func (d *dummyPackagesSource) ParseVersionedPackageFromConfiguration(dep string)
 	return reposource.ParseGoVersionedPackage(dep)
 }
 
-func (d *dummyPackagesSource) ParsePackageFromName(name string) (reposource.Package, error) {
+func (d *dummyPackagesSource) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	d.parsePackageFromNameCalled = true
 	return reposource.ParseGoDependencyFromName(name)
 }
 
-func (d *dummyPackagesSource) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (d *dummyPackagesSource) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	d.parsePackageFromRepoNameCalled = true
 	return reposource.ParseGoDependencyFromRepoName(repoName)
 }

--- a/internal/repos/python_packages.go
+++ b/internal/repos/python_packages.go
@@ -3,6 +3,7 @@ package repos
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/pypi"
@@ -39,7 +40,7 @@ type pythonPackagesSource struct {
 
 var _ packagesSource = &pythonPackagesSource{}
 
-func (s *pythonPackagesSource) Get(ctx context.Context, name, version string) (reposource.VersionedPackage, error) {
+func (s *pythonPackagesSource) Get(ctx context.Context, name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
 	_, err := s.client.Version(ctx, name, version)
 	if err != nil {
 		return nil, err
@@ -51,10 +52,10 @@ func (pythonPackagesSource) ParseVersionedPackageFromConfiguration(dep string) (
 	return reposource.ParseVersionedPackage(dep)
 }
 
-func (pythonPackagesSource) ParsePackageFromName(name string) (reposource.Package, error) {
+func (pythonPackagesSource) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return reposource.ParsePythonPackageFromName(name)
 }
 
-func (pythonPackagesSource) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (pythonPackagesSource) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	return reposource.ParsePythonPackageFromRepoName(repoName)
 }

--- a/internal/repos/rust_packages.go
+++ b/internal/repos/rust_packages.go
@@ -1,9 +1,7 @@
 package repos
 
 import (
-	"context"
-	"fmt"
-
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/crates"
@@ -40,24 +38,13 @@ type rustPackagesSource struct {
 
 var _ packagesSource = &rustPackagesSource{}
 
-func (s *rustPackagesSource) Get(ctx context.Context, name, version string) (reposource.VersionedPackage, error) {
-	dep := reposource.NewRustVersionedPackage(name, version)
-	// Check if crate exists or not. Crates returns a struct detailing the errors if it cannot be found.
-	metaURL := fmt.Sprintf("https://crates.io/api/v1/crates/%s/%s", dep.PackageSyntax(), dep.PackageVersion())
-	if _, err := s.client.Get(ctx, metaURL); err != nil {
-		return nil, errors.Wrapf(err, "failed to fetch crate metadata for %s with URL %s", dep.VersionedPackageSyntax(), metaURL)
-	}
-
-	return dep, nil
-}
-
 func (rustPackagesSource) ParseVersionedPackageFromConfiguration(dep string) (reposource.VersionedPackage, error) {
 	return reposource.ParseRustVersionedPackage(dep)
 }
 
-func (rustPackagesSource) ParsePackageFromName(name string) (reposource.Package, error) {
+func (rustPackagesSource) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return reposource.ParseRustPackageFromName(name)
 }
-func (rustPackagesSource) ParsePackageFromRepoName(repoName string) (reposource.Package, error) {
+func (rustPackagesSource) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	return reposource.ParseRustPackageFromRepoName(repoName)
 }

--- a/lib/codeintel/precise/types.go
+++ b/lib/codeintel/precise/types.go
@@ -1,6 +1,8 @@
 package precise
 
-import "github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/protocol"
+import (
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/protocol"
+)
 
 type ID string
 


### PR DESCRIPTION
Previously, we used strings for both types, which caused a regression
that got fixed in https://github.com/sourcegraph/sourcegraph/pull/38722.
This commit introduces type aliases to avoid regressions like that.

While implementing the refactoring I also found a bug in Python
packages, that's fixed by this commit.



## Test plan

See the CI go green.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
