### PR TITLE
[SG-38783] Multiple `H1`s on Batch Changes list page

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -152,7 +152,6 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
     return (
         <Page>
             <PageHeader
-                path={[{ icon: BatchChangesIcon, text: 'Batch Changes' }]}
                 className="test-batches-list-page mb-3"
                 // TODO: As we haven't finished implementing support for orgs, we've
                 // temporary disabled setting a different namespace. Replace this line
@@ -162,7 +161,11 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                 // actions={canCreate ? <NewBatchChangeButton to={`${location.pathname}/create`} /> : null}
                 headingElement={headingElement}
                 description="Run custom code over hundreds of repositories and manage the resulting changesets."
-            />
+            >
+                <PageHeader.Heading as="h2" styleAs="h1">
+                    <PageHeader.Breadcrumb icon={BatchChangesIcon}>Batch Changes</PageHeader.Breadcrumb>
+                </PageHeader.Heading>
+            </PageHeader>
             <BatchChangesListIntro isLicensed={licenseAndUsageInfo?.batchChanges || licenseAndUsageInfo?.campaigns} />
             <BatchChangeListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
             {selectedTab === 'gettingStarted' && <GettingStarted className="mb-4" footer={<GettingStartedFooter />} />}
@@ -171,9 +174,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                     <ConnectionContainer>
                         <div className={styles.filtersRow}>
                             {(licenseAndUsageInfo?.allBatchChanges.totalCount || 0) > 0 && (
-                                <H3 as={H2} className="align-self-end flex-1">
-                                    {`${lastTotalCount} batch changes`}
-                                </H3>
+                                <H3 className="align-self-end flex-1">{`${lastTotalCount} batch changes`}</H3>
                             )}
                             <H4 as={H3} className="mb-0 mr-2">
                                 Status

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { CardBody, Card, H2, H4, Link, Code } from '@sourcegraph/wildcard'
+import { CardBody, Card, Link, Code, H3, H4 } from '@sourcegraph/wildcard'
 
 import { DismissibleAlert } from '../../../components/DismissibleAlert'
 
@@ -15,7 +15,7 @@ export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWith
     >
         <Card className={classNames(styles.batchChangesListIntroCard, 'h-100')}>
             <CardBody>
-                <H4 as={H2}>Batch Changes updates in version 3.41</H4>
+                <H4 as={H3}>Batch Changes updates in version 3.41</H4>
                 <ul className="mb-0 pl-3">
                     <li>
                         <Link to="/help/batch_changes/explanations/server_side" rel="noopener" target="_blank">


### PR DESCRIPTION
### Description
All the warnings reported under ARC Toolkit's "Structure and Semantics" tests for `Batch Changes` page is solved

### Problem description
On the batch changes list page (`/batch-changes`), there are multiple `<H1/>` elements: the Sourcegraph logo in the navigation bar, and the "Batch Changes" page title, which produces a warning in ARC Toolkit:

<img width="1945" alt="image" src="https://user-images.githubusercontent.com/8942601/178868153-608d495a-345a-4769-8eea-0a91d18af130.png">

### Expected behavior
- The "Batch Changes" page title should be an `<H2/>`, but retain the current style.
- All other `<H2/>`s on the page should be downscaled to `<H3/>`, but retain their current styles.
- No warnings are reported under ARC Toolkit's "Structure and Semantics" tests.

### Refs
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-38783)
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/38783)

## Test Plan

- Go to `Batch Changes` Page
- Ensure no warnings are reported under ARC Toolkit's "Structure and Semantics" tests
- Ensure that "Batch Changes" page title should is an `h2`
- Ensure that All other `h2s` on the page should be downscaled to `h3`

## App preview:

- [Web](https://sg-web-contractors-sg-38783.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-exzdanfsgo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
