### PR TITLE
search ui: scroll to top of search result when hiding matches

### DIFF
--- a/client/search-ui/src/components/ResultContainer.tsx
+++ b/client/search-ui/src/components/ResultContainer.tsx
@@ -1,5 +1,5 @@
 /* eslint jsx-a11y/click-events-have-key-events: warn, jsx-a11y/no-static-element-interactions: warn */
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { mdiArrowCollapseUp, mdiChevronDown, mdiArrowExpandDown, mdiChevronLeft, mdiChevronUp } from '@mdi/js'
 import classNames from 'classnames'
@@ -142,11 +142,20 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
 
     useEffect(() => setExpanded(allExpanded || defaultExpanded), [allExpanded, defaultExpanded])
 
-    const toggle = (): void => {
+    const rootRef = useRef<HTMLElement>(null)
+    const toggle = useCallback((): void => {
         if (collapsible) {
             setExpanded(expanded => !expanded)
         }
-    }
+
+        // Scroll back to top of result when collapsing
+        if (coreWorkflowImprovementsEnabled && expanded) {
+            setTimeout(() => {
+                const reducedMotion = !window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+                rootRef.current?.scrollIntoView({ block: 'nearest', behavior: reducedMotion ? 'auto' : 'smooth' })
+            }, 0)
+        }
+    }, [collapsible, coreWorkflowImprovementsEnabled, expanded])
 
     const trackReferencePanelClick = (): void => {
         if (onResultClicked) {
@@ -161,6 +170,7 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
             data-expanded={allExpanded}
             data-collapsible={collapsible}
             onClick={trackReferencePanelClick}
+            ref={rootRef}
         >
             <article aria-labelledby={`result-container-${index}`}>
                 <div className={styles.header} id={`result-container-${index}`}>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/pull/38900#pullrequestreview-1040743166

Only visible with the "Simple UI" toggle enabled (`coreWorkflowImprovementsEnabled`).
When collapsing a search result's matches, scroll to the top of the search result. If the user hasn't set "reduce motion", the scrolling will be smooth. If the top of the search result is visible already, no scrolling will occur.

https://user-images.githubusercontent.com/206864/179321431-c3f2bab6-1c2f-4edd-a413-455783a42a86.mp4

## Test plan

Manually test with "Simple UI" toggle enabled

## App preview:

- [Web](https://sg-web-jp-resultcollapsescroll.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xpfpgzsnnt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
