### PR TITLE
search: Show Notepad only on certain pages

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -131,7 +131,6 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     const isSearchConsolePage = routeMatch?.startsWith('/search/console')
     const isSearchNotebooksPage = routeMatch?.startsWith(PageRoutes.Notebooks)
     const isSearchNotebookListPage = props.location.pathname === PageRoutes.Notebooks
-    console.log(props.location.pathname, PageRoutes.Notebooks, isSearchNotebookListPage)
     const isRepositoryRelatedPage = routeMatch === '/:repoRevAndRest+' ?? false
 
     // Update patternType, caseSensitivity, and selectedSearchContextSpec based on current URL

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -110,7 +110,7 @@ export interface LayoutProps
 
     // Search
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
-    onCreateNotebook: (blocks: BlockInput[]) => void
+    onCreateNotebookFromNotepad: (blocks: BlockInput[]) => void
 
     globbing: boolean
     isSourcegraphDotCom: boolean
@@ -297,7 +297,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
             />
             <GlobalDebug {...props} />
             {(isSearchNotebookListPage || (isSearchRelatedPage && !isSearchHomepage)) && (
-                <NotepadContainer onCreateNotebook={props.onCreateNotebook} />
+                <NotepadContainer onCreateNotebook={props.onCreateNotebookFromNotepad} />
             )}
         </div>
     )

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -43,6 +43,7 @@ import { GlobalAlerts } from './global/GlobalAlerts'
 import { GlobalDebug } from './global/GlobalDebug'
 import { SurveyToast } from './marketing/toast'
 import { GlobalNavbar } from './nav/GlobalNavbar'
+import type { BlockInput } from './notebooks'
 import { OrgAreaRoute } from './org/area/OrgArea'
 import { OrgAreaHeaderNavItem } from './org/area/OrgHeader'
 import { RepoContainerRoute } from './repo/RepoContainer'
@@ -53,6 +54,7 @@ import { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
 import { LayoutRouteProps, LayoutRouteComponentProps } from './routes'
 import { PageRoutes, EnterprisePageRoutes } from './routes.constants'
 import { parseSearchURLQuery, HomePanelsProps, SearchStreamingProps, parseSearchURL } from './search'
+import { NotepadContainer } from './search/Notepad'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import { setQueryStateFromURL } from './stores'
@@ -108,6 +110,7 @@ export interface LayoutProps
 
     // Search
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
+    onCreateNotebook: (blocks: BlockInput[]) => void
 
     globbing: boolean
     isSourcegraphDotCom: boolean
@@ -127,6 +130,8 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     const isSearchHomepage = props.location.pathname === '/search' && !parseSearchURLQuery(props.location.search)
     const isSearchConsolePage = routeMatch?.startsWith('/search/console')
     const isSearchNotebooksPage = routeMatch?.startsWith(PageRoutes.Notebooks)
+    const isSearchNotebookListPage = props.location.pathname === PageRoutes.Notebooks
+    console.log(props.location.pathname, PageRoutes.Notebooks, isSearchNotebookListPage)
     const isRepositoryRelatedPage = routeMatch === '/:repoRevAndRest+' ?? false
 
     // Update patternType, caseSensitivity, and selectedSearchContextSpec based on current URL
@@ -292,6 +297,9 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
                 history={props.history}
             />
             <GlobalDebug {...props} />
+            {(isSearchNotebookListPage || (isSearchRelatedPage && !isSearchHomepage)) && (
+                <NotepadContainer onCreateNotebook={props.onCreateNotebook} />
+            )}
         </div>
     )
 }

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -86,7 +86,6 @@ import { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
 import { LayoutRouteProps } from './routes'
 import { PageRoutes } from './routes.constants'
 import { parseSearchURL } from './search'
-import { NotepadContainer } from './search/Notepad'
 import { SearchResultsCacheProvider } from './search/results/SearchResultsCacheProvider'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
@@ -418,11 +417,11 @@ export class SourcegraphWebApp extends React.Component<
                                                                         }
                                                                         globbing={this.state.globbing}
                                                                         streamSearch={aggregateStreamingSearch}
+                                                                        onCreateNotebook={this.onCreateNotebook}
                                                                     />
                                                                 </CodeHostScopeProvider>
                                                             )}
                                                         />
-                                                        <NotepadContainer onCreateNotebook={this.onCreateNotebook} />
                                                     </CompatRouter>
                                                 </Router>
                                             </ScrollManager>

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -417,7 +417,9 @@ export class SourcegraphWebApp extends React.Component<
                                                                         }
                                                                         globbing={this.state.globbing}
                                                                         streamSearch={aggregateStreamingSearch}
-                                                                        onCreateNotebook={this.onCreateNotebook}
+                                                                        onCreateNotebookFromNotepad={
+                                                                            this.onCreateNotebook
+                                                                        }
                                                                     />
                                                                 </CodeHostScopeProvider>
                                                             )}


### PR DESCRIPTION
Closes #38521

This commit changes on which pages the notepad is shown. Now the notepad
will be shown on the search results page, the notebooks list page (so
that there is a visiual indicating that somethin happens) and any
repo/file related pages (that would also include pages that don't show
code (e.g. branches) but I think it's an OK tradeoff)

In order to have easier access to route related information I moved the
notepad to `Layout`.

I don't think this needs to be put behind a feature flag, but if you
think otherwise, please let me know.



## Test plan

Manual testing. If notepad is enabled it should not be visible anymore on the search homepage, but on any other search/repo related pages, as well as the notebooks list page.

## App preview:

- [Web](https://sg-web-fkling-38521-show-notepad-on.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ceumbfihjw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
