### PR TITLE
Revert "dependencies: Remove curl dependency from image"

### DIFF
--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -27,6 +27,7 @@ RUN apk update && apk add --no-cache \
     bind-tools \
     busybox \
     ca-certificates \
+    'curl>=7.79.1-r2' \
     mailcap \
     tini \
     wget


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#38711. Image build is failing and there are a lot more dependencies than expected.

## Test plan

- CI Checks