### PR TITLE
dev/sg: implement 'sg ops update-images -k compose'

### DIFF
--- a/dev/sg/internal/images/compose.go
+++ b/dev/sg/internal/images/compose.go
@@ -1,0 +1,107 @@
+package images
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+	"gopkg.in/yaml.v3"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/group"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+// UpdateCompose walks all `*docker-compose.yaml` files and updates Sourcegraph images
+// in each.
+func UpdateCompose(path string, creds credentials.Credentials, pinTag string) error {
+	var checked int
+	if err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.Contains(d.Name(), "docker-compose.yaml") {
+			return nil
+		}
+
+		composeFile, err := os.ReadFile(path)
+		if err != nil {
+			return errors.Wrapf(err, "couldn't read %s", path)
+		}
+
+		checked++
+		newComposeFile, err := updateComposeFile(composeFile, creds, pinTag)
+		if err != nil {
+			return err
+		}
+		if newComposeFile == nil {
+			std.Out.WriteSkippedf("No updates to make to %s", d.Name())
+			return nil
+		}
+
+		if err := os.WriteFile(path, composeFile, 0644); err != nil {
+			return errors.Newf("WriteFile: %w", err)
+		}
+
+		std.Out.WriteSuccessf("%s updated!", path)
+		return nil
+	}); err != nil {
+		return err
+	}
+	if checked == 0 {
+		return errors.New("no valid docker-compose files found")
+	}
+
+	return nil
+}
+
+// updateComposeFile updates composeFile data and returns it.
+func updateComposeFile(composeFile []byte, creds credentials.Credentials, pinTag string) ([]byte, error) {
+	var compose map[string]any
+	if err := yaml.Unmarshal(composeFile, &compose); err != nil {
+		return nil, err
+	}
+
+	type replace struct {
+		original string
+		new      string
+	}
+	checks := group.NewWithResults[*replace]().WithConcurrencyLimiter(group.NewBasicLimiter(10))
+	for name, entry := range compose["services"].(map[string]any) {
+		service := entry.(map[string]any)
+		name := name
+		checks.Go(func() *replace {
+			originalImage := service["image"].(string)
+			newImage, err := getUpdatedSourcegraphImage(originalImage, creds, pinTag)
+			if err != nil {
+				std.Out.WriteWarningf("%s: %s", name, err)
+				return nil
+			}
+
+			std.Out.VerboseLine(output.Styledf(output.StylePending, "%s: will update to %s", name, newImage))
+			return &replace{
+				original: originalImage,
+				new:      newImage,
+			}
+		})
+	}
+
+	replaceOps := checks.Wait()
+	var updates int
+	for _, r := range replaceOps {
+		if r == nil {
+			continue
+		}
+		composeFile = bytes.ReplaceAll(composeFile, []byte(r.original), []byte(r.new))
+		updates++
+	}
+	if updates == 0 {
+		return nil, nil
+	}
+
+	return composeFile, nil
+}

--- a/dev/sg/internal/images/compose.go
+++ b/dev/sg/internal/images/compose.go
@@ -76,7 +76,7 @@ func updateComposeFile(composeFile []byte, creds credentials.Credentials, pinTag
 		original string
 		new      string
 	}
-	checks := group.NewWithResults[*replace]().WithConcurrencyLimiter(group.NewBasicLimiter(10))
+	checks := group.NewWithResults[*replace]().WithMaxConcurrency(10)
 	for name, entry := range services {
 		name := name
 		service, ok := entry.(map[string]any)

--- a/dev/sg/internal/images/compose.go
+++ b/dev/sg/internal/images/compose.go
@@ -89,6 +89,7 @@ func updateComposeFile(composeFile []byte, creds credentials.Credentials, pinTag
 			originalImage, ok := service["image"].(string)
 			if !ok {
 				std.Out.WriteWarningf("%s: invalid image", name)
+				return nil
 			}
 
 			newImage, err := getUpdatedSourcegraphImage(originalImage, creds, pinTag)

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -34,9 +34,16 @@ var (
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "kind",
+				Aliases:     []string{"k"},
 				Usage:       "the `kind` of deployment (one of 'k8s', 'helm', 'compose')",
 				Value:       string(images.DeploymentTypeK8S),
 				Destination: &opsUpdateImagesDeploymentKindFlag,
+			},
+			&cli.StringFlag{
+				Name:        "pin-tag",
+				Aliases:     []string{"t"},
+				Usage:       "pin all images to a specific sourcegraph `tag` (e.g. 3.36.2, insiders)",
+				Destination: &opsUpdateImagesPinTagFlag,
 			},
 			&cli.StringFlag{
 				Name:        "cr-username",
@@ -47,11 +54,6 @@ var (
 				Name:        "cr-password",
 				Usage:       "`password` or access token for the container registry",
 				Destination: &opsUpdateImagesContainerRegistryPasswordFlag,
-			},
-			&cli.StringFlag{
-				Name:        "pin-tag",
-				Usage:       "pin all images to a specific sourcegraph `tag` (e.g. 3.36.2, insiders)",
-				Destination: &opsUpdateImagesPinTagFlag,
 			},
 		},
 		Action: opsUpdateImage,

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -34,7 +34,7 @@ var (
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "kind",
-				Usage:       "the `kind` of deployment (one of 'k8s', 'helm')",
+				Usage:       "the `kind` of deployment (one of 'k8s', 'helm', 'compose')",
 				Value:       string(images.DeploymentTypeK8S),
 				Destination: &opsUpdateImagesDeploymentKindFlag,
 			},
@@ -91,5 +91,5 @@ func opsUpdateImage(ctx *cli.Context) error {
 		std.Out.WriteWarningf("Falling back to the latest deveopment build available.")
 	}
 
-	return images.Parse(args[0], *dockerCredentials, images.DeploymentType(opsUpdateImagesDeploymentKindFlag), opsUpdateImagesPinTagFlag)
+	return images.Update(args[0], *dockerCredentials, images.DeploymentType(opsUpdateImagesDeploymentKindFlag), opsUpdateImagesPinTagFlag)
 }

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1063,8 +1063,8 @@ Flags:
 * `--cr-password="<value>"`: `password` or access token for the container registry
 * `--cr-username="<value>"`: `username` for the container registry
 * `--feedback`: provide feedback about this command by opening up a Github discussion
-* `--kind="<value>"`: the `kind` of deployment (one of 'k8s', 'helm') (default: k8s)
-* `--pin-tag="<value>"`: pin all images to a specific sourcegraph `tag` (e.g. 3.36.2, insiders)
+* `--kind, -k="<value>"`: the `kind` of deployment (one of 'k8s', 'helm', 'compose') (default: k8s)
+* `--pin-tag, -t="<value>"`: pin all images to a specific sourcegraph `tag` (e.g. 3.36.2, insiders)
 
 ## sg analytics
 


### PR DESCRIPTION
Allows `sg ops update-images` to work on Compose manifests.

From a hack session with @davejrt where we tried to deploy otel-collector in a compose deployment - to try opentelemetry we needed the latest insiders images.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
go build -o ../deploy-sourcegraph-docker/sg ./dev/sg
```

then in `deploy-sourcegraph-docker`:

```
./sg -v ops update-images -k compose -t insiders ./docker-compose
```