### PR TITLE
codeintel: init upload janitor with logger

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/fresh/upload_janitor.go
+++ b/enterprise/cmd/worker/internal/codeintel/fresh/upload_janitor.go
@@ -71,6 +71,6 @@ func (j *uploadJanitorJob) Routines(ctx context.Context, logger log.Logger) ([]g
 	uploadSvc := uploads.GetService(database.NewDB(logger, db), database.NewDBWith(logger, lsifStore), gitserverClient)
 
 	return []goroutine.BackgroundRoutine{
-		cleanup.NewJanitor(cleanup.DBStoreShim{Store: dbStore}, uploadSvc, indexSvc, metrics),
+		cleanup.NewJanitor(cleanup.DBStoreShim{Store: dbStore}, uploadSvc, indexSvc, observationContext.Logger, metrics),
 	}, nil
 }

--- a/internal/codeintel/uploads/background/cleanup/init.go
+++ b/internal/codeintel/uploads/background/cleanup/init.go
@@ -5,21 +5,24 @@ import (
 
 	"github.com/derision-test/glock"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
-func NewJanitor(dbStore DBStore, uploadSvc UploadService, indexSvc AutoIndexingService, metrics *metrics) goroutine.BackgroundRoutine {
-	janitor := newJanitor(dbStore, uploadSvc, indexSvc, metrics)
+func NewJanitor(dbStore DBStore, uploadSvc UploadService, indexSvc AutoIndexingService, logger log.Logger, metrics *metrics) goroutine.BackgroundRoutine {
+	janitor := newJanitor(dbStore, uploadSvc, indexSvc, logger, metrics)
 
 	return goroutine.NewPeriodicGoroutine(context.Background(), ConfigInst.Interval, janitor)
 }
 
-func newJanitor(dbStore DBStore, uploadSvc UploadService, indexSvc AutoIndexingService, metrics *metrics) *janitor {
+func newJanitor(dbStore DBStore, uploadSvc UploadService, indexSvc AutoIndexingService, logger log.Logger, metrics *metrics) *janitor {
 	return &janitor{
 		dbStore:   dbStore,
 		uploadSvc: uploadSvc,
 		indexSvc:  indexSvc,
 		metrics:   metrics,
 		clock:     glock.NewRealClock(),
+		logger:    logger,
 	}
 }

--- a/internal/codeintel/uploads/background/cleanup/unknown_commits_test.go
+++ b/internal/codeintel/uploads/background/cleanup/unknown_commits_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -115,6 +117,7 @@ func testUnknownCommitsJanitor(t *testing.T, resolveRevisionFunc func(commit str
 		dbStore,
 		uploadSvc,
 		autoIndexingSvc,
+		logtest.Scoped(t),
 		newMetrics(&observation.TestContext),
 	)
 


### PR DESCRIPTION
Initialized the previously never initialized `log.Logger` in the upload janitor background process. This was causing a panic every time it would be deleting anything. Not sure why it was never caught

## Test plan

Ran locally, no panic
