### PR TITLE
JetBrains: Recreate React app when URL or access token changes

### DIFF
--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -171,12 +171,13 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
         [lastSearch, userQueryState.query, telemetryService, instanceURL]
     )
 
-    const [lastInitialSubmitUser, setLastInitialSubmitUser] = useState<AuthenticatedUser | null>(null)
+    const [didInitialSubmit, setDidInitialSubmit] = useState(false)
     useEffect(() => {
-        if (lastInitialSubmitUser === authenticatedUser) {
+        if (didInitialSubmit) {
             return
         }
-        setLastInitialSubmitUser(authenticatedUser)
+        setDidInitialSubmit(true)
+
         if (initialSearch !== null) {
             onSubmit({
                 caseSensitive: initialSearch.caseSensitive,
@@ -185,7 +186,7 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                 forceNewSearch: true,
             })
         }
-    }, [initialSearch, onSubmit, lastInitialSubmitUser, authenticatedUser])
+    }, [initialSearch, onSubmit, didInitialSubmit])
 
     const statusBar = useMemo(
         () => <StatusBar progress={progress} progressState={progressState} authState={authState} />,
@@ -221,8 +222,6 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                         }}
                     >
                         <JetBrainsSearchBox
-                            // Make sure we recreate the search box component when the instance URL changes
-                            key={instanceURL}
                             caseSensitive={lastSearch.caseSensitive}
                             setCaseSensitivity={caseSensitive => onSubmit({ caseSensitive })}
                             patternType={lastSearch.patternType}

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -68,6 +68,9 @@ export function renderReactApp(): void {
     const node = document.querySelector('#main') as HTMLDivElement
     render(
         <App
+            // Make sure we recreate the React app when the instance URL or access token changes to
+            // avoid showing stale data.
+            key={`${instanceURL}-${accessToken}`}
             isDarkTheme={isDarkTheme}
             instanceURL={instanceURL}
             isGlobbingEnabled={isGlobbingEnabled}


### PR DESCRIPTION
Currently, when you change the URL, we will show a stale search result list and you aren't able to submit the search to get a new one since we store this as "already seared for".

To fix the issues, let's just recreate the whole React tree if either the URL or the access token changes.

## Test plan

I've walked through the updated scenarios in this loom:

https://www.loom.com/share/f3aef8dbe39e4e5f8db19d445a0a184a

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
