### PR TITLE
auto update src-cli to latest

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -31,6 +31,7 @@ import {
     ensureDocker,
     changelogURL,
     ensureReleaseBranchUpToDate,
+    ensureSrcCliUpToDate,
 } from './util'
 
 const sed = process.platform === 'linux' ? 'sed' : 'gsed'
@@ -57,6 +58,7 @@ export type StepID =
     | '_test:batchchange-create-from-changes'
     | '_test:config'
     | '_test:dockerensure'
+    | '_test:srccliensure'
 
 /**
  * Runs given release step with the provided configuration and arguments.
@@ -362,6 +364,8 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                 console.log('Docker required for batch changes')
                 process.exit(1)
             }
+            // ensure src-cli is up to date
+            await ensureSrcCliUpToDate()
             // set up batch change config
             const batchChange = batchChanges.releaseTrackingBatchChange(
                 release.version,
@@ -810,5 +814,12 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                 process.exit(1)
             }
         },
+    },
+    {
+        id: '_test:srccliensure',
+        description: 'test srccli version',
+        run: () => {
+                 ensureSrcCliUpToDate()
+                },
     },
 ]


### PR DESCRIPTION
checks and updates src-cli to the latest version

fixes https://github.com/sourcegraph/sourcegraph/issues/30588

## Test plan

```

➜  release git:(main) ✗ yarn run release _test:srccliensure                                     
yarn run v1.22.17
$ ts-node --transpile-only ./src/main.ts _test:srccliensure
✨  Done in 4.56s.

➜  release git:(main) src version
Current version: 3.41.1
Recommended version: 3.41.1 or later
```