### PR TITLE
insights: Update groupBy for repo-scoped series

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -615,6 +615,7 @@ func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graph
 					Repositories:      series.RepositoryScope.Repositories,
 					StepIntervalUnit:  series.TimeScope.StepInterval.Unit,
 					StepIntervalValue: int(series.TimeScope.StepInterval.Value),
+					GroupBy:           lowercaseGroupBy(series.GroupBy),
 				})
 				if err != nil {
 					return nil, errors.Wrap(err, "UpdateFrontendSeries")
@@ -1017,12 +1018,10 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, scopedBa
 		dynamic = *series.GeneratedFromCaptureGroups
 	}
 
-	var groupBy *string
+	groupBy := lowercaseGroupBy(series.GroupBy)
 	var nextRecordingAfter time.Time
 	var oldestHistoricalAt time.Time
 	if series.GroupBy != nil {
-		temp := strings.ToLower(*series.GroupBy)
-		groupBy = &temp
 		// We want to disable interval recording for compute types.
 		// December 31, 9999 is the maximum possible date in postgres.
 		nextRecordingAfter = time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
@@ -1317,4 +1316,12 @@ func minInt(a, b int32) int32 {
 		return a
 	}
 	return b
+}
+
+func lowercaseGroupBy(groupBy *string) *string {
+	if groupBy != nil {
+		temp := strings.ToLower(*groupBy)
+		return &temp
+	}
+	return groupBy
 }

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -880,10 +880,18 @@ type UpdateFrontendSeriesArgs struct {
 	Repositories      []string
 	StepIntervalUnit  string
 	StepIntervalValue int
+	GroupBy           *string
 }
 
 func (s *InsightStore) UpdateFrontendSeries(ctx context.Context, args UpdateFrontendSeriesArgs) error {
-	return s.Exec(ctx, sqlf.Sprintf(updateFrontendSeriesSql, args.Query, pq.Array(args.Repositories), args.StepIntervalUnit, args.StepIntervalValue, args.SeriesID))
+	return s.Exec(ctx, sqlf.Sprintf(updateFrontendSeriesSql,
+		args.Query,
+		pq.Array(args.Repositories),
+		args.StepIntervalUnit,
+		args.StepIntervalValue,
+		args.GroupBy,
+		args.SeriesID,
+	))
 }
 
 func (s *InsightStore) GetReferenceCount(ctx context.Context, id int) (int, error) {
@@ -1083,7 +1091,7 @@ WHERE series.series_id = %s
 const updateFrontendSeriesSql = `
 -- source: enterprise/internal/insights/store/insight_store.go:UpdateFrontendSeries
 UPDATE insight_series
-SET query = %s, repositories = %s, sample_interval_unit = %s, sample_interval_value = %s
+SET query = %s, repositories = %s, sample_interval_unit = %s, sample_interval_value = %s, group_by = %s
 WHERE series_id = %s
 `
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/38872

## Description

There's a separate codepath for updating repo-scoped series, and the groupBy value was not getting piped through. This PR fixes that.

## Test plan

Try updating a repo-scoped series and make sure that the `group_by` field is updated in the `insight_series` table correctly, and that the right value is returned in the API response as well.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
