### PR TITLE
Search backend: fix HEAD being displayed when no input rev was specified

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -386,7 +386,7 @@ func (r *Resolver) normalizeRepoRefs(
 			// commit ID. We should consider building []gitdomain.Ref here
 			// instead of just []string because we have the exact commit hashes,
 			// so we could avoid resolving later.
-			revs = append(revs, "HEAD")
+			revs = append(revs, rev.RevSpec)
 		case rev.RevSpec != "":
 			trimmedRev := strings.TrimPrefix(rev.RevSpec, "^")
 			_, err := r.gitserver.ResolveRevision(ctx, repo.Name, trimmedRev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -116,7 +116,7 @@ func TestRevisionValidation(t *testing.T) {
 			repoFilters: []string{"repoFoo"},
 			wantRepoRevs: []*search.RepositoryRevisions{{
 				Repo: types.MinimalRepo{Name: "repoFoo"},
-				Revs: []string{"HEAD"},
+				Revs: []string{""},
 			}},
 			wantMissingRepoRevisions: []RepoRevSpecs{},
 			wantErr:                  nil,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -59,30 +59,31 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 	reporev = reporev.Copy()
 	indexed := reporev.Revs[:0]
 
-	for _, rev := range reporev.Revs {
+	for _, inputRev := range reporev.Revs {
 		found := false
+		rev := inputRev
 		if rev == "" {
 			rev = "HEAD"
 		}
 
 		for _, branch := range repo.Branches {
 			if branch.Name == rev {
-				branches = append(branches, branch.Name)
+				branches = append(branches, inputRev)
 				found = true
 				break
 			}
 			// Check if rev is an abbrev commit SHA
 			if len(rev) >= 4 && strings.HasPrefix(branch.Version, rev) {
-				branches = append(branches, branch.Name)
+				branches = append(branches, inputRev)
 				found = true
 				break
 			}
 		}
 
 		if found {
-			indexed = append(indexed, rev)
+			indexed = append(indexed, inputRev)
 		} else {
-			unindexed = append(unindexed, rev)
+			unindexed = append(unindexed, inputRev)
 		}
 	}
 

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -516,7 +516,7 @@ func TestZoektIndexedRepos_single(t *testing.T) {
 	}{
 		{
 			rev:           "",
-			wantIndexed:   []*search.RepositoryRevisions{repoRev("HEAD")},
+			wantIndexed:   []*search.RepositoryRevisions{repoRev("")},
 			wantUnindexed: []*search.RepositoryRevisions{},
 		},
 		{


### PR DESCRIPTION
This fixes an issue that was introduced in https://github.com/sourcegraph/sourcegraph/pull/38773 where, if you search with a `repo:` filter but with no revision, we would return and display results with `@HEAD` as the revision. 

## Test plan

There were tests that covered this, but there were similar changes that were actually expected, so I misunderstood the tests that I had changed as part of that PR. I've reverted the state of those tests to where they were before the change. Also manually tested to see that the HEAD rev does not show up when not specified. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
