### PR TITLE
fix empty values in compute results processing

### DIFF
--- a/enterprise/internal/insights/query/streaming/decoder.go
+++ b/enterprise/internal/insights/query/streaming/decoder.go
@@ -168,6 +168,9 @@ func MatchContextComputeDecoder() (client.ComputeMatchContextStreamDecoder, *Com
 				for _, match := range result.Matches {
 					for _, data := range match.Environment {
 						value := data.Value
+						if value == "" {
+							continue // a bug in upstream compute processing means we need to check for empty replacements (https://github.com/sourcegraph/sourcegraph/issues/37972)
+						}
 						if len(value) > capturedValueMaxLength {
 							value = value[:capturedValueMaxLength]
 						}
@@ -226,6 +229,9 @@ func ComputeTextDecoder() (client.ComputeTextExtraStreamDecoder, *ComputeTabulat
 			for _, result := range results {
 				vals := strings.Split(result.Value, "\n")
 				for _, val := range vals {
+					if val == "" {
+						continue // a bug in upstream compute processing means we need to check for empty replacements (https://github.com/sourcegraph/sourcegraph/issues/37972)
+					}
 					current := getRepoCounts(result)
 					value := val
 					if len(value) > capturedValueMaxLength {

--- a/enterprise/internal/insights/resolvers/live_preview_resolvers.go
+++ b/enterprise/internal/insights/resolvers/live_preview_resolvers.go
@@ -56,16 +56,18 @@ func (r *Resolver) SearchInsightPreview(ctx context.Context, args graphqlbackend
 		var err error
 
 		if seriesArgs.GeneratedFromCaptureGroups {
-			executor := query.NewCaptureGroupExecutor(r.postgresDB, clock)
-			series, err = executor.Execute(ctx, seriesArgs.Query, repos, interval)
-			if err != nil {
-				return nil, err
-			}
-		} else if seriesArgs.GroupBy != nil {
-			executor := query.NewComputeExecutor(r.postgresDB, clock)
-			series, err = executor.Execute(ctx, seriesArgs.Query, *seriesArgs.GroupBy, repos)
-			if err != nil {
-				return nil, err
+			if seriesArgs.GroupBy != nil {
+				executor := query.NewComputeExecutor(r.postgresDB, clock)
+				series, err = executor.Execute(ctx, seriesArgs.Query, *seriesArgs.GroupBy, repos)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				executor := query.NewCaptureGroupExecutor(r.postgresDB, clock)
+				series, err = executor.Execute(ctx, seriesArgs.Query, repos, interval)
+				if err != nil {
+					return nil, err
+				}
 			}
 		} else {
 			executor := query.NewStreamingExecutor(r.postgresDB, clock)


### PR DESCRIPTION
This PR has 2 fixes:
1. Filters empty compute results caused by https://github.com/sourcegraph/sourcegraph/issues/37972
2. Refactored the live preview for compute group insights to require `generatedByCaptureGroups` as well as `groupBy`


## Test plan

Before

``` json
{
  "data": {
    "searchInsightLivePreview": [
      {
        "points": [
          {
            "value": 72,
            "dateTime": "2022-07-14T15:35:47Z"
          }
        ],
        "label": "Go"
      },
      {
        "points": [
          {
            "value": 67,
            "dateTime": "2022-07-14T15:35:47Z"
          }
        ],
        "label": ""
      },
      {
        "points": [
          {
            "value": 49,
            "dateTime": "2022-07-14T15:35:47Z"
          }
        ],
        "label": "Markdown"
      },
      {
        "points": [
          {
            "value": 12,
            "dateTime": "2022-07-14T15:35:47Z"
          }
        ],
        "label": "JSON"
      },
      {
        "points": [
          {
            "value": 10,
            "dateTime": "2022-07-14T15:35:47Z"
          }
        ],
        "label": "PLSQL"
      },
      {
        "points": [
          {
            "value": 3,
            "dateTime": "2022-07-14T15:35:47Z"
          }
        ],
        "label": "Shell"
      }
    ]
  }
}
```

After

``` json
{
  "data": {
    "searchInsightLivePreview": [
      {
        "points": [
          {
            "value": 72,
            "dateTime": "2022-07-14T15:37:26Z"
          }
        ],
        "label": "Go"
      },
      {
        "points": [
          {
            "value": 49,
            "dateTime": "2022-07-14T15:37:26Z"
          }
        ],
        "label": "Markdown"
      },
      {
        "points": [
          {
            "value": 12,
            "dateTime": "2022-07-14T15:37:26Z"
          }
        ],
        "label": "JSON"
      },
      {
        "points": [
          {
            "value": 10,
            "dateTime": "2022-07-14T15:37:26Z"
          }
        ],
        "label": "PLSQL"
      },
      {
        "points": [
          {
            "value": 3,
            "dateTime": "2022-07-14T15:37:26Z"
          }
        ],
        "label": "Shell"
      }
    ]
  }
}
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
