### PR TITLE
[SG-35179] Fixing keyboard navigation issues for notebooks

### DIFF
--- a/client/web/src/notebooks/blocks/menu/NotebookBlockMenu.tsx
+++ b/client/web/src/notebooks/blocks/menu/NotebookBlockMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { Button, ButtonProps } from '@sourcegraph/wildcard'
+import { Button, ButtonLink, ButtonProps } from '@sourcegraph/wildcard'
 
 import styles from './NotebookBlockMenu.module.scss'
 
@@ -39,34 +39,42 @@ const BlockMenuActionComponent: React.FunctionComponent<
 > = props => {
     const { className, label, type, id, isDisabled, icon, iconClassName, variant } = props
 
-    const element = type === 'button' ? 'button' : 'a'
-    const elementSpecificProps =
-        props.type === 'button'
-            ? { onClick: () => id && props.onClick(id) }
-            : { href: props.url, target: '_blank', rel: 'noopener noreferrer' }
+    const commonProps = {
+        key: label,
+        className: classNames('d-flex align-items-center', className, styles.actionButton),
+        disabled: isDisabled,
+        role: 'menuitem',
+        'data-testid': label,
+        'aria-label': label,
+        size: 'sm',
+        variant,
+    } as const
 
-    return (
-        <Button
-            key={label}
-            as={element as 'button'}
-            className={classNames('d-flex align-items-center', className, styles.actionButton)}
-            disabled={isDisabled}
-            role="menuitem"
-            data-testid={label}
-            aria-label={label}
-            size="sm"
-            variant={variant}
-            {...elementSpecificProps}
-        >
+    const commonContent = (
+        <>
             <div className={iconClassName}>{icon}</div>
             <div className={classNames('ml-1', styles.hideOnSmallScreen)}>{label}</div>
             <div className={classNames('flex-grow-1', styles.hideOnSmallScreen)} />
-            {type === 'button' && props.keyboardShortcutLabel && (
-                <small className={classNames(props.keyboardShortcutLabelClassName, styles.hideOnSmallScreen)}>
-                    {props.keyboardShortcutLabel}
-                </small>
-            )}
-        </Button>
+        </>
+    )
+
+    if (type === 'button') {
+        return (
+            <Button {...commonProps} onClick={() => id && props.onClick(id)}>
+                {commonContent}
+                {props.keyboardShortcutLabel && (
+                    <small className={classNames(props.keyboardShortcutLabelClassName, styles.hideOnSmallScreen)}>
+                        {props.keyboardShortcutLabel}
+                    </small>
+                )}
+            </Button>
+        )
+    }
+
+    return (
+        <ButtonLink {...commonProps} to={props.url} target="_blank" rel="noopener noreferrer">
+            {commonContent}
+        </ButtonLink>
     )
 }
 

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -10,7 +10,7 @@ import { catchError, startWith, switchMap } from 'rxjs/operators'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { PageHeader, Link, Button, useEventObservable, Alert } from '@sourcegraph/wildcard'
+import { PageHeader, Button, useEventObservable, Alert, ButtonLink } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { FilteredConnectionFilter } from '../../components/FilteredConnection'
@@ -271,10 +271,10 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                     <div className="nav nav-tabs">
                         {tabs.map(({ tab, title, isActive, logEventName }) => (
                             <div className="nav-item" key={tab}>
-                                <Link
+                                <ButtonLink
                                     to=""
                                     role="button"
-                                    onClick={event => {
+                                    onSelect={event => {
                                         event.preventDefault()
                                         onSelectTab(tab, `SearchNotebooks${logEventName}TabClick`)
                                     }}
@@ -283,7 +283,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                                     <span className="text-content" data-tab-content={title}>
                                         {title}
                                     </span>
-                                </Link>
+                                </ButtonLink>
                             </div>
                         ))}
                     </div>

--- a/client/web/src/notebooks/notebook/useNotebookEventHandlers.ts
+++ b/client/web/src/notebooks/notebook/useNotebookEventHandlers.ts
@@ -87,6 +87,28 @@ export function useNotebookEventHandlers({
                 return
             }
 
+            // Focus on the last `menuitem` of the prev block when using `Shift + Tab`
+            // while focusing on selected block element
+            if (
+                document.activeElement ===
+                    document.querySelector<HTMLDivElement>(`[data-block-id="${selectedBlockId}"] .block`) &&
+                event.shiftKey &&
+                event.key === 'Tab'
+            ) {
+                const previousBlockId = notebook.getPreviousBlockId(selectedBlockId)
+
+                if (previousBlockId) {
+                    event.preventDefault()
+
+                    focusBlock(previousBlockId)
+
+                    const menuItems = document.querySelectorAll<HTMLAnchorElement>(
+                        `[data-block-id="${previousBlockId}"] .block-menu [role="menuitem"]`
+                    )
+                    menuItems[menuItems.length - 1]?.focus()
+                }
+            }
+
             const isModifierKeyDown = isModifierKeyPressed(event.metaKey, event.ctrlKey, isMacPlatform)
             if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
                 const direction = event.key === 'ArrowUp' ? 'up' : 'down'


### PR DESCRIPTION
## Problem description
This PR is all about fixing keyboard navigation issues for notebooks as listed below:
- [x] Space key can be used to activate a tab in the [Notebooks page](https://sourcegraph.com/notebooks)
- [x] Notebook block menu items in a [Notebook view](https://sourcegraph.com/notebooks/new) are always tabbable, even if the block isn't focused or only some items are shown. When focused via tab key, they should become visible. (This likely requires changes to how all Notebook block types set their menu items, since they are currently shown/hidden by removing them from the DOM.
- [x] Notebook block menu item "Open in new tab" in a [Notebook view](https://sourcegraph.com/notebooks/new) should be actionable with the space key

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35179)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35179)

## Expected behavior
All issues listed above are fixed 

## Test plan
Take a look at the issue description. Navigate to URLs mentioned in the description section.  All issues should be fixed

## App preview:

- [Web](https://sg-web-contractors-sg-35179.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bjlrbmaojb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
