### PR TITLE
batches: handle colon in search query

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
@@ -1,4 +1,4 @@
-import { excludeRepo, haveMatchingWorkspaces, insertFieldIntoLibraryItem } from './yaml-util'
+import { excludeRepo, haveMatchingWorkspaces, insertFieldIntoLibraryItem, insertQueryIntoLibraryItem } from './yaml-util'
 
 const SPEC_WITH_ONE_REPOSITORY = `name: hello-world
 on:
@@ -338,6 +338,23 @@ describe('Batch spec yaml utils', () => {
                     SPEC_WITH_ONE_REPOSITORY.replace('hello-world', newName)
                 )
             }
+        })
+    })
+
+    describe('insertQueryIntoLibraryItem', () => {
+        it('should append query to the `repositoriesMatchingQuery` node if query is a valid YAML string', () => {
+            const query = 'context:global repo:github.com/foo/bar file:package.json fork:yes patternType:literal'
+            const newSpec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, query)
+
+            expect(newSpec).toEqual(SPEC_WITH_QUERY.replace('file:README.md', `${query}\n`))
+        })
+
+        it('should append query as multiline statement if query isnt valid YAML string', () => {
+            const query = 'context:global repo:github.com/foo/bar file:package.json fork:yes "@types:node": "..." patternType:structural'
+            const newSpec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, query)
+            expect(newSpec).toEqual(SPEC_WITH_QUERY.replace('file:README.md', `|
+        ${query}
+`))
         })
     })
 })

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
@@ -1,4 +1,9 @@
-import { excludeRepo, haveMatchingWorkspaces, insertFieldIntoLibraryItem, insertQueryIntoLibraryItem } from './yaml-util'
+import {
+    excludeRepo,
+    haveMatchingWorkspaces,
+    insertFieldIntoLibraryItem,
+    insertQueryIntoLibraryItem,
+} from './yaml-util'
 
 const SPEC_WITH_ONE_REPOSITORY = `name: hello-world
 on:
@@ -350,11 +355,17 @@ describe('Batch spec yaml utils', () => {
         })
 
         it('should append query as multiline statement if query isnt valid YAML string', () => {
-            const query = 'context:global repo:github.com/foo/bar file:package.json fork:yes "@types:node": "..." patternType:structural'
+            const query =
+                'context:global repo:github.com/foo/bar file:package.json fork:yes "@types:node": "..." patternType:structural'
             const newSpec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, query)
-            expect(newSpec).toEqual(SPEC_WITH_QUERY.replace('file:README.md', `|
+            expect(newSpec).toEqual(
+                SPEC_WITH_QUERY.replace(
+                    'file:README.md',
+                    `|
         ${query}
-`))
+`
+                )
+            )
         })
     })
 })

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
@@ -343,18 +343,17 @@ describe('Batch spec yaml utils', () => {
 
     describe('quoteYAMLString', () => {
         it('should add double quote a numeric value', () => {
-            const quotedString = quoteYAMLString('name', '1024')
+            const quotedString = quoteYAMLString('1024')
             expect(quotedString).toEqual('"1024"')
         })
 
         it('should not quote a string without special characters', () => {
-            const unQuotedString = quoteYAMLString('name', 'random-name')
+            const unQuotedString = quoteYAMLString('random-name')
             expect(unQuotedString).toEqual('random-name')
         })
 
         it('should double quote and escape special characters if contained in the value', () => {
             const quotedString = quoteYAMLString(
-                'name',
                 String.raw`fork:yes repo:^github\.com/foo/bar$ file:package.json "scaling-palm-tree": "..."`
             )
             console.log(quotedString)

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
@@ -2,7 +2,6 @@ import {
     excludeRepo,
     haveMatchingWorkspaces,
     insertFieldIntoLibraryItem,
-    insertQueryIntoLibraryItem,
 } from './yaml-util'
 
 const SPEC_WITH_ONE_REPOSITORY = `name: hello-world
@@ -343,29 +342,6 @@ describe('Batch spec yaml utils', () => {
                     SPEC_WITH_ONE_REPOSITORY.replace('hello-world', newName)
                 )
             }
-        })
-    })
-
-    describe('insertQueryIntoLibraryItem', () => {
-        it('should append query to the `repositoriesMatchingQuery` node if query is a valid YAML string', () => {
-            const query = 'context:global repo:github.com/foo/bar file:package.json fork:yes patternType:literal'
-            const newSpec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, query)
-
-            expect(newSpec).toEqual(SPEC_WITH_QUERY.replace('file:README.md', `${query}\n`))
-        })
-
-        it('should append query as multiline statement if query isnt valid YAML string', () => {
-            const query =
-                'context:global repo:github.com/foo/bar file:package.json fork:yes "@types:node": "..." patternType:structural'
-            const newSpec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, query)
-            expect(newSpec).toEqual(
-                SPEC_WITH_QUERY.replace(
-                    'file:README.md',
-                    `|
-        ${query}
-`
-                )
-            )
         })
     })
 })

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
@@ -1,9 +1,4 @@
-import {
-    excludeRepo,
-    haveMatchingWorkspaces,
-    insertFieldIntoLibraryItem,
-    quoteYAMLString
-} from './yaml-util'
+import { excludeRepo, haveMatchingWorkspaces, insertFieldIntoLibraryItem, quoteYAMLString } from './yaml-util'
 
 const SPEC_WITH_ONE_REPOSITORY = `name: hello-world
 on:
@@ -348,7 +343,7 @@ describe('Batch spec yaml utils', () => {
 
     describe('quoteYAMLString', () => {
         it('should add double quote a numeric value', () => {
-            const quotedString = quoteYAMLString('name', '1024');
+            const quotedString = quoteYAMLString('name', '1024')
             expect(quotedString).toEqual('"1024"')
         })
 
@@ -358,9 +353,14 @@ describe('Batch spec yaml utils', () => {
         })
 
         it('should double quote and escape special characters if contained in the value', () => {
-            const quotedString = quoteYAMLString('name', String.raw`fork:yes repo:^github\.com/foo/bar$ file:package.json "scaling-palm-tree": "..."`)
+            const quotedString = quoteYAMLString(
+                'name',
+                String.raw`fork:yes repo:^github\.com/foo/bar$ file:package.json "scaling-palm-tree": "..."`
+            )
             console.log(quotedString)
-            expect(quotedString).toEqual(String.raw`"fork:yes repo:^github\\.com/foo/bar$ file:package.json \"scaling-palm-tree\": \"...\""`)
+            expect(quotedString).toEqual(
+                String.raw`"fork:yes repo:^github\\.com/foo/bar$ file:package.json \"scaling-palm-tree\": \"...\""`
+            )
         })
     })
 })

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
@@ -2,6 +2,7 @@ import {
     excludeRepo,
     haveMatchingWorkspaces,
     insertFieldIntoLibraryItem,
+    quoteYAMLString
 } from './yaml-util'
 
 const SPEC_WITH_ONE_REPOSITORY = `name: hello-world
@@ -342,6 +343,24 @@ describe('Batch spec yaml utils', () => {
                     SPEC_WITH_ONE_REPOSITORY.replace('hello-world', newName)
                 )
             }
+        })
+    })
+
+    describe('quoteYAMLString', () => {
+        it('should add double quote a numeric value', () => {
+            const quotedString = quoteYAMLString('name', '1024');
+            expect(quotedString).toEqual('"1024"')
+        })
+
+        it('should not quote a string without special characters', () => {
+            const unQuotedString = quoteYAMLString('name', 'random-name')
+            expect(unQuotedString).toEqual('random-name')
+        })
+
+        it('should double quote and escape special characters if contained in the value', () => {
+            const quotedString = quoteYAMLString('name', String.raw`fork:yes repo:^github\.com/foo/bar$ file:package.json "scaling-palm-tree": "..."`)
+            console.log(quotedString)
+            expect(quotedString).toEqual(String.raw`"fork:yes repo:^github\\.com/foo/bar$ file:package.json \"scaling-palm-tree\": \"...\""`)
         })
     })
 })

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -438,8 +438,12 @@ export const insertNameIntoLibraryItem = (librarySpec: string, name: string): st
  * @param librarySpec the raw batch spec YAML example code from a library spec
  * @param query the updated query to be inserted
  */
-export const insertQueryIntoLibraryItem = (librarySpec: string, query: string): string =>
-    insertFieldIntoLibraryItem(librarySpec, `- repositoriesMatchingQuery: ${query}\n\n`, 'on', false)
+export const insertQueryIntoLibraryItem = (librarySpec: string, query: string): string => {
+    const updatedQuery = `- repositoriesMatchingQuery: |
+        ${query}\n\n`
+
+    return insertFieldIntoLibraryItem(librarySpec, updatedQuery, 'on', false)
+}
 
 /**
  * Parses and performs a comparison between the values for the "on", "importChangesets",

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -435,6 +435,13 @@ export const insertNameIntoLibraryItem = (librarySpec: string, name: string): st
  * Replaces the query of the provided `librarySpec`. If `librarySpec` or its query
  * is not properly parsable, just returns the original `librarySpec`.
  *
+ * Before inserting the updated query into the `librarySpec`, we check if appending
+ * the query to `- repositoriesMatchingQuery` results in a valid YAML, we do this
+ * because sometimes a search query might include an extra colon in it's text, and
+ * this confuses the YAML parser.
+ * If such extra colon exists, we want to append the query as a multi-line statement
+ * then.
+ *
  * @param librarySpec the raw batch spec YAML example code from a library spec
  * @param query the updated query to be inserted
  */

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -439,8 +439,13 @@ export const insertNameIntoLibraryItem = (librarySpec: string, name: string): st
  * @param query the updated query to be inserted
  */
 export const insertQueryIntoLibraryItem = (librarySpec: string, query: string): string => {
-    const updatedQuery = `- repositoriesMatchingQuery: |
+    let updatedQuery = `- repositoriesMatchingQuery: ${query}\n\n`
+    const ast = load(updatedQuery)
+
+    if (ast.errors.length > 0) {
+        updatedQuery = `- repositoriesMatchingQuery: |
         ${query}\n\n`
+    }
 
     return insertFieldIntoLibraryItem(librarySpec, updatedQuery, 'on', false)
 }

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -389,6 +389,8 @@ export function quoteYAMLString(key: string, value: string): string {
     }
 
     if (needsEscaping) {
+        // to properly escape the characters, we pass the raw string value into `JSON.stringify`,
+        // we use the raw string because we don't want to ignore special characters in regular expressions.
         const updatedValue = JSON.stringify(String.raw`${value}`)
         ast = load(key + ': ' + updatedValue + '\n')
 
@@ -398,7 +400,6 @@ export function quoteYAMLString(key: string, value: string): string {
         }
     }
 
-    // If this is still happening, bail out, we don't know what to do here.
     return value
 }
 
@@ -466,6 +467,9 @@ export const insertNameIntoLibraryItem = (librarySpec: string, name: string): st
  * @param query the updated query to be inserted
  */
 export const insertQueryIntoLibraryItem = (librarySpec: string, query: string): string => {
+    // we pass in a key of `repositoriesMatchingQuery` into quoteYAMLString because we want to simplify
+    // the operation for quoting a YAML String. Passing in a YAMLSequence adds an unnecessary overhead,
+    // since we are concerned with quoting the value, passing in a normal string works just fine.
     const possiblyQuotedQuery = quoteYAMLString('repositoriesMatchingQuery', query);
     return insertFieldIntoLibraryItem(librarySpec, `- repositoriesMatchingQuery: ${possiblyQuotedQuery}\n\n`, 'on', false)
 }

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -470,8 +470,13 @@ export const insertQueryIntoLibraryItem = (librarySpec: string, query: string): 
     // we pass in a key of `repositoriesMatchingQuery` into quoteYAMLString because we want to simplify
     // the operation for quoting a YAML String. Passing in a YAMLSequence adds an unnecessary overhead,
     // since we are concerned with quoting the value, passing in a normal string works just fine.
-    const possiblyQuotedQuery = quoteYAMLString('repositoriesMatchingQuery', query);
-    return insertFieldIntoLibraryItem(librarySpec, `- repositoriesMatchingQuery: ${possiblyQuotedQuery}\n\n`, 'on', false)
+    const possiblyQuotedQuery = quoteYAMLString('repositoriesMatchingQuery', query)
+    return insertFieldIntoLibraryItem(
+        librarySpec,
+        `- repositoriesMatchingQuery: ${possiblyQuotedQuery}\n\n`,
+        'on',
+        false
+    )
 }
 
 /**

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -456,13 +456,6 @@ export const insertNameIntoLibraryItem = (librarySpec: string, name: string): st
  * Replaces the query of the provided `librarySpec`. If `librarySpec` or its query
  * is not properly parsable, just returns the original `librarySpec`.
  *
- * Before inserting the updated query into the `librarySpec`, we check if appending
- * the query to `- repositoriesMatchingQuery` results in a valid YAML, we do this
- * because sometimes a search query might include an extra colon in it's text, and
- * this confuses the YAML parser.
- * If such extra colon exists, we want to append the query as a multi-line statement
- * then.
- *
  * @param librarySpec the raw batch spec YAML example code from a library spec
  * @param query the updated query to be inserted
  */

--- a/client/web/src/enterprise/batches/create/go-checker-templates.ts
+++ b/client/web/src/enterprise/batches/create/go-checker-templates.ts
@@ -1,7 +1,7 @@
 import { quoteYAMLString } from '../batch-spec/yaml-util'
 
 export function goCheckerSA6005Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to improve inefficient string comparison with strings.ToLower or strings.ToUpper
 on:
@@ -39,7 +39,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1002Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to omit comparison with boolean constant
 on:
@@ -69,7 +69,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1003Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to replace calls to strings.Index with strings.Contains.
 on:
@@ -150,7 +150,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1004Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to replace call to bytes.Compare with bytes.Equal
 on:
@@ -180,7 +180,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1005Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to drop unnecessary use of the blank identifier
 on:
@@ -217,7 +217,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1006Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to use for { ... } for infinite loops
 on:
@@ -241,7 +241,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1010Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to omit default slice index
 on:
@@ -265,7 +265,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1012Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to replace time.Now().Sub(x) with time.Since(x)
 on:
@@ -289,7 +289,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1019Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}\
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to simplify make call by omitting redundant arguments
 on:
@@ -322,7 +322,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1020Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to omit redundant nil check in type assertion
 on:
@@ -358,7 +358,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1023Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to omit redundant control flow
 on:
@@ -388,7 +388,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1024Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to replace x.Sub(time.Now()) with time.Until(x)
 on:
@@ -417,7 +417,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1025Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to enforce don’t use fmt.Sprintf("%s", x) unnecessarily
 on:
@@ -441,7 +441,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1028Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to simplify error construction with fmt.Errorf
 on:
@@ -466,7 +466,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1029Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to range over the string directly
 on:
@@ -491,7 +491,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1032Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to use sort.Ints(x), sort.Float64s(x), and sort.Strings(x)
 on:
@@ -524,7 +524,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1035Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to remove redundant call to net/http.CanonicalHeaderKey in method call on net/http.Header
 on:
@@ -561,7 +561,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1037Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to remove redundant call to net/http.CanonicalHeaderKey in method call on net/http.Header
 on:
@@ -589,7 +589,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1038Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to remove redundant call to net/http.CanonicalHeaderKey in method call on net/http.Header
 on:
@@ -617,7 +617,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1039Template(name: string): string {
-    return `name: ${quoteYAMLString('name', name)}
+    return `name: ${quoteYAMLString(name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to improve unnecessary use of fmt.Sprint
 on:

--- a/client/web/src/enterprise/batches/create/go-checker-templates.ts
+++ b/client/web/src/enterprise/batches/create/go-checker-templates.ts
@@ -1,7 +1,7 @@
 import { quoteYAMLString } from '../batch-spec/yaml-util'
 
 export function goCheckerSA6005Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to improve inefficient string comparison with strings.ToLower or strings.ToUpper
 on:
@@ -39,7 +39,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1002Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to omit comparison with boolean constant
 on:
@@ -69,7 +69,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1003Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to replace calls to strings.Index with strings.Contains.
 on:
@@ -150,7 +150,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1004Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to replace call to bytes.Compare with bytes.Equal
 on:
@@ -180,7 +180,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1005Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to drop unnecessary use of the blank identifier
 on:
@@ -217,7 +217,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1006Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to use for { ... } for infinite loops
 on:
@@ -241,7 +241,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1010Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to omit default slice index
 on:
@@ -265,7 +265,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1012Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to replace time.Now().Sub(x) with time.Since(x)
 on:
@@ -289,7 +289,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1019Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}\
 description: |
     This batch change uses [Comby](https://comby.dev) to simplify make call by omitting redundant arguments
 on:
@@ -322,7 +322,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1020Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to omit redundant nil check in type assertion
 on:
@@ -358,7 +358,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1023Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to omit redundant control flow
 on:
@@ -388,7 +388,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1024Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to replace x.Sub(time.Now()) with time.Until(x)
 on:
@@ -417,7 +417,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1025Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to enforce don’t use fmt.Sprintf("%s", x) unnecessarily
 on:
@@ -441,7 +441,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1028Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to simplify error construction with fmt.Errorf
 on:
@@ -466,7 +466,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1029Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to range over the string directly
 on:
@@ -491,7 +491,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1032Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to use sort.Ints(x), sort.Float64s(x), and sort.Strings(x)
 on:
@@ -524,7 +524,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1035Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to remove redundant call to net/http.CanonicalHeaderKey in method call on net/http.Header
 on:
@@ -561,7 +561,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1037Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to remove redundant call to net/http.CanonicalHeaderKey in method call on net/http.Header
 on:
@@ -589,7 +589,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1038Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to remove redundant call to net/http.CanonicalHeaderKey in method call on net/http.Header
 on:
@@ -617,7 +617,7 @@ changesetTemplate:
 }
 
 export function goCheckerS1039Template(name: string): string {
-    return `name: ${quoteYAMLString(name)}
+    return `name: ${quoteYAMLString('name', name)}
 description: |
     This batch change uses [Comby](https://comby.dev) to improve unnecessary use of fmt.Sprint
 on:


### PR DESCRIPTION
Closes #38737

When a colon is included in a search query (example: `context:global fork:yes repo:^github\.com/foo/bar$ file:package.json "@types/node": "..." patternType:structural`), creating a batch change from said query results in an error in the `Configuration` page. This happens because the YAML parser assumes the colon is signifying a node.

An easy fix for this is to leverage `multi-line` values in YAML so the parser understands that it's part of the current node.

I took the approach of checking if appending the search query to `- repositoriesMatchingQuery` results in a valid YAML, if it doesn't then I make it a multi-line YAML.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested with search query containing an extra colon

## App preview:

- [Web](https://sg-web-bo-fix-batch-change-from-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bybpsavhsz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
