### PR TITLE
JetBrains: Add connection notification

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQl.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQl.java
@@ -1,0 +1,60 @@
+package com.sourcegraph.api;
+
+import com.google.gson.JsonObject;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+
+public class GraphQl {
+    public static int callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws IOException {
+        HttpPost request = createRequest(instanceUrl, accessToken, query, variables);
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            CloseableHttpResponse response = client.execute(request);
+            response.close();
+            return response.getStatusLine().getStatusCode();
+        }
+    }
+
+    @NotNull
+    private static HttpPost createRequest(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) {
+        HttpPost request = new HttpPost(getGraphQLApiURI(instanceUrl));
+
+        request.setHeader("Content-Type", "application/json");
+        request.setHeader("X-Sourcegraph-Should-Trace", "false");
+        if (accessToken != null) {
+            request.setHeader("Authorization", "token " + accessToken);
+        }
+
+        JsonObject body = new JsonObject();
+        body.addProperty("query", query);
+        body.add("variables", variables);
+
+        ContentType contentType = ContentType.create("application/json", StandardCharsets.UTF_8);
+
+        StringEntity entity = new StringEntity(body.toString(), contentType);
+        entity.setContentEncoding(StandardCharsets.UTF_8.toString());
+
+        request.setEntity(entity);
+        return request;
+    }
+
+    @NotNull
+    private static URI getGraphQLApiURI(String instanceUrl) {
+        try {
+            return new URIBuilder(instanceUrl + ".api/graphql").build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
@@ -1,6 +1,10 @@
 package com.sourcegraph.api;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
@@ -8,6 +12,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,14 +21,24 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
-public class GraphQl {
-    public static int callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws IOException {
+public class GraphQlClient {
+    public static HttpResponse callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws IOException {
         HttpPost request = createRequest(instanceUrl, accessToken, query, variables);
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             CloseableHttpResponse response = client.execute(request);
             response.close();
-            return response.getStatusLine().getStatusCode();
+            return response;
         }
+    }
+
+    public static JsonObject getResponseBodyJson(@NotNull HttpResponse response) throws IOException, JsonSyntaxException, IllegalStateException {
+        HttpEntity entity = response.getEntity();
+        String result = EntityUtils.toString(entity);
+        return JsonParser.parseString(result).getAsJsonObject();
+    }
+
+    public static int getStatusCode(@NotNull HttpResponse response) {
+        return response.getStatusLine().getStatusCode();
     }
 
     @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlResponse.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlResponse.java
@@ -1,0 +1,30 @@
+package com.sourcegraph.api;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import org.jetbrains.annotations.Nullable;
+
+public class GraphQlResponse {
+    private final int statusCode;
+    private final String body;
+
+    public GraphQlResponse(int statusCode, String body) {
+        this.statusCode = statusCode;
+        this.body = body;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    @Nullable
+    public String getBody() {
+        return body;
+    }
+
+    public JsonObject getBodyAsJson() throws JsonSyntaxException {
+        return JsonParser.parseString(body).getAsJsonObject();
+    }
+
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ApiAuthenticator.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ApiAuthenticator.java
@@ -1,0 +1,46 @@
+package com.sourcegraph.config;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import com.sourcegraph.api.GraphQlClient;
+import org.apache.http.HttpResponse;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+public class ApiAuthenticator {
+    private final static Logger logger = Logger.getInstance(ApiAuthenticator.class);
+
+    public static void testConnection(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull Consumer<ConnectionStatus> callback) {
+        new Thread(() -> {
+            String query = "" +
+                "query {" +
+                "    currentUser {" +
+                "        id" +
+                "    }" +
+                "}";
+
+            try {
+                HttpResponse response = GraphQlClient.callGraphQLService(instanceUrl, accessToken, query, new JsonObject());
+                if (GraphQlClient.getStatusCode(response) == 200) {
+                    JsonElement id = GraphQlClient.getResponseBodyJson(response).getAsJsonObject().get("currentUser").getAsJsonObject().get("id");
+                    callback.accept(id.isJsonNull() ? ConnectionStatus.COULD_CONNECT_BUT_NOT_AUTHENTICATED : ConnectionStatus.AUTHENTICATED);
+                } else {
+                    callback.accept(ConnectionStatus.COULD_NOT_CONNECT);
+                }
+            } catch (IOException e) {
+                logger.info(e);
+            }
+        }).start();
+
+    }
+
+    enum ConnectionStatus {
+        AUTHENTICATED,
+        COULD_NOT_CONNECT,
+        COULD_CONNECT_BUT_NOT_AUTHENTICATED
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ApiAuthenticator.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ApiAuthenticator.java
@@ -4,7 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.sourcegraph.api.GraphQlClient;
-import org.apache.http.HttpResponse;
+import com.sourcegraph.api.GraphQlResponse;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,9 +24,9 @@ public class ApiAuthenticator {
                 "}";
 
             try {
-                HttpResponse response = GraphQlClient.callGraphQLService(instanceUrl, accessToken, query, new JsonObject());
-                if (GraphQlClient.getStatusCode(response) == 200) {
-                    JsonElement id = GraphQlClient.getResponseBodyJson(response).getAsJsonObject().get("currentUser").getAsJsonObject().get("id");
+                GraphQlResponse response = GraphQlClient.callGraphQLService(instanceUrl, accessToken, query, new JsonObject());
+                if (response.getStatusCode() == 200) {
+                    JsonElement id = response.getBodyAsJson().getAsJsonObject("data").getAsJsonObject("currentUser").get("id");
                     callback.accept(id.isJsonNull() ? ConnectionStatus.COULD_CONNECT_BUT_NOT_AUTHENTICATED : ConnectionStatus.AUTHENTICATED);
                 } else {
                     callback.accept(ConnectionStatus.COULD_NOT_CONNECT);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -72,8 +72,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
         AnAction openAction = new DumbAwareAction("Open Sourcegraph (" + altSShortcutText + ")") {
             @Override
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-                FindService service = project.getService(FindService.class);
-                service.showPopup();
+                project.getService(FindService.class).showPopup();
                 notification.expire();
             }
         };

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -69,7 +69,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
         String altSShortcutText = KeymapUtil.getShortcutText(altSShortcut);
         Notification notification = new Notification("Sourcegraph plugin updates", "Sourcegraph",
             "Access the new plugin and try out code search with the shortcut " + altSShortcutText + "! Learn more about the plugin’s functionality in our blog post.", NotificationType.INFORMATION);
-        AnAction setUrlAction = new DumbAwareAction("Open Sourcegraph (" + altSShortcutText + ")") {
+        AnAction openAction = new DumbAwareAction("Open Sourcegraph (" + altSShortcutText + ")") {
             @Override
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
                 FindService service = project.getService(FindService.class);
@@ -96,7 +96,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
             }
         };
         notification.setIcon(Icons.SourcegraphLogo);
-        notification.addAction(setUrlAction);
+        notification.addAction(openAction);
         notification.addAction(learnMoreAction);
         Notifications.Bus.notify(notification);
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -66,10 +66,10 @@ public class NotificationActivity implements StartupActivity.DumbAware {
     private void notifyAboutUpdate(@NotNull Project project) {
         // Display notification
         KeyboardShortcut altSShortcut = new KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK), null);
-        String altEnterShortcutText = KeymapUtil.getShortcutText(altSShortcut);
+        String altSShortcutText = KeymapUtil.getShortcutText(altSShortcut);
         Notification notification = new Notification("Sourcegraph plugin updates", "Sourcegraph",
-            "Access the new plugin and try out code search with the shortcut " + altEnterShortcutText + "! Learn more about the plugin’s functionality in our blog post.", NotificationType.INFORMATION);
-        AnAction setUrlAction = new DumbAwareAction("Open Sourcegraph (" + altEnterShortcutText + ")") {
+            "Access the new plugin and try out code search with the shortcut " + altSShortcutText + "! Learn more about the plugin’s functionality in our blog post.", NotificationType.INFORMATION);
+        AnAction setUrlAction = new DumbAwareAction("Open Sourcegraph (" + altSShortcutText + ")") {
             @Override
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
                 FindService service = project.getService(FindService.class);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.MessageBusConnection;
 import com.sourcegraph.browser.JavaToJSBridge;
+import com.sourcegraph.find.FindService;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import org.jetbrains.annotations.NotNull;
 
@@ -56,7 +57,7 @@ public class SettingsChangeListener implements Disposable {
                 if (context.newUrl != null) {
                     ApiAuthenticator.testConnection(context.newUrl, context.newAccessToken, (status) -> {
                         if (status == ApiAuthenticator.ConnectionStatus.AUTHENTICATED) {
-                            notifyAboutSuccessfulConnection();
+                            notifyAboutSuccessfulConnection(project);
                         }
                     });
                 }
@@ -64,17 +65,25 @@ public class SettingsChangeListener implements Disposable {
         });
     }
 
-    private void notifyAboutSuccessfulConnection() {
+    private void notifyAboutSuccessfulConnection(Project project) {
         KeyboardShortcut altSShortcut = new KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK), null);
         String altSShortcutText = KeymapUtil.getShortcutText(altSShortcut);
         Notification notification = new Notification("Sourcegraph access", "Sourcegraph authentication success",
             "Your Sourcegraph account has been connected to the Sourcegraph plugin. Press " + altSShortcutText + " to open Sourcegraph.", NotificationType.INFORMATION);
+        AnAction setUrlAction = new DumbAwareAction("Open Sourcegraph (" + altSShortcutText + ")") {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+                project.getService(FindService.class).showPopup();
+                notification.expire();
+            }
+        };
         AnAction dismissAction = new DumbAwareAction("Dismiss") {
             @Override
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
                 notification.expire();
             }
         };
+        notification.addAction(setUrlAction);
         notification.addAction(dismissAction);
         Notifications.Bus.notify(notification);
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -1,6 +1,14 @@
 package com.sourcegraph.config;
 
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.KeyboardShortcut;
+import com.intellij.openapi.keymap.KeymapUtil;
+import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.MessageBusConnection;
@@ -8,6 +16,9 @@ import com.sourcegraph.browser.JavaToJSBridge;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import org.jetbrains.annotations.NotNull;
 
+import javax.swing.*;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.util.Objects;
 
 public class SettingsChangeListener implements Disposable {
@@ -29,17 +40,43 @@ public class SettingsChangeListener implements Disposable {
 
             @Override
             public void afterAction(@NotNull PluginSettingChangeContext context) {
+                // Notify JCEF about the config changes
                 if (javaToJSBridge != null) {
                     javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
                 }
 
+                // Log install events
                 if (!Objects.equals(context.oldUrl, context.newUrl)) {
                     GraphQlLogger.logInstallEvent(project, ConfigUtil::setInstallEventLogged);
                 } else if (!Objects.equals(context.oldAccessToken, context.newAccessToken) && !ConfigUtil.isInstallEventLogged()) {
                     GraphQlLogger.logInstallEvent(project, ConfigUtil::setInstallEventLogged);
                 }
+
+                // Notify user about a successful connection
+                if (context.newUrl != null) {
+                    ApiAuthenticator.testConnection(context.newUrl, context.newAccessToken, (status) -> {
+                        if (status == ApiAuthenticator.ConnectionStatus.AUTHENTICATED) {
+                            notifyAboutSuccessfulConnection();
+                        }
+                    });
+                }
             }
         });
+    }
+
+    private void notifyAboutSuccessfulConnection() {
+        KeyboardShortcut altSShortcut = new KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK), null);
+        String altSShortcutText = KeymapUtil.getShortcutText(altSShortcut);
+        Notification notification = new Notification("Sourcegraph access", "Sourcegraph authentication success",
+            "Your Sourcegraph account has been connected to the Sourcegraph plugin. Press " + altSShortcutText + " to open Sourcegraph.", NotificationType.INFORMATION);
+        AnAction dismissAction = new DumbAwareAction("Dismiss") {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+                notification.expire();
+            }
+        };
+        notification.addAction(dismissAction);
+        Notifications.Bus.notify(notification);
     }
 
     public void setJavaToJSBridge(JavaToJSBridge javaToJSBridge) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -49,7 +49,7 @@ public class GraphQlLogger {
             variables.add("events", events);
 
             try {
-                int responseStatusCode = GraphQlClient.getStatusCode(GraphQlClient.callGraphQLService(instanceUrl, accessToken, query, variables));
+                int responseStatusCode = GraphQlClient.callGraphQLService(instanceUrl, accessToken, query, variables).getStatusCode();
                 if (callback != null) {
                     callback.accept(responseStatusCode);
                 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -4,7 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.sourcegraph.api.GraphQl;
+import com.sourcegraph.api.GraphQlClient;
 import com.sourcegraph.config.ConfigUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -49,7 +49,7 @@ public class GraphQlLogger {
             variables.add("events", events);
 
             try {
-                int responseStatusCode = GraphQl.callGraphQLService(instanceUrl, accessToken, query, variables);
+                int responseStatusCode = GraphQlClient.getStatusCode(GraphQlClient.callGraphQLService(instanceUrl, accessToken, query, variables));
                 if (callback != null) {
                     callback.accept(responseStatusCode);
                 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -4,21 +4,12 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.sourcegraph.api.GraphQl;
 import com.sourcegraph.config.ConfigUtil;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
 public class GraphQlLogger {
@@ -58,7 +49,7 @@ public class GraphQlLogger {
             variables.add("events", events);
 
             try {
-                int responseStatusCode = callGraphQLService(instanceUrl, accessToken, query, variables);
+                int responseStatusCode = GraphQl.callGraphQLService(instanceUrl, accessToken, query, variables);
                 if (callback != null) {
                     callback.accept(responseStatusCode);
                 }
@@ -66,46 +57,5 @@ public class GraphQlLogger {
                 logger.info(e);
             }
         }).start();
-    }
-
-    private static int callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws IOException {
-        HttpPost request = createRequest(instanceUrl, accessToken, query, variables);
-        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
-            CloseableHttpResponse response = client.execute(request);
-            response.close();
-            return response.getStatusLine().getStatusCode();
-        }
-    }
-
-    @NotNull
-    private static HttpPost createRequest(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) {
-        HttpPost request = new HttpPost(getGraphQLApiURI(instanceUrl));
-
-        request.setHeader("Content-Type", "application/json");
-        request.setHeader("X-Sourcegraph-Should-Trace", "false");
-        if (accessToken != null) {
-            request.setHeader("Authorization", "token " + accessToken);
-        }
-
-        JsonObject body = new JsonObject();
-        body.addProperty("query", query);
-        body.add("variables", variables);
-
-        ContentType contentType = ContentType.create("application/json", StandardCharsets.UTF_8);
-
-        StringEntity entity = new StringEntity(body.toString(), contentType);
-        entity.setContentEncoding(StandardCharsets.UTF_8.toString());
-
-        request.setEntity(entity);
-        return request;
-    }
-
-    @NotNull
-    private static URI getGraphQLApiURI(String instanceUrl) {
-        try {
-            return new URIBuilder(instanceUrl + ".api/graphql").build();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/38802

This is what the notification looks like:

<img width="406" alt="CleanShot 2022-07-15 at 18 28 57@2x" src="https://user-images.githubusercontent.com/2552265/179267003-94af3885-1efc-4b9e-9a89-0b2cc11fa6ac.png">

Important points:
 - @philipp-spiess: I've added a way to test the connection on the Java side! It was pretty simple to do and is much nicer than depending on the browser.
 - @jjinnii: I've added an extra "Open Soucegraph" button and some text, which I think is helpful to users. I can remove it if it's too much.

## Test plan

[1-min Loom](https://www.loom.com/share/59f748b4366440a68466d69aedd493c7)