### PR TITLE
core workflow: simplify file search results display

### DIFF
--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
         <div>
           <div
             class="test-search-result resultContainer resultContainer"
+            data-collapsible="false"
             data-result-type="content"
             data-testid="result-container"
           >
@@ -311,6 +312,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
         <div>
           <div
             class="test-search-result resultContainer resultContainer"
+            data-collapsible="false"
             data-result-type="content"
             data-testid="result-container"
           >
@@ -532,6 +534,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
         <div>
           <div
             class="test-search-result resultContainer resultContainer"
+            data-collapsible="false"
             data-result-type="content"
             data-testid="result-container"
           >

--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -7,6 +7,7 @@ import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { CommitMatch, getCommitMatchUrl, getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 // eslint-disable-next-line no-restricted-imports
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
 import { Link, Code } from '@sourcegraph/wildcard'
@@ -35,6 +36,8 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
     as,
     index,
 }) => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
             <span className={classNames('test-search-result-label flex-grow-1', styles.titleInner)}>
@@ -72,7 +75,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
     return (
         <ResultContainer
             index={index}
-            icon={SourceCommitIcon}
+            icon={!coreWorkflowImprovementsEnabled ? SourceCommitIcon : undefined}
             collapsible={false}
             defaultExpanded={true}
             title={renderTitle()}

--- a/client/search-ui/src/components/FileMatchChildren.module.scss
+++ b/client/search-ui/src/components/FileMatchChildren.module.scss
@@ -4,6 +4,11 @@
     border-radius: var(--border-radius);
     padding: 0.25rem 0;
     position: relative;
+
+    [data-core-workflow-improvements='true'][data-collapsible='true'] & {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
 }
 
 .item {
@@ -33,6 +38,10 @@
 
         &:not(:first-child) {
             border-top: 1px solid var(--border-color-2);
+
+            [data-core-workflow-improvements='true'] & {
+                border-top-color: var(--border-color);
+            }
         }
     }
 }

--- a/client/search-ui/src/components/FileMatchChildren.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.tsx
@@ -300,7 +300,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             ))}
 
             {/* Line matches */}
-            {grouped && (
+            {grouped.length > 0 && (
                 <div>
                     {grouped.map((group, index) => (
                         <div

--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -22,6 +22,7 @@ import {
     getRevision,
 } from '@sourcegraph/shared/src/search/stream'
 import { isSettingsValid, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge } from '@sourcegraph/wildcard'
 
@@ -48,7 +49,7 @@ interface Props extends SettingsCascadeProps, TelemetryProps {
     /**
      * The icon to show to the left of the title.
      */
-    icon: React.ComponentType<{ className?: string }>
+    icon?: React.ComponentType<{ className?: string }>
 
     /**
      * Called when the file's search result is selected.
@@ -92,34 +93,31 @@ const sumHighlightRanges = (count: number, item: MatchItem): number => count + i
 const BY_LINE_RANKING = 'by-line-number'
 const DEFAULT_CONTEXT = 1
 
+type CommonResultContainerProps = Omit<
+    ResultContainerProps,
+    | 'description'
+    | 'collapsedChildren'
+    | 'expandedChildren'
+    | 'collapsible'
+    | 'collapseLabel'
+    | 'expandLabel'
+    | 'matchCountLabel'
+>
+
 // This is a search result for types file (content), path, or symbol.
 export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
     const result = props.result
     const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
     const revisionDisplayName = getRevision(result.branches, result.commit)
     const settings = props.settingsCascade.final
+
     const ranking = useMemo(() => {
         if (!isErrorLike(settings) && settings?.experimentalFeatures?.clientSearchResultRanking === BY_LINE_RANKING) {
-            return new LineRanking()
+            return new LineRanking(coreWorkflowImprovementsEnabled ? 5 : 10)
         }
-        return new ZoektRanking()
-    }, [settings])
-    const renderTitle = (): JSX.Element => (
-        <>
-            <RepoFileLink
-                repoName={result.repository}
-                repoURL={repoAtRevisionURL}
-                filePath={result.path}
-                fileURL={getFileMatchUrl(result)}
-                repoDisplayName={
-                    props.repoDisplayName
-                        ? `${props.repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
-                        : undefined
-                }
-                className={styles.titleInner}
-            />
-        </>
-    )
+        return new ZoektRanking(coreWorkflowImprovementsEnabled ? 3 : 5)
+    }, [settings, coreWorkflowImprovementsEnabled])
 
     // The number of lines of context to show before and after each match.
     const context = useMemo(() => {
@@ -171,8 +169,6 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
             </>
         ) : undefined
 
-    let containerProps: ResultContainerProps
-
     const expandedMatchGroups = useMemo(() => ranking.expandedResults(items, context), [items, context, ranking])
     const collapsedMatchGroups = useMemo(() => ranking.collapsedResults(items, context), [items, context, ranking])
     const collapsedMatchCount = collapsedMatchGroups.matches.length
@@ -186,6 +182,35 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
     const matchCountLabel = matchCount ? `${matchCount} ${pluralize('match', matchCount, 'matches')}` : ''
 
     const expandedChildren = <FileMatchChildren {...props} result={result} {...expandedMatchGroups} />
+
+    const commonContainerProps: CommonResultContainerProps = {
+        index: props.index,
+        defaultExpanded: props.expanded,
+        icon: props.icon,
+        title: (
+            <RepoFileLink
+                repoName={result.repository}
+                repoURL={repoAtRevisionURL}
+                filePath={result.path}
+                fileURL={getFileMatchUrl(result)}
+                repoDisplayName={
+                    props.repoDisplayName
+                        ? `${props.repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
+                        : undefined
+                }
+                className={styles.titleInner}
+            />
+        ),
+        allExpanded: props.allExpanded,
+        repoName: result.repository,
+        repoStars: result.repoStars,
+        repoLastFetched: result.repoLastFetched,
+        onResultClicked: props.onSelect,
+        className: props.containerClassName,
+        resultType: result.type,
+    }
+
+    let containerProps: ResultContainerProps
 
     if (result.type === 'content' && result.hunks) {
         // We should only get here if the new streamed highlight format is sent
@@ -230,87 +255,53 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
             { limitedGrouped: [] as MatchGroup[], limitedMatchCount: 0 }
         )
 
+        const collapsedChildren = <FileMatchChildren {...props} result={result} grouped={limitedGrouped} />
+        const expandedChildren = <FileMatchChildren {...props} result={result} grouped={grouped} />
+
         if (props.showAllMatches) {
             containerProps = {
-                index: props.index,
+                ...commonContainerProps,
                 collapsible: false,
-                defaultExpanded: props.expanded,
-                icon: props.icon,
-                title: renderTitle(),
-                description: undefined, // TODO we need badges for the descripiton
-                allExpanded: props.allExpanded,
-                collapsedChildren: <FileMatchChildren {...props} result={result} grouped={limitedGrouped} />,
-                expandedChildren: <FileMatchChildren {...props} result={result} grouped={grouped} />,
+                description: undefined, // TODO we need badges for the description
+                collapsedChildren,
+                expandedChildren,
                 matchCountLabel,
-                repoName: result.repository,
-                repoStars: result.repoStars,
-                repoLastFetched: result.repoLastFetched,
-                onResultClicked: props.onSelect,
-                className: props.containerClassName,
-                resultType: result.type,
             }
         } else {
             const hideCount = matchCount - limitedMatchCount
             containerProps = {
-                index: props.index,
+                ...commonContainerProps,
                 collapsible: limitedMatchCount < matchCount,
-                defaultExpanded: props.expanded,
-                icon: props.icon,
-                title: renderTitle(),
-                description: undefined,
-                collapsedChildren: <FileMatchChildren {...props} result={result} grouped={limitedGrouped} />,
-                expandedChildren: <FileMatchChildren {...props} result={result} grouped={grouped} />,
-                collapseLabel: `Hide ${hideCount}`,
-                expandLabel: `${hideCount} more`,
-                allExpanded: props.allExpanded,
+                collapsedChildren,
+                expandedChildren,
+                collapseLabel: coreWorkflowImprovementsEnabled ? 'Show less' : `Hide ${hideCount}`,
+                expandLabel: coreWorkflowImprovementsEnabled
+                    ? `Show ${hideCount} more ${pluralize('match', hideCount, 'matches')}`
+                    : `${hideCount} more`,
                 matchCountLabel,
-                repoName: result.repository,
-                repoStars: result.repoStars,
-                repoLastFetched: result.repoLastFetched,
-                onResultClicked: props.onSelect,
-                className: props.containerClassName,
-                resultType: result.type,
             }
         }
     } else if (props.showAllMatches) {
         containerProps = {
-            index: props.index,
+            ...commonContainerProps,
             collapsible: false,
-            defaultExpanded: props.expanded,
-            icon: props.icon,
-            title: renderTitle(),
             description,
             expandedChildren,
-            allExpanded: props.allExpanded,
             matchCountLabel,
-            repoName: result.repository,
-            repoStars: result.repoStars,
-            repoLastFetched: result.repoLastFetched,
-            onResultClicked: props.onSelect,
-            className: props.containerClassName,
-            resultType: result.type,
         }
     } else {
         const length = highlightRangesCount - collapsedHighlightRangesCount
         containerProps = {
-            index: props.index,
+            ...commonContainerProps,
             collapsible: items.length > collapsedMatchCount,
-            defaultExpanded: props.expanded,
-            icon: props.icon,
-            title: renderTitle(),
             description,
             collapsedChildren: <FileMatchChildren {...props} result={result} {...collapsedMatchGroups} />,
             expandedChildren,
-            collapseLabel: `Hide ${length}`,
-            expandLabel: `${length} more`,
-            allExpanded: props.allExpanded,
+            collapseLabel: coreWorkflowImprovementsEnabled ? 'Show less' : `Hide ${length}`,
+            expandLabel: coreWorkflowImprovementsEnabled
+                ? `Show ${length} more ${pluralize('match', length, 'matches')}`
+                : `${length} more`,
             matchCountLabel,
-            repoName: result.repository,
-            repoStars: result.repoStars,
-            repoLastFetched: result.repoLastFetched,
-            onResultClicked: props.onSelect,
-            className: props.containerClassName,
-            resultType: result.type,
             as: props.as,
         }
     }

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -6,6 +6,7 @@ import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { Icon, Link } from '@sourcegraph/wildcard'
 
 import { LastSyncedIcon } from './LastSyncedIcon'
@@ -28,6 +29,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     as,
     index,
 }) => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
             <span className={classNames('test-search-result-label', styles.titleInner)}>
@@ -107,7 +110,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     return (
         <ResultContainer
             index={index}
-            icon={SourceRepositoryIcon}
+            icon={!coreWorkflowImprovementsEnabled ? SourceRepositoryIcon : undefined}
             collapsible={false}
             defaultExpanded={true}
             title={renderTitle()}

--- a/client/search-ui/src/components/ResultContainer.module.scss
+++ b/client/search-ui/src/components/ResultContainer.module.scss
@@ -8,6 +8,10 @@
     &:not(:last-of-type) {
         margin-bottom: 0.5rem;
     }
+
+    &[data-core-workflow-improvements='true']:not(:last-of-type) {
+        margin-bottom: 1rem;
+    }
 }
 
 .header {
@@ -46,4 +50,19 @@
     display: flex;
     flex-shrink: 0;
     padding: 0;
+}
+
+.toggle-matches-button {
+    width: 100%;
+    text-align: left;
+    border: none;
+    padding: 0.25rem 0.5rem;
+    background-color: var(--border-color);
+    border-bottom-left-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
+
+    &-text {
+        color: var(--link-color);
+        margin-right: 0.125rem;
+    }
 }

--- a/client/search-ui/src/components/ResultContainer.tsx
+++ b/client/search-ui/src/components/ResultContainer.tsx
@@ -1,9 +1,10 @@
 /* eslint jsx-a11y/click-events-have-key-events: warn, jsx-a11y/no-static-element-interactions: warn */
 import React, { useEffect, useState } from 'react'
 
-import { mdiArrowCollapseUp, mdiChevronDown, mdiArrowExpandDown, mdiChevronLeft } from '@mdi/js'
+import { mdiArrowCollapseUp, mdiChevronDown, mdiArrowExpandDown, mdiChevronLeft, mdiChevronUp } from '@mdi/js'
 import classNames from 'classnames'
 
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { Button, Icon } from '@sourcegraph/wildcard'
 
 import { formatRepositoryStarCount } from '../util/stars'
@@ -32,7 +33,7 @@ export interface ResultContainerProps {
     /**
      * The icon to show left to the title.
      */
-    icon: React.ComponentType<{ className?: string }>
+    icon?: React.ComponentType<{ className?: string }>
 
     /**
      * The title component.
@@ -137,6 +138,7 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
     as: Component = 'div',
     index,
 }) => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
     const [expanded, setExpanded] = useState(allExpanded || defaultExpanded)
     const formattedRepositoryStarCount = formatRepositoryStarCount(repoStars)
 
@@ -155,26 +157,37 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
     }
     return (
         <Component
-            className={classNames('test-search-result', styles.resultContainer, className)}
+            className={classNames(
+                'test-search-result',
+                styles.resultContainer,
+                coreWorkflowImprovementsEnabled && styles.coreWorkflowImprovements,
+                className
+            )}
             data-testid="result-container"
             data-result-type={resultType}
             data-expanded={allExpanded}
+            data-collapsible={collapsible}
+            data-core-workflow-improvements={coreWorkflowImprovementsEnabled}
             onClick={trackReferencePanelClick}
         >
             <article aria-labelledby={`result-container-${index}`}>
                 <div className={styles.header} id={`result-container-${index}`}>
-                    <Icon
-                        className="flex-shrink-0"
-                        as={icon}
-                        {...(resultType
-                            ? {
-                                  'aria-label': `${resultType} result`,
-                              }
-                            : {
-                                  'aria-hidden': true,
-                              })}
-                    />
-                    <div className={classNames('mx-1', styles.headerDivider)} />
+                    {icon && (
+                        <>
+                            <Icon
+                                className="flex-shrink-0"
+                                as={icon}
+                                {...(resultType
+                                    ? {
+                                          'aria-label': `${resultType} result`,
+                                      }
+                                    : {
+                                          'aria-hidden': true,
+                                      })}
+                            />
+                            <div className={classNames('mx-1', styles.headerDivider)} />
+                        </>
+                    )}
                     <CodeHostIcon repoName={repoName} className="text-muted flex-shrink-0 mr-1" />
                     <div
                         className={classNames(styles.headerTitle, titleClassName)}
@@ -185,13 +198,13 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
                             <span className={classNames('ml-2', styles.headerDescription)}>{description}</span>
                         )}
                     </div>
-                    {matchCountLabel && (
+                    {!coreWorkflowImprovementsEnabled && matchCountLabel && (
                         <span className="d-flex align-items-center">
                             <small>{matchCountLabel}</small>
                             {collapsible && <div className={classNames('mx-2', styles.headerDivider)} />}
                         </span>
                     )}
-                    {collapsible && (
+                    {!coreWorkflowImprovementsEnabled && collapsible && (
                         <Button
                             data-testid="toggle-matches-container"
                             className={classNames('py-0', styles.toggleMatchesContainer)}
@@ -218,7 +231,7 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
                             )}
                         </Button>
                     )}
-                    {matchCountLabel && formattedRepositoryStarCount && (
+                    {!coreWorkflowImprovementsEnabled && matchCountLabel && formattedRepositoryStarCount && (
                         <div className={classNames('mx-2', styles.headerDivider)} />
                     )}
                     {formattedRepositoryStarCount && (
@@ -230,6 +243,12 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
                 </div>
                 {!expanded && collapsedChildren}
                 {expanded && expandedChildren}
+                {coreWorkflowImprovementsEnabled && collapsible && (
+                    <button type="button" className={styles.toggleMatchesButton} onClick={toggle}>
+                        <span className={styles.toggleMatchesButtonText}>{expanded ? collapseLabel : expandLabel}</span>
+                        <Icon aria-hidden={true} svgPath={expanded ? mdiChevronUp : mdiChevronDown} />
+                    </button>
+                )}
             </article>
         </Component>
     )

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -27,6 +27,7 @@ import {
     getMatchUrl,
 } from '@sourcegraph/shared/src/search/stream'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
@@ -90,6 +91,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     executedQuery,
     resultClassName,
 }) => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
     const resultsNumber = results?.results.length || 0
     const { itemsToShow, handleBottomHit } = useItemsToShow(executedQuery, resultsNumber)
     const location = useLocation()
@@ -115,7 +117,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                             index={index}
                             location={location}
                             telemetryService={telemetryService}
-                            icon={getFileMatchIcon(result)}
+                            icon={!coreWorkflowImprovementsEnabled ? getFileMatchIcon(result) : undefined}
                             result={result}
                             onSelect={() => logSearchResultClicked(index, 'fileMatch')}
                             expanded={false}
@@ -158,7 +160,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
         [
             location,
             telemetryService,
-            logSearchResultClicked,
+            coreWorkflowImprovementsEnabled,
             allExpanded,
             fetchHighlightedFileLineRanges,
             settingsCascade,
@@ -167,6 +169,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             hoverifier,
             openMatchesInNewTab,
             resultClassName,
+            logSearchResultClicked,
         ]
     )
 

--- a/client/shared/src/components/ranking/LineRanking.ts
+++ b/client/shared/src/components/ranking/LineRanking.ts
@@ -6,9 +6,12 @@ import { MatchGroup, MatchItem, RankingResult, PerFileResultRanking } from './Pe
  * LineRanking orders hunks purely by line number, disregarding the relevance ranking provided by Zoekt.
  */
 export class LineRanking implements PerFileResultRanking {
+    constructor(private maxMatches: number) {}
+
     public collapsedResults(matches: MatchItem[], context: number): RankingResult {
-        return calculateMatchGroupsSorted(matches, 10, context)
+        return calculateMatchGroupsSorted(matches, this.maxMatches, context)
     }
+
     public expandedResults(matches: MatchItem[], context: number): RankingResult {
         return calculateMatchGroupsSorted(matches, 0, context)
     }

--- a/client/shared/src/components/ranking/ZoektRanking.test.tsx
+++ b/client/shared/src/components/ranking/ZoektRanking.test.tsx
@@ -2,7 +2,7 @@ import { testDataRealMatches } from './PerFileResultRankingTestHelpers'
 import { ZoektRanking } from './ZoektRanking'
 
 describe('ZoektRanking', () => {
-    const ranking = new ZoektRanking()
+    const ranking = new ZoektRanking(5)
     test('collapsedResults', () => {
         expect(ranking.collapsedResults(testDataRealMatches, 1).grouped).toMatchInlineSnapshot(`
             Array [

--- a/client/shared/src/components/ranking/ZoektRanking.ts
+++ b/client/shared/src/components/ranking/ZoektRanking.ts
@@ -4,11 +4,14 @@ import { MatchGroup, MatchGroupMatch, MatchItem, PerFileResultRanking, RankingRe
  * ZoektRanking preserves the original relevance that's computed by Zoekt.
  */
 export class ZoektRanking implements PerFileResultRanking {
+    constructor(private maxResults: number) {}
+
+    public collapsedResults(matches: MatchItem[], context: number): RankingResult {
+        return results(matches, this.maxResults, context)
+    }
+
     public expandedResults(matches: MatchItem[], context: number): RankingResult {
         return results(matches, Number.MAX_VALUE, context)
-    }
-    public collapsedResults(matches: MatchItem[], context: number): RankingResult {
-        return results(matches, 5, context)
     }
 }
 

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -19,7 +19,7 @@ import { ActionsContainer } from '@sourcegraph/shared/src/actions/ActionsContain
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
-import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, ButtonLink, Icon, Tooltip } from '@sourcegraph/wildcard'
 
@@ -141,7 +141,7 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<
 export const SearchResultsInfoBar: React.FunctionComponent<
     React.PropsWithChildren<SearchResultsInfoBarProps>
 > = props => {
-    const [coreWorkflowImprovementsEnabled] = useTemporarySetting('coreWorkflowImprovements.enabled')
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
 
     const canCreateMonitorFromQuery = useMemo(() => {
         if (!props.query) {


### PR DESCRIPTION
Fixes #38566
Fixes #38182

Changes (all contained behind the core workflow temporary setting):
* Add a button for expanding/collapsing matches below the file search result
* Reduce the number of line groups shown by default
* Hide the result type icons


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Disable the core workflow improvements (Simple UI toggle in user settings dropdown)
  * Search results should work the same as before
* Enable Simple UI
  * Run a search
  * You should be able to expand files with a lot of matches
  * No result type icons should appear next to the repo name/file name

