### PR TITLE
Renaming code intel routes

### DIFF
--- a/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
+++ b/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
@@ -71,10 +71,10 @@ export const AfterInstallPageContent: React.FunctionComponent<React.PropsWithChi
                     <H2 className="mb-4">How do I use the extension?</H2>
                     <div className="row">
                         <div className="col-md-6">
-                            <H3>Code intelligence on your code host</H3>
+                            <H3>Code navigation on your code host</H3>
                             <Text>
-                                Sourcegraph browser extension adds code intelligence to files and diffs on GitHub,
-                                GitHub Enterprise, GitLab, Phabricator, Bitbucket Server, and Gerrit.
+                                Sourcegraph browser extension adds code navigation to files and diffs on GitHub, GitHub
+                                Enterprise, GitLab, Phabricator, Bitbucket Server, and Gerrit.
                             </Text>
                             <Video {...props} name="CodeIntelligenceOnCodeHost" width={1760} height={1060} />
                         </div>

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -101,7 +101,7 @@ export const OptionsPage: React.FunctionComponent<React.PropsWithChildren<Option
                 <div className={styles.version}>v{version}</div>
             </section>
             <section className={styles.section}>
-                Get code intelligence tooltips while browsing and reviewing code on your code host.{' '}
+                Get code navigation tooltips while browsing and reviewing code on your code host.{' '}
                 <Link to="https://docs.sourcegraph.com/integration/browser_extension#features" {...NEW_TAB_LINK_PROPS}>
                     Learn more
                 </Link>{' '}

--- a/client/browser/src/browser-extension/scripts/contentPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/contentPage.main.ts
@@ -95,7 +95,7 @@ async function main(): Promise<void> {
         // eslint-disable-next-line rxjs/no-async-subscribe, @typescript-eslint/no-misused-promises
         observeSourcegraphURL(IS_EXTENSION).subscribe(async sourcegraphURL => {
             if (previousSubscription) {
-                console.log('Sourcegraph detached code intelligence')
+                console.log('Sourcegraph detached code navigation')
                 previousSubscription.unsubscribe()
             }
 
@@ -124,7 +124,7 @@ async function main(): Promise<void> {
                         await Promise.all(styleSheets.map(loadStyleSheet).map(waitForStyleSheet))
                     }
                 )
-                console.log('Sourcegraph attached code intelligence')
+                console.log('Sourcegraph attached code navigation')
             } catch (error) {
                 console.log('Sourcegraph code host integration stopped initialization. Reason:', error)
             }

--- a/client/browser/src/native-integration/integration.main.ts
+++ b/client/browser/src/native-integration/integration.main.ts
@@ -51,7 +51,7 @@ function init(): void {
     window.SOURCEGRAPH_URL = sourcegraphURL
     // TODO handle subscription
     injectCodeIntelligence({ sourcegraphURL, assetsURL }, IS_EXTENSION).catch(error => {
-        console.error('Error injecting Sourcegraph code intelligence:', error)
+        console.error('Error injecting Sourcegraph code navigation:', error)
     })
 }
 

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -235,7 +235,7 @@ const genericCodeViewResolver: ViewResolver<CodeView> = {
     },
     resolveView: (element: HTMLElement): CodeView | null => {
         if (element.querySelector('article.markdown-body')) {
-            // This code view is rendered markdown, we shouldn't add code intelligence
+            // This code view is rendered markdown, we shouldn't add code navigation
             return null
         }
 

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
@@ -82,7 +82,7 @@ const resolveView: ViewResolver<CodeView>['resolveView'] = (element: HTMLElement
     if (element.classList.contains('discussion-wrapper')) {
         // This is a commented snippet in a merge request discussion timeline
         // (a snippet where somebody added a review comment on a piece of code in the MR),
-        // we don't support adding code intelligence on those.
+        // we don't support adding code navigation on those.
         return null
     }
     const { pageKind } = getPageInfo()

--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -106,7 +106,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<
         )
     }
 
-    // If the repository does not exist, communicate that to explain why e.g. code intelligence does not work
+    // If the repository does not exist, communicate that to explain why e.g. code navigation does not work
     if (!repoExistsOrError) {
         if (isDefaultSourcegraphUrl(sourcegraphURL) && privateRepository && userSettingsURL) {
             return <ConfigureSourcegraphButton {...commonProps} codeHostType={codeHostType} href={userSettingsURL} />
@@ -152,7 +152,7 @@ export const ConfigureSourcegraphButton: React.FunctionComponent<
         href={commonProps.href || new URL(snakeCase(codeHostType), 'https://docs.sourcegraph.com/integration/').href}
         onClick={onConfigureSourcegraphClick}
         label="Configure Sourcegraph"
-        title="Set up Sourcegraph for search and code intelligence on private repositories"
-        ariaLabel="Set up Sourcegraph for search and code intelligence on private repositories"
+        title="Set up Sourcegraph for search and code navigation on private repositories"
+        ariaLabel="Set up Sourcegraph for search and code navigation on private repositories"
     />
 )

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -168,7 +168,7 @@ export type CodeHostContext = RawRepoSpec & Partial<RevisionSpec> & { privateRep
 
 export type CodeHostType = 'github' | 'phabricator' | 'bitbucket-server' | 'bitbucket-cloud' | 'gitlab' | 'gerrit'
 
-/** Information for adding code intelligence to code views on arbitrary code hosts. */
+/** Information for adding code navigation to code views on arbitrary code hosts. */
 export interface CodeHost extends ApplyLinkPreviewOptions {
     /**
      * The type of the code host. This will be added as a className to the overlay mount.
@@ -355,7 +355,7 @@ export const createGlobalDebugMount = (): HTMLElement => {
 }
 
 /**
- * Prepares the page for code intelligence. It creates the hoverifier, injects
+ * Prepares the page for code navigation. It creates the hoverifier, injects
  * and mounts the hover overlay and then returns the hoverifier.
  */
 function initCodeIntelligence({
@@ -891,7 +891,7 @@ export async function handleCodeHost({
     }
 
     if (!(await isSafeToContinueCodeIntel({ sourcegraphURL, requestGraphQL, codeHost, render }))) {
-        // Stop initializing code intelligence
+        // Stop initializing code navigation
         return subscriptions
     }
 
@@ -1397,7 +1397,7 @@ export async function handleCodeHost({
                     }
                 }
 
-                // Add hover code intelligence
+                // Add hover code navigation
                 const resolveContext: ContextResolver<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec> = ({
                     part,
                 }) => {

--- a/client/extension-api/src/sourcegraph.d.ts
+++ b/client/extension-api/src/sourcegraph.d.ts
@@ -2,7 +2,7 @@
  * ## The Sourcegraph extension API
  *
  * Sourcegraph extensions enhance your code host, code reviews, and Sourcegraph itself by adding features such as:
- * - Code intelligence (go-to-definition, find references, hovers, etc.)
+ * - Code navigation (go-to-definition, find references, hovers, etc.)
  * - Test coverage overlays
  * - Links to live traces, log output, and performance data for a line of code
  * - Git blame
@@ -1258,7 +1258,7 @@ declare module 'sourcegraph' {
          * The current version context of the workspace, if any.
          *
          * A version context is a set of repositories and revisions on a Sourcegraph instance.
-         * When set, extensions use it to scope search queries, code intelligence actions, etc.
+         * When set, extensions use it to scope search queries, code navigation actions, etc.
          *
          * See more information at http://docs.sourcegraph.com/user/search#version-contexts.
          *
@@ -1277,7 +1277,7 @@ declare module 'sourcegraph' {
          * The current search context of the workspace, if any.
          *
          * A search context is a set of repositories and revisions on a Sourcegraph instance.
-         * When set, extensions use it to scope search queries, code intelligence actions, etc.
+         * When set, extensions use it to scope search queries, code navigation actions, etc.
          *
          * See more information at https://docs.sourcegraph.com/code_search/explanations/features#search-contexts.
          */
@@ -1417,7 +1417,7 @@ declare module 'sourcegraph' {
          * values can briefly be used to describe some common property of the underlying result set.
          *
          * We currently use this to display whether a file in the file match locations pane contains
-         * only precise or only search-based code intelligence results.
+         * only precise or only search-based code navigation results.
          */
         aggregableBadges?: AggregableBadge[]
     }

--- a/client/search-ui/src/input/useQueryIntelligence.ts
+++ b/client/search-ui/src/input/useQueryIntelligence.ts
@@ -13,7 +13,7 @@ import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 const SOURCEGRAPH_SEARCH = 'sourcegraphSearch' as const
 
 /**
- * Adds code intelligence for the Sourcegraph search syntax to Monaco.
+ * Adds code navigation for the Sourcegraph search syntax to Monaco.
  */
 export function useQueryIntelligence(
     fetchSuggestions: (query: string) => Observable<SearchMatch[]>,

--- a/client/web/src/codeintel/index.ts
+++ b/client/web/src/codeintel/index.ts
@@ -1,7 +1,7 @@
 import { CodeIntelligenceBadge } from './CodeIntelligenceBadge'
 
 /**
- * Common props for components needing to decide whether to show Code intelligence
+ * Common props for components needing to decide whether to show Code navigation
  */
 export interface CodeIntelligenceProps {
     codeIntelligenceEnabled: boolean

--- a/client/web/src/codeintel/language-specs/languages.ts
+++ b/client/web/src/codeintel/language-specs/languages.ts
@@ -334,7 +334,7 @@ const vhdlSpec: LanguageSpec = {
 }
 
 /**
- * The specification of languages for which search-based code intelligence
+ * The specification of languages for which search-based code graph
  * is supported.
  *
  * The set of languages come from https://madnight.github.io/githut/#/pull_requests/2018/4.

--- a/client/web/src/codeintel/language-specs/languagespec.ts
+++ b/client/web/src/codeintel/language-specs/languagespec.ts
@@ -1,5 +1,5 @@
 /**
- * The specification used to provide search-based code intelligence for a
+ * The specification used to provide search-based code graph for a
  * particular language. This includes things like file extensions, comment
  * patterns and delimiters, and logic for filtering out obviously wrong
  * search results for definitions.

--- a/client/web/src/codeintel/useCodeIntel.ts
+++ b/client/web/src/codeintel/useCodeIntel.ts
@@ -193,7 +193,7 @@ export const useCodeIntel = ({
                         fetchSearchBasedReferences(deduplicateAndAddReferences)
                     }
                 } else {
-                    console.info('No LSIF data. Falling back to search-based code intelligence.')
+                    console.info('No LSIF data. Falling back to search-based code navigation.')
                     fellBackToSearchBased.current = true
 
                     fetchSearchBasedCodeIntel(setReferences, setDefinitions)

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -216,7 +216,7 @@ export const WithDismissibleAlertWithIcon: Story = () => (
                     summary: {
                         kind: MarkupKind.Markdown,
                         value:
-                            'Search based result.<br /> [Learn more about precise code intelligence](https://sourcegraph.com/github.com/sourcegraph/code-intel-extensions/-/blob/shared/indicators.ts#L67)',
+                            'Search based result.<br /> [Learn more about precise code navigation](https://sourcegraph.com/github.com/sourcegraph/code-intel-extensions/-/blob/shared/indicators.ts#L67)',
                     },
                     type: 'test-alert-type',
                     iconKind: 'info',

--- a/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.tsx
@@ -101,14 +101,14 @@ export const CodeIntelligenceBadgeMenu: React.FunctionComponent<
                 <MenuButton
                     className={classNames('text-decoration-none', styles.braindot, dotStyle)}
                     onClick={() => setBadgeUsed(true)}
-                    aria-label="Code intelligence"
+                    aria-label="Code graph"
                 >
                     <Icon aria-hidden={true} svgPath={mdiBrain} />
                 </MenuButton>
 
                 <MenuList position={Position.bottomEnd} className={styles.dropdownMenu} isOpen={isStorybook}>
                     <MenuHeader>
-                        Code intelligence{' '}
+                        Code graph{' '}
                         {isNew && (
                             <Badge variant="info" className="text-uppercase mx-2">
                                 NEW

--- a/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
@@ -123,7 +123,7 @@ export const IndexerSummary: React.FunctionComponent<React.PropsWithChildren<Ind
                                         width={16}
                                     />{' '}
                                     <TelemetricLink
-                                        to={`/${repoName}/-/code-intelligence/uploads?filters=errored`}
+                                        to={`/${repoName}/-/code-graph/uploads?filters=errored`}
                                         label="Latest upload processing"
                                         alwaysShowLabel={true}
                                         eventName="CodeIntelligenceUploadErrorInvestigated"
@@ -143,7 +143,7 @@ export const IndexerSummary: React.FunctionComponent<React.PropsWithChildren<Ind
                                         width={16}
                                     />{' '}
                                     <TelemetricLink
-                                        to={`/${repoName}/-/code-intelligence/indexes?filters=errored`}
+                                        to={`/${repoName}/-/code-graph/indexes?filters=errored`}
                                         label="Latest indexing"
                                         alwaysShowLabel={true}
                                         eventName="CodeIntelligenceIndexErrorInvestigated"

--- a/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
@@ -8,7 +8,7 @@ export const EmptyPoliciesList: React.FunctionComponent<React.PropsWithChildren<
     <Text alignment="center" className="text-muted w-100 mb-0 mt-1" data-testid="summary">
         <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <br />
-        {'No policies have been defined.  Enable precise code intelligence by '}
+        {'No policies have been defined.  Enable precise code navigation by '}
         <Link to="/help/code_intelligence/how-to/configure_data_retention" target="_blank" rel="noreferrer noopener">
             configuring data retention policies
         </Link>

--- a/client/web/src/enterprise/codeintel/configuration/components/RetentionPolicyDescription.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/RetentionPolicyDescription.tsx
@@ -12,7 +12,7 @@ export const RetentionPolicyDescription: FunctionComponent<
         <>
             <strong>Retention policy:</strong>{' '}
             <span>
-                Retain uploads used to resolve code intelligence queries for{' '}
+                Retain uploads used to resolve code navigation queries for{' '}
                 <GitObjectTargetDescription policy={policy} />
                 {policy.retentionDurationHours && (
                     <> for at least {formatDurationValue(policy.retentionDurationHours)} after upload</>

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -93,18 +93,18 @@ export const CodeIntelConfigurationPage: FunctionComponent<
 
     return (
         <>
-            <PageTitle title="Precise code intelligence configuration" />
+            <PageTitle title="Precise code graph configuration" />
             <CodeIntelConfigurationPageHeader>
                 <PageHeader
                     headingElement="h2"
                     path={[
                         {
-                            text: <>Precise code intelligence configuration</>,
+                            text: <>Precise code graph configuration</>,
                         },
                     ]}
                     description={`Rules that control data retention${
                         indexingEnabled ? ' and auto-indexing' : ''
-                    } behavior for precise code intelligence.`}
+                    } behavior for precise code graph.`}
                     className="mb-3"
                 />
                 {authenticatedUser?.siteAdmin && <PolicyListActions history={history} />}

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -113,7 +113,7 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<
 
     return (
         <>
-            <PageTitle title="Precise code intelligence configuration policy" />
+            <PageTitle title="Precise code graph configuration policy" />
             <PageHeader
                 headingElement="h2"
                 path={[

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
@@ -24,13 +24,13 @@ export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
 
     return (
         <>
-            <PageTitle title="Precise code intelligence repository index configuration" />
+            <PageTitle title="Precise code graph repository index configuration" />
             <CodeIntelConfigurationPageHeader>
                 <PageHeader
                     headingElement="h2"
                     path={[
                         {
-                            text: <>Precise code intelligence repository index configuration</>,
+                            text: <>Precise code graph repository index configuration</>,
                         },
                     ]}
                     description={

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelAssociatedUpload.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelAssociatedUpload.tsx
@@ -53,7 +53,7 @@ export const CodeIntelAssociatedUpload: FunctionComponent<React.PropsWithChildre
                     </span>
                     <span>
                         <Link
-                            to={`/${node.projectRoot.repository.name}/-/code-intelligence/uploads/${node.associatedUpload.id}`}
+                            to={`/${node.projectRoot.repository.name}/-/code-graph/uploads/${node.associatedUpload.id}`}
                         >
                             <Icon svgPath={mdiChevronRight} inline={false} aria-label="View more information" />
                         </Link>

--- a/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
@@ -8,7 +8,7 @@ export const EmptyAutoIndex: React.FunctionComponent<React.PropsWithChildren<unk
     <Text alignment="center" className="text-muted w-100 mb-0 mt-1" data-testid="summary">
         <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <br />
-        {'No indexes yet.  Enable precise code intelligence by '}
+        {'No indexes yet.  Enable precise code navigation by '}
         <Link to="/help/code_intelligence/how-to/enable_auto_indexing" target="_blank" rel="noreferrer noopener">
             auto-indexing LSIF data
         </Link>

--- a/client/web/src/enterprise/codeintel/indexes/hooks/queryCommitGraphMetadata.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/hooks/queryCommitGraphMetadata.tsx
@@ -43,7 +43,7 @@ export const queryCommitGraphMetadata = (
                 throw new Error(`The given ID is ${node.__typename}, not Repository`)
             }
             if (!node.codeIntelligenceCommitGraph) {
-                throw new Error('Missing code intelligence commit graph value')
+                throw new Error('Missing code navigation commit graph value')
             }
 
             return {

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
@@ -309,7 +309,7 @@ const completedSteps: LsifIndexStepsFields = {
             stdout:    \\u001b[?25h\\u001b[?25lfile: dump.lsif
             stdout:    \\u001b[?25h\\u001b[?25lindexer: lsif-go
             stdout:    \\u001b[?25h
-            stdout: \\u001b[?25h\\u001b[?25l💡 View processing status at https://sourcegraph.com/github.com/kubernetes/kubernetes/-/code-intelligence/uploads/TFNJRlVwbG9hZDoiNTUyNzg3Ig==
+            stdout: \\u001b[?25h\\u001b[?25l💡 View processing status at https://sourcegraph.com/github.com/kubernetes/kubernetes/-/code-graph/uploads/TFNJRlVwbG9hZDoiNTUyNzg3Ig==
             stdout: \\u001b[?25h
         `),
         durationMilliseconds: 1265,

--- a/client/web/src/enterprise/codeintel/repo/CodeIntelSidebar.tsx
+++ b/client/web/src/enterprise/codeintel/repo/CodeIntelSidebar.tsx
@@ -15,7 +15,7 @@ interface Props extends RouteComponentProps<{}> {
     repo: { url: string }
 }
 
-/** Sidebar for code intelligence pages. */
+/** Sidebar for code navigation pages. */
 export const CodeIntelSidebar: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     codeIntelSidebarGroups,
     className,
@@ -30,11 +30,7 @@ export const CodeIntelSidebar: React.FunctionComponent<React.PropsWithChildren<P
                         {items.map(
                             ({ label, to, exact, condition = () => true }) =>
                                 condition({}) && (
-                                    <SidebarNavItem
-                                        to={`${repo.url}/-/code-intelligence${to}`}
-                                        exact={exact}
-                                        key={label}
-                                    >
+                                    <SidebarNavItem to={`${repo.url}/-/code-graph${to}`} exact={exact} key={label}>
                                         {label}
                                     </SidebarNavItem>
                                 )

--- a/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
@@ -69,7 +69,7 @@ export const routes: readonly CodeIntelAreaRoute[] = [
     {
         path: '/',
         exact: true,
-        render: () => <Redirect to="./code-intelligence/uploads" />,
+        render: () => <Redirect to="./code-graph/uploads" />,
     },
     {
         path: '/uploads',
@@ -119,7 +119,7 @@ const NotFoundPage: React.FunctionComponent<React.PropsWithChildren<unknown>> = 
 )
 
 /**
- * Properties passed to all page components in the repository code intelligence area.
+ * Properties passed to all page components in the repository code navigation area.
  */
 export interface RepositoryCodeIntelAreaPageProps
     extends ThemeProps,
@@ -133,7 +133,7 @@ export interface RepositoryCodeIntelAreaPageProps
 
 const sidebarRoutes: CodeIntelSideBarGroups = [
     {
-        header: { label: 'Code intelligence' },
+        header: { label: 'Code graph' },
         items: [
             {
                 to: '/uploads',
@@ -158,12 +158,12 @@ const sidebarRoutes: CodeIntelSideBarGroups = [
 ]
 
 /**
- * Renders pages related to repository code intelligence.
+ * Renders pages related to repository code navigation.
  */
 export const RepositoryCodeIntelArea: React.FunctionComponent<
     React.PropsWithChildren<RepositoryCodeIntelAreaPageProps>
 > = ({ match, useBreadcrumb, ...props }) => {
-    useBreadcrumb(useMemo(() => ({ key: 'code-intelligence', element: 'Code Intelligence' }), []))
+    useBreadcrumb(useMemo(() => ({ key: 'code-intelligence', element: 'Code Graph' }), []))
 
     return (
         <div className="container d-flex mt-3">

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelAssociatedIndex.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelAssociatedIndex.tsx
@@ -44,7 +44,7 @@ export const CodeIntelAssociatedIndex: FunctionComponent<React.PropsWithChildren
                     </span>
                     <span>
                         <Link
-                            to={`/${node.projectRoot.repository.name}/-/code-intelligence/indexes/${node.associatedIndex.id}`}
+                            to={`/${node.projectRoot.repository.name}/-/code-graph/indexes/${node.associatedIndex.id}`}
                         >
                             <Icon svgPath={mdiChevronRight} inline={false} aria-label="View more information" />
                         </Link>

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelDeleteUpload.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelDeleteUpload.tsx
@@ -23,7 +23,7 @@ export const CodeIntelDeleteUpload: FunctionComponent<React.PropsWithChildren<Co
         <Tooltip
             content={
                 state === LSIFUploadState.COMPLETED
-                    ? 'Deleting this upload will make it unavailable to answer code intelligence queries the next time the repository commit graph is refreshed.'
+                    ? 'Deleting this upload will make it unavailable to answer code navigation queries the next time the repository commit graph is refreshed.'
                     : 'Delete this upload immediately'
             }
         >

--- a/client/web/src/enterprise/codeintel/uploads/components/EmptyUploads.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/EmptyUploads.tsx
@@ -8,7 +8,7 @@ export const EmptyUploads: React.FunctionComponent<React.PropsWithChildren<unkno
     <Text alignment="center" className="text-muted w-100 mb-0 mt-1">
         <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
         <br />
-        No uploads yet. Enable precise code intelligence by{' '}
+        No uploads yet. Enable precise code navigation by{' '}
         <Link
             to="/help/code_intelligence/explanations/precise_code_intelligence"
             target="_blank"

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
@@ -95,7 +95,7 @@ const UploadReferenceRetentionMatchNode: FunctionComponent<
                     {match.uploadSlice
                         .slice(0, 3)
                         .map<React.ReactNode>(upload => (
-                            <Link key={upload.id} to={`/site-admin/code-intelligence/uploads/${upload.id}`}>
+                            <Link key={upload.id} to={`/site-admin/code-graph/uploads/${upload.id}`}>
                                 {upload.projectRoot?.repository.name ?? 'unknown'}
                             </Link>
                         ))

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
@@ -181,7 +181,7 @@ export const CodeIntelUploadPage: FunctionComponent<React.PropsWithChildren<Code
         <ErrorAlert prefix="Error deleting LSIF upload" error={deletionOrError} />
     ) : (
         <div className="site-admin-lsif-upload-page w-100">
-            <PageTitle title="Precise code intelligence uploads" />
+            <PageTitle title="Precise code graph uploads" />
             {isErrorLike(uploadOrError) ? (
                 <ErrorAlert prefix="Error loading LSIF upload" error={uploadOrError} />
             ) : !uploadOrError ? (

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.tsx
@@ -136,10 +136,10 @@ export const CodeIntelUploadsPage: FunctionComponent<React.PropsWithChildren<Cod
 
     return (
         <div className="code-intel-uploads">
-            <PageTitle title="Precise code intelligence uploads" />
+            <PageTitle title="Precise code graph uploads" />
             <PageHeader
                 headingElement="h2"
-                path={[{ text: 'Precise code intelligence uploads' }]}
+                path={[{ text: 'Precise code graph uploads' }]}
                 description={`LSIF indexes uploaded to Sourcegraph from CI or from auto-indexing ${
                     repo ? 'for this repository' : 'over all repositories'
                 }.`}

--- a/client/web/src/enterprise/executors/ExecutorsListPage.tsx
+++ b/client/web/src/enterprise/executors/ExecutorsListPage.tsx
@@ -81,7 +81,7 @@ export const ExecutorsListPage: FunctionComponent<React.PropsWithChildren<Execut
                 <Text className="mb-0">
                     Executors enable{' '}
                     <Link to="/help/code_intelligence/explanations/auto_indexing" rel="noopener">
-                        auto-indexing for Code Intelligence
+                        auto-indexing for Code Graph
                     </Link>{' '}
                     and{' '}
                     <Link to="/help/batch_changes/explanations/server_side" rel="noopener">

--- a/client/web/src/enterprise/repo/routes.tsx
+++ b/client/web/src/enterprise/repo/routes.tsx
@@ -1,3 +1,5 @@
+import { Redirect } from 'react-router'
+
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { RepoContainerRoute } from '../../repo/RepoContainer'
@@ -24,6 +26,11 @@ export const enterpriseRepoContainerRoutes: readonly RepoContainerRoute[] = [
 
     {
         path: '/-/code-intelligence',
+        exact: false,
+        render: props => <Redirect to={props.location.pathname.replace('/code-intelligence', '/code-graph')} />,
+    },
+    {
+        path: '/-/code-graph',
         exact: false,
         render: context => (
             <RepositoryGitDataContainer {...context} repoName={context.repo.name}>

--- a/client/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
@@ -38,7 +38,7 @@ export const SiteAdminLsifUploadPage: FunctionComponent<React.PropsWithChildren<
             ) : !uploadOrError.projectRoot ? (
                 <ErrorAlert prefix="Error loading LSIF upload" error={{ message: 'Cannot resolve project root' }} />
             ) : (
-                <Redirect to={`${uploadOrError.projectRoot.repository.url}/-/code-intelligence/uploads/${id}`} />
+                <Redirect to={`${uploadOrError.projectRoot.repository.url}/-/code-graph/uploads/${id}`} />
             )}
         </div>
     )

--- a/client/web/src/enterprise/site-admin/routes.tsx
+++ b/client/web/src/enterprise/site-admin/routes.tsx
@@ -1,3 +1,5 @@
+import { Redirect } from 'react-router'
+
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { siteAdminAreaRoutes } from '../../site-admin/routes'
@@ -103,35 +105,58 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
             batchChangesEnabled && batchChangesWebhookLogsEnabled,
     },
 
-    // Code intelligence upload routes
+    //     {
+    //     // Allow unauthenticated viewers to view the "new subscription" page to price out a subscription (instead
+    //     // of just dumping them on a sign-in page).
+    //     path: EnterprisePageRoutes.SubscriptionsNew,
+    //     exact: true,
+    //     render: lazyComponent(
+    //         () => import('./user/productSubscriptions/NewProductSubscriptionPageOrRedirectUser'),
+    //         'NewProductSubscriptionPageOrRedirectUser'
+    //     ),
+    // },
+    // {
+    //     // Redirect from old /user/subscriptions/new -> /subscriptions/new.
+    //     path: EnterprisePageRoutes.OldSubscriptionsNew,
+    //     exact: true,
+    //     render: () => <Redirect to="/subscriptions/new" />,
+    // },
+
+    // Code graph upload routes
     {
-        path: '/code-intelligence/uploads',
+        path: '/code-intelligence',
+        exact: false,
+        render: props => <Redirect to={props.location.pathname.replace('/code-intelligence/', '/code-graph/')} />,
+    },
+    {
+        path: '/code-graph/uploads',
         render: lazyComponent(() => import('../codeintel/uploads/pages/CodeIntelUploadsPage'), 'CodeIntelUploadsPage'),
         exact: true,
     },
+
     {
-        path: '/code-intelligence/uploads/:id',
+        path: '/code-graph/uploads/:id',
         render: lazyComponent(() => import('../codeintel/uploads/pages/CodeIntelUploadPage'), 'CodeIntelUploadPage'),
         exact: true,
     },
 
     // Auto-indexing routes
     {
-        path: '/code-intelligence/indexes',
+        path: '/code-graph/indexes',
         render: lazyComponent(() => import('../codeintel/indexes/pages/CodeIntelIndexesPage'), 'CodeIntelIndexesPage'),
         exact: true,
         condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
     },
     {
-        path: '/code-intelligence/indexes/:id',
+        path: '/code-graph/indexes/:id',
         render: lazyComponent(() => import('../codeintel/indexes/pages/CodeIntelIndexPage'), 'CodeIntelIndexPage'),
         exact: true,
         condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
     },
 
-    // Code intelligence configuration
+    // Code graph configuration
     {
-        path: '/code-intelligence/configuration',
+        path: '/code-graph/configuration',
         render: lazyComponent(
             () => import('../codeintel/configuration/pages/CodeIntelConfigurationPage'),
             'CodeIntelConfigurationPage'
@@ -139,7 +164,7 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
     },
     {
-        path: '/code-intelligence/configuration/:id',
+        path: '/code-graph/configuration/:id',
         render: lazyComponent(
             () => import('../codeintel/configuration/pages/CodeIntelConfigurationPolicyPage'),
             'CodeIntelConfigurationPolicyPage'

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -97,19 +97,19 @@ const businessGroup: SiteAdminSideBarGroup = {
 }
 
 const codeIntelGroup: SiteAdminSideBarGroup = {
-    header: { label: 'Code intelligence', icon: BrainIcon },
+    header: { label: 'Code graph', icon: BrainIcon },
     items: [
         {
-            to: '/site-admin/code-intelligence/uploads',
+            to: '/site-admin/code-graph/uploads',
             label: 'Uploads',
         },
         {
-            to: '/site-admin/code-intelligence/indexes',
+            to: '/site-admin/code-graph/indexes',
             label: 'Auto-indexing',
             condition: () => Boolean(window.context?.codeIntelAutoIndexingEnabled),
         },
         {
-            to: '/site-admin/code-intelligence/configuration',
+            to: '/site-admin/code-graph/configuration',
             label: 'Configuration',
         },
     ],

--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -17,7 +17,7 @@ const typescriptRawManifest = JSON.stringify({
     browserslist: [],
     categories: ['Programming languages'],
     contributes: {},
-    description: 'TypeScript/JavaScript code intelligence',
+    description: 'TypeScript/JavaScript code graph',
     devDependencies: {},
     extensionID: 'sourcegraph/typescript',
     main: 'dist/extension.js',
@@ -61,7 +61,7 @@ const registryExtensionNodes: RegistryExtensionFieldsForList[] = [
         name: 'typescript',
         manifest: {
             raw: typescriptRawManifest,
-            description: 'TypeScript/JavaScript code intelligence',
+            description: 'TypeScript/JavaScript code graph',
         },
         createdAt: '2019-01-26T03:39:17Z',
         updatedAt: '2019-01-26T03:39:17Z',

--- a/client/web/src/regression/codeintel.test.ts
+++ b/client/web/src/regression/codeintel.test.ts
@@ -13,7 +13,7 @@ import { ensureLoggedInOrCreateTestUser, getGlobalSettings } from './util/helper
 import { getTestTools } from './util/init'
 import { TestResourceManager } from './util/TestResourceManager'
 
-describe('Code intelligence regression test suite', () => {
+describe('Code graph regression test suite', () => {
     const testUsername = 'test-sg-codeintel'
     const config = getConfig(
         'gitHubToken',
@@ -99,7 +99,7 @@ describe('Code intelligence regression test suite', () => {
         }
     })
 
-    describe('Basic code intelligence regression test suite', () => {
+    describe('Basic code graph regression test suite', () => {
         const innerResourceManager = new TestResourceManager()
         before(async () => {
             innerResourceManager.add('Global setting', 'codeIntel.lsif', await setGlobalLSIFSetting(gqlClient, false))

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -343,7 +343,7 @@ export const RepoContainer: React.FunctionComponent<React.PropsWithChildren<Repo
         props.settingsCascade.final?.experimentalFeatures?.codeIntelRepositoryBadge?.enabled === true
 
     // Remove leading repository name and possible leading revision, then compare the remaining routes to
-    // see if we should display the code intelligence badge for this route. We want this to be visible on
+    // see if we should display the code graph badge for this route. We want this to be visible on
     // the repo root page, as well as directory and code views, but not administrative/non-code views.
     const matchRevisionAndRest = props.match.params.repoRevAndRest.slice(repoName.length)
     const matchOnlyRest =

--- a/client/web/src/repo/tree/TabNavigation.tsx
+++ b/client/web/src/repo/tree/TabNavigation.tsx
@@ -42,12 +42,12 @@ export const TabNavigation: React.FunctionComponent<React.PropsWithChildren<TabN
         </Button>
         {codeIntelligenceEnabled && (
             <Button
-                to={`/${encodeURIPathComponent(repo.name)}/-/code-intelligence`}
+                to={`/${encodeURIPathComponent(repo.name)}/-/code-graph`}
                 variant="secondary"
                 outline={true}
                 as={Link}
             >
-                <Icon aria-hidden={true} svgPath={mdiBrain} /> Code Intelligence
+                <Icon aria-hidden={true} svgPath={mdiBrain} /> Code Graph
             </Button>
         )}
         {batchChangesEnabled && <RepoBatchChangesButton repoName={repo.name} />}

--- a/client/web/src/repo/tree/TreeNavigation.tsx
+++ b/client/web/src/repo/tree/TreeNavigation.tsx
@@ -56,12 +56,12 @@ export const TreeNavigation: React.FunctionComponent<React.PropsWithChildren<Tre
         </Button>
         {codeIntelligenceEnabled && (
             <Button
-                to={`/${encodeURIPathComponent(repo.name)}/-/code-intelligence`}
+                to={`/${encodeURIPathComponent(repo.name)}/-/code-graph`}
                 variant="secondary"
                 outline={true}
                 as={Link}
             >
-                <Icon aria-hidden={true} svgPath={mdiBrain} /> Code Intelligence
+                <Icon aria-hidden={true} svgPath={mdiBrain} /> Code Graph
             </Button>
         )}
         {batchChangesEnabled && <RepoBatchChangesButton repoName={repo.name} />}

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -127,7 +127,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                 <li>Whether new user signup is allowed (true/false)</li>
                 <li>Whether a repository has ever been added (true/false)</li>
                 <li>Whether a code search has ever been executed (true/false)</li>
-                <li>Whether code intelligence has ever been used (true/false)</li>
+                <li>Whether code graph has ever been used (true/false)</li>
                 <li>Aggregate counts of current daily, weekly, and monthly users</li>
                 <li>
                     Aggregate counts of current daily, weekly, and monthly users, by:
@@ -141,21 +141,20 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                 <li>
                     Aggregate daily, weekly, and monthly counts of:
                     <ul>
-                        <li>Code intelligence events (e.g., hover tooltips)</li>
+                        <li>Code navigation events (e.g., hover tooltips)</li>
                         <li>Searches using each search mode (interactive search, plain-text search)</li>
                         <li>Searches using each search filter (e.g. "type:", "repo:", "file:", "lang:", etc.)</li>
                     </ul>
                 </li>
                 <li>
-                    Code intelligence usage data
+                    Code navigation usage data
                     <ul>
                         <li>Total number of repositories with and without an uploaded LSIF index</li>
                         <li>
-                            Total number of code intelligence queries (e.g., hover tooltips) per week grouped by
-                            language
+                            Total number of code navigation queries (e.g., hover tooltips) per week grouped by language
                         </li>
                         <li>
-                            Number of users performing code intelligence queries (e.g., hover tooltips) per week grouped
+                            Number of users performing code navigation queries (e.g., hover tooltips) per week grouped
                             by language
                         </li>
                     </ul>

--- a/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -82,7 +82,7 @@ class UserUsageStatisticsHeader extends React.PureComponent<UserUsageStatisticsH
                     <th>User</th>
                     <th>Page views</th>
                     <th>Search queries</th>
-                    <th>Code intelligence actions</th>
+                    <th>Code navigation actions</th>
                     <th className={styles.dateColumn}>Last active</th>
                     <th className={styles.dateColumn}>Last active in code host or code review</th>
                 </tr>

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -112,7 +112,7 @@
                 <li><a href="code_search/reference">Reference</a></li>
             </ul>
         </li>
-        <li><a href="/code_intelligence">Code intelligence</a>
+        <li><a href="/code_intelligence">Code navigation</a>
             <ul>
                 <li><a href="code_intelligence/tutorials">Tutorials</a></li>
                 <li><a href="code_intelligence/how-to">How-to guides</a></li>


### PR DESCRIPTION
Renaming all occurrences in the UI to code navigation or code graph as applicable. Redirect any /code-intelligence to /code-graph or /code-navigation

## Test plan
Ran test manually
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

![redirect](https://media.giphy.com/media/VevEtDLgBMxOxvSPl5/giphy.gif)