### PR TITLE
trace, tracer, errors, observation: add devx to CODENOTIFY

### DIFF
--- a/internal/observation/CODENOTIFY
+++ b/internal/observation/CODENOTIFY
@@ -1,2 +1,1 @@
-** @keegancsmith
 **/* @sourcegraph/dev-experience

--- a/internal/tracer/CODENOTIFY
+++ b/internal/tracer/CODENOTIFY
@@ -1,1 +1,2 @@
 ** @keegancsmith
+**/* @sourcegraph/dev-experience

--- a/lib/errors/CODENOTIFY
+++ b/lib/errors/CODENOTIFY
@@ -1,2 +1,1 @@
-** @keegancsmith
 **/* @sourcegraph/dev-experience


### PR DESCRIPTION
Adds devx to CODENOTIFY on some of our [responsibilities](https://handbook.sourcegraph.com/departments/engineering/teams/dev-experience/#responsibilities).

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a