### PR TITLE
Migrate graphqlbackend.RepositoryResolver to use sg/log

### DIFF
--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -3,6 +3,8 @@ package graphqlbackend
 import (
 	"sync"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
@@ -17,6 +19,7 @@ type CommitSearchResultResolver struct {
 	// Use Commit() instead.
 	gitCommitResolver *GitCommitResolver
 	gitCommitOnce     sync.Once
+	logger            log.Logger
 }
 
 func (r *CommitSearchResultResolver) Commit() *GitCommitResolver {

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -17,6 +17,8 @@ import (
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -83,7 +85,7 @@ func TestResolverTo(t *testing.T) {
 		&FileMatchResolver{db: db},
 		&NamespaceResolver{},
 		&NodeResolver{},
-		&RepositoryResolver{db: db},
+		&RepositoryResolver{db: db, logger: logtest.Scoped(t)},
 		&CommitSearchResultResolver{},
 		&gitRevSpec{},
 		&settingsSubject{},

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -66,7 +66,10 @@ func NewRepositoryResolver(db database.DB, repo *types.Repo) *RepositoryResolver
 			Name: name,
 			ID:   id,
 		},
-		logger: log.Scoped("nodes.repositoryResolver", ""),
+		logger: log.Scoped("repositoryResolver", "resolve a specific repository").
+			With(log.Object("repo",
+				log.String("name", string(name)),
+				log.String("id", string(id)))),
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -69,7 +69,7 @@ func NewRepositoryResolver(db database.DB, repo *types.Repo) *RepositoryResolver
 		logger: log.Scoped("repositoryResolver", "resolve a specific repository").
 			With(log.Object("repo",
 				log.String("name", string(name)),
-				log.String("id", string(id)))),
+				log.Int32("id", int32(id)))),
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 
 	"github.com/graph-gophers/graphql-go"
@@ -70,8 +69,7 @@ type UserResolver struct {
 func NewUserResolver(db database.DB, user *types.User) *UserResolver {
 	return &UserResolver{db: db, user: user, logger: log.Scoped("userResolver", "resolves a specific user").With(
 		log.Object("repo",
-			log.String("db", fmt.Sprintf("%v", db)),
-			log.String("user", fmt.Sprintf("%v ", user)))),
+			log.String("user", user.Username))),
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	"github.com/graph-gophers/graphql-go"
@@ -67,7 +68,11 @@ type UserResolver struct {
 
 // NewUserResolver returns a new UserResolver with given user object.
 func NewUserResolver(db database.DB, user *types.User) *UserResolver {
-	return &UserResolver{db: db, user: user}
+	return &UserResolver{db: db, user: user, logger: log.Scoped("userResolver", "resolves a specific user").With(
+		log.Object("repo",
+			log.String("db", fmt.Sprintf("%v", db)),
+			log.String("user", fmt.Sprintf("%v ", user)))),
+	}
 }
 
 // UserByID looks up and returns the user with the given GraphQL ID. If no such user exists, it returns a

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/sourcegraph/log"
@@ -109,8 +108,7 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, er
 			user: user,
 			logger: log.Scoped("userResolver", "resolves a specific user").With(
 				log.Object("repo",
-					log.String("db", fmt.Sprintf("%v", r.db)),
-					log.String("user", fmt.Sprintf("%v ", user)))),
+					log.String("user", user.Username))),
 		})
 	}
 	return l, nil

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -2,7 +2,10 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
 	"sync"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -104,6 +107,10 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, er
 		l = append(l, &UserResolver{
 			db:   r.db,
 			user: user,
+			logger: log.Scoped("userResolver", "resolves a specific user").With(
+				log.Object("repo",
+					log.String("db", fmt.Sprintf("%v", r.db)),
+					log.String("user", fmt.Sprintf("%v ", user)))),
 		})
 	}
 	return l, nil

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -615,6 +615,7 @@ func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graph
 					Repositories:      series.RepositoryScope.Repositories,
 					StepIntervalUnit:  series.TimeScope.StepInterval.Unit,
 					StepIntervalValue: int(series.TimeScope.StepInterval.Value),
+					GroupBy:           lowercaseGroupBy(series.GroupBy),
 				})
 				if err != nil {
 					return nil, errors.Wrap(err, "UpdateFrontendSeries")
@@ -1017,12 +1018,10 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, scopedBa
 		dynamic = *series.GeneratedFromCaptureGroups
 	}
 
-	var groupBy *string
+	groupBy := lowercaseGroupBy(series.GroupBy)
 	var nextRecordingAfter time.Time
 	var oldestHistoricalAt time.Time
 	if series.GroupBy != nil {
-		temp := strings.ToLower(*series.GroupBy)
-		groupBy = &temp
 		// We want to disable interval recording for compute types.
 		// December 31, 9999 is the maximum possible date in postgres.
 		nextRecordingAfter = time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
@@ -1317,4 +1316,12 @@ func minInt(a, b int32) int32 {
 		return a
 	}
 	return b
+}
+
+func lowercaseGroupBy(groupBy *string) *string {
+	if groupBy != nil {
+		temp := strings.ToLower(*groupBy)
+		return &temp
+	}
+	return groupBy
 }

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -880,10 +880,18 @@ type UpdateFrontendSeriesArgs struct {
 	Repositories      []string
 	StepIntervalUnit  string
 	StepIntervalValue int
+	GroupBy           *string
 }
 
 func (s *InsightStore) UpdateFrontendSeries(ctx context.Context, args UpdateFrontendSeriesArgs) error {
-	return s.Exec(ctx, sqlf.Sprintf(updateFrontendSeriesSql, args.Query, pq.Array(args.Repositories), args.StepIntervalUnit, args.StepIntervalValue, args.SeriesID))
+	return s.Exec(ctx, sqlf.Sprintf(updateFrontendSeriesSql,
+		args.Query,
+		pq.Array(args.Repositories),
+		args.StepIntervalUnit,
+		args.StepIntervalValue,
+		args.GroupBy,
+		args.SeriesID,
+	))
 }
 
 func (s *InsightStore) GetReferenceCount(ctx context.Context, id int) (int, error) {
@@ -1083,7 +1091,7 @@ WHERE series.series_id = %s
 const updateFrontendSeriesSql = `
 -- source: enterprise/internal/insights/store/insight_store.go:UpdateFrontendSeries
 UPDATE insight_series
-SET query = %s, repositories = %s, sample_interval_unit = %s, sample_interval_value = %s
+SET query = %s, repositories = %s, sample_interval_unit = %s, sample_interval_value = %s, group_by = %s
 WHERE series_id = %s
 `
 

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ require (
 	golang.org/x/net v0.0.0-20220526153639-5463443f8c37
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306
 	golang.org/x/tools v0.1.10
 	gonum.org/v1/gonum v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -2667,6 +2667,8 @@ golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=


### PR DESCRIPTION
## Description

Add a logger to schemaResolver, and initialize it with log.Scoped (or logtest where appropriate) wherever schemaResolver is created (unless an existing logger is easily available, in which case that should be used)
Add a logger to RepositoryResolver, and let it be injected from NewRepositoryResolver. Use log.Scoped (or logtest where appropriate) to provide the logger at [all usages of NewRepositoryResolver](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Ecmd/frontend/graphqlbackend+NewRepositoryResolver&patternType=literal)
[3 log15 usages inside cmd/frontend/graphqlbackend/repository.go](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Ecmd/frontend/graphqlbackend/repository%5C.go+log15+&patternType=literal) are replaced with calls to the appropriate logger
## Test plan
- A good way to test this PR is just to run the branch locally, and open [the issue link](https://github.com/sourcegraph/sourcegraph/issues/36382), compare the changes on the PR and the listed issues. All of them must be fixed
## Refs
- [SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/36382)
- [GitStart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-37398)