### PR TITLE
searcher: use DiffSymbols instead of git.Command

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -56,7 +56,7 @@ func (s *Service) hybrid(ctx context.Context, p *protocol.Request, sender matchS
 		// TODO if our store was more flexible we could cache just based on
 		// indexed and p.Commit and avoid the need of running diff for each
 		// search.
-		out, err := s.GitOutput(ctx, p.Repo, "diff", "-z", "--name-status", "--no-renames", string(indexed), string(p.Commit))
+		out, err := s.GitDiffSymbols(ctx, p.Repo, indexed, p.Commit)
 		if err != nil {
 			return nil, false, err
 		}

--- a/cmd/searcher/internal/search/hybrid_test.go
+++ b/cmd/searcher/internal/search/hybrid_test.go
@@ -108,10 +108,12 @@ Hello world example in go
 
 	// we expect one command against git, lets just fake it.
 	ts := httptest.NewServer(&search.Service{
-		GitOutput: func(ctx context.Context, repo api.RepoName, args ...string) ([]byte, error) {
-			want := []string{"diff", "-z", "--name-status", "--no-renames", "indexedfdeadbeefdeadbeefdeadbeefdeadbeef", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}
-			if d := cmp.Diff(want, args); d != "" {
-				return nil, errors.Errorf("git diff mismatch (-want, +got):\n%s", d)
+		GitDiffSymbols: func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error) {
+			if commitA != "indexedfdeadbeefdeadbeefdeadbeefdeadbeef" {
+				return nil, errors.Errorf("expected first commit to be indexed, got: %s", commitA)
+			}
+			if commitB != "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" {
+				return nil, errors.Errorf("expected first commit to be unindexed, got: %s", commitB)
 			}
 			return []byte(gitDiffOutput), nil
 		},

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -51,12 +51,11 @@ type Service struct {
 	Store *Store
 	Log   log.Logger
 
-	// GitOutput returns the stdout of running git with args against the repo.
+	// GitDiffSymbols returns the stdout of running "git diff -z --name-status
+	// --no-renames commitA commitB" against repo.
 	//
-	// TODO pick a design which doesn't directly depend on Command. Probably
-	// adding a relevant function to the gitserver client. This is only used
-	// by FeatHybrid.
-	GitOutput func(ctx context.Context, repo api.RepoName, args ...string) ([]byte, error)
+	// TODO Git client should be exposing a better API here.
+	GitDiffSymbols func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error)
 }
 
 // ServeHTTP handles HTTP based search requests

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -170,11 +170,8 @@ func run(logger log.Logger) error {
 			ObservationContext: storeObservationContext,
 			DB:                 db,
 		},
-		GitOutput: func(ctx context.Context, repo api.RepoName, args ...string) ([]byte, error) {
-			c := git.GitCommand(repo, args...)
-			return c.Output(ctx)
-		},
-		Log: logger,
+		GitDiffSymbols: git.DiffSymbols,
+		Log:            logger,
 	}
 	service.Store.Start()
 


### PR DESCRIPTION
This runs the same command we are running via git.Command. In the future
we should improve the API here. For now this is a minimal change which
preserves functionality.

Test Plan: go test as well as manually confirming the arguments are the
same in the DiffSymbols implementation.

Part of https://github.com/sourcegraph/sourcegraph/issues/38235