### PR TITLE
ci: cache client bundle on server builds

### DIFF
--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -19,6 +19,7 @@ else
   aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
   aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
 
+  # scan and concat all the sha1sums of the files into a single blob which is then sha1sum'd again to give us our checksum
   checksum=$(find "./client" "./ui" "package.json" -type f -exec sha1sum {} \; | sort -k 2 | sha1sum | awk '{print $1}')
   cache_file="cache-client-bundle-$checksum.tar.gz"
   cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"/../../..
 
 echo "--- (enterprise) pre-build frontend"

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -4,4 +4,38 @@ set -euxo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"/../../..
 
 echo "--- (enterprise) pre-build frontend"
-./enterprise/cmd/frontend/pre-build.sh
+
+if [[ ! "$BUILDKITE" == "true" ]]; then
+  # Not-in-buildkite simple install.
+  ./enterprise/cmd/frontend/pre-build.sh
+else
+  # set the buildkite cache access keys
+  AWS_CONFIG_DIR_PATH="/buildkite/.aws"
+  mkdir -p "$AWS_CONFIG_DIR_PATH"
+  AWS_CONFIG_FILE="$AWS_CONFIG_DIR_PATH/config"
+  export AWS_CONFIG_FILE
+  AWS_SHARED_CREDENTIALS_FILE="/buildkite/.aws/credentials"
+  export AWS_SHARED_CREDENTIALS_FILE
+  aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
+  aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
+
+  checksum=$(find "./client" "./ui" -type f -exec sha1sum {} \; | sort -k 2 | sha1sum | awk '{print $1}')
+  cache_file="cache-client-bundle-$checksum.tar.gz"
+  cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
+
+  echo -e "ClientBundle 🔍 Locating cache: $cache_key"
+  if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" --key "$cache_key"; then
+    echo -e "ClientBundle 🔥 Cache hit: $cache_key"
+    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_key" "./"
+    bsdtar xzf "$cache_file"
+    rm "$cache_file"
+  else
+    echo -e "ClientBundle 🚨 Cache miss: $cache_key"
+    echo "~~~ Building client from scratch"
+    ./enterprise/cmd/frontend/pre-build.sh
+    echo "~~~ Cache build client installation"
+    bsdtar cfz "$cache_file" ./ui
+    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "$cache_file" "s3://sourcegraph_buildkite_cache/$cache_key"
+    rm "$cache_file"
+  fi
+fi

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -20,7 +20,7 @@ else
   aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
 
   # scan and concat all the sha1sums of the files into a single blob which is then sha1sum'd again to give us our checksum
-  checksum=$(find "./client" "./ui" "package.json" -type f -exec sha1sum {} \; | sort -k 2 | sha1sum | awk '{print $1}')
+  checksum=$(find "./client" "./ui" "package.json" "yarn.lock" -type f -exec sha1sum {} \; | sort -k 2 | sha1sum | awk '{print $1}')
   cache_file="cache-client-bundle-$checksum.tar.gz"
   cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
 

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -19,7 +19,7 @@ else
   aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
   aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
 
-  checksum=$(find "./client" "./ui" -type f -exec sha1sum {} \; | sort -k 2 | sha1sum | awk '{print $1}')
+  checksum=$(find "./client" "./ui" "package.json" -type f -exec sha1sum {} \; | sort -k 2 | sha1sum | awk '{print $1}')
   cache_file="cache-client-bundle-$checksum.tar.gz"
   cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
 


### PR DESCRIPTION
So @burmudar and I woke up this morning and we decided that the server image needed a 🧹. 

Half the build time is spent building the client bundle. So we cached the client bundle 🤷‍♂️. 

It's done in a very crude way, but it works unless proven otherwise. It checksums the `/ui`, `/client` folders and `./package.json` in order to build a cache key. It caches the entire `/ui` folder. 

It effectively shaves off about 7~9 minutes on the `server` image build. 


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

1. Build the server image on CI (cache miss) 
2. Build the server image on CI again (cache hit)
3. Pull the docker image locally and run it
4. Check that the assets are being served. 

See https://buildkite.com/sourcegraph/sourcegraph/builds/161358#018211ad-d76c-40b7-b4c6-e37533ccd2d7 (18m) and https://buildkite.com/sourcegraph/sourcegraph/builds/161366#_ (8m)