### PR TITLE
add experimental flag for compute based insights

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
@@ -6,6 +6,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { AuthenticatedUser } from '../../../../../auth'
+import { useExperimentalFeatures } from '../../../../../stores'
 
 import { InsightCreationPageType } from './InsightCreationPage'
 
@@ -28,6 +29,7 @@ export const CreationRoutes: React.FunctionComponent<React.PropsWithChildren<Cre
     const { telemetryService } = props
 
     const match = useRouteMatch()
+    const { codeInsightsCompute } = useExperimentalFeatures()
 
     return (
         <Switch>
@@ -68,15 +70,17 @@ export const CreationRoutes: React.FunctionComponent<React.PropsWithChildren<Cre
                 )}
             />
 
-            <Route
-                path={`${match.url}/group-results`}
-                render={() => (
-                    <InsightCreationLazyPage
-                        mode={InsightCreationPageType.Compute}
-                        telemetryService={telemetryService}
-                    />
-                )}
-            />
+            {codeInsightsCompute && (
+                <Route
+                    path={`${match.url}/group-results`}
+                    render={() => (
+                        <InsightCreationLazyPage
+                            mode={InsightCreationPageType.Compute}
+                            telemetryService={telemetryService}
+                        />
+                    )}
+                />
+            )}
         </Switch>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
+import { useExperimentalFeatures } from '../../../../../stores'
 import { CodeInsightsBackendContext, CreationInsightInput } from '../../../core'
 import { useQueryParameters } from '../../../hooks'
 
@@ -36,6 +37,8 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
 
     const { dashboardId } = useQueryParameters(['dashboardId'])
     const dashboard = useObservable(useMemo(() => getDashboardById({ dashboardId }), [getDashboardById, dashboardId]))
+
+    const { codeInsightsCompute } = useExperimentalFeatures()
 
     if (dashboard === undefined) {
         return <LoadingSpinner inline={false} />
@@ -84,7 +87,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
         )
     }
 
-    if (mode === InsightCreationPageType.Compute) {
+    if (codeInsightsCompute && mode === InsightCreationPageType.Compute) {
         return (
             <ComputeInsightCreationPage
                 telemetryService={telemetryService}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1775,6 +1775,8 @@ type SettingsExperimentalFeatures struct {
 	ShowSearchNotebook *bool `json:"showSearchNotebook,omitempty"`
 	// TreeSitterEnabled description: DEPRECATED: Enables tree sitter for enabled filetypes.
 	TreeSitterEnabled *bool `json:"treeSitterEnabled,omitempty"`
+	// CodeInsightsCompute description: Enables Compute powered Code Insights.
+	CodeInsightsCompute *bool `json:"codeInsightsCompute,omitempty"`
 }
 
 // SiteConfiguration description: Configuration for a Sourcegraph site.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -324,6 +324,14 @@
           "!go": {
             "pointer": true
           }
+        },
+        "codeInsightsCompute": {
+          "description": "Enables Compute powered Code Insights",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
         }
       },
       "group": "Experimental"


### PR DESCRIPTION
Adds `codeInsightsCompute` experimental feature flag.

## Test plan

Navigating to /insights/create/group-results should render a blank page
Add the experimentalFeature flag `"codeInsightsCompute": true`
Navigating to /insights/create/group-results should render the create  page