### PR TITLE
dependencies: only allow site-admins to query graphql for now

### DIFF
--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -1,6 +1,8 @@
 extend type Query {
     """
     A list of lockfile indexes.
+
+    Site-admin only.
     """
     lockfileIndexes(
         """


### PR DESCRIPTION
Main goal for now is to only use this in the site-admin area so I'd rather not expose it too early (since we'd have to do repository permission checks etc.)

## Test plan

- Manual testing