### PR TITLE
compute: use GET request with Sourcegraph header

### DIFF
--- a/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
+++ b/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
@@ -67,9 +67,9 @@ const setupPorts = (sourcegraphURL: string, updateBlockInputWithID: (blockInput:
         openRequests.push(ctrl)
         async function fetch(): Promise<void> {
             await fetchEventSource(address, {
-                method: 'POST',
+                method: 'GET',
                 headers: {
-                    origin: sourcegraphURL,
+                    'X-Requested-With': 'Sourcegraph',
                 },
                 signal: ctrl.signal,
                 onerror(error) {


### PR DESCRIPTION
This is the preferred way to make authenticated requests. https://github.com/sourcegraph/sourcegraph/issues/29399#issuecomment-1136749405

## Test plan
Manually tested for experimental feature (it either works or entirely breaks Compute block)