### PR TITLE
search: Parenthesize query with context if it contains an operator

### DIFF
--- a/client/shared/src/search/query/transformer.test.ts
+++ b/client/shared/src/search/query/transformer.test.ts
@@ -24,6 +24,10 @@ describe('appendContextFilter', () => {
         expect(appendContextFilter('foo', 'ctx')).toMatchInlineSnapshot('context:ctx foo')
     })
 
+    test('appending context to query with OR operator', () => {
+        expect(appendContextFilter('foo or bar', 'ctx')).toMatchInlineSnapshot(`context:ctx (foo or bar)`)
+    })
+
     test('appending when query already contains a context', () => {
         expect(appendContextFilter('context:bar foo', 'ctx')).toMatchInlineSnapshot('context:bar foo')
     })

--- a/client/shared/src/search/query/transformer.ts
+++ b/client/shared/src/search/query/transformer.ts
@@ -7,9 +7,9 @@ import { Filter, Token } from './token'
 import { operatorExists, filterExists } from './validate'
 
 export function appendContextFilter(query: string, searchContextSpec: string | undefined): string {
-    return !filterExists(query, FilterType.context) && searchContextSpec
-        ? `context:${searchContextSpec} ${query}`
-        : query
+    return parenthesizeQueryWithGlobalContext(
+        !filterExists(query, FilterType.context) && searchContextSpec ? `context:${searchContextSpec} ${query}` : query
+    )
 }
 
 export function omitFilter(query: string, filter: Filter): string {
@@ -116,5 +116,5 @@ export function parenthesizeQueryWithGlobalContext(query: string): string {
     }
     const searchContextSpec = globalContextFilter.value?.value || ''
     const queryWithOmittedContext = omitFilter(query, globalContextFilter)
-    return appendContextFilter(`(${queryWithOmittedContext})`, searchContextSpec)
+    return `context:${searchContextSpec} (${queryWithOmittedContext})`
 }


### PR DESCRIPTION
Turns out we already have a function that does exactly that.
`appendContextFilter` is used in quite a few places, which probably all
suffer from the problem of not treating `OR` queries properly.
I think updating the function to apply parenthesis when needed makes the
most sense, but please let me know if that's not the case.



## Test plan

Unit tests

## App preview:

- [Web](https://sg-web-fkling-38829-parenthesize-query.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

