### PR TITLE
sg: add `sg setup` support for Arch Linux

### DIFF
--- a/dev/sg/dependencies/arch.go
+++ b/dev/sg/dependencies/arch.go
@@ -1,0 +1,296 @@
+package dependencies
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sourcegraph/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/check"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/usershell"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var (
+	archPackageManagerDetect sync.Once
+	archPackageManagerCmd    string
+)
+
+func archPackageManager() string {
+	archPackageManagerDetect.Do(func() {
+		// We want to use yay preferentially because some of the required packages
+		// are in the AUR, not the official repositories.
+		c := check.InPath("yay")
+		ctx, _ := usershell.Context(context.Background())
+		if err := c(ctx); err != nil {
+			archPackageManagerCmd = "sudo pacman"
+		} else {
+			archPackageManagerCmd = "yay"
+		}
+	})
+
+	return archPackageManagerCmd
+}
+
+type archInstallOpts struct {
+	before []string
+	after  []string
+}
+
+func archInstall(pkg string, opts archInstallOpts) check.FixAction[CheckArgs] {
+	cmds := []string{}
+	cmds = append(cmds, opts.before...)
+	cmds = append(cmds, fmt.Sprintf("%s -Sy %s", archPackageManager(), pkg))
+	cmds = append(cmds, opts.after...)
+
+	return cmdFixes(cmds...)
+}
+
+func archSimpleInstall(pkg string) check.FixAction[CheckArgs] {
+	return archInstall(pkg, archInstallOpts{})
+}
+
+var Arch = []category{
+	{
+		Name: depsBaseUtilities,
+		Checks: []*dependency{
+			{
+				Name:  "gcc",
+				Check: checkAction(check.InPath("gcc")),
+				Fix:   archSimpleInstall("build-essential"),
+			},
+			{
+				Name:  "git",
+				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1"))),
+				Fix:   archSimpleInstall("git"),
+			},
+			{
+				Name:  "pcre",
+				Check: checkAction(check.InPath("pcre-config")),
+				Fix:   archSimpleInstall("libpcre3-dev"),
+			},
+			{
+				Name:  "sqlite",
+				Check: checkAction(check.InPath("sqlite3")),
+				Fix:   archSimpleInstall("libsqlite3-dev"),
+			},
+			{
+				Name:  "libev",
+				Check: checkAction(check.FileExists("/usr/lib/libev.so.4")),
+				Fix:   archSimpleInstall("libev"),
+			},
+			{
+				Name:  "pkg-config",
+				Check: checkAction(check.InPath("pkg-config")),
+				Fix:   archSimpleInstall("pkgconf"),
+			},
+			{
+				Name:  "jq",
+				Check: checkAction(check.InPath("jq")),
+				Fix:   archSimpleInstall("jq"),
+			},
+			{
+				Name:  "curl",
+				Check: checkAction(check.InPath("curl")),
+				Fix:   archSimpleInstall("curl"),
+			},
+			// Comby will fail systematically on linux/arm64 as there aren't binaries available for that platform.
+			{
+				Name:  "comby",
+				Check: checkAction(check.InPath("comby")),
+				Fix:   cmdFix(`bash <(curl -sL get-comby.netlify.app)`),
+			},
+			{
+				Name:  "bash",
+				Check: checkAction(check.CommandOutputContains("bash --version", "version 5")),
+				Fix:   archSimpleInstall("bash"),
+			},
+			{
+				Name: "asdf",
+				// TODO add the if Keegan check
+				Check: checkAction(check.CommandOutputContains("asdf", "version")),
+				Fix:   archSimpleInstall("asdf-vm"),
+			},
+		},
+	},
+	{
+		Name:    depsDocker,
+		Enabled: disableInCI(), // Very wonky in CI
+		Checks: []*dependency{
+			{
+				Name:  "Docker",
+				Check: checkAction(check.InPath("docker")),
+				Fix: archInstall("docker", archInstallOpts{
+					after: []string{"sudo systemctl enable --now docker"},
+				}),
+			},
+			{
+				Name: "Docker without sudo",
+				Check: checkAction(check.Combine(
+					check.InPath("docker"),
+					// It's possible that the user that installed Docker this way needs sudo to run it, which is not
+					// convenient. The following check diagnose that case.
+					check.CommandOutputContains("docker ps", "CONTAINER")),
+				),
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					if err := usershell.Command(ctx, "sudo groupadd docker || true").Run().StreamLines(cio.Verbose); err != nil {
+						return err
+					}
+					if err := usershell.Command(ctx, "sudo usermod -aG docker $USER").Run().StreamLines(cio.Verbose); err != nil {
+						return err
+					}
+					err := check.CommandOutputContains("docker ps", "CONTAINER")(ctx)
+					if err != nil {
+						cio.WriteAlertf(`You may need to restart your terminal for the permissions needed for Docker to take effect or you can run "newgrp docker" and restart the processe in this terminal.`)
+					}
+					return err
+				},
+			},
+		},
+	},
+	categoryCloneRepositories(),
+	categoryProgrammingLanguagesAndTools(),
+	{
+		Name:      "Postgres database",
+		DependsOn: []string{depsBaseUtilities},
+		Checks: []*dependency{
+			{
+				Name:  "Install Postgres",
+				Check: checkAction(check.Combine(check.InPath("psql"))),
+				Fix: archInstall("postgresql", archInstallOpts{
+					after: []string{"sudo systemctl enable --now postgresql"},
+				}),
+			},
+			{
+				Name: "Start Postgres",
+				// In the eventuality of the user using a non standard configuration and having
+				// set it up appropriately in its configuration, we can bypass the standard postgres
+				// check and directly check for the sourcegraph database.
+				//
+				// Because only the latest error is returned, it's better to finish with the real check
+				// for error message clarity.
+				Check: func(ctx context.Context, out *std.Output, args CheckArgs) error {
+					if err := checkSourcegraphDatabase(ctx, out, args); err == nil {
+						return nil
+					}
+					return checkPostgresConnection(ctx)
+				},
+				Description: `Sourcegraph requires the PostgreSQL database to be running.
+
+We recommend installing it with Homebrew and starting it as a system service.
+If you know what you're doing, you can also install PostgreSQL another way.
+For example: you can use https://postgresapp.com/
+
+If you're not sure: use the recommended commands to install PostgreSQL.`,
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					if err := usershell.Command(ctx, "sudo systemctl enable --now postgresql").Run().StreamLines(cio.Verbose); err != nil {
+						return err
+					}
+					if err := usershell.Command(ctx, "sudo -u postgres createuser --superuser $USER").Run().StreamLines(cio.Verbose); err != nil {
+						return err
+					}
+
+					// Wait for startup
+					time.Sleep(5 * time.Second)
+
+					// Doesn't matter if this succeeds
+					_ = usershell.Cmd(ctx, "createdb").Run()
+					return nil
+				},
+			},
+			{
+				Name:        "Connection to 'sourcegraph' database",
+				Check:       checkSourcegraphDatabase,
+				Description: `Once PostgreSQL is installed and running, we need to set up Sourcegraph database itself and a specific user.`,
+				Fix: cmdFixes(
+					"createuser --superuser sourcegraph || true",
+					`psql -c "ALTER USER sourcegraph WITH PASSWORD 'sourcegraph';"`,
+					`createdb --owner=sourcegraph --encoding=UTF8 --template=template0 sourcegraph`,
+				),
+			},
+		},
+	},
+	{
+		Name: "Redis database",
+		Checks: []*dependency{
+			{
+				Name:  "Install Redis",
+				Check: checkAction(check.InPath("redis-cli")),
+				Fix: archInstall("redis", archInstallOpts{
+					after: []string{"sudo systemctl enable --now redis"},
+				}),
+			},
+			{
+				Name: "Start Redis",
+				Description: `Sourcegraph requires the Redis database to be running.
+We recommend installing it with Homebrew and starting it as a system service.`,
+				Check: checkAction(check.Retry(checkRedisConnection, 5, 500*time.Millisecond)),
+				Fix:   cmdFix("sudo systemctl enable --now redis"),
+			},
+		},
+	},
+	{
+		Name:      "sourcegraph.test development proxy",
+		DependsOn: []string{depsBaseUtilities},
+		Checks: []*dependency{
+			{
+				Name: "/etc/hosts contains sourcegraph.test",
+				Description: `Sourcegraph should be reachable under https://sourcegraph.test:3443.
+To do that, we need to add sourcegraph.test to the /etc/hosts file.`,
+				Check: checkAction(check.FileContains("/etc/hosts", "sourcegraph.test")),
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					return root.Run(usershell.Command(ctx, `./dev/add_https_domain_to_hosts.sh`)).StreamLines(cio.Verbose)
+				},
+			},
+			{
+				Name: "Caddy root certificate is trusted by system",
+				Description: `In order to use TLS to access your local Sourcegraph instance, you need to
+trust the certificate created by Caddy, the proxy we use locally.
+
+YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
+				Enabled: disableInCI(), // Can't seem to get this working
+				Check:   checkAction(checkCaddyTrusted),
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					return root.Run(usershell.Command(ctx, `./dev/caddy.sh trust`)).StreamLines(cio.Verbose)
+				},
+			},
+		},
+	},
+	categoryAdditionalSGConfiguration(),
+	{
+		Name:      "Cloud services",
+		DependsOn: []string{depsBaseUtilities},
+		Enabled:   enableForTeammatesOnly(),
+		Checks: []*dependency{
+			{
+				Name:  "gcloud installed",
+				Check: checkAction(check.InPath("gcloud")),
+				Fix:   archSimpleInstall("gcloud-sdk"),
+			},
+			{
+				Name: "gcloud logged in",
+				// User should have logged in with a sourcegraph.com account
+				Check: checkAction(check.CommandOutputContains("gcloud auth list", "@sourcegraph.com")),
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					if cio.Input == nil {
+						return errors.New("interactive input required to fix this check")
+					}
+
+					if err := run.Cmd(ctx, "gcloud auth login").Input(cio.Input).Run().StreamLines(cio.Write); err != nil {
+						return err
+					}
+
+					return run.Cmd(ctx, "gcloud auth configure-docker").Run().Wait()
+				},
+			},
+			{
+				Name:  "1password",
+				Check: checkAction(check1password()),
+				Fix:   archSimpleInstall("1password-cli"),
+			},
+		},
+	},
+}

--- a/dev/sg/dependencies/dependencies.go
+++ b/dev/sg/dependencies/dependencies.go
@@ -3,8 +3,11 @@ package dependencies
 import (
 	"io"
 
+	"github.com/acobaugh/osrelease"
+
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/check"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type CheckArgs struct {
@@ -23,14 +26,35 @@ var checkAction = check.CheckFuncAction[CheckArgs]
 type OS string
 
 const (
-	OSMac    OS = "darwin"
-	OSUbuntu OS = "ubuntu"
+	OSMac   OS = "darwin"
+	OSLinux OS = "linux"
 )
 
 // Setup instantiates a runner that can check and fix setup dependencies.
-func Setup(in io.Reader, out *std.Output, os OS) *check.Runner[CheckArgs] {
+func Setup(in io.Reader, out *std.Output, os OS) (*check.Runner[CheckArgs], error) {
 	if os == OSMac {
-		return check.NewRunner(in, out, Mac)
+		return check.NewRunner(in, out, Mac), nil
 	}
-	return check.NewRunner(in, out, Ubuntu)
+
+	category, err := detectLinuxDistro()
+	if err != nil {
+		return nil, err
+	}
+	return check.NewRunner(in, out, category), nil
+}
+
+func detectLinuxDistro() ([]check.Category[CheckArgs], error) {
+	osr, err := osrelease.Read()
+	if err != nil {
+		return nil, errors.Wrap(err, "reading os-release")
+	}
+
+	switch osr["ID"] {
+	case "arch":
+		return Arch, nil
+	case "debian", "ubuntu":
+		return Ubuntu, nil
+	}
+
+	return nil, errors.Newf("unknown distribution: %s", osr["ID"])
 }

--- a/dev/sg/dependencies/ubuntu_test.go
+++ b/dev/sg/dependencies/ubuntu_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestUbuntuFix(t *testing.T) {
-	if !strings.Contains(*sgSetupTests, string(OSUbuntu)) {
+	if !strings.Contains(*sgSetupTests, string(OSLinux)) {
 		t.Skip("Skipping Ubuntu sg setup tests")
 	}
 

--- a/dev/sg/internal/check/check.go
+++ b/dev/sg/internal/check/check.go
@@ -76,6 +76,13 @@ func FileContains(fileName, content string) func(context.Context) error {
 	}
 }
 
+func FileExists(fileName string) func(context.Context) error {
+	return func(context.Context) error {
+		_, err := os.Stat(fileName)
+		return err
+	}
+}
+
 // This ties the check to having the library installed with apt-get on Ubuntu,
 // which against the principle of checking dependencies independently of their
 // installation method. Given they're just there for comby and sqlite, the chances

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -43,7 +43,10 @@ var setupCommand = &cli.Command{
 			currentOS = overridesOS
 		}
 
-		setup := dependencies.Setup(cmd.App.Reader, std.Out, dependencies.OS(currentOS))
+		setup, err := dependencies.Setup(cmd.App.Reader, std.Out, dependencies.OS(currentOS))
+		if err != nil {
+			return err
+		}
 		setup.AnalyticsCategory = "setup"
 		setup.RenderDescription = func(out *std.Output) {
 			printSgSetupWelcomeScreen(out)

--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,10 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require go.opentelemetry.io/contrib/propagators/jaeger v1.7.0
+require (
+	github.com/acobaugh/osrelease v0.1.0
+	go.opentelemetry.io/contrib/propagators/jaeger v1.7.0
+)
 
 require (
 	github.com/go-sql-driver/mysql v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:H
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/acobaugh/osrelease v0.1.0 h1:Yb59HQDGGNhCj4suHaFQQfBps5wyoKLSSX/J/+UifRE=
+github.com/acobaugh/osrelease v0.1.0/go.mod h1:4bFEs0MtgHNHBrmHCt67gNisnabCRAlzdVasCEGHTWY=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=


### PR DESCRIPTION
Right now, `sg setup` assumes that anything that's not a Mac is an Ubuntu installation.

btw i use arch

## Test plan

Tried it out; it works (with a workaround for #38851 applied).