### PR TITLE
Code Insights: Add compute insights to the `changelog.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Search query inputs are now backed by the CodeMirror library instead of Monaco. Monaco can be re-enabled by setting `experimentalFeatures.editor` to `"monaco"`. [38584](https://github.com/sourcegraph/sourcegraph/pull/38584)
 - Better search-based code navigation for Python using tree-sitter [#38459](https://github.com/sourcegraph/sourcegraph/pull/38459)
 - Gitserver endpoint access logs can now be enabled by adding `"log": { "gitserver.accessLogs": true }` to the site config. [#38798](https://github.com/sourcegraph/sourcegraph/pull/38798)
+- Code Insights supports a new type of insight - compute-powered insight, currently under the experimental feature flag: `codeInsightsCompute` [#37857](https://github.com/sourcegraph/sourcegraph/issues/37857)
 
 ### Changed
 

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
@@ -113,6 +113,7 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                         includeRepoRegexp: appliedFilters.includeRepoRegex ?? '',
                         excludeRepoRegexp: appliedFilters.excludeRepoRegex ?? '',
                         context: appliedFilters.searchContexts?.[0] ?? '',
+                        seriesDisplayOptions,
                     },
                 } as ComputeInsight
             }


### PR DESCRIPTION
It just adds a note to the `changelod.md` about the compute-powered insight and its experimental feature flag.

Also, it fixes a problem with compute-powered insight on the dashboard page around handling series display filters (sort and limit filters) 

## Test plan
- Make sure that you can see compute-powered insight on the dashboard page (you can use this dashboard as an example https://sourcegraph.test:3443/insights/dashboards/ZGFzaGJvYXJkOnsiSWRUeXBlIjoiY3VzdG9tIiwiQXJnIjo3MjcyNzV9
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-compute-insights-changelog.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vkpywbfbxh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
