### PR TITLE
Jdb/remove-filters-from-insight-type

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -26,7 +26,7 @@ export default defaultStory
 const filters = {
     excludeRepoRegex: '',
     includeRepoRegex: '',
-    searchContexts: '',
+    searchContexts: [''],
     seriesDisplayOptions: {
         limit: '20',
         sortOptions: {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -24,9 +24,9 @@ const defaultStory: Meta = {
 export default defaultStory
 
 const filters = {
-    excludeRepoRegexp: '',
-    includeRepoRegexp: '',
-    context: '',
+    excludeRepoRegex: '',
+    includeRepoRegex: '',
+    searchContexts: '',
     seriesDisplayOptions: {
         limit: '20',
         sortOptions: {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -45,9 +45,9 @@ const INSIGHT_CONFIGURATION_MOCK: SearchBasedInsight = {
     executionType: InsightExecutionType.Backend,
     step: { weeks: 2 },
     filters: {
-        excludeRepoRegexp: '',
-        includeRepoRegexp: '',
-        context: '',
+        excludeRepoRegex: '',
+        includeRepoRegex: '',
+        searchContexts: '',
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {
@@ -260,9 +260,9 @@ const COMPONENT_MIGRATION_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     ],
     step: { weeks: 2 },
     filters: {
-        excludeRepoRegexp: '',
-        includeRepoRegexp: '',
-        context: '',
+        excludeRepoRegex: '',
+        includeRepoRegex: '',
+        searchContexts: '',
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {
@@ -290,9 +290,9 @@ const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     ],
     step: { weeks: 2 },
     filters: {
-        excludeRepoRegexp: '',
-        includeRepoRegexp: '',
-        context: '',
+        excludeRepoRegex: '',
+        includeRepoRegex: '',
+        searchContexts: '',
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {
@@ -317,9 +317,9 @@ const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
     repositories: [],
     query: '',
     filters: {
-        excludeRepoRegexp: '',
-        includeRepoRegexp: '',
-        context: '',
+        excludeRepoRegex: '',
+        includeRepoRegex: '',
+        searchContexts: '',
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -47,7 +47,7 @@ const INSIGHT_CONFIGURATION_MOCK: SearchBasedInsight = {
     filters: {
         excludeRepoRegex: '',
         includeRepoRegex: '',
-        searchContexts: '',
+        searchContexts: [''],
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {
@@ -262,7 +262,7 @@ const COMPONENT_MIGRATION_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     filters: {
         excludeRepoRegex: '',
         includeRepoRegex: '',
-        searchContexts: '',
+        searchContexts: [''],
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {
@@ -292,7 +292,7 @@ const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     filters: {
         excludeRepoRegex: '',
         includeRepoRegex: '',
-        searchContexts: '',
+        searchContexts: [''],
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {
@@ -319,7 +319,7 @@ const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
     filters: {
         excludeRepoRegex: '',
         includeRepoRegex: '',
-        searchContexts: '',
+        searchContexts: [''],
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -10,7 +10,6 @@ import { Link, useDebounce, useDeepMemo } from '@sourcegraph/wildcard'
 
 import { useFeatureFlag } from '../../../../../../featureFlags/useFeatureFlag'
 import {
-    InsightViewFiltersInput,
     SeriesDisplayOptionsInput,
     GetInsightViewResult,
     GetInsightViewVariables,
@@ -82,14 +81,10 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
     const [isFiltersOpen, setIsFiltersOpen] = useState(false)
     const debouncedFilters = useDebounce(useDeepMemo<InsightFilters>(filters), 500)
 
-    const filterInput: InsightViewFiltersInput = {
-        includeRepoRegex: debouncedFilters.includeRepoRegex,
-        excludeRepoRegex: debouncedFilters.excludeRepoRegex,
-        searchContexts: [debouncedFilters.searchContexts],
-    }
+    const { seriesDisplayOptions: seriesFilters, ...filterInput } = debouncedFilters
     const seriesDisplayOptions: SeriesDisplayOptionsInput = {
-        limit: parseSeriesLimit(debouncedFilters.seriesDisplayOptions.limit),
-        sortOptions: debouncedFilters.seriesDisplayOptions.sortOptions,
+        limit: parseSeriesLimit(seriesFilters.limit),
+        sortOptions: seriesFilters.sortOptions,
     }
 
     const { error, loading, stopPolling } = useQuery<GetInsightViewResult, GetInsightViewVariables>(

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -83,9 +83,9 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
     const debouncedFilters = useDebounce(useDeepMemo<InsightFilters>(filters), 500)
 
     const filterInput: InsightViewFiltersInput = {
-        includeRepoRegex: debouncedFilters.includeRepoRegexp,
-        excludeRepoRegex: debouncedFilters.excludeRepoRegexp,
-        searchContexts: [debouncedFilters.context],
+        includeRepoRegex: debouncedFilters.includeRepoRegex,
+        excludeRepoRegex: debouncedFilters.excludeRepoRegex,
+        searchContexts: [debouncedFilters.searchContexts],
     }
     const seriesDisplayOptions: SeriesDisplayOptionsInput = {
         limit: parseSeriesLimit(debouncedFilters.seriesDisplayOptions.limit),

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
@@ -19,7 +19,7 @@ export const DrillDownPopover: Story = () => {
     const initialFiltersValue: InsightFilters = {
         excludeRepoRegex: 'EXCLUDE',
         includeRepoRegex: '',
-        searchContexts: '',
+        searchContexts: [''],
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
@@ -17,9 +17,9 @@ export default defaultStory
 export const DrillDownPopover: Story = () => {
     const exampleReference = useRef(null)
     const initialFiltersValue: InsightFilters = {
-        excludeRepoRegexp: 'EXCLUDE',
-        includeRepoRegexp: '',
-        context: '',
+        excludeRepoRegex: 'EXCLUDE',
+        includeRepoRegex: '',
+        searchContexts: '',
         seriesDisplayOptions: {
             limit: '20',
             sortOptions: {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
@@ -83,9 +83,9 @@ const CONTEXTS_GQL_MOCKS: MockedResponse<GetSearchContextsResult> = {
 }
 
 const ORIGINAL_FILTERS: InsightFilters = {
-    includeRepoRegexp: '',
-    excludeRepoRegexp: '',
-    context: '',
+    includeRepoRegex: '',
+    excludeRepoRegex: '',
+    searchContexts: '',
     seriesDisplayOptions: {
         limit: '20',
         sortOptions: {
@@ -96,9 +96,9 @@ const ORIGINAL_FILTERS: InsightFilters = {
 }
 
 const FILTERS: InsightFilters = {
-    includeRepoRegexp: 'hello world loooong loooooooooooooong repo filter regular expressssssion',
-    excludeRepoRegexp: 'hello world loooong loooooooooooooong repo filter regular expressssssion',
-    context: '',
+    includeRepoRegex: 'hello world loooong loooooooooooooong repo filter regular expressssssion',
+    excludeRepoRegex: 'hello world loooong loooooooooooooong repo filter regular expressssssion',
+    searchContexts: '',
     seriesDisplayOptions: {
         limit: '20',
         sortOptions: {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
@@ -85,7 +85,7 @@ const CONTEXTS_GQL_MOCKS: MockedResponse<GetSearchContextsResult> = {
 const ORIGINAL_FILTERS: InsightFilters = {
     includeRepoRegex: '',
     excludeRepoRegex: '',
-    searchContexts: '',
+    searchContexts: [''],
     seriesDisplayOptions: {
         limit: '20',
         sortOptions: {
@@ -98,7 +98,7 @@ const ORIGINAL_FILTERS: InsightFilters = {
 const FILTERS: InsightFilters = {
     includeRepoRegex: 'hello world loooong loooooooooooooong repo filter regular expressssssion',
     excludeRepoRegex: 'hello world loooong loooooooooooooong repo filter regular expressssssion',
-    searchContexts: '',
+    searchContexts: [''],
     seriesDisplayOptions: {
         limit: '20',
         sortOptions: {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -35,7 +35,7 @@ export enum FilterSectionVisualMode {
 }
 
 export interface DrillDownFiltersFormValues {
-    searchContexts: string
+    searchContexts: InsightViewNode['appliedFilters']['searchContexts']
     includeRepoRegex: InsightViewNode['appliedFilters']['includeRepoRegex']
     excludeRepoRegex: InsightViewNode['appliedFilters']['excludeRepoRegex']
     seriesDisplayOptions: {
@@ -133,7 +133,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
     }
 
     const handleClear = (): void => {
-        contexts.input.onChange('')
+        contexts.input.onChange([''])
         includeRegex.input.onChange('')
         excludeRegex.input.onChange('')
         seriesDisplayOptionsField.input.onChange(originalValues.seriesDisplayOptions)
@@ -240,6 +240,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         className={styles.input}
                         status={getFilterInputStatus(contexts)}
                         {...contexts.input}
+                        value={contexts.input.value ? contexts.input.value[0] : ''}
                     />
                 </FilterCollapseSection>
 
@@ -351,7 +352,17 @@ export function hasActiveFilters(filters: DrillDownFiltersFormValues): boolean {
     return [excludeRepoRegex, includeRepoRegex, searchContexts].some(hasActiveUnaryFilter)
 }
 
-const hasActiveUnaryFilter = (filter: string | null): boolean => !!filter && filter.trim() !== ''
+const hasActiveUnaryFilter = (filter: string[] | string | null): boolean => {
+    if (!filter) {
+        return false
+    }
+
+    if (typeof filter === 'string') {
+        return filter.trim() !== ''
+    }
+
+    return filter.some(value => value.trim() !== '')
+}
 
 interface SubmitButtonTextProps {
     submitting: boolean

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -240,7 +240,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         className={styles.input}
                         status={getFilterInputStatus(contexts)}
                         {...contexts.input}
-                        value={contexts.input.value ? contexts.input.value[0] : ''}
+                        value={contexts.input.value ? contexts.input.value[0] : undefined}
                     />
                 </FilterCollapseSection>
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -35,9 +35,9 @@ export enum FilterSectionVisualMode {
 }
 
 export interface DrillDownFiltersFormValues {
-    context: string
-    includeRepoRegexp: string
-    excludeRepoRegexp: string
+    searchContexts: string
+    includeRepoRegex: string
+    excludeRepoRegex: string
     seriesDisplayOptions: {
         limit: string
         sortOptions: {
@@ -98,19 +98,19 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
     const client = useApolloClient()
 
     const contexts = useField({
-        name: 'context',
+        name: 'searchContexts',
         formApi: formAPI,
         validators: { async: useMemo(() => createSearchContextValidator(client), [client]) },
     })
 
     const includeRegex = useField({
-        name: 'includeRepoRegexp',
+        name: 'includeRepoRegex',
         formApi: formAPI,
         validators: { sync: validRegexp },
     })
 
     const excludeRegex = useField({
-        name: 'excludeRepoRegexp',
+        name: 'excludeRepoRegex',
         formApi: formAPI,
         validators: { sync: validRegexp },
     })
@@ -344,9 +344,9 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
 }
 
 export function hasActiveFilters(filters: DrillDownFiltersFormValues): boolean {
-    const { excludeRepoRegexp, includeRepoRegexp, context } = filters
+    const { excludeRepoRegex, includeRepoRegex, searchContexts } = filters
 
-    return [excludeRepoRegexp, includeRepoRegexp, context].some(hasActiveUnaryFilter)
+    return [excludeRepoRegex, includeRepoRegex, searchContexts].some(hasActiveUnaryFilter)
 }
 
 const hasActiveUnaryFilter = (filter: string): boolean => filter.trim() !== ''

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -9,7 +9,7 @@ import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Button, Icon, Link, H4 } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../../../../../../../components/LoaderButton'
-import { SeriesSortDirection, SeriesSortMode } from '../../../../../../../../../graphql-operations'
+import { InsightViewNode, SeriesSortDirection, SeriesSortMode } from '../../../../../../../../../graphql-operations'
 import { useField } from '../../../../../../form/hooks/useField'
 import { FormChangeEvent, SubmissionResult, useForm, FORM_ERROR } from '../../../../../../form/hooks/useForm'
 import { SortFilterSeriesPanel } from '../../sort-filter-series-panel/SortFilterSeriesPanel'
@@ -36,8 +36,8 @@ export enum FilterSectionVisualMode {
 
 export interface DrillDownFiltersFormValues {
     searchContexts: string
-    includeRepoRegex: string
-    excludeRepoRegex: string
+    includeRepoRegex: InsightViewNode['appliedFilters']['includeRepoRegex']
+    excludeRepoRegex: InsightViewNode['appliedFilters']['excludeRepoRegex']
     seriesDisplayOptions: {
         limit: string
         sortOptions: {
@@ -273,6 +273,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                                 className={styles.input}
                                 status={getFilterInputStatus(includeRegex)}
                                 {...includeRegex.input}
+                                value={includeRegex.input.value ?? undefined}
                             />
                         </LabelWithReset>
 
@@ -288,6 +289,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                                 className={styles.input}
                                 status={getFilterInputStatus(excludeRegex)}
                                 {...excludeRegex.input}
+                                value={excludeRegex.input.value ?? undefined}
                             />
                         </LabelWithReset>
                     </fieldset>
@@ -349,7 +351,7 @@ export function hasActiveFilters(filters: DrillDownFiltersFormValues): boolean {
     return [excludeRepoRegex, includeRepoRegex, searchContexts].some(hasActiveUnaryFilter)
 }
 
-const hasActiveUnaryFilter = (filter: string): boolean => filter.trim() !== ''
+const hasActiveUnaryFilter = (filter: string | null): boolean => !!filter && filter.trim() !== ''
 
 interface SubmitButtonTextProps {
     submitting: boolean

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
@@ -11,8 +11,8 @@ import { Validator } from '../../../../../../form/hooks/useField'
 
 import { DrillDownFiltersFormValues } from './DrillDownInsightFilters'
 
-export const validRegexp: Validator<string> = (value = '') => {
-    if (value.trim() === '') {
+export const validRegexp: Validator<string | null> = (value = '') => {
+    if (!value || value.trim() === '') {
         return
     }
 
@@ -26,8 +26,8 @@ export const validRegexp: Validator<string> = (value = '') => {
 }
 
 interface InsightRepositoriesFilter {
-    include: string
-    exclude: string
+    include: string | null
+    exclude: string | null
 }
 
 export function getSerializedRepositoriesFilter(filter: InsightRepositoriesFilter): string {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
@@ -67,13 +67,13 @@ export const getSortPreview = (seriesDisplayOptions: {
     return `Sorted ${sortBy}, limit ${limit} series`
 }
 
-type InsightContextsFilter = string
+type InsightContextsFilter = string[] | null
 
 export function getSerializedSearchContextFilter(
     filter: InsightContextsFilter,
     withContextPrefix: boolean = true
 ): string {
-    const filterValue = filter !== '' ? filter : 'global (default)'
+    const filterValue = filter && filter[0] !== '' ? filter[0] : 'global (default)'
 
     return withContextPrefix ? `context:${filterValue}` : filterValue
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/validators.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/validators.ts
@@ -16,14 +16,14 @@ const GET_CONTEXT_BY_NAME = gql`
 `
 
 export const createSearchContextValidator = (client: ApolloClient<unknown>) => async (
-    value: string | undefined
+    value: string[] | undefined | null
 ): Promise<string | void> => {
     if (!value) {
         return
     }
 
     try {
-        const sanitizedValue = value.trim()
+        const sanitizedValue = value[0].trim()
         const { data, error } = await client.query<GetSearchContextByNameResult>({
             query: GET_CONTEXT_BY_NAME,
             variables: { query: sanitizedValue },

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
@@ -74,9 +74,9 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                     query,
                     step,
                     filters: {
-                        includeRepoRegex: appliedFilters.includeRepoRegex ?? '',
-                        excludeRepoRegex: appliedFilters.excludeRepoRegex ?? '',
-                        searchContexts: appliedFilters.searchContexts?.[0] ?? '',
+                        includeRepoRegex: appliedFilters.includeRepoRegex,
+                        excludeRepoRegex: appliedFilters.excludeRepoRegex,
+                        searchContexts: appliedFilters.searchContexts,
                         seriesDisplayOptions,
                     },
                     appliedSeriesDisplayOptions: insight.appliedSeriesDisplayOptions,
@@ -102,7 +102,7 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                 // It's safe because capture group insight always has only 1 data series
                 const { groupBy } = insight.dataSeriesDefinitions[0] ?? {}
 
-                return {
+                const computeInsight: ComputeInsight = {
                     ...baseInsight,
                     executionType: InsightExecutionType.Backend,
                     type: InsightType.Compute,
@@ -110,12 +110,14 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                     repositories,
                     series,
                     filters: {
-                        includeRepoRegex: appliedFilters.includeRepoRegex ?? '',
-                        excludeRepoRegex: appliedFilters.excludeRepoRegex ?? '',
-                        searchContexts: appliedFilters.searchContexts?.[0] ?? '',
+                        includeRepoRegex: appliedFilters.includeRepoRegex,
+                        excludeRepoRegex: appliedFilters.excludeRepoRegex,
+                        searchContexts: appliedFilters.searchContexts,
                         seriesDisplayOptions,
                     },
-                } as ComputeInsight
+                }
+
+                return computeInsight
             }
 
             return {
@@ -126,9 +128,9 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                 series,
                 step,
                 filters: {
-                    includeRepoRegex: appliedFilters.includeRepoRegex ?? '',
-                    excludeRepoRegex: appliedFilters.excludeRepoRegex ?? '',
-                    searchContexts: appliedFilters.searchContexts?.[0] ?? '',
+                    includeRepoRegex: appliedFilters.includeRepoRegex,
+                    excludeRepoRegex: appliedFilters.excludeRepoRegex,
+                    searchContexts: appliedFilters.searchContexts,
                     seriesDisplayOptions,
                 },
             }

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
@@ -74,9 +74,9 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                     query,
                     step,
                     filters: {
-                        includeRepoRegexp: appliedFilters.includeRepoRegex ?? '',
-                        excludeRepoRegexp: appliedFilters.excludeRepoRegex ?? '',
-                        context: appliedFilters.searchContexts?.[0] ?? '',
+                        includeRepoRegex: appliedFilters.includeRepoRegex ?? '',
+                        excludeRepoRegex: appliedFilters.excludeRepoRegex ?? '',
+                        searchContexts: appliedFilters.searchContexts?.[0] ?? '',
                         seriesDisplayOptions,
                     },
                     appliedSeriesDisplayOptions: insight.appliedSeriesDisplayOptions,
@@ -110,9 +110,9 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                     repositories,
                     series,
                     filters: {
-                        includeRepoRegexp: appliedFilters.includeRepoRegex ?? '',
-                        excludeRepoRegexp: appliedFilters.excludeRepoRegex ?? '',
-                        context: appliedFilters.searchContexts?.[0] ?? '',
+                        includeRepoRegex: appliedFilters.includeRepoRegex ?? '',
+                        excludeRepoRegex: appliedFilters.excludeRepoRegex ?? '',
+                        searchContexts: appliedFilters.searchContexts?.[0] ?? '',
                         seriesDisplayOptions,
                     },
                 } as ComputeInsight
@@ -126,9 +126,9 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                 series,
                 step,
                 filters: {
-                    includeRepoRegexp: appliedFilters.includeRepoRegex ?? '',
-                    excludeRepoRegexp: appliedFilters.excludeRepoRegex ?? '',
-                    context: appliedFilters.searchContexts?.[0] ?? '',
+                    includeRepoRegex: appliedFilters.includeRepoRegex ?? '',
+                    excludeRepoRegex: appliedFilters.excludeRepoRegex ?? '',
+                    searchContexts: appliedFilters.searchContexts?.[0] ?? '',
                     seriesDisplayOptions,
                 },
             }

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
@@ -64,7 +64,6 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
             if (isCaptureGroupInsight) {
                 // It's safe because capture group insight always has only 1 data series
                 const { query } = insight.dataSeriesDefinitions[0] ?? {}
-                const { appliedFilters } = insight
 
                 return {
                     ...baseInsight,
@@ -74,9 +73,7 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                     query,
                     step,
                     filters: {
-                        includeRepoRegex: appliedFilters.includeRepoRegex,
-                        excludeRepoRegex: appliedFilters.excludeRepoRegex,
-                        searchContexts: appliedFilters.searchContexts,
+                        ...appliedFilters,
                         seriesDisplayOptions,
                     },
                     appliedSeriesDisplayOptions: insight.appliedSeriesDisplayOptions,
@@ -110,9 +107,7 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                     repositories,
                     series,
                     filters: {
-                        includeRepoRegex: appliedFilters.includeRepoRegex,
-                        excludeRepoRegex: appliedFilters.excludeRepoRegex,
-                        searchContexts: appliedFilters.searchContexts,
+                        ...appliedFilters,
                         seriesDisplayOptions,
                     },
                 }
@@ -128,9 +123,7 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
                 series,
                 step,
                 filters: {
-                    includeRepoRegex: appliedFilters.includeRepoRegex,
-                    excludeRepoRegex: appliedFilters.excludeRepoRegex,
-                    searchContexts: appliedFilters.searchContexts,
+                    ...appliedFilters,
                     seriesDisplayOptions,
                 },
             }

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
@@ -58,8 +58,8 @@ export function getCaptureGroupInsightCreateInput(
                 insight.seriesDisplayOptions ||
                 parseSeriesDisplayOptions(insight.seriesCount, insight.appliedSeriesDisplayOptions),
             filters: {
-                excludeRepoRegex: insight.filters.excludeRepoRegexp,
-                includeRepoRegex: insight.filters.includeRepoRegexp,
+                excludeRepoRegex: insight.filters.excludeRepoRegex,
+                includeRepoRegex: insight.filters.includeRepoRegex,
             },
         },
     }

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/serializators.ts
@@ -18,9 +18,9 @@ export function getSearchInsightUpdateInput(insight: MinimalSearchBasedInsightDa
     const repositories = insight.repositories
     const [unit, value] = getStepInterval(insight.step)
     const filters: InsightViewFiltersInput = {
-        includeRepoRegex: insight.filters.includeRepoRegexp,
-        excludeRepoRegex: insight.filters.excludeRepoRegexp,
-        searchContexts: insight.filters.context ? [insight.filters.context] : [],
+        includeRepoRegex: insight.filters.includeRepoRegex,
+        excludeRepoRegex: insight.filters.excludeRepoRegex,
+        searchContexts: insight.filters.searchContexts ? [insight.filters.searchContexts] : [],
     }
 
     const seriesDisplayOptions = parseSeriesDisplayOptions(insight.seriesCount, insight.seriesDisplayOptions)
@@ -66,9 +66,9 @@ export function getCaptureGroupInsightUpdateInput(
         },
         viewControls: {
             filters: {
-                includeRepoRegex: filters.includeRepoRegexp,
-                excludeRepoRegex: filters.excludeRepoRegexp,
-                searchContexts: insight.filters.context ? [filters.context] : [],
+                includeRepoRegex: filters.includeRepoRegex,
+                excludeRepoRegex: filters.excludeRepoRegex,
+                searchContexts: insight.filters.searchContexts ? [filters.searchContexts] : [],
             },
             seriesDisplayOptions: _seriesDisplayOptions,
         },
@@ -79,9 +79,9 @@ export function getComputeInsightUpdateInput(insight: MinimalComputeInsightData)
     const { repositories, filters, groupBy } = insight
 
     const serializedFilters: InsightViewFiltersInput = {
-        includeRepoRegex: filters.includeRepoRegexp,
-        excludeRepoRegex: filters.excludeRepoRegexp,
-        searchContexts: filters.context ? [filters.context] : [],
+        includeRepoRegex: filters.includeRepoRegex,
+        excludeRepoRegex: filters.excludeRepoRegex,
+        searchContexts: filters.searchContexts ? [filters.searchContexts] : [],
     }
 
     return {

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/serializators.ts
@@ -1,5 +1,4 @@
 import {
-    InsightViewFiltersInput,
     LineChartSearchInsightDataSeriesInput,
     TimeIntervalStepUnit,
     UpdateLineChartSearchInsightInput,
@@ -17,11 +16,6 @@ import { getStepInterval } from '../../utils/get-step-interval'
 export function getSearchInsightUpdateInput(insight: MinimalSearchBasedInsightData): UpdateLineChartSearchInsightInput {
     const repositories = insight.repositories
     const [unit, value] = getStepInterval(insight.step)
-    const filters: InsightViewFiltersInput = {
-        includeRepoRegex: insight.filters.includeRepoRegex,
-        excludeRepoRegex: insight.filters.excludeRepoRegex,
-        searchContexts: insight.filters.searchContexts ? [insight.filters.searchContexts] : [],
-    }
 
     const seriesDisplayOptions = parseSeriesDisplayOptions(insight.seriesCount, insight.seriesDisplayOptions)
 
@@ -39,7 +33,7 @@ export function getSearchInsightUpdateInput(insight: MinimalSearchBasedInsightDa
         presentationOptions: {
             title: insight.title,
         },
-        viewControls: { filters, seriesDisplayOptions },
+        viewControls: { filters: insight.filters, seriesDisplayOptions },
     }
 }
 
@@ -65,11 +59,7 @@ export function getCaptureGroupInsightUpdateInput(
             title,
         },
         viewControls: {
-            filters: {
-                includeRepoRegex: filters.includeRepoRegex,
-                excludeRepoRegex: filters.excludeRepoRegex,
-                searchContexts: insight.filters.searchContexts ? [filters.searchContexts] : [],
-            },
+            filters,
             seriesDisplayOptions: _seriesDisplayOptions,
         },
     }
@@ -77,12 +67,6 @@ export function getCaptureGroupInsightUpdateInput(
 
 export function getComputeInsightUpdateInput(insight: MinimalComputeInsightData): UpdateLineChartSearchInsightInput {
     const { repositories, filters, groupBy } = insight
-
-    const serializedFilters: InsightViewFiltersInput = {
-        includeRepoRegex: filters.includeRepoRegex,
-        excludeRepoRegex: filters.excludeRepoRegex,
-        searchContexts: filters.searchContexts ? [filters.searchContexts] : [],
-    }
 
     return {
         dataSeries: insight.series.map<LineChartSearchInsightDataSeriesInput>(series => ({
@@ -102,7 +86,7 @@ export function getComputeInsightUpdateInput(insight: MinimalComputeInsightData)
             title: insight.title,
         },
         // TODO: update when sorting all insights are supported
-        viewControls: { filters: serializedFilters, seriesDisplayOptions: {} },
+        viewControls: { filters, seriesDisplayOptions: {} },
     }
 }
 

--- a/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
@@ -66,7 +66,7 @@ interface GenerateLinkInput {
 
 export function generateLinkURL(input: GenerateLinkInput): string {
     const { query, point, previousPoint, filters, repositories } = input
-    const { includeRepoRegexp = '', excludeRepoRegexp = '', context } = filters ?? {}
+    const { includeRepoRegex = '', excludeRepoRegex = '', searchContexts } = filters ?? {}
 
     const date = Date.parse(point.dateTime)
 
@@ -76,11 +76,11 @@ export function generateLinkURL(input: GenerateLinkInput): string {
     const after = previousPoint ? formatISO(Date.parse(previousPoint.dateTime)) : ''
     const before = formatISO(date)
 
-    const includeRepoFilter = includeRepoRegexp ? `repo:${includeRepoRegexp}` : ''
-    const excludeRepoFilter = excludeRepoRegexp ? `-repo:${excludeRepoRegexp}` : ''
+    const includeRepoFilter = includeRepoRegex ? `repo:${includeRepoRegex}` : ''
+    const excludeRepoFilter = excludeRepoRegex ? `-repo:${excludeRepoRegex}` : ''
 
     const scopeRepoFilters = repositories.length > 0 ? `repo:^(${repositories.map(escapeRegExp).join('|')})$` : ''
-    const contextFilter = context ? `context:${context}` : ''
+    const contextFilter = searchContexts ? `context:${searchContexts}` : ''
     const repoFilter = `${includeRepoFilter} ${excludeRepoFilter}`
     const afterFilter = after ? `after:${after}` : ''
     const beforeFilter = `before:${before}`

--- a/client/web/src/enterprise/insights/core/types/insight/common.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/common.ts
@@ -32,9 +32,9 @@ export enum InsightContentType {
 }
 
 export interface InsightFilters {
-    includeRepoRegexp: string
-    excludeRepoRegexp: string
-    context: string
+    includeRepoRegex: string
+    excludeRepoRegex: string
+    searchContexts: string
     repositories?: string[]
     seriesDisplayOptions: {
         limit: string

--- a/client/web/src/enterprise/insights/core/types/insight/common.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/common.ts
@@ -32,8 +32,8 @@ export enum InsightContentType {
 }
 
 export interface InsightFilters {
-    includeRepoRegex: string
-    excludeRepoRegex: string
+    includeRepoRegex: InsightViewNode['appliedFilters']['includeRepoRegex']
+    excludeRepoRegex: InsightViewNode['appliedFilters']['excludeRepoRegex']
     searchContexts: string
     repositories?: string[]
     seriesDisplayOptions: {

--- a/client/web/src/enterprise/insights/core/types/insight/common.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/common.ts
@@ -34,7 +34,7 @@ export enum InsightContentType {
 export interface InsightFilters {
     includeRepoRegex: InsightViewNode['appliedFilters']['includeRepoRegex']
     excludeRepoRegex: InsightViewNode['appliedFilters']['excludeRepoRegex']
-    searchContexts: string
+    searchContexts: InsightViewNode['appliedFilters']['searchContexts']
     repositories?: string[]
     seriesDisplayOptions: {
         limit: string

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-group-insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-group-insight-sanitizer.ts
@@ -19,7 +19,7 @@ export function getSanitizedCaptureGroupInsight(values: CaptureGroupFormFields):
         filters: {
             includeRepoRegex: '',
             excludeRepoRegex: '',
-            searchContexts: '',
+            searchContexts: [''],
             seriesDisplayOptions: {
                 limit: `${MAX_NUMBER_OF_SERIES}`,
                 sortOptions: {

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-group-insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-group-insight-sanitizer.ts
@@ -17,9 +17,9 @@ export function getSanitizedCaptureGroupInsight(values: CaptureGroupFormFields):
         step: { [values.step]: +values.stepValue },
         repositories: values.allRepos ? [] : getSanitizedRepositories(values.repositories),
         filters: {
-            includeRepoRegexp: '',
-            excludeRepoRegexp: '',
-            context: '',
+            includeRepoRegex: '',
+            excludeRepoRegex: '',
+            searchContexts: '',
             seriesDisplayOptions: {
                 limit: `${MAX_NUMBER_OF_SERIES}`,
                 sortOptions: {

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/utils/insight-sanitaizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/utils/insight-sanitaizer.ts
@@ -18,7 +18,7 @@ export const getSanitizedComputeInsight = (values: CreateComputeInsightFormField
     filters: {
         excludeRepoRegex: '',
         includeRepoRegex: '',
-        searchContexts: '',
+        searchContexts: [''],
         seriesDisplayOptions: {
             limit: `${MAX_NUMBER_OF_SERIES}`,
             sortOptions: {

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/utils/insight-sanitaizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/utils/insight-sanitaizer.ts
@@ -16,9 +16,9 @@ export const getSanitizedComputeInsight = (values: CreateComputeInsightFormField
     isFrozen: false,
     dashboardReferenceCount: 0,
     filters: {
-        excludeRepoRegexp: '',
-        includeRepoRegexp: '',
-        context: '',
+        excludeRepoRegex: '',
+        includeRepoRegex: '',
+        searchContexts: '',
         seriesDisplayOptions: {
             limit: `${MAX_NUMBER_OF_SERIES}`,
             sortOptions: {

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
@@ -19,9 +19,9 @@ export function getSanitizedSearchInsight(rawInsight: CreateInsightFormFields): 
             step: { [rawInsight.step]: +rawInsight.stepValue },
             dashboards: [],
             filters: {
-                excludeRepoRegexp: '',
-                includeRepoRegexp: '',
-                context: '',
+                excludeRepoRegex: '',
+                includeRepoRegex: '',
+                searchContexts: '',
                 seriesDisplayOptions: {
                     limit: `${MAX_NUMBER_OF_SERIES}`,
                     sortOptions: {
@@ -43,9 +43,9 @@ export function getSanitizedSearchInsight(rawInsight: CreateInsightFormFields): 
         step: { [rawInsight.step]: +rawInsight.stepValue },
         dashboards: [],
         filters: {
-            excludeRepoRegexp: '',
-            includeRepoRegexp: '',
-            context: '',
+            excludeRepoRegex: '',
+            includeRepoRegex: '',
+            searchContexts: '',
             seriesDisplayOptions: {
                 limit: `${MAX_NUMBER_OF_SERIES}`,
                 sortOptions: {

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
@@ -21,7 +21,7 @@ export function getSanitizedSearchInsight(rawInsight: CreateInsightFormFields): 
             filters: {
                 excludeRepoRegex: '',
                 includeRepoRegex: '',
-                searchContexts: '',
+                searchContexts: [''],
                 seriesDisplayOptions: {
                     limit: `${MAX_NUMBER_OF_SERIES}`,
                     sortOptions: {
@@ -45,7 +45,7 @@ export function getSanitizedSearchInsight(rawInsight: CreateInsightFormFields): 
         filters: {
             excludeRepoRegex: '',
             includeRepoRegex: '',
-            searchContexts: '',
+            searchContexts: [''],
             seriesDisplayOptions: {
                 limit: `${MAX_NUMBER_OF_SERIES}`,
                 sortOptions: {

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -12,7 +12,6 @@ import { useFeatureFlag } from '../../../../../../../featureFlags/useFeatureFlag
 import {
     GetInsightViewResult,
     GetInsightViewVariables,
-    InsightViewFiltersInput,
     SeriesDisplayOptionsInput,
 } from '../../../../../../../graphql-operations'
 import { useSeriesToggle } from '../../../../../../../insights/utils/use-series-toggle'
@@ -76,13 +75,8 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
     // filter value in filters fields.
     const [filters, setFilters] = useState<InsightFilters>(originalInsightFilters)
     const [filterVisualMode, setFilterVisualMode] = useState<FilterSectionVisualMode>(FilterSectionVisualMode.Preview)
-    const debouncedFilters = useDebounce(useDeepMemo<InsightFilters>(filters), 500)
+    const { seriesDisplayOptions, ...filterInput } = useDebounce(useDeepMemo<InsightFilters>(filters), 500)
 
-    const filterInput: InsightViewFiltersInput = {
-        includeRepoRegex: debouncedFilters.includeRepoRegex,
-        excludeRepoRegex: debouncedFilters.excludeRepoRegex,
-        searchContexts: debouncedFilters.searchContexts,
-    }
     const displayInput: SeriesDisplayOptionsInput = {
         limit: insight.seriesDisplayOptions?.limit,
         sortOptions: insight.seriesDisplayOptions?.sortOptions,

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -79,9 +79,9 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
     const debouncedFilters = useDebounce(useDeepMemo<InsightFilters>(filters), 500)
 
     const filterInput: InsightViewFiltersInput = {
-        includeRepoRegex: debouncedFilters.includeRepoRegexp,
-        excludeRepoRegex: debouncedFilters.excludeRepoRegexp,
-        searchContexts: [debouncedFilters.context],
+        includeRepoRegex: debouncedFilters.includeRepoRegex,
+        excludeRepoRegex: debouncedFilters.excludeRepoRegex,
+        searchContexts: [debouncedFilters.searchContexts],
     }
     const displayInput: SeriesDisplayOptionsInput = {
         limit: insight.seriesDisplayOptions?.limit,

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -81,7 +81,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
     const filterInput: InsightViewFiltersInput = {
         includeRepoRegex: debouncedFilters.includeRepoRegex,
         excludeRepoRegex: debouncedFilters.excludeRepoRegex,
-        searchContexts: [debouncedFilters.searchContexts],
+        searchContexts: debouncedFilters.searchContexts,
     }
     const displayInput: SeriesDisplayOptionsInput = {
         limit: insight.seriesDisplayOptions?.limit,

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -92,9 +92,9 @@ describe('Backend insight drill down filters', () => {
 
         await driver.page.click('button[aria-label="Filters"]')
 
-        // fill in the excludeRepoRegexp filter
+        // fill in the excludeRepoRegex filter
         await driver.page.waitForSelector('[role="dialog"][aria-label="Drill-down filters panel"]')
-        await driver.page.type('[name="excludeRepoRegexp"]', 'github.com/sourcegraph/sourcegraph')
+        await driver.page.type('[name="excludeRepoRegex"]', 'github.com/sourcegraph/sourcegraph')
 
         // fill in the search context filter regexp
         await driver.page.click('button[aria-label="search context filter section"]')
@@ -202,7 +202,7 @@ describe('Backend insight drill down filters', () => {
         await driver.page.click('button[aria-label="Active filters"]')
         await driver.page.waitForSelector('[role="dialog"][aria-label="Drill-down filters panel"]')
 
-        await driver.page.type('[name="includeRepoRegexp"]', 'github.com/sourcegraph/sourcegraph')
+        await driver.page.type('[name="includeRepoRegex"]', 'github.com/sourcegraph/sourcegraph')
 
         // Wait until async validation of the search context field is passed
         await delay(500)


### PR DESCRIPTION
POC updating frontent types to match the backend API.

This PR updates the `filters` property to more closely match what comes from the backend.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-jdb-remove-filters-from-insight.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sebqxnttkp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
