### PR TITLE
dev/sg: init feedback flags first to include in autocomplete

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -129,9 +129,14 @@ var sg = &cli.App{
 		},
 	},
 	Before: func(cmd *cli.Context) (err error) {
+		// Add feedback flag to all commands and subcommands - we add this here, before
+		// we exit in bashCompletionsMode, so that '--feedback' is available via
+		// autocompletions.
+		addFeedbackFlags(cmd.App.Commands)
+
+		// All other setup pertains to running commands - to keep completions fast,
+		// we skip all other setup when in bashCompletions mode.
 		if bashCompletionsMode {
-			// All other setup pertains to running commands - to keep completions fast,
-			// we skip all other setup.
 			return nil
 		}
 
@@ -183,9 +188,6 @@ var sg = &cli.App{
 
 		// Add autosuggestion hooks to commands with subcommands but no action
 		addSuggestionHooks(cmd.App.Commands)
-
-		// Add feedback subcommand to all commands and subcommands
-		addFeedbackFlags(cmd.App.Commands)
 
 		// Validate configuration flags, which is required for sgconf.Get to work everywhere else.
 		if configFile == "" {

--- a/dev/sg/sg_feedback.go
+++ b/dev/sg/sg_feedback.go
@@ -23,19 +23,17 @@ const newDiscussionURL = "https://github.com/sourcegraph/sourcegraph/discussions
 
 // addFeedbackFlags adds a '--feedback' flag to each command to generate feedback
 func addFeedbackFlags(commands []*cli.Command) {
-	giveFeedback := false
 	feedbackFlag := cli.BoolFlag{
-		Name:        "feedback",
-		Usage:       "provide feedback about this command by opening up a Github discussion",
-		Destination: &giveFeedback,
+		Name:  "feedback",
+		Usage: "provide feedback about this command by opening up a Github discussion",
 	}
 
 	for _, command := range commands {
 		command.Flags = append(command.Flags, &feedbackFlag)
 		action := command.Action
 		command.Action = func(ctx *cli.Context) error {
-			if giveFeedback {
-				return feedbackExec(ctx)
+			if feedbackFlag.Get(ctx) {
+				return feedbackAction(ctx)
 			}
 			return action(ctx)
 		}
@@ -48,10 +46,10 @@ var feedbackCommand = &cli.Command{
 	Name:     "feedback",
 	Usage:    "opens up a Github discussion page to provide feedback about sg",
 	Category: CategoryCompany,
-	Action:   feedbackExec,
+	Action:   feedbackAction,
 }
 
-func feedbackExec(ctx *cli.Context) error {
+func feedbackAction(ctx *cli.Context) error {
 	std.Out.WriteLine(output.Styledf(output.StylePending, "Gathering feedback for sg %s ...", ctx.Command.FullName()))
 	title, body, err := gatherFeedback(ctx, std.Out, os.Stdin)
 	if err != nil {


### PR DESCRIPTION
Add feedback flag before we exit in bashCompletionsMode, so that '--feedback' is available via autocompletions.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
go build -o ./sg ./dev/sg && ./sg install -f -p=false
```

<img width="666" alt="image" src="https://user-images.githubusercontent.com/23356519/179064573-9cdd0ce2-e63d-4846-81c5-f481a4432f3c.png">
