### PR TITLE
JetBrains: Add “New version” notification

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -132,6 +132,14 @@ public class ConfigUtil {
         SourcegraphApplicationService.getInstance().isUrlNotificationDismissed = value;
     }
 
+    public static String getLastUpdateNotificationPluginVersion() {
+        return SourcegraphApplicationService.getInstance().getLastUpdateNotificationPluginVersion();
+    }
+
+    public static void setLastUpdateNotificationPluginVersionToCurrent() {
+        SourcegraphApplicationService.getInstance().lastUpdateNotificationPluginVersion = getPluginVersion();
+    }
+
     @NotNull
     private static SourcegraphApplicationService getApplicationLevelConfig() {
         return Objects.requireNonNull(SourcegraphApplicationService.getInstance());

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.config;
 
-import com.intellij.icons.AllIcons;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
@@ -78,7 +77,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
                 notification.expire();
             }
         };
-        AnAction learnMoreAction = new DumbAwareAction("Learn More", "Opens browser to describe the latest changes", AllIcons.Ide.External_link_arrow) {
+        AnAction learnMoreAction = new DumbAwareAction("Learn More", "Opens browser to describe the latest changes", null) {
             @Override
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
                 String whatsNewUrl = "https://plugins.jetbrains.com/plugin/9682-sourcegraph#:~:text=What%E2%80%99s%20New";

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -1,25 +1,47 @@
 package com.sourcegraph.config;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.KeyboardShortcut;
+import com.intellij.openapi.externalSystem.service.execution.NotSupportedException;
+import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import com.sourcegraph.Icons;
+import com.sourcegraph.find.FindService;
 import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class NotificationActivity implements StartupActivity.DumbAware {
     @Override
     public void runActivity(@NotNull Project project) {
-        String url = ConfigUtil.getSourcegraphUrl(project);
-        if (ConfigUtil.isUrlNotificationDismissed() || (url.length() != 0 && !url.startsWith("https://sourcegraph.com"))) {
-            return;
+        String latestReleaseMilestoneVersion = "2.0.0";
+        String lastNotifiedPluginVersion = ConfigUtil.getLastUpdateNotificationPluginVersion();
+        if (lastNotifiedPluginVersion == null || lastNotifiedPluginVersion.compareTo(latestReleaseMilestoneVersion) < 0) {
+            notifyAboutUpdate(project);
+        } else {
+            String url = ConfigUtil.getSourcegraphUrl(project);
+            if (!ConfigUtil.isUrlNotificationDismissed() && (url.length() == 0 || url.startsWith("https://sourcegraph.com"))) {
+                notifyAboutSourcegraphUrl();
+            }
         }
+    }
+
+    private void notifyAboutSourcegraphUrl() {
         // Display notification
-        Notification notification = new Notification("Sourcegraph", "Sourcegraph",
+        Notification notification = new Notification("Sourcegraph access", "Sourcegraph",
             "A custom Sourcegraph URL is not set for this project. You can only access public repos. Do you want to set your custom URL?", NotificationType.INFORMATION);
         AnAction setUrlAction = new OpenPluginSettingsAction("Set URL");
         AnAction cancelAction = new DumbAwareAction("Do Not Set") {
@@ -40,5 +62,45 @@ public class NotificationActivity implements StartupActivity.DumbAware {
         notification.addAction(cancelAction);
         notification.addAction(neverShowAgainAction);
         Notifications.Bus.notify(notification);
+    }
+
+    private void notifyAboutUpdate(@NotNull Project project) {
+        // Display notification
+        KeyboardShortcut altSShortcut = new KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK), null);
+        String altEnterShortcutText = KeymapUtil.getShortcutText(altSShortcut);
+        Notification notification = new Notification("Sourcegraph plugin updates", "Sourcegraph",
+            "Access the new plugin and try out code search with the shortcut " + altEnterShortcutText + "! Learn more about the plugin’s functionality in our blog post.", NotificationType.INFORMATION);
+        AnAction setUrlAction = new DumbAwareAction("Open Sourcegraph (" + altEnterShortcutText + ")") {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+                FindService service = project.getService(FindService.class);
+                service.showPopup();
+                notification.expire();
+            }
+        };
+        AnAction learnMoreAction = new DumbAwareAction("Learn More", "Opens browser to describe the latest changes", AllIcons.Ide.External_link_arrow) {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+                String whatsNewUrl = "https://plugins.jetbrains.com/plugin/9682-sourcegraph#:~:text=What%E2%80%99s%20New";
+
+                if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                    try {
+                        Desktop.getDesktop().browse(new URI(whatsNewUrl));
+                    } catch (IOException | URISyntaxException e) {
+                        throw new NotSupportedException("Can't open link. Wrong URL.");
+                    }
+                } else {
+                    throw new NotSupportedException("Can't open link. Desktop is not supported.");
+                }
+
+
+            }
+        };
+        notification.setIcon(Icons.SourcegraphLogo);
+        notification.addAction(setUrlAction);
+        notification.addAction(learnMoreAction);
+        Notifications.Bus.notify(notification);
+
+        ConfigUtil.setLastUpdateNotificationPluginVersionToCurrent();
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -24,6 +24,8 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     public String anonymousUserId;
     public boolean isInstallEventLogged;
     public boolean isUrlNotificationDismissed;
+    @Nullable
+    public String lastUpdateNotificationPluginVersion; // The version of the plugin that last notified the user about an update
 
     @NotNull
     public static SourcegraphApplicationService getInstance() {
@@ -66,6 +68,11 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
 
     public boolean isUrlNotificationDismissed() {
         return isUrlNotificationDismissed;
+    }
+
+    @Nullable
+    public String getLastUpdateNotificationPluginVersion() {
+        return lastUpdateNotificationPluginVersion;
     }
 
     @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/Copy.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/Copy.java
@@ -18,7 +18,7 @@ public class Copy extends FileActionBase {
         CopyPasteManager.getInstance().setContents(new StringSelection(urlWithoutUtm));
 
         // Display notification
-        Notification notification = new Notification("Sourcegraph", "Sourcegraph",
+        Notification notification = new Notification("Sourcegraph URL sharing", "Sourcegraph",
             "File URL copied to clipboard." + urlWithoutUtm, NotificationType.INFORMATION);
         Notifications.Bus.notify(notification);
     }

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,9 @@
             displayName="Sourcegraph"
             nonDefaultProject="false"
         />
-        <notificationGroup id="Sourcegraph" displayType="BALLOON"/>
+        <notificationGroup id="Sourcegraph access" displayType="BALLOON"/>
+        <notificationGroup id="Sourcegraph URL sharing" displayType="BALLOON"/>
+        <notificationGroup id="Sourcegraph plugin updates" displayType="STICKY_BALLOON"/>
         <projectService id="sourcegraph.findService" serviceImplementation="com.sourcegraph.find.FindService"/>
         <postStartupActivity implementation="com.sourcegraph.telemetry.PostStartupActivity"/>
         <postStartupActivity implementation="com.sourcegraph.config.NotificationActivity"/>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/38574

I've:
 - Added the new notification
 - Made sure the "set your access token" CTA is not displayed together with the update news
 - Organized our notifications to categories

This is how it looks on Mac:

<img width="433" alt="CleanShot 2022-07-15 at 12 40 21@2x" src="https://user-images.githubusercontent.com/2552265/179207770-85d0e00b-e7b9-4ee0-97d3-a4e72aef772c.png">


Caveats:
- We don't know the URL of our future blog post, so I'm currently using the plugin page URL for the "What's new" link.
- The icon is to the left of the action text rather than the right, which is not ideal, but I found no way to add it to its right.

## Test plan

[2-min Loom](https://www.loom.com/share/7df3ef9b6eab45a5b033a8d36aed457c)

## App preview:

- [Web](https://sg-web-dv-jetbrains-add-welcome-balloon.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-stsxigmwmv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
