### PR TITLE
Add a switch to log all GraphQL requests

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -90,7 +90,11 @@ func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, o
 			if requestName == "unknown" {
 				reason = "for unnamed GraphQL request above "
 			}
-			log.Printf(`logging complete query %sname=%s userID=%d source=%s:
+			logFn := log.Printf
+			if logAllRequests {
+				logFn = log15.Debug
+			}
+			logFn(`logging complete query %sname=%s userID=%d source=%s:
 QUERY
 -----
 %s

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -87,12 +87,10 @@ func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, o
 		lvl("serving GraphQL request", "name", requestName, "userID", currentUserID, "source", requestSource)
 		if requestName == "unknown" || logAllRequests {
 			reason := ""
+			logFn := log15.Debug
 			if requestName == "unknown" {
 				reason = "for unnamed GraphQL request above "
-			}
-			logFn := log.Printf
-			if logAllRequests {
-				logFn = log15.Debug
+				logFn = log.Printf
 			}
 			logFn(`logging complete query %sname=%s userID=%d source=%s:
 QUERY

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -61,6 +61,7 @@ func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, o
 	ctx = context.WithValue(ctx, sgtrace.GraphQLQueryKey, queryString)
 
 	_, disableLog := os.LookupEnv("NO_GRAPHQL_LOG")
+	_, logAllRequests := os.LookupEnv("LOG_ALL_GRAPHQL_REQUESTS")
 
 	// Note: We don't care about the error here, we just extract the username if
 	// we get a non-nil user object.
@@ -84,7 +85,7 @@ func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, o
 
 	if !disableLog {
 		lvl("serving GraphQL request", "name", requestName, "userID", currentUserID, "source", requestSource)
-		if requestName == "unknown" {
+		if requestName == "unknown" || logAllRequests {
 			log.Printf(`logging complete query for unnamed GraphQL request above name=%s userID=%d source=%s:
 QUERY
 -----

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -87,12 +87,10 @@ func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, o
 		lvl("serving GraphQL request", "name", requestName, "userID", currentUserID, "source", requestSource)
 		if requestName == "unknown" || logAllRequests {
 			reason := ""
-			logFn := log15.Debug
 			if requestName == "unknown" {
 				reason = "for unnamed GraphQL request above "
-				logFn = log.Printf
 			}
-			logFn(`logging complete query %sname=%s userID=%d source=%s:
+			log.Printf(`logging complete query %sname=%s userID=%d source=%s:
 QUERY
 -----
 %s

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -86,7 +86,11 @@ func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, o
 	if !disableLog {
 		lvl("serving GraphQL request", "name", requestName, "userID", currentUserID, "source", requestSource)
 		if requestName == "unknown" || logAllRequests {
-			log.Printf(`logging complete query for unnamed GraphQL request above name=%s userID=%d source=%s:
+			reason := ""
+			if requestName == "unknown" {
+				reason = "for unnamed GraphQL request above "
+			}
+			log.Printf(`logging complete query %sname=%s userID=%d source=%s:
 QUERY
 -----
 %s
@@ -95,7 +99,7 @@ VARIABLES
 ---------
 %v
 
-`, requestName, currentUserID, requestSource, queryString, variables)
+`, reason, requestName, currentUserID, requestSource, queryString, variables)
 		}
 	}
 


### PR DESCRIPTION
This adds an environment variable that makes `frontend` log all GraphQL requests it receives (unless GraphQL logging is disabled with `NO_GRAPHQL_LOG`).

Sample for unnamed query:
```
[       frontend] logging complete query for unnamed GraphQL request above name=unknown userID=1 source=browser:
[       frontend] QUERY
[       frontend] -----
[       frontend]  query {
[       frontend]         currentUser {
[       frontend]             __typename
[       frontend]             id
[       frontend]             databaseID
[       frontend]             username
[       frontend]             avatarURL
[       frontend]             email
[       frontend]             displayName
[       frontend]             siteAdmin
[       frontend]             tags
[       frontend]             url
[       frontend]             settingsURL
[       frontend]             organizations {
[       frontend]                 nodes {
[       frontend]                     id
[       frontend]                     name
[       frontend]                     displayName
[       frontend]                     url
[       frontend]                     settingsURL
[       frontend]                 }
[       frontend]             }
[       frontend]             session {
[       frontend]                 canSignOut
[       frontend]             }
[       frontend]             viewerCanAdminister
[       frontend]             tags
[       frontend]             tosAccepted
[       frontend]             searchable
[       frontend]         }
[       frontend]     }
[       frontend] VARIABLES
[       frontend] ---------
[       frontend] map[]
```
Sample for `LOG_ALL_GRAPHQL_REQUESTS`:
```
[       frontend] logging complete query name=SpoofedNamedQuery userID=1 source=browser:
[       frontend] QUERY
[       frontend] -----
[       frontend]  query CurrentAuthState {
[       frontend]         currentUser {
[       frontend]             __typename
[       frontend]             id
[       frontend]             databaseID
[       frontend]             username
[       frontend]             avatarURL
[       frontend]             email
[       frontend]             displayName
[       frontend]             siteAdmin
[       frontend]             tags
[       frontend]             url
[       frontend]             settingsURL
[       frontend]             organizations {
[       frontend]                 nodes {
[       frontend]                     id
[       frontend]                     name
[       frontend]                     displayName
[       frontend]                     url
[       frontend]                     settingsURL
[       frontend]                 }
[       frontend]             }
[       frontend]             session {
[       frontend]                 canSignOut
[       frontend]             }
[       frontend]             viewerCanAdminister
[       frontend]             tags
[       frontend]             tosAccepted
[       frontend]             searchable
[       frontend]         }
[       frontend]     }
[       frontend] VARIABLES
[       frontend] ---------
[       frontend] map[]
```
## Test plan

- Tested locally by running `LOG_ALL_GRAPHQL_REQUESTS=please sg start` and `sg start` and:
  - Using sourcegraph UI
  - Using API Console
  - Using curl with query name added manually 
```
curl 'https://sourcegraph.test:3443/.api/graphql?**Bypass**' \
  -H 'authority: sourcegraph.test:3443' \
  -H 'accept: */*' \
  -H 'accept-language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'content-type: text/plain;charset=UTF-8' \
  -H 'cookie: sourcegraphDeviceId=0f150177-a638-49ee-839e-629457a17fb7; SNIP' \
  -H 'origin: https://sourcegraph.test:3443' \
  -H 'referer: https://sourcegraph.test:3443/api/console' \
  -H 'sec-ch-ua: ".Not/A)Brand";v="99", "Google Chrome";v="103", "Chromium";v="103"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: same-origin' \
  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36' \
  -H 'x-requested-with: Sourcegraph GraphQL Explorer' \
  --data-raw '{"query":" query CurrentAuthState {\n        currentUser {\n            __typename\n            id\n            databaseID\n            username\n            avatarURL\n            email\n            displayName\n            siteAdmin\n            tags\n            url\n            settingsURL\n            organizations {\n                nodes {\n                    id\n                    name\n                    displayName\n                    url\n                    settingsURL\n                }\n            }\n            session {\n                canSignOut\n            }\n            viewerCanAdminister\n            tags\n            tosAccepted\n            searchable\n        }\n    }","variables":null,"operationName":"CurrentAuthState"}' \
  --compressed
{"data":{"currentUser":{"__typename":"User","id":"VXNlcjox","databaseID":1,"username":"foobix","avatarURL":null,"email":"foobix@foobix.pl","displayName":null,"siteAdmin":true,"tags":[],"url":"/users/foobix","settingsURL":"/users/foobix/settings","organizations":{"nodes":[]},"session":{"canSignOut":true},"viewerCanAdminister":true,"tosAccepted":true,"searchable":true}}}
```
  
