### PR TITLE
[SG-38638] Webhook logs page icons have no alt text

### DIFF
--- a/client/web/src/site-admin/webhooks/StatusCode.tsx
+++ b/client/web/src/site-admin/webhooks/StatusCode.tsx
@@ -13,9 +13,9 @@ export const StatusCode: React.FunctionComponent<React.PropsWithChildren<Props>>
     <span>
         <span className={classNames('mr-1')}>
             {code < 400 ? (
-                <Icon className="text-success" aria-hidden={true} svgPath={mdiCheck} />
+                <Icon className="text-success" aria-label="Success" svgPath={mdiCheck} />
             ) : (
-                <Icon className="text-danger" aria-hidden={true} svgPath={mdiAlertCircle} />
+                <Icon className="text-danger" aria-label="Failed" svgPath={mdiAlertCircle} />
             )}
         </span>
         {code}


### PR DESCRIPTION
## Description
Added a label text on webhook status icons

### Problem description
The icons on this page (success, failure) have no alt text.

### Expected behavior
They do

### Ref
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/38638)
[Gitstart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-38638)

## Test Plan
- Click your user profile avatar in the top right corner
- Click “Site admin” from the dropdown menu
- Click “Incoming webhooks” from the sidebar, within the “Batch Changes” section
- The list of logs for any recent webhooks will be visible
- Ensure the failure/success icons has `aria-label` texts

## App preview:

- [Web](https://sg-web-contractors-sg-38638.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hhqjmkeckq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
