### PR TITLE
gitserver: set gc.pid file during sg maintenance

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -547,6 +547,24 @@ func TestCleanupOldLocks(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "fresh_gc.pid",
+			files: []file{
+				{
+					name: "gc.pid",
+				},
+			},
+		},
+		{
+			name: "stale_gc.pid",
+			files: []file{
+				{
+					name:        "gc.pid",
+					age:         48 * time.Hour,
+					wantRemoved: true,
+				},
+			},
+		},
 	}
 
 	root := t.TempDir()
@@ -1507,5 +1525,98 @@ error message
 				t.Fatalf("want %d, got %d", tt.wantRetries, got)
 			}
 		})
+	}
+}
+
+// We test whether the lock set by sg maintenance is respected by git gc.
+func TestGitGCRespectsLock(t *testing.T) {
+	dir := GitDir(t.TempDir())
+	cmd := exec.Command("git", "--bare", "init")
+	dir.Set(cmd)
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := lockRepoForGC(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command("git", "gc")
+	dir.Set(cmd)
+	b, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected command to return with non-zero exit value")
+	}
+
+	// We check that git complains about the lockfile as expected. By comparing the
+	// output string we make sure we catch changes to Git. If the test fails here,
+	// this means that a new version of Git might have changed the logic around
+	// locking.
+	if !strings.Contains(string(b), "gc is already running on machine") {
+		t.Fatal("git gc should have complained about an existing lockfile")
+	}
+
+	err = removeGCLockFile(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command("git", "gc")
+	dir.Set(cmd)
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSGMaintenanceRespectsLock(t *testing.T) {
+	logger, getLogs := logtest.Captured(t)
+
+	dir := GitDir(t.TempDir())
+	cmd := exec.Command("git", "--bare", "init")
+	dir.Set(cmd)
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := lockRepoForGC(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = sgMaintenance(logger, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cl := getLogs()
+	if len(cl) == 0 {
+		t.Fatal("expected at least 1 log message")
+	}
+
+	if !strings.Contains(cl[len(cl)-1].Message, "could not lock repository for sg maintenance. There is probably another git gc operation running.") {
+		t.Fatal("expected sg maintenance to complain about the lockfile")
+	}
+}
+
+func TestSGMaintenanceRemovesLock(t *testing.T) {
+	logger := logtest.Scoped(t)
+
+	dir := GitDir(t.TempDir())
+	cmd := exec.Command("git", "--bare", "init")
+	dir.Set(cmd)
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := sgMaintenance(logger, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(dir.Path(gcLockFile))
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("sg maintenance should have removed the lockfile it created")
 	}
 }


### PR DESCRIPTION
With this change we place a gc.pid file in the repo dir while sg
maintenance is running. The gc.pid file acts as a lock and is respected
by git-gc. Internally, [git-gc uses the same mechanism.](https://sourcegraph.com/github.com/git/git@9dd64cb4d310986dd7b8ca7fff92f9b61e0bd21a/-/blob/builtin/gc.c?L409)



## Test plan
- New unit test
- I verified manually that placing a gc.pid file in a repository is respected by git-gc