### PR TITLE
Redo Tooltip Migration in `client/web`

### DIFF
--- a/client/shared/src/components/LinkOrSpan.tsx
+++ b/client/shared/src/components/LinkOrSpan.tsx
@@ -1,30 +1,30 @@
 import * as React from 'react'
 
-import { Link } from '@sourcegraph/wildcard'
+import { ForwardReferenceComponent, Link } from '@sourcegraph/wildcard'
+
+type Props = React.PropsWithChildren<
+    {
+        to: string | undefined | null
+        children?: React.ReactNode
+    } & React.AnchorHTMLAttributes<HTMLAnchorElement>
+>
 
 /**
  * The LinkOrSpan component renders a <Link> if the "to" property is a non-empty string; otherwise it renders the
  * text in a <span> (with no link).
  */
-export const LinkOrSpan: React.FunctionComponent<
-    React.PropsWithChildren<
-        {
-            to: string | undefined | null
-            children?: React.ReactNode
-        } & React.AnchorHTMLAttributes<HTMLAnchorElement>
-    >
-> = ({ to, className = '', children, ...otherProps }) => {
+export const LinkOrSpan = React.forwardRef(({ to, className = '', children, ...otherProps }: Props, reference) => {
     if (to) {
         return (
-            <Link to={to} className={className} {...otherProps}>
+            <Link ref={reference} to={to} className={className} {...otherProps}>
                 {children}
             </Link>
         )
     }
 
     return (
-        <span className={className} {...otherProps}>
+        <span ref={reference} className={className} {...otherProps}>
             {children}
         </span>
     )
-}
+}) as ForwardReferenceComponent<typeof Link, Props>

--- a/client/shared/src/components/icons.tsx
+++ b/client/shared/src/components/icons.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 
 import classNames from 'classnames'
 
+import { ForwardReferenceComponent } from '@sourcegraph/wildcard'
+
 export interface IconProps {
     className?: string
     size?: number
@@ -101,8 +103,10 @@ export const WrapDisabledIcon: React.FunctionComponent<React.PropsWithChildren<I
 )
 
 // TODO: Rename name when refresh design is complete
-export const CloudAlertIconRefresh: React.FunctionComponent<React.PropsWithChildren<IconProps>> = props => (
+// eslint-disable-next-line react/display-name
+export const CloudAlertIconRefresh = React.forwardRef((props, reference) => (
     <svg
+        ref={reference}
         {...props}
         {...sizeProps(props)}
         className={classNames('phabricator-icon mdi-icon', props.className)}
@@ -125,11 +129,14 @@ export const CloudAlertIconRefresh: React.FunctionComponent<React.PropsWithChild
             </clipPath>
         </defs>
     </svg>
-)
+)) as ForwardReferenceComponent<'svg', React.PropsWithChildren<IconProps>>
+CloudAlertIconRefresh.displayName = 'CloudAlertIconRefresh'
 
 // TODO: Rename name when refresh design is complete
-export const CloudSyncIconRefresh: React.FunctionComponent<React.PropsWithChildren<IconProps>> = props => (
+// eslint-disable-next-line react/display-name
+export const CloudSyncIconRefresh = React.forwardRef((props, reference) => (
     <svg
+        ref={reference}
         {...props}
         {...sizeProps(props)}
         className={classNames('phabricator-icon mdi-icon', props.className)}
@@ -156,11 +163,14 @@ export const CloudSyncIconRefresh: React.FunctionComponent<React.PropsWithChildr
             </clipPath>
         </defs>
     </svg>
-)
+)) as ForwardReferenceComponent<'svg', React.PropsWithChildren<IconProps>>
+CloudSyncIconRefresh.displayName = 'CloudSyncIconRefresh'
 
 // TODO: Rename name when refresh design is complete
-export const CloudCheckIconRefresh: React.FunctionComponent<React.PropsWithChildren<IconProps>> = props => (
+// eslint-disable-next-line react/display-name
+export const CloudCheckIconRefresh = React.forwardRef((props, reference) => (
     <svg
+        ref={reference}
         {...props}
         {...sizeProps(props)}
         className={classNames('phabricator-icon mdi-icon', props.className)}
@@ -183,4 +193,5 @@ export const CloudCheckIconRefresh: React.FunctionComponent<React.PropsWithChild
             </clipPath>
         </defs>
     </svg>
-)
+)) as ForwardReferenceComponent<'svg', React.PropsWithChildren<IconProps>>
+CloudCheckIconRefresh.displayName = 'CloudCheckIconRefresh'

--- a/client/web/src/extensions/ExtensionsAreaHeader.tsx
+++ b/client/web/src/extensions/ExtensionsAreaHeader.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { mdiPuzzleOutline } from '@mdi/js'
 import { RouteComponentProps } from 'react-router-dom'
 
-import { PageHeader, Button, Link, Icon } from '@sourcegraph/wildcard'
+import { PageHeader, Button, Link, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { ActionButtonDescriptor } from '../util/contributions'
 
@@ -33,16 +33,11 @@ export const ExtensionsAreaHeader: React.FunctionComponent<
                 actions={props.actionButtons.map(
                     ({ condition = () => true, to, icon: ButtonIcon, label, tooltip }) =>
                         condition(props) && (
-                            <Button
-                                className="ml-2"
-                                to={to(props)}
-                                data-tooltip={tooltip}
-                                key={label}
-                                variant="secondary"
-                                as={Link}
-                            >
-                                {ButtonIcon && <Icon as={ButtonIcon} aria-hidden={true} />} {label}
-                            </Button>
+                            <Tooltip content={tooltip}>
+                                <Button className="ml-2" to={to(props)} key={label} variant="secondary" as={Link}>
+                                    {ButtonIcon && <Icon as={ButtonIcon} aria-hidden={true} />} {label}
+                                </Button>
+                            </Tooltip>
                         )
                 )}
             />

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -18,7 +18,7 @@ import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/feature
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, LoadingSpinner, useObservable, Link, ButtonLink, Icon } from '@sourcegraph/wildcard'
+import { Button, LoadingSpinner, useObservable, Link, ButtonLink, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { useCarousel } from '../../components/useCarousel'
@@ -282,14 +282,15 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
                 {haveExtensionsLoaded && <ActionItemsDivider />}
                 <div className="list-unstyled m-0">
                     <div className={styles.listItem}>
-                        <Link
-                            to="/extensions"
-                            className={classNames(styles.listItem, styles.auxIcon, actionItemClassName)}
-                            data-tooltip="Add extensions"
-                            aria-label="Add extensions"
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiPlus} />
-                        </Link>
+                        <Tooltip content="Add extensions">
+                            <Link
+                                to="/extensions"
+                                className={classNames(styles.listItem, styles.auxIcon, actionItemClassName)}
+                                aria-label="Add"
+                            >
+                                <Icon aria-hidden={true} svgPath={mdiPlus} />
+                            </Link>
+                        </Tooltip>
                     </div>
                 </div>
             </ErrorBoundary>
@@ -323,30 +324,37 @@ export const ActionItemsToggle: React.FunctionComponent<React.PropsWithChildren<
             <li className={styles.dividerVertical} />
             <li className={classNames('nav-item mr-2', className)}>
                 <div className={classNames(styles.toggleContainer, isOpen && styles.toggleContainerOpen)}>
-                    <ButtonLink
-                        data-tooltip={`${isOpen ? 'Close' : 'Open'} extensions panel`}
-                        aria-label={
-                            isOpen
-                                ? 'Close extensions panel. Press the down arrow key to enter the extensions panel.'
-                                : 'Open extensions panel'
-                        }
-                        className={classNames(actionItemClassName, styles.auxIcon, styles.actionToggle)}
-                        onSelect={toggle}
-                        ref={toggleReference}
-                    >
-                        {!haveExtensionsLoaded ? (
-                            <LoadingSpinner />
-                        ) : isOpen ? (
-                            <Icon
-                                data-testid="action-items-toggle-open"
-                                aria-hidden={true}
-                                svgPath={mdiChevronDoubleUp}
-                            />
-                        ) : (
-                            <Icon aria-hidden={true} svgPath={mdiPuzzleOutline} />
-                        )}
-                        {haveExtensionsLoaded && <VisuallyHidden>Down arrow to enter</VisuallyHidden>}
-                    </ButtonLink>
+                    <Tooltip content={`${isOpen ? 'Close' : 'Open'} extensions panel`}>
+                        {/**
+                         * This <ButtonLink> must be wrapped with an additional span, since the tooltip needs to use "ref" to work properly.
+                         * Without the extra span, the tooltip was writing over the ref needed for the toggle behavior to function correctly, breaking toggling.
+                         */}
+                        <span>
+                            <ButtonLink
+                                aria-label={
+                                    isOpen
+                                        ? 'Close extensions panel. Press the down arrow key to enter the extensions panel.'
+                                        : 'Open extensions panel'
+                                }
+                                className={classNames(actionItemClassName, styles.auxIcon, styles.actionToggle)}
+                                onSelect={toggle}
+                                ref={toggleReference}
+                            >
+                                {!haveExtensionsLoaded ? (
+                                    <LoadingSpinner />
+                                ) : isOpen ? (
+                                    <Icon
+                                        data-testid="action-items-toggle-open"
+                                        aria-hidden={true}
+                                        svgPath={mdiChevronDoubleUp}
+                                    />
+                                ) : (
+                                    <Icon aria-hidden={true} svgPath={mdiPuzzleOutline} />
+                                )}
+                                {haveExtensionsLoaded && <VisuallyHidden>Down arrow to enter</VisuallyHidden>}
+                            </ButtonLink>
+                        </span>
+                    </Tooltip>
                 </div>
             </li>
         </>

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -326,8 +326,8 @@ export const ActionItemsToggle: React.FunctionComponent<React.PropsWithChildren<
                 <div className={classNames(styles.toggleContainer, isOpen && styles.toggleContainerOpen)}>
                     <Tooltip content={`${isOpen ? 'Close' : 'Open'} extensions panel`}>
                         {/**
-                         * This <ButtonLink> must be wrapped with an additional span, since the tooltip needs to use "ref" to work properly.
-                         * Without the extra span, the tooltip was writing over the ref needed for the toggle behavior to function correctly, breaking toggling.
+                         * This <ButtonLink> must be wrapped with an additional span, since the tooltip currently has an issue that will
+                         * break its onClick handler and it will no longer prevent the default page reload (with no href).
                          */}
                         <span>
                             <ButtonLink

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -14,7 +14,7 @@ import { StatusBarItemWithKey } from '@sourcegraph/shared/src/api/extension/api/
 import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/features'
 import { syncRemoteSubscription } from '@sourcegraph/shared/src/api/util'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { Badge, Button, useObservable, Link, ButtonLink, Icon } from '@sourcegraph/wildcard'
+import { Badge, Button, useObservable, Link, ButtonLink, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { useCarousel } from '../../components/useCarousel'
@@ -252,24 +252,25 @@ const StatusBarItem: React.FunctionComponent<
     const noop = !command
 
     return (
-        <ButtonLink
-            className={classNames(
-                'h-100 d-flex align-items-center px-1',
-                styles.item,
-                noop && classNames('text-decoration-none', styles.itemNoop),
-                className
-            )}
-            data-tooltip={statusBarItem.tooltip}
-            onSelect={handleCommand}
-            tabIndex={noop ? -1 : 0}
-            to={to}
-            disabled={commandState === 'loading'}
-        >
-            {component || (
-                <small className={classNames(styles.text, commandState === 'loading' && 'text-muted')}>
-                    {statusBarItem.text}
-                </small>
-            )}
-        </ButtonLink>
+        <Tooltip content={statusBarItem.tooltip}>
+            <ButtonLink
+                className={classNames(
+                    'h-100 d-flex align-items-center px-1',
+                    styles.item,
+                    noop && classNames('text-decoration-none', styles.itemNoop),
+                    className
+                )}
+                onSelect={handleCommand}
+                tabIndex={noop ? -1 : 0}
+                to={to}
+                disabled={commandState === 'loading'}
+            >
+                {component || (
+                    <small className={classNames(styles.text, commandState === 'loading' && 'text-muted')}>
+                        {statusBarItem.text}
+                    </small>
+                )}
+            </ButtonLink>
+        </Tooltip>
     )
 }

--- a/client/web/src/extensions/components/__snapshots__/StatusBar.test.tsx.snap
+++ b/client/web/src/extensions/components/__snapshots__/StatusBar.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`StatusBar renders correctly 1`] = `
       >
         <a
           class="h-100 d-flex align-items-center px-1 item text-decoration-none itemNoop"
+          data-state="closed"
           href=""
           role="button"
           tabindex="-1"
@@ -23,7 +24,7 @@ exports[`StatusBar renders correctly 1`] = `
         </a>
         <a
           class="h-100 d-flex align-items-center px-1 item text-decoration-none itemNoop"
-          data-tooltip="Code owners: @felixbecker, @beyang"
+          data-state="closed"
           href=""
           role="button"
           tabindex="-1"

--- a/client/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps } from 'react-router'
 import { ConfiguredRegistryExtension } from '@sourcegraph/shared/src/extensions/extension'
 import extensionSchemaJSON from '@sourcegraph/shared/src/schema/extension.schema.json'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Button, Link, Alert, Icon, Code, H3 } from '@sourcegraph/wildcard'
+import { Button, Link, Alert, Icon, Code, H3, Tooltip } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
 import { DynamicallyImportedMonacoSettingsEditor } from '../../settings/DynamicallyImportedMonacoSettingsEditor'
@@ -76,12 +76,13 @@ export class RegistryExtensionManifestPage extends React.PureComponent<Props, St
                 <div className="d-flex align-items-center justify-content-between">
                     <div className="d-flex align-items-center">
                         <H3 className="mb-0 mr-1">Manifest</H3>
-                        <Icon
-                            className="text-muted"
-                            data-tooltip="The published JSON description of how to run or access the extension"
-                            aria-label="The published JSON description of how to run or access the extension"
-                            svgPath={mdiInformationOutline}
-                        />
+                        <Tooltip content="The published JSON description of how to run or access the extension">
+                            <Icon
+                                className="text-muted"
+                                aria-label="The published JSON description of how to run or access the extension"
+                                svgPath={mdiInformationOutline}
+                            />
+                        </Tooltip>
                     </div>
                     <div>
                         {this.props.extension.manifest && (

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -9,7 +9,7 @@ import { isObject } from 'lodash'
 import { isErrorLike, isDefined, isEncodedImage } from '@sourcegraph/common'
 import { splitExtensionID } from '@sourcegraph/shared/src/extensions/extension'
 import { ExtensionCategory, ExtensionManifest } from '@sourcegraph/shared/src/schema/extensionSchema'
-import { Button, Link, Icon, H2, H3 } from '@sourcegraph/wildcard'
+import { Button, Link, Icon, H2, H3, Tooltip } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
@@ -109,11 +109,9 @@ export const RegistryExtensionOverviewPage: React.FunctionComponent<React.PropsW
                 {publisher && (
                     <div className="pt-2 pb-3">
                         <H3 as={H2}>Publisher</H3>
-                        <small
-                            data-tooltip={isSourcegraphExtension ? 'Created and maintained by Sourcegraph' : undefined}
-                        >
-                            {publisher}
-                        </small>
+                        <Tooltip content={isSourcegraphExtension ? 'Created and maintained by Sourcegraph' : undefined}>
+                            <small>{publisher}</small>
+                        </Tooltip>
                         {isSourcegraphExtension && <SourcegraphExtensionIcon className={styles.sourcegraphIcon} />}
                     </div>
                 )}

--- a/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
         >
           Publisher
         </h2>
-        <small>
+        <small
+          data-state="closed"
+        >
           x
         </small>
       </div>
@@ -224,7 +226,9 @@ exports[`RegistryExtensionOverviewPage renders with no tags 1`] = `
         >
           Publisher
         </h2>
-        <small>
+        <small
+          data-state="closed"
+        >
           x
         </small>
       </div>

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -15,7 +15,18 @@ import {
     CloudSyncIconRefresh,
     CloudCheckIconRefresh,
 } from '@sourcegraph/shared/src/components/icons'
-import { Button, Link, Popover, PopoverContent, PopoverTrigger, Position, Icon, H4, Text } from '@sourcegraph/wildcard'
+import {
+    Button,
+    Link,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    Position,
+    Icon,
+    H4,
+    Text,
+    Tooltip,
+} from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../backend/graphql'
 import { CircleDashedIcon } from '../components/CircleDashedIcon'
@@ -444,12 +455,9 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
     private renderIcon(): JSX.Element | null {
         if (isErrorLike(this.state.messagesOrError)) {
             return (
-                <Icon
-                    data-tooltip="Sorry, we couldn’t fetch notifications!"
-                    as={CloudAlertIconRefresh}
-                    size="md"
-                    aria-label="Sorry, we couldn’t fetch notifications!"
-                />
+                <Tooltip content="Sorry, we couldn’t fetch notifications!">
+                    <Icon aria-label="Sorry, we couldn’t fetch notifications!" as={CloudAlertIconRefresh} size="md" />
+                </Tooltip>
             )
         }
 
@@ -460,12 +468,13 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
             : 'No repositories'
         if (isNoActivityReason(this.state.messagesOrError)) {
             return (
-                <Icon
-                    data-tooltip={codeHostMessage}
-                    size="md"
-                    {...(codeHostMessage ? { 'aria-label': codeHostMessage } : { 'aria-hidden': true })}
-                    svgPath={mdiCloudOffOutline}
-                />
+                <Tooltip content={codeHostMessage}>
+                    <Icon
+                        svgPath={mdiCloudOffOutline}
+                        size="md"
+                        {...(codeHostMessage ? { 'aria-label': codeHostMessage } : { 'aria-hidden': true })}
+                    />
+                </Tooltip>
             )
         }
 
@@ -474,33 +483,24 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
         ) {
             codeHostMessage = this.state.isOpen ? undefined : 'Syncing repositories failed!'
             return (
-                <Icon
-                    data-tooltip={codeHostMessage}
-                    as={CloudAlertIconRefresh}
-                    size="md"
-                    {...(codeHostMessage ? { 'aria-label': codeHostMessage } : { 'aria-hidden': true })}
-                />
+                <Tooltip content={codeHostMessage}>
+                    <Icon aria-label={codeHostMessage ?? ''} as={CloudAlertIconRefresh} size="md" />
+                </Tooltip>
             )
         }
         if (this.state.messagesOrError.some(({ type }) => type === 'CloningProgress')) {
             codeHostMessage = this.state.isOpen ? undefined : 'Cloning repositories...'
             return (
-                <Icon
-                    data-tooltip={codeHostMessage}
-                    as={CloudSyncIconRefresh}
-                    size="md"
-                    {...(codeHostMessage ? { 'aria-label': codeHostMessage } : { 'aria-hidden': true })}
-                />
+                <Tooltip content={codeHostMessage}>
+                    <Icon aria-label={codeHostMessage ?? ''} as={CloudSyncIconRefresh} size="md" />
+                </Tooltip>
             )
         }
         codeHostMessage = this.state.isOpen ? undefined : 'Repositories up-to-date'
         return (
-            <Icon
-                data-tooltip={codeHostMessage}
-                as={CloudCheckIconRefresh}
-                size="md"
-                {...(codeHostMessage ? { 'aria-label': codeHostMessage } : { 'aria-hidden': true })}
-            />
+            <Tooltip content={codeHostMessage}>
+                <Icon aria-label={codeHostMessage ?? ''} as={CloudCheckIconRefresh} size="md" />
+            </Tooltip>
         )
     }
 

--- a/client/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`StatusMessagesNavItem no messages 1`] = `
     <svg
       aria-label="Repositories up-to-date"
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-tooltip="Repositories up-to-date"
+      data-state="closed"
       fill="currentColor"
       height="24"
       role="img"
@@ -53,7 +53,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`]
     <svg
       aria-label="Repositories up-to-date"
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-tooltip="Repositories up-to-date"
+      data-state="closed"
       fill="currentColor"
       height="24"
       role="img"
@@ -96,7 +96,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
     <svg
       aria-label="Repositories up-to-date"
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-tooltip="Repositories up-to-date"
+      data-state="closed"
       fill="currentColor"
       height="24"
       role="img"
@@ -139,7 +139,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as non-site 
     <svg
       aria-label="Repositories up-to-date"
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-tooltip="Repositories up-to-date"
+      data-state="closed"
       fill="currentColor"
       height="24"
       role="img"
@@ -182,7 +182,7 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as site admi
     <svg
       aria-label="Repositories up-to-date"
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-tooltip="Repositories up-to-date"
+      data-state="closed"
       fill="currentColor"
       height="24"
       role="img"
@@ -225,7 +225,7 @@ exports[`StatusMessagesNavItem one SyncError message as non-site admin 1`] = `
     <svg
       aria-label="Repositories up-to-date"
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-tooltip="Repositories up-to-date"
+      data-state="closed"
       fill="currentColor"
       height="24"
       role="img"
@@ -268,7 +268,7 @@ exports[`StatusMessagesNavItem one SyncError message as site admin 1`] = `
     <svg
       aria-label="Repositories up-to-date"
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-tooltip="Repositories up-to-date"
+      data-state="closed"
       fill="currentColor"
       height="24"
       role="img"

--- a/client/web/src/notebooks/notebook/NotebookAddBlockButtons.tsx
+++ b/client/web/src/notebooks/notebook/NotebookAddBlockButtons.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 
 import { mdiLanguageMarkdownOutline, mdiMagnify, mdiCodeTags, mdiFunction, mdiLaptop } from '@mdi/js'
 
-import { Button, Icon } from '@sourcegraph/wildcard'
+import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { BlockInput } from '..'
 import { useExperimentalFeatures } from '../../stores'
@@ -23,53 +23,58 @@ export const NotebookAddBlockButtons: React.FunctionComponent<
     const addBlock = useCallback((blockInput: BlockInput) => onAddBlock(index, blockInput), [index, onAddBlock])
     return (
         <>
-            <Button
-                className={styles.addBlockButton}
-                data-tooltip="Add Markdown text"
-                aria-label="Add markdown"
-                onClick={() => addBlock({ type: 'md', input: { text: '', initialFocusInput: true } })}
-                data-testid="add-md-block"
-            >
-                <Icon aria-hidden={true} size="sm" svgPath={mdiLanguageMarkdownOutline} />
-            </Button>
-            <Button
-                className={styles.addBlockButton}
-                data-tooltip="Add a Sourcegraph query"
-                aria-label="Add query"
-                onClick={() => addBlock({ type: 'query', input: { query: '', initialFocusInput: true } })}
-                data-testid="add-query-block"
-            >
-                <Icon aria-hidden={true} size="sm" svgPath={mdiMagnify} />
-            </Button>
-            <Button
-                className={styles.addBlockButton}
-                data-tooltip="Add code from a file"
-                aria-label="Add code from file"
-                onClick={() => addBlock({ type: 'file', input: EMPTY_FILE_BLOCK_INPUT })}
-                data-testid="add-file-block"
-            >
-                <Icon aria-hidden={true} size="sm" svgPath={mdiCodeTags} />
-            </Button>
-            <Button
-                className={styles.addBlockButton}
-                data-tooltip="Add a symbol"
-                aria-label="Add symbol"
-                onClick={() => addBlock({ type: 'symbol', input: EMPTY_SYMBOL_BLOCK_INPUT })}
-                data-testid="add-symbol-block"
-            >
-                <Icon aria-hidden={true} size="sm" svgPath={mdiFunction} />
-            </Button>
-            {showComputeComponent && (
+            <Tooltip content="Add Markdown text">
                 <Button
                     className={styles.addBlockButton}
-                    data-tooltip="Add compute block"
-                    aria-label="Add compute block"
-                    onClick={() => addBlock({ type: 'compute', input: '' })}
-                    data-testid="add-compute-block"
+                    onClick={() => addBlock({ type: 'md', input: { text: '', initialFocusInput: true } })}
+                    data-testid="add-md-block"
+                    aria-label="Add markdown"
                 >
-                    {/* // TODO: Fix icon */}
-                    <Icon aria-hidden={true} size="sm" svgPath={mdiLaptop} />
+                    <Icon aria-hidden={true} size="sm" svgPath={mdiLanguageMarkdownOutline} />
                 </Button>
+            </Tooltip>
+            <Tooltip content="Add a Sourcegraph query">
+                <Button
+                    className={styles.addBlockButton}
+                    onClick={() => addBlock({ type: 'query', input: { query: '', initialFocusInput: true } })}
+                    data-testid="add-query-block"
+                    aria-label="Add query"
+                >
+                    <Icon aria-hidden={true} size="sm" svgPath={mdiMagnify} />
+                </Button>
+            </Tooltip>
+            <Tooltip content="Add code from a file">
+                <Button
+                    className={styles.addBlockButton}
+                    onClick={() => addBlock({ type: 'file', input: EMPTY_FILE_BLOCK_INPUT })}
+                    data-testid="add-file-block"
+                    aria-label="Add code"
+                >
+                    <Icon aria-hidden={true} size="sm" svgPath={mdiCodeTags} />
+                </Button>
+            </Tooltip>
+            <Tooltip content="Add a symbol">
+                <Button
+                    className={styles.addBlockButton}
+                    onClick={() => addBlock({ type: 'symbol', input: EMPTY_SYMBOL_BLOCK_INPUT })}
+                    data-testid="add-symbol-block"
+                    aria-label="Add symbol"
+                >
+                    <Icon aria-hidden={true} size="sm" svgPath={mdiFunction} />
+                </Button>
+            </Tooltip>
+            {showComputeComponent && (
+                <Tooltip content="Add compute block">
+                    <Button
+                        className={styles.addBlockButton}
+                        onClick={() => addBlock({ type: 'compute', input: '' })}
+                        data-testid="add-compute-block"
+                        aria-label="Add compute block"
+                    >
+                        {/* // TODO: Fix icon */}
+                        <Icon aria-hidden={true} size="sm" svgPath={mdiLaptop} />
+                    </Button>
+                </Tooltip>
             )}
         </>
     )

--- a/client/web/src/notebooks/notebook/NotebookOutline.tsx
+++ b/client/web/src/notebooks/notebook/NotebookOutline.tsx
@@ -8,7 +8,7 @@ import { marked, Slugger } from 'marked'
 import ReactDOM from 'react-dom'
 
 import { markdownLexer } from '@sourcegraph/common'
-import { Button, Icon, Link } from '@sourcegraph/wildcard'
+import { Button, Icon, Link, Tooltip } from '@sourcegraph/wildcard'
 
 import { Block, MarkdownBlock } from '..'
 
@@ -181,9 +181,9 @@ export const NotebookOutline: React.FunctionComponent<React.PropsWithChildren<No
                                 {highlightedHeading === heading.id && (
                                     <span className={styles.highlightDot}>&middot;</span>
                                 )}
-                                <span data-tooltip={heading.text} className={classNames(styles.headingLinkText)}>
-                                    {heading.text}
-                                </span>
+                                <Tooltip content={heading.text} placement="right">
+                                    <span className={classNames(styles.headingLinkText)}>{heading.text}</span>
+                                </Tooltip>
                             </Link>
                         </li>
                     ))}

--- a/client/web/src/org/members/OrgMembersListPage.tsx
+++ b/client/web/src/org/members/OrgMembersListPage.tsx
@@ -20,6 +20,7 @@ import {
     PageSelector,
     H3,
     Icon,
+    Tooltip,
 } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
@@ -105,12 +106,9 @@ const MemberItem: React.FunctionComponent<React.PropsWithChildren<MemberItemProp
                     )}
                 >
                     <div className={styles.avatarContainer}>
-                        <UserAvatar
-                            size={36}
-                            className={styles.avatar}
-                            user={member}
-                            data-tooltip={member.displayName || member.username}
-                        />
+                        <Tooltip content={member.displayName || member.username}>
+                            <UserAvatar size={36} className={styles.avatar} user={member} />
+                        </Tooltip>
                     </div>
 
                     <div className="d-flex flex-column">

--- a/client/web/src/org/members/OrgPendingInvites.tsx
+++ b/client/web/src/org/members/OrgPendingInvites.tsx
@@ -19,6 +19,7 @@ import {
     PageSelector,
     H3,
     Icon,
+    Tooltip,
 } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
@@ -174,12 +175,9 @@ const InvitationItem: React.FunctionComponent<React.PropsWithChildren<Invitation
                 >
                     <div className={styles.avatarContainer}>
                         {invite.recipient && (
-                            <UserAvatar
-                                size={24}
-                                className={styles.avatar}
-                                user={invite.recipient}
-                                data-tooltip={invite.recipient.displayName || invite.recipient.username}
-                            />
+                            <Tooltip content={invite.recipient.displayName || invite.recipient.username}>
+                                <UserAvatar size={24} className={styles.avatar} user={invite.recipient} />
+                            </Tooltip>
                         )}
                         {!invite.recipient && invite.recipientEmail && (
                             <Icon className={styles.emailIcon} svgPath={mdiEmail} inline={false} aria-hidden={true} />

--- a/client/web/src/org/members/SearchUserAutocomplete.tsx
+++ b/client/web/src/org/members/SearchUserAutocomplete.tsx
@@ -6,7 +6,7 @@ import { debounce } from 'lodash'
 // eslint-disable-next-line no-restricted-imports
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 
-import { Input } from '@sourcegraph/wildcard'
+import { Input, Tooltip } from '@sourcegraph/wildcard'
 
 import { AutocompleteMembersSearchResult, AutocompleteMembersSearchVariables, Maybe } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -61,12 +61,13 @@ const UserResultItem: React.FunctionComponent<
         >
             <div className={classNames('d-flex align-items-center justify-content-between', styles.userContainer)}>
                 <div className={styles.avatarContainer}>
-                    <UserAvatar
-                        size={24}
-                        className={classNames(styles.avatar, user.inOrg ? styles.avatarDisabled : undefined)}
-                        user={user}
-                        data-tooltip={user.displayName || user.username}
-                    />
+                    <Tooltip content={user.displayName || user.username}>
+                        <UserAvatar
+                            size={24}
+                            className={classNames(styles.avatar, user.inOrg ? styles.avatarDisabled : undefined)}
+                            user={user}
+                        />
+                    </Tooltip>
                 </div>
                 <div className="d-flex flex-column">
                     <div>

--- a/client/web/src/org/openBeta/GettingStarted.tsx
+++ b/client/web/src/org/openBeta/GettingStarted.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
-import { Link, LoadingSpinner, PageHeader, Badge, H3, Icon } from '@sourcegraph/wildcard'
+import { Link, LoadingSpinner, PageHeader, Badge, H3, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../../components/MarketingBlock'
 import { PageTitle } from '../../components/PageTitle'
@@ -372,25 +372,23 @@ export const OpenBetaGetStartedPage: React.FunctionComponent<React.PropsWithChil
                             <div className="d-flex  flex-0 justify-content-center align-items-center mb-3 flex-wrap">
                                 <div className={styles.membersList}>
                                     <div className={styles.avatarContainer}>
-                                        <UserAvatar
-                                            size={36}
-                                            className={styles.avatar}
-                                            user={authenticatedUser}
-                                            data-tooltip={authenticatedUser.displayName || authenticatedUser.username}
-                                        />
+                                        <Tooltip content={authenticatedUser.displayName || authenticatedUser.username}>
+                                            <UserAvatar size={36} className={styles.avatar} user={authenticatedUser} />
+                                        </Tooltip>
                                     </div>
                                     {otherMembers.length > 0 && (
                                         <div className={styles.avatarContainer}>
                                             <div className={classNames(styles.avatarEllipse)} />
                                             <div className={classNames(styles.avatarContainer, styles.secondAvatar)}>
-                                                <UserAvatar
-                                                    size={36}
-                                                    className={styles.avatar}
-                                                    user={otherMembers[0]}
-                                                    data-tooltip={
-                                                        otherMembers[0].displayName || otherMembers[0].username
-                                                    }
-                                                />
+                                                <Tooltip
+                                                    content={otherMembers[0].displayName || otherMembers[0].username}
+                                                >
+                                                    <UserAvatar
+                                                        size={36}
+                                                        className={styles.avatar}
+                                                        user={otherMembers[0]}
+                                                    />
+                                                </Tooltip>
                                             </div>
                                         </div>
                                     )}

--- a/client/web/src/org/settings/members-v1/InviteForm.tsx
+++ b/client/web/src/org/settings/members-v1/InviteForm.tsx
@@ -9,7 +9,7 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, createAggregateError, isErrorLike } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
-import { LoadingSpinner, Button, Link, Alert, Icon, Input, Text, Code } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Button, Link, Alert, Icon, Input, Text, Code, Tooltip } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { requestGraphQL } from '../../../backend/graphql'
@@ -120,45 +120,52 @@ export const InviteForm: React.FunctionComponent<React.PropsWithChildren<Props>>
                     />
                     <div className="d-block d-md-inline mb-sm-2">
                         {viewerCanAddUserToOrganization && (
-                            <Button
-                                type="submit"
-                                disabled={loading === 'addUserToOrganization' || loading === 'inviteUserToOrganization'}
-                                className="mr-2"
-                                data-tooltip="Add immediately without sending invitation (site admins only)"
-                                variant="primary"
-                            >
-                                {loading === 'addUserToOrganization' ? (
-                                    <LoadingSpinner />
-                                ) : (
-                                    <Icon aria-hidden={true} svgPath={mdiPlus} />
-                                )}{' '}
-                                Add member
-                            </Button>
+                            <Tooltip content="Add immediately without sending invitation (site admins only)">
+                                <Button
+                                    type="submit"
+                                    disabled={
+                                        loading === 'addUserToOrganization' || loading === 'inviteUserToOrganization'
+                                    }
+                                    className="mr-2"
+                                    variant="primary"
+                                >
+                                    {loading === 'addUserToOrganization' ? (
+                                        <LoadingSpinner />
+                                    ) : (
+                                        <Icon aria-hidden={true} svgPath={mdiPlus} />
+                                    )}{' '}
+                                    Add member
+                                </Button>
+                            </Tooltip>
                         )}
                         {(emailInvitesEnabled || !viewerCanAddUserToOrganization) && (
-                            <Button
-                                type={viewerCanAddUserToOrganization ? 'button' : 'submit'}
-                                disabled={loading === 'addUserToOrganization' || loading === 'inviteUserToOrganization'}
-                                variant={viewerCanAddUserToOrganization ? 'secondary' : 'primary'}
-                                data-tooltip={
+                            <Tooltip
+                                content={
                                     emailInvitesEnabled
                                         ? 'Send invitation email with link to join this organization'
                                         : 'Generate invitation link to manually send to user'
                                 }
-                                aria-label="Send or Generate Invitation link"
-                                onClick={viewerCanAddUserToOrganization ? onInviteClick : undefined}
                             >
-                                {loading === 'inviteUserToOrganization' ? (
-                                    <LoadingSpinner />
-                                ) : (
-                                    <Icon aria-hidden={true} svgPath={mdiEmailOpenOutline} />
-                                )}{' '}
-                                {emailInvitesEnabled
-                                    ? viewerCanAddUserToOrganization
-                                        ? 'Send invitation to join'
-                                        : 'Send invitation'
-                                    : 'Generate invitation link'}
-                            </Button>
+                                <Button
+                                    type={viewerCanAddUserToOrganization ? 'button' : 'submit'}
+                                    disabled={
+                                        loading === 'addUserToOrganization' || loading === 'inviteUserToOrganization'
+                                    }
+                                    variant={viewerCanAddUserToOrganization ? 'secondary' : 'primary'}
+                                    onClick={viewerCanAddUserToOrganization ? onInviteClick : undefined}
+                                >
+                                    {loading === 'inviteUserToOrganization' ? (
+                                        <LoadingSpinner />
+                                    ) : (
+                                        <Icon aria-hidden={true} svgPath={mdiEmailOpenOutline} />
+                                    )}{' '}
+                                    {emailInvitesEnabled
+                                        ? viewerCanAddUserToOrganization
+                                            ? 'Send invitation to join'
+                                            : 'Send invitation'
+                                        : 'Generate invitation link'}
+                                </Button>
+                            </Tooltip>
                         )}
                     </div>
                 </Form>

--- a/client/web/src/person/PersonLink.tsx
+++ b/client/web/src/person/PersonLink.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import { gql } from '@sourcegraph/http-client'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
+import { Tooltip } from '@sourcegraph/wildcard'
 
 import { PersonLinkFields } from '../graphql-operations'
 
@@ -41,15 +42,15 @@ export const PersonLink: React.FunctionComponent<
         userClassName?: string
     }>
 > = ({ person, className = '', userClassName = '' }) => (
-    <LinkOrSpan
-        to={person.user?.url}
-        className={classNames(className, person.user && userClassName)}
-        data-tooltip={
+    <Tooltip
+        content={
             person.user && (person.user.displayName || person.displayName)
                 ? `${person.user.displayName || person.displayName} <${person.email}>`
                 : person.email
         }
     >
-        {formatPersonName(person)}
-    </LinkOrSpan>
+        <LinkOrSpan to={person.user?.url} className={classNames(className, person.user && userClassName)}>
+            {formatPersonName(person)}
+        </LinkOrSpan>
+    </Tooltip>
 )

--- a/client/web/src/person/__snapshots__/PersonLink.test.tsx.snap
+++ b/client/web/src/person/__snapshots__/PersonLink.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`PersonLink no user account 1`] = `
 <DocumentFragment>
   <span
     class="a"
-    data-tooltip="alice@example.com"
+    data-state="closed"
   >
     alice
   </span>
@@ -15,7 +15,7 @@ exports[`PersonLink with user account 1`] = `
 <DocumentFragment>
   <a
     class="a b"
-    data-tooltip="Alice Smith <alice@example.com>"
+    data-state="closed"
     href="u"
   >
     alice

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -20,6 +20,7 @@ import {
     Tabs,
     Icon,
     Panel,
+    Tooltip,
 } from '@sourcegraph/wildcard'
 
 import settingsSchemaJSON from '../../../../schema/settings.schema.json'
@@ -75,15 +76,19 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
 
     if (!isVisible) {
         return (
-            <Button
-                variant="icon"
-                className={classNames('position-absolute border-top border-bottom border-right mt-4', styles.toggle)}
-                onClick={() => handleSidebarToggle(true)}
-                data-tooltip="Show sidebar"
-                aria-label="Show sidebar"
-            >
-                <Icon aria-hidden={true} svgPath={mdiChevronDoubleRight} />
-            </Button>
+            <Tooltip content="Show sidebar">
+                <Button
+                    aria-label="Show sidebar"
+                    variant="icon"
+                    className={classNames(
+                        'position-absolute border-top border-bottom border-right mt-4',
+                        styles.toggle
+                    )}
+                    onClick={() => handleSidebarToggle(true)}
+                >
+                    <Icon aria-hidden={true} svgPath={mdiChevronDoubleRight} />
+                </Button>
+            </Tooltip>
         )
     }
 
@@ -104,16 +109,19 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
                 >
                     <TabList
                         actions={
-                            <Button
-                                onClick={() => handleSidebarToggle(false)}
-                                className="bg-transparent border-0 ml-auto p-1 position-relative focus-behaviour"
-                                title="Hide sidebar"
-                                data-tooltip="Hide sidebar"
-                                data-placement="right"
-                                aria-label="Hide sidebar"
-                            >
-                                <Icon className={styles.closeIcon} aria-hidden={true} svgPath={mdiChevronDoubleLeft} />
-                            </Button>
+                            <Tooltip content="Hide sidebar" placement="right">
+                                <Button
+                                    aria-label="Hide sidebar"
+                                    onClick={() => handleSidebarToggle(false)}
+                                    className="bg-transparent border-0 ml-auto p-1 position-relative focus-behaviour"
+                                >
+                                    <Icon
+                                        className={styles.closeIcon}
+                                        aria-hidden={true}
+                                        svgPath={mdiChevronDoubleLeft}
+                                    />
+                                </Button>
+                            </Tooltip>
                         }
                     >
                         <Tab data-tab-content="files">

--- a/client/web/src/repo/actions/CopyPathAction.tsx
+++ b/client/web/src/repo/actions/CopyPathAction.tsx
@@ -4,7 +4,7 @@ import { mdiContentCopy } from '@mdi/js'
 import copy from 'copy-to-clipboard'
 import { useLocation } from 'react-router'
 
-import { Button, DeprecatedTooltipController, Icon, screenReaderAnnounce } from '@sourcegraph/wildcard'
+import { Button, DeprecatedTooltipController, Icon, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../tracking/eventLogger'
 import { parseBrowserRepoURL } from '../../util/url'
@@ -38,8 +38,10 @@ export const CopyPathAction: React.FunctionComponent<React.PropsWithChildren<unk
     const label = copied ? 'Copied!' : 'Copy path to clipboard'
 
     return (
-        <Button variant="icon" className="p-2" data-tooltip={label} aria-label={label} onClick={onClick} size="sm">
-            <Icon className={styles.copyIcon} aria-hidden={true} svgPath={mdiContentCopy} />
-        </Button>
+        <Tooltip content={label}>
+            <Button aria-label="Copy" variant="icon" className="p-2" onClick={onClick} size="sm">
+                <Icon className={styles.copyIcon} aria-hidden={true} svgPath={mdiContentCopy} />
+            </Button>
+        </Tooltip>
     )
 }

--- a/client/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/client/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -12,7 +12,7 @@ import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { Position, Range } from '@sourcegraph/extension-api-types'
 import { PhabricatorIcon } from '@sourcegraph/shared/src/components/icons' // TODO: Switch mdi icon
 import { RevisionSpec, FileSpec } from '@sourcegraph/shared/src/util/url'
-import { useObservable, Icon } from '@sourcegraph/wildcard'
+import { useObservable, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { ExternalLinkFields, RepositoryFields, ExternalServiceKind } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -151,15 +151,16 @@ export const GoToCodeHostAction: React.FunctionComponent<
         id: TARGET_ID,
         onClick,
         onAuxClick: onClick,
-        'data-tooltip': descriptiveText,
-        'aria-label': descriptiveText,
         className: 'btn-icon test-go-to-code-host',
+        'aria-label': descriptiveText,
     }
 
     return (
-        <RepoHeaderActionAnchor {...commonProps}>
-            <Icon as={exportIcon} aria-hidden={true} />
-        </RepoHeaderActionAnchor>
+        <Tooltip content={descriptiveText}>
+            <RepoHeaderActionAnchor {...commonProps}>
+                <Icon as={exportIcon} aria-hidden={true} />
+            </RepoHeaderActionAnchor>
+        </Tooltip>
     )
 }
 

--- a/client/web/src/repo/actions/GoToPermalinkAction.tsx
+++ b/client/web/src/repo/actions/GoToPermalinkAction.tsx
@@ -7,7 +7,7 @@ import { filter } from 'rxjs/operators'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { isInputElement } from '@sourcegraph/shared/src/util/dom'
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { replaceRevisionInURL } from '../../util/url'
 import { RepoHeaderActionButtonLink } from '../components/RepoHeaderActions'
@@ -75,16 +75,17 @@ export class GoToPermalinkAction extends React.PureComponent<
         }
 
         return (
-            <RepoHeaderActionButtonLink
-                className="btn-icon"
-                file={false}
-                to={this.permalinkURL}
-                onSelect={this.onClick.bind(this)}
-                data-tooltip="Permalink (with full Git commit SHA)"
-                aria-label="Permalink (with full Git commit SHA)"
-            >
-                <Icon aria-hidden={true} svgPath={mdiLink} />
-            </RepoHeaderActionButtonLink>
+            <Tooltip content="Permalink (with full Git commit SHA)">
+                <RepoHeaderActionButtonLink
+                    aria-label="Permalink"
+                    className="btn-icon"
+                    file={false}
+                    to={this.permalinkURL}
+                    onSelect={this.onClick.bind(this)}
+                >
+                    <Icon aria-hidden={true} svgPath={mdiLink} />
+                </RepoHeaderActionButtonLink>
+            </Tooltip>
         )
     }
 

--- a/client/web/src/repo/blob/ColumnDecorator.tsx
+++ b/client/web/src/repo/blob/ColumnDecorator.tsx
@@ -13,6 +13,7 @@ import {
 } from '@sourcegraph/shared/src/api/extension/api/decorations'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './ColumnDecorator.module.scss'
 
@@ -136,34 +137,37 @@ export const ColumnDecorator = React.memo<LineDecoratorProps>(
                                 const style = decorationAttachmentStyleForTheme(attachment, isLightTheme)
 
                                 return (
-                                    <LinkOrSpan
+                                    <Tooltip
+                                        content={attachment.hoverMessage}
                                         key={`${decoration.after.contentText ?? decoration.after.hoverMessage ?? ''}-${
                                             portalRoot.dataset.line ?? ''
                                         }`}
-                                        className={styles.item}
-                                        // eslint-disable-next-line react/forbid-dom-props
-                                        style={{ color: style.color }}
-                                        to={attachment.linkURL}
-                                        // Use target to open external URLs
-                                        target={
-                                            attachment.linkURL && isAbsoluteUrl(attachment.linkURL)
-                                                ? '_blank'
-                                                : undefined
-                                        }
-                                        // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
-                                        rel="noreferrer noopener"
-                                        data-tooltip={attachment.hoverMessage || null}
-                                        onMouseEnter={selectRow}
-                                        onMouseLeave={deselectRow}
-                                        onFocus={selectRow}
-                                        onBlur={deselectRow}
                                     >
-                                        <span
-                                            className={styles.contents}
-                                            data-line-decoration-attachment-content={true}
-                                            data-contents={attachment.contentText || ''}
-                                        />
-                                    </LinkOrSpan>
+                                        <LinkOrSpan
+                                            className={styles.item}
+                                            // eslint-disable-next-line react/forbid-dom-props
+                                            style={{ color: style.color }}
+                                            to={attachment.linkURL}
+                                            // Use target to open external URLs
+                                            target={
+                                                attachment.linkURL && isAbsoluteUrl(attachment.linkURL)
+                                                    ? '_blank'
+                                                    : undefined
+                                            }
+                                            // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
+                                            rel="noreferrer noopener"
+                                            onMouseEnter={selectRow}
+                                            onMouseLeave={deselectRow}
+                                            onFocus={selectRow}
+                                            onBlur={deselectRow}
+                                        >
+                                            <span
+                                                className={styles.contents}
+                                                data-line-decoration-attachment-content={true}
+                                                data-contents={attachment.contentText || ''}
+                                            />
+                                        </LinkOrSpan>
+                                    </Tooltip>
                                 )
                             }),
                             portalRoot.querySelector(`.${styles.wrapper}`) as HTMLDivElement

--- a/client/web/src/repo/blob/GoToRawAction.tsx
+++ b/client/web/src/repo/blob/GoToRawAction.tsx
@@ -4,7 +4,7 @@ import { mdiFileDownloadOutline } from '@mdi/js'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { encodeRepoRevision, RepoSpec, RevisionSpec, FileSpec } from '@sourcegraph/shared/src/util/url'
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { RepoHeaderActionAnchor } from '../components/RepoHeaderActions'
 import { RepoHeaderContext } from '../RepoHeader'
@@ -42,17 +42,18 @@ export class GoToRawAction extends React.PureComponent<Props> {
         }
 
         return (
-            <RepoHeaderActionAnchor
-                to={to}
-                target="_blank"
-                onClick={this.onClick.bind(this)}
-                className="btn-icon"
-                data-tooltip={descriptiveText}
-                aria-label={descriptiveText}
-                download={true}
-            >
-                <Icon aria-hidden={true} svgPath={mdiFileDownloadOutline} />
-            </RepoHeaderActionAnchor>
+            <Tooltip content={descriptiveText}>
+                <RepoHeaderActionAnchor
+                    aria-label={descriptiveText}
+                    to={to}
+                    target="_blank"
+                    onClick={this.onClick.bind(this)}
+                    className="btn-icon"
+                    download={true}
+                >
+                    <Icon aria-hidden={true} svgPath={mdiFileDownloadOutline} />
+                </RepoHeaderActionAnchor>
+            </Tooltip>
         )
     }
 }

--- a/client/web/src/repo/blob/LineDecorator.tsx
+++ b/client/web/src/repo/blob/LineDecorator.tsx
@@ -12,6 +12,7 @@ import {
 } from '@sourcegraph/shared/src/api/extension/api/decorations'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './LineDecorator.module.scss'
 
@@ -139,29 +140,32 @@ export const LineDecorator = React.memo<LineDecoratorProps>(
                 const style = decorationAttachmentStyleForTheme(attachment, isLightTheme)
 
                 return (
-                    <LinkOrSpan
+                    <Tooltip
+                        content={attachment.hoverMessage}
                         // Key by content, use index to remove possibility of duplicate keys
                         key={`${decoration.after.contentText ?? decoration.after.hoverMessage ?? ''}-${index}`}
-                        className={styles.lineDecorationAttachment}
-                        data-line-decoration-attachment={true}
-                        to={attachment.linkURL}
-                        data-tooltip={attachment.hoverMessage}
-                        // Use target to open external URLs
-                        target={attachment.linkURL && isAbsoluteUrl(attachment.linkURL) ? '_blank' : undefined}
-                        // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
-                        rel="noreferrer noopener"
                     >
-                        <span
-                            className={styles.contents}
-                            data-line-decoration-attachment-content={true}
-                            // eslint-disable-next-line react/forbid-dom-props
-                            style={{
-                                color: style.color,
-                                backgroundColor: style.backgroundColor,
-                            }}
-                            data-contents={attachment.contentText || ''}
-                        />
-                    </LinkOrSpan>
+                        <LinkOrSpan
+                            className={styles.lineDecorationAttachment}
+                            data-line-decoration-attachment={true}
+                            to={attachment.linkURL}
+                            // Use target to open external URLs
+                            target={attachment.linkURL && isAbsoluteUrl(attachment.linkURL) ? '_blank' : undefined}
+                            // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
+                            rel="noreferrer noopener"
+                        >
+                            <span
+                                className={styles.contents}
+                                data-line-decoration-attachment-content={true}
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={{
+                                    color: style.color,
+                                    backgroundColor: style.backgroundColor,
+                                }}
+                                data-contents={attachment.contentText || ''}
+                            />
+                        </LinkOrSpan>
+                    </Tooltip>
                 )
             }),
             portalNode

--- a/client/web/src/repo/blob/__snapshots__/LineDecorator.test.tsx.snap
+++ b/client/web/src/repo/blob/__snapshots__/LineDecorator.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`LineDecorator renders multiple attachments 1`] = `
     <span
       class="lineDecorationAttachment"
       data-line-decoration-attachment="true"
+      data-state="closed"
       rel="noreferrer noopener"
     >
       <span
@@ -23,6 +24,7 @@ exports[`LineDecorator renders multiple attachments 1`] = `
     <span
       class="lineDecorationAttachment"
       data-line-decoration-attachment="true"
+      data-state="closed"
       rel="noreferrer noopener"
     >
       <span
@@ -47,6 +49,7 @@ exports[`LineDecorator renders one attachment 1`] = `
     <span
       class="lineDecorationAttachment"
       data-line-decoration-attachment="true"
+      data-state="closed"
       rel="noreferrer noopener"
     >
       <span

--- a/client/web/src/repo/blob/actions/ToggleHistoryPanel.tsx
+++ b/client/web/src/repo/blob/actions/ToggleHistoryPanel.tsx
@@ -13,7 +13,7 @@ import {
     toViewStateHash,
 } from '@sourcegraph/common'
 import { parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
-import { DeprecatedTooltipController, Icon } from '@sourcegraph/wildcard'
+import { DeprecatedTooltipController, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../../tracking/eventLogger'
 import { RepoHeaderActionButtonLink } from '../../components/RepoHeaderActions'
@@ -96,15 +96,16 @@ export class ToggleHistoryPanel extends React.PureComponent<
             )
         }
         return (
-            <RepoHeaderActionButtonLink
-                className="btn-icon"
-                file={false}
-                onSelect={this.onClick}
-                data-tooltip={`${visible ? 'Hide' : 'Show'} history (Alt+H/Opt+H)`}
-                aria-label={`${visible ? 'Hide' : 'Show'} history (Alt+H/Opt+H)`}
-            >
-                <Icon aria-hidden={true} svgPath={mdiHistory} />
-            </RepoHeaderActionButtonLink>
+            <Tooltip content={`${visible ? 'Hide' : 'Show'} history (Alt+H/Opt+H)`}>
+                <RepoHeaderActionButtonLink
+                    aria-label={visible ? 'Hide' : 'Show'}
+                    className="btn-icon"
+                    file={false}
+                    onSelect={this.onClick}
+                >
+                    <Icon aria-hidden={true} svgPath={mdiHistory} />
+                </RepoHeaderActionButtonLink>
+            </Tooltip>
         )
     }
 

--- a/client/web/src/repo/blob/actions/ToggleHistoryPanel.tsx
+++ b/client/web/src/repo/blob/actions/ToggleHistoryPanel.tsx
@@ -97,14 +97,20 @@ export class ToggleHistoryPanel extends React.PureComponent<
         }
         return (
             <Tooltip content={`${visible ? 'Hide' : 'Show'} history (Alt+H/Opt+H)`}>
-                <RepoHeaderActionButtonLink
-                    aria-label={visible ? 'Hide' : 'Show'}
-                    className="btn-icon"
-                    file={false}
-                    onSelect={this.onClick}
-                >
-                    <Icon aria-hidden={true} svgPath={mdiHistory} />
-                </RepoHeaderActionButtonLink>
+                {/**
+                 * This <RepoHeaderActionButtonLink> must be wrapped with an additional span, since the tooltip currently has an issue that will
+                 * break its underlying <ButtonLink>'s onClick handler and it will no longer prevent the default page reload (with no href).
+                 */}
+                <span>
+                    <RepoHeaderActionButtonLink
+                        aria-label={visible ? 'Hide' : 'Show'}
+                        className="btn-icon"
+                        file={false}
+                        onSelect={this.onClick}
+                    >
+                        <Icon aria-hidden={true} svgPath={mdiHistory} />
+                    </RepoHeaderActionButtonLink>
+                </span>
             </Tooltip>
         )
     }

--- a/client/web/src/repo/blob/actions/ToggleLineWrap.tsx
+++ b/client/web/src/repo/blob/actions/ToggleLineWrap.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 
-import { mdiWrap } from '@mdi/js'
+import { mdiWrap, mdiWrapDisabled } from '@mdi/js'
 import { fromEvent, Subject, Subscription } from 'rxjs'
 import { filter } from 'rxjs/operators'
 
 import { WrapDisabledIcon } from '@sourcegraph/shared/src/components/icons'
-import { DeprecatedTooltipController, Icon } from '@sourcegraph/wildcard'
+import { DeprecatedTooltipController, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../../tracking/eventLogger'
 import { RepoHeaderActionButtonLink } from '../../components/RepoHeaderActions'
@@ -87,19 +87,16 @@ export class ToggleLineWrap extends React.PureComponent<
         }
 
         return (
-            <RepoHeaderActionButtonLink
-                className="btn-icon"
-                file={false}
-                onSelect={this.onClick}
-                data-tooltip={`${this.state.value ? 'Disable' : 'Enable'} wrapping long lines (Alt+Z/Opt+Z)`}
-                aria-label={`${this.state.value ? 'Disable' : 'Enable'} wrapping long lines (Alt+Z/Opt+Z)`}
-            >
-                <Icon
-                    as={this.state.value ? WrapDisabledIcon : undefined}
-                    svgPath={!this.state.value ? mdiWrap : undefined}
-                    aria-hidden={true}
-                />
-            </RepoHeaderActionButtonLink>
+            <Tooltip content={`${this.state.value ? 'Disable' : 'Enable'} wrapping long lines (Alt+Z/Opt+Z)`}>
+                <RepoHeaderActionButtonLink
+                    aria-label={this.state.value ? 'Disable' : 'Enable'}
+                    className="btn-icon"
+                    file={false}
+                    onSelect={this.onClick}
+                >
+                    <Icon svgPath={this.state.value ? mdiWrapDisabled : mdiWrap} aria-hidden={true} />
+                </RepoHeaderActionButtonLink>
+            </Tooltip>
         )
     }
 

--- a/client/web/src/repo/blob/actions/ToggleLineWrap.tsx
+++ b/client/web/src/repo/blob/actions/ToggleLineWrap.tsx
@@ -88,14 +88,20 @@ export class ToggleLineWrap extends React.PureComponent<
 
         return (
             <Tooltip content={`${this.state.value ? 'Disable' : 'Enable'} wrapping long lines (Alt+Z/Opt+Z)`}>
-                <RepoHeaderActionButtonLink
-                    aria-label={this.state.value ? 'Disable' : 'Enable'}
-                    className="btn-icon"
-                    file={false}
-                    onSelect={this.onClick}
-                >
-                    <Icon svgPath={this.state.value ? mdiWrapDisabled : mdiWrap} aria-hidden={true} />
-                </RepoHeaderActionButtonLink>
+                {/**
+                 * This <ButtonLink> must be wrapped with an additional span, since the tooltip currently has an issue that will
+                 * break its onClick handler and it will no longer prevent the default page reload (with no href).
+                 */}
+                <span>
+                    <RepoHeaderActionButtonLink
+                        aria-label={this.state.value ? 'Disable' : 'Enable'}
+                        className="btn-icon"
+                        file={false}
+                        onSelect={this.onClick}
+                    >
+                        <Icon svgPath={this.state.value ? mdiWrapDisabled : mdiWrap} aria-hidden={true} />
+                    </RepoHeaderActionButtonLink>
+                </span>
             </Tooltip>
         )
     }

--- a/client/web/src/repo/blob/actions/ToggleRenderedFileMode.tsx
+++ b/client/web/src/repo/blob/actions/ToggleRenderedFileMode.tsx
@@ -4,7 +4,7 @@ import { mdiEye } from '@mdi/js'
 import { useLocation } from 'react-router'
 
 import { RenderMode } from '@sourcegraph/shared/src/util/url'
-import { createLinkUrl, DeprecatedTooltipController, Icon } from '@sourcegraph/wildcard'
+import { createLinkUrl, DeprecatedTooltipController, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { RepoHeaderActionButtonLink } from '../../components/RepoHeaderActions'
 import { RepoHeaderContext } from '../../RepoHeader'
@@ -46,14 +46,15 @@ export const ToggleRenderedFileMode: React.FunctionComponent<React.PropsWithChil
     }
 
     return (
-        <RepoHeaderActionButtonLink
-            className="btn-icon"
-            file={false}
-            to={createLinkUrl(getURLForMode(location, otherMode))}
-            data-tooltip={label}
-        >
-            <Icon aria-hidden={true} svgPath={mdiEye} />{' '}
-            <span className="d-none d-lg-inline ml-1">{mode === 'rendered' ? 'Raw' : 'Formatted'}</span>
-        </RepoHeaderActionButtonLink>
+        <Tooltip content={label}>
+            <RepoHeaderActionButtonLink
+                className="btn-icon"
+                file={false}
+                to={createLinkUrl(getURLForMode(location, otherMode))}
+            >
+                <Icon aria-hidden={true} svgPath={mdiEye} />{' '}
+                <span className="d-none d-lg-inline ml-1">{mode === 'rendered' ? 'Raw' : 'Formatted'}</span>
+            </RepoHeaderActionButtonLink>
+        </Tooltip>
     )
 }

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -13,6 +13,7 @@ import {
     Icon,
     Code,
     screenReaderAnnounce,
+    Tooltip,
 } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../components/time/Timestamp'
@@ -171,15 +172,16 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                 <span className={styles.shaAndParentsLabel}>Commit:</span>
                 <Code className={styles.shaAndParentsSha}>
                     {node.oid}{' '}
-                    <Button
-                        variant="icon"
-                        className={styles.shaAndParentsCopy}
-                        onClick={() => copyToClipboard(node.oid)}
-                        data-tooltip={flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'}
-                        aria-label="Copy full SHA"
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiContentCopy} />
-                    </Button>
+                    <Tooltip content={flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'}>
+                        <Button
+                            variant="icon"
+                            className={styles.shaAndParentsCopy}
+                            onClick={() => copyToClipboard(node.oid)}
+                            aria-label="Copy full SHA"
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiContentCopy} />
+                        </Button>
+                    </Tooltip>
                 </Code>
             </div>
             <div className="align-items-center d-flex">
@@ -196,15 +198,16 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                                 <Link className={styles.shaAndParentsParent} to={parent.url}>
                                     <Code>{parent.oid}</Code>
                                 </Link>
-                                <Button
-                                    variant="icon"
-                                    className={styles.shaAndParentsCopy}
-                                    onClick={() => copyToClipboard(parent.oid)}
-                                    data-tooltip={flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'}
-                                    aria-label="Copy full SHA"
-                                >
-                                    <Icon aria-hidden={true} svgPath={mdiContentCopy} />
-                                </Button>
+                                <Tooltip content={flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'}>
+                                    <Button
+                                        variant="icon"
+                                        className={styles.shaAndParentsCopy}
+                                        onClick={() => copyToClipboard(parent.oid)}
+                                        aria-label="Copy full SHA"
+                                    >
+                                        <Icon aria-hidden={true} svgPath={mdiContentCopy} />
+                                    </Button>
+                                </Tooltip>
                             </div>
                         ))}
                     </>
@@ -225,18 +228,19 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
 
     const viewFilesCommitElement = node.tree && (
         <div className="d-flex justify-content-between">
-            <Button
-                className="align-center d-inline-flex"
-                to={node.tree.canonicalURL}
-                data-tooltip="Browse files in the repository at this point in history"
-                variant="secondary"
-                outline={true}
-                size="sm"
-                as={Link}
-            >
-                <Icon className="mr-1" aria-hidden={true} svgPath={mdiFileDocument} />
-                Browse files at @{node.abbreviatedOID}
-            </Button>
+            <Tooltip content="Browse files in the repository at this point in history">
+                <Button
+                    className="align-center d-inline-flex"
+                    to={node.tree.canonicalURL}
+                    variant="secondary"
+                    outline={true}
+                    size="sm"
+                    as={Link}
+                >
+                    <Icon className="mr-1" aria-hidden={true} svgPath={mdiFileDocument} />
+                    Browse files at @{node.abbreviatedOID}
+                </Button>
+            </Tooltip>
             {diffModeSelector()}
         </div>
     )
@@ -282,39 +286,44 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                                 {!showSHAAndParentsRow && (
                                     <div>
                                         <ButtonGroup className="mr-2">
-                                            <Button
-                                                to={node.canonicalURL}
-                                                data-tooltip="View this commit"
-                                                variant="secondary"
-                                                as={Link}
-                                                size="sm"
-                                                aria-label="View this commit"
+                                            <Tooltip content="View this commit">
+                                                <Button to={node.canonicalURL} variant="secondary" as={Link} size="sm">
+                                                    <strong>{oidElement}</strong>
+                                                </Button>
+                                            </Tooltip>
+                                            <Tooltip
+                                                content={flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'}
                                             >
-                                                <strong>{oidElement}</strong>
-                                            </Button>
-                                            <Button
-                                                onClick={() => copyToClipboard(node.oid)}
-                                                data-tooltip={
-                                                    flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'
-                                                }
-                                                variant="secondary"
-                                                size="sm"
-                                                aria-label="Copy full SHA"
-                                            >
-                                                <Icon className="small" aria-hidden={true} svgPath={mdiContentCopy} />
-                                            </Button>
+                                                <Button
+                                                    onClick={() => copyToClipboard(node.oid)}
+                                                    variant="secondary"
+                                                    size="sm"
+                                                    aria-label="Copy full SHA"
+                                                >
+                                                    <Icon
+                                                        className="small"
+                                                        aria-hidden={true}
+                                                        svgPath={mdiContentCopy}
+                                                    />
+                                                </Button>
+                                            </Tooltip>
                                         </ButtonGroup>
                                         {node.tree && (
-                                            <Button
-                                                to={node.tree.canonicalURL}
-                                                data-tooltip="View files at this commit"
-                                                variant="secondary"
-                                                size="sm"
-                                                as={Link}
-                                                aria-label="View files at this commit"
-                                            >
-                                                <Icon className="mr-1" aria-hidden={true} svgPath={mdiFileDocument} />
-                                            </Button>
+                                            <Tooltip content="View files at this commit">
+                                                <Button
+                                                    aria-label="View files"
+                                                    to={node.tree.canonicalURL}
+                                                    variant="secondary"
+                                                    size="sm"
+                                                    as={Link}
+                                                >
+                                                    <Icon
+                                                        className="mr-1"
+                                                        aria-hidden={true}
+                                                        svgPath={mdiFileDocument}
+                                                    />
+                                                </Button>
+                                            </Tooltip>
                                         )}
                                     </div>
                                 )}

--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import classNames from 'classnames'
 
+import { Tooltip } from '@sourcegraph/wildcard'
+
 import { Timestamp } from '../../components/time/Timestamp'
 import { SignatureFields } from '../../graphql-operations'
 import { formatPersonName, PersonLink } from '../../person/PersonLink'
@@ -47,18 +49,16 @@ export const GitCommitNodeByline: React.FunctionComponent<React.PropsWithChildre
         return (
             <div data-testid="git-commit-node-byline" className={className}>
                 <div className="flex-shrink-0">
-                    <UserAvatar
-                        inline={true}
-                        className={avatarClassName}
-                        user={author.person}
-                        data-tooltip={`${formatPersonName(author.person)} (author)`}
-                    />{' '}
-                    <UserAvatar
-                        inline={true}
-                        className={classNames('mr-2', avatarClassName)}
-                        user={committer.person}
-                        data-tooltip={`${formatPersonName(committer.person)} (committer)`}
-                    />
+                    <Tooltip content={`${formatPersonName(author.person)} (author)`}>
+                        <UserAvatar inline={true} className={avatarClassName} user={author.person} />
+                    </Tooltip>{' '}
+                    <Tooltip content={`${formatPersonName(committer.person)} (committer)`}>
+                        <UserAvatar
+                            inline={true}
+                            className={classNames('mr-2', avatarClassName)}
+                            user={committer.person}
+                        />
+                    </Tooltip>
                 </div>
                 <div className="overflow-hidden">
                     {!compact ? (
@@ -83,12 +83,13 @@ export const GitCommitNodeByline: React.FunctionComponent<React.PropsWithChildre
     return (
         <div data-testid="git-commit-node-byline" className={className}>
             <div>
-                <UserAvatar
-                    inline={true}
-                    className={classNames('mr-1 mr-2', avatarClassName)}
-                    user={author.person}
-                    data-tooltip={formatPersonName(author.person)}
-                />
+                <Tooltip content={formatPersonName(author.person)}>
+                    <UserAvatar
+                        inline={true}
+                        className={classNames('mr-1 mr-2', avatarClassName)}
+                        user={author.person}
+                    />
+                </Tooltip>
             </div>
             <div className="overflow-hidden">
                 {!compact && (

--- a/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
+++ b/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`GitCommitNodeByline author (compact) 1`] = `
       <img
         aria-hidden="true"
         class="mdi-icon iconInline userAvatar mr-1 mr-2"
-        data-tooltip="Alice Zhao"
+        data-state="closed"
         role="presentation"
         src="http://example.com/alice.png"
       />
@@ -21,7 +21,7 @@ exports[`GitCommitNodeByline author (compact) 1`] = `
       committed by 
       <span
         class="font-weight-bold"
-        data-tooltip="alice@example.com"
+        data-state="closed"
       >
         Alice Zhao
       </span>
@@ -47,7 +47,7 @@ exports[`GitCommitNodeByline author 1`] = `
       <img
         aria-hidden="true"
         class="mdi-icon iconInline userAvatar mr-1 mr-2"
-        data-tooltip="Alice Zhao"
+        data-state="closed"
         role="presentation"
         src="http://example.com/alice.png"
       />
@@ -58,7 +58,7 @@ exports[`GitCommitNodeByline author 1`] = `
       committed by 
       <span
         class="font-weight-bold"
-        data-tooltip="alice@example.com"
+        data-state="closed"
       >
         Alice Zhao
       </span>
@@ -86,7 +86,7 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
       <img
         aria-hidden="true"
         class="mdi-icon iconInline userAvatar"
-        data-tooltip="Alice Zhao (author)"
+        data-state="closed"
         role="presentation"
         src="http://example.com/alice.png"
       />
@@ -94,7 +94,7 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
       <img
         aria-hidden="true"
         class="mdi-icon iconInline userAvatar mr-2"
-        data-tooltip="bYang (committer)"
+        data-state="closed"
         role="presentation"
         src="http://example.com/bob.png"
       />
@@ -104,14 +104,14 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
     >
       <span
         class="font-weight-bold"
-        data-tooltip="alice@example.com"
+        data-state="closed"
       >
         Alice Zhao
       </span>
        authored and commited by 
       <a
         class="font-weight-bold"
-        data-tooltip="Bob Yang <bob@example.com>"
+        data-state="closed"
         href="https://example.com/bobyang"
       >
         bYang
@@ -140,7 +140,7 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
       <img
         aria-hidden="true"
         class="mdi-icon iconInline userAvatar"
-        data-tooltip="Alice Zhao (author)"
+        data-state="closed"
         role="presentation"
         src="http://example.com/alice.png"
       />
@@ -148,7 +148,7 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
       <img
         aria-hidden="true"
         class="mdi-icon iconInline userAvatar mr-2"
-        data-tooltip="bYang (committer)"
+        data-state="closed"
         role="presentation"
         src="http://example.com/bob.png"
       />
@@ -158,14 +158,14 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
     >
       <span
         class="font-weight-bold"
-        data-tooltip="alice@example.com"
+        data-state="closed"
       >
         Alice Zhao
       </span>
        authored and commited by 
       <a
         class="font-weight-bold"
-        data-tooltip="Bob Yang <bob@example.com>"
+        data-state="closed"
         href="https://example.com/bobyang"
       >
         bYang
@@ -192,7 +192,7 @@ exports[`GitCommitNodeByline omit GitHub committer 1`] = `
       <img
         aria-hidden="true"
         class="mdi-icon iconInline userAvatar mr-1 mr-2"
-        data-tooltip="Alice Zhao"
+        data-state="closed"
         role="presentation"
         src="http://example.com/alice.png"
       />
@@ -203,7 +203,7 @@ exports[`GitCommitNodeByline omit GitHub committer 1`] = `
       committed by 
       <span
         class="font-weight-bold"
-        data-tooltip="alice@example.com"
+        data-state="closed"
       >
         Alice Zhao
       </span>
@@ -229,7 +229,7 @@ exports[`GitCommitNodeByline same author and committer 1`] = `
       <img
         aria-hidden="true"
         class="mdi-icon iconInline userAvatar mr-1 mr-2"
-        data-tooltip="Alice Zhao"
+        data-state="closed"
         role="presentation"
         src="http://example.com/alice.png"
       />
@@ -240,7 +240,7 @@ exports[`GitCommitNodeByline same author and committer 1`] = `
       committed by 
       <span
         class="font-weight-bold"
-        data-tooltip="alice@example.com"
+        data-state="closed"
       >
         Alice Zhao
       </span>

--- a/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.tsx
+++ b/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.tsx
@@ -13,13 +13,19 @@ type RepoHeaderButtonLinkProps = ButtonLinkProps & {
     file?: boolean
 }
 
-export const RepoHeaderActionButtonLink: React.FunctionComponent<
-    React.PropsWithChildren<RepoHeaderButtonLinkProps>
-> = ({ children, className, file, ...rest }) => (
-    <ButtonLink className={classNames(file ? styles.fileAction : styles.action, className)} {...rest}>
-        {children}
-    </ButtonLink>
-)
+// eslint-disable-next-line react/display-name
+export const RepoHeaderActionButtonLink = React.forwardRef(
+    ({ children, className, file, ...rest }: React.PropsWithChildren<RepoHeaderButtonLinkProps>, reference) => (
+        <ButtonLink
+            ref={reference}
+            className={classNames(file ? styles.fileAction : styles.action, className)}
+            {...rest}
+        >
+            {children}
+        </ButtonLink>
+    )
+) as ForwardReferenceComponent<typeof ButtonLink, React.PropsWithChildren<RepoHeaderButtonLinkProps>>
+RepoHeaderActionButtonLink.displayName = 'RepoHeaderActionButtonLink'
 
 export const RepoHeaderActionDropdownToggle: React.FunctionComponent<
     React.PropsWithChildren<Pick<React.AriaAttributes, 'aria-label'>>
@@ -36,6 +42,7 @@ export type RepoHeaderActionAnchorProps = Omit<ButtonLinkProps, 'as' | 'href'> &
     file?: boolean
 }
 
+// eslint-disable-next-line react/display-name
 export const RepoHeaderActionAnchor = React.forwardRef((props: RepoHeaderActionAnchorProps, reference) => {
     const { children, className, file, ...rest } = props
 
@@ -49,3 +56,4 @@ export const RepoHeaderActionAnchor = React.forwardRef((props: RepoHeaderActionA
         </ButtonLink>
     )
 }) as ForwardReferenceComponent<typeof ButtonLink, RepoHeaderActionAnchorProps>
+RepoHeaderActionAnchor.displayName = 'RepoHeaderActionAnchor'

--- a/client/web/src/repo/settings/components/ActionContainer.tsx
+++ b/client/web/src/repo/settings/components/ActionContainer.tsx
@@ -5,7 +5,7 @@ import * as H from 'history'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError } from '@sourcegraph/common'
-import { Button, H4 } from '@sourcegraph/wildcard'
+import { Button, H4, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './ActionContainer.module.scss'
 
@@ -78,15 +78,16 @@ export class ActionContainer extends React.PureComponent<Props, State> {
                 className={this.props.className}
                 action={
                     <>
-                        <Button
-                            className={classNames(styles.btn, this.props.buttonClassName)}
-                            variant={this.props.buttonClassName ? undefined : 'primary'}
-                            onClick={this.onClick}
-                            data-tooltip={this.props.buttonSubtitle}
-                            disabled={this.props.buttonDisabled || this.state.loading}
-                        >
-                            {this.props.buttonLabel}
-                        </Button>
+                        <Tooltip content={this.props.buttonSubtitle}>
+                            <Button
+                                className={classNames(styles.btn, this.props.buttonClassName)}
+                                variant={this.props.buttonClassName ? undefined : 'primary'}
+                                onClick={this.onClick}
+                                disabled={this.props.buttonDisabled || this.state.loading}
+                            >
+                                {this.props.buttonLabel}
+                            </Button>
+                        </Tooltip>
                         {this.props.buttonSubtitle && (
                             <div className={styles.btnSubtitle}>
                                 <small>{this.props.buttonSubtitle}</small>

--- a/client/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
+++ b/client/web/src/repo/tree/__snapshots__/TreeEntriesSection.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`TreeEntriesSection should render a grid of tree entries at the root 1`]
             >
               <small
                 class="text-monospace font-weight-normal test-file-decoration-text after"
-                data-placement="bottom"
+                data-state="closed"
               >
                 src decoration
               </small>
@@ -82,7 +82,7 @@ exports[`TreeEntriesSection should render a grid of tree entries at the root 1`]
             >
               <small
                 class="text-monospace font-weight-normal test-file-decoration-text after"
-                data-placement="bottom"
+                data-state="closed"
               >
                 testdata decoration
               </small>
@@ -192,7 +192,7 @@ exports[`TreeEntriesSection should render a grid of tree entries in a subdirecto
             >
               <small
                 class="text-monospace font-weight-normal test-file-decoration-text after"
-                data-placement="bottom"
+                data-state="closed"
               >
                 testutils decoration
               </small>
@@ -235,7 +235,7 @@ exports[`TreeEntriesSection should render a grid of tree entries in a subdirecto
             >
               <small
                 class="text-monospace font-weight-normal test-file-decoration-text after"
-                data-placement="bottom"
+                data-state="closed"
               >
                 typings decoration
               </small>
@@ -345,7 +345,7 @@ exports[`TreeEntriesSection should render only direct children 1`] = `
             >
               <small
                 class="text-monospace font-weight-normal test-file-decoration-text after"
-                data-placement="bottom"
+                data-state="closed"
               >
                 ref decoration
               </small>

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -13,7 +13,7 @@ import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { SearchPatternTypeProps } from '@sourcegraph/search'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
-import { Container, PageHeader, LoadingSpinner, Button, Link, Icon } from '@sourcegraph/wildcard'
+import { Container, PageHeader, LoadingSpinner, Button, Link, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../components/PageTitle'
 import { NamespaceProps } from '../namespaces'
@@ -82,27 +82,29 @@ class SavedSearchNode extends React.PureComponent<NodeProps, NodeState> {
                     </Link>
                 </div>
                 <div>
-                    <Button
-                        className="test-edit-saved-search-button"
-                        to={`${this.props.match.path}/${this.props.savedSearch.id}`}
-                        data-tooltip="Saved search settings"
-                        variant="secondary"
-                        size="sm"
-                        as={Link}
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiCog} /> Settings
-                    </Button>{' '}
-                    <Button
-                        className="test-delete-saved-search-button"
-                        onClick={this.onDelete}
-                        disabled={this.state.isDeleting}
-                        data-tooltip="Delete saved search"
-                        variant="danger"
-                        size="sm"
-                        aria-label="Delete saved search"
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiDelete} />
-                    </Button>
+                    <Tooltip content="Saved search settings">
+                        <Button
+                            className="test-edit-saved-search-button"
+                            to={`${this.props.match.path}/${this.props.savedSearch.id}`}
+                            variant="secondary"
+                            size="sm"
+                            as={Link}
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiCog} /> Settings
+                        </Button>
+                    </Tooltip>{' '}
+                    <Tooltip content="Delete saved search">
+                        <Button
+                            aria-label="Delete"
+                            className="test-delete-saved-search-button"
+                            onClick={this.onDelete}
+                            disabled={this.state.isDeleting}
+                            variant="danger"
+                            size="sm"
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiDelete} />
+                        </Button>
+                    </Tooltip>
                 </div>
                 {this.state.isDeleting && (
                     <VisuallyHidden aria-live="polite">{`Deleted saved search: ${this.props.savedSearch.description}`}</VisuallyHidden>

--- a/client/web/src/search/QuickLinks.tsx
+++ b/client/web/src/search/QuickLinks.tsx
@@ -4,7 +4,7 @@ import { mdiLink } from '@mdi/js'
 import classNames from 'classnames'
 
 import { QuickLink } from '@sourcegraph/shared/src/schema/settings.schema'
-import { Link, Icon } from '@sourcegraph/wildcard'
+import { Link, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './QuickLinks.module.scss'
 
@@ -19,10 +19,12 @@ export const QuickLinks: React.FunctionComponent<React.PropsWithChildren<Props>>
         <div className={className}>
             {quickLinks.map((quickLink, index) => (
                 <small className={classNames('text-nowrap mr-2', styles.quicklink)} key={index}>
-                    <Link to={quickLink.url} data-tooltip={quickLink.description}>
-                        <Icon aria-hidden={true} className="pr-1" svgPath={mdiLink} />
-                        {quickLink.name}
-                    </Link>
+                    <Tooltip content={quickLink.description}>
+                        <Link to={quickLink.url}>
+                            <Icon aria-hidden={true} className="pr-1" svgPath={mdiLink} />
+                            {quickLink.name}
+                        </Link>
+                    </Tooltip>
                 </small>
             ))}
         </div>

--- a/client/web/src/search/home/SelfHostInstructions.tsx
+++ b/client/web/src/search/home/SelfHostInstructions.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import copy from 'copy-to-clipboard'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Link, Icon, Code, H2 } from '@sourcegraph/wildcard'
+import { Button, Link, Icon, Code, H2, Tooltip } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../../components/MarketingBlock'
 
@@ -65,16 +65,16 @@ export const SelfHostInstructions: React.FunctionComponent<React.PropsWithChildr
                     <strong>Quickstart:</strong> launch Sourcegraph at http://localhost:7080
                 </div>
                 <MarketingBlock wrapperClassName={styles.codeWrapper} contentClassName={styles.codeContent}>
-                    <Button
-                        className={styles.copyButton}
-                        onClick={onCopy}
-                        data-tooltip={currentCopyTooltip}
-                        data-placement="top"
-                        aria-label="Copy Docker command to clipboard"
-                        variant="link"
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiContentCopy} />
-                    </Button>
+                    <Tooltip content={currentCopyTooltip} placement="top">
+                        <Button
+                            className={styles.copyButton}
+                            onClick={onCopy}
+                            aria-label="Copy Docker command to clipboard"
+                            variant="link"
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiContentCopy} />
+                        </Button>
+                    </Tooltip>
                     <Code className={styles.codeBlock}>{dockerCommand}</Code>
                 </MarketingBlock>
                 <div className="d-flex justify-content-between">

--- a/client/web/src/search/results/CreateActionsMenu.tsx
+++ b/client/web/src/search/results/CreateActionsMenu.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Position, Menu, MenuButton, MenuList, MenuLink, Icon, Link } from '@sourcegraph/wildcard'
+import { Position, Menu, MenuButton, MenuList, MenuLink, Icon, Link, Tooltip } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 
@@ -54,30 +54,28 @@ export const CreateActionsMenu: React.FunctionComponent<CreateActionsMenuProps> 
                         </MenuLink>
                     ))}
                     {createCodeMonitorAction && (
-                        <MenuLink
-                            as={Link}
-                            disabled={!authenticatedUser || !canCreateMonitor}
-                            data-tooltip={
+                        <Tooltip
+                            content={
                                 authenticatedUser && !canCreateMonitor
                                     ? 'Code monitors only support type:diff or type:commit searches.'
                                     : undefined
                             }
-                            aria-label={
-                                authenticatedUser && !canCreateMonitor
-                                    ? 'Code monitors only support type:diff or type:commit searches.'
-                                    : undefined
-                            }
-                            to={createCodeMonitorAction.url}
                         >
-                            <Icon
-                                aria-hidden={true}
-                                className="mr-1"
-                                {...(typeof createCodeMonitorAction.icon === 'string'
-                                    ? { svgPath: createCodeMonitorAction.icon }
-                                    : { as: createCodeMonitorAction.icon })}
-                            />
-                            Create Monitor
-                        </MenuLink>
+                            <MenuLink
+                                as={Link}
+                                disabled={!authenticatedUser || !canCreateMonitor}
+                                to={createCodeMonitorAction.url}
+                            >
+                                <Icon
+                                    aria-hidden={true}
+                                    className="mr-1"
+                                    {...(typeof createCodeMonitorAction.icon === 'string'
+                                        ? { svgPath: createCodeMonitorAction.icon }
+                                        : { as: createCodeMonitorAction.icon })}
+                                />
+                                Create Monitor
+                            </MenuLink>
+                        </Tooltip>
                     )}
                 </MenuList>
             </>

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -21,7 +21,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, ButtonLink, Icon } from '@sourcegraph/wildcard'
+import { Button, ButtonLink, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { BookmarkRadialGradientIcon, CodeMonitorRadialGradientIcon } from '../../components/CtaIcons'
@@ -124,15 +124,14 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<
     React.PropsWithChildren<SearchResultsInfoBarProps>
 > = props =>
     props.patternType === SearchPatternType.literal && props.query && props.query.includes('"') ? (
-        <small
-            className={styles.notice}
-            data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
-        >
-            <span>
-                <Icon aria-hidden={true} svgPath={mdiFormatQuoteOpen} />
-                Searching literally <strong>(including quotes)</strong>
-            </span>
-        </small>
+        <Tooltip content="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search.">
+            <small className={styles.notice}>
+                <span>
+                    <Icon aria-hidden={true} svgPath={mdiFormatQuoteOpen} />
+                    Searching literally <strong>(including quotes)</strong>
+                </span>
+            </small>
+        </Tooltip>
     ) : null
 
 /**
@@ -196,51 +195,52 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         }
 
         return (
-            <li
-                className={classNames('mr-2', createActionsStyles.button, styles.navItem)}
-                data-tooltip={
+            <Tooltip
+                content={
                     props.authenticatedUser && !canCreateMonitorFromQuery
                         ? 'Code monitors only support type:diff or type:commit searches.'
                         : undefined
                 }
-                data-placement="bottom"
+                placement="bottom"
             >
-                {/*
+                <li className={classNames('mr-2', createActionsStyles.button, styles.navItem)}>
+                    {/*
                     a11y-ignore
                     Rule: "color-contrast" (Elements must have sufficient color contrast)
                     GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
                 */}
-                <ExperimentalActionButton
-                    showExperimentalVersion={showActionButtonExperimentalVersion}
-                    nonExperimentalLinkTo={createCodeMonitorAction.url}
-                    isNonExperimentalLinkDisabled={!canCreateMonitorFromQuery}
-                    className="a11y-ignore create-code-monitor-button"
-                    button={
-                        <>
-                            <Icon
-                                aria-hidden={true}
-                                className="mr-1"
-                                {...(typeof createCodeMonitorAction.icon === 'string'
-                                    ? { svgPath: createCodeMonitorAction.icon }
-                                    : { as: createCodeMonitorAction.icon })}
-                            />
-                            {createCodeMonitorAction.label}
-                        </>
-                    }
-                    icon={<CodeMonitorRadialGradientIcon />}
-                    title="Monitor code for changes"
-                    copyText="Create a monitor and get notified when your code changes. Free for registered users."
-                    telemetryService={props.telemetryService}
-                    source="Monitor"
-                    viewEventName="SearchResultMonitorCTAShown"
-                    returnTo={createCodeMonitorAction.url}
-                    ariaLabel={
-                        props.authenticatedUser && !canCreateMonitorFromQuery
-                            ? 'Code monitors only support type:diff or type:commit searches.'
-                            : undefined
-                    }
-                />
-            </li>
+                    <ExperimentalActionButton
+                        showExperimentalVersion={showActionButtonExperimentalVersion}
+                        nonExperimentalLinkTo={createCodeMonitorAction.url}
+                        isNonExperimentalLinkDisabled={!canCreateMonitorFromQuery}
+                        className="a11y-ignore create-code-monitor-button"
+                        button={
+                            <>
+                                <Icon
+                                    aria-hidden={true}
+                                    className="mr-1"
+                                    {...(typeof createCodeMonitorAction.icon === 'string'
+                                        ? { svgPath: createCodeMonitorAction.icon }
+                                        : { as: createCodeMonitorAction.icon })}
+                                />
+                                {createCodeMonitorAction.label}
+                            </>
+                        }
+                        icon={<CodeMonitorRadialGradientIcon />}
+                        title="Monitor code for changes"
+                        copyText="Create a monitor and get notified when your code changes. Free for registered users."
+                        telemetryService={props.telemetryService}
+                        source="Monitor"
+                        viewEventName="SearchResultMonitorCTAShown"
+                        returnTo={createCodeMonitorAction.url}
+                        ariaLabel={
+                            props.authenticatedUser && !canCreateMonitorFromQuery
+                                ? 'Code monitors only support type:diff or type:commit searches.'
+                                : undefined
+                        }
+                    />
+                </li>
+            </Tooltip>
         )
     }, [
         createCodeMonitorAction,
@@ -365,29 +365,30 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                     ) : (
                         <>
                             {createActions.map(createActionButton => (
-                                <li
+                                <Tooltip
                                     key={createActionButton.label}
-                                    className={classNames('nav-item mr-2', createActionsStyles.button)}
-                                    data-tooltip={createActionButton.tooltip}
-                                    data-placement="bottom"
+                                    content={createActionButton.tooltip}
+                                    placement="bottom"
                                 >
-                                    <ButtonLink
-                                        to={createActionButton.url}
-                                        className="text-decoration-none"
-                                        variant="secondary"
-                                        outline={true}
-                                        size="sm"
-                                    >
-                                        <Icon
-                                            aria-hidden={true}
-                                            className="mr-1"
-                                            {...(typeof createActionButton.icon === 'string'
-                                                ? { svgPath: createActionButton.icon }
-                                                : { as: createActionButton.icon })}
-                                        />
-                                        {createActionButton.label}
-                                    </ButtonLink>
-                                </li>
+                                    <li className={classNames('nav-item mr-2', createActionsStyles.button)}>
+                                        <ButtonLink
+                                            to={createActionButton.url}
+                                            className="text-decoration-none"
+                                            variant="secondary"
+                                            outline={true}
+                                            size="sm"
+                                        >
+                                            <Icon
+                                                aria-hidden={true}
+                                                className="mr-1"
+                                                {...(typeof createActionButton.icon === 'string'
+                                                    ? { svgPath: createActionButton.icon }
+                                                    : { as: createActionButton.icon })}
+                                            />
+                                            {createActionButton.label}
+                                        </ButtonLink>
+                                    </li>
+                                </Tooltip>
                             ))}
 
                             {createCodeMonitorButton}
@@ -407,29 +408,34 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                                 <>
                                     <li className={styles.divider} aria-hidden="true" />
                                     <li className={classNames(styles.navItem)}>
-                                        <Button
-                                            aria-label={props.allExpanded ? 'Collapse' : 'Expand'}
-                                            onClick={props.onExpandAllResultsToggle}
-                                            className="text-decoration-none"
-                                            aria-live="polite"
-                                            data-tooltip={`${
+                                        <Tooltip
+                                            content={`${
                                                 props.allExpanded ? 'Hide' : 'Show'
                                             } more matches on all results`}
-                                            data-placement="bottom"
-                                            data-testid="search-result-expand-btn"
-                                            data-test-tooltip-content={`${
-                                                props.allExpanded ? 'Hide' : 'Show'
-                                            } more matches on all results`}
-                                            outline={true}
-                                            variant="secondary"
-                                            size="sm"
+                                            placement="bottom"
                                         >
-                                            <Icon
-                                                aria-hidden={true}
-                                                className="mr-0"
-                                                svgPath={props.allExpanded ? mdiArrowCollapseUp : mdiArrowExpandDown}
-                                            />
-                                        </Button>
+                                            <Button
+                                                aria-label={props.allExpanded ? 'Collapse' : 'Expand'}
+                                                onClick={props.onExpandAllResultsToggle}
+                                                className="text-decoration-none"
+                                                aria-live="polite"
+                                                data-testid="search-result-expand-btn"
+                                                data-test-tooltip-content={`${
+                                                    props.allExpanded ? 'Hide' : 'Show'
+                                                } more matches on all results`}
+                                                outline={true}
+                                                variant="secondary"
+                                                size="sm"
+                                            >
+                                                <Icon
+                                                    aria-hidden={true}
+                                                    className="mr-0"
+                                                    svgPath={
+                                                        props.allExpanded ? mdiArrowCollapseUp : mdiArrowExpandDown
+                                                    }
+                                                />
+                                            </Button>
+                                        </Tooltip>
                                     </li>
                                 </>
                             )}

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -124,7 +124,7 @@ describe('StreamingSearchResults', () => {
         renderWrapper(<StreamingSearchResults {...defaultProps} streamSearch={() => of(COLLAPSABLE_SEARCH_RESULT)} />)
 
         expect(screen.getByTestId('search-result-expand-btn')).toHaveAttribute(
-            'data-tooltip',
+            'data-test-tooltip-content',
             'Show more matches on all results'
         )
 
@@ -135,7 +135,7 @@ describe('StreamingSearchResults', () => {
         userEvent.click(screen.getByTestId('search-result-expand-btn'))
 
         expect(screen.getByTestId('search-result-expand-btn')).toHaveAttribute(
-            'data-tooltip',
+            'data-test-tooltip-content',
             'Hide more matches on all results'
         )
 

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -92,10 +92,9 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
             aria-label="Collapse"
             aria-live="polite"
             class="btn btnOutlineSecondary btnSm text-decoration-none"
-            data-placement="bottom"
+            data-state="closed"
             data-test-tooltip-content="Hide more matches on all results"
             data-testid="search-result-expand-btn"
-            data-tooltip="Hide more matches on all results"
             type="button"
           >
             <svg
@@ -177,7 +176,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         />
         <li
           class="mr-2 button navItem"
-          data-placement="bottom"
+          data-state="closed"
         >
           <a
             class="anchorLink btn btnOutlineSecondary btnSm text-decoration-none a11y-ignore create-code-monitor-button"
@@ -267,10 +266,9 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
             aria-label="Collapse"
             aria-live="polite"
             class="btn btnOutlineSecondary btnSm text-decoration-none"
-            data-placement="bottom"
+            data-state="closed"
             data-test-tooltip-content="Hide more matches on all results"
             data-testid="search-result-expand-btn"
-            data-tooltip="Hide more matches on all results"
             type="button"
           >
             <svg
@@ -352,7 +350,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         />
         <li
           class="mr-2 button navItem"
-          data-placement="bottom"
+          data-state="closed"
         >
           <button
             class="btn btnOutlineSecondary btnSm a11y-ignore create-code-monitor-button"
@@ -439,10 +437,9 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
             aria-label="Collapse"
             aria-live="polite"
             class="btn btnOutlineSecondary btnSm text-decoration-none"
-            data-placement="bottom"
+            data-state="closed"
             data-test-tooltip-content="Hide more matches on all results"
             data-testid="search-result-expand-btn"
-            data-tooltip="Hide more matches on all results"
             type="button"
           >
             <svg
@@ -524,8 +521,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
         />
         <li
           class="mr-2 button navItem"
-          data-placement="bottom"
-          data-tooltip="Code monitors only support type:diff or type:commit searches."
+          data-state="closed"
         >
           <a
             aria-disabled="true"
@@ -619,10 +615,9 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
             aria-label="Collapse"
             aria-live="polite"
             class="btn btnOutlineSecondary btnSm text-decoration-none"
-            data-placement="bottom"
+            data-state="closed"
             data-test-tooltip-content="Hide more matches on all results"
             data-testid="search-result-expand-btn"
-            data-tooltip="Hide more matches on all results"
             type="button"
           >
             <svg
@@ -704,7 +699,7 @@ exports[`SearchResultsInfoBar unauthenticated user 1`] = `
         />
         <li
           class="mr-2 button navItem"
-          data-placement="bottom"
+          data-state="closed"
         >
           <button
             class="btn btnOutlineSecondary btnSm a11y-ignore create-code-monitor-button"
@@ -791,10 +786,9 @@ exports[`SearchResultsInfoBar unauthenticated user 1`] = `
             aria-label="Collapse"
             aria-live="polite"
             class="btn btnOutlineSecondary btnSm text-decoration-none"
-            data-placement="bottom"
+            data-state="closed"
             data-test-tooltip-content="Hide more matches on all results"
             data-testid="search-result-expand-btn"
-            data-tooltip="Hide more matches on all results"
             type="button"
           >
             <svg

--- a/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -10,7 +10,7 @@ import { catchError, distinctUntilChanged, map, switchMap } from 'rxjs/operators
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError } from '@sourcegraph/common'
 import * as GQL from '@sourcegraph/shared/src/schema'
-import { Button, Link, Alert, Icon, H2, Text } from '@sourcegraph/wildcard'
+import { Button, Link, Alert, Icon, H2, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { CopyableText } from '../components/CopyableText'
@@ -131,15 +131,16 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                     <div>
                         {window.context.sourcegraphDotComMode && (
                             <>
-                                <Button
-                                    onClick={() => this.toggleOrgCreationTag(orgCreationLabel === 'Enable')}
-                                    disabled={this.state.loading}
-                                    data-tooltip={`${orgCreationLabel} user tag to allow user to create organizations`}
-                                    variant="secondary"
-                                    size="sm"
-                                >
-                                    {orgCreationLabel} org creation
-                                </Button>{' '}
+                                <Tooltip content={`${orgCreationLabel} user tag to allow user to create organizations`}>
+                                    <Button
+                                        onClick={() => this.toggleOrgCreationTag(orgCreationLabel === 'Enable')}
+                                        disabled={this.state.loading}
+                                        variant="secondary"
+                                        size="sm"
+                                    >
+                                        {orgCreationLabel} org creation
+                                    </Button>
+                                </Tooltip>{' '}
                             </>
                         )}
                         {!window.context.sourcegraphDotComMode && (
@@ -154,15 +155,16 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                             ) &&
                             ' '}
                         {this.props.node.id !== this.props.authenticatedUser.id && (
-                            <Button
-                                onClick={this.invalidateSessions}
-                                disabled={this.state.loading}
-                                data-tooltip="Force the user to re-authenticate on their next request"
-                                variant="secondary"
-                                size="sm"
-                            >
-                                Force sign-out
-                            </Button>
+                            <Tooltip content="Force the user to re-authenticate on their next request">
+                                <Button
+                                    onClick={this.invalidateSessions}
+                                    disabled={this.state.loading}
+                                    variant="secondary"
+                                    size="sm"
+                                >
+                                    Force sign-out
+                                </Button>
+                            </Tooltip>
                         )}{' '}
                         {window.context.resetPasswordEnabled && (
                             <Button

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -9,7 +9,7 @@ import { catchError, map, mergeMap } from 'rxjs/operators'
 import { asError, ErrorLike, isErrorLike, pluralize } from '@sourcegraph/common'
 import { aggregateStreamingSearch, ContentMatch } from '@sourcegraph/shared/src/search/stream'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Link, PageHeader, Container, Button, Code, H3, Text, Icon } from '@sourcegraph/wildcard'
+import { Link, PageHeader, Container, Button, Code, H3, Text, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionFilter } from '../components/FilteredConnection'
 import { PageTitle } from '../components/PageTitle'
@@ -264,17 +264,17 @@ const FeatureFlagNode: React.FunctionComponent<React.PropsWithChildren<FeatureFl
                     </div>
 
                     {node.__typename === 'FeatureFlagRollout' && (
-                        <div>
-                            <meter
-                                min={0}
-                                max={1}
-                                optimum={1}
-                                value={node.rolloutBasisPoints / (100 * 100)}
-                                data-tooltip={`${Math.floor(node.rolloutBasisPoints / 100) || 0}%`}
-                                aria-label="rollout progress"
-                                data-placement="bottom"
-                            />
-                        </div>
+                        <Tooltip content={`${Math.floor(node.rolloutBasisPoints / 100) || 0}%`} placement="bottom">
+                            <div>
+                                <meter
+                                    min={0}
+                                    max={1}
+                                    optimum={1}
+                                    value={node.rolloutBasisPoints / (100 * 100)}
+                                    aria-label="rollout progress"
+                                />
+                            </div>
+                        </Tooltip>
                     )}
                 </div>
             </span>

--- a/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
@@ -10,7 +10,7 @@ import { parse as _parseVersion, SemVer } from 'semver'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { LoadingSpinner, useObservable, Alert, Icon, Code, H2, H3, Text } from '@sourcegraph/wildcard'
+import { LoadingSpinner, useObservable, Alert, Icon, Code, H2, H3, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { Collapsible } from '../components/Collapsible'
 import { FilteredConnection, FilteredConnectionFilter, Connection } from '../components/FilteredConnection'
@@ -316,19 +316,19 @@ const MigrationNode: React.FunctionComponent<React.PropsWithChildren<MigrationNo
                     {Math.floor(node.progress * 100)}%
                 </div>
 
-                <div>
-                    <meter
-                        min={0}
-                        low={0.2}
-                        high={0.8}
-                        max={1}
-                        optimum={1}
-                        value={node.progress}
-                        data-tooltip={`${Math.floor(node.progress * 100)}%`}
-                        aria-label="migration progress"
-                        data-placement="bottom"
-                    />
-                </div>
+                <Tooltip content={`${Math.floor(node.progress * 100)}%`} placement="bottom">
+                    <div>
+                        <meter
+                            min={0}
+                            low={0.2}
+                            high={0.8}
+                            max={1}
+                            optimum={1}
+                            value={node.progress}
+                            aria-label="migration progress"
+                        />
+                    </div>
+                </Tooltip>
 
                 {node.lastUpdated && node.lastUpdated !== '' && (
                     <>

--- a/client/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -8,7 +8,7 @@ import { Subject } from 'rxjs'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, isErrorLike, pluralize } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Link, Alert, Icon, H2, H3, Text } from '@sourcegraph/wildcard'
+import { Button, Link, Alert, Icon, H2, H3, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { FilteredConnection } from '../components/FilteredConnection'
 import { PageTitle } from '../components/PageTitle'
@@ -62,39 +62,32 @@ const OrgNode: React.FunctionComponent<React.PropsWithChildren<OrgNodeProps>> = 
                     <span className="text-muted">{node.displayName}</span>
                 </div>
                 <div>
-                    <Button
-                        to={`${orgURL(node.name)}/settings`}
-                        data-tooltip="Organization settings"
-                        variant="secondary"
-                        size="sm"
-                        as={Link}
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiCog} /> Settings
-                    </Button>{' '}
-                    <Button
-                        to={`${orgURL(node.name)}/settings/members`}
-                        data-tooltip="Organization members"
-                        variant="secondary"
-                        size="sm"
-                        as={Link}
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiAccount} />{' '}
-                        {node.members && (
-                            <>
-                                {node.members.totalCount} {pluralize('member', node.members.totalCount)}
-                            </>
-                        )}
-                    </Button>{' '}
-                    <Button
-                        onClick={deleteOrg}
-                        disabled={loading === true}
-                        data-tooltip="Delete organization"
-                        variant="danger"
-                        size="sm"
-                        aria-label="Delete organization"
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiDelete} />
-                    </Button>
+                    <Tooltip content="Organization settings">
+                        <Button to={`${orgURL(node.name)}/settings`} variant="secondary" size="sm" as={Link}>
+                            <Icon aria-hidden={true} svgPath={mdiCog} /> Settings
+                        </Button>
+                    </Tooltip>{' '}
+                    <Tooltip content="Organization members">
+                        <Button to={`${orgURL(node.name)}/settings/members`} variant="secondary" size="sm" as={Link}>
+                            <Icon aria-hidden={true} svgPath={mdiAccount} />{' '}
+                            {node.members && (
+                                <>
+                                    {node.members.totalCount} {pluralize('member', node.members.totalCount)}
+                                </>
+                            )}
+                        </Button>
+                    </Tooltip>{' '}
+                    <Tooltip content="Delete organization">
+                        <Button
+                            aria-label="Delete"
+                            onClick={deleteOrg}
+                            disabled={loading === true}
+                            variant="danger"
+                            size="sm"
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiDelete} />
+                        </Button>
+                    </Tooltip>
                 </div>
             </div>
             {isErrorLike(loading) && <ErrorAlert className="mt-2" error={loading.message} />}

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs'
 
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { LoadingSpinner, Button, Link, Alert, Icon, H2, Text } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Button, Link, Alert, Icon, H2, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { TerminalLine } from '../auth/Terminal'
 import {
@@ -42,12 +42,11 @@ const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Repository
                     </small>
                 )}
                 {!node.mirrorInfo.cloneInProgress && !node.mirrorInfo.cloned && (
-                    <small
-                        className="ml-2 text-muted"
-                        data-tooltip="Visit the repository to clone it. See its mirroring settings for diagnostics."
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiCloudOutline} /> Not yet cloned
-                    </small>
+                    <Tooltip content="Visit the repository to clone it. See its mirroring settings for diagnostics.">
+                        <small className="ml-2 text-muted">
+                            <Icon aria-hidden={true} svgPath={mdiCloudOutline} /> Not yet cloned
+                        </small>
+                    </Tooltip>
                 )}
             </div>
 
@@ -58,15 +57,11 @@ const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Repository
                     </Button>
                 )}{' '}
                 {
-                    <Button
-                        to={`/${node.name}/-/settings`}
-                        data-tooltip="Repository settings"
-                        variant="secondary"
-                        size="sm"
-                        as={Link}
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiCog} /> Settings
-                    </Button>
+                    <Tooltip content="Repository settings">
+                        <Button to={`/${node.name}/-/settings`} variant="secondary" size="sm" as={Link}>
+                            <Icon aria-hidden={true} svgPath={mdiCog} /> Settings
+                        </Button>
+                    </Tooltip>
                 }{' '}
             </div>
         </div>

--- a/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -8,7 +8,7 @@ import { Subscription } from 'rxjs'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { UserActivePeriod } from '@sourcegraph/shared/src/graphql-operations'
 import * as GQL from '@sourcegraph/shared/src/schema'
-import { Button, Icon, H2, H3 } from '@sourcegraph/wildcard'
+import { Button, Icon, H2, H3, Tooltip } from '@sourcegraph/wildcard'
 
 import { BarChart } from '../components/d3/BarChart'
 import { FilteredConnection, FilteredConnectionFilter } from '../components/FilteredConnection'
@@ -250,15 +250,11 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
                 <H2>Usage statistics</H2>
                 {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
 
-                <Button
-                    href="/site-admin/usage-statistics/archive"
-                    data-tooltip="Download usage stats archive"
-                    download="true"
-                    variant="secondary"
-                    as="a"
-                >
-                    <Icon aria-hidden={true} svgPath={mdiFileDownload} /> Download usage stats archive
-                </Button>
+                <Tooltip content="Download usage stats archive">
+                    <Button href="/site-admin/usage-statistics/archive" download="true" variant="secondary" as="a">
+                        <Icon aria-hidden={true} svgPath={mdiFileDownload} /> Download usage stats archive
+                    </Button>
+                </Tooltip>
 
                 {this.state.stats && (
                     <>

--- a/client/web/src/tree/FileDecorator.tsx
+++ b/client/web/src/tree/FileDecorator.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { FileDecoration } from 'sourcegraph'
 
 import { fileDecorationColorForTheme } from '@sourcegraph/shared/src/api/extension/api/decorations'
+import { Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './FileDecorator.module.scss'
 
@@ -54,44 +55,44 @@ export const FileDecorator: React.FunctionComponent<React.PropsWithChildren<File
                             key={fileDecoration.uri + String(index)}
                         >
                             {fileDecoration.after && (
-                                <small
-                                    // eslint-disable-next-line react/forbid-dom-props
-                                    style={{
-                                        color: fileDecorationColorForTheme(
-                                            fileDecoration.after,
-                                            isLightTheme,
-                                            isActive
-                                        ),
-                                    }}
-                                    data-tooltip={fileDecoration.after.hoverMessage}
-                                    data-placement="bottom"
-                                    className={classNames(
-                                        'text-monospace font-weight-normal test-file-decoration-text',
-                                        styles.after,
-                                        isActive && styles.afterActive
-                                    )}
-                                >
-                                    {fileDecoration.after.contentText}
-                                </small>
+                                <Tooltip content={fileDecoration.after.hoverMessage} placement="bottom">
+                                    <small
+                                        // eslint-disable-next-line react/forbid-dom-props
+                                        style={{
+                                            color: fileDecorationColorForTheme(
+                                                fileDecoration.after,
+                                                isLightTheme,
+                                                isActive
+                                            ),
+                                        }}
+                                        className={classNames(
+                                            'text-monospace font-weight-normal test-file-decoration-text',
+                                            styles.after,
+                                            isActive && styles.afterActive
+                                        )}
+                                    >
+                                        {fileDecoration.after.contentText}
+                                    </small>
+                                </Tooltip>
                             )}
                             {fileDecoration.meter && (
-                                <div>
-                                    <VisuallyHidden>{fileDecoration.meter.hoverMessage}</VisuallyHidden>
-                                    <meter
-                                        className={classNames('test-file-decoration-meter', styles.meter, {
-                                            'ml-2': !!fileDecoration.after,
-                                        })}
-                                        min={fileDecoration.meter.min}
-                                        low={fileDecoration.meter.low}
-                                        high={fileDecoration.meter.high}
-                                        max={fileDecoration.meter.max}
-                                        optimum={fileDecoration.meter.optimum}
-                                        value={fileDecoration.meter.value}
-                                        data-tooltip={fileDecoration.meter.hoverMessage}
-                                        aria-hidden={true}
-                                        data-placement="bottom"
-                                    />
-                                </div>
+                                <Tooltip content={fileDecoration.meter.hoverMessage} placement="bottom">
+                                    <div>
+                                        <VisuallyHidden>{fileDecoration.meter.hoverMessage}</VisuallyHidden>
+                                        <meter
+                                            className={classNames('test-file-decoration-meter', styles.meter, {
+                                                'ml-2': !!fileDecoration.after,
+                                            })}
+                                            min={fileDecoration.meter.min}
+                                            low={fileDecoration.meter.low}
+                                            high={fileDecoration.meter.high}
+                                            max={fileDecoration.meter.max}
+                                            optimum={fileDecoration.meter.optimum}
+                                            value={fileDecoration.meter.value}
+                                            aria-hidden={true}
+                                        />
+                                    </div>
+                                </Tooltip>
                             )}
                         </div>
                     )

--- a/client/web/src/tree/__snapshots__/FileDecorator.test.tsx.snap
+++ b/client/web/src/tree/__snapshots__/FileDecorator.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`FileDecorator renders after text content 1`] = `
     >
       <small
         class="text-monospace font-weight-normal test-file-decoration-text after"
-        data-placement="bottom"
+        data-state="closed"
       >
         src decoration
       </small>
@@ -29,18 +29,19 @@ exports[`FileDecorator renders both after text content and meter 1`] = `
     >
       <small
         class="text-monospace font-weight-normal test-file-decoration-text after"
-        data-placement="bottom"
+        data-state="closed"
       >
         src decoration
       </small>
-      <div>
+      <div
+        data-state="closed"
+      >
         <span
           style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
         />
         <meter
           aria-hidden="true"
           class="test-file-decoration-meter meter ml-2"
-          data-placement="bottom"
           high="60"
           low="50"
           max="100"
@@ -62,14 +63,15 @@ exports[`FileDecorator renders meter 1`] = `
     <div
       class="d-flex align-items-center fileDecoration"
     >
-      <div>
+      <div
+        data-state="closed"
+      >
         <span
           style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
         />
         <meter
           aria-hidden="true"
           class="test-file-decoration-meter meter"
-          data-placement="bottom"
           high="60"
           low="50"
           max="100"
@@ -93,7 +95,7 @@ exports[`FileDecorator respects active state 1`] = `
     >
       <small
         class="text-monospace font-weight-normal test-file-decoration-text after afterActive"
-        data-placement="bottom"
+        data-state="closed"
       >
         src decoration
       </small>

--- a/client/web/src/user/settings/repositories/RepositoryNode.tsx
+++ b/client/web/src/user/settings/repositories/RepositoryNode.tsx
@@ -12,7 +12,7 @@ import {
 import classNames from 'classnames'
 
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
-import { Badge, LoadingSpinner, Link, Icon, Checkbox } from '@sourcegraph/wildcard'
+import { Badge, LoadingSpinner, Link, Icon, Checkbox, Tooltip } from '@sourcegraph/wildcard'
 
 import { ExternalServiceKind } from '../../../graphql-operations'
 
@@ -46,20 +46,20 @@ const StatusIcon: React.FunctionComponent<React.PropsWithChildren<StatusIconProp
     }
     if (mirrorInfo.cloneInProgress) {
         return (
-            <small data-tooltip="Clone in progress." className="mr-2 text-success">
-                <LoadingSpinner />
-            </small>
+            <Tooltip content="Clone in progress.">
+                <small className="mr-2 text-success">
+                    <LoadingSpinner />
+                </small>
+            </Tooltip>
         )
     }
     if (!mirrorInfo.cloned) {
         return (
-            <small
-                className="mr-2 text-muted"
-                data-tooltip="Visit the repository to clone it. See its mirroring settings for diagnostics."
-                aria-label="Visit the repository to clone it. See its mirroring settings for diagnostics."
-            >
-                <Icon aria-hidden={true} svgPath={mdiCloudOutline} />
-            </small>
+            <Tooltip content="Visit the repository to clone it. See its mirroring settings for diagnostics.">
+                <small className="mr-2 text-muted">
+                    <Icon aria-hidden={true} svgPath={mdiCloudOutline} />
+                </small>
+            </Tooltip>
         )
     }
     return (

--- a/client/wildcard/src/components/Tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.tsx
@@ -85,6 +85,9 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
                         className={styles.tooltipContent}
                         side={placement}
                         role="tooltip"
+                        // This offset helps prevent the tooltip from immediately closing when it gets triggered in the
+                        // exact spot the arrow is overlapping the content
+                        alignOffset={1}
                     >
                         {content}
 

--- a/client/wildcard/src/components/Tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.tsx
@@ -32,6 +32,11 @@ function onPointerDownOutside(event: Event): void {
  * Renders a Tooltip that will be positioned relative to the wrapped child element. Please reference the examples in Storybook
  * for more details on specific use cases.
  *
+ * **NOTE:** The Tooltip implementation currently breaks the behavior of triggers that use `ButtonLink` with no `to` prop. Specifically,
+ * the onClick handler of `<ButtonLink>` does not get composed correctly, and the default behavior will not be prevented when that component
+ * has an empty href (resulting in a page reload). If the trigger element you are using is not working as expected, please wrap that
+ * element with an additional element (such as a `<span>`). That should resolve the issue.
+ *
  * To support accessibility, our tooltips should:
  * - Be supplemental to the user journey, not essential.
  * - Use clear and concise text.


### PR DESCRIPTION
Redoing the work that was reverted in #38866 and resolving the underlying problem.

Specifically, any `<ButtonLink>` that is wrapped with a `<Tooltip>` but does _not_ have a `to` prop (i.e. no `href` for the link) will need to be wrapped with an additional element first (e.g. a `<span>`).

The `onClick` handler specified in `<ButtonLink>` to prevent the default behavior (page reload) for an empty `href` does not get properly composed with the rest of the tooltip props (I believe since it is defined within the underlying component, it is not a prop "for" the component). This results in that onClick being completely ignored (and the page will, in fact, reload when clicking the link).

I'm also wondering why, in these cases, we wouldn't want to just use a `<Button>` element _without_ specifying `as={AnchorLink}` when we know it will not be a link to anything (since there is no `to` property)? It might be worthwhile to make a separate ticket to investigate. Maybe just these specific toggle buttons should be switched, since they are buttons to toggle behavior on/off, and obviously are not links.

cc @umpox this might also be a semantic/accessibility thing, having `<a>` tags that are not actually links to anything. From what I've read in the past, it seems like that is frowned upon - links should take you someplace else, and buttons should perform an action. Thoughts on that?

## Test plan

Tooltips and buttons, including those to toggle file history and line wrapping, should all be working now.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
