### PR TITLE
codeintel: add audit log reason for delete upload by ID

### DIFF
--- a/internal/codeintel/stores/dbstore/uploads.go
+++ b/internal/codeintel/stores/dbstore/uploads.go
@@ -766,6 +766,9 @@ func (s *Store) DeleteUploadByID(ctx context.Context, id int) (_ bool, err error
 	}
 	defer func() { err = tx.Done(err) }()
 
+	unset, _ := tx.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "direct delete by ID request")
+	defer unset(ctx)
+
 	repositoryID, deleted, err := basestore.ScanFirstInt(tx.Store.Query(ctx, sqlf.Sprintf(deleteUploadByIDQuery, id)))
 	if err != nil {
 		return false, err

--- a/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -313,7 +313,7 @@ func (s *store) SoftDeleteExpiredUploads(ctx context.Context) (count int, err er
 		return 0, nil
 	}
 
-	unset, _ := s.db.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "soft-deleting expired uploads")
+	unset, _ := tx.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "soft-deleting expired uploads")
 	defer unset(ctx)
 	repositories, err := scanCounts(tx.Query(ctx, sqlf.Sprintf(softDeleteExpiredUploadsQuery)))
 	if err != nil {


### PR DESCRIPTION
Add reason for direct upload delete by ID, I think the last remaining area where set state = 'deleting' occurs

## Test plan

N/A, doesnt affect any logic. Tested locally reason gets set
