### PR TITLE
dev/Caddyfile: use 127.0.0.1 instead of localhost

### DIFF
--- a/dev/Caddyfile
+++ b/dev/Caddyfile
@@ -9,12 +9,12 @@
 # Caddy (tls :3443) -> webpack (:3080) -> Caddy (:3081) -> sourcegraph-frontend (:3082)
 {$SOURCEGRAPH_HTTPS_DOMAIN}:{$SOURCEGRAPH_HTTPS_PORT} {
 	tls internal
-	reverse_proxy localhost:3080 {
+	reverse_proxy 127.0.0.1:3080 {
 		lb_try_duration 60s
 	}
 }
 
 # Caddy (:3081) -> sourcegraph-frontend (:3082)
 :3081 {
-	reverse_proxy localhost:3082
+	reverse_proxy 127.0.0.1:3082
 }


### PR DESCRIPTION
This aligns with what Sourcegraph services listen on in dev with `INSECURE_DEV` mode.

I noticed Rob getting indismissible popups with Caddy - this didn't quite solve that, but it did solve his browser treating sourcegraph.test as insecure, and seems to be a reasonable change regardless to align with other services. We also have an anti-localhost linter with additional reasoning.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
sg start web-standalone
```