### PR TITLE
dependencies: add basic site-admin page to list lockfile indexes

### DIFF
--- a/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.module.scss
+++ b/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.module.scss
@@ -7,3 +7,9 @@
         padding-bottom: 1rem;
     }
 }
+
+.information {
+    @media (--xs-breakpoint-down) {
+        grid-column: 1 / -1;
+    }
+}

--- a/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.module.scss
+++ b/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.module.scss
@@ -1,0 +1,9 @@
+.separator {
+    // Make it full width in the current row.
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--border-color-2);
+    @media (--xs-breakpoint-down) {
+        margin-top: 1rem;
+        padding-bottom: 1rem;
+    }
+}

--- a/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.tsx
@@ -1,0 +1,39 @@
+import React, { FunctionComponent } from 'react'
+
+import classNames from 'classnames'
+
+import { Link, H3, Code } from '@sourcegraph/wildcard'
+
+import { LockfileIndexFields } from '../../../../graphql-operations'
+
+import styles from './CodeIntelLockfileIndexNode.module.scss'
+
+export interface CodeIntelLockfileNodeProps {
+    node: LockfileIndexFields
+}
+
+export const CodeIntelLockfileNode: FunctionComponent<React.PropsWithChildren<CodeIntelLockfileNodeProps>> = ({
+    node,
+}) => (
+    <>
+        <span className={styles.separator} />
+
+        <div className={classNames(styles.information, 'd-flex flex-column')}>
+            <div className="m-0">
+                <H3 className="m-0 d-block d-md-inline">
+                    <Link to={node.repository.url}>{node.repository.name}</Link>
+                </H3>
+            </div>
+
+            <div>
+                <span className="mr-2 d-block d-mdinline-block">
+                    Lockfile <Code>{node.lockfile}</Code> indexed at commit{' '}
+                    <Link to={node.commit.url}>
+                        <Code>{node.commit.abbreviatedOID}</Code>
+                    </Link>
+                    . Dependency graph fidelity: {node.fidelity}.
+                </span>
+            </div>
+        </div>
+    </>
+)

--- a/client/web/src/enterprise/codeintel/lockfiles/components/EmptyLockfiles.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/components/EmptyLockfiles.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { mdiMapSearch } from '@mdi/js'
+
+import { Link, Text, Icon } from '@sourcegraph/wildcard'
+
+export const EmptyLockfiles: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
+    <Text alignment="center" className="text-muted w-100 mb-0 mt-1">
+        <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
+        <br />
+        No lockfiles indexed yet. Enable lockfile indexing by{' '}
+        <Link to="/help/code_search/how-to/dependencies_search" target="_blank" rel="noreferrer noopener">
+            following the instructions here
+        </Link>
+        .
+    </Text>
+)

--- a/client/web/src/enterprise/codeintel/lockfiles/hooks/queries.ts
+++ b/client/web/src/enterprise/codeintel/lockfiles/hooks/queries.ts
@@ -1,0 +1,38 @@
+import { gql } from '@sourcegraph/http-client'
+
+export const LOCKFILE_INDEXES_LIST = gql`
+    fragment LockfileIndexFields on LockfileIndex {
+        id
+        lockfile
+        fidelity
+
+        repository {
+            id
+            name
+            url
+        }
+
+        commit {
+            url
+            abbreviatedOID
+            oid
+        }
+    }
+
+    fragment LockfileIndexConnectionFields on LockfileIndexConnection {
+        nodes {
+            ...LockfileIndexFields
+        }
+        totalCount
+        pageInfo {
+            endCursor
+            hasNextPage
+        }
+    }
+
+    query LockfileIndexes($first: Int, $after: String) {
+        lockfileIndexes(first: $first, after: $after) {
+            ...LockfileIndexConnectionFields
+        }
+    }
+`

--- a/client/web/src/enterprise/codeintel/lockfiles/hooks/queryLockfileIndexesList.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/hooks/queryLockfileIndexesList.tsx
@@ -1,0 +1,34 @@
+import { ApolloClient } from '@apollo/client'
+import { from, Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { getDocumentNode } from '@sourcegraph/http-client'
+import * as GQL from '@sourcegraph/shared/src/schema'
+
+import {
+    LockfileIndexConnectionFields,
+    LockfileIndexesResult,
+    LockfileIndexesVariables,
+} from '../../../../graphql-operations'
+
+import { LOCKFILE_INDEXES_LIST } from './queries'
+
+export const queryLockfileIndexesList = (
+    { first, after }: GQL.ILsifUploadsOnQueryArguments,
+    client: ApolloClient<object>
+): Observable<LockfileIndexConnectionFields> => {
+    const variables: LockfileIndexesVariables = {
+        first: first ?? null,
+        after: after ?? null,
+    }
+
+    return from(
+        client.query<LockfileIndexesResult, LockfileIndexesVariables>({
+            query: getDocumentNode(LOCKFILE_INDEXES_LIST),
+            variables: { ...variables },
+        })
+    ).pipe(
+        map(({ data }) => data),
+        map(({ lockfileIndexes }) => lockfileIndexes)
+    )
+}

--- a/client/web/src/enterprise/codeintel/lockfiles/hooks/queryLockfileIndexesList.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/hooks/queryLockfileIndexesList.tsx
@@ -27,8 +27,5 @@ export const queryLockfileIndexesList = (
             query: getDocumentNode(LOCKFILE_INDEXES_LIST),
             variables: { ...variables },
         })
-    ).pipe(
-        map(({ data }) => data),
-        map(({ lockfileIndexes }) => lockfileIndexes)
-    )
+    ).pipe(map(({ data }) => data.lockfileIndexes))
 }

--- a/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.module.scss
+++ b/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.module.scss
@@ -1,0 +1,12 @@
+.grid {
+    display: grid;
+    grid-template-columns: [info] minmax(auto, 1fr) [state] min-content [caret] min-content [end];
+    row-gap: 1rem;
+    column-gap: 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
+    @media (--sm-breakpoint-down) {
+        row-gap: 0.5rem;
+        column-gap: 0.5rem;
+    }
+}

--- a/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable arrow-body-style */
+import { FunctionComponent, useCallback, useEffect } from 'react'
+
+import { useApolloClient } from '@apollo/client'
+import classNames from 'classnames'
+import { RouteComponentProps } from 'react-router'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
+
+import {
+    FilteredConnection,
+    FilteredConnectionFilter,
+    FilteredConnectionQueryArguments,
+} from '../../../../components/FilteredConnection'
+import { PageTitle } from '../../../../components/PageTitle'
+import { LockfileIndexFields } from '../../../../graphql-operations'
+import { CodeIntelLockfileNode, CodeIntelLockfileNodeProps } from '../components/CodeIntelLockfileIndexNode'
+import { EmptyLockfiles } from '../components/EmptyLockfiles'
+import { queryLockfileIndexesList as defaultQueryLockfileIndexesList } from '../hooks/queryLockfileIndexesList'
+
+import styles from './CodeIntelLockfilesPage.module.scss'
+
+export interface CodeIntelLockfilesPageProps extends RouteComponentProps<{}>, TelemetryProps {
+    queryLockfileIndexesList?: typeof defaultQueryLockfileIndexesList
+}
+
+const filters: FilteredConnectionFilter[] = []
+
+export const CodeIntelLockfilesPage: FunctionComponent<React.PropsWithChildren<CodeIntelLockfilesPageProps>> = ({
+    queryLockfileIndexesList = defaultQueryLockfileIndexesList,
+    telemetryService,
+    history,
+    ...props
+}) => {
+    useEffect(() => telemetryService.logViewEvent('CodeIntelLockfiles'), [telemetryService])
+
+    const apolloClient = useApolloClient()
+    const queryLockfileIndexes = useCallback(
+        (args: FilteredConnectionQueryArguments) => {
+            return queryLockfileIndexesList({ ...args }, apolloClient)
+        },
+        [queryLockfileIndexesList, apolloClient]
+    )
+
+    return (
+        <div className="code-intel-lockfiles">
+            <PageTitle title="Lockfile indexes" />
+            <PageHeader
+                headingElement="h2"
+                path={[{ text: 'Lockfile indexes' }]}
+                description="Lockfile indexes created by lockfile-indexing"
+                className="mb-3"
+            />
+
+            <Container>
+                <div className="list-group position-relative">
+                    <FilteredConnection<LockfileIndexFields, Omit<CodeIntelLockfileNodeProps, 'node'>>
+                        listComponent="div"
+                        listClassName={classNames(styles.grid, 'mb-3')}
+                        inputClassName="w-auto"
+                        noun="lockfile index"
+                        pluralNoun="lockfile indexes"
+                        nodeComponent={CodeIntelLockfileNode}
+                        queryConnection={queryLockfileIndexes}
+                        history={history}
+                        location={props.location}
+                        cursorPaging={true}
+                        filters={filters}
+                        hideSearch={true}
+                        emptyElement={<EmptyLockfiles />}
+                    />
+                </div>
+            </Container>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/site-admin/routes.ts
+++ b/client/web/src/enterprise/site-admin/routes.ts
@@ -129,6 +129,17 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
     },
 
+    // Lockfile indexes & dependency search routes
+    {
+        path: '/code-intelligence/lockfiles',
+        render: lazyComponent(
+            () => import('../codeintel/lockfiles/pages/CodeIntelLockfilesPage'),
+            'CodeIntelLockfilesPage'
+        ),
+        exact: true,
+        condition: () => Boolean(window.context?.codeIntelLockfileIndexingEnabled),
+    },
+
     // Code intelligence configuration
     {
         path: '/code-intelligence/configuration',

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -109,6 +109,11 @@ const codeIntelGroup: SiteAdminSideBarGroup = {
             condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
         },
         {
+            to: '/site-admin/code-intelligence/lockfiles',
+            label: 'Lockfiles',
+            condition: () => Boolean(window.context?.codeIntelLockfileIndexingEnabled),
+        },
+        {
             to: '/site-admin/code-intelligence/configuration',
             label: 'Configuration',
         },

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -36,7 +36,6 @@ type LockfileIndexConnection {
     pageInfo: PageInfo!
 }
 
-
 """
 Fidelity of a lockfile index.
 """

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -36,6 +36,29 @@ type LockfileIndexConnection {
     pageInfo: PageInfo!
 }
 
+
+"""
+Fidelity of a lockfile index.
+"""
+enum LockfileIndexFidelity {
+    """
+    Couldn't build a complete graph from lockfile. It's instead a flat list of
+    dependencies found in the lockfile.
+    """
+    FLAT
+
+    """
+    If we couldn't determine the roots of the dependency graph because it's
+    circular. That means we can't say what's a direct dependency and what not, but
+    we can tell which dependency depends on which other dependency.
+    """
+    CIRCULAR
+
+    """
+    Full dependency graph.
+    """
+    GRAPH
+}
 """
 Fidelity of a lockfile index.
 """

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -17,26 +17,6 @@ extend type Query {
 }
 
 """
-A list of lockfile indexes.
-"""
-type LockfileIndexConnection {
-    """
-    A list of lockfile indexes.
-    """
-    nodes: [LockfileIndex!]!
-
-    """
-    The total number of lockfile indexes in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
-
-"""
 Fidelity of a lockfile index.
 """
 enum LockfileIndexFidelity {
@@ -58,28 +38,7 @@ enum LockfileIndexFidelity {
     """
     GRAPH
 }
-"""
-Fidelity of a lockfile index.
-"""
-enum LockfileIndexFidelity {
-    """
-    Couldn't build a complete graph from lockfile. It's instead a flat list of
-    dependencies found in the lockfile.
-    """
-    FLAT
 
-    """
-    If we couldn't determine the roots of the dependency graph because it's
-    circular. That means we can't say what's a direct dependency and what not, but
-    we can tell which dependency depends on which other dependency.
-    """
-    CIRCULAR
-
-    """
-    Full dependency graph.
-    """
-    GRAPH
-}
 """
 A lockfile index is an indexed lockfile in a repository.
 """

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -17,6 +17,26 @@ extend type Query {
 }
 
 """
+A list of lockfile indexes.
+"""
+type LockfileIndexConnection {
+    """
+    A list of lockfile indexes.
+    """
+    nodes: [LockfileIndex!]!
+
+    """
+    The total number of lockfile indexes in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
 Fidelity of a lockfile index.
 """
 enum LockfileIndexFidelity {

--- a/internal/codeintel/dependencies/transport/graphql/resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/resolver.go
@@ -54,9 +54,13 @@ func (r *resolver) LockfileIndexes(ctx context.Context, args *graphqlbackend.Lis
 		repoIDs[i] = api.RepoID(li.RepositoryID)
 	}
 
-	repos, err := backend.NewRepos(r.logger, r.db).List(ctx, database.ReposListOptions{IDs: repoIDs})
-	if err != nil {
-		return nil, err
+	var repos []*types.Repo
+	if len(repoIDs) > 0 {
+		var err error
+		repos, err = backend.NewRepos(r.logger, r.db).List(ctx, database.ReposListOptions{IDs: repoIDs})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	reposByID := make(map[api.RepoID]*types.Repo, len(repos))


### PR DESCRIPTION
This adds a basic site-admin page that lists lockfile indexes. It's essentially copy&pasted from the existing uploads page, except that I stripped out 80%.

Next steps would be to add more data to this (`indexed_at`?) and a page to view a single index and its data.

## Test plan

- tested manually