### PR TITLE
dependencies: add GraphQL resolver to list lockfile indexes

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -35,6 +35,7 @@ type Services struct {
 	OrgRepositoryResolver         graphqlbackend.OrgRepositoryResolver
 	NotebooksResolver             graphqlbackend.NotebooksResolver
 	ComputeResolver               graphqlbackend.ComputeResolver
+	DependenciesResolver          graphqlbackend.DependenciesResolver
 }
 
 // NewCodeIntelUploadHandler creates a new handler for the LSIF upload endpoint. The

--- a/cmd/frontend/graphqlbackend/dependencies.go
+++ b/cmd/frontend/graphqlbackend/dependencies.go
@@ -1,0 +1,28 @@
+package graphqlbackend
+
+import (
+	"context"
+
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+)
+
+type ListLockfileIndexesArgs struct {
+	First int32
+	After *string
+}
+
+type DependenciesResolver interface {
+	LockfileIndexes(ctx context.Context, args *ListLockfileIndexesArgs) (LockfileIndexConnectionResolver, error)
+}
+
+type LockfileIndexConnectionResolver interface {
+	Nodes(ctx context.Context) []LockfileIndexResolver
+	TotalCount(ctx context.Context) int32
+	PageInfo(ctx context.Context) *graphqlutil.PageInfo
+}
+
+type LockfileIndexResolver interface {
+	ID() graphql.ID
+}

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -1,0 +1,45 @@
+extend type Query {
+    """
+    A list of lockfile indexes.
+    """
+    lockfileIndexes(
+        """
+        Returns the first n lockfile indexes from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): LockfileIndexConnection!
+}
+
+"""
+A list of lockfile indexes.
+"""
+type LockfileIndexConnection {
+    """
+    A list of lockfile indexes.
+    """
+    nodes: [LockfileIndex!]!
+
+    """
+    The total number of lockfile indexes in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A lockfile index is an indexed lockfile in a repository.
+"""
+type LockfileIndex implements Node {
+    """
+    The unique ID for the lockfile index.
+    """
+    id: ID!
+}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -362,6 +362,7 @@ func NewSchema(
 	orgRepositoryResolver OrgRepositoryResolver,
 	notebooks NotebooksResolver,
 	compute ComputeResolver,
+	dependencies DependenciesResolver,
 ) (*graphql.Schema, error) {
 	resolver := newSchemaResolver(db)
 	schemas := []string{mainSchema}
@@ -457,6 +458,12 @@ func NewSchema(
 		schemas = append(schemas, computeSchema)
 	}
 
+	if dependencies != nil {
+		EnterpriseResolvers.dependenciesResolver = dependencies
+		resolver.DependenciesResolver = dependencies
+		schemas = append(schemas, dependenciesSchema)
+	}
+
 	return graphql.ParseSchema(
 		strings.Join(schemas, "\n"),
 		resolver,
@@ -489,6 +496,7 @@ type schemaResolver struct {
 	SearchContextsResolver
 	OrgRepositoryResolver
 	NotebooksResolver
+	DependenciesResolver
 }
 
 // newSchemaResolver will return a new, safely instantiated schemaResolver with some
@@ -564,6 +572,7 @@ var EnterpriseResolvers = struct {
 	searchContextsResolver SearchContextsResolver
 	orgRepositoryResolver  OrgRepositoryResolver
 	notebooksResolver      NotebooksResolver
+	dependenciesResolver   DependenciesResolver
 }{}
 
 // DEPRECATED

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -278,3 +278,8 @@ func (r *NodeResolver) ToExecutor() (*executor.ExecutorResolver, bool) {
 	n, ok := r.Node.(*executor.ExecutorResolver)
 	return n, ok
 }
+
+func (r *NodeResolver) ToLockfileIndex() (LockfileIndexResolver, bool) {
+	n, ok := r.Node.(LockfileIndexResolver)
+	return n, ok
+}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -52,3 +52,7 @@ var orgSchema string
 // notebooksSchema is the Notebooks raw graqhql schema.
 //go:embed notebooks.graphql
 var notebooksSchema string
+
+// dependenciesSchema is the dependencies raw graqhql schema.
+//go:embed dependencies.graphql
+var dependenciesSchema string

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -20,7 +20,7 @@ import (
 func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 	t.Helper()
 
-	parsedSchema, parseSchemaErr := NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	parsedSchema, parseSchemaErr := NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)
 	}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -289,6 +289,7 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 		enterprise.OrgRepositoryResolver,
 		enterprise.NotebooksResolver,
 		enterprise.ComputeResolver,
+		enterprise.DependenciesResolver,
 	)
 	if err != nil {
 		return err

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -40,7 +40,7 @@ func clock() time.Time {
 func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 	t.Helper()
 
-	parsedSchema, err := graphqlbackend.NewSchema(db, nil, nil, nil, NewResolver(db, clock), nil, nil, nil, nil, nil, nil, nil)
+	parsedSchema, err := graphqlbackend.NewSchema(db, nil, nil, nil, NewResolver(db, clock), nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
@@ -79,7 +79,7 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestBatchChangesListing(t *testing.T) {
 	store := store.New(db, &observation.TestContext, nil)
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
@@ -62,7 +62,7 @@ func TestBatchChangeResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestBatchChangeResolver_BatchSpecs(t *testing.T) {
 	clock := func() time.Time { return now }
 	cstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -87,7 +87,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +291,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
@@ -79,7 +79,7 @@ func TestBatchSpecWorkspaceResolver(t *testing.T) {
 	}
 	apiID := string(marshalBatchSpecWorkspaceID(workspace.ID))
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_connection_test.go
@@ -83,7 +83,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(db, New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_test.go
@@ -102,7 +102,7 @@ func TestBulkOperationResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(db, New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -77,7 +77,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -109,7 +109,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 		OwnedByBatchChange: batchChange.ID,
 	})
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestChangesetApplyPreviewResolverWithPublicationStates(t *testing.T) {
 	repo := newGitHubTestRepo("github.com/sourcegraph/test", newGitHubExternalService(t, esStore))
 	require.Nil(t, repoStore.Create(ctx, repo))
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.Nil(t, err)
 
 	// To make it easier to assert against the operations in a preview node,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
@@ -112,7 +112,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	addChangeset(t, ctx, cstore, changeset3, batchChange.ID)
 	addChangeset(t, ctx, cstore, changeset4, batchChange.ID)
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -182,7 +182,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		}
 	}
 
-	s, err := graphqlbackend.NewSchema(db, New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
@@ -101,7 +101,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	addChangeset(t, ctx, cstore, changeset, batchChange.ID)
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_connection_test.go
@@ -73,7 +73,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
@@ -67,7 +67,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -239,7 +239,7 @@ func TestChangesetResolver(t *testing.T) {
 	// Associate the changeset with a batch change, so it's considered in syncer logic.
 	addChangeset(t, ctx, cstore, syncedGitHubChangeset, batchChange.ID)
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
@@ -45,7 +45,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 	bbsRepos, _ := ct.CreateBbsTestRepos(t, ctx, db, 1)
 	bbsRepo := bbsRepos[0]
 
-	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -48,7 +48,7 @@ func TestPermissionLevels(t *testing.T) {
 
 	cstore := store.New(db, &observation.TestContext, key)
 	sr := New(cstore)
-	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1276,7 +1276,7 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	bstore := store.New(db, &observation.TestContext, nil)
 	sr := &Resolver{store: bstore}
-	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -2197,5 +2197,5 @@ query($includeLocallyExecutedSpecs: Boolean!) {
 func stringPtr(s string) *string { return &s }
 
 func newSchema(db database.DB, r graphqlbackend.BatchChangesResolver) (*graphql.Schema, error) {
-	return graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -375,7 +375,7 @@ func TestQueryMonitor(t *testing.T) {
 	_, err = r.insertTestMonitorWithOpts(ctx, t, actionOpt, postHookOpt)
 	require.NoError(t, err)
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, r, nil, nil, nil, nil, nil, nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, r, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	t.Run("query by user", func(t *testing.T) {
@@ -702,7 +702,7 @@ func TestEditCodeMonitor(t *testing.T) {
 
 	// Update the code monitor.
 	// We update all fields, delete one action, and add a new action.
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, r, nil, nil, nil, nil, nil, nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, r, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	updateInput := map[string]any{
 		"monitorID": string(relay.MarshalID(MonitorKind, 1)),

--- a/enterprise/cmd/frontend/internal/dependencies/init.go
+++ b/enterprise/cmd/frontend/internal/dependencies/init.go
@@ -1,0 +1,19 @@
+package dependencies
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/transport/graphql"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// Init initializes the given enterpriseServices to include the required
+// resolvers for Dependencies.
+func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+	// Register enterprise services.
+	enterpriseServices.DependenciesResolver = graphql.New(db)
+	return nil
+}

--- a/enterprise/cmd/frontend/internal/licensing/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/resolvers/resolvers_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestEnterpriseLicenseHasFeature(t *testing.T) {
 	r := &LicenseResolver{}
-	schema, err := graphqlbackend.NewSchema(nil, nil, nil, nil, nil, nil, r, nil, nil, nil, nil, nil)
+	schema, err := graphqlbackend.NewSchema(nil, nil, nil, nil, nil, nil, r, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
@@ -207,7 +207,7 @@ func TestSingleNotebookCRUD(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,7 +600,7 @@ func TestListNotebooks(t *testing.T) {
 		return ids
 	}
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
@@ -79,7 +79,7 @@ func TestCreateAndDeleteNotebookStars(t *testing.T) {
 
 	createdNotebooks := createNotebooks(t, db, []*notebooks.Notebook{userNotebookFixture(user1.ID, true), userNotebookFixture(user1.ID, false)})
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestListNotebookStars(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/orgrepos/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/orgrepos/resolvers/resolvers_test.go
@@ -49,7 +49,7 @@ func TestOrgRepositories(t *testing.T) {
 			Schema: func() *graphql.Schema {
 				t.Helper()
 
-				parsedSchema, parseSchemaErr := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
+				parsedSchema, parseSchemaErr := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil, nil)
 				if parseSchemaErr != nil {
 					t.Fatal(parseSchemaErr)
 				}
@@ -101,7 +101,7 @@ func TestAddOrgsOpenBetaStats(t *testing.T) {
 	db.OrgsFunc.SetDefaultReturn(orgs)
 	db.UsersFunc.SetDefaultReturn(users)
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dependencies"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom"
 	executor "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue"
 	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
@@ -60,6 +61,7 @@ var initFunctions = map[string]EnterpriseInitializer{
 	"enterprise":     orgrepos.Init,
 	"notebooks":      notebooks.Init,
 	"compute":        compute.Init,
+	"dependencies":   dependencies.Init,
 }
 
 var codeIntelConfig = &codeintel.Config{}

--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -19,7 +19,6 @@ type operations struct {
 	upsertDependencyRepos        *observation.Operation
 	upsertLockfileGraph          *observation.Operation
 	listLockfileIndexes          *observation.Operation
-	countLockfileIndexes         *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -50,6 +49,5 @@ func newOperations(observationContext *observation.Context) *operations {
 		upsertDependencyRepos:        op("UpsertDependencyRepos"),
 		upsertLockfileGraph:          op("UpsertLockfileGraph"),
 		listLockfileIndexes:          op("ListLockfileIndexes"),
-		countLockfileIndexes:         op("CountLockfileIndexes"),
 	}
 }

--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -19,6 +19,7 @@ type operations struct {
 	upsertDependencyRepos        *observation.Operation
 	upsertLockfileGraph          *observation.Operation
 	listLockfileIndexes          *observation.Operation
+	countLockfileIndexes         *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -49,5 +50,6 @@ func newOperations(observationContext *observation.Context) *operations {
 		upsertDependencyRepos:        op("UpsertDependencyRepos"),
 		upsertLockfileGraph:          op("UpsertLockfileGraph"),
 		listLockfileIndexes:          op("ListLockfileIndexes"),
+		countLockfileIndexes:         op("CountLockfileIndexes"),
 	}
 }

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -1240,18 +1240,13 @@ func TestListAndCountLockfileIndexes(t *testing.T) {
 			expectedCount: 1,
 		},
 	} {
-		lockfiles, err := store.ListLockfileIndexes(ctx, tt.opts)
+		lockfiles, count, err := store.ListLockfileIndexes(ctx, tt.opts)
 		if err != nil {
 			t.Fatalf("error: %s", err)
 		}
 
 		if diff := cmp.Diff(tt.expected, lockfiles); diff != "" {
 			t.Errorf("[%d] unexpected lockfiles (-want +got):\n%s", i, diff)
-		}
-
-		count, err := store.CountLockfileIndexes(ctx, tt.opts)
-		if err != nil {
-			t.Fatalf("error: %s", err)
 		}
 
 		if diff := cmp.Diff(tt.expectedCount, count); diff != "" {

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 	"github.com/sourcegraph/log/logtest"
@@ -1124,7 +1125,7 @@ func TestLockfileDependents(t *testing.T) {
 	}
 }
 
-func TestListLockfileIndexes(t *testing.T) {
+func TestListAndCountLockfileIndexes(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
@@ -1183,49 +1184,60 @@ func TestListLockfileIndexes(t *testing.T) {
 		{ID: 3, RepositoryID: 2, Commit: "d34db33f", LockfileReferenceIDs: []int{5}, Lockfile: "lock2.file", Fidelity: "flat"},
 	}
 
-	for _, tt := range []struct {
-		opts     ListLockfileIndexesOpts
-		expected []shared.LockfileIndex
+	for i, tt := range []struct {
+		opts          ListLockfileIndexesOpts
+		expected      []shared.LockfileIndex
+		expectedCount int
 	}{
 		{
-			opts:     ListLockfileIndexesOpts{},
-			expected: []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1], lockfileIndexes[2]},
+			opts:          ListLockfileIndexesOpts{},
+			expected:      []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1], lockfileIndexes[2]},
+			expectedCount: 3,
 		},
 		{
-			opts:     ListLockfileIndexesOpts{Limit: 2},
-			expected: []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1]},
+			opts:          ListLockfileIndexesOpts{Limit: 2},
+			expected:      []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1]},
+			expectedCount: 3,
 		},
 		{
-			opts:     ListLockfileIndexesOpts{After: 1, Limit: 2},
-			expected: []shared.LockfileIndex{lockfileIndexes[1], lockfileIndexes[2]},
+			opts:          ListLockfileIndexesOpts{After: 1, Limit: 2},
+			expected:      []shared.LockfileIndex{lockfileIndexes[1], lockfileIndexes[2]},
+			expectedCount: 3,
 		},
 		{
-			opts:     ListLockfileIndexesOpts{After: 2, Limit: 2},
-			expected: []shared.LockfileIndex{lockfileIndexes[2]},
+			opts:          ListLockfileIndexesOpts{After: 2, Limit: 2},
+			expected:      []shared.LockfileIndex{lockfileIndexes[2]},
+			expectedCount: 3,
 		},
 		{
-			opts:     ListLockfileIndexesOpts{RepoName: "foo"},
-			expected: []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1]},
+			opts:          ListLockfileIndexesOpts{RepoName: "foo"},
+			expected:      []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1]},
+			expectedCount: 2,
 		},
 		{
-			opts:     ListLockfileIndexesOpts{RepoName: "bar"},
-			expected: []shared.LockfileIndex{lockfileIndexes[2]},
+			opts:          ListLockfileIndexesOpts{RepoName: "bar"},
+			expected:      []shared.LockfileIndex{lockfileIndexes[2]},
+			expectedCount: 1,
 		},
 		{
-			opts:     ListLockfileIndexesOpts{Commit: "cafebabe"},
-			expected: []shared.LockfileIndex{lockfileIndexes[0]},
+			opts:          ListLockfileIndexesOpts{Commit: "cafebabe"},
+			expected:      []shared.LockfileIndex{lockfileIndexes[0]},
+			expectedCount: 1,
 		},
 		{
-			opts:     ListLockfileIndexesOpts{Commit: "d34db33f", RepoName: "bar"},
-			expected: []shared.LockfileIndex{lockfileIndexes[2]},
+			opts:          ListLockfileIndexesOpts{Commit: "d34db33f", RepoName: "bar"},
+			expected:      []shared.LockfileIndex{lockfileIndexes[2]},
+			expectedCount: 1,
 		},
 		{
-			opts:     ListLockfileIndexesOpts{Lockfile: "lock.file"},
-			expected: []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1]},
+			opts:          ListLockfileIndexesOpts{Lockfile: "lock.file"},
+			expected:      []shared.LockfileIndex{lockfileIndexes[0], lockfileIndexes[1]},
+			expectedCount: 2,
 		},
 		{
-			opts:     ListLockfileIndexesOpts{Lockfile: "lock2.file"},
-			expected: []shared.LockfileIndex{lockfileIndexes[2]},
+			opts:          ListLockfileIndexesOpts{Lockfile: "lock2.file"},
+			expected:      []shared.LockfileIndex{lockfileIndexes[2]},
+			expectedCount: 1,
 		},
 	} {
 		lockfiles, err := store.ListLockfileIndexes(ctx, tt.opts)
@@ -1234,7 +1246,16 @@ func TestListLockfileIndexes(t *testing.T) {
 		}
 
 		if diff := cmp.Diff(tt.expected, lockfiles); diff != "" {
-			t.Errorf("unexpected lockfiles (-want +got):\n%s", diff)
+			t.Errorf("[%d] unexpected lockfiles (-want +got):\n%s", i, diff)
+		}
+
+		count, err := store.CountLockfileIndexes(ctx, tt.opts)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+
+		if diff := cmp.Diff(tt.expectedCount, count); diff != "" {
+			t.Errorf("[%d] unexpected lockfiles count (-want +got):\n%s", i, diff)
 		}
 	}
 }

--- a/internal/codeintel/dependencies/mocks_test.go
+++ b/internal/codeintel/dependencies/mocks_test.go
@@ -549,7 +549,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		ListLockfileIndexesFunc: &StoreListLockfileIndexesFunc{
-			defaultHook: func(context.Context, store.ListLockfileIndexesOpts) (r0 []shared.LockfileIndex, r1 error) {
+			defaultHook: func(context.Context, store.ListLockfileIndexesOpts) (r0 []shared.LockfileIndex, r1 int, r2 error) {
 				return
 			},
 		},
@@ -611,7 +611,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		ListLockfileIndexesFunc: &StoreListLockfileIndexesFunc{
-			defaultHook: func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
+			defaultHook: func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error) {
 				panic("unexpected invocation of MockStore.ListLockfileIndexes")
 			},
 		},
@@ -923,24 +923,24 @@ func (c StoreListDependencyReposFuncCall) Results() []interface{} {
 // StoreListLockfileIndexesFunc describes the behavior when the
 // ListLockfileIndexes method of the parent MockStore instance is invoked.
 type StoreListLockfileIndexesFunc struct {
-	defaultHook func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error)
-	hooks       []func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error)
+	defaultHook func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error)
+	hooks       []func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error)
 	history     []StoreListLockfileIndexesFuncCall
 	mutex       sync.Mutex
 }
 
 // ListLockfileIndexes delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockStore) ListLockfileIndexes(v0 context.Context, v1 store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
-	r0, r1 := m.ListLockfileIndexesFunc.nextHook()(v0, v1)
-	m.ListLockfileIndexesFunc.appendCall(StoreListLockfileIndexesFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockStore) ListLockfileIndexes(v0 context.Context, v1 store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error) {
+	r0, r1, r2 := m.ListLockfileIndexesFunc.nextHook()(v0, v1)
+	m.ListLockfileIndexesFunc.appendCall(StoreListLockfileIndexesFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the ListLockfileIndexes
 // method of the parent MockStore instance is invoked and the hook queue is
 // empty.
-func (f *StoreListLockfileIndexesFunc) SetDefaultHook(hook func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error)) {
+func (f *StoreListLockfileIndexesFunc) SetDefaultHook(hook func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -948,7 +948,7 @@ func (f *StoreListLockfileIndexesFunc) SetDefaultHook(hook func(context.Context,
 // ListLockfileIndexes method of the parent MockStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *StoreListLockfileIndexesFunc) PushHook(hook func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error)) {
+func (f *StoreListLockfileIndexesFunc) PushHook(hook func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -956,20 +956,20 @@ func (f *StoreListLockfileIndexesFunc) PushHook(hook func(context.Context, store
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreListLockfileIndexesFunc) SetDefaultReturn(r0 []shared.LockfileIndex, r1 error) {
-	f.SetDefaultHook(func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
-		return r0, r1
+func (f *StoreListLockfileIndexesFunc) SetDefaultReturn(r0 []shared.LockfileIndex, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreListLockfileIndexesFunc) PushReturn(r0 []shared.LockfileIndex, r1 error) {
-	f.PushHook(func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
-		return r0, r1
+func (f *StoreListLockfileIndexesFunc) PushReturn(r0 []shared.LockfileIndex, r1 int, r2 error) {
+	f.PushHook(func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *StoreListLockfileIndexesFunc) nextHook() func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
+func (f *StoreListLockfileIndexesFunc) nextHook() func(context.Context, store.ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1013,7 +1013,10 @@ type StoreListLockfileIndexesFuncCall struct {
 	Result0 []shared.LockfileIndex
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 error
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -1025,7 +1028,7 @@ func (c StoreListLockfileIndexesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreListLockfileIndexesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreLockfileDependenciesFunc describes the behavior when the

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -498,10 +498,6 @@ type ListLockfileIndexesOpts struct {
 	Limit int
 }
 
-func (s *Service) ListLockfileIndexes(ctx context.Context, opts ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
+func (s *Service) ListLockfileIndexes(ctx context.Context, opts ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error) {
 	return s.dependenciesStore.ListLockfileIndexes(ctx, store.ListLockfileIndexesOpts(opts))
-}
-
-func (s *Service) CountLockfileIndexes(ctx context.Context, opts ListLockfileIndexesOpts) (int, error) {
-	return s.dependenciesStore.CountLockfileIndexes(ctx, store.ListLockfileIndexesOpts(opts))
 }

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -488,3 +488,20 @@ func (s *Service) UpsertDependencyRepos(ctx context.Context, deps []Repo) ([]Rep
 func (s *Service) DeleteDependencyReposByID(ctx context.Context, ids ...int) error {
 	return s.dependenciesStore.DeleteDependencyReposByID(ctx, ids...)
 }
+
+type ListLockfileIndexesOpts struct {
+	RepoName string
+	Commit   string
+	Lockfile string
+
+	After int
+	Limit int
+}
+
+func (s *Service) ListLockfileIndexes(ctx context.Context, opts ListLockfileIndexesOpts) ([]shared.LockfileIndex, error) {
+	return s.dependenciesStore.ListLockfileIndexes(ctx, store.ListLockfileIndexesOpts(opts))
+}
+
+func (s *Service) CountLockfileIndexes(ctx context.Context, opts ListLockfileIndexesOpts) (int, error) {
+	return s.dependenciesStore.CountLockfileIndexes(ctx, store.ListLockfileIndexesOpts(opts))
+}

--- a/internal/codeintel/dependencies/transport/graphql/lockfile_index_connection_resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/lockfile_index_connection_resolver.go
@@ -1,0 +1,48 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+)
+
+type LockfileIndexConnectionResolver struct {
+	resolvers  []*LockfileIndexResolver
+	totalCount int
+	nextOffset *int
+}
+
+func NewLockfileIndexConnectionConnection(resolvers []*LockfileIndexResolver, totalCount int, nextOffset *int) *LockfileIndexConnectionResolver {
+	return &LockfileIndexConnectionResolver{
+		resolvers:  resolvers,
+		totalCount: totalCount,
+		nextOffset: nextOffset,
+	}
+}
+
+func (r *LockfileIndexConnectionResolver) Nodes(ctx context.Context) (resolvers []graphqlbackend.LockfileIndexResolver) {
+	resolvers = make([]graphqlbackend.LockfileIndexResolver, len(r.resolvers))
+	for i, r := range r.resolvers {
+		resolvers[i] = r
+	}
+	return resolvers
+}
+
+func (r *LockfileIndexConnectionResolver) TotalCount(ctx context.Context) int32 {
+	return int32(r.totalCount)
+}
+
+func (r *LockfileIndexConnectionResolver) PageInfo(ctx context.Context) *graphqlutil.PageInfo {
+	return graphqlutil.EncodeIntCursor(toInt32(r.nextOffset))
+}
+
+// toInt32 translates the given int pointer into an int32 pointer.
+func toInt32(val *int) *int32 {
+	if val == nil {
+		return nil
+	}
+
+	v := int32(*val)
+	return &v
+}

--- a/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
@@ -1,0 +1,20 @@
+package graphql
+
+import (
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
+)
+
+type LockfileIndexResolver struct {
+	executor shared.LockfileIndex
+}
+
+func NewExecutorResolver(executor shared.LockfileIndex) *LockfileIndexResolver {
+	return &LockfileIndexResolver{executor: executor}
+}
+
+func (e *LockfileIndexResolver) ID() graphql.ID {
+	return relay.MarshalID("LockfileIndex", (int64(e.executor.ID)))
+}

--- a/internal/codeintel/dependencies/transport/graphql/resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/resolver.go
@@ -63,10 +63,11 @@ type params struct {
 	limit int
 }
 
-func validateArgs(args *graphqlbackend.ListLockfileIndexesArgs) (p params, err error) {
+func validateArgs(args *graphqlbackend.ListLockfileIndexesArgs) (params, error) {
+	var p params
 	afterCount, err := graphqlutil.DecodeIntCursor(args.After)
 	if err != nil {
-		return
+		return p, err
 	}
 	p.after = afterCount
 
@@ -76,5 +77,5 @@ func validateArgs(args *graphqlbackend.ListLockfileIndexesArgs) (p params, err e
 	}
 	p.limit = limit
 
-	return
+	return p, nil
 }

--- a/internal/codeintel/dependencies/transport/graphql/resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/resolver.go
@@ -35,12 +35,7 @@ func (r *resolver) LockfileIndexes(ctx context.Context, args *graphqlbackend.Lis
 		Limit: p.limit,
 	}
 
-	lockfileIndexes, err := r.svc.ListLockfileIndexes(ctx, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	totalCount, err := r.svc.CountLockfileIndexes(ctx, opts)
+	lockfileIndexes, totalCount, err := r.svc.ListLockfileIndexes(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codeintel/dependencies/transport/graphql/resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/resolver.go
@@ -1,0 +1,80 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
+	livedependencies "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/live"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+type Resolver interface {
+	LockfileIndexes(ctx context.Context, args *graphqlbackend.ListLockfileIndexesArgs) (graphqlbackend.LockfileIndexConnectionResolver, error)
+}
+
+type resolver struct {
+	svc *dependencies.Service
+}
+
+func New(db database.DB) Resolver {
+	return &resolver{
+		svc: livedependencies.GetService(db, livedependencies.NewSyncer()),
+	}
+}
+
+func (r *resolver) LockfileIndexes(ctx context.Context, args *graphqlbackend.ListLockfileIndexesArgs) (graphqlbackend.LockfileIndexConnectionResolver, error) {
+	p, err := validateArgs(args)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := dependencies.ListLockfileIndexesOpts{
+		After: p.after,
+		Limit: p.limit,
+	}
+
+	lockfileIndexes, err := r.svc.ListLockfileIndexes(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	totalCount, err := r.svc.CountLockfileIndexes(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvers := make([]*LockfileIndexResolver, 0, len(lockfileIndexes))
+	for _, executor := range lockfileIndexes {
+		resolvers = append(resolvers, NewExecutorResolver(executor))
+	}
+
+	nextOffset := graphqlutil.NextOffset(p.after, len(lockfileIndexes), totalCount)
+	lockfileIndexesConnection := NewLockfileIndexConnectionConnection(resolvers, totalCount, nextOffset)
+
+	return lockfileIndexesConnection, nil
+}
+
+const DefaultLockfileIndexesLimit = 50
+
+type params struct {
+	after int
+	limit int
+}
+
+func validateArgs(args *graphqlbackend.ListLockfileIndexesArgs) (p params, err error) {
+	afterCount, err := graphqlutil.DecodeIntCursor(args.After)
+	if err != nil {
+		return
+	}
+	p.after = afterCount
+
+	limit := DefaultLockfileIndexesLimit
+	if args.First != 0 {
+		limit = int(args.First)
+	}
+	p.limit = limit
+
+	return
+}


### PR DESCRIPTION
This is just a tiny resolver and a lot of boilerplate. I'll need to extend the LockfileIndex resolver to have more attributes, etc.

But I want to get this in because there's so much boilerplate and high chance of yak-shaving around how to hook up services, resolvers, etc.

What's in here is a mixture of the `executors` resolvers and the patterns we have in other resolvers, such as the `codeintel` or `batches` resolvers.

## Test plan

- Existing and new tests added in this PR
- Manual testing in API console