### PR TITLE
sg: Fix nil map panic when merging envs from overwrites

### DIFF
--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -65,10 +65,16 @@ func (c Command) Merge(other Command) Command {
 	merged.ContinueWatchOnExit = other.ContinueWatchOnExit || merged.ContinueWatchOnExit
 
 	for k, v := range other.Env {
+		if merged.Env == nil {
+			merged.Env = make(map[string]string)
+		}
 		merged.Env[k] = v
 	}
 
 	for k, v := range other.ExternalSecrets {
+		if merged.ExternalSecrets == nil {
+			merged.ExternalSecrets = make(map[string]secrets.ExternalSecret)
+		}
 		merged.ExternalSecrets[k] = v
 	}
 


### PR DESCRIPTION
Saw a panic locally here, this fixes it.



## Test plan

Validated that sg is able to start again now with my config. 