### PR TITLE
dev/sg: source files recommended by gcloud during setup

### DIFF
--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -1,11 +1,15 @@
 package dependencies
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/grafana/regexp"
 	"github.com/sourcegraph/run"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/check"
@@ -269,6 +273,8 @@ func categoryAdditionalSGConfiguration() category {
 	}
 }
 
+var gcloudSourceRegexp = regexp.MustCompile(`(Source \[)(?P<path>[^\]]*)(\] in your profile)`)
+
 func dependencyGcloud() *dependency {
 	return &dependency{
 		Name: "gcloud",
@@ -284,11 +290,49 @@ func dependencyGcloud() *dependency {
 			}
 
 			if err := check.InPath("gcloud")(ctx); err != nil {
+				var pathsToSource []string
+
 				// This is the official interactive installer: https://cloud.google.com/sdk/docs/downloads-interactive
-				if err := run.Cmd(ctx, "curl https://sdk.cloud.google.com | bash -s -- --disable-prompts").
+				if err := usershell.Command(ctx,
+					"curl https://sdk.cloud.google.com | bash -s -- --disable-prompts").
 					Input(cio.Input).
-					Run().StreamLines(cio.Write); err != nil {
+					Run().
+					Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+						// Listen for gcloud telling us to source paths
+						if matches := gcloudSourceRegexp.FindSubmatch(line); len(matches) > 0 {
+							shouldSource := matches[gcloudSourceRegexp.SubexpIndex("path")]
+							if len(shouldSource) > 0 {
+								pathsToSource = append(pathsToSource, string(shouldSource))
+							}
+						}
+						// Pass through to underlying writer
+						return dst.Write(line)
+					}).
+					StreamLines(cio.Write); err != nil {
 					return err
+				}
+
+				// If gcloud tells us to source some stuff, try to do it
+				if len(pathsToSource) > 0 {
+					shellConfig := usershell.ShellConfigPath(ctx)
+					if shellConfig == "" {
+						return errors.New("Failed to detect shell config path")
+					}
+					conf, err := os.ReadFile(shellConfig)
+					if err != nil {
+						return err
+					}
+					for _, p := range pathsToSource {
+						if !bytes.Contains(conf, []byte(p)) {
+							source := fmt.Sprintf("source %s", p)
+							cio.Verbosef("Adding %q to %s", source, shellConfig)
+							if err := usershell.Run(ctx,
+								"echo", run.Arg(source), ">>", shellConfig,
+							).Wait(); err != nil {
+								return errors.Wrapf(err, "adding %q", source)
+							}
+						}
+					}
 				}
 			}
 
@@ -298,35 +342,5 @@ func dependencyGcloud() *dependency {
 
 			return run.Cmd(ctx, "gcloud auth configure-docker").Run().Wait()
 		},
-	}
-}
-
-func opLoginFix() check.FixAction[CheckArgs] {
-	return func(ctx context.Context, cio check.IO, args CheckArgs) error {
-		if cio.Input == nil {
-			return errors.New("interactive input required")
-		}
-
-		key, err := cio.Output.PromptPasswordf(cio.Input, "Enter secret key:")
-		if err != nil {
-			return err
-		}
-
-		email, err := cio.Output.PromptPasswordf(cio.Input, "Enter account email:")
-		if err != nil {
-			return err
-		}
-
-		password, err := cio.Output.PromptPasswordf(cio.Input, "Enter account password:")
-		if err != nil {
-			return err
-		}
-
-		return usershell.Command(ctx,
-			"op account add --signin --address team-sourcegraph.1password.com --email", email).
-			Env(map[string]string{"OP_SECRET_KEY": key}).
-			Input(strings.NewReader(password)).
-			Run().
-			StreamLines(cio.Verbose)
 	}
 }

--- a/dev/sg/dependencies/shared_test.go
+++ b/dev/sg/dependencies/shared_test.go
@@ -1,0 +1,20 @@
+package dependencies
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGcloudSourceRegexp(t *testing.T) {
+	example1 := "==> Source [/foobar/completion.zsh.inc] in your profile to enable shell command completion for gcloud."
+	matches := gcloudSourceRegexp.FindStringSubmatch(example1)
+	require.Greater(t, len(matches), 0)
+	assert.Equal(t, matches[gcloudSourceRegexp.SubexpIndex("path")], "/foobar/completion.zsh.inc")
+
+	example2 := "==> Source [/foobar/path.zsh.inc] in your profile to add the Google Cloud SDK command line tools to your $PATH."
+	matches = gcloudSourceRegexp.FindStringSubmatch(example2)
+	require.Greater(t, len(matches), 0)
+	assert.Equal(t, matches[gcloudSourceRegexp.SubexpIndex("path")], "/foobar/path.zsh.inc")
+}


### PR DESCRIPTION
gcloud emits output like this during installation it seems when it doesn't automatically add `gcloud` etc to your path:

```
==> Source [/Users/robrhyne/google-cloud-sdk/completion.zsh.inc] in your profile to enable shell command completion for gcloud.
==> Source [/Users/robrhyne/google-cloud-sdk/path.zsh.inc] in your profile to add the Google Cloud SDK command line tools to your $PATH.
```

This change adds a `Map` that watches for this type of output and applies the suggestions automatically to profile.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Unit tests on the regexp, manually applied fixes while working on Rob's `sg setup` which worked.