### PR TITLE
dev/sg: clarify behaviour of -t='', optimize getUpdatedImage

### DIFF
--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -449,16 +449,18 @@ func createAndFillImageRepository(ref *ImageReference, pinTag string) (repo *ima
 	return repo, nil
 }
 
-// MainTag is a structured representation of a parsed tag of MainBranchTagPublishFormat
-type MainTag struct {
+// ParsedMainBranchImageTag is a structured representation of a parsed tag created by
+// images.ParsedMainBranchImageTag.
+type ParsedMainBranchImageTag struct {
 	buildNum  int
 	date      string
 	shortSHA1 string
 }
 
-// ParseMainTag creates MainTag structs for strings that follow MainBranchTagPublishFormat
-func ParseMainTag(t string) (*MainTag, error) {
-	s := MainTag{}
+// ParseMainBranchImageTag creates MainTag structs for tags created by
+// images.MainBranchImageTag.
+func ParseMainBranchImageTag(t string) (*ParsedMainBranchImageTag, error) {
+	s := ParsedMainBranchImageTag{}
 	t = strings.TrimSpace(t)
 	var err error
 	n := strings.Split(t, "_")
@@ -482,7 +484,7 @@ func findLatestMainTag(tags []string) (string, error) {
 
 	var errs error
 	for _, tag := range tags {
-		stag, err := ParseMainTag(tag)
+		stag, err := ParseMainBranchImageTag(tag)
 		if err != nil {
 			errs = errors.Append(errs, err)
 			continue

--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -449,6 +449,7 @@ func createAndFillImageRepository(ref *ImageReference, pinTag string) (repo *ima
 	return repo, nil
 }
 
+// MainTag is a structured representation of a parsed tag of MainBranchTagPublishFormat
 type MainTag struct {
 	buildNum  int
 	date      string

--- a/dev/sg/internal/images/images_test.go
+++ b/dev/sg/internal/images/images_test.go
@@ -3,7 +3,18 @@ package images
 import (
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"
 )
+
+func mustTime() time.Time {
+	t, err := time.Parse("2006-01-02", "2006-01-02")
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
 
 func TestParseTag(t *testing.T) {
 	tests := []struct {
@@ -27,6 +38,16 @@ func TestParseTag(t *testing.T) {
 			"3.25.5",
 			nil,
 			true,
+		},
+		{
+			"from constructor",
+			images.MainBranchImageTag(mustTime(), "abcde", 1234),
+			&MainTag{
+				buildNum:  1234,
+				date:      "2006-01-02",
+				shortSHA1: "abcde",
+			},
+			false,
 		},
 	}
 	for _, tt := range tests {

--- a/dev/sg/internal/images/images_test.go
+++ b/dev/sg/internal/images/images_test.go
@@ -9,13 +9,13 @@ func TestParseTag(t *testing.T) {
 	tests := []struct {
 		name    string
 		tag     string
-		want    *SgImageTag
+		want    *MainTag
 		wantErr bool
 	}{
 		{
 			"base",
 			"12345_2021-01-02_abcdefghijkl",
-			&SgImageTag{
+			&MainTag{
 				buildNum:  12345,
 				date:      "2021-01-02",
 				shortSHA1: "abcdefghijkl",
@@ -31,7 +31,7 @@ func TestParseTag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseTag(tt.tag)
+			got, err := ParseMainTag(tt.tag)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseTag() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -63,7 +63,7 @@ func Test_findLatestTag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := findLatestTag(tt.tags); got != tt.want {
+			if got, _ := findLatestMainTag(tt.tags); got != tt.want {
 				t.Errorf("findLatestTag() = %v, want %v", got, tt.want)
 			}
 		})

--- a/dev/sg/internal/images/images_test.go
+++ b/dev/sg/internal/images/images_test.go
@@ -20,13 +20,13 @@ func TestParseTag(t *testing.T) {
 	tests := []struct {
 		name    string
 		tag     string
-		want    *MainTag
+		want    *ParsedMainBranchImageTag
 		wantErr bool
 	}{
 		{
 			"base",
 			"12345_2021-01-02_abcdefghijkl",
-			&MainTag{
+			&ParsedMainBranchImageTag{
 				buildNum:  12345,
 				date:      "2021-01-02",
 				shortSHA1: "abcdefghijkl",
@@ -42,7 +42,7 @@ func TestParseTag(t *testing.T) {
 		{
 			"from constructor",
 			images.MainBranchImageTag(mustTime(), "abcde", 1234),
-			&MainTag{
+			&ParsedMainBranchImageTag{
 				buildNum:  1234,
 				date:      "2006-01-02",
 				shortSHA1: "abcde",
@@ -52,7 +52,7 @@ func TestParseTag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseMainTag(tt.tag)
+			got, err := ParseMainBranchImageTag(tt.tag)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseTag() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -42,7 +42,7 @@ var (
 			&cli.StringFlag{
 				Name:        "pin-tag",
 				Aliases:     []string{"t"},
-				Usage:       "pin all images to a specific sourcegraph `tag` (e.g. 3.36.2, insiders)",
+				Usage:       "pin all images to a specific sourcegraph `tag` (e.g. '3.36.2', 'insiders') (default: latest main branch tag)",
 				Destination: &opsUpdateImagesPinTagFlag,
 			},
 			&cli.StringFlag{
@@ -83,14 +83,13 @@ func opsUpdateImage(ctx *cli.Context) error {
 			dockerCredentials.Username = ""
 			dockerCredentials.Secret = ""
 		} else {
-			std.Out.WriteNoticef("Using credentials from docker credentials store (learn more https://docs.docker.com/engine/reference/commandline/login/#credentials-store)")
+			std.Out.WriteSuccessf("Using credentials from docker credentials store (learn more https://docs.docker.com/engine/reference/commandline/login/#credentials-store)")
 			dockerCredentials = creds
 		}
 	}
 
 	if opsUpdateImagesPinTagFlag == "" {
-		std.Out.WriteWarningf("No pin tag is provided.")
-		std.Out.WriteWarningf("Falling back to the latest deveopment build available.")
+		std.Out.WriteWarningf("No pin tag (-t) is provided - will fall back to latest main branch tag available.")
 	}
 
 	return images.Update(args[0], *dockerCredentials, images.DeploymentType(opsUpdateImagesDeploymentKindFlag), opsUpdateImagesPinTagFlag)

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1064,7 +1064,7 @@ Flags:
 * `--cr-username="<value>"`: `username` for the container registry
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 * `--kind, -k="<value>"`: the `kind` of deployment (one of 'k8s', 'helm', 'compose') (default: k8s)
-* `--pin-tag, -t="<value>"`: pin all images to a specific sourcegraph `tag` (e.g. 3.36.2, insiders)
+* `--pin-tag, -t="<value>"`: pin all images to a specific sourcegraph `tag` (e.g. '3.36.2', 'insiders') (default: latest main branch tag)
 
 ## sg analytics
 

--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -8,6 +8,7 @@ package images
 
 import (
 	"fmt"
+	"time"
 )
 
 const (
@@ -89,6 +90,12 @@ var DeploySourcegraphDockerImages = []string{
 //
 // Note that the availability of this image depends on whether a candidate gets built,
 // as determined in `addDockerImages()`.
-func CandidateImageTag(commit, buildNumber string) string {
-	return fmt.Sprintf("%s_%s_candidate", commit, buildNumber)
+func CandidateImageTag(commit string, buildNumber int) string {
+	return fmt.Sprintf("%s_%d_candidate", commit, buildNumber)
+}
+
+// MainBranchImageTag provides the tag for all commits built on main, which are used for
+// continuous deployment.
+func MainBranchImageTag(now time.Time, commit string, buildNumber int) string {
+	return fmt.Sprintf("%05d_%10s_%.12s", buildNumber, now.Format("2006-01-02"), commit)
 }

--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -109,7 +109,7 @@ func NewConfig(now time.Time) Config {
 	case runType.Is(runtype.MainBranch):
 		// This tag is used for deploying continuously. Only ever generate this on the
 		// main branch.
-		tag = fmt.Sprintf("%05d_%10s_%.12s", buildNumber, now.Format("2006-01-02"), commit)
+		tag = images.MainBranchImageTag(now, commit, buildNumber)
 	default:
 		// Encode branch inside build tag by default.
 		tag = fmt.Sprintf("%s_%05d_%10s_%.12s", sanitizeBranchForDockerTag(branch), buildNumber, now.Format("2006-01-02"), commit)
@@ -178,7 +178,7 @@ func (c Config) ensureCommit() error {
 // Note that the availability of this image depends on whether a candidate gets built,
 // as determined in `addDockerImages()`.
 func (c Config) candidateImageTag() string {
-	return images.CandidateImageTag(c.Commit, strconv.Itoa(c.BuildNumber))
+	return images.CandidateImageTag(c.Commit, c.BuildNumber)
 }
 
 // MessageFlags indicates flags that can be parsed out of commit messages to change


### PR DESCRIPTION
@kalanchan and I were both confused by what "latest deveopment build" means - to clarify, we formalize the tag format and:

- rename various generic references to tag to indicate what they really refer to (main branch tag)
- update the help text
- remove unnecessary calls to Docker's list tags API in `getUpdatedImage` if `-t` is set

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Only renames + reading of `fetchAllTags` indicates no behavioural changes with the move