### PR TITLE
dependencies: add ListLockfileIndexes to store

### DIFF
--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -18,6 +18,7 @@ type operations struct {
 	updateResolvedRevisions      *observation.Operation
 	upsertDependencyRepos        *observation.Operation
 	upsertLockfileDependencies   *observation.Operation
+	listLockfileIndexes          *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -47,5 +48,6 @@ func newOperations(observationContext *observation.Context) *operations {
 		updateResolvedRevisions:      op("UpdateResolvedRevisions"),
 		upsertDependencyRepos:        op("UpsertDependencyRepos"),
 		upsertLockfileDependencies:   op("UpsertLockfileDependencies"),
+		listLockfileIndexes:          op("ListLockfileIndexes"),
 	}
 }

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -1071,3 +1071,119 @@ func TestLockfileDependents(t *testing.T) {
 		t.Errorf("unexpected lockfile dependents (-want +got):\n%s", diff)
 	}
 }
+
+func TestListLockfileIndexes(t *testing.T) {
+
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(db, &observation.TestContext)
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo')`); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('bar')`); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "1", "2", "pkg-A", "4")
+	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "2", "3", "pkg-B", "5")
+
+	// Insert data
+	for _, tt := range []struct {
+		repoName string
+		deps     []shared.PackageDependency
+		graph    shared.DependencyGraph
+		commit   string
+		lockfile string
+	}{
+		{
+			repoName: "foo",
+			deps:     []shared.PackageDependency{packageA, packageB},
+			graph:    shared.TestDependencyGraphLiteral([]shared.PackageDependency{packageA}, false, [][]shared.PackageDependency{{packageA, packageB}}),
+			commit:   "cafebabe",
+			lockfile: "lock.file",
+		},
+		{
+			repoName: "foo",
+			deps:     []shared.PackageDependency{packageA, packageB},
+			graph:    shared.TestDependencyGraphLiteral([]shared.PackageDependency{packageA}, false, [][]shared.PackageDependency{{packageA, packageB}}),
+			commit:   "d34db33f",
+			lockfile: "lock.file",
+		},
+		{
+			repoName: "bar",
+			deps:     []shared.PackageDependency{packageA},
+			graph:    nil,
+			commit:   "d34db33f",
+			lockfile: "lock2.file",
+		},
+	} {
+		if err := store.UpsertLockfileGraph(ctx, tt.repoName, tt.commit, tt.lockfile, tt.deps, tt.graph); err != nil {
+			t.Fatalf("error: %s", err)
+		}
+	}
+
+	// Query
+	lockfileIndexes := []shared.LockfileIndex{
+		{ID: 1, RepositoryID: 1, Commit: "cafebabe", LockfileReferenceIDs: []int{1}, Lockfile: "lock.file", Fidelity: "graph"},
+		{ID: 2, RepositoryID: 1, Commit: "d34db33f", LockfileReferenceIDs: []int{3}, Lockfile: "lock.file", Fidelity: "graph"},
+		{ID: 3, RepositoryID: 2, Commit: "d34db33f", LockfileReferenceIDs: []int{5}, Lockfile: "lock2.file", Fidelity: "flat"},
+	}
+
+	for _, tt := range []struct {
+		opts     ListLockfileIndexesOpts
+		expected []shared.LockfileIndex
+	}{
+		{
+			opts:     ListLockfileIndexesOpts{},
+			expected: []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1], lockfileIndexes[2]},
+		},
+		{
+			opts:     ListLockfileIndexesOpts{Limit: 2},
+			expected: []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1]},
+		},
+		{
+			opts:     ListLockfileIndexesOpts{After: 1, Limit: 2},
+			expected: []shared.LockfileIndex{lockfileIndexes[1], lockfileIndexes[2]},
+		},
+		{
+			opts:     ListLockfileIndexesOpts{After: 2, Limit: 2},
+			expected: []shared.LockfileIndex{lockfileIndexes[2]},
+		},
+		{
+			opts:     ListLockfileIndexesOpts{RepoName: "foo"},
+			expected: []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1]},
+		},
+		{
+			opts:     ListLockfileIndexesOpts{RepoName: "bar"},
+			expected: []shared.LockfileIndex{lockfileIndexes[2]},
+		},
+		{
+			opts:     ListLockfileIndexesOpts{Commit: "cafebabe"},
+			expected: []shared.LockfileIndex{lockfileIndexes[0]},
+		},
+		{
+			opts:     ListLockfileIndexesOpts{Commit: "d34db33f", RepoName: "bar"},
+			expected: []shared.LockfileIndex{lockfileIndexes[2]},
+		},
+		{
+			opts:     ListLockfileIndexesOpts{Lockfile: "lock.file"},
+			expected: []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1]},
+		},
+		{
+			opts:     ListLockfileIndexesOpts{Lockfile: "lock2.file"},
+			expected: []shared.LockfileIndex{lockfileIndexes[2]},
+		},
+	} {
+		lockfiles, err := store.ListLockfileIndexes(ctx, tt.opts)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+
+		if diff := cmp.Diff(tt.expected, lockfiles); diff != "" {
+			t.Errorf("unexpected lockfiles (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -1073,7 +1073,6 @@ func TestLockfileDependents(t *testing.T) {
 }
 
 func TestListLockfileIndexes(t *testing.T) {
-
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))

--- a/internal/codeintel/dependencies/mocks_test.go
+++ b/internal/codeintel/dependencies/mocks_test.go
@@ -504,6 +504,9 @@ type MockStore struct {
 	// ListDependencyReposFunc is an instance of a mock function object
 	// controlling the behavior of the method ListDependencyRepos.
 	ListDependencyReposFunc *StoreListDependencyReposFunc
+	// ListLockfileIndexesFunc is an instance of a mock function object
+	// controlling the behavior of the method ListLockfileIndexes.
+	ListLockfileIndexesFunc *StoreListLockfileIndexesFunc
 	// LockfileDependenciesFunc is an instance of a mock function object
 	// controlling the behavior of the method LockfileDependencies.
 	LockfileDependenciesFunc *StoreLockfileDependenciesFunc
@@ -542,6 +545,11 @@ func NewMockStore() *MockStore {
 		},
 		ListDependencyReposFunc: &StoreListDependencyReposFunc{
 			defaultHook: func(context.Context, store.ListDependencyReposOpts) (r0 []shared.Repo, r1 error) {
+				return
+			},
+		},
+		ListLockfileIndexesFunc: &StoreListLockfileIndexesFunc{
+			defaultHook: func(context.Context, store.ListLockfileIndexesOpts) (r0 []shared.LockfileIndex, r1 error) {
 				return
 			},
 		},
@@ -602,6 +610,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ListDependencyRepos")
 			},
 		},
+		ListLockfileIndexesFunc: &StoreListLockfileIndexesFunc{
+			defaultHook: func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
+				panic("unexpected invocation of MockStore.ListLockfileIndexes")
+			},
+		},
 		LockfileDependenciesFunc: &StoreLockfileDependenciesFunc{
 			defaultHook: func(context.Context, store.LockfileDependenciesOpts) ([]shared.PackageDependency, bool, error) {
 				panic("unexpected invocation of MockStore.LockfileDependencies")
@@ -654,6 +667,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		ListDependencyReposFunc: &StoreListDependencyReposFunc{
 			defaultHook: i.ListDependencyRepos,
+		},
+		ListLockfileIndexesFunc: &StoreListLockfileIndexesFunc{
+			defaultHook: i.ListLockfileIndexes,
 		},
 		LockfileDependenciesFunc: &StoreLockfileDependenciesFunc{
 			defaultHook: i.LockfileDependencies,
@@ -901,6 +917,114 @@ func (c StoreListDependencyReposFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreListDependencyReposFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreListLockfileIndexesFunc describes the behavior when the
+// ListLockfileIndexes method of the parent MockStore instance is invoked.
+type StoreListLockfileIndexesFunc struct {
+	defaultHook func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error)
+	hooks       []func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error)
+	history     []StoreListLockfileIndexesFuncCall
+	mutex       sync.Mutex
+}
+
+// ListLockfileIndexes delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) ListLockfileIndexes(v0 context.Context, v1 store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
+	r0, r1 := m.ListLockfileIndexesFunc.nextHook()(v0, v1)
+	m.ListLockfileIndexesFunc.appendCall(StoreListLockfileIndexesFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ListLockfileIndexes
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreListLockfileIndexesFunc) SetDefaultHook(hook func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListLockfileIndexes method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StoreListLockfileIndexesFunc) PushHook(hook func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreListLockfileIndexesFunc) SetDefaultReturn(r0 []shared.LockfileIndex, r1 error) {
+	f.SetDefaultHook(func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreListLockfileIndexesFunc) PushReturn(r0 []shared.LockfileIndex, r1 error) {
+	f.PushHook(func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreListLockfileIndexesFunc) nextHook() func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreListLockfileIndexesFunc) appendCall(r0 StoreListLockfileIndexesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreListLockfileIndexesFuncCall objects
+// describing the invocations of this function.
+func (f *StoreListLockfileIndexesFunc) History() []StoreListLockfileIndexesFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreListLockfileIndexesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreListLockfileIndexesFuncCall is an object that describes an
+// invocation of method ListLockfileIndexes on an instance of MockStore.
+type StoreListLockfileIndexesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 store.ListLockfileIndexesOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.LockfileIndex
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreListLockfileIndexesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreListLockfileIndexesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/dependencies/shared/types.go
+++ b/internal/codeintel/dependencies/shared/types.go
@@ -26,6 +26,15 @@ const (
 	IndexFidelityGraph IndexFidelity = "graph"
 )
 
+type LockfileIndex struct {
+	ID                   int
+	RepositoryID         int
+	Commit               string
+	LockfileReferenceIDs []int
+	Lockfile             string
+	Fidelity             IndexFidelity
+}
+
 type Repo struct {
 	ID      int
 	Scheme  string


### PR DESCRIPTION
I'm going to need this to return `LockfileIndexes` in the GraphQL layer.

## Test plan

- Existing and new unit tests
