### PR TITLE
sg: remove feedback flag from parent command

### DIFF
--- a/dev/sg/sg_feedback.go
+++ b/dev/sg/sg_feedback.go
@@ -40,7 +40,6 @@ func addFeedbackFlags(commands []*cli.Command) {
 			}
 		}
 		
-
 		addFeedbackFlags(command.Subcommands)
 	}
 }

--- a/dev/sg/sg_feedback.go
+++ b/dev/sg/sg_feedback.go
@@ -29,23 +29,17 @@ func addFeedbackFlags(commands []*cli.Command) {
 	}
 
 	for _, command := range commands {
-		// if the command is an ancestor command, there's no need to add the feedback
-		// flag to the command, we bail out early here.
-		if command.Action == nil {
-			if len(command.Subcommands) != 0 {
-				addFeedbackFlags(command.Subcommands)
+		if command.Action != nil {
+			command.Flags = append(command.Flags, &feedbackFlag)
+			action := command.Action
+			command.Action = func(ctx *cli.Context) error {
+				if feedbackFlag.Get(ctx) {
+					return feedbackAction(ctx)
+				}
+				return action(ctx)
 			}
-			continue
 		}
-
-		command.Flags = append(command.Flags, &feedbackFlag)
-		action := command.Action
-		command.Action = func(ctx *cli.Context) error {
-			if feedbackFlag.Get(ctx) {
-				return feedbackAction(ctx)
-			}
-			return action(ctx)
-		}
+		
 
 		addFeedbackFlags(command.Subcommands)
 	}

--- a/dev/sg/sg_feedback.go
+++ b/dev/sg/sg_feedback.go
@@ -32,6 +32,9 @@ func addFeedbackFlags(commands []*cli.Command) {
 		// if the command is an ancestor command, there's no need to add the feedback
 		// flag to the command, we bail out early here.
 		if command.Action == nil {
+			if len(command.Subcommands) != 0 {
+				addFeedbackFlags(command.Subcommands)
+			}
 			continue
 		}
 

--- a/dev/sg/sg_feedback.go
+++ b/dev/sg/sg_feedback.go
@@ -29,6 +29,12 @@ func addFeedbackFlags(commands []*cli.Command) {
 	}
 
 	for _, command := range commands {
+		// if the command is an ancestor command, there's no need to add the feedback
+		// flag to the command, we bail out early here.
+		if command.Action == nil {
+			continue
+		}
+
 		command.Flags = append(command.Flags, &feedbackFlag)
 		action := command.Action
 		command.Action = func(ctx *cli.Context) error {

--- a/dev/sg/sg_feedback.go
+++ b/dev/sg/sg_feedback.go
@@ -39,7 +39,7 @@ func addFeedbackFlags(commands []*cli.Command) {
 				return action(ctx)
 			}
 		}
-		
+
 		addFeedbackFlags(command.Subcommands)
 	}
 }

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -179,10 +179,6 @@ $ sg ci build --force --commit my-commit main-dry-run
 $ sg ci build --help
 ```
 
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
-
 ### sg ci preview
 
 Preview the pipeline that would be run against the currently checked out branch.
@@ -459,10 +455,6 @@ $ sg db reset-redis
 $ sg db add-user -name=foo
 ```
 
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
-
 ### sg db reset-pg
 
 Drops, recreates and migrates the specified Sourcegraph database.
@@ -517,10 +509,6 @@ $ sg migration add --db codeintel 'add missing index'
 # Squash migrations for default database
 $ sg migration squash
 ```
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
 
 ### sg migration add
 
@@ -794,10 +782,6 @@ Flags:
 Tools to interact with Code Insights data.
 
 
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
-
 ### sg insights decode-id
 
 Decodes an encoded insight ID found on the frontend into a view unique_id.
@@ -841,10 +825,6 @@ $ sg secret list
 # ease of use
 $ sg secret reset buildkite
 ```
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
 
 ### sg secret reset
 
@@ -894,10 +874,6 @@ $ sg teammate time thorsten ball
 # Open their handbook bio
 $ sg teammate handbook asdine
 ```
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
 
 ### sg teammate time
 
@@ -966,10 +942,6 @@ $ sg adr view 420
 # Create a new ADR!
 $ sg adr create my ADR title
 ```
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
 
 ### sg adr list
 
@@ -1045,10 +1017,6 @@ Commands used by operations teams to perform common tasks.
 Supports internal deploy-sourcegraph repos (non-customer facing)
 
 
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
-
 ### sg ops update-images
 
 Updates images in given directory to latest published image.
@@ -1090,10 +1058,6 @@ Flags:
 
 Manage analytics collected by sg.
 
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
 
 ### sg analytics submit
 


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Running a parent command (i.e a. command that has subcommands) like `sg db` or `sg migration` now displays the appropriate help text.

### Context

When I ran a parent command `sg adr` to get the available subcommands resulted in a panic. I tested with commands without subcommands, and they work fine.

Before | After 
:-------:|:-------:|
<img width="521" alt="CleanShot 2022-07-18 at 05 58 09@2x" src="https://user-images.githubusercontent.com/25608335/179447805-d7c16775-813d-4f7c-bf0c-327d314bca70.png"> |  <img width="517" alt="CleanShot 2022-07-18 at 06 02 55@2x" src="https://user-images.githubusercontent.com/25608335/179448169-99799758-11e5-404d-8276-05dfc580f3bf.png">

A major side-effect of this PR is that the parent commands won't have the `--feedback` flag included in the doc anymore, however the flag will continue to work.
The documentation generated should reflect the above point.