### PR TITLE
Fix build by making LockfileIndexResolver interface less generic

### DIFF
--- a/cmd/frontend/graphqlbackend/dependencies.go
+++ b/cmd/frontend/graphqlbackend/dependencies.go
@@ -25,4 +25,5 @@ type LockfileIndexConnectionResolver interface {
 
 type LockfileIndexResolver interface {
 	ID() graphql.ID
+	Lockfile() string
 }

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -42,4 +42,9 @@ type LockfileIndex implements Node {
     The unique ID for the lockfile index.
     """
     id: ID!
+
+    """
+    The relative path of the lockfile that was resolved and indexed.
+    """
+    lockfile: String!
 }

--- a/go.mod
+++ b/go.mod
@@ -421,7 +421,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220713181107-267622ccb496
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220714211435-94ab14fe73c8
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -2039,8 +2039,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220713181107-267622ccb496 h1:LhaDsOZYouJHEUbIwjeUItZJIez+PPQHXXTtw7ES/DY=
-github.com/sourcegraph/zoekt v0.0.0-20220713181107-267622ccb496/go.mod h1:EvI7mOEF5BxYn5z2AgBXRFLjD9PxSB999bXeSHMDdPo=
+github.com/sourcegraph/zoekt v0.0.0-20220714211435-94ab14fe73c8 h1:1RTfjljxxpF8o3ZH8iNSXFd87e3cQRGH+ZCMn8yI1M0=
+github.com/sourcegraph/zoekt v0.0.0-20220714211435-94ab14fe73c8/go.mod h1:EvI7mOEF5BxYn5z2AgBXRFLjD9PxSB999bXeSHMDdPo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
@@ -8,13 +8,17 @@ import (
 )
 
 type LockfileIndexResolver struct {
-	executor shared.LockfileIndex
+	lockfile shared.LockfileIndex
 }
 
 func NewExecutorResolver(executor shared.LockfileIndex) *LockfileIndexResolver {
-	return &LockfileIndexResolver{executor: executor}
+	return &LockfileIndexResolver{lockfile: executor}
 }
 
 func (e *LockfileIndexResolver) ID() graphql.ID {
-	return relay.MarshalID("LockfileIndex", (int64(e.executor.ID)))
+	return relay.MarshalID("LockfileIndex", (int64(e.lockfile.ID)))
+}
+
+func (e *LockfileIndexResolver) Lockfile() string {
+	return e.lockfile.Lockfile
 }


### PR DESCRIPTION
With only an ID property every resolver implementation matched it, that
broke QA and E2E tests.

## Test plan

- Manual testing