### PR TITLE
codeintel: alert when all executor jobs are failing

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -5899,6 +5899,40 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
+## executor: executor_processor_error_rate
+
+<p class="subtitle">handler operation error rate over 5m</p>
+
+**Descriptions**
+
+- <span class="badge badge-critical">critical</span> executor: 100%+ handler operation error rate over 5m for 1h0m0s
+
+<details>
+<summary>Technical details</summary>
+
+Query: `last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors).*"}[5m]))[5h:]) / (last_over_time(sum(increase(src_executor_processor_total{queue=~"${queue:regex}",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors).*"}[5m]))[5h:]) + last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors).*"}[5m]))[5h:])) * 100`
+
+</details>
+
+**Next steps**
+
+- Determine the cause of failure from the auto-indexing job logs in the site-admin page.
+- This alert fires if all executor jobs have been failing for the past hour. The alert will continue for up
+to 5 hours until the error rate is no longer 100%, even if there are no running jobs in that time, as the
+problem is not know to be resolved until jobs start succeeding again.
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#executor-executor-processor-error-rate).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "critical_executor_executor_processor_error_rate"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<br />
+
 ## executor: go_goroutines
 
 <p class="subtitle">maximum active goroutines</p>

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -5910,7 +5910,7 @@ with your code hosts connections or networking issues affecting communication wi
 <details>
 <summary>Technical details</summary>
 
-Query: `last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors).*"}[5m]))[5h:]) / (last_over_time(sum(increase(src_executor_processor_total{queue=~"${queue:regex}",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors).*"}[5m]))[5h:]) + last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors).*"}[5m]))[5h:])) * 100`
+Custom alert query: `last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors).*"}[5m]))[5h:]) / (last_over_time(sum(increase(src_executor_processor_total{queue=~"${queue:regex}",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors).*"}[5m]))[5h:]) + last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors).*"}[5m]))[5h:])) * 100`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -17383,7 +17383,7 @@ Query: `sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}"
 
 <p class="subtitle">Handler operation error rate over 5m</p>
 
-This panel has no related alerts.
+Refer to the [alerts reference](./alerts.md#executor-executor-processor-error-rate) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100113` on your Sourcegraph instance.
 

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/common/model"
+
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
@@ -283,23 +285,35 @@ func (codeIntelligence) NewExecutorQueueGroup(containerName string) monitoring.G
 func (codeIntelligence) NewExecutorProcessorGroup(containerName string) monitoring.Group {
 	filters := []string{`queue=~"${queue:regex}"`}
 
+	constructorOptions := ObservableConstructorOptions{
+		MetricNameRoot:        "executor",
+		MetricDescriptionRoot: "handler",
+		Filters:               filters,
+	}
+
 	return Workerutil.NewGroup(containerName, monitoring.ObservableOwnerCodeIntel, WorkerutilGroupOptions{
 		GroupConstructorOptions: GroupConstructorOptions{
 			Namespace:       "executor",
 			DescriptionRoot: "Executor jobs",
 
-			ObservableConstructorOptions: ObservableConstructorOptions{
-				MetricNameRoot:        "executor",
-				MetricDescriptionRoot: "handler",
-				Filters:               filters,
-			},
+			ObservableConstructorOptions: constructorOptions,
 		},
 
 		SharedObservationGroupOptions: SharedObservationGroupOptions{
-			Total:     NoAlertsOption("none"),
-			Duration:  NoAlertsOption("none"),
-			Errors:    NoAlertsOption("none"),
-			ErrorRate: NoAlertsOption("none"),
+			Total:    NoAlertsOption("none"),
+			Duration: NoAlertsOption("none"),
+			Errors:   NoAlertsOption("none"),
+			ErrorRate: CriticalOption(
+				monitoring.Alert().
+					Query(Workerutil.LastOverTimeErrorRate(containerName, model.Duration(time.Hour*5), constructorOptions)).
+					For(time.Hour).
+					GreaterOrEqual(100),
+				`
+				- Determine the cause of failure from the auto-indexing job logs in the site-admin page.
+				- This alert fires if all executor jobs have been failing for the past hour. The alert will continue for up
+				to 5 hours until the error rate is no longer 100%, even if there are no running jobs in that time, as the
+				problem is not know to be resolved until jobs start succeeding again.
+			`),
 		},
 		Handlers: NoAlertsOption("none"),
 	})

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -305,7 +305,7 @@ func (codeIntelligence) NewExecutorProcessorGroup(containerName string) monitori
 			Errors:   NoAlertsOption("none"),
 			ErrorRate: CriticalOption(
 				monitoring.Alert().
-					Query(Workerutil.LastOverTimeErrorRate(containerName, model.Duration(time.Hour*5), constructorOptions)).
+					CustomQuery(Workerutil.LastOverTimeErrorRate(containerName, model.Duration(time.Hour*5), constructorOptions)).
 					For(time.Hour).
 					GreaterOrEqual(100),
 				`

--- a/monitoring/definitions/shared/shared.go
+++ b/monitoring/definitions/shared/shared.go
@@ -78,6 +78,14 @@ func (f ObservableOption) safeApply(observable Observable) Observable {
 	return f(observable)
 }
 
+// and creates a chained ObservableOption that first invokes the receiver,
+// and the the argument on the result of invoking the receiver.
+func (f ObservableOption) and(m ObservableOption) ObservableOption {
+	return func(observable Observable) Observable {
+		return m.safeApply(f.safeApply(observable))
+	}
+}
+
 // WarningOption creates an ObservableOption that overrides this Observable's
 // warning-level alert with the given alert.
 func WarningOption(a *monitoring.ObservableAlertDefinition) ObservableOption {

--- a/monitoring/definitions/shared/standard.go
+++ b/monitoring/definitions/shared/standard.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/grafana-tools/sdk"
+	"github.com/prometheus/common/model"
 
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
@@ -133,10 +134,19 @@ func (standardConstructor) ErrorRate(legend string) observableConstructor {
 			return Observable{
 				Name:        fmt.Sprintf("%s_error_rate", options.MetricNameRoot),
 				Description: fmt.Sprintf("%s%s error rate over 5m", options.MetricDescriptionRoot, legend),
-				Query:       fmt.Sprintf(`sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m])) / (sum%[1]s(increase(src_%[2]s_total{%[3]s}[5m])) + sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m]))) * 100`, by, options.MetricNameRoot, filters),
-				Panel:       monitoring.Panel().LegendFormat(fmt.Sprintf("%s%s error rate", legendPrefix, legend)).With(monitoring.PanelOptions.ZeroIfNoData(options.By...)).Unit(monitoring.Percentage),
-				Owner:       owner,
+				Query: fmt.Sprintf(`sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m])) / (sum%[1]s(increase(src_%[2]s_total{%[3]s}[5m])) + sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m]))) * 100`,
+					by, options.MetricNameRoot, filters),
+				Panel: monitoring.Panel().LegendFormat(fmt.Sprintf("%s%s error rate", legendPrefix, legend)).With(monitoring.PanelOptions.ZeroIfNoData(options.By...)).Unit(monitoring.Percentage).Max(200),
+				Owner: owner,
 			}
 		}
 	}
+}
+
+// LastOverTime creates a last-over-time aggregate for the error-rate metric, stretching back over the lookback-window time range.
+func (standardConstructor) LastOverTimeErrorRate(containerName string, lookbackWindow model.Duration, options ObservableConstructorOptions) string {
+	filters := makeFilters(containerName, options.Filters...)
+	by, _ := makeBy(options.By...)
+	return fmt.Sprintf(`last_over_time(sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m]))[%[4]s:]) / (last_over_time(sum%[1]s(increase(src_%[2]s_total{%[3]s}[5m]))[%[4]s:]) + last_over_time(sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m]))[%[4]s:])) * 100`,
+		by, options.MetricNameRoot, filters, lookbackWindow)
 }

--- a/monitoring/definitions/shared/workerutil.go
+++ b/monitoring/definitions/shared/workerutil.go
@@ -3,6 +3,8 @@ package shared
 import (
 	"fmt"
 
+	"github.com/prometheus/common/model"
+
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
@@ -68,6 +70,12 @@ func (workerutilConstructor) Handlers(options ObservableConstructorOptions) shar
 			Owner:       owner,
 		}
 	}
+}
+
+// LastOverTime creates a workerutil-specific last-over-time aggregate for the error-rate metric.
+func (workerutilConstructor) LastOverTimeErrorRate(containerName string, lookbackWindow model.Duration, options ObservableConstructorOptions) string {
+	options.MetricNameRoot += "_processor"
+	return Standard.LastOverTimeErrorRate(containerName, lookbackWindow, options)
 }
 
 type WorkerutilGroupOptions struct {

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -127,6 +127,16 @@ func (d *documentation) renderAlertSolutionEntry(c *Dashboard, o Observable) err
 			return err
 		}
 		fmt.Fprintf(&d.alertDocs, "- <span class=\"badge badge-%s\">%s</span> %s\n", alert.level, alert.level, desc)
+		if alert.threshold.query != "" {
+			fmt.Fprintf(&d.alertDocs, `
+<details>
+<summary>Technical details</summary>
+
+Query: %s
+
+</details>
+`, fmt.Sprintf("`%s`", alert.threshold.query))
+		}
 		prometheusAlertNames = append(prometheusAlertNames,
 			fmt.Sprintf("  \"%s\"", prometheusAlertName(alert.level, c.Name, o.Name)))
 	}

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -132,7 +132,7 @@ func (d *documentation) renderAlertSolutionEntry(c *Dashboard, o Observable) err
 <details>
 <summary>Technical details</summary>
 
-Query: %s
+Custom alert query: %s
 
 </details>
 `, fmt.Sprintf("`%s`", alert.threshold.query))

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -326,8 +326,12 @@ func (c *Dashboard) renderRules() (*promRulesFile, error) {
 					}
 
 					// The alertQuery must contribute a query that returns true when it should be firing.
-					alertQuery := fmt.Sprintf("%s((%s) %s %v)",
-						a.aggregator, o.Query, a.comparator, a.threshold)
+					var alertQuery string
+					if a.query != "" {
+						alertQuery = fmt.Sprintf("%s((%s) %s %v)", a.aggregator, a.query, a.comparator, a.threshold)
+					} else {
+						alertQuery = fmt.Sprintf("%s((%s) %s %v)", a.aggregator, o.Query, a.comparator, a.threshold)
+					}
 
 					// If the data must exist, we alert if the query returns no value as well
 					if o.DataMustExist {
@@ -893,10 +897,12 @@ type ObservableAlertDefinition struct {
 	// See https://github.com/sourcegraph/sourcegraph/issues/11571#issuecomment-654571953,
 	// https://github.com/sourcegraph/sourcegraph/issues/17599, and related pull requests.
 	aggregator Aggregator
-	// Comparator sets how a metric should be compared against a threshold
+	// Comparator sets how a metric should be compared against a threshold.
 	comparator string
-	// Threshold sets the value to be compared against
+	// Threshold sets the value to be compared against.
 	threshold float64
+	// alternative query to use for an alert instead of the observables query.
+	query string
 }
 
 // GreaterOrEqual indicates the alert should fire when greater or equal the given value.
@@ -939,6 +945,13 @@ func (a *ObservableAlertDefinition) Less(f float64) *ObservableAlertDefinition {
 // considered firing. Defaults to 0s (immediately alerts when threshold is exceeded).
 func (a *ObservableAlertDefinition) For(d time.Duration) *ObservableAlertDefinition {
 	a.duration = d
+	return a
+}
+
+// Query sets a different query to be used for this alert instead of the query used
+// in the Grafana panel.
+func (a *ObservableAlertDefinition) Query(query string) *ObservableAlertDefinition {
+	a.query = query
 	return a
 }
 

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -948,9 +948,11 @@ func (a *ObservableAlertDefinition) For(d time.Duration) *ObservableAlertDefinit
 	return a
 }
 
-// Query sets a different query to be used for this alert instead of the query used
-// in the Grafana panel.
-func (a *ObservableAlertDefinition) Query(query string) *ObservableAlertDefinition {
+// CustomQuery sets a different query to be used for this alert instead of the query used
+// in the Grafana panel. Note that thresholds, etc will still be generated for the panel, so
+// ensure the panel query still makes sense in the context of an alert with a custom
+// query.
+func (a *ObservableAlertDefinition) CustomQuery(query string) *ObservableAlertDefinition {
 	a.query = query
 	return a
 }


### PR DESCRIPTION
Creates alert for executors error rate that alerts when the rate of errors is 100%, indicating some global misconfiguration (as happened before with src-cli related issues).

The alert is a bit special in that it uses a different query to the panel, one based on [`last_over_time`](https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time) aggregate. We do this as we dont want the alert to mark itself as resolved if there happens to be a period over the defined window where there are _no_ auto indexing jobs (aka when the error rate is "technically" < 100%). 

The screenshot below illustrates how the alert query maintains the last value over a predefined window, so that if no executor jobs are processing but over the error rate was 100% before, we will continue alerting as the absence of running jobs does not imply the issue is resolved.

![image](https://user-images.githubusercontent.com/18282288/178816415-d456432e-0150-49e1-a131-175c7a8c8684.png)


Closes https://github.com/sourcegraph/sourcegraph/issues/30494

## Test plan

Only modifies dashboards/alerts, n/a
