### PR TITLE
gitserver: Extract GitoliteLister

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -326,17 +326,6 @@ func (c *ClientImplementor) RendezvousAddrForRepo(repo api.RepoName) string {
 	return RendezvousAddrForRepo(repo, addrs)
 }
 
-// addrForKey returns the gitserver address to use for the given string key,
-// which is hashed for sharding purposes.
-func (c *ClientImplementor) addrForKey(key string) string {
-	// TODO: Move zero check into addrForKey and remove this method
-	addrs := c.Addrs()
-	if len(addrs) == 0 {
-		panic("unexpected state: no gitserver addresses")
-	}
-	return addrForKey(key, addrs)
-}
-
 var addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "src_gitserver_addr_for_repo_invoked",
 	Help: "Number of times gitserver.AddrForRepo was invoked",

--- a/internal/gitserver/gitolite.go
+++ b/internal/gitserver/gitolite.go
@@ -12,13 +12,13 @@ import (
 )
 
 type GitoliteLister struct {
-	addrs func() []string
-	cli   httpcli.Doer
+	addrs      func() []string
+	httpClient httpcli.Doer
 }
 
 func NewGitoliteLister(cli httpcli.Doer) *GitoliteLister {
 	return &GitoliteLister{
-		cli: cli,
+		httpClient: cli,
 		addrs: func() []string {
 			return conf.Get().ServiceConnections().GitServers
 		},
@@ -39,7 +39,7 @@ func (c *GitoliteLister) ListRepos(ctx context.Context, gitoliteHost string) (li
 		return nil, err
 	}
 
-	resp, err := c.cli.Do(req.WithContext(ctx))
+	resp, err := c.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitserver/gitolite.go
+++ b/internal/gitserver/gitolite.go
@@ -1,0 +1,50 @@
+package gitserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+)
+
+type GitoliteLister struct {
+	addrs func() []string
+	cli   httpcli.Doer
+}
+
+func NewGitoliteLister(cli httpcli.Doer) *GitoliteLister {
+	return &GitoliteLister{
+		cli: cli,
+		addrs: func() []string {
+			return conf.Get().ServiceConnections().GitServers
+		},
+	}
+}
+
+func (c *GitoliteLister) ListRepos(ctx context.Context, gitoliteHost string) (list []*gitolite.Repo, err error) {
+	addrs := c.addrs()
+	if len(addrs) == 0 {
+		panic("unexpected state: no gitserver addresses")
+	}
+	// The gitserver calls the shared Gitolite server in response to this request, so
+	// we need to only call a single gitserver (or else we'd get duplicate results).
+	addr := addrForKey(gitoliteHost, addrs)
+
+	req, err := http.NewRequest("GET", "http://"+addr+"/list-gitolite?gitolite="+url.QueryEscape(gitoliteHost), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.cli.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&list)
+	return list, err
+}

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -17,7 +17,6 @@ import (
 	diff "github.com/sourcegraph/go-diff/diff"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
 	authz "github.com/sourcegraph/sourcegraph/internal/authz"
-	gitolite "github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	protocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )
@@ -74,9 +73,6 @@ type MockClient struct {
 	// ListClonedFunc is an instance of a mock function object controlling
 	// the behavior of the method ListCloned.
 	ListClonedFunc *ClientListClonedFunc
-	// ListGitoliteFunc is an instance of a mock function object controlling
-	// the behavior of the method ListGitolite.
-	ListGitoliteFunc *ClientListGitoliteFunc
 	// ListRefsFunc is an instance of a mock function object controlling the
 	// behavior of the method ListRefs.
 	ListRefsFunc *ClientListRefsFunc
@@ -208,11 +204,6 @@ func NewMockClient() *MockClient {
 		},
 		ListClonedFunc: &ClientListClonedFunc{
 			defaultHook: func(context.Context) (r0 []string, r1 error) {
-				return
-			},
-		},
-		ListGitoliteFunc: &ClientListGitoliteFunc{
-			defaultHook: func(context.Context, string) (r0 []*gitolite.Repo, r1 error) {
 				return
 			},
 		},
@@ -383,11 +374,6 @@ func NewStrictMockClient() *MockClient {
 				panic("unexpected invocation of MockClient.ListCloned")
 			},
 		},
-		ListGitoliteFunc: &ClientListGitoliteFunc{
-			defaultHook: func(context.Context, string) ([]*gitolite.Repo, error) {
-				panic("unexpected invocation of MockClient.ListGitolite")
-			},
-		},
 		ListRefsFunc: &ClientListRefsFunc{
 			defaultHook: func(context.Context, api.RepoName) ([]gitdomain.Ref, error) {
 				panic("unexpected invocation of MockClient.ListRefs")
@@ -522,9 +508,6 @@ func NewMockClientFrom(i Client) *MockClient {
 		},
 		ListClonedFunc: &ClientListClonedFunc{
 			defaultHook: i.ListCloned,
-		},
-		ListGitoliteFunc: &ClientListGitoliteFunc{
-			defaultHook: i.ListGitolite,
 		},
 		ListRefsFunc: &ClientListRefsFunc{
 			defaultHook: i.ListRefs,
@@ -2328,113 +2311,6 @@ func (c ClientListClonedFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ClientListClonedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// ClientListGitoliteFunc describes the behavior when the ListGitolite
-// method of the parent MockClient instance is invoked.
-type ClientListGitoliteFunc struct {
-	defaultHook func(context.Context, string) ([]*gitolite.Repo, error)
-	hooks       []func(context.Context, string) ([]*gitolite.Repo, error)
-	history     []ClientListGitoliteFuncCall
-	mutex       sync.Mutex
-}
-
-// ListGitolite delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockClient) ListGitolite(v0 context.Context, v1 string) ([]*gitolite.Repo, error) {
-	r0, r1 := m.ListGitoliteFunc.nextHook()(v0, v1)
-	m.ListGitoliteFunc.appendCall(ClientListGitoliteFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the ListGitolite method
-// of the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientListGitoliteFunc) SetDefaultHook(hook func(context.Context, string) ([]*gitolite.Repo, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ListGitolite method of the parent MockClient instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *ClientListGitoliteFunc) PushHook(hook func(context.Context, string) ([]*gitolite.Repo, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ClientListGitoliteFunc) SetDefaultReturn(r0 []*gitolite.Repo, r1 error) {
-	f.SetDefaultHook(func(context.Context, string) ([]*gitolite.Repo, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientListGitoliteFunc) PushReturn(r0 []*gitolite.Repo, r1 error) {
-	f.PushHook(func(context.Context, string) ([]*gitolite.Repo, error) {
-		return r0, r1
-	})
-}
-
-func (f *ClientListGitoliteFunc) nextHook() func(context.Context, string) ([]*gitolite.Repo, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ClientListGitoliteFunc) appendCall(r0 ClientListGitoliteFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ClientListGitoliteFuncCall objects
-// describing the invocations of this function.
-func (f *ClientListGitoliteFunc) History() []ClientListGitoliteFuncCall {
-	f.mutex.Lock()
-	history := make([]ClientListGitoliteFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ClientListGitoliteFuncCall is an object that describes an invocation of
-// method ListGitolite on an instance of MockClient.
-type ClientListGitoliteFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 string
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []*gitolite.Repo
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ClientListGitoliteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ClientListGitoliteFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -16,20 +16,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// gitoliteLister allows us to list Gitlolite repos. In practice, we ask
-// gitserver to talk to gitolite because it holds the ssh keys required for
-// authentication.
-type gitoliteLister interface {
-	ListRepos(ctx context.Context, gitoliteHost string) (list []*gitolite.Repo, err error)
-}
-
 // A GitoliteSource yields repositories from a single Gitolite connection configured
 // in Sourcegraph via the external services configuration.
 type GitoliteSource struct {
 	svc     *types.ExternalService
 	conn    *schema.GitoliteConnection
-	lister  gitoliteLister
 	exclude excludeFunc
+
+	// gitoliteLister allows us to list Gitlolite repos. In practice, we ask
+	// gitserver to talk to gitolite because it holds the ssh keys required for
+	// authentication.
+	lister *gitserver.GitoliteLister
 }
 
 // NewGitoliteSource returns a new GitoliteSource from the given external service.

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -36,7 +36,7 @@ func NewGitoliteSource(db database.DB, svc *types.ExternalService, cf *httpcli.F
 		return nil, errors.Wrapf(err, "external service id=%d config error", svc.ID)
 	}
 
-	gioliteDoer, err := cf.Doer(
+	gitoliteDoer, err := cf.Doer(
 		httpcli.NewMaxIdleConnsPerHostOpt(500),
 		// The provided httpcli.Factory is one used for external services - however,
 		// GitoliteSource asks gitserver to communicate to gitolite instead, so we
@@ -56,7 +56,7 @@ func NewGitoliteSource(db database.DB, svc *types.ExternalService, cf *httpcli.F
 		return nil, err
 	}
 
-	lister := gitserver.NewGitoliteLister(gioliteDoer)
+	lister := gitserver.NewGitoliteLister(gitoliteDoer)
 
 	return &GitoliteSource{
 		svc:     svc,


### PR DESCRIPTION
Extracted a new minimal type out of our gitserver client just for listing gitolite repos.

This leads to a couple of nice properties:

* Gitserver client no longer needs to expose public HTTPClient
* Smaller gitserver interface

## Test plan

Existing unit tests still pass