### PR TITLE
codeintel-qa: Add `pg_dump` to output

### DIFF
--- a/dev/codeintel-qa/cmd/upload/state.go
+++ b/dev/codeintel-qa/cmd/upload/state.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -98,6 +99,13 @@ func monitor(ctx context.Context, repoNames []string, uploads []uploadMeta) erro
 							logs = upload.AuditLogs
 							break
 						}
+					}
+
+					out, err := exec.Command("pg_dump", "-a", "--column-inserts", "--table='lsif_uploads*'").CombinedOutput()
+					if err != nil {
+						fmt.Printf("Failed to dump: %s", err.Error())
+					} else {
+						fmt.Printf("DUMP:\n\n%s\n\n\n", out)
 					}
 
 					return errors.Newf("unexpected state '%s' for %s@%s - ID %s\nAudit Logs:\n%s", uploadState.state, uploadState.upload.repoName, uploadState.upload.commit[:7], uploadState.upload.id, logs)


### PR DESCRIPTION
Print pg_dump of relevant tables when the codeintel-qa pipeline fails. I'm not sure if pg_dump is available on the buildkite host correctly, but this is just a temporary measure to sanity check our data.

## Test plan

We just print the error if this isn't set up correctly - should not affect the codeintel-qa pipeline negatively.