### PR TITLE
add toggle for core workflow improvements in user menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights over some repos now get 12 historic data points in addition to a current daily value and future points that align with the defined interval. [#37756](https://github.com/sourcegraph/sourcegraph/pull/37756)
 - A Kustomize overlay and Helm override file to apply envoy filter for networking error caused by service mesh. [#4150](https://github.com/sourcegraph/deploy-sourcegraph/pull/4150) & [#148](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/148)
 - Resource Estimator: Ability to export the estimated results as override file for Helm and Docker Compose. [#18](https://github.com/sourcegraph/resource-estimator/pull/18)
+- A toggle to enable/disable a beta simplified UI has been added to the user menu. This new UI is still actively in development and any changes visible with the toggle enabled may not be stable are subject to change. [#38763](https://github.com/sourcegraph/sourcegraph/pull/38763)
 
 ### Changed
 

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -6,8 +6,10 @@ import classNames from 'classnames'
 // eslint-disable-next-line no-restricted-imports
 import { Tooltip } from 'reactstrap'
 
+import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { KEYBOARD_SHORTCUT_SHOW_HELP } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
     Menu,
@@ -24,6 +26,7 @@ import {
     Select,
     Icon,
     Badge,
+    ProductStatusBadge,
 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
@@ -123,6 +126,8 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
     const onThemeCycle = useCallback((): void => {
         onThemePreferenceChange(themePreference === ThemePreference.Dark ? ThemePreference.Light : ThemePreference.Dark)
     }, [onThemePreferenceChange, themePreference])
+
+    const [coreWorkflowImprovementsEnabled, setCoreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
 
     // Target ID for tooltip
     const targetID = 'target-user-avatar'
@@ -240,6 +245,17 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
                                         </small>
                                     </div>
                                 )}
+                            </div>
+                            <div className="px-2 py-1">
+                                <div className="d-flex align-items-center justify-content-between">
+                                    <div className="mr-2">
+                                        Simple UI <ProductStatusBadge status="beta" className="ml-1" />
+                                    </div>
+                                    <Toggle
+                                        value={coreWorkflowImprovementsEnabled}
+                                        onToggle={setCoreWorkflowImprovementsEnabled}
+                                    />
+                                </div>
                             </div>
                             {!isOpenBetaEnabled && props.authenticatedUser.organizations.nodes.length > 0 && (
                                 <>

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import { mdiPlus } from '@mdi/js'
 import { RouteComponentProps } from 'react-router-dom'
 
-import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { ProductStatusBadge, Button, Link, Icon, ProductStatusType } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
@@ -45,7 +44,6 @@ export const UserSettingsSidebar: React.FunctionComponent<
     React.PropsWithChildren<UserSettingsSidebarProps>
 > = props => {
     const [isOpenBetaEnabled] = useFeatureFlag('open-beta-enabled')
-    const [coreWorkflowImprovementsEnabled, setCoreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
 
     if (!props.authenticatedUser) {
         return null
@@ -107,12 +105,6 @@ export const UserSettingsSidebar: React.FunctionComponent<
                 <SidebarGroupHeader label="Other actions" />
                 {!siteAdminViewingOtherUser && <SidebarNavItem to="/api/console">API console</SidebarNavItem>}
                 {props.authenticatedUser.siteAdmin && <SidebarNavItem to="/site-admin">Site admin</SidebarNavItem>}
-                <Button
-                    className="text-left sidebar__link--inactive d-flex w-100"
-                    onClick={() => setCoreWorkflowImprovementsEnabled(!coreWorkflowImprovementsEnabled)}
-                >
-                    {coreWorkflowImprovementsEnabled ? 'Disable' : 'Enable'} workflow improvements
-                </Button>
             </SidebarGroup>
             <div>Version: {window.context.version}</div>
         </div>


### PR DESCRIPTION
Closes #38696

Adds a new toggle in the user menu to toggle the core workflow improvements on or off.

- The toggle is visible to *all* users and is not under any kind of feature flag. Adding a feature flag on top of the toggle seemed excessive to me.
- The toggle is labeled as "Beta" because "Experimental" looked too long and ugly 🙈
- This also removes the toggle button on the user settings page sidebar.

![image](https://user-images.githubusercontent.com/206864/178801605-e666ade8-6edc-4624-84e5-0f071fc9a7ec.png)

## Test plan

Test turning the toggle on and off and verify that the UI changes (eg from #38685) are correctly changed.

## App preview:

- [Web](https://sg-web-jp-simpleuitoggle.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zvlrvcgedl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
