### PR TITLE
dev/sg: remove 1pass setup

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -377,13 +377,6 @@ func checkRustVersion(ctx context.Context, out *std.Output, args CheckArgs) erro
 	return check.Version("cargo", parts[1], constraint)
 }
 
-// check1password defines the 1password dependency check which is uniform across platforms.
-func check1password() check.CheckFunc {
-	return check.Combine(
-		check.WrapErrMessage(check.InPath("op"), "The 1password CLI, 'op', is required"),
-		check.CommandOutputContains("op account list", "team-sourcegraph.1password.com"))
-}
-
 func forceASDFPluginAdd(ctx context.Context, plugin string, source string) error {
 	err := usershell.Run(ctx, "asdf plugin-add", plugin, source).Wait()
 	if err != nil && strings.Contains(err.Error(), "already added") {

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -247,17 +247,6 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 		Enabled:   enableForTeammatesOnly(),
 		Checks: []*dependency{
 			dependencyGcloud(),
-			{
-				Name:  "1password",
-				Check: checkAction(check1password()),
-				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
-					if err := usershell.Run(ctx, "brew install --cask 1password/tap/1password-cli").StreamLines(cio.Verbose); err != nil {
-						return err
-					}
-
-					return opLoginFix()(ctx, cio, args)
-				},
-			},
 		},
 	},
 }

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -238,26 +238,6 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 		Enabled:   enableForTeammatesOnly(),
 		Checks: []*dependency{
 			dependencyGcloud(),
-			{
-				Name:  "1password",
-				Check: checkAction(check1password()),
-				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
-					// Convoluted directions from https://developer.1password.com/docs/cli/get-started/#install
-					if err := cmdFixes(
-						"curl -sS https://downloads.1password.com/linux/keys/1password.asc | sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg",
-						`echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" |  sudo tee /etc/apt/sources.list.d/1password.list`,
-						`sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/`,
-						`curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol | sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol`,
-						`sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22`,
-						`curl -ss https://downloads.1password.com/linux/keys/1password.asc | sudo gpg --dearmor --output /usr/share/debsig/keyrings/ac2d62742012ea22/debsig.gpg`,
-						`sudo apt update && sudo apt install 1password-cli`,
-					)(ctx, cio, args); err != nil {
-						return err
-					}
-
-					return opLoginFix()(ctx, cio, args)
-				},
-			},
 		},
 	},
 }


### PR DESCRIPTION
This integration seems to cause a lot of confusion, it's rarely used at the moment (currently only used by the soon-to-be-deprecated OkayHQ integration), and [the integration is clunky](https://github.com/sourcegraph/sourcegraph/pull/37033) :grimacing:

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a