### PR TITLE
JetBrains: Separate dotcom vs enterprise settings

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -13,6 +13,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public class ConfigUtil {
+    private static final String DOTCOM_URL = "https://sourcegraph.com/";
+
     @NotNull
     public static JsonObject getConfigAsJson(@NotNull Project project) {
         JsonObject configAsJson = new JsonObject();
@@ -43,17 +45,17 @@ public class ConfigUtil {
 
         // User level or default
         String enterpriseUrl = getEnterpriseUrl(project);
-        return (enterpriseUrl.equals("") || enterpriseUrl.startsWith("https://sourcegraph.com"))
+        return (enterpriseUrl.equals("") || enterpriseUrl.startsWith(DOTCOM_URL))
             ? SettingsComponent.InstanceType.DOTCOM : SettingsComponent.InstanceType.ENTERPRISE;
     }
 
     @NotNull
     public static String getSourcegraphUrl(@NotNull Project project) {
         if (getInstanceType(project) == SettingsComponent.InstanceType.DOTCOM) {
-            return "https://sourcegraph.com/";
+            return DOTCOM_URL;
         } else {
             String enterpriseUrl = getEnterpriseUrl(project);
-            return !enterpriseUrl.isEmpty() ? enterpriseUrl : "https://sourcegraph.com/";
+            return !enterpriseUrl.isEmpty() ? enterpriseUrl : DOTCOM_URL;
         }
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -25,6 +25,29 @@ public class ConfigUtil {
     }
 
     @NotNull
+    public static SettingsComponent.InstanceType getInstanceType(Project project) {
+        // Project level
+        String projectLevelSetting = getProjectLevelConfig(project).getInstanceType();
+        if (projectLevelSetting != null && !projectLevelSetting.isEmpty()) {
+            return projectLevelSetting.equals(SettingsComponent.InstanceType.ENTERPRISE.name())
+                ? SettingsComponent.InstanceType.ENTERPRISE : SettingsComponent.InstanceType.DOTCOM;
+        }
+
+
+        // Application level
+        String applicationLevelSetting = getApplicationLevelConfig().getInstanceType();
+        if (applicationLevelSetting != null && !applicationLevelSetting.isEmpty()) {
+            return applicationLevelSetting.equals(SettingsComponent.InstanceType.ENTERPRISE.name())
+                ? SettingsComponent.InstanceType.ENTERPRISE : SettingsComponent.InstanceType.DOTCOM;
+        }
+
+        // User level or default
+        String sourcegraphUrl = getSourcegraphUrl(project);
+        return sourcegraphUrl.startsWith("https://sourcegraph.com")
+            ? SettingsComponent.InstanceType.DOTCOM : SettingsComponent.InstanceType.ENTERPRISE;
+    }
+
+    @NotNull
     public static String getSourcegraphUrl(@NotNull Project project) {
         // Project level
         String projectLevelUrl = getProjectLevelConfig(project).getSourcegraphUrl();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public class ConfigUtil {
-    private static final String DOTCOM_URL = "https://sourcegraph.com/";
+    public static final String DOTCOM_URL = "https://sourcegraph.com/";
 
     @NotNull
     public static JsonObject getConfigAsJson(@NotNull Project project) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -26,73 +26,81 @@ public class ConfigUtil {
 
     @NotNull
     public static String getSourcegraphUrl(@NotNull Project project) {
-        String projectLevelUrl = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getSourcegraphUrl();
+        // Project level
+        String projectLevelUrl = getProjectLevelConfig(project).getSourcegraphUrl();
         if (projectLevelUrl != null && projectLevelUrl.length() > 0) {
             return addSlashIfNeeded(projectLevelUrl);
         }
 
-        String applicationLevelUrl = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getSourcegraphUrl();
+        // Application level
+        String applicationLevelUrl = getProjectLevelConfig(project).getSourcegraphUrl();
         if (applicationLevelUrl != null && applicationLevelUrl.length() > 0) {
             return addSlashIfNeeded(applicationLevelUrl);
         }
 
+        // User level or default
         return addSlashIfNeeded(UserLevelConfig.getSourcegraphUrl());
-    }
-
-    @NotNull
-    private static String addSlashIfNeeded(@NotNull String url) {
-        return url.endsWith("/") ? url : url + "/";
     }
 
     @Nullable
     public static String getAccessToken(Project project) {
+        // Project level → application level
         String projectLevelAccessToken = getProjectLevelConfig(project).getAccessToken();
         return projectLevelAccessToken != null ? projectLevelAccessToken : getApplicationLevelConfig().getAccessToken();
     }
 
     @NotNull
     public static String getDefaultBranchName(@NotNull Project project) {
-        String projectLevelDefaultBranchName = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getDefaultBranchName();
+        // Project level
+        String projectLevelDefaultBranchName = getProjectLevelConfig(project).getDefaultBranchName();
         if (projectLevelDefaultBranchName != null && projectLevelDefaultBranchName.length() > 0) {
             return projectLevelDefaultBranchName;
         }
 
-        String applicationLevelDefaultBranchName = Objects.requireNonNull(SourcegraphApplicationService.getInstance()).getDefaultBranchName();
+        // Application level
+        String applicationLevelDefaultBranchName = getApplicationLevelConfig().getDefaultBranchName();
         if (applicationLevelDefaultBranchName != null && applicationLevelDefaultBranchName.length() > 0) {
             return applicationLevelDefaultBranchName;
         }
 
+        // User level or default
         String userLevelDefaultBranchName = UserLevelConfig.getDefaultBranchName();
         return userLevelDefaultBranchName != null ? userLevelDefaultBranchName : "main";
     }
 
     @NotNull
     public static String getRemoteUrlReplacements(@NotNull Project project) {
-        String projectLevelReplacements = Objects.requireNonNull(SourcegraphProjectService.getInstance(project)).getRemoteUrlReplacements();
+        // Project level
+        String projectLevelReplacements = getProjectLevelConfig(project).getRemoteUrlReplacements();
         if (projectLevelReplacements != null && projectLevelReplacements.length() > 0) {
             return projectLevelReplacements;
         }
 
-        String applicationLevelReplacements = Objects.requireNonNull(SourcegraphApplicationService.getInstance()).getRemoteUrlReplacements();
+        // Application level
+        String applicationLevelReplacements = getApplicationLevelConfig().getRemoteUrlReplacements();
         if (applicationLevelReplacements != null && applicationLevelReplacements.length() > 0) {
             return applicationLevelReplacements;
         }
 
+        // User level or default
         String userLevelRemoteUrlReplacements = UserLevelConfig.getRemoteUrlReplacements();
         return userLevelRemoteUrlReplacements != null ? userLevelRemoteUrlReplacements : "";
     }
 
     public static boolean isGlobbingEnabled(@NotNull Project project) {
+        // Project level → application level
         Boolean projectLevelIsGlobbingEnabled = getProjectLevelConfig(project).isGlobbingEnabled();
         return projectLevelIsGlobbingEnabled != null ? projectLevelIsGlobbingEnabled : getApplicationLevelConfig().isGlobbingEnabled();
     }
 
     @Nullable
     public static Search getLastSearch(@NotNull Project project) {
+        // Project level
         return getProjectLevelConfig(project).getLastSearch();
     }
 
     public static void setLastSearch(@NotNull Project project, @NotNull Search lastSearch) {
+        // Project level
         SourcegraphProjectService settings = getProjectLevelConfig(project);
         settings.lastSearchQuery = lastSearch.getQuery() != null ? lastSearch.getQuery() : "";
         settings.lastSearchCaseSensitive = lastSearch.isCaseSensitive();
@@ -103,33 +111,39 @@ public class ConfigUtil {
     @NotNull
     @Contract(pure = true)
     public static String getPluginVersion() {
+        // Internal version
         IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId("com.sourcegraph.jetbrains"));
         return plugin != null ? plugin.getVersion() : "unknown";
     }
 
     @Nullable
     public static String getAnonymousUserId() {
-        return SourcegraphApplicationService.getInstance().getAnonymousUserId();
+        return getApplicationLevelConfig().getAnonymousUserId();
     }
 
     public static void setAnonymousUserId(@Nullable String anonymousUserId) {
-        SourcegraphApplicationService.getInstance().anonymousUserId = anonymousUserId;
+        getApplicationLevelConfig().anonymousUserId = anonymousUserId;
     }
 
     public static boolean isInstallEventLogged() {
-        return SourcegraphApplicationService.getInstance().isInstallEventLogged();
+        return getApplicationLevelConfig().isInstallEventLogged();
     }
 
     public static void setInstallEventLogged(boolean value) {
-        SourcegraphApplicationService.getInstance().isInstallEventLogged = value;
+        getApplicationLevelConfig().isInstallEventLogged = value;
     }
 
     public static boolean isUrlNotificationDismissed() {
-        return SourcegraphApplicationService.getInstance().isUrlNotificationDismissed();
+        return getApplicationLevelConfig().isUrlNotificationDismissed();
     }
 
     public static void setUrlNotificationDismissed(boolean value) {
-        SourcegraphApplicationService.getInstance().isUrlNotificationDismissed = value;
+        getApplicationLevelConfig().isUrlNotificationDismissed = value;
+    }
+
+    @NotNull
+    private static String addSlashIfNeeded(@NotNull String url) {
+        return url.endsWith("/") ? url : url + "/";
     }
 
     public static String getLastUpdateNotificationPluginVersion() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -56,7 +56,7 @@ public class ConfigUtil {
         }
 
         // Application level
-        String applicationLevelUrl = getProjectLevelConfig(project).getSourcegraphUrl();
+        String applicationLevelUrl = getApplicationLevelConfig().getSourcegraphUrl();
         if (applicationLevelUrl != null && applicationLevelUrl.length() > 0) {
             return addSlashIfNeeded(applicationLevelUrl);
         }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -31,7 +31,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
         if (lastNotifiedPluginVersion == null || lastNotifiedPluginVersion.compareTo(latestReleaseMilestoneVersion) < 0) {
             notifyAboutUpdate(project);
         } else {
-            String url = ConfigUtil.getSourcegraphUrl(project);
+            String url = ConfigUtil.getEnterpriseUrl(project);
             if (!ConfigUtil.isUrlNotificationDismissed() && (url.length() == 0 || url.startsWith("https://sourcegraph.com"))) {
                 notifyAboutSourcegraphUrl();
             }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -32,7 +32,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
             notifyAboutUpdate(project);
         } else {
             String url = ConfigUtil.getEnterpriseUrl(project);
-            if (!ConfigUtil.isUrlNotificationDismissed() && (url.length() == 0 || url.startsWith("https://sourcegraph.com"))) {
+            if (!ConfigUtil.isUrlNotificationDismissed() && (url.length() == 0 || url.startsWith(ConfigUtil.DOTCOM_URL))) {
                 notifyAboutSourcegraphUrl();
             }
         }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -82,7 +82,7 @@ public class SettingsComponent {
         urlTextField = new JBTextField();
         //noinspection DialogTitleCapitalization
         urlTextField.getEmptyText().setText("https://sourcegraph.example.com");
-        urlTextField.setToolTipText("The default is \"https://sourcegraph.com\".");
+        urlTextField.setToolTipText("The default is \"" + ConfigUtil.DOTCOM_URL + "\".");
         addValidation(urlTextField, () ->
             urlTextField.getText().length() == 0 ? new ValidationInfo("Missing URL", urlTextField)
                 : (!JsonSchemaConfigurable.isValidURL(urlTextField.getText()) ? new ValidationInfo("This is an invalid URL", urlTextField)

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -17,6 +17,9 @@ import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.JTextComponent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.util.Enumeration;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -26,13 +29,19 @@ import java.util.function.Supplier;
 public class SettingsComponent {
     private final Project project;
     private final JPanel panel;
+    private ButtonGroup instanceTypeButtonGroup;
     private JBTextField sourcegraphUrlTextField;
     private JBTextField accessTokenTextField;
+    private JBLabel userDocsLinkComment;
+    private JBLabel accessTokenLinkComment;
     private JBTextField defaultBranchNameTextField;
     private JBTextField remoteUrlReplacementsTextField;
     private JBCheckBox globbingCheckBox;
     private JBCheckBox isUrlNotificationDismissedCheckBox;
-    private JBLabel accessTokenLinkComment;
+
+    public JComponent getPreferredFocusedComponent() {
+        return defaultBranchNameTextField;
+    }
 
     public SettingsComponent(@NotNull Project project) {
         this.project = project;
@@ -50,8 +59,94 @@ public class SettingsComponent {
         return panel;
     }
 
-    public JComponent getPreferredFocusedComponent() {
-        return sourcegraphUrlTextField;
+    @NotNull
+    public InstanceType getInstanceType() {
+        return instanceTypeButtonGroup.getSelection().getActionCommand().equals(InstanceType.DOTCOM.name()) ? InstanceType.DOTCOM : InstanceType.ENTERPRISE;
+    }
+
+    public void setInstanceType(@NotNull InstanceType instanceType) {
+        for (Enumeration<AbstractButton> buttons = instanceTypeButtonGroup.getElements(); buttons.hasMoreElements(); ) {
+            AbstractButton button = buttons.nextElement();
+
+            button.setSelected(button.getActionCommand().equals(instanceType.name()));
+        }
+
+        setEnterpriseSettingsEnabled(instanceType == InstanceType.ENTERPRISE);
+    }
+
+    @NotNull
+    private JPanel createAuthenticationPanel() {
+        // Create URL field for the enterprise section
+        JBLabel urlLabel = new JBLabel("Sourcegraph URL:");
+        sourcegraphUrlTextField = new JBTextField();
+        //noinspection DialogTitleCapitalization
+        sourcegraphUrlTextField.getEmptyText().setText("https://sourcegraph.example.com");
+        sourcegraphUrlTextField.setToolTipText("The default is \"https://sourcegraph.com\".");
+        addValidation(sourcegraphUrlTextField, () ->
+            sourcegraphUrlTextField.getText().length() == 0 ? new ValidationInfo("Missing URL", sourcegraphUrlTextField)
+                : (!JsonSchemaConfigurable.isValidURL(sourcegraphUrlTextField.getText()) ? new ValidationInfo("This is an invalid URL", sourcegraphUrlTextField)
+                : null));
+        addDocumentListener(sourcegraphUrlTextField, e -> updateAccessTokenLinkCommentText());
+
+        // Create access token field
+        JBLabel accessTokenLabel = new JBLabel("Access token:");
+        accessTokenTextField = new JBTextField();
+        accessTokenTextField.getEmptyText().setText("Paste your access token here");
+        addValidation(accessTokenTextField, () ->
+            (accessTokenTextField.getText().length() > 0 && accessTokenTextField.getText().length() != 40)
+                ? new ValidationInfo("Invalid access token", accessTokenTextField)
+                : null);
+
+        // Create comments
+        userDocsLinkComment = new JBLabel("<html><body>You might need an access token to sign in. See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> for a video guide,</body></html>", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
+        userDocsLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
+        userDocsLinkComment.setCopyable(true);
+        accessTokenLinkComment = new JBLabel("", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
+        accessTokenLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
+        accessTokenLinkComment.setCopyable(true);
+
+        // Set up radio buttons
+        ActionListener actionListener = event -> setEnterpriseSettingsEnabled(event.getActionCommand().equals(InstanceType.ENTERPRISE.name()));
+        JRadioButton sourcegraphDotComRadioButton = new JRadioButton("Use sourcegraph.com");
+        sourcegraphDotComRadioButton.setMnemonic(KeyEvent.VK_C);
+        sourcegraphDotComRadioButton.setActionCommand(InstanceType.DOTCOM.name());
+        sourcegraphDotComRadioButton.addActionListener(actionListener);
+        JRadioButton enterpriseInstanceRadioButton = new JRadioButton("Use an enterprise instance");
+        enterpriseInstanceRadioButton.setMnemonic(KeyEvent.VK_E);
+        enterpriseInstanceRadioButton.setActionCommand(InstanceType.ENTERPRISE.name());
+        enterpriseInstanceRadioButton.addActionListener(actionListener);
+        instanceTypeButtonGroup = new ButtonGroup();
+        instanceTypeButtonGroup.add(sourcegraphDotComRadioButton);
+        instanceTypeButtonGroup.add(enterpriseInstanceRadioButton);
+
+        // Assemble the two main panels
+        JBLabel dotComComment = new JBLabel("Use sourcegraph.com to search public code", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
+        dotComComment.setBorder(JBUI.Borders.emptyLeft(20));
+        JPanel dotComPanel = FormBuilder.createFormBuilder()
+            .addComponent(sourcegraphDotComRadioButton, 1)
+            .addComponentToRightColumn(dotComComment, 2)
+            .getPanel();
+        JPanel enterprisePanelContent = FormBuilder.createFormBuilder()
+            .addLabeledComponent(urlLabel, sourcegraphUrlTextField, 1)
+            .addTooltip("If your company has your own Sourcegraph instance, set its URL here")
+            .addLabeledComponent(accessTokenLabel, accessTokenTextField, 1)
+            .addComponentToRightColumn(userDocsLinkComment, 1)
+            .addComponentToRightColumn(accessTokenLinkComment, 1)
+            .getPanel();
+        enterprisePanelContent.setBorder(IdeBorderFactory.createEmptyBorder(JBUI.insets(1, 30, 0, 0)));
+        JPanel enterprisePanel = FormBuilder.createFormBuilder()
+            .addComponent(enterpriseInstanceRadioButton, 1)
+            .addComponent(enterprisePanelContent, 1)
+            .getPanel();
+
+        // Assemble the main panel
+        JPanel userAuthenticationPanel = FormBuilder.createFormBuilder()
+            .addComponent(dotComPanel)
+            .addComponent(enterprisePanel, 5)
+            .getPanel();
+        userAuthenticationPanel.setBorder(IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
+
+        return userAuthenticationPanel;
     }
 
     @NotNull
@@ -106,45 +201,16 @@ public class SettingsComponent {
         isUrlNotificationDismissedCheckBox.setSelected(value);
     }
 
-    @NotNull
-    private JPanel createAuthenticationPanel() {
-        JBLabel urlLabel = new JBLabel("Sourcegraph URL:");
-        sourcegraphUrlTextField = new JBTextField();
-        //noinspection DialogTitleCapitalization
-        sourcegraphUrlTextField.getEmptyText().setText("https://sourcegraph.example.com");
-        sourcegraphUrlTextField.setToolTipText("The default is \"https://sourcegraph.com\".");
+    private void setEnterpriseSettingsEnabled(boolean enable) {
+        sourcegraphUrlTextField.setEnabled(enable);
+        accessTokenTextField.setEnabled(enable);
+        userDocsLinkComment.setEnabled(enable);
+        accessTokenLinkComment.setEnabled(enable);
+    }
 
-        addValidation(sourcegraphUrlTextField, () ->
-            sourcegraphUrlTextField.getText().length() == 0 ? new ValidationInfo("Missing URL", sourcegraphUrlTextField)
-                : (!JsonSchemaConfigurable.isValidURL(sourcegraphUrlTextField.getText()) ? new ValidationInfo("This is an invalid URL", sourcegraphUrlTextField)
-                : null));
-        addDocumentListener(sourcegraphUrlTextField, e -> updateAccessTokenLinkCommentText());
-
-        JBLabel accessTokenLabel = new JBLabel("Access token:");
-        accessTokenTextField = new JBTextField();
-        accessTokenTextField.getEmptyText().setText("Paste your access token here");
-        addValidation(accessTokenTextField, () ->
-            (accessTokenTextField.getText().length() > 0 && accessTokenTextField.getText().length() != 40)
-                ? new ValidationInfo("Invalid access token", accessTokenTextField)
-                : null);
-
-        JBLabel userDocsLinkComment = new JBLabel("<html><body>You might need an access token to sign in. See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> for a video guide,</body></html>", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
-        userDocsLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
-        userDocsLinkComment.setCopyable(true);
-        accessTokenLinkComment = new JBLabel("", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
-        accessTokenLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
-        accessTokenLinkComment.setCopyable(true);
-
-        JPanel userAuthenticationPanel = FormBuilder.createFormBuilder()
-            .addLabeledComponent(urlLabel, sourcegraphUrlTextField)
-            .addTooltip("If your company has your own Sourcegraph instance, set its URL here")
-            .addLabeledComponent(accessTokenLabel, accessTokenTextField)
-            .addComponentToRightColumn(userDocsLinkComment, 1)
-            .addComponentToRightColumn(accessTokenLinkComment, 1)
-            .getPanel();
-        userAuthenticationPanel.setBorder(IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
-
-        return userAuthenticationPanel;
+    public enum InstanceType {
+        DOTCOM,
+        ENTERPRISE,
     }
 
     private void addValidation(@NotNull JTextComponent component, @NotNull Supplier<ValidationInfo> validator) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -12,6 +12,7 @@ import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import com.jetbrains.jsonSchema.settings.mappings.JsonSchemaConfigurable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
@@ -30,7 +31,7 @@ public class SettingsComponent {
     private final Project project;
     private final JPanel panel;
     private ButtonGroup instanceTypeButtonGroup;
-    private JBTextField sourcegraphUrlTextField;
+    private JBTextField urlTextField;
     private JBTextField accessTokenTextField;
     private JBLabel userDocsLinkComment;
     private JBLabel accessTokenLinkComment;
@@ -78,15 +79,15 @@ public class SettingsComponent {
     private JPanel createAuthenticationPanel() {
         // Create URL field for the enterprise section
         JBLabel urlLabel = new JBLabel("Sourcegraph URL:");
-        sourcegraphUrlTextField = new JBTextField();
+        urlTextField = new JBTextField();
         //noinspection DialogTitleCapitalization
-        sourcegraphUrlTextField.getEmptyText().setText("https://sourcegraph.example.com");
-        sourcegraphUrlTextField.setToolTipText("The default is \"https://sourcegraph.com\".");
-        addValidation(sourcegraphUrlTextField, () ->
-            sourcegraphUrlTextField.getText().length() == 0 ? new ValidationInfo("Missing URL", sourcegraphUrlTextField)
-                : (!JsonSchemaConfigurable.isValidURL(sourcegraphUrlTextField.getText()) ? new ValidationInfo("This is an invalid URL", sourcegraphUrlTextField)
+        urlTextField.getEmptyText().setText("https://sourcegraph.example.com");
+        urlTextField.setToolTipText("The default is \"https://sourcegraph.com\".");
+        addValidation(urlTextField, () ->
+            urlTextField.getText().length() == 0 ? new ValidationInfo("Missing URL", urlTextField)
+                : (!JsonSchemaConfigurable.isValidURL(urlTextField.getText()) ? new ValidationInfo("This is an invalid URL", urlTextField)
                 : null));
-        addDocumentListener(sourcegraphUrlTextField, e -> updateAccessTokenLinkCommentText());
+        addDocumentListener(urlTextField, e -> updateAccessTokenLinkCommentText());
 
         // Create access token field
         JBLabel accessTokenLabel = new JBLabel("Access token:");
@@ -98,12 +99,10 @@ public class SettingsComponent {
                 : null);
 
         // Create comments
-        userDocsLinkComment = new JBLabel("<html><body>You might need an access token to sign in. See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> for a video guide,</body></html>", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
+        userDocsLinkComment = new JBLabel("<html><body>You might need an access token to sign in. See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> for a video guide</body></html>", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
         userDocsLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
-        userDocsLinkComment.setCopyable(true);
         accessTokenLinkComment = new JBLabel("", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
         accessTokenLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
-        accessTokenLinkComment.setCopyable(true);
 
         // Set up radio buttons
         ActionListener actionListener = event -> setEnterpriseSettingsEnabled(event.getActionCommand().equals(InstanceType.ENTERPRISE.name()));
@@ -127,7 +126,7 @@ public class SettingsComponent {
             .addComponentToRightColumn(dotComComment, 2)
             .getPanel();
         JPanel enterprisePanelContent = FormBuilder.createFormBuilder()
-            .addLabeledComponent(urlLabel, sourcegraphUrlTextField, 1)
+            .addLabeledComponent(urlLabel, urlTextField, 1)
             .addTooltip("If your company has your own Sourcegraph instance, set its URL here")
             .addLabeledComponent(accessTokenLabel, accessTokenTextField, 1)
             .addComponentToRightColumn(userDocsLinkComment, 1)
@@ -150,12 +149,12 @@ public class SettingsComponent {
     }
 
     @NotNull
-    public String getSourcegraphUrl() {
-        return sourcegraphUrlTextField.getText();
+    public String getEnterpriseUrl() {
+        return urlTextField.getText();
     }
 
-    public void setSourcegraphUrl(@NotNull String value) {
-        sourcegraphUrlTextField.setText(value);
+    public void setEnterpriseUrl(@Nullable String value) {
+        urlTextField.setText(value != null ? value : "");
     }
 
     @NotNull
@@ -202,10 +201,12 @@ public class SettingsComponent {
     }
 
     private void setEnterpriseSettingsEnabled(boolean enable) {
-        sourcegraphUrlTextField.setEnabled(enable);
+        urlTextField.setEnabled(enable);
         accessTokenTextField.setEnabled(enable);
         userDocsLinkComment.setEnabled(enable);
+        userDocsLinkComment.setCopyable(enable);
         accessTokenLinkComment.setEnabled(enable);
+        accessTokenLinkComment.setCopyable(enable);
     }
 
     public enum InstanceType {
@@ -238,7 +239,7 @@ public class SettingsComponent {
     }
 
     private void updateAccessTokenLinkCommentText() {
-        String baseUrl = sourcegraphUrlTextField.getText();
+        String baseUrl = urlTextField.getText();
         String settingsUrl = (baseUrl.endsWith("/") ? baseUrl : baseUrl + "/") + "settings";
         accessTokenLinkComment.setText(isUrlValid(baseUrl)
             ? "<html><body>or go to <a href=\"" + settingsUrl + "\">" + settingsUrl + "</a> | \"Access tokens\" to create one.</body></html>"

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -99,7 +99,7 @@ public class SettingsComponent {
                 : null);
 
         // Create comments
-        userDocsLinkComment = new JBLabel("<html><body>You might need an access token to sign in. See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> for a video guide</body></html>", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
+        userDocsLinkComment = new JBLabel("<html><body>You will need an access token to sign in. See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> for a video guide</body></html>", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
         userDocsLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
         accessTokenLinkComment = new JBLabel("", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
         accessTokenLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
@@ -127,7 +127,7 @@ public class SettingsComponent {
             .getPanel();
         JPanel enterprisePanelContent = FormBuilder.createFormBuilder()
             .addLabeledComponent(urlLabel, urlTextField, 1)
-            .addTooltip("If your company has its own Sourcegraph instance, set its URL here")
+            .addTooltip("If your company uses a private Sourcegraph instance, set its URL here")
             .addLabeledComponent(accessTokenLabel, accessTokenTextField, 1)
             .addComponentToRightColumn(userDocsLinkComment, 1)
             .addComponentToRightColumn(accessTokenLinkComment, 1)

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -127,7 +127,7 @@ public class SettingsComponent {
             .getPanel();
         JPanel enterprisePanelContent = FormBuilder.createFormBuilder()
             .addLabeledComponent(urlLabel, urlTextField, 1)
-            .addTooltip("If your company has your own Sourcegraph instance, set its URL here")
+            .addTooltip("If your company has its own Sourcegraph instance, set its URL here")
             .addLabeledComponent(accessTokenLabel, accessTokenTextField, 1)
             .addComponentToRightColumn(userDocsLinkComment, 1)
             .addComponentToRightColumn(accessTokenLinkComment, 1)

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -39,7 +39,8 @@ public class SettingsConfigurable implements Configurable {
 
     @Override
     public boolean isModified() {
-        return !mySettingsComponent.getSourcegraphUrl().equals(ConfigUtil.getSourcegraphUrl(project))
+        return !mySettingsComponent.getInstanceType().equals(ConfigUtil.getInstanceType(project))
+            || !mySettingsComponent.getSourcegraphUrl().equals(ConfigUtil.getSourcegraphUrl(project))
             || !mySettingsComponent.getAccessToken().equals(ConfigUtil.getAccessToken(project))
             || !mySettingsComponent.getDefaultBranchName().equals(ConfigUtil.getDefaultBranchName(project))
             || !mySettingsComponent.getRemoteUrlReplacements().equals(ConfigUtil.getRemoteUrlReplacements(project))
@@ -63,6 +64,11 @@ public class SettingsConfigurable implements Configurable {
 
         publisher.beforeAction(context);
 
+        if (pSettings.instanceType != null) {
+            pSettings.instanceType = mySettingsComponent.getInstanceType().name();
+        } else {
+            aSettings.instanceType = mySettingsComponent.getInstanceType().name();
+        }
         if (pSettings.url != null) {
             pSettings.url = newUrl;
         } else {
@@ -96,6 +102,7 @@ public class SettingsConfigurable implements Configurable {
 
     @Override
     public void reset() {
+        mySettingsComponent.setInstanceType(ConfigUtil.getInstanceType(project));
         mySettingsComponent.setSourcegraphUrl(ConfigUtil.getSourcegraphUrl(project));
         String accessToken = ConfigUtil.getAccessToken(project);
         mySettingsComponent.setAccessToken(accessToken != null ? accessToken : "");

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -40,8 +40,8 @@ public class SettingsConfigurable implements Configurable {
     @Override
     public boolean isModified() {
         return !mySettingsComponent.getInstanceType().equals(ConfigUtil.getInstanceType(project))
-            || !mySettingsComponent.getSourcegraphUrl().equals(ConfigUtil.getSourcegraphUrl(project))
-            || !mySettingsComponent.getAccessToken().equals(ConfigUtil.getAccessToken(project))
+            || !mySettingsComponent.getEnterpriseUrl().equals(ConfigUtil.getEnterpriseUrl(project))
+            || !(mySettingsComponent.getAccessToken().equals(ConfigUtil.getAccessToken(project)) || mySettingsComponent.getAccessToken().isEmpty() && ConfigUtil.getAccessToken(project) == null)
             || !mySettingsComponent.getDefaultBranchName().equals(ConfigUtil.getDefaultBranchName(project))
             || !mySettingsComponent.getRemoteUrlReplacements().equals(ConfigUtil.getRemoteUrlReplacements(project))
             || mySettingsComponent.isGlobbingEnabled() != ConfigUtil.isGlobbingEnabled(project)
@@ -58,7 +58,7 @@ public class SettingsConfigurable implements Configurable {
 
         String oldUrl = ConfigUtil.getSourcegraphUrl(project);
         String oldAccessToken = ConfigUtil.getAccessToken(project);
-        String newUrl = mySettingsComponent.getSourcegraphUrl();
+        String newUrl = mySettingsComponent.getEnterpriseUrl();
         String newAccessToken = mySettingsComponent.getAccessToken();
         PluginSettingChangeContext context = new PluginSettingChangeContext(oldUrl, oldAccessToken, newUrl, newAccessToken);
 
@@ -103,7 +103,7 @@ public class SettingsConfigurable implements Configurable {
     @Override
     public void reset() {
         mySettingsComponent.setInstanceType(ConfigUtil.getInstanceType(project));
-        mySettingsComponent.setSourcegraphUrl(ConfigUtil.getSourcegraphUrl(project));
+        mySettingsComponent.setEnterpriseUrl(ConfigUtil.getEnterpriseUrl(project));
         String accessToken = ConfigUtil.getAccessToken(project);
         mySettingsComponent.setAccessToken(accessToken != null ? accessToken : "");
         String defaultBranchName = ConfigUtil.getDefaultBranchName(project);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.Nullable;
     storages = {@Storage("sourcegraph.xml")})
 public class SourcegraphApplicationService implements PersistentStateComponent<SourcegraphApplicationService> {
     @Nullable
+    public String instanceType;
+    @Nullable
     public String url;
     @Nullable
     public String accessToken;
@@ -31,6 +33,11 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     public static SourcegraphApplicationService getInstance() {
         return ApplicationManager.getApplication()
             .getService(SourcegraphApplicationService.class);
+    }
+
+    @Nullable
+    public String getInstanceType() {
+        return instanceType;
     }
 
     @Nullable
@@ -83,6 +90,7 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
 
     @Override
     public void loadState(@NotNull SourcegraphApplicationService settings) {
+        this.instanceType = settings.instanceType;
         this.url = settings.url;
         this.accessToken = settings.accessToken;
         this.defaultBranch = settings.defaultBranch;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -13,6 +13,8 @@ import org.jetbrains.annotations.Nullable;
     storages = {@Storage("sourcegraph.xml")})
 public class SourcegraphProjectService implements PersistentStateComponent<SourcegraphProjectService> {
     @Nullable
+    public String instanceType;
+    @Nullable
     public String url;
     @Nullable
     public String accessToken;
@@ -33,6 +35,11 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     @NotNull
     public static SourcegraphProjectService getInstance(@NotNull Project project) {
         return project.getService(SourcegraphProjectService.class);
+    }
+
+    @Nullable
+    public String getInstanceType() {
+        return instanceType;
     }
 
     @Nullable
@@ -77,6 +84,7 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
 
     @Override
     public void loadState(@NotNull SourcegraphProjectService settings) {
+        this.instanceType = settings.instanceType;
         this.url = settings.url;
         this.accessToken = settings.accessToken;
         this.defaultBranch = settings.defaultBranch;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -27,7 +27,7 @@ public class UserLevelConfig {
     @NotNull
     public static String getSourcegraphUrl() {
         Properties properties = readProperties();
-        return properties.getProperty("url", "https://sourcegraph.com/");
+        return properties.getProperty("url", "");
     }
 
     // readProps returns the first properties file it's able to parse from the following paths:

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.SettingsComponent;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
@@ -43,7 +44,7 @@ public class GraphQlLogger {
     // This could be exposed later as public, but currently, we don't use it externally.
     private static void logEvent(Project project, @NotNull Event event, @Nullable Consumer<Integer> callback) {
         String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
-        String accessToken = ConfigUtil.getAccessToken(project);
+        String accessToken = ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE ? ConfigUtil.getAccessToken(project) : null;
         new Thread(() -> {
             String query = "" +
                 "mutation LogEvents($events: [Event!]) {" +


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/38575

This is what our Preferences look like now:

![CleanShot 2022-07-15 at 15 36 34@2x](https://user-images.githubusercontent.com/2552265/179234131-cbbee167-239e-4f06-9fea-82de8c0241f8.png)

This change also fixes the URL-saving bug that Coury encountered yesterday. It was a silly one, basically a typo, and a one-line fix. (You can see it as a separate commit if interested.)

## Test plan

Made this [4-min Loom](https://www.loom.com/share/ddf27863a807413a83fdf204fc685c44) where I demo the UI and the functionality

## App preview:

- [Web](https://sg-web-dv-jetbrains-reorganize-settings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-betsnabnvc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
