### PR TITLE
Move code-intel flake notifications to separate channel.

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -559,7 +559,7 @@ func codeIntelQA(candidateTag string) operations.Operation {
 		p.AddStep(":docker::brain: Code Intel QA",
 			bk.SlackStepNotify(&bk.SlackStepNotifyConfigPayload{
 				Message:     ":alert: :noemi-handwriting: Code Intel QA Flake detected <@Noah S-C>",
-				ChannelName: "code-intel",
+				ChannelName: "code-intel-buildkite",
 				Conditions: bk.SlackStepNotifyPayloadConditions{
 					Failed: true,
 				},


### PR DESCRIPTION
The notifications in #code-intel [got a bit too much](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1657787188405039).

## Test plan

n/a