### PR TITLE
Fix duplicate command exit message in execution logs

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -492,10 +492,6 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                 outputLines.push('stdout: This command did not produce any output')
             }
 
-            if (step.exitCode !== null) {
-                outputLines.push(`\nstdout: \nstdout: Command exited with status ${step.exitCode}`)
-            }
-
             if (step.exitCode === 0) {
                 outputLines.push(`\nstdout: \nstdout: Command exited successfully with status ${step.exitCode}`)
             }


### PR DESCRIPTION
Must've been a refactoring oversight, this logged two messages currently.

## Test plan

Manually verified.

## App preview:

- [Web](https://sg-web-es-fix-log-output.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yacieoowcg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
