### PR TITLE
dependencies: remove noop-writer-shim since we don't write anymore

### DIFF
--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -17,7 +17,7 @@ type operations struct {
 	selectRepoRevisionsToResolve *observation.Operation
 	updateResolvedRevisions      *observation.Operation
 	upsertDependencyRepos        *observation.Operation
-	upsertLockfileDependencies   *observation.Operation
+	upsertLockfileGraph          *observation.Operation
 	listLockfileIndexes          *observation.Operation
 }
 
@@ -47,7 +47,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		selectRepoRevisionsToResolve: op("SelectRepoRevisionsToResolve"),
 		updateResolvedRevisions:      op("UpdateResolvedRevisions"),
 		upsertDependencyRepos:        op("UpsertDependencyRepos"),
-		upsertLockfileDependencies:   op("UpsertLockfileDependencies"),
+		upsertLockfileGraph:          op("UpsertLockfileGraph"),
 		listLockfileIndexes:          op("ListLockfileIndexes"),
 	}
 }

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -263,7 +264,7 @@ func populatePackageDependencyChannel(deps []shared.PackageDependency, lockfile,
 // `codeintel_lockfiles` entry and the full graph is represented in
 // `codeintel_lockfile_references` as edges in the `depends_on` column.
 func (s *store) UpsertLockfileGraph(ctx context.Context, repoName, commit, lockfile string, deps []shared.PackageDependency, graph shared.DependencyGraph) (err error) {
-	ctx, _, endObservation := s.operations.upsertLockfileDependencies.With(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, _, endObservation := s.operations.upsertLockfileGraph.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("repoName", repoName),
 		log.String("commit", commit),
 	}})

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -254,7 +254,7 @@ func (s *Service) listAndPersistLockfileDependencies(ctx context.Context, repoCo
 			serializableGraph,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, "store.UpsertLockfileDependencies")
+			return nil, errors.Wrap(err, "store.UpsertLockfileGraph")
 		}
 
 		for _, d := range serializableRepoDeps {

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -346,7 +346,7 @@ func TestIndexLockfiles(t *testing.T) {
 		t.Fatalf("unexpected error querying dependencies: %s", err)
 	}
 
-	// Assert `store.UpsertLockfileDependencies` was called
+	// Assert `store.UpsertLockfileGraph` was called
 	mockassert.CalledN(t, mockStore.UpsertLockfileGraphFunc, 7)
 	mockassert.CalledOnceWith(t, mockStore.UpsertLockfileGraphFunc, mockassert.Values(mockassert.Skip, "github.com/example/foo", "deadbeef1", "pom.xml", mockassert.Skip))
 	// deadbeef2 has 2 results


### PR DESCRIPTION
We don't write on the request path anymore, so we don't need the shim. Also fixes operations name.

## Test plan

- Existing tests