### PR TITLE
Dv/jetbrains UI fixes

### DIFF
--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -120,6 +120,7 @@ export function applyTheme(theme: Theme): void {
     root.style.setProperty('--jb-inactive-text-color', intelliJTheme.textInactiveText)
     root.style.setProperty('--jb-hover-button-bg', intelliJTheme['ActionButton.hoverBackground'])
     root.style.setProperty('--jb-input-bg', intelliJTheme['TextField.background'])
+    root.style.setProperty('--jb-selection-bg', intelliJTheme['TextField.selectionBackground'] || '#2675bf')
     root.style.setProperty('--jb-tooltip-bg', intelliJTheme['ToolTip.background'])
     root.style.setProperty('--jb-border-color', intelliJTheme['Component.borderColor'])
     root.style.setProperty('--jb-focus-border-color', intelliJTheme['Component.focusedBorderColor'])

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -115,6 +115,7 @@ export function applyTheme(theme: Theme): void {
     root.style.setProperty('--dropdown-link-hover-bg', intelliJTheme['ToolbarComboWidget.hoverBackground'])
     root.style.setProperty('--light-text', intelliJTheme['List.selectionForeground'])
 
+    root.style.setProperty('--jb-list-bg', intelliJTheme['List.background'])
     root.style.setProperty('--jb-button-bg', intelliJTheme['Button.startBackground'])
     root.style.setProperty('--jb-text-color', intelliJTheme.text)
     root.style.setProperty('--jb-inactive-text-color', intelliJTheme.textInactiveText)
@@ -129,7 +130,7 @@ export function applyTheme(theme: Theme): void {
     // There is no color for this in the serialized theme, so I have picked this option from the
     // Dracula theme
     root.style.setProperty('--code-bg', theme.isDarkTheme ? '#2b2b2b' : '#ffffff')
-    root.style.setProperty('--body-bg', theme.isDarkTheme ? '#2b2b2b' : '#ffffff')
+    root.style.setProperty('--body-bg', intelliJTheme['List.background'])
 }
 
 function applyLastSearch(lastSearch: Search | null): void {

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -114,6 +114,8 @@ export function applyTheme(theme: Theme): void {
     root.style.setProperty('--dropdown-link-active-bg', intelliJTheme['List.selectionBackground'])
     root.style.setProperty('--dropdown-link-hover-bg', intelliJTheme['ToolbarComboWidget.hoverBackground'])
     root.style.setProperty('--light-text', intelliJTheme['List.selectionForeground'])
+    root.style.setProperty('--tooltip-bg', intelliJTheme['ToolTip.background'])
+    root.style.setProperty('--tooltip-color', intelliJTheme['ToolTip.foreground'])
 
     root.style.setProperty('--jb-list-bg', intelliJTheme['List.background'])
     root.style.setProperty('--jb-button-bg', intelliJTheme['Button.startBackground'])

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -127,6 +127,7 @@ export function applyTheme(theme: Theme): void {
     root.style.setProperty('--jb-focus-border-color', intelliJTheme['Component.focusedBorderColor'])
     root.style.setProperty('--jb-icon-color', intelliJTheme['Component.iconColor'] || '#7f8b91')
     root.style.setProperty('--jb-info-text-color', intelliJTheme['Component.infoForeground'])
+    root.style.setProperty('--jb-secondary-info-text-color', intelliJTheme['Component.infoForeground'] + '80') // 50% opacity
 
     // There is no color for this in the serialized theme, so I have picked this option from the
     // Dracula theme

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -126,6 +126,7 @@ export function applyTheme(theme: Theme): void {
     root.style.setProperty('--jb-border-color', intelliJTheme['Component.borderColor'])
     root.style.setProperty('--jb-focus-border-color', intelliJTheme['Component.focusedBorderColor'])
     root.style.setProperty('--jb-icon-color', intelliJTheme['Component.iconColor'] || '#7f8b91')
+    root.style.setProperty('--jb-info-text-color', intelliJTheme['Component.infoForeground'])
 
     // There is no color for this in the serialized theme, so I have picked this option from the
     // Dracula theme

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
@@ -20,7 +20,7 @@
         display: flex;
         flex-grow: 1;
         align-items: center;
-        background-color: var(--code-bg);
+        background-color: var(--jb-list-bg);
         height: 100%;
 
         @media (--xs-breakpoint-down) {

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
@@ -289,6 +289,12 @@
             font-family: inherit;
         }
 
+        :global(.cm-line) {
+            ::selection {
+                background-color: var(--jb-selection-bg);
+            }
+        }
+
         :global(.cm-tooltip):global(.cm-tooltip-autocomplete) {
             color: var(--jb-text-color);
             background-color: var(--dropdown-bg);

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useState } from 'react'
 
 import classNames from 'classnames'
 
-import { SearchContextInputProps, QueryState, SubmitSearchProps } from '@sourcegraph/search'
+import { QueryState, SearchContextInputProps, SubmitSearchProps } from '@sourcegraph/search'
 import {
     IEditor,
     LazyMonacoQueryInput,
@@ -136,9 +136,7 @@ export const JetBrainsSearchBox: React.FunctionComponent<React.PropsWithChildren
                         submitSearch={props.submitSearchOnToggle}
                         navbarSearchQuery={queryState.query}
                         className={styles.searchBoxToggles}
-                        showCopyQueryButton={props.showCopyQueryButton}
                         structuralSearchDisabled={props.structuralSearchDisabled}
-                        selectedSearchContextSpec={props.selectedSearchContextSpec}
                         clearSearch={clearSearch}
                     />
                 </div>

--- a/client/jetbrains/webview/src/search/input/JetBrainsToggles.module.scss
+++ b/client/jetbrains/webview/src/search/input/JetBrainsToggles.module.scss
@@ -36,7 +36,7 @@
     border: 2px solid transparent;
 
     &:hover {
-        background-color: var(--color-bg-2);
+        background-color: var(--jb-hover-button-bg);
     }
 
     &:focus {
@@ -56,7 +56,7 @@
         opacity: 1;
 
         :global(.theme-light) & {
-            background-color: var(--color-bg-2);
+            background-color: var(--jb-hover-button-bg);
         }
 
         &:active {

--- a/client/jetbrains/webview/src/search/input/JetBrainsToggles.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsToggles.tsx
@@ -9,7 +9,7 @@ import FormatLetterCaseIcon from 'mdi-react/FormatLetterCaseIcon'
 import LightningBoltIcon from 'mdi-react/LightningBoltIcon'
 import RegexIcon from 'mdi-react/RegexIcon'
 
-import { isErrorLike, isMacPlatform } from '@sourcegraph/common'
+import { isErrorLike } from '@sourcegraph/common'
 import {
     CaseSensitivityProps,
     SearchContextProps,
@@ -17,9 +17,7 @@ import {
     SearchPatternTypeProps,
     SubmitSearchProps,
 } from '@sourcegraph/search'
-import { CopyQueryButton } from '@sourcegraph/search-ui/src/input/toggles/CopyQueryButton'
 import { QueryInputToggle } from '@sourcegraph/search-ui/src/input/toggles/QueryInputToggle'
-import { KEYBOARD_SHORTCUT_COPY_FULL_QUERY } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
@@ -75,9 +73,7 @@ export const JetBrainsToggles: React.FunctionComponent<React.PropsWithChildren<J
         setCaseSensitivity,
         settingsCascade,
         className,
-        selectedSearchContextSpec,
         submitSearch,
-        showCopyQueryButton = true,
         structuralSearchDisabled,
         clearSearch,
     } = props
@@ -138,17 +134,6 @@ export const JetBrainsToggles: React.FunctionComponent<React.PropsWithChildren<J
 
     const luckySearchEnabled = defaultPatternTypeValue === SearchPatternType.lucky
 
-    const fullQuery = getFullQuery(navbarSearchQuery, selectedSearchContextSpec || '', caseSensitive, patternType)
-
-    const copyQueryButton = showCopyQueryButton && (
-        <CopyQueryButton
-            fullQuery={fullQuery}
-            keyboardShortcutForFullCopy={KEYBOARD_SHORTCUT_COPY_FULL_QUERY}
-            isMacPlatform={isMacPlatform()}
-            className={classNames(styles.toggle, styles.copyQueryButton)}
-        />
-    )
-
     return (
         <div className={classNames(className, styles.toggleContainer)}>
             {navbarSearchQuery !== '' && (
@@ -169,7 +154,6 @@ export const JetBrainsToggles: React.FunctionComponent<React.PropsWithChildren<J
                         activeClassName="test-expert-mode-toggle--active"
                         disableOn={[]}
                     />
-                    {copyQueryButton}
                 </>
             ) : (
                 <>
@@ -248,7 +232,6 @@ export const JetBrainsToggles: React.FunctionComponent<React.PropsWithChildren<J
                             disableOn={[]}
                         />
                     )}
-                    {copyQueryButton}
                 </>
             )}
         </div>

--- a/client/jetbrains/webview/src/search/input/JetBrainsToggles.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsToggles.tsx
@@ -11,17 +11,17 @@ import RegexIcon from 'mdi-react/RegexIcon'
 
 import { isErrorLike, isMacPlatform } from '@sourcegraph/common'
 import {
-    SearchPatternTypeProps,
     CaseSensitivityProps,
     SearchContextProps,
     SearchPatternTypeMutationProps,
+    SearchPatternTypeProps,
     SubmitSearchProps,
 } from '@sourcegraph/search'
 import { CopyQueryButton } from '@sourcegraph/search-ui/src/input/toggles/CopyQueryButton'
 import { QueryInputToggle } from '@sourcegraph/search-ui/src/input/toggles/QueryInputToggle'
 import { KEYBOARD_SHORTCUT_COPY_FULL_QUERY } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
-import { findFilter, FilterKind } from '@sourcegraph/shared/src/search/query/query'
+import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { Button } from '@sourcegraph/wildcard'
@@ -165,7 +165,7 @@ export const JetBrainsToggles: React.FunctionComponent<React.PropsWithChildren<J
                         onToggle={toggleExpertMode}
                         icon={LightningBoltIcon}
                         interactive={props.interactive}
-                        className="test-expert-mode-toggle"
+                        className={classNames(styles.toggle, 'test-expert-mode-toggle')}
                         activeClassName="test-expert-mode-toggle--active"
                         disableOn={[]}
                     />
@@ -179,7 +179,7 @@ export const JetBrainsToggles: React.FunctionComponent<React.PropsWithChildren<J
                         onToggle={toggleCaseSensitivity}
                         icon={FormatLetterCaseIcon}
                         interactive={props.interactive}
-                        className="test-case-sensitivity-toggle"
+                        className={classNames(styles.toggle, 'test-case-sensitivity-toggle')}
                         activeClassName="test-case-sensitivity-toggle--active"
                         disableOn={[
                             {
@@ -206,7 +206,7 @@ export const JetBrainsToggles: React.FunctionComponent<React.PropsWithChildren<J
                         onToggle={toggleRegexp}
                         icon={RegexIcon}
                         interactive={props.interactive}
-                        className="test-regexp-toggle"
+                        className={classNames(styles.toggle, 'test-regexp-toggle')}
                         activeClassName="test-regexp-toggle--active"
                         disableOn={[
                             {
@@ -220,7 +220,7 @@ export const JetBrainsToggles: React.FunctionComponent<React.PropsWithChildren<J
                     {!structuralSearchDisabled && (
                         <QueryInputToggle
                             title="Structural search"
-                            className="test-structural-search-toggle"
+                            className={classNames(styles.toggle, 'test-structural-search-toggle')}
                             activeClassName="test-structural-search-toggle--active"
                             isActive={patternType === SearchPatternType.structural}
                             onToggle={toggleStructuralSearch}

--- a/client/jetbrains/webview/src/search/results/CommitSearchResult.module.scss
+++ b/client/jetbrains/webview/src/search/results/CommitSearchResult.module.scss
@@ -11,4 +11,9 @@
 .commit-oid {
     display: inline-block;
     padding: 0.25rem;
+    color: var(--jb-secondary-info-text-color);
+}
+
+.timestamp {
+    color: var(--jb-secondary-info-text-color);
 }

--- a/client/jetbrains/webview/src/search/results/FileSearchResult.module.scss
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.module.scss
@@ -11,3 +11,7 @@
         border-radius: 3px;
     }
 }
+
+.matches {
+    color: var(--jb-secondary-info-text-color);
+}

--- a/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
@@ -101,7 +101,9 @@ export const FileSearchResult: React.FunctionComponent<Props> = ({
                 infoColumn={
                     formattedRepositoryStarCount && (
                         <>
-                            {lines.length} {lines.length > 1 ? 'matches' : 'match'}
+                            <span className={styles.matches}>
+                                {lines.length} {lines.length > 1 ? 'matches' : 'match'}
+                            </span>
                             <InfoDivider />
                             <SearchResultStar />
                             {formattedRepositoryStarCount}

--- a/client/jetbrains/webview/src/search/results/SearchResultLayout.module.scss
+++ b/client/jetbrains/webview/src/search/results/SearchResultLayout.module.scss
@@ -40,8 +40,7 @@
 }
 
 .info-column {
-    // @TODO: Make configurable, this is copied from the Figma file
-    color: #8c8c8c;
+    color: var(--jb-info-text-color);
     text-align: right;
     font-variant-numeric: tabular-nums;
     display: flex;

--- a/client/jetbrains/webview/src/search/results/SearchResultLayout.module.scss
+++ b/client/jetbrains/webview/src/search/results/SearchResultLayout.module.scss
@@ -5,7 +5,7 @@
     height: 1.5rem;
     align-items: center;
     white-space: nowrap;
-    padding: 0 0.5rem;
+    padding: 0 4px;
 
     // The below options are extracted from the native JetBrains find in files
     // model.
@@ -45,7 +45,7 @@
     text-align: right;
     font-variant-numeric: tabular-nums;
     display: flex;
-    font-size: 0.625rem;
+    font-size: 13px;
     flex-shrink: 0;
     align-items: center;
     justify-content: flex-end;

--- a/client/jetbrains/webview/src/search/results/SearchResultList.module.scss
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.module.scss
@@ -1,5 +1,5 @@
 .list {
     height: auto;
     overflow-y: auto;
-    background-color: var(--code-bg);
+    background-color: var(--jb-panel-bg);
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/38390
Also contributes to Icebox item https://github.com/sourcegraph/sourcegraph/issues/37688

- Using the right IDE color for the result list background color and search box background color (a a lighter gray for dark themes)
- Set selection background color to a blue that matches the IDE color (see caveats)
- Increased column info font size : 10px→13px
- Very slightly decreased column info horizontal padding
- Made search result info color dynamic (it was hard-coded and a "TODO" was in the code)
- Faded secondary info (item no. 3 in https://github.com/sourcegraph/sourcegraph/issues/37688)
- Made the search box button hover colors match the IDE color (see caveats)
- Made the search box button hover tooltip background and foreground color match the IDE colors (see caveats)
- Removed "copy query" button (It added little value, and the shortcut written on it never worked.)

Caveats:
- Selection doesn't disappear when the preview is selected (see video)
- Button hover colors are probably not 100% the same as the native IDE hover colors, not sure why but it's much better than it was. (see video)
- Tooltips don't have a border and I've found no easy way to add one. (see video)

## Test plan

- All changes demoed for both the dark and light themes in this [5-min Loom](https://www.loom.com/share/4613085e6d7c44da8548b084ed4355b9)
