### PR TITLE
dependencies: add remaining fields to LockfileIndex resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/dependencies.go
+++ b/cmd/frontend/graphqlbackend/dependencies.go
@@ -26,4 +26,7 @@ type LockfileIndexConnectionResolver interface {
 type LockfileIndexResolver interface {
 	ID() graphql.ID
 	Lockfile() string
+	Repository() *RepositoryResolver
+	Commit() *GitCommitResolver
+	Fidelity() string
 }

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -36,6 +36,29 @@ type LockfileIndexConnection {
     pageInfo: PageInfo!
 }
 
+
+"""
+Fidelity of a lockfile index.
+"""
+enum LockfileIndexFidelity {
+    """
+    Couldn't build a complete graph from lockfile. It's instead a flat list of
+    dependencies found in the lockfile.
+    """
+    FLAT
+
+    """
+    If we couldn't determine the roots of the dependency graph because it's
+    circular. That means we can't say what's a direct dependency and what not, but
+    we can tell which dependency depends on which other dependency.
+    """
+    CIRCULAR
+
+    """
+    Full dependency graph.
+    """
+    GRAPH
+}
 """
 A lockfile index is an indexed lockfile in a repository.
 """
@@ -49,4 +72,19 @@ type LockfileIndex implements Node {
     The relative path of the lockfile that was resolved and indexed.
     """
     lockfile: String!
+
+    """
+    The repository of the lockfile.
+    """
+    repository: Repository!
+
+    """
+    The commit at which the lockfile was indexed.
+    """
+    commit: GitCommit!
+
+    """
+    The fidelity of the dependency graph.
+    """
+    fidelity: LockfileIndexFidelity!
 }

--- a/enterprise/cmd/frontend/internal/dependencies/init.go
+++ b/enterprise/cmd/frontend/internal/dependencies/init.go
@@ -14,6 +14,6 @@ import (
 // resolvers for Dependencies.
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	// Register enterprise services.
-	enterpriseServices.DependenciesResolver = graphql.New(db)
+	enterpriseServices.DependenciesResolver = graphql.New(db, observationContext.Logger)
 	return nil
 }

--- a/internal/codeintel/dependencies/shared/types.go
+++ b/internal/codeintel/dependencies/shared/types.go
@@ -1,6 +1,8 @@
 package shared
 
 import (
+	"strings"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/lockfiles"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -9,6 +11,8 @@ import (
 // IndexFidelity describes the fidelity of the indexed dependency graph we
 // could get by parsing a lockfile.
 type IndexFidelity string
+
+func (i IndexFidelity) ToGraphQL() string { return strings.ToUpper(string(i)) }
 
 const (
 	// IndexFidelityFlat is the default fidelity if we couldn't build a graph

--- a/internal/codeintel/dependencies/transport/graphql/lockfile_index_connection_resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/lockfile_index_connection_resolver.go
@@ -8,12 +8,12 @@ import (
 )
 
 type LockfileIndexConnectionResolver struct {
-	resolvers  []*LockfileIndexResolver
+	resolvers  []graphqlbackend.LockfileIndexResolver
 	totalCount int
 	nextOffset *int
 }
 
-func NewLockfileIndexConnectionConnection(resolvers []*LockfileIndexResolver, totalCount int, nextOffset *int) *LockfileIndexConnectionResolver {
+func NewLockfileIndexConnectionConnection(resolvers []graphqlbackend.LockfileIndexResolver, totalCount int, nextOffset *int) *LockfileIndexConnectionResolver {
 	return &LockfileIndexConnectionResolver{
 		resolvers:  resolvers,
 		totalCount: totalCount,
@@ -21,12 +21,8 @@ func NewLockfileIndexConnectionConnection(resolvers []*LockfileIndexResolver, to
 	}
 }
 
-func (r *LockfileIndexConnectionResolver) Nodes(ctx context.Context) (resolvers []graphqlbackend.LockfileIndexResolver) {
-	resolvers = make([]graphqlbackend.LockfileIndexResolver, len(r.resolvers))
-	for i, r := range r.resolvers {
-		resolvers[i] = r
-	}
-	return resolvers
+func (r *LockfileIndexConnectionResolver) Nodes(ctx context.Context) []graphqlbackend.LockfileIndexResolver {
+	return r.resolvers
 }
 
 func (r *LockfileIndexConnectionResolver) TotalCount(ctx context.Context) int32 {

--- a/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
@@ -4,15 +4,18 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 )
 
 type LockfileIndexResolver struct {
 	lockfile shared.LockfileIndex
+	repo     *graphqlbackend.RepositoryResolver
+	commit   *graphqlbackend.GitCommitResolver
 }
 
-func NewExecutorResolver(executor shared.LockfileIndex) *LockfileIndexResolver {
-	return &LockfileIndexResolver{lockfile: executor}
+func NewLockfileIndexResolver(lockfile shared.LockfileIndex, repo *graphqlbackend.RepositoryResolver, commit *graphqlbackend.GitCommitResolver) graphqlbackend.LockfileIndexResolver {
+	return &LockfileIndexResolver{lockfile: lockfile, repo: repo, commit: commit}
 }
 
 func (e *LockfileIndexResolver) ID() graphql.ID {
@@ -21,4 +24,16 @@ func (e *LockfileIndexResolver) ID() graphql.ID {
 
 func (e *LockfileIndexResolver) Lockfile() string {
 	return e.lockfile.Lockfile
+}
+
+func (e *LockfileIndexResolver) Repository() *graphqlbackend.RepositoryResolver {
+	return e.repo
+}
+
+func (e *LockfileIndexResolver) Commit() *graphqlbackend.GitCommitResolver {
+	return e.commit
+}
+
+func (e *LockfileIndexResolver) Fidelity() string {
+	return e.lockfile.Fidelity.ToGraphQL()
 }


### PR DESCRIPTION
This just adds the remaining fields to the resolver and cleans up some minor things.

## Test plan

- `echo 'query { lockfileIndexes { nodes { id, repository { name }, lockfile, commit { message } } pageInfo { hasNextPage, endCursor } totalCount } }' | src api`