### PR TITLE
cut branch and notify slack channel

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -44,8 +44,8 @@ export type StepID =
     | 'tracking:issues'
     // branch cut
     | 'changelog:cut'
-    // release
     | 'release:branch-cut'
+    // release
     | 'release:status'
     | 'release:create-candidate'
     | 'release:stage'

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -309,6 +309,7 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                 message = `:mega: *${release.version} branch has been cut.`
             }
             try {
+                // Create and push new release branch from changelog commit
                 await execa('git', ['branch', branch])
                 await execa('git', ['push', 'origin', branch])
                 await postMessage(message, config.slackAnnounceChannel)

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -301,11 +301,17 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
         run: async config => {
             const { upcoming: release } = await releaseVersions(config)
             const branch = `${release.major}.${release.minor}`
-
+            let message: string
+            // notify cs team on patch release cut
+            if (release.patch !== 0) {
+                message = `:mega: *${release.version} branch has been cut cc: @cs`
+            } else {
+                message = `:mega: *${release.version} branch has been cut.`
+            }
             try {
                 await execa('git', ['branch', branch])
                 await execa('git', ['push', 'origin', branch])
-                await postMessage(`:mega: *${release.version} branch has been cut`, config.slackAnnounceChannel)
+                await postMessage(message, config.slackAnnounceChannel)
             } catch (error) {
                 console.error('Failed to create release branch', error)
             }


### PR DESCRIPTION
automates the branch cut and sends a slack message for more visibility
fixes https://github.com/sourcegraph/sourcegraph/issues/31737 and https://github.com/sourcegraph/sourcegraph/issues/32448


## Test plan

works locally with some no-op style stuff that isn't really relevant to include in the end code