### PR TITLE
[Admin Analytics] update code intel stats

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -13,7 +13,8 @@ export type FeatureFlagName =
     | 'ab-email-verification-alert'
     | 'hide-run-batch-spec-for-mi'
     | 'contrast-compliant-syntax-highlighting'
-    | 'admin-analytics-enabled'
+    | 'admin-analytics-disabled'
+    | 'admin-analytics-cache-disabled'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -131,9 +131,9 @@ function useCalculatedNavLinkVariant(
 }
 
 const AnalyticsNavItem: React.FunctionComponent = () => {
-    const [isAdminAnalyticsEnabled] = useFeatureFlag('admin-analytics-enabled', false)
+    const [isAdminAnalyticsDisabled] = useFeatureFlag('admin-analytics-disabled', false)
 
-    if (!isAdminAnalyticsEnabled) {
+    if (isAdminAnalyticsDisabled) {
         return null
     }
 

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -163,14 +163,14 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
         }
     }, [pathname])
 
-    const [isAdminAnalyticsEnabled] = useFeatureFlag('admin-analytics-enabled', false)
+    const [isAdminAnalyticsDisabled] = useFeatureFlag('admin-analytics-disabled', false)
 
     const adminSideBarGroups = useMemo(
-        () => (isAdminAnalyticsEnabled ? [analyticsGroup, ...props.sideBarGroups] : props.sideBarGroups),
-        [isAdminAnalyticsEnabled, props.sideBarGroups]
+        () => (!isAdminAnalyticsDisabled ? [analyticsGroup, ...props.sideBarGroups] : props.sideBarGroups),
+        [isAdminAnalyticsDisabled, props.sideBarGroups]
     )
-    const routes = useMemo(() => (isAdminAnalyticsEnabled ? [...analyticsRoutes, ...props.routes] : props.routes), [
-        isAdminAnalyticsEnabled,
+    const routes = useMemo(() => (!isAdminAnalyticsDisabled ? [...analyticsRoutes, ...props.routes] : props.routes), [
+        isAdminAnalyticsDisabled,
         props.routes,
     ])
 

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -46,6 +46,8 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
         const {
             referenceClicks,
             definitionClicks,
+            inAppEvents,
+            codeHostEvents,
             searchBasedEvents,
             preciseEvents,
             crossRepoEvents,
@@ -115,18 +117,18 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
             value: totalEvents,
             items: [
                 {
-                    label: 'Search based',
+                    label: 'In app code navigation',
                     minPerItem: 0.5,
-                    value: Math.floor((searchBasedEvents.summary.totalCount * totalEvents) / totalHoverEvents || 0),
+                    value: inAppEvents.summary.totalCount,
                     description:
-                        'Searched based code intel reconizes symbols and is supported across all languages. Search intel events are not exact, thus their time savings is not as high as precise events. ',
+                        'In app code navigation supports developers find the impact of a change by listing references and finding definitions to reference.',
                 },
                 {
-                    label: 'Precise events',
-                    minPerItem: 1,
-                    value: Math.floor((preciseEvents.summary.totalCount * totalEvents) / totalHoverEvents || 0),
+                    label: 'Code intel on code hosts <br/> via the browser extension',
+                    minPerItem: 1.5,
+                    value: codeHostEvents.summary.totalCount,
                     description:
-                        'Compiler-accurate code intel takes users to the correct result as defined by SCIP, and does so cross repository. The reduction in false positives produced by other search engines represents significant time savings.',
+                        'Intel events on the code host typically occur during PR reviews, where the ability to quickly understand code is key to efficient reviews.',
                 },
                 {
                     label: 'Cross repository <br/> code intel events',
@@ -134,6 +136,16 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                     value: Math.floor((crossRepoEvents.summary.totalCount * totalEvents) / totalHoverEvents || 0),
                     description:
                         'Cross repository code intel identifies the correct symbol in code throughout your entire code base in a single click, without locating and downloading a repository.',
+                },
+                {
+                    label: 'Precise code intel',
+                    minPerItem: 1,
+                    value: Math.floor((preciseEvents.summary.totalCount * totalEvents) / totalHoverEvents || 0),
+                    eventsLabel: `Events (${Math.floor(
+                        (preciseEvents.summary.totalCount * 100) / totalHoverEvents || 0
+                    )}%)*`,
+                    description:
+                        'Compiler-accurate code intel takes users to the correct result as defined by SCIP, and does so cross repository. The reduction in false positives produced by other search engines represents significant additional time savings.',
                 },
             ],
         }
@@ -153,7 +165,6 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
     const totalUsers = data?.users?.totalCount || 0
     const browserExtensionInstalls =
         data?.site.analytics.codeIntel.browserExtensionInstalls.summary.totalRegisteredUsers || 0
-    const browserExtensionInstallPercentage = totalUsers ? (browserExtensionInstalls * 100) / totalUsers : 0
 
     return (
         <>
@@ -210,7 +221,8 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                     <div className={classNames(styles.border, 'mb-3')} />
                     <ul className="mb-3 pl-3">
                         <Text as="li">
-                            <b>{browserExtensionInstallPercentage}%</b> of users have installed the browser extension.{' '}
+                            <b>{browserExtensionInstalls}</b> {browserExtensionInstalls === 1 ? 'user' : 'users'} have
+                            installed the browser extension.{' '}
                             <AnchorLink to="/help/integration/browser_extension" target="_blank">
                                 Promote installation of the browser extesion to increase value.
                             </AnchorLink>
@@ -232,6 +244,7 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
             </Card>
             <Text className="font-italic text-center mt-2">
                 All events are generated from entries in the event logs table and are updated every 24 hours.
+                <br />* Calculated from precise code intel events
             </Text>
         </>
     )

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -121,7 +121,7 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                     minPerItem: 0.5,
                     value: inAppEvents.summary.totalCount,
                     description:
-                        'In app code navigation supports developers find the impact of a change by listing references and finding definitions to reference.',
+                        'In app code navigation supports developers finding the impact of a change by listing references and finding definitions to reference.',
                 },
                 {
                     label: 'Code intel on code hosts <br/> via the browser extension',

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -162,7 +162,6 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
     }
 
     const repos = data?.site.analytics.repos
-    const totalUsers = data?.users?.totalCount || 0
     const browserExtensionInstalls =
         data?.site.analytics.codeIntel.browserExtensionInstalls.summary.totalRegisteredUsers || 0
 

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
@@ -16,9 +16,6 @@ const analyticsStatItemFragment = gql`
 
 export const CODEINTEL_STATISTICS = gql`
     query CodeIntelStatistics($dateRange: AnalyticsDateRange!) {
-        users {
-            totalCount
-        }
         site {
             analytics {
                 repos {

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
@@ -32,6 +32,16 @@ export const CODEINTEL_STATISTICS = gql`
                     definitionClicks {
                         ...AnalyticsStatItemFragment
                     }
+                    inAppEvents {
+                        summary {
+                            totalCount
+                        }
+                    }
+                    codeHostEvents {
+                        summary {
+                            totalCount
+                        }
+                    }
                     browserExtensionInstalls {
                         summary {
                             totalRegisteredUsers

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 
 import { useQuery } from '@sourcegraph/http-client'
+import { AlertType } from '@sourcegraph/shared/src/graphql-operations'
 import { Card, LoadingSpinner, useMatchMedia, Text } from '@sourcegraph/wildcard'
 
 import { LineChart, Series } from '../../../charts'
@@ -138,7 +139,8 @@ export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>
                     alert={{
                         message:
                             'Note these charts are experimental. For billing information, use [usage stats](/site-admin/usage-statistics).',
-                        type: 'INFO',
+                        type: AlertType.INFO,
+                        isDismissibleWithKey: '',
                     }}
                     className="my-3"
                 />

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -8,6 +8,7 @@ import { Card, LoadingSpinner, useMatchMedia, Text } from '@sourcegraph/wildcard
 
 import { LineChart, Series } from '../../../charts'
 import { BarChart } from '../../../charts/components/bar-chart/BarChart'
+import { GlobalAlert } from '../../../global/GlobalAlert'
 import { AnalyticsDateRange, UsersStatisticsResult, UsersStatisticsVariables } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
@@ -133,6 +134,14 @@ export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>
                         ]}
                     />
                 </div>
+                <GlobalAlert
+                    alert={{
+                        message:
+                            'Note these charts are experimental. For billing information, use [usage stats](/site-admin/usage-statistics).',
+                        type: 'INFO',
+                    }}
+                    className="my-3"
+                />
                 {legends && <ValueLegendList className="mb-3" items={legends} />}
                 {activities && (
                     <div>

--- a/client/web/src/site-admin/analytics/components/TimeSavedCalculatorGroup.tsx
+++ b/client/web/src/site-admin/analytics/components/TimeSavedCalculatorGroup.tsx
@@ -15,6 +15,7 @@ interface TimeSavedCalculatorGroupItem {
     description: string
     percentage?: number
     hoursSaved?: number
+    eventsLabel?: string
 }
 
 interface TimeSavedCalculatorGroupProps {
@@ -121,54 +122,62 @@ export const TimeSavedCalculatorGroup: React.FunctionComponent<TimeSavedCalculat
                 </div>
             </Card>
             <div className={styles.calculatorList}>
-                {memoizedItems.map(({ label, percentage, minPerItem, hoursSaved, value, description }, index) => (
-                    <React.Fragment key={label}>
-                        <Text
-                            className="text-nowrap d-flex align-items-center"
-                            dangerouslySetInnerHTML={{ __html: label }}
-                        />
-                        {!!percentage && percentage >= 0 ? (
+                {memoizedItems.map(
+                    (
+                        { label, percentage, minPerItem, hoursSaved, value, description, eventsLabel = 'Events' },
+                        index
+                    ) => (
+                        <React.Fragment key={label}>
+                            <Text
+                                className="text-nowrap d-flex align-items-center"
+                                dangerouslySetInnerHTML={{ __html: label }}
+                            />
+                            {!!percentage && percentage >= 0 ? (
+                                <div className="d-flex flex-column align-items-center justify-content-center">
+                                    <Input
+                                        type="number"
+                                        value={percentage}
+                                        className={classNames(styles.calculatorInput, 'mb-1')}
+                                        onChange={event => updatePercentage(index, Number(event.target.value))}
+                                    />
+                                    <Text as="span">% of total</Text>
+                                </div>
+                            ) : (
+                                <div className="d-flex flex-column align-items-center justify-content-center">
+                                    <Text as="span" weight="bold" className={styles.countBoxValue}>
+                                        {formatNumber(value)}
+                                    </Text>
+                                    <Text as="span" alignment="center">
+                                        {eventsLabel}
+                                    </Text>
+                                </div>
+                            )}
                             <div className="d-flex flex-column align-items-center justify-content-center">
                                 <Input
                                     type="number"
-                                    value={percentage}
+                                    value={minPerItem}
                                     className={classNames(styles.calculatorInput, 'mb-1')}
-                                    onChange={event => updatePercentage(index, Number(event.target.value))}
+                                    onChange={event => updateMinPerItem(index, Number(event.target.value))}
                                 />
-                                <Text as="span">% of total</Text>
+                                <Text as="span" className="text-nowrap">
+                                    Minutes per
+                                </Text>
                             </div>
-                        ) : (
                             <div className="d-flex flex-column align-items-center justify-content-center">
                                 <Text as="span" weight="bold" className={styles.countBoxValue}>
-                                    {formatNumber(value)}
+                                    {formatNumber(hoursSaved)}
                                 </Text>
                                 <Text as="span" alignment="center">
-                                    Events
+                                    Hours saved
                                 </Text>
                             </div>
-                        )}
-                        <div className="d-flex flex-column align-items-center justify-content-center">
-                            <Input
-                                type="number"
-                                value={minPerItem}
-                                className={classNames(styles.calculatorInput, 'mb-1')}
-                                onChange={event => updateMinPerItem(index, Number(event.target.value))}
+                            <Text
+                                dangerouslySetInnerHTML={{ __html: description }}
+                                className="d-flex align-items-center"
                             />
-                            <Text as="span" className="text-nowrap">
-                                Minutes per
-                            </Text>
-                        </div>
-                        <div className="d-flex flex-column align-items-center justify-content-center">
-                            <Text as="span" weight="bold" className={styles.countBoxValue}>
-                                {formatNumber(hoursSaved)}
-                            </Text>
-                            <Text as="span" alignment="center">
-                                Hours saved
-                            </Text>
-                        </div>
-                        <Text dangerouslySetInnerHTML={{ __html: description }} className="d-flex align-items-center" />
-                    </React.Fragment>
-                ))}
+                        </React.Fragment>
+                    )
+                )}
             </div>
         </div>
     )

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6057,6 +6057,14 @@ type AnalyticsCodeIntelResult {
     """
     definitionClicks: AnalyticsStatItem!
     """
+    Code Intel events made from web
+    """
+    inAppEvents: AnalyticsStatItem!
+    """
+    Code Intel events made from code host
+    """
+    codeHostEvents: AnalyticsStatItem!
+    """
     Browser extension installs
     """
     browserExtensionInstalls: AnalyticsStatItem!

--- a/cmd/frontend/graphqlbackend/site_analytics.go
+++ b/cmd/frontend/graphqlbackend/site_analytics.go
@@ -21,8 +21,8 @@ func (r *siteResolver) Analytics(ctx context.Context) (*siteAnalyticsResolver, e
 		return nil, err
 	}
 
-	if !featureflag.FromContext(ctx).GetBoolOr("admin-analytics-enabled", false) {
-		return nil, errors.New("'admin-analytics-enabled' feature flag is not enabled")
+	if featureflag.FromContext(ctx).GetBoolOr("admin-analytics-disabled", false) {
+		return nil, errors.New("'admin-analytics-disabled' feature flag is enabled")
 	}
 
 	cache := !featureflag.FromContext(ctx).GetBoolOr("admin-analytics-cache-disabled", false)

--- a/internal/adminanalytics/cache.go
+++ b/internal/adminanalytics/cache.go
@@ -129,7 +129,7 @@ func StartAnalyticsCacheRefresh(ctx context.Context, db database.DB) {
 
 	const delay = 24 * time.Hour
 	for {
-		if featureflag.FromContext(ctx).GetBoolOr("admin-analytics-enabled", false) {
+		if !featureflag.FromContext(ctx).GetBoolOr("admin-analytics-disabled", false) {
 			if err := refreshAnalyticsCache(ctx, db); err != nil {
 				logger.Error("Error refreshing admin analytics cache", log.Error(err))
 			}

--- a/internal/adminanalytics/codeintel.go
+++ b/internal/adminanalytics/codeintel.go
@@ -3,6 +3,7 @@ package adminanalytics
 import (
 	"context"
 
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
@@ -40,6 +41,40 @@ func (s *CodeIntel) DefinitionClicks() (*AnalyticsFetcher, error) {
 		nodesQuery:   nodesQuery,
 		summaryQuery: summaryQuery,
 		group:        "CodeIntel:DefinitionClicks",
+		cache:        s.Cache,
+	}, nil
+}
+
+func (s *CodeIntel) InAppEvents() (*AnalyticsFetcher, error) {
+	sourceCond := sqlf.Sprintf("source = 'WEB'")
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, []string{"goToDefinition.preloaded", "goToDefinition", "findReferences"}, sourceCond)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AnalyticsFetcher{
+		db:           s.DB,
+		dateRange:    s.DateRange,
+		nodesQuery:   nodesQuery,
+		summaryQuery: summaryQuery,
+		group:        "CodeIntel:InAppEvents",
+		cache:        s.Cache,
+	}, nil
+}
+
+func (s *CodeIntel) CodeHostEvents() (*AnalyticsFetcher, error) {
+	sourceCond := sqlf.Sprintf("source = 'CODEHOSTINTEGRATION'")
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, []string{"goToDefinition.preloaded", "goToDefinition", "findReferences"}, sourceCond)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AnalyticsFetcher{
+		db:           s.DB,
+		dateRange:    s.DateRange,
+		nodesQuery:   nodesQuery,
+		summaryQuery: summaryQuery,
+		group:        "CodeIntel:CodeHostEvents",
 		cache:        s.Cache,
 	}, nil
 }

--- a/internal/adminanalytics/search.go
+++ b/internal/adminanalytics/search.go
@@ -82,7 +82,7 @@ func (s *Search) FileOpens() (*AnalyticsFetcher, error) {
 }
 
 func (s *Search) CacheAll(ctx context.Context) error {
-	fetcherBuilders := []func() (*AnalyticsFetcher, error){s.Searches, s.FileViews, s.FileOpens}
+	fetcherBuilders := []func() (*AnalyticsFetcher, error){s.Searches, s.FileViews, s.FileOpens, s.ResultClicks}
 	for _, buildFetcher := range fetcherBuilders {
 		fetcher, err := buildFetcher()
 		if err != nil {

--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -69,7 +69,7 @@ FROM
 %s
 `
 
-func makeEventLogsQueries(dateRange string, events []string) (*sqlf.Query, *sqlf.Query, error) {
+func makeEventLogsQueries(dateRange string, events []string, conditions ...*sqlf.Query) (*sqlf.Query, *sqlf.Query, error) {
 	dateTruncExp, dateBetweenCond, err := makeDateParameters(dateRange, "timestamp")
 	if err != nil {
 		return nil, nil, err
@@ -78,6 +78,10 @@ func makeEventLogsQueries(dateRange string, events []string) (*sqlf.Query, *sqlf
 	conds := []*sqlf.Query{
 		sqlf.Sprintf("anonymous_user_id <> 'backend'"),
 		sqlf.Sprintf("timestamp %s", dateBetweenCond),
+	}
+
+	if len(conditions) > 0 {
+		conds = append(conds, conditions...)
 	}
 
 	if len(events) > 0 {


### PR DESCRIPTION
- [x] Update code intel stats to show in app vs code host events
- [x] Add alert on users stats page to mention that its experimental
- [x] Flip working on feature flag to make admin analytics enabled by default

### Users Stats

<img width="960" alt="CleanShot 2022-07-14 at 22 47 34@2x" src="https://user-images.githubusercontent.com/22571395/179044037-2b668eea-77c4-430e-805d-715dbf38a6b4.png">

### Code Intel Stats

<img width="945" alt="CleanShot 2022-07-14 at 22 47 54@2x" src="https://user-images.githubusercontent.com/22571395/179044083-18792e85-7e63-450e-8493-04fc8c81b5da.png">

## Test plan

- visit https://sourcegraph.test:3443/site-admin/analytics/code-intel
- visit https://sourcegraph.test:3443/site-admin/analytics/users
