### PR TITLE
notify release captain to merge changelog PR

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -226,7 +226,7 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
         run: async (config, changelogFile = 'CHANGELOG.md') => {
             const { upcoming: release } = await releaseVersions(config)
             const prMessage = `changelog: cut sourcegraph@${release.version}`
-            await createChangesets({
+            const pr = await createChangesets({
                 requiredCommands: [],
                 changes: [
                     {
@@ -293,6 +293,10 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                 ],
                 dryRun: config.dryRun.changesets,
             })
+            const changeLogPrUrl = pr[0].pullRequestURL
+            console.log(
+                `\nPlease review the changelog PR at ${changeLogPrUrl}, and merge manually when checks have passed.`
+            )
         },
     },
     {


### PR DESCRIPTION
notify the release captain to check/approve and merge the created changelog PR before proceeding. 

closes https://github.com/sourcegraph/sourcegraph/issues/31745


## Test plan

Just adds a log message