### PR TITLE
cm blob view: Improve initial render, scroll into view and navigation between files

### DIFF
--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -869,7 +869,8 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
 export function updateBrowserHistoryIfNecessary(
     history: H.History,
     location: H.Location,
-    newSearchParameters: URLSearchParams
+    newSearchParameters: URLSearchParams,
+    replace: boolean = false
 ): void {
     const currentSearchParameters = [...new URLSearchParams(location.search).entries()]
 
@@ -883,10 +884,16 @@ export function updateBrowserHistoryIfNecessary(
         currentSearchParameters.some(([key, value]) => newSearchParameters.get(key) !== value)
 
     if (needsUpdate) {
-        history.push({
+        const entry = {
             ...location,
             search: formatSearchParameters(newSearchParameters),
-        })
+        }
+
+        if (replace) {
+            history.replace(entry)
+        } else {
+            history.push(entry)
+        }
     }
 }
 

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -869,8 +869,7 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
 export function updateBrowserHistoryIfNecessary(
     history: H.History,
     location: H.Location,
-    newSearchParameters: URLSearchParams,
-    replace: boolean = false
+    newSearchParameters: URLSearchParams
 ): void {
     const currentSearchParameters = [...new URLSearchParams(location.search).entries()]
 
@@ -884,16 +883,10 @@ export function updateBrowserHistoryIfNecessary(
         currentSearchParameters.some(([key, value]) => newSearchParameters.get(key) !== value)
 
     if (needsUpdate) {
-        const entry = {
+        history.push({
             ...location,
             search: formatSearchParameters(newSearchParameters),
-        }
-
-        if (replace) {
-            history.replace(entry)
-        } else {
-            history.push(entry)
-        }
+        })
     }
 }
 

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -4,12 +4,12 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { Compartment, Extension } from '@codemirror/state'
+import { Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { useHistory, useLocation } from 'react-router'
 
 import { addLineRangeQueryParameter, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
-import { editorHeight, useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import { editorHeight, useCodeMirror, useCompartment } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
 
 import { BlobProps, updateBrowserHistoryIfNecessary } from './Blob'
@@ -95,32 +95,4 @@ export const Blob: React.FunctionComponent<BlobProps> = ({ className, blobInfo, 
     }, [editor, position])
 
     return <div ref={setContainer} className={`${className} overflow-hidden`} />
-}
-
-/**
- * Helper hook for extensions that depend on on some input props.
- * With this hook the extension is isolated in a compartment so it can be
- * updated without reconfiguring the whole editor.
- *
- * If this proves to be useful it should be moved to the shared CodeMirror
- * directory.
- */
-export function useCompartment(
-    initialExtension: Extension
-): [Extension, (editor: EditorView, extension: Extension) => void] {
-    return useMemo(() => {
-        const compartment = new Compartment()
-        return [
-            compartment.of(initialExtension),
-            (editor, extension: Extension) => {
-                // This check avoids an unnecessary update when the editor is
-                // first created
-                if (initialExtension !== extension) {
-                    editor.dispatch({ effects: compartment.reconfigure(extension) })
-                }
-            },
-        ]
-        // initialExtension is intentionally ignored in subsequent renders
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
 }

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -90,9 +90,16 @@ export const Blob: React.FunctionComponent<BlobProps> = ({ className, blobInfo, 
     const position = useMemo(() => parseQueryAndHash(location.search, location.hash), [location.search, location.hash])
     useEffect(() => {
         if (editor) {
-            selectLines(editor, position.line ? position : null)
+            // This check is necessary because at the moment the position
+            // information is updated before the file content, meaning it's
+            // possible that the currently loaded document has fewer lines.
+            if (!position?.line || editor.state.doc.lines >= (position.endLine ?? position.line)) {
+                selectLines(editor, position.line ? position : null)
+            }
         }
-    }, [editor, position])
+        // blobInfo isn't used but we need to trigger the line selection and focus
+        // logic whenever the content changes
+    }, [editor, position, blobInfo])
 
     return <div ref={setContainer} className={`${className} overflow-hidden`} />
 }

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -51,15 +51,9 @@ export const Blob: React.FunctionComponent<BlobProps> = ({ className, blobInfo, 
     const locationRef = useRef(location)
     locationRef.current = location
 
-    const onSelection = useCallback((range: SelectedLineRange, event: MouseEvent) => {
+    const onSelection = useCallback((range: SelectedLineRange) => {
         const parameters = new URLSearchParams(locationRef.current.search)
         let query: string | undefined
-        // If the shift key is pressed and the URL currently contains a position
-        // then we are going to replace the history entry instead of adding a
-        // new one. This avoids two history entries for the common operation of
-        // selecting the start line first and then selecting the end line via
-        // shift+click
-        const replace = event.shiftKey
 
         if (range?.line !== range?.endLine && range?.endLine) {
             query = toPositionOrRangeQueryParameter({
@@ -75,8 +69,7 @@ export const Blob: React.FunctionComponent<BlobProps> = ({ className, blobInfo, 
         updateBrowserHistoryIfNecessary(
             historyRef.current,
             locationRef.current,
-            addLineRangeQueryParameter(parameters, query),
-            replace
+            addLineRangeQueryParameter(parameters, query)
         )
     }, [])
 

--- a/client/web/src/repo/blob/CodeMirrorLineNumbers.ts
+++ b/client/web/src/repo/blob/CodeMirrorLineNumbers.ts
@@ -71,9 +71,7 @@ const selectedLines = StateField.define<SelectedLineRange>({
  * NOTE: Dragging to select on the gutter won't automatically scroll the
  * document.
  */
-export function selectableLineNumbers(config: {
-    onSelection: (range: SelectedLineRange, event: MouseEvent) => void
-}): Extension {
+export function selectableLineNumbers(config: { onSelection: (range: SelectedLineRange) => void }): Extension {
     let dragging = false
 
     return [
@@ -91,7 +89,7 @@ export function selectableLineNumbers(config: {
 
                     dragging = true
 
-                    function onmouseup(event: MouseEvent): void {
+                    function onmouseup(): void {
                         dragging = false
                         window.removeEventListener('mouseup', onmouseup)
 
@@ -109,7 +107,7 @@ export function selectableLineNumbers(config: {
                                 range = { ...range }
                             }
                         }
-                        config.onSelection(range, event)
+                        config.onSelection(range)
                     }
                     window.addEventListener('mouseup', onmouseup)
                     return true


### PR DESCRIPTION
This commit addresses minor issues with the initial implementation:

The `useExtension` hook as it were resulted in creating the editor
without the configured extensions and only adding them via a transaction
afterwards. While that should generally be fine, if something like dark
theme is set via such an extension (as it is in our case), the incorrect
theme might be briefly visible.
To fix this the hook was completely redesigned: It's now officially a
compartment hook. The extension(s) now has to be created inside the
component and passed to the hook. The hook will return a compartment
extension and a function to update said compartment.
This allows the component to compute the extensions via `useMemo` and
update the compartment via `useEffect`.
I moved the hook into the shared CodeMirror editor module because
it's API seems generic enough now.

The "scroll into view" logic was a bit inconsistent: Because it wasn't
clear which lines are actually _visible_, the effect would be configured
with `"nearest"` to ensure that the line was definitely visible. But
that leads to an inconsistent behavior.
While I'm not sure whether that's the current way to do it, it's
actually possible to determine whether or not a line is visible by
getting its vertical position and compare it against the scroll
containers scroll position.
Now a selected line is always centered when it is not visible (whether
or not _that_ behavior is the best UX is a different question)

Finally there is an issue when navigating back to a file that has a line
selected that is outside of the range of lines of the _current_ file. That's
because the position change triggers an update before the new file content
is loaded. A simple workaround is to verify that the selected line is 
within the range of the current document. (long term I'd like to find
another solution)

I originally also included a change that would change how browser history
entries are added when shift+clicking a line but such a behavior
change needs more thought.


https://user-images.githubusercontent.com/179026/179524456-381a617e-1a43-46c2-8f02-26d7619cf74a.mp4


## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-codemirror-blob-tweaks.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kfcwcwshoj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
