### PR TITLE
blob: Add experimental support for rendering files with CodeMirror

### DIFF
--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -866,7 +866,7 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
  * from the current ones. This prevents adding a new entry when e.g. the user
  * clicks the same line multiple times.
  */
-function updateBrowserHistoryIfNecessary(
+export function updateBrowserHistoryIfNecessary(
     history: H.History,
     location: H.Location,
     newSearchParameters: URLSearchParams

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -41,7 +41,8 @@ import { ToggleLineWrap } from './actions/ToggleLineWrap'
 import { ToggleRenderedFileMode } from './actions/ToggleRenderedFileMode'
 import { getModeFromURL } from './actions/utils'
 import { fetchBlob } from './backend'
-import { Blob, BlobInfo } from './Blob'
+import { Blob, BlobInfo, BlobProps } from './Blob'
+import { Blob as CodeMirrorBlob } from './CodeMirrorBlob'
 import { GoToRawAction } from './GoToRawAction'
 import { useBlobPanelViews } from './panel/BlobPanel'
 import { RenderedFile } from './RenderedFile'
@@ -364,7 +365,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
             )}
             {/* Render the (unhighlighted) blob also in the case highlighting timed out */}
             {renderMode === 'code' && (
-                <Blob
+                <BlobContainer
                     data-testid="repo-blob"
                     className={classNames(styles.blob, styles.border)}
                     blobInfo={blobInfoOrError}
@@ -383,4 +384,11 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
             )}
         </>
     )
+}
+
+const BlobContainer: React.FunctionComponent<BlobProps> = props => {
+    const Component = useExperimentalFeatures(features => features.enableCodeMirrorFileView ?? false)
+        ? CodeMirrorBlob
+        : Blob
+    return <Component {...props} />
 }

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -1,0 +1,119 @@
+/**
+ * An experimental implementation of the Blob view using CodeMirror
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { Compartment, Extension } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { useHistory, useLocation } from 'react-router'
+
+import { addLineRangeQueryParameter, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
+import { editorHeight, useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import { parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
+
+import { BlobProps, updateBrowserHistoryIfNecessary } from './Blob'
+import { selectLines, selectableLineNumbers, SelectedLineRange } from './CodeMirrorLineNumbers'
+
+const staticExtensions: Extension = [
+    EditorView.editable.of(false),
+    editorHeight({ height: '100%' }),
+    EditorView.theme({
+        '&': {
+            fontFamily: 'var(--code-font-family)',
+            fontSize: 'var(--code-font-size)',
+            backgroundColor: 'var(--code-bg)',
+        },
+        '.selected-line': {
+            backgroundColor: 'var(--code-selection-bg)',
+        },
+    }),
+]
+
+export const Blob: React.FunctionComponent<BlobProps> = ({ className, blobInfo, wrapCode, isLightTheme }) => {
+    const [container, setContainer] = useState<HTMLDivElement | null>(null)
+
+    const [dynamicExtensions, updateExtensions] = useExtension((wrapCode: boolean, isLightTheme: boolean) => [
+        wrapCode ? EditorView.lineWrapping : [],
+        EditorView.darkTheme.of(isLightTheme === false),
+    ])
+
+    const history = useHistory()
+    const historyRef = useRef(history)
+    historyRef.current = history
+
+    const location = useLocation()
+    const locationRef = useRef(location)
+    locationRef.current = location
+
+    const onSelection = useCallback((range: SelectedLineRange) => {
+        const parameters = new URLSearchParams(locationRef.current.search)
+        let query: string | undefined
+
+        if (range?.line !== range?.endLine && range?.endLine) {
+            query = toPositionOrRangeQueryParameter({
+                range: {
+                    start: { line: range.line },
+                    end: { line: range.endLine },
+                },
+            })
+        } else if (range?.line) {
+            query = toPositionOrRangeQueryParameter({ position: { line: range.line } })
+        }
+
+        updateBrowserHistoryIfNecessary(
+            historyRef.current,
+            locationRef.current,
+            addLineRangeQueryParameter(parameters, query)
+        )
+    }, [])
+
+    const extensions = useMemo(() => [staticExtensions, dynamicExtensions, selectableLineNumbers({ onSelection })], [
+        dynamicExtensions,
+        onSelection,
+    ])
+
+    const editor = useCodeMirror(container, blobInfo.content, extensions)
+
+    // Update extensions when prop change
+    useEffect(() => {
+        if (editor) {
+            updateExtensions(editor, wrapCode, isLightTheme)
+        }
+    }, [editor, updateExtensions, wrapCode, isLightTheme])
+
+    // Update selected lines when URL changes
+    const position = useMemo(() => parseQueryAndHash(location.search, location.hash), [location.search, location.hash])
+    useEffect(() => {
+        if (editor) {
+            selectLines(editor, position.line ? position : null)
+        }
+    }, [editor, position])
+
+    return <div ref={setContainer} className={`${className} overflow-hidden`} />
+}
+
+/**
+ * Helper hook for creating an extension that depends on on some input props.
+ * If this proves to be useful it should be moved to the shared CodeMirror code.
+ *
+ * The provided callback is not called by this hook directly. It is only called
+ * when the returned setter is called. It's the responsibily of the component to
+ * call the setter with all necessary values.
+ *
+ * Like with useState, the callback function is ignored in subsequent renders,
+ * so it shouldn't close over any variables that change during render.
+ */
+export function useExtension<T extends unknown[]>(
+    callback: (...args: T) => Extension
+): [Extension, (editor: EditorView, ...args: T) => void] {
+    return useMemo(() => {
+        const compartment = new Compartment()
+        return [
+            compartment.of([]),
+            (editor, ...args) => editor.dispatch({ effects: compartment.reconfigure(callback(...args)) }),
+        ]
+        // callback is intentionally ignored in subsequent renders
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+}

--- a/client/web/src/repo/blob/CodeMirrorLineNumbers.ts
+++ b/client/web/src/repo/blob/CodeMirrorLineNumbers.ts
@@ -1,0 +1,182 @@
+import { Extension, RangeSetBuilder, StateEffect, StateField } from '@codemirror/state'
+import { EditorView, Decoration, lineNumbers } from '@codemirror/view'
+
+/**
+ * Represents the currently selected line range. null means no lines are
+ * selected. Line numbers are 1-based.
+ * endLine may be smaller than line
+ */
+export type SelectedLineRange = { line: number; endLine?: number } | null
+
+const highlighedLineDecoration = Decoration.line({ class: 'selected-line' })
+const setSelectedLines = StateEffect.define<SelectedLineRange>()
+const setEndLine = StateEffect.define<number>()
+
+/**
+ * This field stores the selected line range and provides the corresponding line
+ * decorations.
+ */
+const selectedLines = StateField.define<SelectedLineRange>({
+    create() {
+        return null
+    },
+    update(value, transaction) {
+        for (const effect of transaction.effects) {
+            if (effect.is(setSelectedLines)) {
+                return effect.value
+            }
+            if (effect.is(setEndLine)) {
+                if (!value?.line) {
+                    value = { line: effect.value }
+                }
+                return { ...value, endLine: effect.value }
+            }
+        }
+        return value
+    },
+    provide: field => [
+        EditorView.decorations.compute([field], state => {
+            const range = state.field(field)
+            if (!range) {
+                return Decoration.none
+            }
+
+            // By ordering line and endLine here we make "inverse" selection
+            // work automagically
+
+            const endLine = range.endLine ?? range.line
+            const from = Math.min(range.line, endLine)
+            const to = from === endLine ? range.line : endLine
+
+            const builder = new RangeSetBuilder<Decoration>()
+
+            for (let line = from; line <= to; line++) {
+                const from = state.doc.line(line).from
+                builder.add(from, from, highlighedLineDecoration)
+            }
+
+            return builder.finish()
+        }),
+    ],
+})
+
+/**
+ * This extension provides a line gutter that allows selecting (ranges of) lines
+ * by clicking (and dragging over) the line numbers. Shift+click to select a
+ * range is also supported.
+ *
+ * onSelection is called when a selection was made. range.line will always be <
+ * range.endLine.
+ *
+ * NOTE: Dragging to select on the gutter won't automatically scroll the
+ * document.
+ */
+export function selectableLineNumbers(config: { onSelection: (range: SelectedLineRange) => void }): Extension {
+    let dragging = false
+
+    return [
+        lineNumbers({
+            domEventHandlers: {
+                mousedown(view, block, event) {
+                    const line = view.state.doc.lineAt(block.from).number
+                    const range = view.state.field(selectedLines)
+
+                    view.dispatch({
+                        effects: (event as MouseEvent).shiftKey
+                            ? setEndLine.of(line)
+                            : setSelectedLines.of(isSingleLine(range) && range?.line === line ? null : { line }),
+                    })
+
+                    dragging = true
+
+                    function onmouseup(): void {
+                        dragging = false
+                        window.removeEventListener('mouseup', onmouseup)
+
+                        let range = view.state.field(selectedLines)
+                        if (range) {
+                            // Order line and endLine
+                            if (range.endLine && range.line > range.endLine) {
+                                range = {
+                                    line: range.endLine,
+                                    endLine: range.line,
+                                }
+                            } else if (range.line === range.endLine) {
+                                range = { line: range.line }
+                            } else {
+                                range = { ...range }
+                            }
+                        }
+                        config.onSelection(range)
+                    }
+                    window.addEventListener('mouseup', onmouseup)
+                    return true
+                },
+                mousemove(view, line) {
+                    if (dragging) {
+                        const newEndline = view.state.doc.lineAt(line.from).number
+                        const { endLine } = view.state.field(selectedLines) ?? {}
+                        if (endLine !== newEndline) {
+                            view.dispatch({ effects: setEndLine.of(newEndline) })
+                        }
+                        return true
+                    }
+                    return false
+                },
+            },
+        }),
+        selectedLines,
+        EditorView.theme({
+            '.cm-lineNumbers': {
+                cursor: 'pointer',
+            },
+            '.cm-lineNumbers .cm-gutterElement:hover': {
+                textDecoration: 'underline',
+            },
+        }),
+    ]
+}
+
+/**
+ * Set selected lines (e.g. from the URL). The function won't trigger an update
+ * if the same lines are already selected.
+ */
+export function selectLines(view: EditorView, newRange: SelectedLineRange): void {
+    const currentRange = view.state.field(selectedLines)
+
+    if (currentRange?.line === newRange?.line && currentRange?.endLine === newRange?.endLine) {
+        return
+    }
+
+    const effects: StateEffect<unknown>[] = [setSelectedLines.of(newRange)]
+
+    if (newRange) {
+        effects.push(
+            EditorView.scrollIntoView(
+                view.state.doc.line(newRange.line).from,
+                // This is not ideal but  shouldScrollIntoView operates on the
+                // rendered lines, of which not all might be in view. In that case
+                // "nearest" ensures that the line will be visible but it won't have
+                // any affect if the line is already visible.
+                { y: shouldScrollIntoView(view, newRange) ? 'center' : 'nearest' }
+            )
+        )
+    }
+
+    view.dispatch({ effects })
+}
+
+function shouldScrollIntoView(view: EditorView, range: SelectedLineRange): boolean {
+    if (!range) {
+        return false
+    }
+
+    const from = view.state.doc.line(range.line).from
+    const to = range.endLine ? view.state.doc.line(range.endLine).to : undefined
+
+    return from >= view.viewport.to || (to ?? from) <= view.viewport.from
+}
+
+function isSingleLine(range: SelectedLineRange): boolean {
+    return !!range && (!range.endLine || range.line === range.endLine)
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1727,6 +1727,8 @@ type SettingsExperimentalFeatures struct {
 	CopyQueryButton *bool `json:"copyQueryButton,omitempty"`
 	// Editor description: Specifies which (code) editor to use for query and text input
 	Editor *string `json:"editor,omitempty"`
+	// EnableCodeMirrorFileView description: Uses CodeMirror to display files. In this first iteration not all features of the current file view are available.
+	EnableCodeMirrorFileView *bool `json:"enableCodeMirrorFileView,omitempty"`
 	// EnableExtensionsDecorationsColumnView description: If extension supports column view show its decorations in a separate column in the blob view.
 	EnableExtensionsDecorationsColumnView *bool `json:"enableExtensionsDecorationsColumnView,omitempty"`
 	// EnableFastResultLoading description: Enables optimized search result loading (syntax highlighting / file contents fetching)

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -324,6 +324,14 @@
           "!go": {
             "pointer": true
           }
+        },
+        "enableCodeMirrorFileView": {
+          "description": "Uses CodeMirror to display files. In this first iteration not all features of the current file view are available.",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
         }
       },
       "group": "Experimental"


### PR DESCRIPTION
This commit introduces a file view backed by CodeMirror. It shows the
file as plain text without syntax highlighting.
I spent a little bit of time to implement a line gutter that supports
line (range) selection.

To use the CodeMirror version
`experimentalFeatures.enableCodeMirrorFileView` needs to be set to
`true`.

Note that this is a rough minimal drop in replacement and the way things
are implemented might not be optimal.



https://user-images.githubusercontent.com/179026/179315917-6e9072ef-8b52-4f4a-b328-ec1e23e1addd.mp4



## Test plan

- Navigate to file: Shows current blob view
- Enable feature flag (`enableCodemirrorFileView`), navigate to file: Shows CodeMirror based file view