### PR TITLE
Fetch the latest commit from the crates index before syncing

### DIFF
--- a/internal/codeintel/dependencies/background/cratesyncer/init.go
+++ b/internal/codeintel/dependencies/background/cratesyncer/init.go
@@ -33,6 +33,7 @@ type syncer struct {
 	dbStore               *dbstore.Store
 	externalServicesStore database.ExternalServiceStore
 	gitClient             *gitserver.ClientImplementor
+	interval              time.Duration
 }
 
 var _ goroutine.Handler = &syncer{}
@@ -55,11 +56,18 @@ func (s *syncer) Handle(ctx context.Context) error {
 		return nil
 	}
 
-	// TODO: automatically fetch the latest commit before syncing https://github.com/sourcegraph/sourcegraph/issues/37690
+	repoName := api.RepoName(config.IndexRepositoryName)
+	update, err := s.gitClient.RequestRepoUpdate(ctx, repoName, s.interval)
+	if err != nil {
+		return err
+	}
+	if update != nil && update.Error != "" {
+		return errors.Newf("failed to update repo %s, error %s", repoName, update.Error)
+	}
 	reader, err := s.gitClient.ArchiveReader(
 		ctx,
 		nil,
-		api.RepoName(config.IndexRepositoryName),
+		repoName,
 		gitserver.ArchiveOptions{
 			Treeish:   "HEAD",
 			Format:    "tar",
@@ -160,6 +168,7 @@ func NewCratesSyncer(db database.DB) goroutine.BackgroundRoutine {
 		dbStore:               dbstore.NewWithDB(db, observationContext),
 		externalServicesStore: extSvcStore,
 		gitClient:             gitserver.NewClient(db),
+		interval:              interval,
 	})
 }
 


### PR DESCRIPTION
Previously, the crates syncer job could index a stale commit from
rust-lang/crates.io-index because we didn't trigger a "git fetch" on
the repo before calling "git archive". This commit, adds a "git fetch"
step so that we always index the latest commit from the index.

Fixes https://github.com/sourcegraph/sourcegraph/issues/37690 

## Test plan

Deploy the change and manually observer that we're picking up new releases. Once we complete https://github.com/sourcegraph/sourcegraph/issues/38656 we'll have better infrastructure to test changes like this.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
