### PR TITLE
repos: have `diff.Modified` track which field(s) changed in a sync

### DIFF
--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -302,7 +302,7 @@ func (s *UpdateScheduler) UpdateFromDiff(diff Diff) {
 	for _, r := range diff.Added {
 		s.upsert(r, true)
 	}
-	for _, r := range diff.Modified {
+	for _, r := range diff.Modified.Repos() {
 		s.upsert(r, true)
 	}
 

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -598,10 +598,12 @@ func Test_updateScheduler_UpdateFromDiff(t *testing.T) {
 						Name: a.Name,
 					},
 				},
-				Modified: []*types.Repo{
-					{
-						ID:   b.ID,
-						Name: b.Name,
+				Modified: ReposModified{
+					RepoModified{
+						Repo: &types.Repo{
+							ID:   b.ID,
+							Name: b.Name,
+						},
 					},
 				},
 			},

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -154,7 +154,8 @@ func (r *Repo) IsBlocked() error {
 type RepoModified uint64
 
 const (
-	RepoModifiedName RepoModified = 1 << iota
+	RepoUnmodified   RepoModified = 0
+	RepoModifiedName              = 1 << iota
 	RepoModifiedURI
 	RepoModifiedDescription
 	RepoModifiedExternalRepo
@@ -164,8 +165,6 @@ const (
 	RepoModifiedStars
 	RepoModifiedMetadata
 	RepoModifiedSources
-
-	RepoUnmodified RepoModified = 0
 )
 
 func (m RepoModified) String() string {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -149,50 +149,122 @@ func (r *Repo) IsBlocked() error {
 	return nil
 }
 
-// Update updates Repo r with the fields from the given newer Repo n,
-// returning true if modified.
-func (r *Repo) Update(n *Repo) (modified bool) {
+// RepoModified is a bitfield that tracks which fields were modified while
+// syncing a repository.
+type RepoModified uint64
+
+const (
+	RepoModifiedName RepoModified = 1 << iota
+	RepoModifiedURI
+	RepoModifiedDescription
+	RepoModifiedExternalRepo
+	RepoModifiedArchived
+	RepoModifiedFork
+	RepoModifiedPrivate
+	RepoModifiedStars
+	RepoModifiedMetadata
+	RepoModifiedSources
+
+	RepoUnmodified RepoModified = 0
+)
+
+func (m RepoModified) String() string {
+	if m == RepoUnmodified {
+		return "repo unmodified"
+	}
+
+	modifications := []string{}
+	if m&RepoModifiedName == RepoModifiedName {
+		modifications = append(modifications, "name")
+	}
+	if m&RepoModifiedURI == RepoModifiedURI {
+		modifications = append(modifications, "uri")
+	}
+	if m&RepoModifiedDescription == RepoModifiedDescription {
+		modifications = append(modifications, "description")
+	}
+	if m&RepoModifiedExternalRepo == RepoModifiedExternalRepo {
+		modifications = append(modifications, "external repo")
+	}
+	if m&RepoModifiedArchived == RepoModifiedArchived {
+		modifications = append(modifications, "archived")
+	}
+	if m&RepoModifiedFork == RepoModifiedFork {
+		modifications = append(modifications, "fork")
+	}
+	if m&RepoModifiedPrivate == RepoModifiedPrivate {
+		modifications = append(modifications, "private")
+	}
+	if m&RepoModifiedStars == RepoModifiedStars {
+		modifications = append(modifications, "stars")
+	}
+	if m&RepoModifiedMetadata == RepoModifiedMetadata {
+		modifications = append(modifications, "metadata")
+	}
+	if m&RepoModifiedSources == RepoModifiedSources {
+		modifications = append(modifications, "sources")
+	}
+	if m&RepoUnmodified == RepoUnmodified {
+		modifications = append(modifications, "unmodified")
+	}
+
+	return "repo modifications: " + strings.Join(modifications, ", ")
+}
+
+// Update updates Repo r with the fields from the given newer Repo n, returning
+// RepoUnmodified (0) if no fields were modified, and a non-zero value if one
+// or more fields were modified.
+func (r *Repo) Update(n *Repo) (modified RepoModified) {
 	if !r.Name.Equal(n.Name) {
-		r.Name, modified = n.Name, true
+		r.Name = n.Name
+		modified |= RepoModifiedName
 	}
 
 	if r.URI != n.URI {
-		r.URI, modified = n.URI, true
+		r.URI = n.URI
+		modified |= RepoModifiedURI
 	}
 
 	if r.Description != n.Description {
-		r.Description, modified = n.Description, true
+		r.Description = n.Description
+		modified |= RepoModifiedDescription
 	}
 
 	if n.ExternalRepo != (api.ExternalRepoSpec{}) &&
 		!r.ExternalRepo.Equal(&n.ExternalRepo) {
-		r.ExternalRepo, modified = n.ExternalRepo, true
+		r.ExternalRepo = n.ExternalRepo
+		modified |= RepoModifiedExternalRepo
 	}
 
 	if r.Archived != n.Archived {
-		r.Archived, modified = n.Archived, true
+		r.Archived = n.Archived
+		modified |= RepoModifiedArchived
 	}
 
 	if r.Fork != n.Fork {
-		r.Fork, modified = n.Fork, true
+		r.Fork = n.Fork
+		modified |= RepoModifiedFork
 	}
 
 	if r.Private != n.Private {
-		r.Private, modified = n.Private, true
+		r.Private = n.Private
+		modified |= RepoModifiedPrivate
 	}
 
 	if r.Stars != n.Stars {
-		r.Stars, modified = n.Stars, true
+		r.Stars = n.Stars
+		modified |= RepoModifiedStars
 	}
 
 	if !reflect.DeepEqual(r.Metadata, n.Metadata) {
-		r.Metadata, modified = n.Metadata, true
+		r.Metadata = n.Metadata
+		modified |= RepoModifiedMetadata
 	}
 
 	for urn, info := range n.Sources {
 		if old, ok := r.Sources[urn]; !ok || !reflect.DeepEqual(info, old) {
 			r.Sources[urn] = info
-			modified = true
+			modified |= RepoModifiedSources
 		}
 	}
 


### PR DESCRIPTION
This split out of a discussion in #38702, where we were grappling with how to signal that a specific field had been modified in a repo when it was synced. @ryanslade suggested extending `Modified` to be more than a simple slice of repos, and after implementing it, I actually quite like it.

Basically, `Modified` is now a slice of structs with the repo and a bitfield indicating what fields were modified. There are currently 10 fields and it's a `uint64`, so we have some future proofing there.

Most existing uses of `Diff.Modified` were simply replaced with `Diff.Modified.Repos()`, and then the `Diff.ArchivedChanged` field added in #38702 could be removed completely.

Technically, `RepoModified` doesn't need to be a `Stringer`, but I quickly found it made debugging unit tests considerably easier to have it. I suggest we keep it just for that.

Tagging @sourcegraph/batchers as reviewers here as well, but just for the little bit that touches Batch Changes. This one's mostly for @sourcegraph/repo-management.

## Test plan

Basically using the unit tests: we have pretty good coverage here. Running Sourcegraph locally for a while with this still synced as expected.