### PR TITLE
search: Query input tooltip tweaks (CodeMirror)

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -467,7 +467,7 @@ const querySyntaxHighlighting = EditorView.decorations.compute([decoratedTokens]
     const tokens = state.facet(decoratedTokens)
     const builder = new RangeSetBuilder<Decoration>()
     for (const token of tokens) {
-        builder.add(token.range.start, getEndPosition(token), decoratedToDecoration(token))
+        builder.add(token.range.start, token.range.end, decoratedToDecoration(token))
     }
     return builder.finish()
 })
@@ -572,46 +572,31 @@ function tokenInfo(): Extension {
         provide(field) {
             return EditorView.decorations.compute([field, decoratedTokens], state => {
                 const position = state.field(field)
-                if (position === null) {
+                if (!position) {
                     return Decoration.none
                 }
-                let tokenAtPosition = state.facet(decoratedTokens).find(token => isTokenInRange(position, token))
 
-                switch (tokenAtPosition?.type) {
-                    case 'field':
-                    case 'pattern':
-                    case 'metaRevision':
-                    case 'metaRepoRevisionSeparator':
-                    case 'metaSelector':
-                    case 'metaRegexp':
-                    case 'metaStructural':
-                    case 'metaPredicate':
-                        // These are the tokens we show hover information for
-                        break
+                const tooltipInfo = getTokensTooltipInformation(state.facet(decoratedTokens), position)
+                if (!tooltipInfo) {
+                    return Decoration.none
+                }
+                let { range } = tooltipInfo
+
+                const token = tooltipInfo.tokensAtCursor[0]
+                switch (token.type) {
                     case 'keyword': {
-                        // Find operator (AND and OR are supported)
+                        // Find operator (AND and OR are supported) and
+                        // highlight its operands too if possible
                         const operator = findOperatorNode(position, state.facet(parsedQuery))
                         if (operator) {
-                            return Decoration.set([
-                                focusedFilterDeco.range(
-                                    (operator.groupRange ?? operator.range).start,
-                                    (operator.groupRange ?? operator.range).end
-                                ),
-                            ])
+                            range = operator.groupRange ?? operator.range
                         }
                         // Highlight operator keyword only
                         break
                     }
-
-                    default:
-                        tokenAtPosition = undefined
-                        break
                 }
-                return tokenAtPosition
-                    ? Decoration.set([
-                          focusedFilterDeco.range(tokenAtPosition.range.start, getEndPosition(tokenAtPosition)),
-                      ])
-                    : Decoration.none
+
+                return Decoration.set([focusedFilterDeco.range(range.start, range.end)])
             })
         },
     })
@@ -642,7 +627,15 @@ function tokenInfo(): Extension {
 
                 return {
                     pos: tooltipInfo.range.start,
-                    end: tooltipInfo.range.end,
+                    // tooltipInfo.range.end is exclusive, but this needs to be
+                    // inclusive to correctly hide the tooltip when the cursor
+                    // moves to the next token
+                    end: tooltipInfo.range.end - 1,
+                    // Show token info above the text by default to avoid
+                    // interfering with autcompletion (otherwise this could show
+                    // the token info *below* the autocompletion popover, which
+                    // looks bad)
+                    above: true,
                     create(): TooltipView {
                         const dom = document.createElement('div')
                         dom.innerHTML = renderMarkdown(tooltipInfo.value)
@@ -664,10 +657,19 @@ function tokenInfo(): Extension {
 }
 
 function getTokensTooltipInformation(
-    tokens: DecoratedToken[],
+    tokens: readonly DecoratedToken[],
     position: number
-): { range: { start: number; end: number }; value: string } | null {
-    const tokensAtCursor = tokens.filter(token => isTokenInRange(position, token))
+): { tokensAtCursor: readonly DecoratedToken[]; range: { start: number; end: number }; value: string } | null {
+    const tokensAtCursor = tokens.filter(token => {
+        let { start, end } = token.range
+        switch (token.type) {
+            case 'field':
+                // +1 to include field separator :
+                end += 1
+                break
+        }
+        return start <= position && end > position
+    })
 
     if (tokensAtCursor?.length === 0) {
         return null
@@ -686,7 +688,8 @@ function getTokensTooltipInformation(
                             ? resolvedFilter.definition.description(resolvedFilter.negated)
                             : resolvedFilter.definition.description
                     )
-                    range = { start: token.range.start, end: getEndPosition(token) }
+                    // +1 to include field separator :
+                    range = { start: token.range.start, end: token.range.end + 1 }
                 }
                 break
             }
@@ -720,7 +723,7 @@ function getTokensTooltipInformation(
     if (!range) {
         return null
     }
-    return { range, value: values.join('') }
+    return { tokensAtCursor, range, value: values.join('') }
 }
 
 // Hooks query diagnostics into the editor.
@@ -793,14 +796,4 @@ function findOperatorNode(position: number, node: Node | null): Extract<Node, { 
         }
     }
     return node
-}
-
-function isTokenInRange(position: number, token: Pick<DecoratedToken, 'type' | 'range'>): boolean {
-    return token.range.start <= position && getEndPosition(token) > position
-}
-
-// Looks like there might be a bug with how the end range for a field is
-// computed? Need to add 1 to make this work properly.
-function getEndPosition(token: Pick<DecoratedToken, 'type' | 'range'>): number {
-    return token.range.end + (token.type === 'field' ? 1 : 0)
 }

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -1045,7 +1045,7 @@ export const decorate = (token: Token): DecoratedToken[] => {
         case 'filter': {
             decorated.push({
                 type: 'field',
-                range: { start: token.field.range.start, end: token.field.range.end - 1 },
+                range: { start: token.field.range.start, end: token.field.range.end },
                 value: token.field.value,
             })
             decorated.push({

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -28,7 +28,7 @@ describe('getHoverResult()', () => {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
                 "startColumn": 1,
-                "endColumn": 5
+                "endColumn": 6
               }
             }
         `)
@@ -43,7 +43,7 @@ describe('getHoverResult()', () => {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
                 "startColumn": 18,
-                "endColumn": 22
+                "endColumn": 23
               }
             }
         `)
@@ -78,7 +78,7 @@ describe('getHoverResult()', () => {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
                 "startColumn": 1,
-                "endColumn": 5
+                "endColumn": 6
               }
             }
         `)


### PR DESCRIPTION
A couple of small improvements to the token tooltip behavior:

- Fixed the end position of `type: field` tokens. It looks like `- 1`
  was intentionally subtracted to ensure that Monaco would highlight the
  token with a different color, but that doesn't seem necessary. Monaco
  highlights the separator correctly even without that change.

  <img width="688" alt="2022-07-14_12-37" src="https://user-images.githubusercontent.com/179026/178967237-44f33b69-2702-4bfe-a47d-3dbd456fe211.png">


- Extend and use `getTokensTooltipInformation` also in the extension for
  highlighting the token, so that we don't need to duplicate (and sync)
  the logic for determining whether we have tooltip information for a
  token.
- Fixed the end position of the hover tooltip to be inclusive. This
  ensures that the proper tooltip is shown when moving the cursor from
  left to right to the next token. Otherwise the information for the
  previous token might still be shown. This is especially apparent for
  single character tokens.
- Extend the highlight/hover range for field tokens to include the
  filter separate (`:`)
- Show token info above the line by default to prevent interference with
  the autocompletion popover

Before/after autocompletion interference: 

https://user-images.githubusercontent.com/179026/178967409-c17e181f-8b94-48c3-b8bd-197facfe72c5.mp4

Before/after filter highlight and single character tooltips: 

https://user-images.githubusercontent.com/179026/178967488-c6690e48-d692-4d4a-8d60-6e7b2ed8bc99.mp4





## Test plan

Enter query, e.g. `file:test/.*` and hover over the individual tokens.

## App preview:

- [Web](https://sg-web-fkling-query-input-tooltip-tweaks.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qubsvwxofg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
