### PR TITLE
[SG-35532] Accessibility: Compare page: Focus lost when selecting a revision

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
@@ -3,7 +3,16 @@ import React, { DOMAttributes, useRef, useState } from 'react'
 import { mdiFilterOutline } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Button, createRectangle, Popover, PopoverContent, PopoverTrigger, Position, Icon } from '@sourcegraph/wildcard'
+import {
+    Button,
+    createRectangle,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    Position,
+    useUpdateEffect,
+    Icon,
+} from '@sourcegraph/wildcard'
 
 import { Insight, InsightFilters } from '../../../../../../core'
 import { FormChangeEvent, SubmissionResult } from '../../../../../form/hooks/useForm'
@@ -76,6 +85,12 @@ export const DrillDownFiltersPopover: React.FunctionComponent<
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         onInsightCreate(values)
     }
+
+    useUpdateEffect(() => {
+        if (!isOpen) {
+            targetButtonReference.current?.focus()
+        }
+    }, [isOpen])
 
     return (
         <Popover isOpen={isOpen} anchor={anchor} onOpenChange={event => onVisibilityChange(event.isOpen)}>

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-learn-more/CodeInsightsLearnMore.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-learn-more/CodeInsightsLearnMore.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, PopoverTrigger, FeedbackPrompt, H2, H3, Text } from '@sourcegraph/wildcard'
@@ -14,6 +14,7 @@ export const CodeInsightsLearnMore: React.FunctionComponent<
     React.PropsWithChildren<CodeInsightsLearnMoreProps>
 > = props => {
     const { telemetryService, ...otherProps } = props
+    const triggerButtonReference = useRef<HTMLButtonElement>(null)
     const textDocumentClickPingName = useLogEventName('InsightsGetStartedDocsClicks')
 
     const { handleSubmitFeedback } = useHandleSubmitFeedback({
@@ -62,8 +63,13 @@ export const CodeInsightsLearnMore: React.FunctionComponent<
                         Have a question or idea about Code Insights? We want to hear your feedback!
                     </Text>
 
-                    <FeedbackPrompt onSubmit={handleSubmitFeedback}>
-                        <PopoverTrigger as={Button} variant="link" className={styles.feedbackTrigger}>
+                    <FeedbackPrompt onSubmit={handleSubmitFeedback} triggerButtonReference={triggerButtonReference}>
+                        <PopoverTrigger
+                            as={Button}
+                            variant="link"
+                            className={styles.feedbackTrigger}
+                            ref={triggerButtonReference}
+                        >
                             Share your thoughts
                         </PopoverTrigger>
                     </FeedbackPrompt>

--- a/client/web/src/extensions/extension/SourcegraphExtensionFeedback.tsx
+++ b/client/web/src/extensions/extension/SourcegraphExtensionFeedback.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 
 import { Button, FeedbackPrompt } from '@sourcegraph/wildcard'
 
@@ -11,15 +11,21 @@ interface SourcegraphExtensionFeedbackProps {
 export const SourcegraphExtensionFeedback: React.FunctionComponent<
     React.PropsWithChildren<SourcegraphExtensionFeedbackProps>
 > = ({ extensionID }) => {
+    const triggerButtonReference = useRef<HTMLButtonElement>(null)
     const textPrefix = `Sourcegraph extension ${extensionID}: `
     const labelId = 'sourcegraph-extension-feedback-modal'
 
     const { handleSubmitFeedback } = useHandleSubmitFeedback({ textPrefix })
 
     return (
-        <FeedbackPrompt modal={true} modalLabelId={labelId} onSubmit={handleSubmitFeedback}>
+        <FeedbackPrompt
+            triggerButtonReference={triggerButtonReference}
+            modal={true}
+            modalLabelId={labelId}
+            onSubmit={handleSubmitFeedback}
+        >
             {({ onClick }) => (
-                <Button className="p-0" onClick={onClick} variant="link">
+                <Button className="p-0" onClick={onClick} variant="link" ref={triggerButtonReference}>
                     <small>Message the author</small>
                 </Button>
             )}

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -161,6 +161,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
     searchContextsEnabled,
     ...props
 }) => {
+    const triggerButtonReference = useRef<HTMLButtonElement>(null)
     // Workaround: can't put this in optional parameter value because of https://github.com/babel/babel/issues/11166
     branding = branding ?? window.context?.branding
 
@@ -347,13 +348,18 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
                     {props.authenticatedUser?.siteAdmin && <AnalyticsNavItem />}
                     {props.authenticatedUser && (
                         <NavAction>
-                            <FeedbackPrompt onSubmit={handleSubmitFeedback} productResearchEnabled={true}>
+                            <FeedbackPrompt
+                                triggerButtonReference={triggerButtonReference}
+                                onSubmit={handleSubmitFeedback}
+                                productResearchEnabled={true}
+                            >
                                 <PopoverTrigger
                                     as={Button}
                                     aria-label="Feedback"
                                     variant="secondary"
                                     outline={true}
                                     size="sm"
+                                    ref={triggerButtonReference}
                                     className={styles.feedbackTrigger}
                                 >
                                     <span>Feedback</span>

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState, useRef } from 'react'
 
 import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
@@ -22,7 +22,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { RevisionSpec } from '@sourcegraph/shared/src/util/url'
-import { Button, Popover, PopoverContent, PopoverTrigger, Position } from '@sourcegraph/wildcard'
+import { Button, Popover, PopoverContent, PopoverTrigger, Position, useUpdateEffect } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { BatchChangesProps } from '../batches'
@@ -132,8 +132,16 @@ interface RepoRevisionBreadcrumbProps extends Pick<RepoRevisionContainerProps, '
 const RepoRevisionContainerBreadcrumb: React.FunctionComponent<
     React.PropsWithChildren<RepoRevisionBreadcrumbProps>
 > = ({ revision, resolvedRevisionOrError, repo }) => {
+    const popoverTriggerReference = useRef<HTMLButtonElement | null>(null)
     const [popoverOpen, setPopoverOpen] = useState(false)
     const togglePopover = useCallback(() => setPopoverOpen(previous => !previous), [])
+
+    useUpdateEffect(() => {
+        if (!popoverOpen) {
+            popoverTriggerReference.current?.focus()
+        }
+    }, [popoverOpen])
+
     return (
         <Popover isOpen={popoverOpen} onOpenChange={event => setPopoverOpen(event.isOpen)}>
             <PopoverTrigger
@@ -145,6 +153,7 @@ const RepoRevisionContainerBreadcrumb: React.FunctionComponent<
                 outline={true}
                 variant="secondary"
                 size="sm"
+                ref={popoverTriggerReference}
             >
                 {(revision && revision === resolvedRevisionOrError.commitID
                     ? resolvedRevisionOrError.commitID.slice(0, 7)

--- a/client/web/src/repo/compare/RepositoryComparePopover.tsx
+++ b/client/web/src/repo/compare/RepositoryComparePopover.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 
 import { escapeRevspecForURL } from '@sourcegraph/common'
-import { Button, Popover, PopoverContent, PopoverTrigger, Position } from '@sourcegraph/wildcard'
+import { Button, Popover, PopoverContent, PopoverTrigger, Position, useUpdateEffect } from '@sourcegraph/wildcard'
 
 import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -38,6 +38,7 @@ interface RepositoryComparePopoverProps {
 export const RepositoryComparePopover: React.FunctionComponent<
     React.PropsWithChildren<RepositoryComparePopoverProps>
 > = ({ id, comparison, repo, type }) => {
+    const popoverTriggerReference = useRef<HTMLButtonElement | null>(null)
     const [popoverOpen, setPopoverOpen] = useState(false)
     const togglePopover = (): void => setPopoverOpen(previous => !previous)
 
@@ -68,6 +69,12 @@ export const RepositoryComparePopover: React.FunctionComponent<
     const defaultBranch = repo.defaultBranch?.abbrevName || 'HEAD'
     const currentRevision = comparison[type]?.revision || undefined
 
+    useUpdateEffect(() => {
+        if (!popoverOpen) {
+            popoverTriggerReference.current?.focus()
+        }
+    }, [popoverOpen])
+
     return (
         <Popover isOpen={popoverOpen} onOpenChange={event => setPopoverOpen(event.isOpen)}>
             <PopoverTrigger
@@ -76,6 +83,7 @@ export const RepositoryComparePopover: React.FunctionComponent<
                 outline={true}
                 className="d-flex align-items-center text-nowrap"
                 id={id}
+                ref={popoverTriggerReference}
                 aria-label={`Change ${type} Git revspec for comparison`}
             >
                 <div className="text-muted mr-1">{type}: </div>

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
@@ -4,7 +4,7 @@ import { mdiClose, mdiCheck } from '@mdi/js'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, useUpdateEffect } from '@sourcegraph/wildcard'
 
 import { Popover, PopoverContent, Position, Button, FlexTextArea, LoadingSpinner, Link, H3, Text } from '../..'
 import { useAutoFocus, useLocalStorage } from '../../..'
@@ -191,6 +191,7 @@ interface FeedbackPromptProps extends FeedbackPromptContentProps {
     modal?: boolean
     modalLabelId?: string
     children: React.FunctionComponent<React.PropsWithChildren<FeedbackPromptTriggerProps>> | ReactNode
+    triggerButtonReference?: React.RefObject<HTMLButtonElement>
 }
 
 export const FeedbackPrompt: React.FunctionComponent<FeedbackPromptProps> = ({
@@ -202,6 +203,7 @@ export const FeedbackPrompt: React.FunctionComponent<FeedbackPromptProps> = ({
     modal = false,
     modalLabelId = 'sourcegraph-feedback-modal',
     productResearchEnabled,
+    triggerButtonReference,
 }) => {
     const [isOpen, setIsOpen] = useState(() => !!openByDefault)
     const ChildrenComponent = typeof children === 'function' && children
@@ -223,6 +225,12 @@ export const FeedbackPrompt: React.FunctionComponent<FeedbackPromptProps> = ({
             onClose={handleClosePrompt}
         />
     )
+
+    useUpdateEffect(() => {
+        if (!isOpen && triggerButtonReference) {
+            triggerButtonReference.current?.focus()
+        }
+    }, [isOpen])
 
     if (modal) {
         return (

--- a/client/wildcard/src/hooks/index.ts
+++ b/client/wildcard/src/hooks/index.ts
@@ -18,6 +18,7 @@ export { useSearchParameters } from './useSearchParameters'
 export { useStopwatch } from './useStopwatch'
 export { useTimeoutManager } from './useTimeoutManager'
 export { WildcardThemeContext, useWildcardTheme } from './useWildcardTheme'
+export { useUpdateEffect } from './useUpdateEffect'
 // Export type is required to avoid Webpack warnings.
 export type { WildcardTheme } from './useWildcardTheme'
 export { useWindowSize } from './useWindowSize'

--- a/client/wildcard/src/hooks/useUpdateEffect.ts
+++ b/client/wildcard/src/hooks/useUpdateEffect.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * This hook is the same as `useEffect` but ignore the first call for `didMount`
+ */
+export const useUpdateEffect: typeof useEffect = (effect, deps): void => {
+    const isFirst = useRef(true)
+
+    useEffect(() => {
+        if (!isFirst.current) {
+            return effect()
+        }
+
+        isFirst.current = false
+
+        // We only care about `deps` for this hook usages
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, deps)
+}


### PR DESCRIPTION
## Description
After opening Popover and selecting revision to compare on the repository comparison page the focus doesn't return to the trigger button.
- This happens for `Popover` which renders `Input` with `autoFocus`
### Problem description
Using a keyboard, select a revision like this:
![compare pic](https://user-images.githubusercontent.com/9516420/168784823-0544a352-150b-4158-9647-a89240033f81.png)
Notice that focus is lost
 > This happens in components with PopoverContent with text field + autoFocus inside
### Expected behavior
Focus should be returned to the trigger that opened the selector (the button)
## Refs
- [Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/35532)
- [Gitstart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35532)

## Test plan
- Navigate to [this page](https://k8s.sgdev.org/github.com/sourcegraph/sourcegraph/-/compare) trigger the revision popover buttons,. These buttons should regain focus after popover is closed.
- Do same for other use cases of popover

### Limitation
Unable to cleanly maintain focus on `RepoContainer`'s Popover since `useMemo` gets re-rendered (Input element's autoFocus takes the focus here) when we control open state of `Popover` as in other use cases.

## App preview:

- [Web](https://sg-web-contractors-sg-35532.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vbefcxiwdm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

