### PR TITLE
[debug] codeintel: print stderr of pg_dump

### DIFF
--- a/dev/codeintel-qa/cmd/upload/state.go
+++ b/dev/codeintel-qa/cmd/upload/state.go
@@ -103,7 +103,7 @@ func monitor(ctx context.Context, repoNames []string, uploads []uploadMeta) erro
 
 					out, err := exec.Command("pg_dump", "-a", "--column-inserts", "--table='lsif_uploads*'").CombinedOutput()
 					if err != nil {
-						fmt.Printf("Failed to dump: %s", err.Error())
+						fmt.Printf("Failed to dump: %s\n%s", err.Error(), out)
 					} else {
 						fmt.Printf("DUMP:\n\n%s\n\n\n", out)
 					}


### PR DESCRIPTION
`Failed to dump: exit status 1` not useful, need stderr :noemi-handwriting:

Its not 128 so the command exists at least, but the command works on my own machine. Wonder if theres some env-vars not set so it doesnt know where postgres is?

## Test plan

n/a, debugging tests
