### PR TITLE
global state: Rewrite store

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -37,7 +37,7 @@ func TestRedirects(t *testing.T) {
 		t.Helper()
 
 		gss := database.NewMockGlobalStateStore()
-		gss.GetFunc.SetDefaultReturn(&database.GlobalState{SiteID: "a"}, nil)
+		gss.GetFunc.SetDefaultReturn(database.GlobalState{SiteID: "a"}, nil)
 
 		db := database.NewMockDB()
 		db.GlobalStateFunc.SetDefaultReturn(gss)
@@ -178,7 +178,7 @@ func TestNewCommon_repo_error(t *testing.T) {
 			}
 
 			gss := database.NewMockGlobalStateStore()
-			gss.GetFunc.SetDefaultReturn(&database.GlobalState{SiteID: "a"}, nil)
+			gss.GetFunc.SetDefaultReturn(database.GlobalState{SiteID: "a"}, nil)
 
 			db := database.NewMockDB()
 			db.GlobalStateFunc.SetDefaultReturn(gss)
@@ -433,7 +433,7 @@ func TestRedirectTreeOrBlob(t *testing.T) {
 func init() {
 	globals.ConfigurationServerFrontendOnly = &conf.Server{}
 	gss := database.NewMockGlobalStateStore()
-	gss.GetFunc.SetDefaultReturn(&database.GlobalState{SiteID: "a"}, nil)
+	gss.GetFunc.SetDefaultReturn(database.GlobalState{SiteID: "a"}, nil)
 
 	db := database.NewMockDB()
 	db.GlobalStateFunc.SetDefaultReturn(gss)

--- a/cmd/frontend/internal/siteid/siteid_test.go
+++ b/cmd/frontend/internal/siteid/siteid_test.go
@@ -42,7 +42,7 @@ func TestGet(t *testing.T) {
 	t.Run("from DB", func(t *testing.T) {
 		defer reset()
 		gss := database.NewMockGlobalStateStore()
-		gss.GetFunc.SetDefaultReturn(&database.GlobalState{SiteID: "a"}, nil)
+		gss.GetFunc.SetDefaultReturn(database.GlobalState{SiteID: "a"}, nil)
 
 		db := database.NewMockDB()
 		db.GlobalStateFunc.SetDefaultReturn(gss)
@@ -61,7 +61,7 @@ func TestGet(t *testing.T) {
 	t.Run("panics if DB unavailable", func(t *testing.T) {
 		defer reset()
 		gss := database.NewMockGlobalStateStore()
-		gss.GetFunc.SetDefaultReturn(nil, errors.New("x"))
+		gss.GetFunc.SetDefaultReturn(database.GlobalState{}, errors.New("x"))
 
 		db := database.NewMockDB()
 		db.GlobalStateFunc.SetDefaultReturn(gss)
@@ -102,7 +102,7 @@ func TestGet(t *testing.T) {
 		defer os.Unsetenv("TRACKING_APP_ID")
 
 		gss := database.NewMockGlobalStateStore()
-		gss.GetFunc.SetDefaultReturn(&database.GlobalState{SiteID: "b"}, nil)
+		gss.GetFunc.SetDefaultReturn(database.GlobalState{SiteID: "b"}, nil)
 
 		db := database.NewMockDB()
 		db.GlobalStateFunc.SetDefaultReturn(gss)

--- a/internal/database/global_state.go
+++ b/internal/database/global_state.go
@@ -2,18 +2,18 @@ package database
 
 import (
 	"context"
-	"database/sql"
+	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgconn"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type GlobalStateStore interface {
-	Get(context.Context) (*GlobalState, error)
+	Get(context.Context) (GlobalState, error)
 	SiteInitialized(context.Context) (bool, error)
 
 	// EnsureInitialized ensures the site is marked as having been initialized. If the site was already
@@ -38,99 +38,148 @@ type GlobalState struct {
 	Initialized bool // whether the initial site admin account has been created
 }
 
+func scanGlobalState(s dbutil.Scanner) (value GlobalState, err error) {
+	err = s.Scan(&value.SiteID, &value.Initialized)
+	return
+}
+
+var scanFirstGlobalState = basestore.NewFirstScanner(scanGlobalState)
+
 type globalStateStore struct {
 	*basestore.Store
 }
 
-func (g *globalStateStore) Get(ctx context.Context) (*GlobalState, error) {
-	configuration, err := g.getConfiguration(ctx)
-	if err == nil {
-		return configuration, nil
-	}
-
-	if err != sql.ErrNoRows {
-		return nil, errors.Wrap(err, "getConfiguration")
-	}
-
-	err = g.tryInsertNew(ctx)
+func (g *globalStateStore) Transact(ctx context.Context) (*globalStateStore, error) {
+	tx, err := g.Store.Transact(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return g.getConfiguration(ctx)
+
+	return &globalStateStore{Store: tx}, nil
 }
 
-func (g *globalStateStore) SiteInitialized(ctx context.Context) (bool, error) {
-	var alreadyInitialized bool
-	q := sqlf.Sprintf(`SELECT initialized FROM global_state LIMIT 1`)
-	err := g.QueryRow(ctx, q).Scan(&alreadyInitialized)
-	if err != nil && errors.Is(err, sql.ErrNoRows) {
-		return false, nil
+func (g *globalStateStore) Get(ctx context.Context) (GlobalState, error) {
+	if err := g.initializeDBState(ctx); err != nil {
+		return GlobalState{}, err
 	}
+
+	state, found, err := scanFirstGlobalState(g.Query(ctx, sqlf.Sprintf(globalStateGetQuery)))
+	if err != nil {
+		return GlobalState{}, err
+	}
+	if !found {
+		return GlobalState{}, errors.New("expected global_state to be initialized - no rows found")
+	}
+
+	return state, nil
+}
+
+var globalStateSiteIDFragment = `
+SELECT site_id FROM global_state ORDER BY ctid LIMIT 1
+`
+
+var globalStateInitializedFragment = `
+SELECT coalesce(bool_or(gs.initialized), false) FROM global_state gs
+`
+
+var globalStateGetQuery = fmt.Sprintf(`
+-- source: internal/database/global_state.go:Get
+SELECT (%s) AS site_id, (%s) AS initialized
+`,
+	globalStateSiteIDFragment,
+	globalStateInitializedFragment,
+)
+
+func (g *globalStateStore) SiteInitialized(ctx context.Context) (bool, error) {
+	alreadyInitialized, _, err := basestore.ScanFirstBool(g.Query(ctx, sqlf.Sprintf(globalStateSiteInitializedQuery)))
 	return alreadyInitialized, err
 }
 
-func (g *globalStateStore) EnsureInitialized(ctx context.Context) (bool, error) {
-	if err := g.tryInsertNew(ctx); err != nil {
+var globalStateSiteInitializedQuery = fmt.Sprintf(`
+-- source: internal/database/global_state.go:SiteInitialized
+%s
+`,
+	globalStateInitializedFragment,
+)
+
+func (g *globalStateStore) EnsureInitialized(ctx context.Context) (_ bool, err error) {
+	if err := g.initializeDBState(ctx); err != nil {
 		return false, err
 	}
 
-	// The "SELECT ... FOR UPDATE" prevents a race condition where two calls,
-	// each in their own transaction, would see this initialized value as false
-	// and then set it to true below.
-	var alreadyInitialized bool
-	q := sqlf.Sprintf(`SELECT initialized FROM global_state FOR UPDATE LIMIT 1`)
-	err := g.QueryRow(ctx, q).Scan(&alreadyInitialized)
+	tx, err := g.Transact(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	alreadyInitialized, err := tx.SiteInitialized(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	if !alreadyInitialized {
-		err = g.Exec(ctx, sqlf.Sprintf("UPDATE global_state SET initialized=true"))
+	if err := tx.Exec(ctx, sqlf.Sprintf(globalStateEnsureInitializedQuery)); err != nil {
+		return false, err
 	}
 
-	return alreadyInitialized, err
+	return alreadyInitialized, nil
 }
 
-func (g *globalStateStore) getConfiguration(ctx context.Context) (*GlobalState, error) {
-	var s GlobalState
-	q := sqlf.Sprintf("SELECT site_id, initialized FROM global_state LIMIT 1")
-	err := g.QueryRow(ctx, q).Scan(
-		&s.SiteID,
-		&s.Initialized,
-	)
-	return &s, err
-}
+var globalStateEnsureInitializedQuery = `
+-- source: internal/database/global_state.go:EnsureInitialized
+UPDATE global_state SET initialized = true
+`
 
-func (g *globalStateStore) tryInsertNew(ctx context.Context) error {
+func (g *globalStateStore) initializeDBState(ctx context.Context) (err error) {
+	tx, err := g.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(globalStateInitializeDBStateUpdateQuery)); err != nil {
+		return err
+	}
+	if err := tx.Exec(ctx, sqlf.Sprintf(globalStateInitializeDBStatePruneQuery)); err != nil {
+		return err
+	}
+
 	siteID, err := uuid.NewRandom()
 	if err != nil {
 		return err
 	}
-
-	// In the normal case (when no users exist yet because the instance is brand new), create the row
-	// with initialized=false.
-	//
-	// If any users exist, then set the site as initialized so that the init screen doesn't show
-	// up. (It would not let the visitor initialize the site anyway, because other users exist.) The
-	// most likely reason the instance would get into this state (uninitialized but has users) is
-	// because previously global state had a siteID and now we ignore that (or someone ran `DELETE
-	// FROM global_state;` in the PostgreSQL database). In either case, it's safe to generate a new
-	// site ID and set the site as initialized.
-	err = g.Exec(ctx, sqlf.Sprintf(`
-	INSERT INTO global_state(
-		site_id,
-		initialized
-	) values(
-		%s,
-		EXISTS (SELECT 1 FROM users WHERE deleted_at IS NULL)
-	);`, siteID))
-	if err != nil {
-		var e *pgconn.PgError
-		if errors.As(err, &e) && e.ConstraintName == "global_state_pkey" {
-			// The row we were trying to insert already exists.
-			// Don't treat this as an error.
-			err = nil
-		}
-	}
-	return err
+	return tx.Exec(ctx, sqlf.Sprintf(globalStateInitializeDBStateInsertIfNotExistsQuery, siteID))
 }
+
+var globalStateInitializeDBStateUpdateQuery = fmt.Sprintf(`
+-- source: internal/database/global_state.go:initializeDBState
+UPDATE global_state SET initialized = (%s)
+`,
+	globalStateInitializedFragment,
+)
+
+var globalStateInitializeDBStatePruneQuery = fmt.Sprintf(`
+-- source: internal/database/global_state.go:initializeDBState
+DELETE FROM global_state WHERE site_id NOT IN (%s)
+`,
+	globalStateSiteIDFragment,
+)
+
+var globalStateInitializeDBStateInsertIfNotExistsQuery = `
+-- source: internal/database/global_state.go:initializeDBState
+INSERT INTO global_state(
+	site_id,
+	initialized
+)
+SELECT
+	%s AS site_id,
+	EXISTS (
+		SELECT 1
+		FROM users
+		WHERE deleted_at IS NULL
+	) AS initialized
+WHERE
+	NOT EXISTS (
+		SELECT 1 FROM global_state
+	)
+`

--- a/internal/database/global_state_test.go
+++ b/internal/database/global_state_test.go
@@ -4,25 +4,116 @@ import (
 	"context"
 	"testing"
 
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
 func TestGlobalState_Get(t *testing.T) {
+	ctx := context.Background()
+	store := testGlobalStateStore(t)
+
+	// Test pre-initialization
+	config1, err := store.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config1.SiteID == "" {
+		t.Fatal("expected site_id to be set")
+	}
+	if config1.Initialized {
+		t.Fatal("site expected to be uninitialized")
+	}
+
+	// Test post-initialization
+	if _, err := store.EnsureInitialized(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	config2, err := store.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config2.SiteID != config1.SiteID {
+		t.Fatalf("unexpected site id. want=%s have=%s", config1.SiteID, config2.SiteID)
+	}
+	if !config2.Initialized {
+		t.Fatal("site expected to be initialized")
+	}
+}
+
+func TestGlobalState_SiteInitialized(t *testing.T) {
+	ctx := context.Background()
+	store := testGlobalStateStore(t)
+
+	// Test pre-initialization
+	siteInitialized, err := store.SiteInitialized(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if siteInitialized {
+		t.Fatal("site expected to be uninitialized")
+	}
+
+	// Test post-initialization
+	if _, err := store.EnsureInitialized(ctx); err != nil {
+		t.Fatal(err)
+	}
+	siteInitialized, err = store.SiteInitialized(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !siteInitialized {
+		t.Fatal("site expected to be initialized")
+	}
+}
+
+func TestGlobalState_PrunesValues(t *testing.T) {
+	ctx := context.Background()
+	store := testGlobalStateStore(t)
+
+	if err := store.(*globalStateStore).Exec(ctx, sqlf.Sprintf(`
+		INSERT INTO global_state(
+			site_id,
+			initialized
+		)
+		VALUES
+			('00000000-0000-0000-0000-000000000000', false),
+			('00000000-0000-0000-0000-000000000001', false),
+			('00000000-0000-0000-0000-000000000010', false),
+			('00000000-0000-0000-0000-000000000100', false),
+			('00000000-0000-0000-0000-000000001000', false),
+			('00000000-0000-0000-0000-000000010000', false),
+			('00000000-0000-0000-0000-000000100000', false),
+			('00000000-0000-0000-0000-000001000000', false),
+			('00000000-0000-0000-0000-000010000000', true),
+			('00000000-0000-0000-0000-000100000000', false),
+			('00000000-0000-0000-0000-001000000000', false),
+			('00000000-0000-0000-0000-010000000000', false),
+			('00000000-0000-0000-0000-100000000000', false)
+	`)); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := store.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSiteID := "00000000-0000-0000-0000-000000000000"
+	if config.SiteID != expectedSiteID {
+		t.Fatalf("unexpected site-id. want=%s have=%s", expectedSiteID, config.SiteID)
+	}
+	if !config.Initialized {
+		t.Fatal("expected site to be initialized")
+	}
+}
+
+func testGlobalStateStore(t *testing.T) GlobalStateStore {
 	if testing.Short() {
 		t.Skip()
 	}
 
 	logger := logtest.Scoped(t)
-
-	db := NewDB(logger, dbtest.NewDB(logger, t))
-	ctx := context.Background()
-	config, err := db.GlobalState().Get(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if config.SiteID == "" {
-		t.Fatal("expected site_id to be set")
-	}
+	return NewDB(logger, dbtest.NewDB(logger, t)).GlobalState()
 }

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -19580,7 +19580,7 @@ func NewMockGlobalStateStore() *MockGlobalStateStore {
 			},
 		},
 		GetFunc: &GlobalStateStoreGetFunc{
-			defaultHook: func(context.Context) (r0 *GlobalState, r1 error) {
+			defaultHook: func(context.Context) (r0 GlobalState, r1 error) {
 				return
 			},
 		},
@@ -19602,7 +19602,7 @@ func NewStrictMockGlobalStateStore() *MockGlobalStateStore {
 			},
 		},
 		GetFunc: &GlobalStateStoreGetFunc{
-			defaultHook: func(context.Context) (*GlobalState, error) {
+			defaultHook: func(context.Context) (GlobalState, error) {
 				panic("unexpected invocation of MockGlobalStateStore.Get")
 			},
 		},
@@ -19742,15 +19742,15 @@ func (c GlobalStateStoreEnsureInitializedFuncCall) Results() []interface{} {
 // GlobalStateStoreGetFunc describes the behavior when the Get method of the
 // parent MockGlobalStateStore instance is invoked.
 type GlobalStateStoreGetFunc struct {
-	defaultHook func(context.Context) (*GlobalState, error)
-	hooks       []func(context.Context) (*GlobalState, error)
+	defaultHook func(context.Context) (GlobalState, error)
+	hooks       []func(context.Context) (GlobalState, error)
 	history     []GlobalStateStoreGetFuncCall
 	mutex       sync.Mutex
 }
 
 // Get delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockGlobalStateStore) Get(v0 context.Context) (*GlobalState, error) {
+func (m *MockGlobalStateStore) Get(v0 context.Context) (GlobalState, error) {
 	r0, r1 := m.GetFunc.nextHook()(v0)
 	m.GetFunc.appendCall(GlobalStateStoreGetFuncCall{v0, r0, r1})
 	return r0, r1
@@ -19759,7 +19759,7 @@ func (m *MockGlobalStateStore) Get(v0 context.Context) (*GlobalState, error) {
 // SetDefaultHook sets function that is called when the Get method of the
 // parent MockGlobalStateStore instance is invoked and the hook queue is
 // empty.
-func (f *GlobalStateStoreGetFunc) SetDefaultHook(hook func(context.Context) (*GlobalState, error)) {
+func (f *GlobalStateStoreGetFunc) SetDefaultHook(hook func(context.Context) (GlobalState, error)) {
 	f.defaultHook = hook
 }
 
@@ -19767,7 +19767,7 @@ func (f *GlobalStateStoreGetFunc) SetDefaultHook(hook func(context.Context) (*Gl
 // Get method of the parent MockGlobalStateStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *GlobalStateStoreGetFunc) PushHook(hook func(context.Context) (*GlobalState, error)) {
+func (f *GlobalStateStoreGetFunc) PushHook(hook func(context.Context) (GlobalState, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -19775,20 +19775,20 @@ func (f *GlobalStateStoreGetFunc) PushHook(hook func(context.Context) (*GlobalSt
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GlobalStateStoreGetFunc) SetDefaultReturn(r0 *GlobalState, r1 error) {
-	f.SetDefaultHook(func(context.Context) (*GlobalState, error) {
+func (f *GlobalStateStoreGetFunc) SetDefaultReturn(r0 GlobalState, r1 error) {
+	f.SetDefaultHook(func(context.Context) (GlobalState, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GlobalStateStoreGetFunc) PushReturn(r0 *GlobalState, r1 error) {
-	f.PushHook(func(context.Context) (*GlobalState, error) {
+func (f *GlobalStateStoreGetFunc) PushReturn(r0 GlobalState, r1 error) {
+	f.PushHook(func(context.Context) (GlobalState, error) {
 		return r0, r1
 	})
 }
 
-func (f *GlobalStateStoreGetFunc) nextHook() func(context.Context) (*GlobalState, error) {
+func (f *GlobalStateStoreGetFunc) nextHook() func(context.Context) (GlobalState, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -19826,7 +19826,7 @@ type GlobalStateStoreGetFuncCall struct {
 	Arg0 context.Context
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *GlobalState
+	Result0 GlobalState
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error


### PR DESCRIPTION
Fixes #12229 and #3201. See [slack context](https://sourcegraph.slack.com/archives/C07KZF47K/p1657750497585769) in which we discovered that most `global_states` tables have nearly one row per user on the instance.

## Test plan

New unit tests.