### PR TITLE
fix issue where snapshot enqueuer is connecting to the wrong database

### DIFF
--- a/enterprise/internal/insights/background/insight_enqueuer_test.go
+++ b/enterprise/internal/insights/background/insight_enqueuer_test.go
@@ -81,7 +81,8 @@ func Test_discoverAndEnqueueInsights(t *testing.T) {
 	}
 	clock := func() time.Time { return now }
 
-	ie := NewInsightEnqueuer(clock, enqueueQueryRunnerJob)
+	ie := NewInsightEnqueuer(clock, nil)
+	ie.enqueueQueryRunnerJob = enqueueQueryRunnerJob
 
 	dataSeriesStore := store.NewMockDataSeriesStore()
 	featureStore := database.NewMockFeatureFlagStore()

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -57,6 +57,7 @@ type Resolver struct {
 	insightMetadataStore store.InsightMetadataStore
 	dataSeriesStore      store.DataSeriesStore
 	backfiller           *background.ScopedBackfiller
+	insightEnqueuer      *background.InsightEnqueuer
 
 	baseInsightResolver
 }
@@ -77,6 +78,7 @@ func newWithClock(db edb.InsightsDB, postgres database.DB, clock func() time.Tim
 		insightMetadataStore: base.insightStore,
 		dataSeriesStore:      base.insightStore,
 		backfiller:           background.NewScopedBackfiller(base.workerBaseStore, base.timeSeriesStore),
+		insightEnqueuer:      background.NewInsightEnqueuer(clock, base.workerBaseStore),
 	}
 }
 


### PR DESCRIPTION
Recently this new snapshot enqueuer was added to support the prototype capture group insight. It seems harmless enough that it was loading the database handle from the transaction in the resolver, but this actually breaks quite badly. In the dev environment we stack all the databases into one, so this works fine. In customer environments these are separate databases, so this handle is pointing at the `codeinsights-db` instead of the `pgsql` db where the table lives.

These stores and db handles need to become type safe so that this can't ever happen. Ultimately this is an artifact of this debt in the codebase, not the change itself.

## Test plan

Generated insights and made sure both global and non-global can queue up work.

Global and scoped standard search:

<img width="822" alt="CleanShot 2022-07-13 at 10 27 33@2x" src="https://user-images.githubusercontent.com/5090588/178794438-ed0da287-4925-4b1f-85b4-ec31b5bd686f.png">

Compute type (the offending type):
<img width="643" alt="CleanShot 2022-07-13 at 10 29 07@2x" src="https://user-images.githubusercontent.com/5090588/178794730-4e406069-fd26-4d87-abcf-feafbd269aa9.png">
