### PR TITLE
search ui: follow up search result items improvements

### DIFF
--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -128,66 +128,65 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
               <div
                 class=""
               >
-                <div
-                  class="fileMatchChildren"
-                  data-testid="file-match-children"
-                >
-                  <div>
-                    <div
-                      class="test-file-match-children-item-wrapper itemCodeWrapper"
-                    >
+                <div>
+                  <div
+                    class="fileMatchChildren"
+                    data-testid="file-match-children"
+                  >
+                    <div>
                       <div
-                        class="test-file-match-children-item item itemClickable"
-                        data-href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
-                        data-testid="file-match-children-item"
-                        role="link"
-                        tabindex="0"
+                        class="test-file-match-children-item-wrapper itemCodeWrapper"
                       >
-                        <code
-                          class="code codeExcerpt"
-                          data-testid="code-excerpt"
+                        <div
+                          class="test-file-match-children-item item itemClickable"
+                          data-href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
+                          data-testid="file-match-children-item"
+                          role="link"
+                          tabindex="0"
                         >
-                          <table>
-                            <tbody>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  1
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  2
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  3
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </code>
+                          <code
+                            class="code codeExcerpt"
+                            data-testid="code-excerpt"
+                          >
+                            <table>
+                              <tbody>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="1"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="2"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="3"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </code>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -404,90 +403,87 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
               <div
                 class=""
               >
-                <div
-                  class="fileMatchChildren"
-                  data-testid="file-match-children"
-                >
-                  <div>
-                    <div
-                      class="test-file-match-children-item-wrapper itemCodeWrapper"
-                    >
+                <div>
+                  <div
+                    class="fileMatchChildren"
+                    data-testid="file-match-children"
+                  >
+                    <div>
                       <div
-                        class="test-file-match-children-item item itemClickable"
-                        data-href="/github.com/foo/bar/-/blob/file1.txt?L2:1&subtree=true"
-                        data-testid="file-match-children-item"
-                        role="link"
-                        tabindex="0"
+                        class="test-file-match-children-item-wrapper itemCodeWrapper"
                       >
-                        <code
-                          class="code codeExcerpt"
-                          data-testid="code-excerpt"
+                        <div
+                          class="test-file-match-children-item item itemClickable"
+                          data-href="/github.com/foo/bar/-/blob/file1.txt?L2:1&subtree=true"
+                          data-testid="file-match-children-item"
+                          role="link"
+                          tabindex="0"
                         >
-                          <table>
-                            <tbody>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  1
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  2
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  3
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  4
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  5
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </code>
+                          <code
+                            class="code codeExcerpt"
+                            data-testid="code-excerpt"
+                          >
+                            <table>
+                              <tbody>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="1"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="2"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="3"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="4"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="5"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </code>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -630,66 +626,65 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
               <div
                 class=""
               >
-                <div
-                  class="fileMatchChildren"
-                  data-testid="file-match-children"
-                >
-                  <div>
-                    <div
-                      class="test-file-match-children-item-wrapper itemCodeWrapper"
-                    >
+                <div>
+                  <div
+                    class="fileMatchChildren"
+                    data-testid="file-match-children"
+                  >
+                    <div>
                       <div
-                        class="test-file-match-children-item item itemClickable"
-                        data-href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
-                        data-testid="file-match-children-item"
-                        role="link"
-                        tabindex="0"
+                        class="test-file-match-children-item-wrapper itemCodeWrapper"
                       >
-                        <code
-                          class="code codeExcerpt"
-                          data-testid="code-excerpt"
+                        <div
+                          class="test-file-match-children-item item itemClickable"
+                          data-href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
+                          data-testid="file-match-children-item"
+                          role="link"
+                          tabindex="0"
                         >
-                          <table>
-                            <tbody>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  1
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  2
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                              <tr>
-                                <td
-                                  class="line"
-                                >
-                                  3
-                                </td>
-                                <td
-                                  class="code"
-                                >
-                                   
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </code>
+                          <code
+                            class="code codeExcerpt"
+                            data-testid="code-excerpt"
+                          >
+                            <table>
+                              <tbody>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="1"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="2"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td
+                                    class="line"
+                                    data-line="3"
+                                  />
+                                  <td
+                                    class="code"
+                                  >
+                                     
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </code>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/client/search-ui/src/components/CodeExcerpt.tsx
+++ b/client/search-ui/src/components/CodeExcerpt.tsx
@@ -215,7 +215,7 @@ export const CodeExcerpt: React.FunctionComponent<Props> = ({
                         <tbody>
                             {range(startLine, endLine).map(index => (
                                 <tr key={index}>
-                                    <td className="line">{index + 1}</td>
+                                    <td className="line" data-line={index + 1} />
                                     {/* create empty space to fill viewport (as if the blob content were already fetched, otherwise we'll overfetch) */}
                                     <td className="code"> </td>
                                 </tr>

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -6,6 +6,7 @@ import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { Icon, Link } from '@sourcegraph/wildcard'
 
 import { LastSyncedIcon } from './LastSyncedIcon'
@@ -28,9 +29,17 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     as,
     index,
 }) => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
-            <span className={classNames('test-search-result-label', styles.titleInner)}>
+            <span
+                className={classNames(
+                    'test-search-result-label',
+                    styles.titleInner,
+                    coreWorkflowImprovementsEnabled && styles.mutedRepoFileLink
+                )}
+            >
                 <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
             </span>
         </div>

--- a/client/search-ui/src/components/ResultContainer.module.scss
+++ b/client/search-ui/src/components/ResultContainer.module.scss
@@ -8,6 +8,10 @@
     }
 
     :global(.core-workflow-improvements-enabled) &:not(:last-of-type) {
+        // Prevents the sticky items below from affecting
+        // anything outside of the result container.
+        isolation: isolate;
+
         margin-bottom: 1rem;
     }
 }
@@ -18,6 +22,13 @@
     display: flex;
     align-items: center;
     flex-wrap: wrap;
+
+    :global(.core-workflow-improvements-enabled) & {
+        position: sticky;
+        top: 0;
+        z-index: 1; // Show on top of search result contents
+        background-color: var(--body-bg);
+    }
 
     &-title {
         flex: 1 1 auto;
@@ -60,12 +71,24 @@
     border-bottom-right-radius: var(--border-radius);
     color: var(--text-muted);
 
+    // When expanded, stick collapse button to the bottom of the
+    // screen if there are enough search results to cause scrolling.
+    &--expanded {
+        position: sticky;
+        bottom: 0;
+    }
+
     &-text {
         margin-left: 0.125rem;
     }
 }
 
 .collapsible-results {
+    // The LastSyncedIcon is absolutely-positions inside the search results.
+    // This causes it to show over the sticky header when scrolling unless
+    // we isolate the search result contents.
+    isolation: isolate;
+
     border-radius: var(--border-radius);
     border: 1px solid var(--border-color);
 

--- a/client/search-ui/src/components/ResultContainer.tsx
+++ b/client/search-ui/src/components/ResultContainer.tsx
@@ -234,10 +234,16 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
                     )}
                 </div>
                 <div className={classNames(coreWorkflowImprovementsEnabled && styles.collapsibleResults)}>
-                    {!expanded && collapsedChildren}
-                    {expanded && expandedChildren}
+                    <div>{expanded ? expandedChildren : collapsedChildren}</div>
                     {coreWorkflowImprovementsEnabled && collapsible && (
-                        <button type="button" className={styles.toggleMatchesButton} onClick={toggle}>
+                        <button
+                            type="button"
+                            className={classNames(
+                                styles.toggleMatchesButton,
+                                expanded && styles.toggleMatchesButtonExpanded
+                            )}
+                            onClick={toggle}
+                        >
                             <Icon aria-hidden={true} svgPath={expanded ? mdiChevronUp : mdiChevronDown} />
                             <span className={styles.toggleMatchesButtonText}>
                                 {expanded ? collapseLabel : expandLabel}

--- a/client/web/src/search/results/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/StreamingSearchResults.module.scss
@@ -3,7 +3,10 @@
 .container {
     width: 100%;
     display: grid;
-    grid-template-columns: auto 1fr;
+    // minmax(0, 1fr) for the contents column so it shrinks down. This causes
+    // horizontal scrollbars to appear on the search results code chunks instead
+    // of on the whole page.
+    grid-template-columns: auto minmax(0, 1fr);
     grid-template-rows: auto 1fr;
     grid-template-areas:
         'sidebar infobar'
@@ -13,7 +16,7 @@
     column-gap: 1rem;
 
     &--with-improvements {
-        grid-template-columns: 1fr auto;
+        grid-template-columns: minmax(0, 1fr) auto;
         grid-template-areas:
             'infobar  sidebar'
             'contents sidebar';
@@ -22,7 +25,7 @@
     @media (--md-breakpoint-down) {
         &,
         &--with-improvements {
-            grid-template-columns: auto;
+            grid-template-columns: minmax(0, 1fr);
             grid-template-rows: auto auto 1fr;
             grid-template-areas:
                 'infobar'
@@ -50,12 +53,6 @@
 }
 
 .contents {
-    // Hack!! Fixes some possible nested scrolling on diff searches
-    // due to size calculations on diff results. The parent will scroll
-    // instead so this doesn't really hide anything.
-    overflow-y: hidden;
-    overflow-x: hidden;
-
     grid-area: contents;
 }
 


### PR DESCRIPTION
Follow up to #38785

- Removes hacky `overflow: hidden` properties on the search results page, instead relying on grid's `minmax` to prevent horizontal scrolling. This is necessary so sticky positioning works.
- Made the header of search results sticky so it stays at the top of the screen while scrolling
- Made the collapse button of the search results sticky so it stays at the bottom of the screen while scrolling
- Fixed the flash of content when expanding/collapsing search results when the core workflow improvements are enabled
  - Also fixed the text color of placeholder line numbers to match the color of loaded line numbers
- Fixed the repo result text color so it matches the other result types when the core workflow improvements are enabled

https://user-images.githubusercontent.com/206864/179296495-8276379e-664f-474b-b3e9-acade164610c.mp4

## Test plan

Test manually with feature flag on and off. No changes should occur in visual tests.

## App preview:

- [Web](https://sg-web-jp-searchfilesimprovements.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hipcfhjnuu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
