### PR TITLE
dev/sg: forcibly exit on double interrupt

### DIFF
--- a/dev/sg/interrupt/interrupt.go
+++ b/dev/sg/interrupt/interrupt.go
@@ -17,10 +17,16 @@ func Register(hook func()) {
 // Listen starts a goroutine that listens for interrupts and executes registered hooks
 // before exiting with status 1.
 func Listen() {
-	interrupt := make(chan os.Signal, 1)
+	interrupt := make(chan os.Signal, 2)
 	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		<-interrupt
+		go func() {
+			// If we receive a second interrupt, forcibly exit.
+			<-interrupt
+			os.Exit(1)
+		}()
+
 		for _, h := range hooks {
 			h()
 		}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -156,7 +156,7 @@ var sg = &cli.App{
 		if err != nil {
 			std.Out.WriteWarningf("Unable to infer user shell context: " + err.Error())
 		}
-		cmd.Context = background.Context(cmd.Context)
+		cmd.Context = background.Context(cmd.Context, verbose)
 		interrupt.Register(func() { background.Wait(cmd.Context, std.Out) })
 
 		// Set up analytics and hooks for each command.
@@ -218,7 +218,7 @@ var sg = &cli.App{
 				if err != nil {
 					out.WriteWarningf("update check: %s", err)
 				}
-			}, verbose)
+			})
 		}
 
 		// Call registered hooks last


### PR DESCRIPTION
Implements https://github.com/sourcegraph/sourcegraph/pull/38848#discussion_r921944149 . I also noticed that it's annoying to provide `verbose` on every `background.Run` when it could just be set up once, so I bundled that into this change as well

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


<img width="513" alt="image" src="https://user-images.githubusercontent.com/23356519/179338470-399b8dc0-f99e-4877-bb5e-528bf21f38b9.png">
