### PR TITLE
gh: update `team/frontend-platform` labeler config

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -2,8 +2,10 @@ team/frontend-platform:
   - '@alicjasuska'
   - '@umpox'
   - '@valerybugakov'
-  - '@pdubroy'
-  - '@oleggromov'
+  - '@jasongornall'
+  - '@lrhacker'
+  - '@plibither8'
+  - '@lmelende20'
 
 team/iam:
   - '@unknwon'


### PR DESCRIPTION
## Context

Updating `team/frontend-platform` GitHub labeler configuration. This automation adds the `team/frontend-platform` label to PRs created by users in the team config.

## Test plan

n/a — GitHub automation.
