### PR TITLE
dev/sg: improve error handling in updates

### DIFF
--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -51,9 +51,12 @@ func updateToPrebuiltSG(ctx context.Context) (string, error) {
 	// with redirections.
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "GitHub latest release")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return "", errors.Newf("GitHub latest release: unexpected status code %d", resp.StatusCode)
+	}
 
 	location := resp.Header.Get("location")
 	if location == "" {


### PR DESCRIPTION
Some users reported `sg` installations getting botched (https://sourcegraph.slack.com/archives/C01N83PS4TU/p1657925934690789) - this might have been fixed by #38848 , but just to be safe I did an audit of our error handling in auto updates and found a few places to make some improvements.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a