### PR TITLE
[Admin Analytics] fix users DAU stats

### DIFF
--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -147,7 +147,9 @@ var (
 		GROUP BY
 			month
 	)
+
 	SELECT
+		'DAU' AS metric,
 		ROUND(sum_total_count / total_days)::int AS avg_total_count
 	FROM
 		(
@@ -157,8 +159,11 @@ var (
 			FROM
 				daus
 		) AS f
+
 	UNION ALL
+
 	SELECT
+		'WAU' AS metric,
 		CASE
 			WHEN total_weeks > 1 THEN ROUND(sum_total_count / total_weeks)::int
 			ELSE sum_total_count::int
@@ -171,8 +176,11 @@ var (
 			FROM
 				waus
 		) AS f
+
 	UNION ALL
+
 	SELECT
+		'MAU' AS metric,
 		CASE
 			WHEN total_months > 1 THEN ROUND(sum_total_count / total_months)::int
 			ELSE sum_total_count::int
@@ -216,15 +224,16 @@ func (s *Users) Summary(ctx context.Context) (*UsersSummary, error) {
 		rows.Next()
 
 		var totalCount float64
-		if err := rows.Scan(&totalCount); err != nil {
+		var metric string
+		if err := rows.Scan(&metric, &totalCount); err != nil {
 			return nil, err
 		}
 
-		if i == 0 {
+		if metric == "DAU" {
 			summaryData.AvgDAU = totalCount
-		} else if i == 1 {
+		} else if metric == "WAU" {
 			summaryData.AvgWAU = totalCount
-		} else {
+		} else if metric == "MAU" {
 			summaryData.AvgMAU = totalCount
 		}
 	}


### PR DESCRIPTION
https://k8s.sgdev.org/site-admin/analytics/users

The DAU/WAU/MAU stats on the admin analytics users statistics page are wrong. The numbers themselves seem right but they are getting mix-matched with each other. MAU > WAU > DAU (should be).

<img width="349" alt="CleanShot 2022-07-14 at 14 39 47@2x" src="https://user-images.githubusercontent.com/22571395/178946884-a6481d97-7d49-44de-9ecc-615d0821abac.png">

In the SQL query we are using UNION ALL and scanning rows based on their index, considering 0th row as DAU and so on...

UNION ALL doesn't guarantee any sorting order and[ I tested it as well](https://console.cloud.google.com/bigquery?sq=839055276916:3917764c0f0d46708ec88f3e98fe79df&project=makeshot-dev). 

Fixing the scanning logic in the PR.

## Test plan
check the diff