### PR TITLE
Fix broken build by adding missing param

### DIFF
--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
@@ -737,7 +737,7 @@ func TestGetNotebookWithSoftDeletedUserColumns(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Commit 91f3b61f782a7733eef6cea172a3d6b81156f7e8 and
c043cc9fbee5f8167725502729f86187080d1b9c got merged around the same
time, so the param added by the latter wasn't added in the former.

This fixes the build.


## Test plan

- Existing tests