### PR TITLE
Update jaeger versions

### DIFF
--- a/docker-images/jaeger-agent/build.sh
+++ b/docker-images/jaeger-agent/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-export JAEGER_VERSION="${JAEGER_VERSION:-1.24.0}"
+export JAEGER_VERSION="${JAEGER_VERSION:-1.36.0}"
 IMAGE=${IMAGE:-sourcegraph/jaeger-agent}
 
 echo "Building image ${IMAGE} from Jaeger ${JAEGER_VERSION}"

--- a/docker-images/jaeger-all-in-one/build.sh
+++ b/docker-images/jaeger-all-in-one/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-export JAEGER_VERSION="${JAEGER_VERSION:-1.34.1}"
+export JAEGER_VERSION="${JAEGER_VERSION:-1.36.0}"
 IMAGE=${IMAGE:-sourcegraph/jaeger-all-in-one}
 
 echo "Building image ${IMAGE} from Jaeger ${JAEGER_VERSION}"


### PR DESCRIPTION
This takes us to Golang 1.18 on jaeger, which contains several security fixes
in jaeger's dependencies.

There's only a single breaking change that's relevant – in v1.29.0, a deprecated
CLI flag that we don't appear to use was removed. See https://github.com/jaegertracing/jaeger/releases/tag/v1.29.0

## Test plan

CI checks
