### PR TITLE
Code Insights: Unbind creation and edit UI pages and insight models 

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/creation-actions/CodeInsightsCreationActions.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/creation-actions/CodeInsightsCreationActions.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react'
+
+import { noop } from 'lodash'
+
+import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { Button } from '@sourcegraph/wildcard'
+
+import { LoaderButton } from '../../../../../components/LoaderButton'
+import { LimitedAccessLabel } from '../../limited-access-label/LimitedAccessLabel'
+
+export enum CodeInsightCreationMode {
+    Creation = 'creation',
+    Edit = 'edit',
+}
+
+interface CodeInsightsCreationActionsProps {
+    mode: CodeInsightCreationMode
+    submitting: boolean
+    available?: boolean
+    errors?: unknown
+    licensed?: boolean
+    clear?: boolean
+    onCancel?: () => void
+}
+
+export const CodeInsightsCreationActions: FC<CodeInsightsCreationActionsProps> = props => {
+    const { mode, submitting, licensed, available, clear, errors, onCancel = noop } = props
+
+    const isEditMode = mode === CodeInsightCreationMode.Edit
+
+    return (
+        <footer>
+            {!licensed && !isEditMode && (
+                <LimitedAccessLabel
+                    message="Unlock Code Insights to create unlimited insights"
+                    className="my-3 mt-n2"
+                />
+            )}
+
+            <div className="d-flex flex-wrap align-items-center">
+                {errors && <ErrorAlert className="w-100" error={errors} />}
+
+                <LoaderButton
+                    type="submit"
+                    variant="primary"
+                    label={submitting ? 'Submitting' : isEditMode ? 'Save changes' : 'Create code insight'}
+                    data-testid="insight-save-button"
+                    alwaysShowLabel={true}
+                    loading={submitting}
+                    disabled={submitting || !available}
+                    className="mr-2 mb-2"
+                />
+
+                <Button type="button" variant="secondary" outline={true} className="mb-2 mr-auto" onClick={onCancel}>
+                    Cancel
+                </Button>
+
+                <Button type="reset" variant="secondary" outline={true} disabled={!clear} className="border-0">
+                    Clear all fields
+                </Button>
+            </div>
+        </footer>
+    )
+}

--- a/client/web/src/enterprise/insights/components/creation-ui/creation-ui-layout/CreationUiLayout.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/creation-ui-layout/CreationUiLayout.tsx
@@ -13,10 +13,10 @@ export const CreationUiLayout = forwardRef((props, reference) => {
 }) as ForwardReferenceComponent<'div', {}>
 
 export const CreationUIForm = forwardRef((props, reference) => {
-    const { as: Component = 'div', className, ...attributes } = props
+    const { as: Component = 'form', className, ...attributes } = props
 
     return <Component ref={reference} {...attributes} className={classNames(styles.rootForm, className)} />
-}) as ForwardReferenceComponent<'div', {}>
+}) as ForwardReferenceComponent<'form', {}>
 
 export const CreationUIPreview = forwardRef((props, reference) => {
     const { as: Component = 'aside', className, ...attributes } = props

--- a/client/web/src/enterprise/insights/components/creation-ui/index.ts
+++ b/client/web/src/enterprise/insights/components/creation-ui/index.ts
@@ -6,6 +6,7 @@ export { getSanitizedRepositories } from './sanitizers/repositories'
 export { CodeInsightDashboardsVisibility } from './CodeInsightDashboardsVisibility'
 export { CodeInsightTimeStepPicker } from './code-insight-time-step-picker/CodeInsightTimeStepPicker'
 export { FormSeries, createDefaultEditSeries } from './form-series'
+export { CodeInsightCreationMode, CodeInsightsCreationActions } from './creation-actions/CodeInsightsCreationActions'
 export type { EditableDataSeries } from './form-series'
 
 export {

--- a/client/web/src/enterprise/insights/components/form/hooks/useForm.ts
+++ b/client/web/src/enterprise/insights/components/form/hooks/useForm.ts
@@ -303,10 +303,11 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
                     submitResult && setSubmitErrors(submitResult)
                 }
             } else {
+                const formElement = formElementReference.current ?? (event.target as Element)
                 // Hack to focus first invalid input on submit, since we are not using
                 // native behavior in order to avoid poor UX of native validation focus on error
                 // we have to find and focus invalid input by ourselves
-                formElementReference.current?.querySelector<HTMLInputElement>(':invalid:not(fieldset)')?.focus()
+                formElement.querySelector<HTMLInputElement>(':invalid:not(fieldset)')?.focus()
             }
         },
     }

--- a/client/web/src/enterprise/insights/hooks/use-ui-features.ts
+++ b/client/web/src/enterprise/insights/hooks/use-ui-features.ts
@@ -37,7 +37,7 @@ export interface UseUiFeatures {
     insight: {
         getContextActionsPermissions: (insight: Insight) => { showYAxis: boolean }
         getCreationPermissions: () => Observable<{ available: boolean }>
-        getEditPermissions: (insight: Insight) => Observable<{ available: boolean }>
+        getEditPermissions: (insight: Insight | undefined | null) => Observable<{ available: boolean }>
     }
 }
 
@@ -87,16 +87,15 @@ export function useUiFeatures(): UseUiFeatures {
                 },
             },
             insight: {
-                getContextActionsPermissions: (insight: Insight) => ({
-                    showYAxis: isSearchBasedInsight(insight),
-                }),
+                getContextActionsPermissions: (insight: Insight) => ({ showYAxis: isSearchBasedInsight(insight) }),
                 getCreationPermissions: () =>
                     insightsLimit !== null
                         ? getActiveInsightsCount(insightsLimit).pipe(
                               map(insightCount => ({ available: insightCount < insightsLimit }))
                           )
                         : of({ available: true }),
-                getEditPermissions: (insight: Insight) => of({ available: licensed || !insight.isFrozen }),
+                getEditPermissions: (insight: Insight | undefined | null) =>
+                    insight ? of({ available: licensed || !insight?.isFrozen }) : of({ available: false }),
             },
         }),
         [licensed, insightsLimit, getActiveInsightsCount]

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react'
+import { FC, ReactNode, useCallback } from 'react'
 
 import { noop } from 'lodash'
 
@@ -16,12 +16,11 @@ import {
     insightRepositoriesAsyncValidator,
     insightTitleValidator,
 } from '../../../../../components'
-import { Insight } from '../../../../../core'
 import { LineChartLivePreview } from '../../LineChartLivePreview'
 import { CaptureGroupFormFields } from '../types'
 import { searchQueryValidator } from '../utils/search-query-validator'
 
-import { CaptureGroupCreationForm } from './CaptureGoupCreationForm'
+import { CaptureGroupCreationForm, RenderPropertyInputs } from './CaptureGoupCreationForm'
 
 const INITIAL_VALUES: CaptureGroupFormFields = {
     repositories: '',
@@ -36,18 +35,17 @@ const INITIAL_VALUES: CaptureGroupFormFields = {
 const queryRequiredValidator = createRequiredValidator('Query is a required field.')
 
 interface CaptureGroupCreationContentProps {
-    mode: 'creation' | 'edit'
+    touched: boolean
     initialValues?: Partial<CaptureGroupFormFields>
     className?: string
-    insight?: Insight
-
+    children: (inputs: RenderPropertyInputs) => ReactNode
     onSubmit: (values: CaptureGroupFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
     onChange?: (event: FormChangeEvent<CaptureGroupFormFields>) => void
     onCancel: () => void
 }
 
 export const CaptureGroupCreationContent: FC<CaptureGroupCreationContentProps> = props => {
-    const { mode, className, initialValues = {}, onSubmit, onChange = noop, onCancel, insight } = props
+    const { touched, className, initialValues = {}, children, onSubmit, onChange = noop } = props
 
     // Search query validators
     const validateChecks = useCallback((value: string | undefined) => {
@@ -67,7 +65,7 @@ export const CaptureGroupCreationContent: FC<CaptureGroupCreationContentProps> =
 
     const form = useForm<CaptureGroupFormFields>({
         initialValues: { ...INITIAL_VALUES, ...initialValues },
-        touched: mode === 'edit',
+        touched,
         onSubmit,
         onChange,
     })
@@ -146,7 +144,6 @@ export const CaptureGroupCreationContent: FC<CaptureGroupCreationContentProps> =
         <CreationUiLayout className={className}>
             <CreationUIForm
                 as={CaptureGroupCreationForm}
-                mode={mode}
                 form={form}
                 title={title}
                 repositories={repositories}
@@ -156,10 +153,10 @@ export const CaptureGroupCreationContent: FC<CaptureGroupCreationContentProps> =
                 isFormClearActive={hasFilledValue}
                 allReposMode={allReposMode}
                 dashboardReferenceCount={initialValues.dashboardReferenceCount}
-                insight={insight}
-                onCancel={onCancel}
                 onFormReset={handleFormReset}
-            />
+            >
+                {children}
+            </CreationUIForm>
 
             <CreationUIPreview
                 as={LineChartLivePreview}

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
@@ -47,7 +47,7 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
     const { mode = 'creation', initialValue, onChange, onSubmit, onCancel, ...attributes } = props
     const { licensed } = useUiFeatures()
 
-    const { formAPI, ref, handleSubmit } = useForm<CreateComputeInsightFormFields>({
+    const { formAPI, handleSubmit } = useForm<CreateComputeInsightFormFields>({
         initialValues: { ...INITIAL_INSIGHT_VALUES, ...initialValue },
         onSubmit,
         onChange,
@@ -82,7 +82,7 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
 
     return (
         <CreationUiLayout {...attributes}>
-            <CreationUIForm as="form" ref={ref} onSubmit={handleSubmit}>
+            <CreationUIForm onSubmit={handleSubmit}>
                 <FormGroup
                     name="insight repositories"
                     title="Targeted repositories"

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -1,15 +1,21 @@
-import React, { useCallback, useEffect } from 'react'
+import { FC, useCallback, useEffect, useMemo } from 'react'
 
 import classNames from 'classnames'
 
 import { asError } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { useLocalStorage, Link, PageHeader } from '@sourcegraph/wildcard'
+import { useLocalStorage, Link, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../../../../insights/Icons'
-import { CodeInsightsPage, FORM_ERROR, FormChangeEvent } from '../../../../components'
+import {
+    CodeInsightCreationMode,
+    CodeInsightsCreationActions,
+    CodeInsightsPage,
+    FORM_ERROR,
+} from '../../../../components'
 import { MinimalLangStatsInsightData } from '../../../../core'
+import { useUiFeatures } from '../../../../hooks'
 import { CodeInsightTrackType } from '../../../../pings'
 
 import {
@@ -45,10 +51,12 @@ export interface LangStatsInsightCreationPageProps extends TelemetryProps {
     onCancel: () => void
 }
 
-export const LangStatsInsightCreationPage: React.FunctionComponent<
-    React.PropsWithChildren<LangStatsInsightCreationPageProps>
-> = props => {
+export const LangStatsInsightCreationPage: FC<LangStatsInsightCreationPageProps> = props => {
     const { telemetryService, onInsightCreateRequest, onCancel, onSuccessfulCreation } = props
+
+    const { licensed, insight } = useUiFeatures()
+
+    const creationPermission = useObservable(useMemo(() => insight.getCreationPermissions(), [insight]))
 
     // We do not use temporal user settings since form values are not so important to
     // waste users time for waiting response of yet another network request to just
@@ -97,10 +105,6 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<
         onCancel()
     }, [setInitialFormValues, telemetryService, onCancel])
 
-    const handleChange = (event: FormChangeEvent<LangStatsCreationFormFields>): void => {
-        setInitialFormValues(event.values)
-    }
-
     return (
         <CodeInsightsPage className={classNames(styles.creationPage, 'col-10')}>
             <PageTitle title="Create insight - Code Insights" />
@@ -119,12 +123,25 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<
             />
 
             <LangStatsInsightCreationContent
-                className="pb-5"
                 initialValues={initialFormValues}
+                touched={false}
+                className="pb-5"
                 onSubmit={handleSubmit}
-                onCancel={handleCancel}
-                onChange={handleChange}
-            />
+                // onCancel={handleCancel}
+                onChange={event => setInitialFormValues(event.values)}
+            >
+                {form => (
+                    <CodeInsightsCreationActions
+                        mode={CodeInsightCreationMode.Creation}
+                        licensed={licensed}
+                        available={creationPermission?.available}
+                        submitting={form.submitting}
+                        errors={form.submitErrors?.[FORM_ERROR]}
+                        clear={form.isFormClearActive}
+                        onCancel={handleCancel}
+                    />
+                )}
+            </LangStatsInsightCreationContent>
         </CodeInsightsPage>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -126,7 +126,6 @@ export const LangStatsInsightCreationPage: FC<LangStatsInsightCreationPageProps>
                 touched={false}
                 className="pb-5"
                 onSubmit={handleSubmit}
-                // onCancel={handleCancel}
                 onChange={event => setInitialFormValues(event.values)}
             >
                 {form => (

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -55,7 +55,6 @@ export const LangStatsInsightCreationPage: FC<LangStatsInsightCreationPageProps>
     const { telemetryService, onInsightCreateRequest, onCancel, onSuccessfulCreation } = props
 
     const { licensed, insight } = useUiFeatures()
-
     const creationPermission = useObservable(useMemo(() => insight.getCreationPermissions(), [insight]))
 
     // We do not use temporal user settings since form values are not so important to

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/LangStatsInsightCreationContent.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 
 import { noop } from 'rxjs'
 
@@ -15,10 +15,12 @@ import {
     insightRepositoriesValidator,
     insightRepositoriesAsyncValidator,
 } from '../../../../../components'
-import { Insight } from '../../../../../core'
 import { LangStatsCreationFormFields } from '../types'
 
-import { LangStatsInsightCreationForm } from './lang-stats-insight-creation-form/LangStatsInsightCreationForm'
+import {
+    LangStatsInsightCreationForm,
+    RenderPropertyInputs,
+} from './lang-stats-insight-creation-form/LangStatsInsightCreationForm'
 import { LangStatsInsightLivePreview } from './live-preview-chart/LangStatsInsightLivePreview'
 
 export const thresholdFieldValidator = createRequiredValidator('Threshold is a required field for code insight.')
@@ -31,43 +33,29 @@ const INITIAL_VALUES: LangStatsCreationFormFields = {
 }
 
 export interface LangStatsInsightCreationContentProps {
-    /**
-     * This component might be used in two different modes for creation and
-     * edit mode. In edit mode we change some text keys for form and trigger
-     * validation on form fields immediately.
-     */
-    mode?: 'creation' | 'edit'
-
+    touched: boolean
+    children: (input: RenderPropertyInputs) => ReactNode
     initialValues?: Partial<LangStatsCreationFormFields>
     className?: string
-    insight?: Insight
 
     onSubmit: (values: LangStatsCreationFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
-    onCancel?: () => void
+    // onCancel?: () => void
 
     /** Change handlers is called every time when user changed any field within the form. */
     onChange?: (event: FormChangeEvent<LangStatsCreationFormFields>) => void
 }
 
 export const LangStatsInsightCreationContent: FC<LangStatsInsightCreationContentProps> = props => {
-    const {
-        mode = 'creation',
-        initialValues = {},
-        className,
-        onSubmit,
-        onCancel = noop,
-        onChange = noop,
-        insight,
-    } = props
+    const { touched, initialValues = {}, className, children, onSubmit, onChange = noop } = props
 
-    const { values, handleSubmit, formAPI, ref } = useForm<LangStatsCreationFormFields>({
+    const { values, handleSubmit, formAPI } = useForm<LangStatsCreationFormFields>({
         initialValues: {
             ...INITIAL_VALUES,
             ...initialValues,
         },
         onSubmit,
         onChange,
-        touched: mode === 'edit',
+        touched,
     })
 
     const repository = useField({
@@ -110,8 +98,6 @@ export const LangStatsInsightCreationContent: FC<LangStatsInsightCreationContent
         <CreationUiLayout data-testid="code-stats-insight-creation-page-content" className={className}>
             <CreationUIForm
                 as={LangStatsInsightCreationForm}
-                mode={mode}
-                innerRef={ref}
                 handleSubmit={handleSubmit}
                 submitErrors={formAPI.submitErrors}
                 submitting={formAPI.submitting}
@@ -120,10 +106,10 @@ export const LangStatsInsightCreationContent: FC<LangStatsInsightCreationContent
                 threshold={threshold}
                 isFormClearActive={hasFilledValue}
                 dashboardReferenceCount={initialValues.dashboardReferenceCount}
-                insight={insight}
-                onCancel={onCancel}
                 onFormReset={handleFormReset}
-            />
+            >
+                {children}
+            </CreationUIForm>
 
             <CreationUIPreview
                 as={LangStatsInsightLivePreview}

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/LangStatsInsightCreationContent.tsx
@@ -39,7 +39,6 @@ export interface LangStatsInsightCreationContentProps {
     className?: string
 
     onSubmit: (values: LangStatsCreationFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
-    // onCancel?: () => void
 
     /** Change handlers is called every time when user changed any field within the form. */
     onChange?: (event: FormChangeEvent<LangStatsCreationFormFields>) => void

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationContent.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 
 import { noop } from 'rxjs'
 
@@ -11,44 +11,29 @@ import {
     createDefaultEditSeries,
     EditableDataSeries,
 } from '../../../../../components'
-import { Insight } from '../../../../../core'
 import { LineChartLivePreview, LivePreviewSeries } from '../../LineChartLivePreview'
 import { CreateInsightFormFields } from '../types'
 import { getSanitizedSeries } from '../utils/insight-sanitizer'
 
-import { SearchInsightCreationForm } from './SearchInsightCreationForm'
+import { RenderPropertyInputs, SearchInsightCreationForm } from './SearchInsightCreationForm'
 import { useInsightCreationForm } from './use-insight-creation-form'
 
 export interface SearchInsightCreationContentProps {
-    /** This component might be used in edit or creation insight case. */
-    mode?: 'creation' | 'edit'
-
+    touched: boolean
+    children: (input: RenderPropertyInputs) => ReactNode
     initialValue?: Partial<CreateInsightFormFields>
-    className?: string
     dataTestId?: string
-    insight?: Insight
-
+    className?: string
     onSubmit: (values: CreateInsightFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
-    onCancel?: () => void
-
     /** Change handlers is called every time when user changed any field within the form. */
     onChange?: (event: FormChangeEvent<CreateInsightFormFields>) => void
 }
 
 export const SearchInsightCreationContent: FC<SearchInsightCreationContentProps> = props => {
-    const {
-        mode = 'creation',
-        initialValue,
-        className,
-        dataTestId,
-        insight,
-        onSubmit,
-        onCancel = noop,
-        onChange = noop,
-    } = props
+    const { touched, children, initialValue, className, dataTestId, onSubmit, onChange = noop } = props
 
     const {
-        form: { values, formAPI, ref, handleSubmit },
+        form: { values, formAPI, handleSubmit },
         title,
         repositories,
         series,
@@ -56,7 +41,7 @@ export const SearchInsightCreationContent: FC<SearchInsightCreationContentProps>
         stepValue,
         allReposMode,
     } = useInsightCreationForm({
-        mode,
+        touched,
         initialValue,
         onChange,
         onSubmit,
@@ -91,8 +76,6 @@ export const SearchInsightCreationContent: FC<SearchInsightCreationContentProps>
         <CreationUiLayout data-testid={dataTestId} className={className}>
             <CreationUIForm
                 as={SearchInsightCreationForm}
-                mode={mode}
-                innerRef={ref}
                 handleSubmit={handleSubmit}
                 submitErrors={formAPI.submitErrors}
                 submitting={formAPI.submitting}
@@ -105,10 +88,10 @@ export const SearchInsightCreationContent: FC<SearchInsightCreationContentProps>
                 stepValue={stepValue}
                 isFormClearActive={hasFilledValue}
                 dashboardReferenceCount={initialValue?.dashboardReferenceCount}
-                insight={insight}
-                onCancel={onCancel}
                 onFormReset={handleFormReset}
-            />
+            >
+                {children}
+            </CreationUIForm>
 
             <CreationUIPreview
                 as={LineChartLivePreview}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/use-insight-creation-form.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/use-insight-creation-form.ts
@@ -29,7 +29,7 @@ export const INITIAL_INSIGHT_VALUES: CreateInsightFormFields = {
 }
 
 export interface UseInsightCreationFormProps {
-    mode: 'creation' | 'edit'
+    touched: boolean
     initialValue?: Partial<CreateInsightFormFields>
     onSubmit: (values: CreateInsightFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
     onChange?: (event: FormChangeEvent<CreateInsightFormFields>) => void
@@ -50,8 +50,7 @@ export interface InsightCreationForm {
  * validations, fields dependencies)
  */
 export function useInsightCreationForm(props: UseInsightCreationFormProps): InsightCreationForm {
-    const { mode, initialValue = {}, onSubmit, onChange } = props
-    const isEdit = mode === 'edit'
+    const { touched, initialValue = {}, onSubmit, onChange } = props
 
     const form = useForm<CreateInsightFormFields>({
         initialValues: {
@@ -60,7 +59,7 @@ export function useInsightCreationForm(props: UseInsightCreationFormProps): Insi
         },
         onSubmit,
         onChange,
-        touched: isEdit,
+        touched,
     })
 
     const allReposMode = useField({

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -91,7 +91,8 @@ export const EditInsightPage: React.FunctionComponent<React.PropsWithChildren<Ed
                     isEditAvailable={editPermission?.available}
                     insight={insight}
                     onSubmit={handleSubmit}
-                    onCancel={handleCancel} />
+                    onCancel={handleCancel}
+                />
             )}
 
             {isCaptureGroupInsight(insight) && (
@@ -100,7 +101,8 @@ export const EditInsightPage: React.FunctionComponent<React.PropsWithChildren<Ed
                     isEditAvailable={editPermission?.available}
                     insight={insight}
                     onSubmit={handleSubmit}
-                    onCancel={handleCancel} />
+                    onCancel={handleCancel}
+                />
             )}
 
             {isLangStatsInsight(insight) && (

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -8,13 +8,14 @@ import { AuthenticatedUser } from '../../../../../auth'
 import { HeroPage } from '../../../../../components/HeroPage'
 import { PageTitle } from '../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../../../insights/Icons'
-import { CodeInsightsPage } from '../../../components/code-insights-page/CodeInsightsPage'
+import { CodeInsightsPage } from '../../../components'
 import {
     CodeInsightsBackendContext,
     isCaptureGroupInsight,
     isLangStatsInsight,
     isSearchBasedInsight,
 } from '../../../core'
+import { useUiFeatures } from '../../../hooks'
 
 import { EditCaptureGroupInsight } from './components/EditCaptureGroupInsight'
 import { EditLangStatsInsight } from './components/EditLangStatsInsight'
@@ -36,9 +37,14 @@ export const EditInsightPage: React.FunctionComponent<React.PropsWithChildren<Ed
     const { insightID, authenticatedUser } = props
 
     const { getInsightById } = useContext(CodeInsightsBackendContext)
+    const { licensed, insight: insightFeatures } = useUiFeatures()
 
     const insight = useObservable(useMemo(() => getInsightById(insightID), [getInsightById, insightID]))
     const { handleSubmit, handleCancel } = useEditPageHandlers({ id: insight?.id })
+
+    const editPermission = useObservable(
+        useMemo(() => insightFeatures.getEditPermissions(insight), [insightFeatures, insight])
+    )
 
     if (insight === undefined) {
         return <LoadingSpinner inline={false} />
@@ -88,7 +94,13 @@ export const EditInsightPage: React.FunctionComponent<React.PropsWithChildren<Ed
             )}
 
             {isLangStatsInsight(insight) && (
-                <EditLangStatsInsight insight={insight} onSubmit={handleSubmit} onCancel={handleCancel} />
+                <EditLangStatsInsight
+                    licensed={licensed}
+                    isEditAvailable={editPermission?.available}
+                    insight={insight}
+                    onSubmit={handleSubmit}
+                    onCancel={handleCancel}
+                />
             )}
         </CodeInsightsPage>
     )

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -86,11 +86,21 @@ export const EditInsightPage: React.FunctionComponent<React.PropsWithChildren<Ed
             />
 
             {isSearchBasedInsight(insight) && (
-                <EditSearchBasedInsight insight={insight} onSubmit={handleSubmit} onCancel={handleCancel} />
+                <EditSearchBasedInsight
+                    licensed={licensed}
+                    isEditAvailable={editPermission?.available}
+                    insight={insight}
+                    onSubmit={handleSubmit}
+                    onCancel={handleCancel} />
             )}
 
             {isCaptureGroupInsight(insight) && (
-                <EditCaptureGroupInsight insight={insight} onSubmit={handleSubmit} onCancel={handleCancel} />
+                <EditCaptureGroupInsight
+                    licensed={licensed}
+                    isEditAvailable={editPermission?.available}
+                    insight={insight}
+                    onSubmit={handleSubmit}
+                    onCancel={handleCancel} />
             )}
 
             {isLangStatsInsight(insight) && (

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditCaptureGroupInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditCaptureGroupInsight.tsx
@@ -1,6 +1,11 @@
 import React, { useMemo } from 'react'
 
-import { SubmissionErrors } from '../../../../components'
+import {
+    CodeInsightCreationMode,
+    CodeInsightsCreationActions,
+    FORM_ERROR,
+    SubmissionErrors,
+} from '../../../../components'
 import { MinimalCaptureGroupInsightData, CaptureGroupInsight } from '../../../../core'
 import { CaptureGroupFormFields } from '../../creation/capture-group'
 import { CaptureGroupCreationContent } from '../../creation/capture-group/components/CaptureGroupCreationContent'
@@ -9,6 +14,8 @@ import { InsightStep } from '../../creation/search-insight'
 
 interface EditCaptureGroupInsightProps {
     insight: CaptureGroupInsight
+    licensed: boolean
+    isEditAvailable: boolean | undefined
     onSubmit: (insight: MinimalCaptureGroupInsightData) => SubmissionErrors | Promise<SubmissionErrors> | void
     onCancel: () => void
 }
@@ -16,7 +23,7 @@ interface EditCaptureGroupInsightProps {
 export const EditCaptureGroupInsight: React.FunctionComponent<
     React.PropsWithChildren<EditCaptureGroupInsightProps>
 > = props => {
-    const { insight, onSubmit, onCancel } = props
+    const { insight, licensed, isEditAvailable, onSubmit, onCancel } = props
 
     const insightFormValues = useMemo<CaptureGroupFormFields>(
         () => ({
@@ -41,12 +48,23 @@ export const EditCaptureGroupInsight: React.FunctionComponent<
 
     return (
         <CaptureGroupCreationContent
-            mode="edit"
+            touched={true}
             initialValues={insightFormValues}
             className="pb-5"
-            insight={insight}
             onSubmit={handleSubmit}
             onCancel={onCancel}
-        />
+        >
+            {form => (
+                <CodeInsightsCreationActions
+                    mode={CodeInsightCreationMode.Edit}
+                    licensed={licensed}
+                    available={isEditAvailable}
+                    submitting={form.submitting}
+                    errors={form.submitErrors?.[FORM_ERROR]}
+                    clear={form.isFormClearActive}
+                    onCancel={onCancel}
+                />
+            )}
+        </CaptureGroupCreationContent>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditLangStatsInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditLangStatsInsight.tsx
@@ -48,7 +48,7 @@ export const EditLangStatsInsight: FC<EditLangStatsInsightProps> = props => {
         >
             {form => (
                 <CodeInsightsCreationActions
-                    mode={CodeInsightCreationMode.Creation}
+                    mode={CodeInsightCreationMode.Edit}
                     licensed={licensed}
                     available={isEditAvailable}
                     submitting={form.submitting}

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditLangStatsInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditLangStatsInsight.tsx
@@ -1,6 +1,11 @@
-import React, { useMemo } from 'react'
+import { FC, useMemo } from 'react'
 
-import { SubmissionErrors } from '../../../../components'
+import {
+    CodeInsightCreationMode,
+    CodeInsightsCreationActions,
+    FORM_ERROR,
+    SubmissionErrors,
+} from '../../../../components'
 import { MinimalLangStatsInsightData, LangStatsInsight } from '../../../../core'
 import { LangStatsCreationFormFields } from '../../creation/lang-stats'
 import { LangStatsInsightCreationContent } from '../../creation/lang-stats/components/LangStatsInsightCreationContent'
@@ -8,14 +13,14 @@ import { getSanitizedLangStatsInsight } from '../../creation/lang-stats/utils/in
 
 export interface EditLangStatsInsightProps {
     insight: LangStatsInsight
+    licensed: boolean
+    isEditAvailable: boolean | undefined
     onSubmit: (insight: MinimalLangStatsInsightData) => SubmissionErrors | Promise<SubmissionErrors> | void
     onCancel: () => void
 }
 
-export const EditLangStatsInsight: React.FunctionComponent<
-    React.PropsWithChildren<EditLangStatsInsightProps>
-> = props => {
-    const { insight, onSubmit, onCancel } = props
+export const EditLangStatsInsight: FC<EditLangStatsInsightProps> = props => {
+    const { insight, licensed, isEditAvailable, onSubmit, onCancel } = props
 
     const insightFormValues = useMemo<LangStatsCreationFormFields>(
         () => ({
@@ -36,12 +41,22 @@ export const EditLangStatsInsight: React.FunctionComponent<
 
     return (
         <LangStatsInsightCreationContent
-            mode="edit"
-            className="pb-5"
             initialValues={insightFormValues}
-            insight={insight}
+            touched={true}
+            className="pb-5"
             onSubmit={handleSubmit}
-            onCancel={onCancel}
-        />
+        >
+            {form => (
+                <CodeInsightsCreationActions
+                    mode={CodeInsightCreationMode.Creation}
+                    licensed={licensed}
+                    available={isEditAvailable}
+                    submitting={form.submitting}
+                    errors={form.submitErrors?.[FORM_ERROR]}
+                    clear={form.isFormClearActive}
+                    onCancel={onCancel}
+                />
+            )}
+        </LangStatsInsightCreationContent>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
@@ -1,21 +1,27 @@
-import React, { useMemo } from 'react'
+import { FC, useMemo } from 'react'
 
-import { SubmissionErrors, createDefaultEditSeries } from '../../../../components'
+import {
+    SubmissionErrors,
+    createDefaultEditSeries,
+    CodeInsightsCreationActions,
+    CodeInsightCreationMode,
+    FORM_ERROR,
+} from '../../../../components'
 import { MinimalSearchBasedInsightData, SearchBasedInsight } from '../../../../core'
 import { CreateInsightFormFields, InsightStep } from '../../creation/search-insight'
 import { SearchInsightCreationContent } from '../../creation/search-insight/components/SearchInsightCreationContent'
 import { getSanitizedSearchInsight } from '../../creation/search-insight/utils/insight-sanitizer'
 
 interface EditSearchBasedInsightProps {
+    licensed: boolean
+    isEditAvailable: boolean | undefined
     insight: SearchBasedInsight
     onSubmit: (insight: MinimalSearchBasedInsightData) => SubmissionErrors | Promise<SubmissionErrors> | void
     onCancel: () => void
 }
 
-export const EditSearchBasedInsight: React.FunctionComponent<
-    React.PropsWithChildren<EditSearchBasedInsightProps>
-> = props => {
-    const { insight, onSubmit, onCancel } = props
+export const EditSearchBasedInsight: FC<EditSearchBasedInsightProps> = props => {
+    const { insight, licensed, isEditAvailable, onSubmit, onCancel } = props
 
     const insightFormValues = useMemo<CreateInsightFormFields>(
         () => ({
@@ -40,13 +46,23 @@ export const EditSearchBasedInsight: React.FunctionComponent<
 
     return (
         <SearchInsightCreationContent
-            mode="edit"
+            touched={true}
             initialValue={insightFormValues}
             dataTestId="search-insight-edit-page-content"
             className="pb-5"
             onSubmit={handleSubmit}
-            onCancel={onCancel}
-            insight={insight}
-        />
+        >
+            {form => (
+                <CodeInsightsCreationActions
+                    mode={CodeInsightCreationMode.Edit}
+                    licensed={licensed}
+                    available={isEditAvailable}
+                    submitting={form.submitting}
+                    errors={form.submitErrors?.[FORM_ERROR]}
+                    clear={form.isFormClearActive}
+                    onCancel={onCancel}
+                />
+            )}
+        </SearchInsightCreationContent>
     )
 }


### PR DESCRIPTION
Preparation for https://github.com/sourcegraph/sourcegraph/issues/37965

## Background 
Prior to this PR, we had creation and edit UI forms in which we had explicit binding between the insight model and its permissions and UI itself. This was a problem because we couldn't freely reuse UI across different creation UI forms. This PR bubbles up all common parts and unbinds permissions calls from the creation UI forms. 

### Main idea

Instead of having big god like components that combine UI and permissions calls like this 
```tsx
const Form = props => {
   const isEditMode = mode === 'edit'
   const { licensed, insight: insightFeatures } = useUiFeatures()

   const creationPermission = useObservable(
       useMemo(
           () =>
               isEditMode && insight
                   ? insightFeatures.getEditPermissions(insight)
                   : insightFeatures.getCreationPermissions(),
           [insightFeatures, isEditMode, insight]
       )
   )
   
  return (/*... UI that depends on creation permissions ... */)
}
```

In this PR we unify form UI that this UI doesn't know anything about its possible consumers 
and lift all dependent logic to the specific page level (creation or edit UI pages) 

```tsx
// creation UI
const creationPermission = useObservable(useMemo(() => getCreationPermissions(), []))

return (
 <LangStatsInsightCreationContent
   initialValues={initialFormValues}
   touched={false}
 >
      {form => (
           <CodeInsightsCreationActions
                  mode={CodeInsightCreationMode.Creation} 
                  available={creationPermission?.available}
                  submitting={form.submitting}
                  { ... }
            />
       )}
 </LangStatsInsightCreationContent>
)

// edit UI page
const creationPermission = useObservable(useMemo(() => getEditPermissions(), []))

return (
 <LangStatsInsightCreationContent
   initialValues={initialFormValues}
   touched={true}
 >
      {form => (
           <CodeInsightsCreationActions
                  mode={CodeInsightCreationMode.Edit} 
                  available={editPermission?.available}
                  submitting={form.submitting}
                  { ... }
            />
       )}
 </LangStatsInsightCreationContent>
)
```
 
## Test plan
- Make sure that all creation and edit UI pages don't have any visual and creation flow regressions
- Make sure that all creation and edit pages are rendered properly in limited access mode

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-connect-ui-and-compute-insight.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yqlldbhfjr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
