### PR TITLE
[SG-35196] Accessibility: Congratulate users on getting help filling out a form

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
@@ -49,7 +49,21 @@ export const ConfigurationEditor: FunctionComponent<React.PropsWithChildren<Conf
 
     const [dirty, setDirty] = useState<boolean>()
     const [editor, setEditor] = useState<editor.ICodeEditor>()
-    const infer = useCallback(() => editor?.setValue(inferredConfiguration), [editor, inferredConfiguration])
+    const infer = useCallback(() => {
+        const model = editor?.getModel()
+
+        if (!editor || !model) {
+            return
+        }
+
+        screenReaderAnnounce('Inferred index configuration from HEAD')
+        editor.setValue(inferredConfiguration)
+        editor.focus()
+        editor.setPosition({
+            lineNumber: model.getLineCount(),
+            column: model.getLineContent(model.getLineCount()).length + 1,
+        })
+    }, [editor, inferredConfiguration])
 
     const customToolbar = useMemo<{
         saveToolbar: FunctionComponent<SaveToolbarProps & IndexConfigurationSaveToolbarProps>

--- a/client/web/src/enterprise/codeintel/configuration/components/IndexConfigurationSaveToolbar.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/IndexConfigurationSaveToolbar.tsx
@@ -25,7 +25,7 @@ export const IndexConfigurationSaveToolbar: React.FunctionComponent<
             <LoadingSpinner className="mt-2 ml-2" />
         ) : (
             inferEnabled && (
-                <Button type="button" title="Infer index configuration from HEAD" variant="link" onClick={onInfer}>
+                <Button type="button" aria-live="polite" variant="link" onClick={onInfer}>
                     Infer index configuration from HEAD
                 </Button>
             )


### PR DESCRIPTION
### Problem description
![Image](https://user-images.githubusercontent.com/103087/167509485-e811ee5e-974e-4c84-82f3-1d0ef12f31be.png)
Hitting infer configuration from HEAD does not announce any change in state to the user. Inversely, when the button becomes available on the screen it's also not announced. Its visibility can toggle depending on if the current text area state has changed from the inferred config or not.

### Expected behavior
I would expect that the entire contents of the text area on the page changing should be announced in some manner.

### Ref
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35196)
[GitStart Issue](https://app.gitstart.com/tasks/68129)

### Test Plan
1)  run sg start web-standalone
2)  Go through [this link](http://localhost:3080/github.com/sourcegraph/sourcegraph/-/code-intelligence/index-configuration)
3)  On clicking the entire contents of the text area on the page get announced by the screen reader announce

## App preview:

- [Web](https://sg-web-contractors-sg-35196.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vnynrzkkrq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
