### PR TITLE
[SG-37398] - Migrate graphqlbackend.RepositoryResolver to use sourcegraph/log

### DIFF
--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -3,6 +3,8 @@ package graphqlbackend
 import (
 	"sync"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
@@ -17,6 +19,7 @@ type CommitSearchResultResolver struct {
 	// Use Commit() instead.
 	gitCommitResolver *GitCommitResolver
 	gitCommitOnce     sync.Once
+	logger            log.Logger
 }
 
 func (r *CommitSearchResultResolver) Commit() *GitCommitResolver {

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -17,8 +17,6 @@ import (
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/inconshreveable/log15"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -27,6 +25,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/sourcegraph/log/logtest"
 )
 
 func BenchmarkPrometheusFieldName(b *testing.B) {

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -17,6 +17,8 @@ import (
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -83,7 +85,7 @@ func TestResolverTo(t *testing.T) {
 		&FileMatchResolver{db: db},
 		&NamespaceResolver{},
 		&NodeResolver{},
-		&RepositoryResolver{db: db},
+		&RepositoryResolver{db: db, logger: logtest.Scoped(t)},
 		&CommitSearchResultResolver{},
 		&gitRevSpec{},
 		&settingsSubject{},

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -66,7 +66,10 @@ func NewRepositoryResolver(db database.DB, repo *types.Repo) *RepositoryResolver
 			Name: name,
 			ID:   id,
 		},
-		logger: log.Scoped("nodes.repositoryResolver", ""),
+		logger: log.Scoped("repositoryResolver", "resolve a specific repository").
+			With(log.Object("repo",
+				log.String("name", string(name)),
+				log.String("id", string(id)))),
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/log"
 
@@ -514,7 +513,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 	return getCommit()
 }
 
-func makePhabClientForOrigin(ctx context.Context, db database.DB, origin string) (*phabricator.Client, error) {
+func makePhabClientForOrigin(ctx context.Context, logger log.Logger, db database.DB, origin string) (*phabricator.Client, error) {
 	opt := database.ExternalServicesListOptions{
 		Kinds: []string{extsvc.KindPhabricator},
 		LimitOffset: &database.LimitOffset{
@@ -542,7 +541,8 @@ func makePhabClientForOrigin(ctx context.Context, db database.DB, origin string)
 			case *schema.PhabricatorConnection:
 				conn = c
 			default:
-				log15.Error("makePhabClientForOrigin", "error", errors.Errorf("want *schema.PhabricatorConnection but got %T", cfg))
+				err := errors.Errorf("want *schema.PhabricatorConnection but got %T", cfg)
+				logger.Error("makePhabClientForOrigin", log.Error(err))
 				continue
 			}
 

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/sourcegraph/log/logtest"
 )
 
 const exampleCommitSHA1 = "1234567890123456789012345678901234567890"
@@ -152,6 +154,7 @@ func assertRepoResolverHydrated(ctx context.Context, t *testing.T, r *Repository
 func TestRepositoryLabel(t *testing.T) {
 	test := func(name string) string {
 		r := &RepositoryResolver{
+			logger: logtest.Scoped(t),
 			RepoMatch: result.RepoMatch{
 				Name: api.RepoName(name),
 				ID:   api.RepoID(0),
@@ -219,7 +222,7 @@ func TestRepository_DefaultBranch(t *testing.T) {
 				gitserver.Mocks.ResolveRevision = nil
 			})
 
-			res := &RepositoryResolver{RepoMatch: result.RepoMatch{Name: "repo"}}
+			res := &RepositoryResolver{RepoMatch: result.RepoMatch{Name: "repo"}, logger: logtest.Scoped(t)}
 			branch, err := res.DefaultBranch(ctx)
 			if tt.wantErr != nil && err != nil {
 				if tt.wantErr.Error() != err.Error() {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/web"
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -584,6 +584,7 @@ func (r *UserResolver) PublicRepositories(ctx context.Context) ([]*RepositoryRes
 	var out []*RepositoryResolver
 	for _, repo := range repos {
 		out = append(out, &RepositoryResolver{
+			logger: r.logger,
 			RepoMatch: result.RepoMatch{
 				ID:   repo.RepoID,
 				Name: api.RepoName(repo.RepoURI),

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
+
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ require (
 	golang.org/x/net v0.0.0-20220526153639-5463443f8c37
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306
 	golang.org/x/tools v0.1.10
 	gonum.org/v1/gonum v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -2667,6 +2667,8 @@ golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=


### PR DESCRIPTION
## Description

Add a logger to schemaResolver, and initialize it with log.Scoped (or logtest where appropriate) wherever schemaResolver is created (unless an existing logger is easily available, in which case that should be used)
Add a logger to RepositoryResolver, and let it be injected from NewRepositoryResolver. Use log.Scoped (or logtest where appropriate) to provide the logger at [all usages of NewRepositoryResolver](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Ecmd/frontend/graphqlbackend+NewRepositoryResolver&patternType=literal)
[3 log15 usages inside cmd/frontend/graphqlbackend/repository.go](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Ecmd/frontend/graphqlbackend/repository%5C.go+log15+&patternType=literal) are replaced with calls to the appropriate logger
## Test plan
- A good way to test this PR is just to run the branch locally, and open [the issue link](https://github.com/sourcegraph/sourcegraph/issues/36382), compare the changes on the PR and the listed issues. All of them must be fixed
## Refs
- [SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/36382)
- [GitStart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-37398)