### PR TITLE
worker: change the way of fetching repos by name

### DIFF
--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
 	"sort"
 	"strconv"
 	"time"
@@ -14,8 +13,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -113,13 +110,13 @@ func (h *bitbucketProjectPermissionsHandler) Handle(ctx context.Context, logger 
 	projectKey := workerJob.ProjectKey
 
 	// These repos are fetched from Bitbucket, therefore their IDs are Bitbucket IDs
-	// and we need to search for these repos in frontend DB using the name
+	// and we need to search for these repos in frontend DB to get Sourcegraph internal IDs
 	bitbucketRepos, err := client.ProjectRepos(ctx, projectKey)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list repositories of Bitbucket Project %q", projectKey)
 	}
 
-	repoIDs, err := h.getRepoIDsByNames(ctx, svc, projectKey, bitbucketRepos)
+	repoIDs, err := h.getRepoIDsByNames(ctx, svc, bitbucketRepos)
 	if err != nil {
 		return errors.Wrap(err, "failed to get gitserver repos from the database")
 	}
@@ -182,47 +179,30 @@ func (h *bitbucketProjectPermissionsHandler) setReposUnrestricted(ctx context.Co
 	return nil
 }
 
-// getRepoIDsByNames queries repo IDs from frontend database using repo names fetched from
+// getRepoIDsByNames queries repo IDs from frontend database using external repo IDs fetched from
 // Bitbucket code host.
-func (h *bitbucketProjectPermissionsHandler) getRepoIDsByNames(ctx context.Context, svc *types.ExternalService, projectKey string, repos []*bitbucketserver.Repo) ([]api.RepoID, error) {
+func (h *bitbucketProjectPermissionsHandler) getRepoIDsByNames(ctx context.Context, svc *types.ExternalService, repos []*bitbucketserver.Repo) ([]api.RepoID, error) {
 	count := len(repos)
 	IDs := make([]api.RepoID, 0, count)
 	if count == 0 {
 		return IDs, nil
 	}
 
-	// unmarshalling external service config
-	var cfg schema.BitbucketServerConnection
-	if err := jsonc.Unmarshal(svc.Config, &cfg); err != nil {
-		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
-	}
-
-	// parsing the hostname from the URL
-	parsedURL, err := url.Parse(cfg.Url)
-	if err != nil {
-		return nil, errors.Errorf("error during parsing external service URL", err)
-	}
-	hostname := parsedURL.Hostname()
-
-	names := make([]string, 0, count)
+	specs := make([]api.ExternalRepoSpec, 0, count)
+	extSvcType := extsvc.KindToType(svc.Kind)
+	extSvcID := strconv.FormatInt(svc.ID, 10)
 	for _, repo := range repos {
-		// this is how repo names are composed before creating repos in `repo` table
-		// we are reconstructing this name for successful pattern matching
-		name := reposource.BitbucketServerRepoName(
-			cfg.RepositoryPathPattern,
-			hostname,
-			projectKey,
-			repo.Slug,
-		)
+		// using external ID, external service type and external service ID of the repo to find it
+		spec := api.ExternalRepoSpec{
+			ID:          strconv.Itoa(repo.ID),
+			ServiceType: extSvcType,
+			ServiceID:   extSvcID,
+		}
 
-		names = append(names, string(name))
+		specs = append(specs, spec)
 	}
 
-	// searching for repos by names
-	foundRepos, err := h.db.Repos().List(ctx, database.ReposListOptions{
-		Names:              names,
-		ExternalServiceIDs: []int64{svc.ID},
-	})
+	foundRepos, err := h.db.Repos().List(ctx, database.ReposListOptions{ExternalRepos: specs})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -40,18 +39,6 @@ func TestStore(t *testing.T) {
 	count, err := store.QueuedCount(ctx, true)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
-}
-
-func intPtr(v int) *int              { return &v }
-func stringPtr(v string) *string     { return &v }
-func timePtr(v time.Time) *time.Time { return &v }
-
-func mustParseTime(v string) time.Time {
-	t, err := time.Parse("2006-01-02", v)
-	if err != nil {
-		panic(err)
-	}
-	return t
 }
 
 func TestGetBitbucketClient(t *testing.T) {
@@ -342,14 +329,14 @@ func TestHandleRestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, external_service_id, name, fork)
+	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork)
 	VALUES
-		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 1, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 1, 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 1, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 1, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 1, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+		(1, 10060, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/go', false),
+		(2, 10056, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
+		(3, 10061, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/mux', false),
+		(4, 10058, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
+		(5, 10059, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
+		(6, 10072, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
 
 	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
 	VALUES
@@ -451,14 +438,14 @@ func TestHandleUnrestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, external_service_id, name, fork)
+	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork)
 	VALUES
-		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 1, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 1, 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 1, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 1, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 1, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+		(1, 10060, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/go', false),
+		(2, 10056, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
+		(3, 10061, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/mux', false),
+		(4, 10058, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
+		(5, 10059, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
+		(6, 10072, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
 
 	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
 	VALUES

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -342,14 +342,23 @@ func TestHandleRestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, name, fork)
+	INSERT INTO repo (id, external_service_id, name, fork)
 	VALUES
-		(1, 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false)
+		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go', false),
+		(2, 1, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
+		(3, 1, 'bitbucket.sgdev.org/SGDEMO/mux', false),
+		(4, 1, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
+		(5, 1, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
+		(6, 1, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+
+	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
+	VALUES
+		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go'),
+		(1, 2, 'bitbucket.sgdev.org/SGDEMO/jenkins'),
+		(1, 3, 'bitbucket.sgdev.org/SGDEMO/mux'),
+		(1, 4, 'bitbucket.sgdev.org/SGDEMO/sentry'),
+		(1, 5, 'bitbucket.sgdev.org/SGDEMO/sinatra'),
+		(1, 6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph');
 `)
 	require.NoError(t, err)
 
@@ -442,14 +451,23 @@ func TestHandleUnrestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, name, fork)
+	INSERT INTO repo (id, external_service_id, name, fork)
 	VALUES
-		(1, 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go', false),
+		(2, 1, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
+		(3, 1, 'bitbucket.sgdev.org/SGDEMO/mux', false),
+		(4, 1, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
+		(5, 1, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
+		(6, 1, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+
+	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
+	VALUES
+		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go'),
+		(1, 2, 'bitbucket.sgdev.org/SGDEMO/jenkins'),
+		(1, 3, 'bitbucket.sgdev.org/SGDEMO/mux'),
+		(1, 4, 'bitbucket.sgdev.org/SGDEMO/sentry'),
+		(1, 5, 'bitbucket.sgdev.org/SGDEMO/sinatra'),
+		(1, 6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph');
 
 	INSERT INTO repo_permissions (repo_id, permission, updated_at)
 	VALUES


### PR DESCRIPTION
As discussed [here](https://github.com/sourcegraph/sourcegraph/commit/dda458ed8922cc48a10f256492ccb6550abe1381#r78374541) it is safer to query repos by name using Repos store rather than GitserverRepos store

## Test plan
Unit tests are updated and should pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
