### PR TITLE
integration tests: Expose and use CodeMirror API to read editor value

### DIFF
--- a/client/shared/src/components/CodeMirrorEditor.ts
+++ b/client/shared/src/components/CodeMirrorEditor.ts
@@ -8,8 +8,11 @@ import { tags } from '@lezer/highlight'
 if (process.env.INTEGRATION_TESTS) {
     // Expose findFromDOM on the global object to be able to get the real input
     // value in integration tests
-    // @ts-ignore
-    window.CodeMirrorFindFromDOM = (element: HTMLElement): ReturnType<EditorView['findFromDOM']> =>
+    // Typecast "as any" is used to avoid TypeScript complaining about window
+    // not having this property. We decided that it's fine to use this in a test
+    // context
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
+    ;(window as any).CodeMirrorFindFromDOM = (element: HTMLElement): ReturnType<typeof EditorView['findFromDOM']> =>
         EditorView.findFromDOM(element)
 }
 

--- a/client/shared/src/components/CodeMirrorEditor.ts
+++ b/client/shared/src/components/CodeMirrorEditor.ts
@@ -9,7 +9,8 @@ if (process.env.INTEGRATION_TESTS) {
     // Expose findFromDOM on the global object to be able to get the real input
     // value in integration tests
     // @ts-ignore
-    window.CodeMirrorFindFromDOM = EditorView.findFromDOM
+    window.CodeMirrorFindFromDOM = (element: HTMLElement): ReturnType<EditorView['findFromDOM']> =>
+        EditorView.findFromDOM(element)
 }
 
 /**

--- a/client/shared/src/components/CodeMirrorEditor.ts
+++ b/client/shared/src/components/CodeMirrorEditor.ts
@@ -5,6 +5,13 @@ import { EditorState, EditorStateConfig, Extension, StateEffect } from '@codemir
 import { EditorView } from '@codemirror/view'
 import { tags } from '@lezer/highlight'
 
+if (process.env.INTEGRATION_TESTS) {
+    // Expose findFromDOM on the global object to be able to get the real input
+    // value in integration tests
+    // @ts-ignore
+    window.CodeMirrorFindFromDOM = EditorView.findFromDOM
+}
+
 /**
  * Hook for rendering and updating a CodeMirror instance.
  */

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -138,9 +138,7 @@ describe('Search', () => {
                 const editor = await createEditorAPI(driver, queryInputSelector)
                 await editor.replace('-file')
                 await editor.selectSuggestion('-file')
-                // Using a regular expression here because currently the
-                // value for CodeMirror includes placeholders
-                expect(await editor.getValue()).toMatch(/^-file:/)
+                expect(await editor.getValue()).toStrictEqual('-file:')
                 await percySnapshotWithVariants(driver.page, `Search home page (${editorName})`)
                 await accessibilityAudit(driver.page)
             })

--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -241,16 +241,12 @@ const editors: Record<Editor, (driver: Driver, rootSelector: string) => EditorAP
                         )
                     }
                     const editorElement = document.querySelector<HTMLElement>(selector)
-                    if (!editorElement) {
-                        throw new Error(`Unable to find element with selector: ${selector}`)
+                    if (editorElement) {
+                        // Returns an EditorView
+                        // See https://codemirror.net/docs/ref/#view.EditorView^findFromDOM
+                        return fromDOM(editorElement)?.state.sliceDoc()
                     }
-                    // Returns an EditorView
-                    // See https://codemirror.net/docs/ref/#view.EditorView^findFromDOM
-                    const editor = fromDOM(editorElement)
-                    if (!editor) {
-                        throw new Error(`Element with selector "${selector}" is not a CodeMirror editor.`)
-                    }
-                    return editor.state.sliceDoc()
+                    return undefined
                 }, rootSelector)
             },
             replace(newText: string, method = 'type') {

--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -1,3 +1,4 @@
+import { EditorView } from '@codemirror/view'
 import { Page } from 'puppeteer'
 
 import { SearchGraphQlOperations } from '@sourcegraph/search'
@@ -7,7 +8,6 @@ import { Driver, percySnapshot } from '@sourcegraph/shared/src/testing/driver'
 import { readEnvironmentBoolean } from '@sourcegraph/shared/src/testing/utils'
 
 import { WebGraphQlOperations } from '../graphql-operations'
-import { EditorView } from '@codemirror/view'
 
 const CODE_HIGHLIGHTING_QUERIES: Partial<
     keyof (WebGraphQlOperations & SharedGraphQlOperations & SearchGraphQlOperations)
@@ -226,9 +226,9 @@ const editors: Record<Editor, (driver: Driver, rootSelector: string) => EditorAP
                 await api.waitForIt()
                 await driver.page.click(rootSelector)
             },
-            async getValue() {
-                return await driver.page.evaluate((selector: string) => {
-                    //@ts-ignore
+            getValue() {
+                return driver.page.evaluate((selector: string) => {
+                    // @ts-ignore
                     const fromDOM = window.CodeMirrorFindFromDOM as typeof EditorView['findFromDOM'] | undefined
                     if (!fromDOM) {
                         throw new Error('CodeMirror DOM API not exposed')


### PR DESCRIPTION
Reading the value directly from the DOM nodes is unreliable since we
don't necessarily know which decorations are displayed which could
impact the return value.

Using the work from #38805 this exposes CodeMirror's own API to get an
editor instance from the DOM and read the real value from that API.


## Test plan

```
INTEGRATION_TESTS=1 yarn watch-web
yarn _test-integration client/web/src/integration/search.test.ts
```

## App preview:

- [Web](https://sg-web-fkling-codemirror-integration.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xdfbrigxxu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
