### PR TITLE
Code ownership: Register file:has.owner() predicate

### DIFF
--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -45,6 +45,7 @@ var DefaultPredicateRegistry = PredicateRegistry{
 	FieldFile: {
 		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
 		"contains":         func() Predicate { return &FileContainsContentPredicate{} },
+		"has.owner":        func() Predicate { return &FileHasOwnerPredicate{} },
 	},
 }
 
@@ -342,7 +343,7 @@ func (f *RepoHasDescriptionPredicate) Plan(parent Basic) (Plan, error) {
 	return nil, nil
 }
 
-/* repo:contains.content(pattern) */
+/* file:contains.content(pattern) */
 
 type FileContainsContentPredicate struct {
 	Pattern string
@@ -377,6 +378,26 @@ func (f *FileContainsContentPredicate) Plan(parent Basic) (Plan, error) {
 
 	nodes = append(nodes, nonPredicateRepos(parent)...)
 	return BuildPlan(nodes), nil
+}
+
+/* file:has.owner(pattern) */
+
+type FileHasOwnerPredicate struct {
+	Owner string
+}
+
+func (f *FileHasOwnerPredicate) ParseParams(params string) error {
+	if params == "" {
+		return errors.Errorf("file:has.owner argument should not be empty")
+	}
+	f.Owner = params
+	return nil
+}
+
+func (f FileHasOwnerPredicate) Field() string { return FieldFile }
+func (f FileHasOwnerPredicate) Name() string  { return "has.owner" }
+func (f *FileHasOwnerPredicate) Plan(parent Basic) (Plan, error) {
+	return nil, nil
 }
 
 // nonPredicateRepos returns the repo nodes in a query that aren't predicates,

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -213,3 +213,47 @@ func TestRepoHasDescriptionPredicate(t *testing.T) {
 		}
 	})
 }
+
+func TestFileHasOwnerPredicate(t *testing.T) {
+	t.Run("ParseParams", func(t *testing.T) {
+		type test struct {
+			name     string
+			params   string
+			expected *FileHasOwnerPredicate
+		}
+
+		valid := []test{
+			{`literal`, `test`, &FileHasOwnerPredicate{Owner: "test"}},
+			{`regexp`, `@octo-org/octocats`, &FileHasOwnerPredicate{Owner: "@octo-org/octocats"}},
+			{`regexp`, `test@example.com`, &FileHasOwnerPredicate{Owner: "test@example.com"}},
+		}
+
+		for _, tc := range valid {
+			t.Run(tc.name, func(t *testing.T) {
+				p := &FileHasOwnerPredicate{}
+				err := p.ParseParams(tc.params)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+
+				if !reflect.DeepEqual(tc.expected, p) {
+					t.Fatalf("expected %#v, got %#v", tc.expected, p)
+				}
+			})
+		}
+
+		invalid := []test{
+			{`empty`, ``, nil},
+		}
+
+		for _, tc := range invalid {
+			t.Run(tc.name, func(t *testing.T) {
+				p := &FileHasOwnerPredicate{}
+				err := p.ParseParams(tc.params)
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
Closes #38937

As a first step towards bringing the code ownership concepts into our core workflows, we're registering a new predicate that we can later use to filter results based on ownership (c.f. https://github.com/sourcegraph/sourcegraph/issues/38148#issuecomment-1183579162).

The current consensus seems to be to use a file predicate, the syntax would look like this:

```
file:has.owner(@philipp-spiess)
```

(cc @muratsu @jjinnii @ryankscott for syntax feedback?) 

## Test plan

Added a test:

```
ok  	github.com/sourcegraph/sourcegraph/internal/search/query	0.259s
```

The predicate does not have an implementation so this will currently look for filenames with `has.owner(@philipp-spiess)` in it's path AFAICT.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
