### PR TITLE
doc: drop duplicate info in browser extension readme

### DIFF
--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -14,7 +14,6 @@ The tooltips include features like:
 
 - symbol type information & documentation
 - go to definition & find references (currently for Go, Java, TypeScript, JavaScript, Python)
-- find references
 
 #### 🚀 Install: [**Sourcegraph for Chrome**](https://chrome.google.com/webstore/detail/sourcegraph/dgjhfomjieaadpoljlnidmbgkdffpack)
 


### PR DESCRIPTION
"Find references" is said twice.