### PR TITLE
search ui: show sidebar on right when simple ui enabled

### DIFF
--- a/client/search-ui/src/components/ResultContainer.module.scss
+++ b/client/search-ui/src/components/ResultContainer.module.scss
@@ -1,6 +1,4 @@
 .result-container {
-    margin-right: 1rem;
-
     &:last-child {
         border-bottom-width: 1px;
     }

--- a/client/search-ui/src/results/NoResultsPage.tsx
+++ b/client/search-ui/src/results/NoResultsPage.tsx
@@ -207,37 +207,35 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
             <H2>Sourcegraph basics</H2>
             <div className={styles.panels}>
                 {!hiddenSectionIDs?.includes(SectionID.VIDEOS) && (
-                    <div className="mr-3">
-                        <Container
-                            sectionID={SectionID.VIDEOS}
-                            title="Video explanations"
-                            className={styles.videoContainer}
-                            onClose={onClose}
-                        >
-                            {videos.map(video => (
-                                <ModalVideo
-                                    key={video.title}
-                                    className={styles.video}
-                                    id={`video-${video.title.toLowerCase().replace(/[^a-z]+/, '-')}`}
-                                    title={video.title}
-                                    src={video.src}
-                                    thumbnail={{
-                                        src: `${video.thumbnailPrefix}-${isLightTheme ? 'light' : 'dark'}.png`,
-                                        alt: `${video.title} video thumbnail`,
-                                    }}
-                                    showCaption={true}
-                                    onToggle={isOpen => {
-                                        if (isOpen) {
-                                            telemetryService.log('NoResultsVideoPlayed', { video: video.title })
-                                        }
-                                    }}
-                                    assetsRoot={assetsRoot}
-                                />
-                            ))}
-                        </Container>
-                    </div>
+                    <Container
+                        sectionID={SectionID.VIDEOS}
+                        title="Video explanations"
+                        className={styles.videoContainer}
+                        onClose={onClose}
+                    >
+                        {videos.map(video => (
+                            <ModalVideo
+                                key={video.title}
+                                className={styles.video}
+                                id={`video-${video.title.toLowerCase().replace(/[^a-z]+/, '-')}`}
+                                title={video.title}
+                                src={video.src}
+                                thumbnail={{
+                                    src: `${video.thumbnailPrefix}-${isLightTheme ? 'light' : 'dark'}.png`,
+                                    alt: `${video.title} video thumbnail`,
+                                }}
+                                showCaption={true}
+                                onToggle={isOpen => {
+                                    if (isOpen) {
+                                        telemetryService.log('NoResultsVideoPlayed', { video: video.title })
+                                    }
+                                }}
+                                assetsRoot={assetsRoot}
+                            />
+                        ))}
+                    </Container>
                 )}
-                <div className="mr-3 flex-1 flex-shrink-past-contents">
+                <div className="flex-1 flex-shrink-past-contents">
                     {!hiddenSectionIDs?.includes(SectionID.SEARCH_BAR) && (
                         <Container sectionID={SectionID.SEARCH_BAR} title="The search bar" onClose={onClose}>
                             <div className={styles.annotatedSearchInput}>

--- a/client/search-ui/src/results/sidebar/SearchSidebar.module.scss
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.module.scss
@@ -1,35 +1,35 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
-.search-sidebar {
+.sidebar {
     width: 15.5rem;
 
     @media (--md-breakpoint-down) {
         width: 100%;
     }
+}
 
-    &__item {
-        @media (--md-breakpoint-down) {
-            width: calc(50% - 0.75rem);
-        }
-
-        @media (--xs-breakpoint-down) {
-            width: 100%;
-        }
+.item {
+    @media (--md-breakpoint-down) {
+        width: calc(50% - 0.75rem);
     }
 
-    &__sticky-box {
-        @media (--md-breakpoint-down) {
-            // Sidebar shouldn't be sticky in smaller screens
-            position: static !important;
+    @media (--xs-breakpoint-down) {
+        width: 100%;
+    }
+}
 
-            display: flex;
-            flex-direction: row;
-            flex-wrap: wrap;
-            column-gap: 1.5rem;
-        }
+.sticky-box {
+    @media (--md-breakpoint-down) {
+        // Sidebar shouldn't be sticky in smaller screens
+        position: static !important;
 
-        @media (--xs-breakpoint-down) {
-            display: block;
-        }
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        column-gap: 1.5rem;
+    }
+
+    @media (--xs-breakpoint-down) {
+        display: block;
     }
 }

--- a/client/search-ui/src/results/sidebar/SearchSidebar.module.scss
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.module.scss
@@ -1,9 +1,7 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .search-sidebar {
-    padding: 0 1rem;
-    width: 17.5rem;
-    flex-shrink: 0;
+    width: 15.5rem;
 
     @media (--md-breakpoint-down) {
         width: 100%;

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -144,10 +144,10 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
     // we got the settings.
     if (collapsedSections) {
         body = (
-            <StickyBox className={styles.searchSidebarStickyBox}>
+            <StickyBox className={styles.stickyBox}>
                 <SearchSidebarSection
                     sectionId={SectionID.SEARCH_TYPES}
-                    className={styles.searchSidebarItem}
+                    className={styles.item}
                     header="Search Types"
                     startCollapsed={collapsedSections?.[SectionID.SEARCH_TYPES]}
                     onToggle={persistToggleState}
@@ -162,7 +162,7 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                 </SearchSidebarSection>
                 <SearchSidebarSection
                     sectionId={SectionID.DYNAMIC_FILTERS}
-                    className={styles.searchSidebarItem}
+                    className={styles.item}
                     header="Dynamic filters"
                     startCollapsed={collapsedSections?.[SectionID.DYNAMIC_FILTERS]}
                     onToggle={persistToggleState}
@@ -172,7 +172,7 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                 {showReposSection ? (
                     <SearchSidebarSection
                         sectionId={SectionID.REPOSITORIES}
-                        className={styles.searchSidebarItem}
+                        className={styles.item}
                         header="Repositories"
                         startCollapsed={collapsedSections?.[SectionID.REPOSITORIES]}
                         onToggle={persistToggleState}
@@ -190,7 +190,7 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                 {props.getRevisions && repoName ? (
                     <SearchSidebarSection
                         sectionId={SectionID.REVISIONS}
-                        className={styles.searchSidebarItem}
+                        className={styles.item}
                         header="Revisions"
                         startCollapsed={collapsedSections?.[SectionID.REVISIONS]}
                         onToggle={persistToggleState}
@@ -202,7 +202,7 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                 ) : null}
                 <SearchSidebarSection
                     sectionId={SectionID.SEARCH_REFERENCE}
-                    className={styles.searchSidebarItem}
+                    className={styles.item}
                     header="Search reference"
                     showSearch={true}
                     startCollapsed={collapsedSections?.[SectionID.SEARCH_REFERENCE]}
@@ -218,7 +218,7 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                 </SearchSidebarSection>
                 <SearchSidebarSection
                     sectionId={SectionID.SEARCH_SNIPPETS}
-                    className={styles.searchSidebarItem}
+                    className={styles.item}
                     header="Search snippets"
                     startCollapsed={collapsedSections?.[SectionID.SEARCH_SNIPPETS]}
                     onToggle={persistToggleState}
@@ -227,7 +227,7 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                 </SearchSidebarSection>
                 <SearchSidebarSection
                     sectionId={SectionID.QUICK_LINKS}
-                    className={styles.searchSidebarItem}
+                    className={styles.item}
                     header="Quicklinks"
                     startCollapsed={collapsedSections?.[SectionID.QUICK_LINKS]}
                     onToggle={persistToggleState}
@@ -239,7 +239,7 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
     }
 
     return (
-        <aside className={classNames(styles.searchSidebar, props.className)} role="region" aria-label="Search sidebar">
+        <aside className={classNames(styles.sidebar, props.className)} role="region" aria-label="Search sidebar">
             {props.prefixContent}
             {body}
         </aside>

--- a/client/web/src/search/results/SearchAlert.tsx
+++ b/client/web/src/search/results/SearchAlert.tsx
@@ -23,7 +23,7 @@ export const SearchAlert: React.FunctionComponent<React.PropsWithChildren<Search
     searchContextSpec,
     children,
 }) => (
-    <Alert className="my-2 mr-3" data-testid="alert-container" variant="info">
+    <Alert className="my-2" data-testid="alert-container" variant="info">
         <H3>{alert.title}</H3>
 
         {alert.description && <Markdown className="mb-3" dangerousInnerHTML={renderMarkdown(alert.description)} />}

--- a/client/web/src/search/results/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/StreamingSearchResults.module.scss
@@ -10,11 +10,10 @@
         'sidebar contents';
     height: min-content;
     padding: 0.5rem 1rem 0 1rem;
-    gap: 0.25rem 1rem;
+    column-gap: 1rem;
 
     &--with-improvements {
         grid-template-columns: 1fr auto;
-        grid-template-rows: 1fr auto;
         grid-template-areas:
             'infobar  sidebar'
             'contents sidebar';
@@ -47,6 +46,7 @@
 
 .infobar {
     grid-area: infobar;
+    margin-bottom: 0.25rem;
 }
 
 .contents {

--- a/client/web/src/search/results/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/StreamingSearchResults.module.scss
@@ -1,65 +1,65 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
-.streaming-search-results {
+.container {
     width: 100%;
     display: grid;
     grid-template-columns: auto 1fr;
-    grid-template-rows: auto auto 1fr;
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+        'sidebar infobar'
+        'sidebar contents';
     height: min-content;
-    padding-top: 0.5rem;
+    padding: 0.5rem 1rem 0 1rem;
+    gap: 0.25rem 1rem;
+
+    &--with-improvements {
+        grid-template-columns: 1fr auto;
+        grid-template-rows: 1fr auto;
+        grid-template-areas:
+            'infobar  sidebar'
+            'contents sidebar';
+    }
 
     @media (--md-breakpoint-down) {
-        grid-template-columns: auto;
-        grid-template-rows: auto auto 1fr;
-    }
-
-    &__sidebar {
-        grid-column: 1;
-        grid-row: 1 / span 3;
-
-        @media (--md-breakpoint-down) {
-            grid-column: 1;
-            grid-row: 3;
-            display: none;
-
-            &--show {
-                display: block;
-            }
+        &,
+        &--with-improvements {
+            grid-template-columns: auto;
+            grid-template-rows: auto auto 1fr;
+            grid-template-areas:
+                'infobar'
+                'sidebar'
+                'contents';
         }
     }
+}
 
-    &__infobar {
-        grid-column: 2;
-        grid-row: 1;
-        padding-right: 1rem;
-        padding-bottom: 0.25rem;
+.sidebar {
+    grid-area: sidebar;
 
-        @media (--md-breakpoint-down) {
-            grid-column: 1;
-            grid-row: 1;
-            padding-left: 1rem;
+    @media (--md-breakpoint-down) {
+        display: none;
+
+        &--show {
+            display: block;
         }
     }
+}
 
-    &__container {
-        // Hack!! Fixes some possible nested scrolling on diff searches
-        // due to size calculations on diff results. The parent will scroll
-        // instead so this doesn't really hide anything.
-        overflow-y: hidden;
+.infobar {
+    grid-area: infobar;
+}
 
-        overflow-x: hidden;
-        grid-column: 2;
-        grid-row: 3;
+.contents {
+    // Hack!! Fixes some possible nested scrolling on diff searches
+    // due to size calculations on diff results. The parent will scroll
+    // instead so this doesn't really hide anything.
+    overflow-y: hidden;
+    overflow-x: hidden;
 
-        @media (--md-breakpoint-down) {
-            grid-column: 1;
-            grid-row: 4;
-            padding-left: 1rem;
-        }
-    }
+    grid-area: contents;
+}
 
-    &__content-centered {
-        max-width: 65rem;
-        margin: auto;
-    }
+.alert-area {
+    max-width: 65rem;
+    margin: auto;
 }

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -271,18 +271,19 @@ export const StreamingSearchResults: React.FunctionComponent<
                 }
             />
 
-            <DidYouMean
-                telemetryService={props.telemetryService}
-                query={query}
-                patternType={patternType}
-                caseSensitive={caseSensitive}
-                selectedSearchContextSpec={props.selectedSearchContextSpec}
-            />
-
-            {results?.alert?.kind && <LuckySearch alert={results?.alert} />}
-
             <div className={styles.contents}>
-                <GettingStartedTour.Info className="mt-2 mr-3 mb-3" isSourcegraphDotCom={props.isSourcegraphDotCom} />
+                <DidYouMean
+                    telemetryService={props.telemetryService}
+                    query={query}
+                    patternType={patternType}
+                    caseSensitive={caseSensitive}
+                    selectedSearchContextSpec={props.selectedSearchContextSpec}
+                />
+
+                {results?.alert?.kind && <LuckySearch alert={results?.alert} />}
+
+                <GettingStartedTour.Info className="mt-2 mb-3" isSourcegraphDotCom={props.isSourcegraphDotCom} />
+
                 {showSavedSearchModal && (
                     <SavedSearchModal
                         {...props}

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -20,6 +20,7 @@ import { collectMetrics } from '@sourcegraph/shared/src/search/query/metrics'
 import { sanitizeQueryForTelemetry, updateFilters } from '@sourcegraph/shared/src/search/query/transformer'
 import { LATEST_VERSION, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
@@ -84,6 +85,7 @@ export const StreamingSearchResults: React.FunctionComponent<
     const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)
     const patternType = useNavbarQueryState(state => state.searchPatternType)
     const query = useNavbarQueryState(state => state.searchQueryFromURL)
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
 
     // Log view event on first load
     useEffect(
@@ -217,7 +219,12 @@ export const StreamingSearchResults: React.FunctionComponent<
     const resultsFound = useMemo<boolean>(() => (results ? results.results.length > 0 : false), [results])
 
     return (
-        <div className={styles.streamingSearchResults}>
+        <div
+            className={classNames(
+                styles.container,
+                coreWorkflowImprovementsEnabled && styles.containerWithImprovements
+            )}
+        >
             <PageTitle key="page-title" title={query} />
 
             <SearchSidebar
@@ -227,10 +234,7 @@ export const StreamingSearchResults: React.FunctionComponent<
                 settingsCascade={props.settingsCascade}
                 telemetryService={props.telemetryService}
                 selectedSearchContextSpec={props.selectedSearchContextSpec}
-                className={classNames(
-                    styles.streamingSearchResultsSidebar,
-                    showSidebar && styles.streamingSearchResultsSidebarShow
-                )}
+                className={classNames(styles.sidebar, showSidebar && styles.sidebarShow)}
                 filters={results?.filters}
                 getRevisions={getRevisions}
                 prefixContent={
@@ -252,7 +256,7 @@ export const StreamingSearchResults: React.FunctionComponent<
                 enableCodeInsights={codeInsightsEnabled && isCodeInsightsEnabled(props.settingsCascade)}
                 enableCodeMonitoring={enableCodeMonitoring}
                 resultsFound={resultsFound}
-                className={classNames('flex-grow-1', styles.streamingSearchResultsInfobar)}
+                className={classNames('flex-grow-1', styles.infobar)}
                 allExpanded={allExpanded}
                 onExpandAllResultsToggle={onExpandAllResultsToggle}
                 onSaveQueryClick={onSaveQueryClick}
@@ -277,7 +281,7 @@ export const StreamingSearchResults: React.FunctionComponent<
 
             {results?.alert?.kind && <LuckySearch alert={results?.alert} />}
 
-            <div className={styles.streamingSearchResultsContainer}>
+            <div className={styles.contents}>
                 <GettingStartedTour.Info className="mt-2 mr-3 mb-3" isSourcegraphDotCom={props.isSourcegraphDotCom} />
                 {showSavedSearchModal && (
                     <SavedSearchModal
@@ -289,7 +293,7 @@ export const StreamingSearchResults: React.FunctionComponent<
                     />
                 )}
                 {results?.alert && !results?.alert.kind && (
-                    <div className={classNames(styles.streamingSearchResultsContentCentered, 'mt-4')}>
+                    <div className={classNames(styles.alertArea, 'mt-4')}>
                         <SearchAlert alert={results.alert} caseSensitive={caseSensitive} patternType={patternType} />
                     </div>
                 )}

--- a/client/web/src/search/results/sidebar/Revisions.story.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.story.tsx
@@ -95,7 +95,7 @@ export function RevisionsSection() {
                             style={{ border: '1px solid #AAA', borderRadius: '3px', padding: '1rem', margin: '1rem' }}
                         >
                             <H2>{title}</H2>
-                            <div className={sidebarStyles.searchSidebar}>
+                            <div className={sidebarStyles.sidebar}>
                                 <MockedTestProvider mocks={mocks}>
                                     <Revisions {...props} />
                                 </MockedTestProvider>

--- a/client/web/src/search/suggestion/QuerySuggestion.module.scss
+++ b/client/web/src/search/suggestion/QuerySuggestion.module.scss
@@ -1,21 +1,12 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .root {
-    grid-column: 2;
-    grid-row: 2;
     padding: 0.5rem;
     background-color: var(--subtle-bg);
     border: 1px solid var(--border-color);
     border-radius: 3px;
-    margin-right: 1rem;
     margin-bottom: 0.25rem;
     margin-top: 0.25rem;
-
-    @media (--md-breakpoint-down) {
-        grid-column: 1;
-        grid-row: 2;
-        margin-left: 1rem;
-    }
 }
 
 .root > h3 {


### PR DESCRIPTION
**Review with "Hide whitespace" turned on**

Part of #37552

Sidebar should show on the right if the "Simple UI" toggle is enabled. This simplifies the CSS of the search result page, now using `grid-area` instead of `grid-row`/`grid-column` and removing margins/padding between components in favor of `grid-gap`.

https://user-images.githubusercontent.com/206864/179089333-89db56a3-e5fa-4591-93b5-d018a73ffa4d.mp4

## Test plan

Manually test with toggle on and off

## App preview:

- [Web](https://sg-web-jp-rightsidebar.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xvkbyjqtds.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
