### PR TITLE
release: don't close issue before post-release steps

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -246,25 +246,6 @@ export async function ensureTrackingIssues({
             parentIssue = { ...issue }
         }
         created.push({ ...issue })
-
-        // close previous iterations of this issue
-        const previous = await queryIssues(octokit, template.titleSuffix, template.labels)
-        for (const previousIssue of previous) {
-            if (previousIssue.number === issue.number) {
-                // don't close self
-                continue
-            }
-
-            if (dryRun) {
-                console.log(`dryRun enabled, skipping closure of #${previousIssue.number} '${previousIssue.title}'`)
-                continue
-            }
-            const comment = await commentOnIssue(octokit, previousIssue, `Superseded by #${issue.number}`)
-            console.log(
-                `Closing #${previousIssue.number} '${previousIssue.title}' - commented with an update: ${comment}`
-            )
-            await closeIssue(octokit, previousIssue)
-        }
     }
     return created
 }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -51,7 +51,7 @@ export type StepID =
     | 'release:stage'
     | 'release:add-to-batch-change'
     | 'release:finalize'
-    | 'release:close'
+    | 'release:announce'
     // util
     | 'util:clear-cache'
     // testing
@@ -690,8 +690,8 @@ Batch change: ${batchChangeURL}`,
         },
     },
     {
-        id: 'release:close',
-        description: 'Mark a release as closed',
+        id: 'release:announce',
+        description: 'Announce a release as live',
         run: async config => {
             const { slackAnnounceChannel, dryRun } = config
             const { upcoming: release } = await releaseVersions(config)


### PR DESCRIPTION
There's some confusion around the order of steps in the release process. The issue should be closed after all steps, including setting up the next release are completed. The command is renamed to announce to more accurately describe what it's doing. 

Thought about putting in a yarn close command here...but seems redundant given the release captain is reading the instructions, from an issue they can close manually. 

## Test plan

n/a