### PR TITLE
JetBrains: Remove “Sourcegraph” menu from “Find Actions” list

### DIFF
--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -82,7 +82,8 @@
             icon="/icons/sourcegraphLogo.svg">
         </action>
 
-        <group id="SourcegraphEditor" icon="/icons/sourcegraphLogo.svg" popup="true" text="Sourcegraph">
+        <group id="SourcegraphEditor" icon="/icons/sourcegraphLogo.svg" popup="true" text="Sourcegraph"
+               searchable="false">
             <reference ref="sourcegraph.openFindPopup"/>
             <reference ref="sourcegraph.searchSelection"/>
             <reference ref="sourcegraph.searchRepository"/>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/37994

Just removed the “Sourcegraph” menu. It added clutter because the user couldn’t tell what it did (based on the user tests), and all the other options were already there.

## Test plan

Tested, this is the only thing that changed (the “Sourcegraph” menu is gone):

![CleanShot 2022-07-15 at 16 36 47@2x](https://user-images.githubusercontent.com/2552265/179245748-8df1905c-938b-4a13-bcf7-58c3d1e44d34.png)

## App preview:

- [Web](https://sg-web-dv-jetbrains-clean-up-find-actions.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-smgyewxwvq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
