### PR TITLE
Vk/add compute edit UI

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsights.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsights.ts
@@ -32,6 +32,7 @@ const INSIGHT_VIEW_SERIES_FRAGMENT = gql`
                 }
                 isCalculated
                 generatedFromCaptureGroups
+                groupBy
             }
         }
     }

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/update-insight.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/update-insight.ts
@@ -1,7 +1,7 @@
 import { ApolloClient } from '@apollo/client'
 import { ApolloCache } from '@apollo/client/cache'
 import { MutationUpdaterFunction } from '@apollo/client/core/types'
-import { from, Observable, throwError } from 'rxjs'
+import { from, Observable } from 'rxjs'
 
 import {
     UpdateLangStatsInsightResult,
@@ -16,6 +16,7 @@ import { UPDATE_LINE_CHART_SEARCH_INSIGHT_GQL } from '../../gql/UpdateLineChartS
 
 import {
     getCaptureGroupInsightUpdateInput,
+    getComputeInsightUpdateInput,
     getLangStatsInsightUpdateInput,
     getSearchInsightUpdateInput,
 } from './serializators'
@@ -52,7 +53,13 @@ export const updateInsight = (
         }
 
         case InsightType.Compute: {
-            return throwError(new Error('update mutation for the compute-powered insight is not implemented yet'))
+            return from(
+                client.mutate<UpdateLineChartSearchInsightResult, UpdateLineChartSearchInsightVariables>({
+                    mutation: UPDATE_LINE_CHART_SEARCH_INSIGHT_GQL,
+                    variables: { input: getComputeInsightUpdateInput(nextInsightData), id: insightId },
+                    update,
+                })
+            )
         }
 
         case InsightType.LangStats: {

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
@@ -47,7 +47,7 @@ interface ComputeInsightCreationContentProps extends NativeContainerProps {
     touched: boolean
     children: (input: RenderPropertyInputs) => ReactNode
     initialValue?: Partial<CreateComputeInsightFormFields>
-    onChange: (event: FormChangeEvent<CreateComputeInsightFormFields>) => void
+    onChange?: (event: FormChangeEvent<CreateComputeInsightFormFields>) => void
     onSubmit: (values: CreateComputeInsightFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
 }
 

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -12,12 +12,14 @@ import { CodeInsightsPage } from '../../../components'
 import {
     CodeInsightsBackendContext,
     isCaptureGroupInsight,
+    isComputeInsight,
     isLangStatsInsight,
     isSearchBasedInsight,
 } from '../../../core'
 import { useUiFeatures } from '../../../hooks'
 
 import { EditCaptureGroupInsight } from './components/EditCaptureGroupInsight'
+import { EditComputeInsight } from './components/EditComputeInsight'
 import { EditLangStatsInsight } from './components/EditLangStatsInsight'
 import { EditSearchBasedInsight } from './components/EditSearchInsight'
 import { useEditPageHandlers } from './hooks/use-edit-page-handlers'
@@ -107,6 +109,16 @@ export const EditInsightPage: React.FunctionComponent<React.PropsWithChildren<Ed
 
             {isLangStatsInsight(insight) && (
                 <EditLangStatsInsight
+                    licensed={licensed}
+                    isEditAvailable={editPermission?.available}
+                    insight={insight}
+                    onSubmit={handleSubmit}
+                    onCancel={handleCancel}
+                />
+            )}
+
+            {isComputeInsight(insight) && (
+                <EditComputeInsight
                     licensed={licensed}
                     isEditAvailable={editPermission?.available}
                     insight={insight}

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditComputeInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditComputeInsight.tsx
@@ -1,0 +1,67 @@
+import { FC, useMemo } from 'react'
+
+import {
+    CodeInsightCreationMode,
+    CodeInsightsCreationActions,
+    createDefaultEditSeries,
+    FORM_ERROR,
+    SubmissionErrors,
+} from '../../../../components'
+import { ComputeInsight, MinimalComputeInsightData } from '../../../../core'
+import { ComputeInsightCreationContent } from '../../creation/compute/components/ComputeInsightCreationContent'
+import { CreateComputeInsightFormFields } from '../../creation/compute/types'
+import { getSanitizedComputeInsight } from '../../creation/compute/utils/insight-sanitaizer'
+
+interface EditComputeInsightProps {
+    insight: ComputeInsight
+    licensed: boolean
+    isEditAvailable: boolean | undefined
+    onSubmit: (insight: MinimalComputeInsightData) => SubmissionErrors | Promise<SubmissionErrors> | void
+    onCancel: () => void
+}
+
+export const EditComputeInsight: FC<EditComputeInsightProps> = props => {
+    const { insight, licensed, isEditAvailable, onCancel, onSubmit } = props
+
+    const insightFormValues = useMemo<CreateComputeInsightFormFields>(
+        () => ({
+            title: insight.title,
+            repositories: insight.repositories.join(', '),
+            series: insight.series.map(line => createDefaultEditSeries({ ...line, valid: true })),
+            dashboardReferenceCount: insight.dashboardReferenceCount,
+            groupBy: insight.groupBy,
+        }),
+        [insight]
+    )
+
+    const handleSubmit = (
+        values: CreateComputeInsightFormFields
+    ): SubmissionErrors | Promise<SubmissionErrors> | void => {
+        const sanitizedInsight = getSanitizedComputeInsight(values)
+        return onSubmit({
+            ...sanitizedInsight,
+            filters: insight.filters,
+        })
+    }
+
+    return (
+        <ComputeInsightCreationContent
+            touched={true}
+            initialValue={insightFormValues}
+            className="pb-5"
+            onSubmit={handleSubmit}
+        >
+            {form => (
+                <CodeInsightsCreationActions
+                    mode={CodeInsightCreationMode.Edit}
+                    licensed={licensed}
+                    available={isEditAvailable}
+                    submitting={form.submitting}
+                    errors={form.submitErrors?.[FORM_ERROR]}
+                    clear={form.isFormClearActive}
+                    onCancel={onCancel}
+                />
+            )}
+        </ComputeInsightCreationContent>
+    )
+}

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
@@ -6,11 +6,9 @@ import { asError } from '@sourcegraph/common'
 import { useObservable } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../../../../../tracking/eventLogger'
-import { FORM_ERROR, SubmissionErrors } from '../../../../components/form/hooks/useForm'
-import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
-import { CreationInsightInput } from '../../../../core/backend/code-insights-backend-types'
-import { ALL_INSIGHTS_DASHBOARD } from '../../../../core/constants'
-import { useQueryParameters } from '../../../../hooks/use-query-parameters'
+import { FORM_ERROR, SubmissionErrors } from '../../../../components'
+import { CodeInsightsBackendContext, CreationInsightInput, ALL_INSIGHTS_DASHBOARD } from '../../../../core'
+import { useQueryParameters } from '../../../../hooks'
 import { getTrackingTypeByInsightType } from '../../../../pings'
 
 export interface useHandleSubmitOutput {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/37970

## Test plan
- Go to the creation UI /insight/create/group-results
- Fill out the creation form and create insight 
- In the network tab find create insight mutation and copy the newly created insight id
- Go to the edit UI /insights/edit/<insight id>
- You have to see the edit UI for compute-powered insight
- Change something in the form and click save changes 
- Visit edit UI again and you should see the most recent updated values in the form

## For reviewers 
At the moment groupBy setting doesn't work and therefore you can update it. You can change it on the edit UI page but after refreshing, you will see that this setting was set back to the group by the author. This is a known problem and it lives on the backend. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
