### PR TITLE
dev/sg/ops: continue on error if image fetch fails

### DIFF
--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -212,7 +212,8 @@ func findImage(r *yaml.RNode, credential credentials.Credentials, pinTag string)
 		}
 		updatedImage, err := getUpdatedSourcegraphImage(originalImage, credential, pinTag)
 		if err != nil {
-			return err
+			std.Out.WriteWarningf("%s: could not get updated image: %s", node.GetName(), err)
+			return nil
 		}
 
 		std.Out.Verbosef("found image %s for container %s in file %s+%s\n Replaced with %s", originalImage, node.GetName(), r.GetKind(), r.GetName(), updatedImage)


### PR DESCRIPTION
Fixes a regression introduced in #38827 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

