### PR TITLE
gqltest: allow writing of request and response bodies to a sink

### DIFF
--- a/dev/codeintel-qa/internal/graphql.go
+++ b/dev/codeintel-qa/internal/graphql.go
@@ -1,11 +1,15 @@
 package internal
 
-import "github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+import (
+	"os"
+
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+)
 
 var client *gqltestutil.Client
 
 func InitializeGraphQLClient() (err error) {
-	client, err = gqltestutil.NewClient(SourcegraphEndpoint)
+	client, err = gqltestutil.NewClient(SourcegraphEndpoint, os.Stderr, os.Stderr)
 	return err
 }
 


### PR DESCRIPTION
Allow defining sinks for request/response bodies in the gqltest client for GraphQL requests only, not direct Get/Post requests, as they return the raw `*http.Response`, so users can do their own logging there.

Part of the grander "why is codeintel QA flaking" effort

## Test plan

Running a main-dry-run pipeline here: https://buildkite.com/sourcegraph/sourcegraph/builds/160829