### PR TITLE
dependencies: parse transitive:yes in query & pass to service

### DIFF
--- a/internal/codeintel/dependencies/background/indexer/indexer.go
+++ b/internal/codeintel/dependencies/background/indexer/indexer.go
@@ -108,9 +108,8 @@ func (i *indexer) handleRepository(
 
 			revs[api.RevSpec(commit)] = struct{}{}
 		}
-		repoRevs := map[api.RepoName]types.RevSpecSet{api.RepoName(repoName): revs}
-
-		if err := i.dependenciesSvc.IndexLockfiles(ctx, repoRevs); err != nil {
+		params := dependencies.QueryParams{Repo: api.RepoName(repoName), RevSpecs: revs}
+		if err := i.dependenciesSvc.IndexLockfiles(ctx, params); err != nil {
 			return err
 		}
 

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -118,13 +118,10 @@ func (s *Service) Dependencies(ctx context.Context, params []QueryParams) (depen
 
 	notFound = make(map[api.RepoName]types.RevSpecSet, len(notFoundParams))
 	for _, param := range notFoundParams {
-		repo := param.Repo
-		rev := api.RevSpec(param.RevSpec)
-
-		if _, ok := notFound[repo]; !ok {
-			notFound[repo] = types.RevSpecSet{}
+		if _, ok := notFound[param.Repo]; !ok {
+			notFound[param.Repo] = types.RevSpecSet{}
 		}
-		notFound[repo][rev] = struct{}{}
+		notFound[param.Repo][param.RevSpec] = struct{}{}
 	}
 
 	if !enablePreciseQueries {
@@ -251,7 +248,7 @@ func (s *Service) resolveLockfileDependenciesFromStore(ctx context.Context, para
 // given repo-commit pair and persists the result to the database. This aids in both caching
 // and building an inverted index to power dependents search.
 func (s *Service) listAndPersistLockfileDependencies(ctx context.Context, param resolvedQueryParams) ([]shared.PackageDependency, error) {
-	results, err := s.lockfilesSvc.ListDependencies(ctx, param.Repo, string(param.ResolvedCommit))
+	results, err := s.lockfilesSvc.ListDependencies(ctx, param.Repo, param.ResolvedCommit)
 	if err != nil {
 		return nil, errors.Wrap(err, "lockfiles.ListDependencies")
 	}

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -55,10 +55,36 @@ func newService(
 	}
 }
 
+// QueryParams can be used to query the dependencies or the dependents of the
+// given revspecs in a repository.
+type QueryParams struct {
+	// Repo is the repository in which to search for dependency relationships.
+	Repo api.RepoName
+	// IncludeTransitive determines whether or not transitive dependencies are
+	// included in response. It's ignored by Dependents right now.
+	IncludeTransitive bool
+	// RevSpecs is the set of revspecs over which to query.
+	RevSpecs types.RevSpecSet
+}
+
+// resolvedQueryParams is used internally to represent flattened QueryParams
+// whose RevSpecs have been resolved by a call to gitserver to a concrete
+// ResolvedCommit. One QueryParams can be resolved into N resolvedQueryParams,
+// where N is maximum len(queryParams.RevSpecs).
+type resolvedQueryParams struct {
+	Repo              api.RepoName
+	IncludeTransitive bool
+
+	// RevSpec is the original revspec as defined in QueryParams.RevSpec.
+	RevSpec api.RevSpec
+	// ResolvedCommit is the commit into which RevSpec has been resolved.
+	ResolvedCommit string
+}
+
 // Dependencies resolves the (transitive) dependencies for a set of repository and revisions.
-// Both the input repoRevs and the output dependencyRevs are a map from repository names to revspecs.
-func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet, includeTransitive bool) (dependencyRevs map[api.RepoName]types.RevSpecSet, notFound map[api.RepoName]types.RevSpecSet, err error) {
-	ctx, _, endObservation := s.operations.dependencies.With(ctx, &err, observation.Args{LogFields: constructLogFields(repoRevs)})
+// The output dependencyRevs are a map from repository names to revspecs.
+func (s *Service) Dependencies(ctx context.Context, params []QueryParams) (dependencyRevs map[api.RepoName]types.RevSpecSet, notFound map[api.RepoName]types.RevSpecSet, err error) {
+	ctx, _, endObservation := s.operations.dependencies.With(ctx, &err, observation.Args{LogFields: constructLogFields(params)})
 	defer func() {
 		endObservation(1, observation.Args{LogFields: []log.Field{
 			log.Int("numDependencyRevs", len(dependencyRevs)),
@@ -67,19 +93,19 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 
 	// Resolve the revhashes for the source repo-commit pairs.
 	// TODO - Process unresolved commits.
-	repoCommits, _, err := s.resolveRepoCommits(ctx, repoRevs)
+	resolvedParams, _, err := s.resolveDependenciesParams(ctx, params)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Load lockfile dependencies for the given repository and revision pairs
-	deps, notFoundRepoCommits, err := s.resolveLockfileDependenciesFromStore(ctx, repoCommits, includeTransitive)
+	deps, notFoundParams, err := s.resolveLockfileDependenciesFromStore(ctx, resolvedParams)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Populate return value map from the given information.
-	dependencyRevs = make(map[api.RepoName]types.RevSpecSet, len(repoRevs))
+	dependencyRevs = make(map[api.RepoName]types.RevSpecSet, len(params))
 	for _, dep := range deps {
 		repo := dep.RepoName()
 		rev := api.RevSpec(dep.GitTagFromVersion())
@@ -90,15 +116,10 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 		dependencyRevs[repo][rev] = struct{}{}
 	}
 
-	notFound = make(map[api.RepoName]types.RevSpecSet, len(notFoundRepoCommits))
-	for _, repoCommit := range notFoundRepoCommits {
-		repo := repoCommit.Repo
-		// TODO: This is wrong. what we want is to find out which revspec we
-		// couldn't find results for. So if the user is querying for
-		// dependencies of foo@v1 we want to tell user that we couldn't find
-		// anything for foo@v1 and not foo@d34db33f, if that is the commit that
-		// v1 resolved to.
-		rev := api.RevSpec(repoCommit.CommitID)
+	notFound = make(map[api.RepoName]types.RevSpecSet, len(notFoundParams))
+	for _, param := range notFoundParams {
+		repo := param.Repo
+		rev := api.RevSpec(param.RevSpec)
 
 		if _, ok := notFound[repo]; !ok {
 			notFound[repo] = types.RevSpecSet{}
@@ -110,9 +131,9 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 		return dependencyRevs, notFound, nil
 	}
 
-	for _, repoCommit := range repoCommits {
+	for _, param := range resolvedParams {
 		// TODO - batch these requests in the store layer
-		preciseDeps, err := s.dependenciesStore.PreciseDependencies(ctx, string(repoCommit.Repo), repoCommit.ResolvedCommit)
+		preciseDeps, err := s.dependenciesStore.PreciseDependencies(ctx, string(param.Repo), param.ResolvedCommit)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "store.PreciseDependencies")
 		}
@@ -126,13 +147,13 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 			}
 
 			// If we found a precise result, we remove repoRev from notFound.
-			if notFoundRevs, ok := notFound[repoCommit.Repo]; ok {
+			if notFoundRevs, ok := notFound[param.Repo]; ok {
 				for commit := range commits {
 					delete(notFoundRevs, commit)
 				}
 
 				if len(notFoundRevs) == 0 {
-					delete(notFound, repoCommit.Repo)
+					delete(notFound, param.Repo)
 				}
 			}
 		}
@@ -141,27 +162,30 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 	return dependencyRevs, notFound, nil
 }
 
-type repoCommitResolvedCommit struct {
-	api.RepoCommit
-	ResolvedCommit string
-}
-
-// resolveRepoCommits flattens the given map into a slice of api.RepoCommits with an extra
-// field indicating the canonical 40-character commit hash of the given revlike, which is
-// often symbolic. The commits that failed to resolve are returned in a separate slice.
-func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) ([]repoCommitResolvedCommit, []api.RepoCommit, error) {
+// resolveDependenciesParams flattens the given map into a slice of api.RepoCommits with two extra fields:
+//
+// - ResolvedCommit: the canonical 40-character commit hash of the given revlike, which is often symbolic.
+// - IncludeTransitive: the boolean from the original DependenciesParam from the revlike originated.
+//
+// The commits that failed to resolve are returned in a separate slice.
+func (s *Service) resolveDependenciesParams(ctx context.Context, params []QueryParams) ([]resolvedQueryParams, []api.RepoCommit, error) {
 	n := 0
-	for _, revs := range repoRevs {
-		n += len(revs)
+	for _, p := range params {
+		n += len(p.RevSpecs)
 	}
 
 	repoCommits := make([]api.RepoCommit, 0, n)
-	for repoName, revs := range repoRevs {
-		for rev := range revs {
+	// repoCommitToParam maps repoCommit entries to the entry in params from
+	// which they originate.
+	// Example: param corresponding to repoCommits[5] is params[repoCommitToParam[5]].
+	repoCommitToParam := make([]int, 0, n)
+	for i, p := range params {
+		for rev := range p.RevSpecs {
 			repoCommits = append(repoCommits, api.RepoCommit{
-				Repo:     repoName,
+				Repo:     p.Repo,
 				CommitID: api.CommitID(rev),
 			})
+			repoCommitToParam = append(repoCommitToParam, i)
 		}
 	}
 
@@ -175,28 +199,29 @@ func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoN
 		return nil, nil, errors.Newf("expected slice returned from git.GetCommits to have len %d, but has len %d", len(repoCommits), len(commits))
 	}
 
-	resolvedCommits := make([]repoCommitResolvedCommit, 0, len(repoCommits))
+	resolvedParams := make([]resolvedQueryParams, 0, len(repoCommits))
 	var unresolvedCommits []api.RepoCommit
 	for i, repoCommit := range repoCommits {
 		if commits[i] == nil {
 			unresolvedCommits = append(unresolvedCommits, repoCommit)
 			continue
 		}
-		resolvedCommits = append(resolvedCommits, repoCommitResolvedCommit{
-			RepoCommit:     repoCommit,
-			ResolvedCommit: string(commits[i].ID),
+
+		param := params[repoCommitToParam[i]]
+		resolvedParams = append(resolvedParams, resolvedQueryParams{
+			Repo:              param.Repo,
+			IncludeTransitive: param.IncludeTransitive,
+			RevSpec:           api.RevSpec(repoCommit.CommitID),
+			ResolvedCommit:    string(commits[i].ID),
 		})
 	}
 
-	return resolvedCommits, unresolvedCommits, nil
+	return resolvedParams, unresolvedCommits, nil
 }
 
 // resolveLockfileDependenciesFromStore returns a flattened list of package dependencies for each
-// of the given repo-commit pairs from the database. The given `repoCommits` slice is altered in-place.
-// The returned `numUnqueried` value is the number of elements at the prefix of the slice that had no data.
-// It is expected that the remaining elements be passed to the fallback dependencies resolver, if one is
-// registered.
-func (s *Service) resolveLockfileDependenciesFromStore(ctx context.Context, repoCommits []repoCommitResolvedCommit, includeTransitive bool) (deps []shared.PackageDependency, notFound []repoCommitResolvedCommit, err error) {
+// of the given repo-commit pairs from the database.
+func (s *Service) resolveLockfileDependenciesFromStore(ctx context.Context, params []resolvedQueryParams) (deps []shared.PackageDependency, notFound []resolvedQueryParams, err error) {
 	ctx, _, endObservation := s.operations.resolveLockfileDependenciesFromStore.With(ctx, &err, observation.Args{})
 	defer func() {
 		endObservation(1, observation.Args{LogFields: []log.Field{
@@ -204,16 +229,16 @@ func (s *Service) resolveLockfileDependenciesFromStore(ctx context.Context, repo
 		}})
 	}()
 
-	for _, repoCommit := range repoCommits {
+	for _, param := range params {
 		// TODO - batch these requests in the store layer
 		if repoDeps, ok, err := s.dependenciesStore.LockfileDependencies(ctx, store.LockfileDependenciesOpts{
-			RepoName:          string(repoCommit.Repo),
-			Commit:            repoCommit.ResolvedCommit,
-			IncludeTransitive: includeTransitive,
+			RepoName:          string(param.Repo),
+			Commit:            param.ResolvedCommit,
+			IncludeTransitive: param.IncludeTransitive,
 		}); err != nil {
 			return nil, notFound, errors.Wrap(err, "store.LockfileDependencies")
 		} else if !ok {
-			notFound = append(notFound, repoCommit)
+			notFound = append(notFound, param)
 		} else {
 			deps = append(deps, repoDeps...)
 		}
@@ -225,8 +250,8 @@ func (s *Service) resolveLockfileDependenciesFromStore(ctx context.Context, repo
 // listAndPersistLockfileDependencies gathers dependencies from the lockfiles service for the
 // given repo-commit pair and persists the result to the database. This aids in both caching
 // and building an inverted index to power dependents search.
-func (s *Service) listAndPersistLockfileDependencies(ctx context.Context, repoCommit repoCommitResolvedCommit) ([]shared.PackageDependency, error) {
-	results, err := s.lockfilesSvc.ListDependencies(ctx, repoCommit.Repo, string(repoCommit.CommitID))
+func (s *Service) listAndPersistLockfileDependencies(ctx context.Context, param resolvedQueryParams) ([]shared.PackageDependency, error) {
+	results, err := s.lockfilesSvc.ListDependencies(ctx, param.Repo, string(param.ResolvedCommit))
 	if err != nil {
 		return nil, errors.Wrap(err, "lockfiles.ListDependencies")
 	}
@@ -250,8 +275,8 @@ func (s *Service) listAndPersistLockfileDependencies(ctx context.Context, repoCo
 
 		err = s.dependenciesStore.UpsertLockfileGraph(
 			ctx,
-			string(repoCommit.Repo),
-			repoCommit.ResolvedCommit,
+			string(param.Repo),
+			param.ResolvedCommit,
 			result.Lockfile,
 			serializableRepoDeps,
 			serializableGraph,
@@ -304,25 +329,27 @@ func (s *Service) sync(ctx context.Context, repos []api.RepoName) error {
 	return g.Wait()
 }
 
-// IndexLockfiles resolves the lockfile dependencies for a set of repository and revsisions
+// IndexLockfiles resolves the lockfile dependencies for a set of repository and revisions
 // and writes them the database.
 //
 // This method is expected to be used only from background routines controlling lockfile indexing
 // scheduling. Additional users may impact the performance profile of the application as a whole.
-func (s *Service) IndexLockfiles(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) (err error) {
+//
+// It ignores most fields of QueryParams and only uses Repo and the RevSpecs.
+func (s *Service) IndexLockfiles(ctx context.Context, params QueryParams) (err error) {
 	if !lockfileIndexingEnabled() {
 		return nil
 	}
 
 	// Resolve the revhashes for the source repo-commit pairs
-	repoCommits, _, err := s.resolveRepoCommits(ctx, repoRevs)
+	resolvedParams, _, err := s.resolveDependenciesParams(ctx, []QueryParams{params})
 	if err != nil {
 		return err
 	}
 
 	var allDependencies []shared.PackageDependency
-	for _, repoCommit := range repoCommits {
-		deps, err := s.listAndPersistLockfileDependencies(ctx, repoCommit)
+	for _, param := range resolvedParams {
+		deps, err := s.listAndPersistLockfileDependencies(ctx, param)
 		if err != nil {
 			return err
 		}
@@ -378,16 +405,16 @@ func (s *Service) upsertAndSyncDependencies(ctx context.Context, deps []shared.P
 
 // Dependents resolves the (transitive) inverse dependencies for a set of repository and revisions.
 // Both the input repoRevs and the output dependencyRevs are a map from repository names to revspecs.
-func (s *Service) Dependents(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) (dependentsRevs map[api.RepoName]types.RevSpecSet, err error) {
+func (s *Service) Dependents(ctx context.Context, params []QueryParams) (dependentsRevs map[api.RepoName]types.RevSpecSet, err error) {
 	// Resolve the revhashes for the source repo-commit pairs.
 	// TODO - Process unresolved commits.
-	repoCommits, _, err := s.resolveRepoCommits(ctx, repoRevs)
+	resolvedParams, _, err := s.resolveDependenciesParams(ctx, params)
 	if err != nil {
 		return nil, err
 	}
 
 	var deps []api.RepoCommit
-	for _, commit := range repoCommits {
+	for _, commit := range resolvedParams {
 		// TODO - batch these requests in the store layer
 		repoDeps, err := s.dependenciesStore.LockfileDependents(ctx, string(commit.Repo), commit.ResolvedCommit)
 		if err != nil {
@@ -409,7 +436,7 @@ func (s *Service) Dependents(ctx context.Context, repoRevs map[api.RepoName]type
 		return dependentsRevs, nil
 	}
 
-	for _, repoCommit := range repoCommits {
+	for _, repoCommit := range resolvedParams {
 		// TODO - batch these requests in the store layer
 		preciseDeps, err := s.dependenciesStore.PreciseDependents(ctx, string(repoCommit.Repo), repoCommit.ResolvedCommit)
 		if err != nil {
@@ -429,24 +456,20 @@ func (s *Service) Dependents(ctx context.Context, repoRevs map[api.RepoName]type
 	return dependentsRevs, nil
 }
 
-func constructLogFields(repoRevs map[api.RepoName]types.RevSpecSet) []log.Field {
-	if len(repoRevs) == 1 {
-		for repoName, revs := range repoRevs {
-			revStrs := make([]string, 0, len(revs))
-			for rev := range revs {
-				revStrs = append(revStrs, string(rev))
-			}
-
-			return []log.Field{
-				log.String("repo", string(repoName)),
-				log.String("revs", strings.Join(revStrs, ",")),
-			}
+func constructLogFields(params []QueryParams) (fields []log.Field) {
+	for i, repoParam := range params {
+		revStrs := make([]string, 0, len(repoParam.RevSpecs))
+		for rev := range repoParam.RevSpecs {
+			revStrs = append(revStrs, string(rev))
 		}
+
+		fields = append(fields,
+			log.String(fmt.Sprintf("repo-%d", i), string(repoParam.Repo)),
+			log.String(fmt.Sprintf("revs-%d", i), strings.Join(revStrs, ",")),
+		)
 	}
 
-	return []log.Field{
-		log.Int("repoRevs", len(repoRevs)),
-	}
+	return fields
 }
 
 func (s *Service) SelectRepoRevisionsToResolve(ctx context.Context, batchSize int, minimumCheckInterval time.Duration) (map[string][]string, error) {

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -245,8 +245,10 @@ type RepoDependenciesPredicate struct {
 	Transitive bool
 }
 
+var emptyRepoDependencies = errors.New("no pattern to match a repository in repo:dependencies predicate parameter")
+
 func (f *RepoDependenciesPredicate) ParseParams(params string) (err error) {
-	for _, elem := range strings.Split(params, " ") {
+	for _, elem := range strings.Fields(params) {
 		if trimmed := strings.TrimPrefix(elem, "transitive:"); trimmed != elem {
 			f.Transitive = parseYesNoOnly(trimmed) == Yes
 		} else {
@@ -256,7 +258,7 @@ func (f *RepoDependenciesPredicate) ParseParams(params string) (err error) {
 			}
 
 			if re == "" {
-				return errors.Errorf("empty repo:dependencies predicate parameter %q", re)
+				return emptyRepoDependencies
 			}
 
 			_, err = syntax.Parse(re, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
@@ -266,6 +268,10 @@ func (f *RepoDependenciesPredicate) ParseParams(params string) (err error) {
 
 			f.RepoRev = elem
 		}
+	}
+
+	if f.RepoRev == "" {
+		return emptyRepoDependencies
 	}
 
 	return nil

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -90,13 +90,13 @@ func TestRepoDependenciesPredicate(t *testing.T) {
 		}
 
 		valid := []test{
-			{`literal`, `test`, &RepoDependenciesPredicate{RepoRev: "test"}},
+			{`literal`, `repo`, &RepoDependenciesPredicate{RepoRev: "repo"}},
 			{`regex with revs`, `^github\.com/org/repo$@v3.0:v4.0`, &RepoDependenciesPredicate{RepoRev: `^github\.com/org/repo$@v3.0:v4.0`}},
 			{`regex with transitive:yes`, `^github\.com/org/repo$ transitive:yes`, &RepoDependenciesPredicate{RepoRev: `^github\.com/org/repo$`, Transitive: true}},
-			{`transitive:no`, `transitive:no`, &RepoDependenciesPredicate{Transitive: false}},
+			{`transitive:no`, `repo transitive:no`, &RepoDependenciesPredicate{RepoRev: "repo", Transitive: false}},
 			// transitive:only is ignored for now
-			{`transitive:only`, `transitive:only`, &RepoDependenciesPredicate{Transitive: false}},
-			{`transitive:horse`, `transitive:horse`, &RepoDependenciesPredicate{Transitive: false}},
+			{`transitive:only`, `repo transitive:only`, &RepoDependenciesPredicate{RepoRev: "repo", Transitive: false}},
+			{`transitive:horse`, `repo transitive:horse`, &RepoDependenciesPredicate{RepoRev: "repo", Transitive: false}},
 		}
 
 		for _, tc := range valid {
@@ -116,6 +116,7 @@ func TestRepoDependenciesPredicate(t *testing.T) {
 		invalid := []test{
 			{`empty`, ``, nil},
 			{`catch invalid regexp`, `([)`, nil},
+			{`only transitive`, `transitive:yes`, nil},
 		}
 
 		for _, tc := range invalid {

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -90,8 +90,13 @@ func TestRepoDependenciesPredicate(t *testing.T) {
 		}
 
 		valid := []test{
-			{`literal`, `test`, &RepoDependenciesPredicate{}},
-			{`regex with revs`, `^npm/@bar:baz`, &RepoDependenciesPredicate{}},
+			{`literal`, `test`, &RepoDependenciesPredicate{RepoRev: "test"}},
+			{`regex with revs`, `^github\.com/org/repo$@v3.0:v4.0`, &RepoDependenciesPredicate{RepoRev: `^github\.com/org/repo$@v3.0:v4.0`}},
+			{`regex with transitive:yes`, `^github\.com/org/repo$ transitive:yes`, &RepoDependenciesPredicate{RepoRev: `^github\.com/org/repo$`, Transitive: true}},
+			{`transitive:no`, `transitive:no`, &RepoDependenciesPredicate{Transitive: false}},
+			// transitive:only is ignored for now
+			{`transitive:only`, `transitive:only`, &RepoDependenciesPredicate{Transitive: false}},
+			{`transitive:horse`, `transitive:horse`, &RepoDependenciesPredicate{Transitive: false}},
 		}
 
 		for _, tc := range valid {
@@ -103,7 +108,7 @@ func TestRepoDependenciesPredicate(t *testing.T) {
 				}
 
 				if !reflect.DeepEqual(tc.expected, p) {
-					t.Fatalf("expected %#v, got %#v", tc.expected, p)
+					t.Fatalf("expected %+v, got %+v", tc.expected, p)
 				}
 			})
 		}

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -416,13 +416,15 @@ func (p Parameters) Exists(field string) bool {
 	return found
 }
 
-func (p Parameters) Dependencies() (dependencies []string) {
+func (p Parameters) Dependencies() (preds []RepoDependenciesPredicate) {
 	VisitPredicate(toNodes(p), func(field, name, value string) {
 		if field == FieldRepo && (name == "dependencies" || name == "deps") {
-			dependencies = append(dependencies, value)
+			var pred RepoDependenciesPredicate
+			pred.ParseParams(value)
+			preds = append(preds, pred)
 		}
 	})
-	return dependencies
+	return preds
 }
 
 func (p Parameters) Dependents() (dependents []string) {

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -298,7 +298,7 @@ type Features struct {
 type RepoOptions struct {
 	RepoFilters         []string
 	MinusRepoFilters    []string
-	Dependencies        []string
+	Dependencies        []query.RepoDependenciesPredicate
 	Dependents          []string
 	DescriptionPatterns []string
 
@@ -342,7 +342,7 @@ func (op *RepoOptions) Tags() []otlog.Field {
 		add(trace.Strings("minusRepoFilters", op.MinusRepoFilters))
 	}
 	if len(op.Dependencies) > 0 {
-		add(trace.Strings("dependencies", op.Dependencies))
+		add(trace.Printf("dependencies", "%+v", op.Dependencies))
 	}
 	if len(op.Dependents) > 0 {
 		add(trace.Strings("dependents", op.Dependents))


### PR DESCRIPTION
This PR extends the `repo:deps()` predicate to accept an additional
parameter: `transitive:yes|no|only`.

When `transitive:yes` is given and a full-fidelity dependency graph has
been persisted, transitive + direct dependencies of an indexed lockfile
are returned. If it's `transitive:no` then only direct ones will be
returned. `transitive:only` is ignored for now.

The changes in here can be put into two buckets:

1. Search query changes to parse/validate `transitive:yes` in
   `repo:deps()`.
2. Grunt work to make sure `transitive:` is applied only to the
   repo+revspecs for which it was used. i.e.: if the user specified

       repo:deps(^github\.com/org-\w+/repo.*$@main:v4 transitive:yes) \
         repo:deps(^github\.com/org-\w+/repo2.*$@v5:v6 transitive:no)

   Then the the repo+revs yielded in first predicate should have
   `transitive:yes` set, but the repo+revs yielded by second one should
   not.

Point (2) required a lot of busy work in the service layer to pass the repo+revspec pairs from the search backend to the database layer correctly. But I think the end result is actually easier to understand than what we had before.

With all the bits in place now, I can easily add `level:1` or `lockfile:client/web/yarn.lock` as parameters.

## Reviewers

@camdencheek tagging you for the search parts, since we paired on this.

@efritz @stefanhengl @eseliger tagging you for the backend parts.

## Test plan

- Existing and newly modified tests
- Manual testing
