### PR TITLE
docs: fix inconsistent indendation of headers

### DIFF
--- a/doc/dev/background-information/languages/go_errors.md
+++ b/doc/dev/background-information/languages/go_errors.md
@@ -80,7 +80,7 @@ if err := Some(ctx); err != nil {
 
 As with the `Is` function, the second argument to this function should generally be an error constant.
 
-#### Use of `errors.HasType`
+## Use of `errors.HasType`
 
 Use this function to determine if a given error has a particular type.
 


### PR DESCRIPTION
Pretty sure this was an oversight. All the other headers are `h2` and not `h4`.

## Test plan

- N/A