### PR TITLE
dev/sg: explicitly check if revision is found locally in autoupdates

### DIFF
--- a/dev/sg/internal/repo/commit.go
+++ b/dev/sg/internal/repo/commit.go
@@ -1,0 +1,32 @@
+package repo
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sourcegraph/run"
+)
+
+// HasCommit returns true if and only if the given commit is successfully found in locally
+// tracked remote branches.
+func HasCommit(ctx context.Context, commit string) bool {
+	remoteBranches, err := run.Cmd(ctx, "git branch -r --contains", commit).Run().Lines()
+	if err != nil {
+		return false
+	}
+	if len(remoteBranches) == 0 {
+		return false
+	}
+	// All remote branches this commit exists in should be in 'origin/', which will most
+	// likely be 'github.com/sourcegraph/sourcegraph'.
+	return allLinesPrefixed(remoteBranches, "origin/")
+}
+
+func allLinesPrefixed(lines []string, match string) bool {
+	for _, l := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(l), match) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
It seems the old workaround for detecting missing revision no longer works, since the output of git might have changed. Either way we probably shouldn't depend on git's human output so instead we reuse the logic used to generate warnings in `sg ci build` in the update checker

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tag a build with a commit that is not yet in remote:

```
go build -trimpath -ldflags "-X main.BuildCommit=$(git hash)" -o ./sg ./dev/sg
```

Run a `sg` command with `-v`:

<img width="949" alt="Screenshot 2022-07-13 at 1 33 52 PM" src="https://user-images.githubusercontent.com/23356519/178829369-f6a5a77e-e58b-43a0-afc2-0c2ea4edf646.png">

Run an `sg` command _without_ -v: no output :)