### PR TITLE
insights: skip get insights calls when insight card is not visible

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -58,14 +58,14 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
     // deleted when the insight is scrolled out of view
     const seriesToggleState = useSeriesToggle()
     const [insightData, setInsightData] = useState<BackendInsightData | undefined>()
-    const [enablePolling] = useFeatureFlag('insight-polling-enabled', false)
+    const [enablePolling] = useFeatureFlag('insight-polling-enabled', true)
     const pollingInterval = enablePolling ? insightPollingInterval(insight) : 0
 
     // Visual line chart settings
     const [zeroYAxisMin, setZeroYAxisMin] = useState(false)
     const insightCardReference = useRef<HTMLDivElement>(null)
     const mergedInsightCardReference = useMergeRefs([insightCardReference, innerRef])
-    const { isVisible, wasEverVisible } = useVisibility(insightCardReference)
+    const { isVisible } = useVisibility(insightCardReference)
 
     // Use deep copy check in case if a setting subject has re-created copy of
     // the insight config with same structure and values. To avoid insight data
@@ -98,8 +98,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
             variables: { id: insight.id, filters: filterInput, seriesDisplayOptions },
             fetchPolicy: 'cache-and-network',
             pollInterval: pollingInterval,
-            // TODO: Fix problem with offscreen pooling see https://github.com/sourcegraph/sourcegraph/issues/38425
-            skip: !wasEverVisible,
+            skip: !isVisible,
             context: { concurrentRequests: { key: 'GET_INSIGHT_VIEW' } },
             onCompleted: data => {
                 const parsedData = createBackendInsightData({ ...insight, filters }, data.insightViews.nodes[0])

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -108,9 +108,16 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
         }
     )
 
+    const isFetchingHistoricalData = insightData?.isFetchingHistoricalData
+
     useEffect(() => {
+        // polling is disabled ignore all
+        if (!enablePolling) {
+            return
+        }
+
         // No insight data yet nothing to do
-        if (!insightData) {
+        if (isFetchingHistoricalData === undefined) {
             return
         }
 
@@ -130,12 +137,21 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
 
         // we should start polling but multiple calls to startPolling reset the timer so
         // make sure we aren't already polling.
-        if (insightData.isFetchingHistoricalData && !isPolling) {
+        if (isFetchingHistoricalData && !isPolling) {
             setIsPolling(true)
             startPolling(pollingInterval)
             return
         }
-    }, [error, insightData, isPolling, isVisible, pollingInterval, startPolling, stopPolling])
+    }, [
+        enablePolling,
+        error,
+        isFetchingHistoricalData,
+        isPolling,
+        isVisible,
+        pollingInterval,
+        startPolling,
+        stopPolling,
+    ])
 
     async function handleFilterSave(filters: InsightFilters): Promise<SubmissionErrors> {
         try {

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/utils/insight-polling.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/utils/insight-polling.ts
@@ -1,6 +1,6 @@
 import { BackendInsight } from '../../..'
 const ALL_REPOS_POLL_INTERVAL = 30000
-const SOME_REPOS_POLL_INTERVAL = 1500
+const SOME_REPOS_POLL_INTERVAL = 2000
 
 export function insightPollingInterval(insight: BackendInsight): number {
     return insight.repositories.length > 0 ? SOME_REPOS_POLL_INTERVAL : ALL_REPOS_POLL_INTERVAL


### PR DESCRIPTION
This re-enables insight polling by default but only polls when the insight card is visible. I also slightly slowed down the polling rate.

Some notes:
`stopPolling` is safe to call as often as you want it's a noop if you are not polling
`startPolling` if called multiple time causes the previous interval to get canceled a new one to start, so we need to be careful not to call it over and over.



## Test plan

- Created 3 rows of insights (one permanently in a processing state)  and shrunk screen so that only 1 row was visible at a time
- Scrolled and monitored that network requests occurred when row appeared
- Verified polling stoped when insight left screen and resumed when it reentered
- Verified changing filter and sorting values correctly updated ui
- Verified setting `insight-polling-enabled` = false ensured that no polling occurred.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
