### PR TITLE
Modify sub-repo filtering for diff searches to be in line w/ P4

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -129,6 +129,11 @@ func main() {
 		logger.Fatal("failed to initialise keyring", zap.Error(err))
 	}
 
+	authz.DefaultSubRepoPermsChecker, err = authz.NewSubRepoPermsClient(db.SubRepoPerms())
+	if err != nil {
+		logger.Fatal("Failed to create sub-repo client", zap.Error(err))
+	}
+
 	gitserver := server.Server{
 		Logger:             logger,
 		ReposDir:           reposDir,

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1161,6 +1161,7 @@ func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, match
 
 		searcher := &search.CommitSearcher{
 			Logger:               s.Logger,
+			RepoName:             args.Repo,
 			RepoDir:              dir.Path(),
 			Revisions:            args.Revisions,
 			Query:                mt,

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -425,8 +425,7 @@ func SubRepoEnabledForRepo(ctx context.Context, checker SubRepoPermissionChecker
 	return checker.EnabledForRepo(ctx, repo)
 }
 
-// CanReadAllPaths returns true if the actor can read all paths.
-func CanReadAllPaths(ctx context.Context, checker SubRepoPermissionChecker, repo api.RepoName, paths []string) (bool, error) {
+func canReadPaths(ctx context.Context, checker SubRepoPermissionChecker, repo api.RepoName, paths []string, any bool) (bool, error) {
 	if !SubRepoEnabled(checker) {
 		return true, nil
 	}
@@ -448,12 +447,24 @@ func CanReadAllPaths(ctx context.Context, checker SubRepoPermissionChecker, repo
 		if err != nil {
 			return false, err
 		}
-		if !perms.Include(Read) {
+		if !perms.Include(Read) && !any {
 			return false, nil
+		} else if perms.Include(Read) && any {
+			return true, nil
 		}
 	}
 
-	return true, nil
+	return true && !any, nil
+}
+
+// CanReadAllPaths returns true if the actor can read all paths.
+func CanReadAllPaths(ctx context.Context, checker SubRepoPermissionChecker, repo api.RepoName, paths []string) (bool, error) {
+	return canReadPaths(ctx, checker, repo, paths, false)
+}
+
+// CanReadAnyPath returns true if the actor can read any path in the list of paths.
+func CanReadAnyPath(ctx context.Context, checker SubRepoPermissionChecker, repo api.RepoName, paths []string) (bool, error) {
+	return canReadPaths(ctx, checker, repo, paths, true)
 }
 
 // FilterActorPaths will filter the given list of paths for the given actor

--- a/internal/authz/sub_repo_perms_test.go
+++ b/internal/authz/sub_repo_perms_test.go
@@ -209,6 +209,13 @@ func TestCanReadAllPaths(t *testing.T) {
 	if !ok {
 		t.Fatal("Should be allowed to read all paths")
 	}
+	ok, err = CanReadAnyPath(ctx, checker, repo, testPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("CanReadyAnyPath should've returned true since the user can read all paths")
+	}
 
 	// Add path we can't read
 	testPaths = append(testPaths, "file4")
@@ -219,6 +226,13 @@ func TestCanReadAllPaths(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("Should fail, not allowed to read file4")
+	}
+	ok, err = CanReadAnyPath(ctx, checker, repo, testPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("user can read some of the testPaths, so CanReadAnyPath should return true")
 	}
 }
 

--- a/internal/gitserver/search/diff_format.go
+++ b/internal/gitserver/search/diff_format.go
@@ -17,13 +17,19 @@ const (
 	maxFiles          = 5
 )
 
-func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff) (string, result.Ranges) {
+func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff, filterFunc func(string) (bool, error)) (string, result.Ranges) {
 	var buf strings.Builder
 	var loc result.Location
 	var ranges result.Ranges
 
 	fileCount := 0
 	for fileIdx, fileDiff := range rawDiff {
+		if filterFunc != nil {
+			if isAllowed, err := filterFunc(fileDiff.NewName); !isAllowed || err != nil {
+				continue
+			}
+		}
+
 		fdh, ok := highlights[fileIdx]
 		if !ok && len(highlights) > 0 {
 			continue

--- a/internal/gitserver/search/diff_format_test.go
+++ b/internal/gitserver/search/diff_format_test.go
@@ -35,7 +35,7 @@ index dbace57d5f..53357b4971 100644
 			}},
 		}
 
-		formatted, ranges := FormatDiff(parsedDiff, highlights)
+		formatted, ranges := FormatDiff(parsedDiff, highlights, nil)
 		expectedFormatted := `.mailmap .mailmap
 @@ -60,1 +60,2 @@ Unknown <u@gogs.io> 无闻 <u@gogs.io>
  Matt King <kingy895@gmail.com> Matthew King <kingy895@gmail.com>

--- a/internal/gitserver/search/diff_test.go
+++ b/internal/gitserver/search/diff_test.go
@@ -61,7 +61,7 @@ func TestDiffSearch(t *testing.T) {
 	}
 	require.Equal(t, expectedHighlights, highlights)
 
-	formatted, ranges := FormatDiff(fileDiffs, highlights.Diff)
+	formatted, ranges := FormatDiff(fileDiffs, highlights.Diff, nil)
 	expectedFormatted := `web/src/integration/helpers.ts web/src/integration/helpers.ts
 @@ -7,3 +7,3 @@ import { createDriverForTest, Driver } from '../../../shared/src/testing/driver'
  import express from 'express'

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -12,7 +12,9 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -87,6 +89,7 @@ type CommitSearcher struct {
 	Revisions            []protocol.RevisionSpecifier
 	IncludeDiff          bool
 	IncludeModifiedFiles bool
+	RepoName             api.RepoName
 }
 
 // Search runs a search for commits matching the given predicate across the revisions passed in as revisionArgs.
@@ -201,6 +204,16 @@ func tryInterpretErrorWithStderr(ctx context.Context, err error, stderr string, 
 	return err
 }
 
+func getSubRepoFilterFunc(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName) func(string) (bool, error) {
+	if !authz.SubRepoEnabled(checker) {
+		return nil
+	}
+	a := actor.FromContext(ctx)
+	return func(filePath string) (bool, error) {
+		return authz.FilterActorPath(ctx, checker, a, repo, filePath)
+	}
+}
+
 func (cs *CommitSearcher) runJobs(ctx context.Context, jobs chan job) error {
 	// Create a new diff fetcher subprocess for each worker
 	diffFetcher, err := NewDiffFetcher(cs.RepoDir)
@@ -230,7 +243,7 @@ func (cs *CommitSearcher) runJobs(ctx context.Context, jobs chan job) error {
 				return err
 			}
 			if mergedResult.Satisfies() {
-				cm, err := CreateCommitMatch(lc, highlights, cs.IncludeDiff)
+				cm, err := CreateCommitMatch(lc, highlights, cs.IncludeDiff, getSubRepoFilterFunc(ctx, authz.DefaultSubRepoPermsChecker, cs.RepoName))
 				if err != nil {
 					return err
 				}
@@ -366,7 +379,7 @@ func (c *CommitScanner) Err() error {
 	return c.err
 }
 
-func CreateCommitMatch(lc *LazyCommit, hc MatchedCommit, includeDiff bool) (*protocol.CommitMatch, error) {
+func CreateCommitMatch(lc *LazyCommit, hc MatchedCommit, includeDiff bool, filterFunc func(string) (bool, error)) (*protocol.CommitMatch, error) {
 	authorDate, err := lc.AuthorDate()
 	if err != nil {
 		return nil, err
@@ -383,7 +396,7 @@ func CreateCommitMatch(lc *LazyCommit, hc MatchedCommit, includeDiff bool) (*pro
 		if err != nil {
 			return nil, err
 		}
-		diff.Content, diff.MatchedRanges = FormatDiff(rawDiff, hc.Diff)
+		diff.Content, diff.MatchedRanges = FormatDiff(rawDiff, hc.Diff, filterFunc)
 	}
 
 	return &protocol.CommitMatch{

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -104,7 +104,7 @@ func applySubRepoFiltering(ctx context.Context, logger log.Logger, checker authz
 				filtered = append(filtered, m)
 			}
 		case *result.CommitMatch:
-			allowed, err := authz.CanReadAllPaths(ctx, checker, mm.Repo.Name, mm.ModifiedFiles)
+			allowed, err := authz.CanReadAnyPath(ctx, checker, mm.Repo.Name, mm.ModifiedFiles)
 			if err != nil {
 				errs = errors.Append(errs, err)
 				continue

--- a/internal/search/job/jobutil/sub_repo_perms_job_test.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job_test.go
@@ -157,16 +157,23 @@ func TestApplySubRepoFiltering(t *testing.T) {
 			},
 		},
 		{
-			name: "should filter commit matches",
+			name: "should filter commit matches where the user doesn't have access to any file in the ModifiedFiles",
 			args: args{
 				ctxActor: actor.FromUser(userWithSubRepoPerms),
 				matches: []result.Match{
 					&result.CommitMatch{
 						ModifiedFiles: []string{unauthorizedFileName},
 					},
+					&result.CommitMatch{
+						ModifiedFiles: []string{unauthorizedFileName, "another-file.txt"},
+					},
 				},
 			},
-			wantMatches: []result.Match{},
+			wantMatches: []result.Match{
+				&result.CommitMatch{
+					ModifiedFiles: []string{unauthorizedFileName, "another-file.txt"},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
For `type:diff` searches w/ sub-repo permissions enabled:
Previous behavior: filter out all commits/diffs where the user doesn't have access to view _all_ the files in the diff.
New behavior: show the user any commits that modify at least one file that they have access to, but filter any files the user _doesn't_ have access to out of the raw diff.

## Test plan
- New/updated unit tests pass
- Local testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
