### PR TITLE
batches: improve screen reader experience with server-side workflow

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
@@ -68,7 +68,7 @@ export const WorkspacesPreviewList: React.FunctionComponent<React.PropsWithChild
     return (
         <ConnectionContainer className="w-100">
             {error && <ConnectionError errors={[error]} />}
-            <ConnectionList className="list-group list-group-flush w-100">
+            <ConnectionList className="list-group list-group-flush w-100" aria-label="Workspace results found">
                 {connectionOrCached?.nodes?.map(node => (
                     <WorkspacesPreviewListItem
                         key={node.id}

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewListItem.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewListItem.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 
 import { mdiClose } from '@mdi/js'
 
-import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
+import { Button, Icon, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
 
 import {
     PreviewHiddenBatchSpecWorkspaceFields,
@@ -33,6 +33,7 @@ export const WorkspacesPreviewListItem: React.FunctionComponent<
         }
         setToBeExcluded(true)
         exclude(workspace.repository.name, workspace.branch.displayName)
+        screenReaderAnnounce('Batch spec has been updated to exclude this workspace.')
     }, [exclude, workspace])
 
     const statusIndicator = useMemo(() => {

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/useWorkspacesPreview.ts
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/useWorkspacesPreview.ts
@@ -4,6 +4,7 @@ import { FetchResult } from '@apollo/client'
 import { noop } from 'lodash'
 
 import { useLazyQuery, useMutation, useQuery } from '@sourcegraph/http-client'
+import { screenReaderAnnounce } from '@sourcegraph/wildcard'
 
 import {
     CreateBatchSpecFromRawResult,
@@ -250,6 +251,7 @@ export const useWorkspacesPreview = (
             uiState === BatchSpecWorkspaceResolutionState.ERRORED ||
             uiState === BatchSpecWorkspaceResolutionState.FAILED
         ) {
+            screenReaderAnnounce('Workspaces preview failed.')
             // We can stop polling if the workspace resolution fails.
             stop()
         } else if (uiState === BatchSpecWorkspaceResolutionState.COMPLETED) {

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react'
 
 import { mdiSourceBranch } from '@mdi/js'
+import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { Icon, H4, Badge } from '@sourcegraph/wildcard'
@@ -34,7 +35,10 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
         <div className="flex-1">
             <H4 className={styles.name}>{workspace?.repository.name ?? 'Workspace in hidden repository'}</H4>
             {workspace && workspace.path !== '' && workspace.path !== '/' ? (
-                <span className={styles.path}>{workspace?.path}</span>
+                <>
+                    <VisuallyHidden>Workspace path: </VisuallyHidden>
+                    <span className={styles.path}>{workspace?.path}</span>
+                </>
             ) : null}
             {workspace && (
                 <div className={classNames(styles.workspaceDetails, '.text-monospace')}>
@@ -57,7 +61,10 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
                         </Badge>
                     )}
                     <Icon aria-hidden={true} className="mr-1" svgPath={mdiSourceBranch} />
-                    <small>{workspace.branch.displayName}</small>
+                    <small>
+                        <VisuallyHidden>Workspace branch: </VisuallyHidden>
+                        {workspace.branch.displayName}
+                    </small>
                 </div>
             )}
         </div>

--- a/client/web/src/enterprise/batches/workspaces-list/Icons.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Icons.tsx
@@ -9,7 +9,12 @@ import styles from './Icons.module.scss'
 
 export const CachedIcon: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <Tooltip content="A cached result was found for this workspace.">
-        <Icon aria-label="A cached result was found for this workspace." svgPath={mdiContentSave} />
+        <Icon
+            tabIndex={0}
+            role="tooltip"
+            aria-label="A cached result was found for this workspace."
+            svgPath={mdiContentSave}
+        />
     </Tooltip>
 )
 
@@ -19,7 +24,8 @@ export const PartiallyCachedIcon: React.FunctionComponent<React.PropsWithChildre
         <Tooltip content={label}>
             <Icon
                 aria-label={label}
-                role="img"
+                tabIndex={0}
+                role="tooltip"
                 className={styles.partiallyCachedIcon}
                 svgPath={mdiContentSaveEditOutline}
             />
@@ -31,6 +37,8 @@ export const ExcludeIcon: React.FunctionComponent<React.PropsWithChildren<unknow
     <Tooltip content="Your batch spec was modified to exclude this workspace. Preview again to update.">
         <Icon
             aria-label="Your batch spec was modified to exclude this workspace. Preview again to update."
+            tabIndex={0}
+            role="tooltip"
             svgPath={mdiDelete}
         />
     </Tooltip>


### PR DESCRIPTION
Okay so _technically_ this closes #34074, #34075, #34076, #34077, and #34087. But we have some serious follow-up to do on the screen reader experience front with SSBC.

I spent the better half of today trying to wrestle with `screenReaderAnnounce` and live content alerts, gracefully transfer focus when previously interactive items become un-interactive or are removed from the DOM entirely, debug problems with multiple elements fighting for screen reader attention at the same time, and figure out how on earth to even _begin_ to coherently convey everything that's changing all the time on the execution screen. I tore most of it out at the end of the day because it either didn't work right, was way too hacky to commit, was way too fragile and difficult to test, or all of the above (most of the time it was all of the above). 😞 The new SSBC UI is fabulous and expressive and remarkably detailed, but that complexity comes with an accessibility cost. I think it's in our best interest to reprioritize investing time into this until after the UI and SSBC workflows have stabilized after beta feedback and we have better application-wide guidelines on accessibility design for dynamic UIs. I've filed https://github.com/sourcegraph/sourcegraph/issues/38789 in our backlog to track this.

So anyway, what remains here is the bare minimum: a few changes here and there that seemed to be net improvements that work fairly consistently (`screenReaderAnnounce`'s behavior still eludes me sometimes...).

## Test plan

Lots of VoiceOver testing. That's the best I can do right now.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-ssbc-screen-reader-fixes.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-snpsmbpoym.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
