### PR TITLE
ssbc: Make computation of candidate queues faster

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -356,7 +356,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	// Now enqueue jobs
 	var jobs []*btypes.BatchSpecWorkspaceExecutionJob
 	for _, ws := range workspaces {
-		job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: ws.ID}
+		job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: ws.ID, UserID: user.ID}
 		if err := ct.CreateBatchSpecWorkspaceExecutionJob(ctx, bstore, store.ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
@@ -127,6 +127,7 @@ func TestBatchSpecWorkspaceResolver(t *testing.T) {
 	t.Run("Queued", func(t *testing.T) {
 		job := &btypes.BatchSpecWorkspaceExecutionJob{
 			BatchSpecWorkspaceID: workspace.ID,
+			UserID:               userID,
 		}
 		if err := ct.CreateBatchSpecWorkspaceExecutionJob(ctx, bstore, store.ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
 			t.Fatal(err)

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1307,6 +1307,7 @@ func TestService(t *testing.T) {
 
 				job := &btypes.BatchSpecWorkspaceExecutionJob{
 					BatchSpecWorkspaceID: ws.ID,
+					UserID:               user.ID,
 				}
 				if err := ct.CreateBatchSpecWorkspaceExecutionJob(ctx, s, store.ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
 					t.Fatal(err)
@@ -1367,6 +1368,7 @@ func TestService(t *testing.T) {
 
 			job := &btypes.BatchSpecWorkspaceExecutionJob{
 				BatchSpecWorkspaceID: ws.ID,
+				UserID:               user.ID,
 			}
 			if err := ct.CreateBatchSpecWorkspaceExecutionJob(ctx, s, store.ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
 				t.Fatal(err)
@@ -1721,7 +1723,7 @@ changesetTemplate:
 					t.Fatal(err)
 				}
 
-				job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: ws.ID}
+				job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: ws.ID, UserID: user.ID}
 				if err := ct.CreateBatchSpecWorkspaceExecutionJob(ctx, s, store.ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
 					t.Fatal(err)
 				}
@@ -2643,6 +2645,10 @@ changesetTemplate:
 
 func createJob(t *testing.T, s *store.Store, job *btypes.BatchSpecWorkspaceExecutionJob) {
 	t.Helper()
+
+	if job.UserID == 0 {
+		job.UserID = 1
+	}
 
 	clone := *job
 

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
@@ -375,7 +375,7 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 					t.Fatal(err)
 				}
 
-				job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: ws.ID}
+				job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: ws.ID, UserID: spec.UserID}
 				if err := ct.CreateBatchSpecWorkspaceExecutionJob(ctx, s, ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
 					t.Fatal(err)
 				}

--- a/enterprise/internal/batches/store/worker_workspace_execution_test.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution_test.go
@@ -125,7 +125,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 			t.Fatal(err)
 		}
 
-		job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: workspace.ID}
+		job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: workspace.ID, UserID: 1}
 		if err := ct.CreateBatchSpecWorkspaceExecutionJob(ctx, s, ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
 			t.Fatal(err)
 		}
@@ -241,7 +241,7 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkFailed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: workspace.ID}
+	job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: workspace.ID, UserID: user.ID}
 	if err := ct.CreateBatchSpecWorkspaceExecutionJob(ctx, s, ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
 		t.Fatal(err)
 	}
@@ -397,7 +397,7 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete_EmptyDiff(t *testin
 		t.Fatal(err)
 	}
 
-	job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: workspace.ID}
+	job := &btypes.BatchSpecWorkspaceExecutionJob{BatchSpecWorkspaceID: workspace.ID, UserID: user.ID}
 	if err := ct.CreateBatchSpecWorkspaceExecutionJob(ctx, s, ScanBatchSpecWorkspaceExecutionJob, job); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -77,6 +77,10 @@
   ],
   "Functions": [
     {
+      "Name": "batch_spec_workspace_execution_last_dequeues_upsert",
+      "Definition": "CREATE OR REPLACE FUNCTION public.batch_spec_workspace_execution_last_dequeues_upsert()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$ BEGIN\n    INSERT INTO\n        batch_spec_workspace_execution_last_dequeues\n    SELECT\n        user_id,\n        MAX(started_at) as latest_dequeue\n    FROM\n        newtab\n    GROUP BY\n        user_id\n    ON CONFLICT (user_id) DO UPDATE SET\n        latest_dequeue = GREATEST(batch_spec_workspace_execution_last_dequeues.latest_dequeue, EXCLUDED.latest_dequeue);\n\n    RETURN NULL;\nEND $function$\n"
+    },
+    {
       "Name": "delete_batch_change_reference_on_changesets",
       "Definition": "CREATE OR REPLACE FUNCTION public.delete_batch_change_reference_on_changesets()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        UPDATE\n          changesets\n        SET\n          batch_change_ids = changesets.batch_change_ids - OLD.id::text\n        WHERE\n          changesets.batch_change_ids ? OLD.id::text;\n\n        RETURN OLD;\n    END;\n$function$\n"
     },
@@ -2048,6 +2052,69 @@
           "RefTableName": "batch_spec_workspaces",
           "IsDeferrable": true,
           "ConstraintDefinition": "FOREIGN KEY (batch_spec_workspace_id) REFERENCES batch_spec_workspaces(id) ON DELETE CASCADE DEFERRABLE"
+        }
+      ],
+      "Triggers": [
+        {
+          "Name": "batch_spec_workspace_execution_last_dequeues_insert",
+          "Definition": "CREATE TRIGGER batch_spec_workspace_execution_last_dequeues_insert AFTER INSERT ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert()"
+        },
+        {
+          "Name": "batch_spec_workspace_execution_last_dequeues_update",
+          "Definition": "CREATE TRIGGER batch_spec_workspace_execution_last_dequeues_update AFTER UPDATE ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert()"
+        }
+      ]
+    },
+    {
+      "Name": "batch_spec_workspace_execution_last_dequeues",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "latest_dequeue",
+          "Index": 2,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "user_id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "batch_spec_workspace_execution_last_dequeues_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX batch_spec_workspace_execution_last_dequeues_pkey ON batch_spec_workspace_execution_last_dequeues USING btree (user_id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (user_id)"
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "batch_spec_workspace_execution_last_dequeues_user_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "users",
+          "IsDeferrable": true,
+          "ConstraintDefinition": "FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED"
         }
       ],
       "Triggers": []
@@ -17650,7 +17717,7 @@
     },
     {
       "Name": "batch_spec_workspace_execution_queue",
-      "Definition": " WITH user_queues AS (\n         SELECT exec.user_id,\n            max(exec.started_at) AS latest_dequeue\n           FROM batch_spec_workspace_execution_jobs exec\n          GROUP BY exec.user_id\n        ), queue_candidates AS (\n         SELECT exec.id,\n            rank() OVER (PARTITION BY queue.user_id ORDER BY exec.created_at, exec.id) AS place_in_user_queue\n           FROM (batch_spec_workspace_execution_jobs exec\n             JOIN user_queues queue ON ((queue.user_id = exec.user_id)))\n          WHERE (exec.state = 'queued'::text)\n          ORDER BY (rank() OVER (PARTITION BY queue.user_id ORDER BY exec.created_at, exec.id)), queue.latest_dequeue NULLS FIRST\n        )\n SELECT queue_candidates.id,\n    row_number() OVER () AS place_in_global_queue,\n    queue_candidates.place_in_user_queue\n   FROM queue_candidates;"
+      "Definition": " WITH queue_candidates AS (\n         SELECT exec.id,\n            rank() OVER (PARTITION BY queue.user_id ORDER BY exec.created_at, exec.id) AS place_in_user_queue\n           FROM (batch_spec_workspace_execution_jobs exec\n             JOIN batch_spec_workspace_execution_last_dequeues queue ON ((queue.user_id = exec.user_id)))\n          WHERE (exec.state = 'queued'::text)\n          ORDER BY (rank() OVER (PARTITION BY queue.user_id ORDER BY exec.created_at, exec.id)), queue.latest_dequeue NULLS FIRST\n        )\n SELECT queue_candidates.id,\n    row_number() OVER () AS place_in_global_queue,\n    queue_candidates.place_in_user_queue\n   FROM queue_candidates;"
     },
     {
       "Name": "branch_changeset_specs_and_changesets",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -156,6 +156,22 @@ Indexes:
     "batch_spec_workspace_execution_jobs_state" btree (state)
 Foreign-key constraints:
     "batch_spec_workspace_execution_job_batch_spec_workspace_id_fkey" FOREIGN KEY (batch_spec_workspace_id) REFERENCES batch_spec_workspaces(id) ON DELETE CASCADE DEFERRABLE
+Triggers:
+    batch_spec_workspace_execution_last_dequeues_insert AFTER INSERT ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert()
+    batch_spec_workspace_execution_last_dequeues_update AFTER UPDATE ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert()
+
+```
+
+# Table "public.batch_spec_workspace_execution_last_dequeues"
+```
+     Column     |           Type           | Collation | Nullable | Default 
+----------------+--------------------------+-----------+----------+---------
+ user_id        | integer                  |           | not null | 
+ latest_dequeue | timestamp with time zone |           |          | 
+Indexes:
+    "batch_spec_workspace_execution_last_dequeues_pkey" PRIMARY KEY, btree (user_id)
+Foreign-key constraints:
+    "batch_spec_workspace_execution_last_dequeues_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 
 ```
 
@@ -2682,6 +2698,7 @@ Referenced by:
     TABLE "batch_changes" CONSTRAINT "batch_changes_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "batch_spec_execution_cache_entries" CONSTRAINT "batch_spec_execution_cache_entries_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "batch_spec_resolution_jobs" CONSTRAINT "batch_spec_resolution_jobs_initiator_id_fkey" FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE DEFERRABLE
+    TABLE "batch_spec_workspace_execution_last_dequeues" CONSTRAINT "batch_spec_workspace_execution_last_dequeues_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
     TABLE "batch_specs" CONSTRAINT "batch_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "changeset_jobs" CONSTRAINT "changeset_jobs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "changeset_specs" CONSTRAINT "changeset_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
@@ -2800,16 +2817,11 @@ Foreign-key constraints:
 ## View query:
 
 ```sql
- WITH user_queues AS (
-         SELECT exec.user_id,
-            max(exec.started_at) AS latest_dequeue
-           FROM batch_spec_workspace_execution_jobs exec
-          GROUP BY exec.user_id
-        ), queue_candidates AS (
+ WITH queue_candidates AS (
          SELECT exec.id,
             rank() OVER (PARTITION BY queue.user_id ORDER BY exec.created_at, exec.id) AS place_in_user_queue
            FROM (batch_spec_workspace_execution_jobs exec
-             JOIN user_queues queue ON ((queue.user_id = exec.user_id)))
+             JOIN batch_spec_workspace_execution_last_dequeues queue ON ((queue.user_id = exec.user_id)))
           WHERE (exec.state = 'queued'::text)
           ORDER BY (rank() OVER (PARTITION BY queue.user_id ORDER BY exec.created_at, exec.id)), queue.latest_dequeue NULLS FIRST
         )

--- a/migrations/frontend/1658174103_workspace_execution_user_queues/down.sql
+++ b/migrations/frontend/1658174103_workspace_execution_user_queues/down.sql
@@ -1,0 +1,49 @@
+DROP TRIGGER IF EXISTS batch_spec_workspace_execution_last_dequeues_insert ON batch_spec_workspace_execution_jobs;
+DROP TRIGGER IF EXISTS batch_spec_workspace_execution_last_dequeues_update ON batch_spec_workspace_execution_jobs;
+DROP FUNCTION IF EXISTS batch_spec_workspace_execution_last_dequeues_upsert();
+
+DROP VIEW IF EXISTS batch_spec_workspace_execution_jobs_with_rank;
+DROP VIEW IF EXISTS batch_spec_workspace_execution_queue;
+
+CREATE VIEW batch_spec_workspace_execution_queue AS
+WITH user_queues AS (
+    SELECT
+        exec.user_id,
+        MAX(exec.started_at) AS latest_dequeue
+    FROM batch_spec_workspace_execution_jobs AS exec
+    GROUP BY exec.user_id
+),
+queue_candidates AS (
+    SELECT
+        exec.id,
+        RANK() OVER (
+            PARTITION BY queue.user_id
+            -- Make sure the jobs are still fulfilled in timely order, and that the ordering is stable.
+            ORDER BY exec.created_at ASC, exec.id ASC
+        ) AS place_in_user_queue
+    FROM batch_spec_workspace_execution_jobs exec
+    JOIN user_queues queue ON queue.user_id = exec.user_id
+    WHERE
+    	-- Only queued records should get a rank.
+        exec.state = 'queued'
+    ORDER BY
+        -- Round-robin let users dequeue jobs.
+        place_in_user_queue,
+        -- And ensure the user who dequeued the longest ago is next.
+        queue.latest_dequeue ASC NULLS FIRST
+)
+SELECT
+    queue_candidates.id, ROW_NUMBER() OVER () AS place_in_global_queue, queue_candidates.place_in_user_queue
+FROM queue_candidates;
+
+CREATE VIEW batch_spec_workspace_execution_jobs_with_rank AS (
+    SELECT
+        j.*,
+        q.place_in_global_queue,
+        q.place_in_user_queue
+    FROM
+        batch_spec_workspace_execution_jobs j
+    LEFT JOIN batch_spec_workspace_execution_queue q ON j.id = q.id
+);
+
+DROP TABLE IF EXISTS batch_spec_workspace_execution_last_dequeues;

--- a/migrations/frontend/1658174103_workspace_execution_user_queues/metadata.yaml
+++ b/migrations/frontend/1658174103_workspace_execution_user_queues/metadata.yaml
@@ -1,0 +1,2 @@
+name: workspace_execution_user_queues
+parents: [1657635365]

--- a/migrations/frontend/1658174103_workspace_execution_user_queues/up.sql
+++ b/migrations/frontend/1658174103_workspace_execution_user_queues/up.sql
@@ -1,0 +1,74 @@
+CREATE TABLE IF NOT EXISTS batch_spec_workspace_execution_last_dequeues (
+    user_id integer PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    latest_dequeue timestamp with time zone
+);
+
+CREATE OR REPLACE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ BEGIN
+    INSERT INTO
+        batch_spec_workspace_execution_last_dequeues
+    SELECT
+        user_id,
+        MAX(started_at) as latest_dequeue
+    FROM
+        newtab
+    GROUP BY
+        user_id
+    ON CONFLICT (user_id) DO UPDATE SET
+        latest_dequeue = GREATEST(batch_spec_workspace_execution_last_dequeues.latest_dequeue, EXCLUDED.latest_dequeue);
+
+    RETURN NULL;
+END $$;
+
+DROP TRIGGER IF EXISTS batch_spec_workspace_execution_last_dequeues_insert ON batch_spec_workspace_execution_jobs;
+CREATE TRIGGER batch_spec_workspace_execution_last_dequeues_insert AFTER INSERT ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert();
+
+DROP TRIGGER IF EXISTS batch_spec_workspace_execution_last_dequeues_update ON batch_spec_workspace_execution_jobs;
+CREATE TRIGGER batch_spec_workspace_execution_last_dequeues_update AFTER UPDATE ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert();
+
+DROP VIEW IF EXISTS batch_spec_workspace_execution_jobs_with_rank;
+DROP VIEW IF EXISTS batch_spec_workspace_execution_queue;
+
+CREATE VIEW batch_spec_workspace_execution_queue AS
+WITH queue_candidates AS (
+    SELECT
+        exec.id,
+        RANK() OVER (
+            PARTITION BY queue.user_id
+            -- Make sure the jobs are still fulfilled in timely order, and that the ordering is stable.
+            ORDER BY exec.created_at ASC, exec.id ASC
+        ) AS place_in_user_queue
+    FROM batch_spec_workspace_execution_jobs exec
+    JOIN batch_spec_workspace_execution_last_dequeues queue ON queue.user_id = exec.user_id
+    WHERE
+    	-- Only queued records should get a rank.
+        exec.state = 'queued'
+    ORDER BY
+        -- Round-robin let users dequeue jobs.
+        place_in_user_queue,
+        -- And ensure the user who dequeued the longest ago is next.
+        queue.latest_dequeue ASC NULLS FIRST
+)
+SELECT
+    queue_candidates.id, ROW_NUMBER() OVER () AS place_in_global_queue, queue_candidates.place_in_user_queue
+FROM queue_candidates;
+
+CREATE VIEW batch_spec_workspace_execution_jobs_with_rank AS (
+    SELECT
+        j.*,
+        q.place_in_global_queue,
+        q.place_in_user_queue
+    FROM
+        batch_spec_workspace_execution_jobs j
+    LEFT JOIN batch_spec_workspace_execution_queue q ON j.id = q.id
+);
+
+INSERT INTO batch_spec_workspace_execution_last_dequeues
+SELECT
+    exec.user_id as user_id,
+    MAX(exec.started_at) AS latest_dequeue
+FROM batch_spec_workspace_execution_jobs exec
+GROUP BY exec.user_id
+ON CONFLICT (user_id) DO UPDATE
+    SET latest_dequeue = GREATEST(batch_spec_workspace_execution_last_dequeues.latest_dequeue, EXCLUDED.latest_dequeue);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -99,6 +99,24 @@ CREATE TYPE persistmode AS ENUM (
     'snapshot'
 );
 
+CREATE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ BEGIN
+    INSERT INTO
+        batch_spec_workspace_execution_last_dequeues
+    SELECT
+        user_id,
+        MAX(started_at) as latest_dequeue
+    FROM
+        newtab
+    GROUP BY
+        user_id
+    ON CONFLICT (user_id) DO UPDATE SET
+        latest_dequeue = GREATEST(batch_spec_workspace_execution_last_dequeues.latest_dequeue, EXCLUDED.latest_dequeue);
+
+    RETURN NULL;
+END $$;
+
 CREATE FUNCTION delete_batch_change_reference_on_changesets() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -642,17 +660,17 @@ CREATE SEQUENCE batch_spec_workspace_execution_jobs_id_seq
 
 ALTER SEQUENCE batch_spec_workspace_execution_jobs_id_seq OWNED BY batch_spec_workspace_execution_jobs.id;
 
+CREATE TABLE batch_spec_workspace_execution_last_dequeues (
+    user_id integer NOT NULL,
+    latest_dequeue timestamp with time zone
+);
+
 CREATE VIEW batch_spec_workspace_execution_queue AS
- WITH user_queues AS (
-         SELECT exec.user_id,
-            max(exec.started_at) AS latest_dequeue
-           FROM batch_spec_workspace_execution_jobs exec
-          GROUP BY exec.user_id
-        ), queue_candidates AS (
+ WITH queue_candidates AS (
          SELECT exec.id,
             rank() OVER (PARTITION BY queue.user_id ORDER BY exec.created_at, exec.id) AS place_in_user_queue
            FROM (batch_spec_workspace_execution_jobs exec
-             JOIN user_queues queue ON ((queue.user_id = exec.user_id)))
+             JOIN batch_spec_workspace_execution_last_dequeues queue ON ((queue.user_id = exec.user_id)))
           WHERE (exec.state = 'queued'::text)
           ORDER BY (rank() OVER (PARTITION BY queue.user_id ORDER BY exec.created_at, exec.id)), queue.latest_dequeue NULLS FIRST
         )
@@ -3208,6 +3226,9 @@ ALTER TABLE ONLY batch_spec_resolution_jobs
 ALTER TABLE ONLY batch_spec_workspace_execution_jobs
     ADD CONSTRAINT batch_spec_workspace_execution_jobs_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY batch_spec_workspace_execution_last_dequeues
+    ADD CONSTRAINT batch_spec_workspace_execution_last_dequeues_pkey PRIMARY KEY (user_id);
+
 ALTER TABLE ONLY batch_spec_workspaces
     ADD CONSTRAINT batch_spec_workspaces_pkey PRIMARY KEY (id);
 
@@ -3812,6 +3833,10 @@ CREATE INDEX webhook_logs_received_at_idx ON webhook_logs USING btree (received_
 
 CREATE INDEX webhook_logs_status_code_idx ON webhook_logs USING btree (status_code);
 
+CREATE TRIGGER batch_spec_workspace_execution_last_dequeues_insert AFTER INSERT ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert();
+
+CREATE TRIGGER batch_spec_workspace_execution_last_dequeues_update AFTER UPDATE ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert();
+
 CREATE TRIGGER trig_delete_batch_change_reference_on_changesets AFTER DELETE ON batch_changes FOR EACH ROW EXECUTE FUNCTION delete_batch_change_reference_on_changesets();
 
 CREATE TRIGGER trig_delete_repo_ref_on_external_service_repos AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE FUNCTION delete_repo_ref_on_external_service_repos();
@@ -3868,6 +3893,9 @@ ALTER TABLE ONLY batch_spec_resolution_jobs
 
 ALTER TABLE ONLY batch_spec_workspace_execution_jobs
     ADD CONSTRAINT batch_spec_workspace_execution_job_batch_spec_workspace_id_fkey FOREIGN KEY (batch_spec_workspace_id) REFERENCES batch_spec_workspaces(id) ON DELETE CASCADE DEFERRABLE;
+
+ALTER TABLE ONLY batch_spec_workspace_execution_last_dequeues
+    ADD CONSTRAINT batch_spec_workspace_execution_last_dequeues_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
 ALTER TABLE ONLY batch_spec_workspaces
     ADD CONSTRAINT batch_spec_workspaces_batch_spec_id_fkey FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) ON DELETE CASCADE DEFERRABLE;


### PR DESCRIPTION
Before we had to do full table scans to find the latest dequeue times for each user each time we would compute the next item to dequeue. This makes it faster by persisting the last dequeue time to a table using triggers to ensure it's always up to date. This approach has been used by code intel for some tables for some time, so it's production approved, I'd say.

# Comparison

## Nothing in queue

Before:

```
QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=10718.47..10718.49 rows=1 width=62) (actual time=0.041..0.043 rows=0 loops=1)
   ->  LockRows  (cost=10718.47..10718.49 rows=1 width=62) (actual time=0.040..0.042 rows=0 loops=1)
         ->  Sort  (cost=10718.47..10718.48 rows=1 width=62) (actual time=0.040..0.042 rows=0 loops=1)
               Sort Key: pc."order"
               Sort Method: quicksort  Memory: 25kB
               ->  Nested Loop  (cost=10585.37..10718.46 rows=1 width=62) (actual time=0.034..0.035 rows=0 loops=1)
                     ->  Subquery Scan on pc  (cost=10584.95..10586.32 rows=50 width=56) (actual time=0.033..0.035 rows=0 loops=1)
                           ->  Limit  (cost=10584.95..10585.82 rows=50 width=24) (actual time=0.033..0.034 rows=0 loops=1)
                                 ->  WindowAgg  (cost=10584.95..10590.65 rows=326 width=24) (actual time=0.033..0.034 rows=0 loops=1)
                                       ->  Sort  (cost=10584.95..10585.76 rows=326 width=16) (actual time=0.032..0.033 rows=0 loops=1)
                                             Sort Key: q.place_in_global_queue
                                             Sort Method: quicksort  Memory: 25kB
                                             ->  Hash Left Join  (cost=10295.15..10571.34 rows=326 width=16) (actual time=0.020..0.022 rows=0 loops=1)
                                                   Hash Cond: (j.id = q.id)
                                                   ->  Index Scan using batch_spec_workspace_execution_jobs_state on batch_spec_workspace_execution_jobs j  (cost=0.42..275.38 rows=326 width=8) (actual time=0.020..0.020 rows=0 loops=1)
                                                         Index Cond: (state = 'queued'::text)
                                                         Filter: ((process_after IS NULL) OR (process_after <= now()))
                                                   ->  Hash  (cost=10290.65..10290.65 rows=326 width=16) (never executed)
                                                         ->  Subquery Scan on q  (cost=10279.24..10290.65 rows=326 width=16) (never executed)
                                                               ->  WindowAgg  (cost=10279.24..10287.39 rows=326 width=24) (never executed)
                                                                     ->  Subquery Scan on queue_candidates  (cost=10279.24..10283.31 rows=326 width=8) (never executed)
                                                                           ->  Sort  (cost=10279.24..10280.05 rows=326 width=36) (never executed)
                                                                                 Sort Key: (rank() OVER (?)), queue.latest_dequeue NULLS FIRST
                                                                                 ->  WindowAgg  (cost=10258.29..10265.63 rows=326 width=36) (never executed)
                                                                                       ->  Sort  (cost=10258.29..10259.11 rows=326 width=28) (never executed)
                                                                                             Sort Key: queue.user_id, exec.created_at, exec.id
                                                                                             ->  Nested Loop  (cost=0.84..10244.69 rows=326 width=28) (never executed)
                                                                                                   Join Filter: (exec.user_id = queue.user_id)
                                                                                                   ->  Index Scan using batch_spec_workspace_execution_jobs_state on batch_spec_workspace_execution_jobs exec  (cost=0.42..273.75 rows=326 width=20) (never executed)
                                                                                                         Index Cond: (state = 'queued'::text)
                                                                                                   ->  Materialize  (cost=0.42..9892.15 rows=17 width=12) (never executed)
                                                                                                         ->  Subquery Scan on queue  (cost=0.42..9892.07 rows=17 width=12) (never executed)
                                                                                                               ->  GroupAggregate  (cost=0.42..9891.90 rows=17 width=12) (never executed)
                                                                                                                     Group Key: exec_1.user_id
                                                                                                                     ->  Index Only Scan using batch_spec_workspace_execution_jobs_last_dequeue on batch_spec_workspace_execution_jobs exec_1  (cost=0.42..8206.51 rows=337044 width=12) (never executed)
                                                                                                                           Heap Fetches: 0
                     ->  Index Scan using batch_spec_workspace_execution_jobs_pkey on batch_spec_workspace_execution_jobs  (cost=0.42..2.64 rows=1 width=14) (never executed)
                           Index Cond: (id = pc.candidate_id)
                           Filter: (state = ANY ('{queued,errored}'::text[]))
 Planning Time: 0.977 ms
 Execution Time: 0.265 ms
```

After:

```
                                                                                                                              QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=804.29..804.31 rows=1 width=62) (actual time=0.038..0.040 rows=0 loops=1)
   ->  LockRows  (cost=804.29..804.31 rows=1 width=62) (actual time=0.038..0.039 rows=0 loops=1)
         ->  Sort  (cost=804.29..804.30 rows=1 width=62) (actual time=0.037..0.039 rows=0 loops=1)
               Sort Key: pc."order"
               Sort Method: quicksort  Memory: 25kB
               ->  Nested Loop  (cost=671.19..804.28 rows=1 width=62) (actual time=0.030..0.031 rows=0 loops=1)
                     ->  Subquery Scan on pc  (cost=670.77..672.14 rows=50 width=56) (actual time=0.029..0.031 rows=0 loops=1)
                           ->  Limit  (cost=670.77..671.64 rows=50 width=24) (actual time=0.029..0.031 rows=0 loops=1)
                                 ->  WindowAgg  (cost=670.77..676.47 rows=326 width=24) (actual time=0.029..0.030 rows=0 loops=1)
                                       ->  Sort  (cost=670.77..671.58 rows=326 width=16) (actual time=0.028..0.029 rows=0 loops=1)
                                             Sort Key: q.place_in_global_queue
                                             Sort Method: quicksort  Memory: 25kB
                                             ->  Hash Left Join  (cost=380.97..657.16 rows=326 width=16) (actual time=0.019..0.020 rows=0 loops=1)
                                                   Hash Cond: (j.id = q.id)
                                                   ->  Index Scan using batch_spec_workspace_execution_jobs_state on batch_spec_workspace_execution_jobs j  (cost=0.42..275.38 rows=326 width=8) (actual time=0.018..0.018 rows=0 loops=1)
                                                         Index Cond: (state = 'queued'::text)
                                                         Filter: ((process_after IS NULL) OR (process_after <= now()))
                                                   ->  Hash  (cost=376.47..376.47 rows=326 width=16) (never executed)
                                                         ->  Subquery Scan on q  (cost=365.06..376.47 rows=326 width=16) (never executed)
                                                               ->  WindowAgg  (cost=365.06..373.21 rows=326 width=24) (never executed)
                                                                     ->  Subquery Scan on queue_candidates  (cost=365.06..369.14 rows=326 width=8) (never executed)
                                                                           ->  Sort  (cost=365.06..365.88 rows=326 width=36) (never executed)
                                                                                 Sort Key: (rank() OVER (?)), queue.latest_dequeue NULLS FIRST
                                                                                 ->  WindowAgg  (cost=344.12..351.45 rows=326 width=36) (never executed)
                                                                                       ->  Sort  (cost=344.12..344.93 rows=326 width=28) (never executed)
                                                                                             Sort Key: queue.user_id, exec.created_at, exec.id
                                                                                             ->  Hash Join  (cost=56.32..330.51 rows=326 width=28) (never executed)
                                                                                                   Hash Cond: (exec.user_id = queue.user_id)
                                                                                                   ->  Index Scan using batch_spec_workspace_execution_jobs_state on batch_spec_workspace_execution_jobs exec  (cost=0.42..273.75 rows=326 width=20) (never executed)
                                                                                                         Index Cond: (state = 'queued'::text)
                                                                                                   ->  Hash  (cost=30.40..30.40 rows=2040 width=12) (never executed)
                                                                                                         ->  Seq Scan on batch_spec_workspace_execution_last_dequeues queue  (cost=0.00..30.40 rows=2040 width=12) (never executed)
                     ->  Index Scan using batch_spec_workspace_execution_jobs_pkey on batch_spec_workspace_execution_jobs  (cost=0.42..2.64 rows=1 width=14) (never executed)
                           Index Cond: (id = pc.candidate_id)
                           Filter: (state = ANY ('{queued,errored}'::text[]))
 Planning Time: 0.743 ms
 Execution Time: 0.207 ms
(37 rows)
```

## 24000 records queued

Before:

```
QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=10718.47..10718.49 rows=1 width=62) (actual time=186.816..186.825 rows=1 loops=1)
   ->  LockRows  (cost=10718.47..10718.49 rows=1 width=62) (actual time=186.815..186.823 rows=1 loops=1)
         ->  Sort  (cost=10718.47..10718.48 rows=1 width=62) (actual time=186.796..186.804 rows=1 loops=1)
               Sort Key: pc."order"
               Sort Method: quicksort  Memory: 32kB
               ->  Nested Loop  (cost=10585.37..10718.46 rows=1 width=62) (actual time=186.608..186.783 rows=50 loops=1)
                     ->  Subquery Scan on pc  (cost=10584.95..10586.32 rows=50 width=56) (actual time=186.578..186.629 rows=50 loops=1)
                           ->  Limit  (cost=10584.95..10585.82 rows=50 width=24) (actual time=186.558..186.597 rows=50 loops=1)
                                 ->  WindowAgg  (cost=10584.95..10590.65 rows=326 width=24) (actual time=186.558..186.592 rows=50 loops=1)
                                       ->  Sort  (cost=10584.95..10585.76 rows=326 width=16) (actual time=186.544..186.554 rows=51 loops=1)
                                             Sort Key: q.place_in_global_queue
                                             Sort Method: quicksort  Memory: 1910kB
                                             ->  Hash Left Join  (cost=10295.15..10571.34 rows=326 width=16) (actual time=168.569..182.523 rows=24362 loops=1)
                                                   Hash Cond: (j.id = q.id)
                                                   ->  Index Scan using batch_spec_workspace_execution_jobs_state on batch_spec_workspace_execution_jobs j  (cost=0.42..275.38 rows=326 width=8) (actual time=0.044..8.551 rows=24362 loops=1)
                                                         Index Cond: (state = 'queued'::text)
                                                         Filter: ((process_after IS NULL) OR (process_after <= now()))
                                                   ->  Hash  (cost=10290.65..10290.65 rows=326 width=16) (actual time=168.500..168.505 rows=24362 loops=1)
                                                         Buckets: 32768 (originally 1024)  Batches: 1 (originally 1)  Memory Usage: 1398kB
                                                         ->  Subquery Scan on q  (cost=10279.24..10290.65 rows=326 width=16) (actual time=151.406..163.611 rows=24362 loops=1)
                                                               ->  WindowAgg  (cost=10279.24..10287.39 rows=326 width=24) (actual time=151.405..161.738 rows=24362 loops=1)
                                                                     ->  Subquery Scan on queue_candidates  (cost=10279.24..10283.31 rows=326 width=8) (actual time=151.402..154.977 rows=24362 loops=1)
                                                                           ->  Sort  (cost=10279.24..10280.05 rows=326 width=36) (actual time=151.401..152.885 rows=24362 loops=1)
                                                                                 Sort Key: (rank() OVER (?)), queue.latest_dequeue NULLS FIRST
                                                                                 Sort Method: quicksort  Memory: 2672kB
                                                                                 ->  WindowAgg  (cost=10258.29..10265.63 rows=326 width=36) (actual time=129.476..145.426 rows=24362 loops=1)
                                                                                       ->  Sort  (cost=10258.29..10259.11 rows=326 width=28) (actual time=129.457..130.688 rows=24362 loops=1)
                                                                                             Sort Key: queue.user_id, exec.created_at, exec.id
                                                                                             Sort Method: quicksort  Memory: 2672kB
                                                                                             ->  Nested Loop  (cost=0.84..10244.69 rows=326 width=28) (actual time=99.031..123.881 rows=24362 loops=1)
                                                                                                   Join Filter: (exec.user_id = queue.user_id)
                                                                                                   Rows Removed by Join Filter: 97448
                                                                                                   ->  Index Scan using batch_spec_workspace_execution_jobs_state on batch_spec_workspace_execution_jobs exec  (cost=0.42..273.75 rows=326 width=20) (actual time=0.024..8.702 rows=24362 loops=1)
                                                                                                         Index Cond: (state = 'queued'::text)
                                                                                                   ->  Materialize  (cost=0.42..9892.15 rows=17 width=12) (actual time=0.000..0.004 rows=5 loops=24362)
                                                                                                         ->  Subquery Scan on queue  (cost=0.42..9892.07 rows=17 width=12) (actual time=0.042..98.995 rows=5 loops=1)
                                                                                                               ->  GroupAggregate  (cost=0.42..9891.90 rows=17 width=12) (actual time=0.041..98.993 rows=5 loops=1)
                                                                                                                     Group Key: exec_1.user_id
                                                                                                                     ->  Index Only Scan using batch_spec_workspace_execution_jobs_last_dequeue on batch_spec_workspace_execution_jobs exec_1  (cost=0.42..8206.51 rows=337044 width=12) (actual time=0.027..73.499 rows=351240 loops=1)
                                                                                                                           Heap Fetches: 90581
                     ->  Index Scan using batch_spec_workspace_execution_jobs_pkey on batch_spec_workspace_execution_jobs  (cost=0.42..2.64 rows=1 width=14) (actual time=0.003..0.003 rows=1 loops=50)
                           Index Cond: (id = pc.candidate_id)
                           Filter: (state = ANY ('{queued,errored}'::text[]))
 Planning Time: 0.881 ms
 Execution Time: 188.086 ms
(45 rows)
```

After:

```
QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=804.29..804.31 rows=1 width=62) (actual time=74.121..74.127 rows=1 loops=1)
   ->  LockRows  (cost=804.29..804.31 rows=1 width=62) (actual time=74.120..74.126 rows=1 loops=1)
         ->  Sort  (cost=804.29..804.30 rows=1 width=62) (actual time=74.095..74.101 rows=1 loops=1)
               Sort Key: pc."order"
               Sort Method: quicksort  Memory: 32kB
               ->  Nested Loop  (cost=671.19..804.28 rows=1 width=62) (actual time=73.953..74.082 rows=50 loops=1)
                     ->  Subquery Scan on pc  (cost=670.77..672.14 rows=50 width=56) (actual time=73.934..73.985 rows=50 loops=1)
                           ->  Limit  (cost=670.77..671.64 rows=50 width=24) (actual time=73.928..73.968 rows=50 loops=1)
                                 ->  WindowAgg  (cost=670.77..676.47 rows=326 width=24) (actual time=73.927..73.964 rows=50 loops=1)
                                       ->  Sort  (cost=670.77..671.58 rows=326 width=16) (actual time=73.909..73.916 rows=51 loops=1)
                                             Sort Key: q.place_in_global_queue
                                             Sort Method: quicksort  Memory: 1910kB
                                             ->  Hash Left Join  (cost=380.97..657.16 rows=326 width=16) (actual time=56.822..70.091 rows=24360 loops=1)
                                                   Hash Cond: (j.id = q.id)
                                                   ->  Index Scan using batch_spec_workspace_execution_jobs_state on batch_spec_workspace_execution_jobs j  (cost=0.42..275.38 rows=326 width=8) (actual time=0.041..8.347 rows=24360 loops=1)
                                                         Index Cond: (state = 'queued'::text)
                                                         Filter: ((process_after IS NULL) OR (process_after <= now()))
                                                   ->  Hash  (cost=376.47..376.47 rows=326 width=16) (actual time=56.766..56.770 rows=24360 loops=1)
                                                         Buckets: 32768 (originally 1024)  Batches: 1 (originally 1)  Memory Usage: 1398kB
                                                         ->  Subquery Scan on q  (cost=365.06..376.47 rows=326 width=16) (actual time=39.565..51.897 rows=24360 loops=1)
                                                               ->  WindowAgg  (cost=365.06..373.21 rows=326 width=24) (actual time=39.565..49.976 rows=24360 loops=1)
                                                                     ->  Subquery Scan on queue_candidates  (cost=365.06..369.14 rows=326 width=8) (actual time=39.561..43.137 rows=24360 loops=1)
                                                                           ->  Sort  (cost=365.06..365.88 rows=326 width=36) (actual time=39.560..41.026 rows=24360 loops=1)
                                                                                 Sort Key: (rank() OVER (?)), queue.latest_dequeue NULLS FIRST
                                                                                 Sort Method: quicksort  Memory: 2672kB
                                                                                 ->  WindowAgg  (cost=344.12..351.45 rows=326 width=36) (actual time=18.974..33.974 rows=24360 loops=1)
                                                                                       ->  Sort  (cost=344.12..344.93 rows=326 width=28) (actual time=18.955..20.070 rows=24360 loops=1)
                                                                                             Sort Key: queue.user_id, exec.created_at, exec.id
                                                                                             Sort Method: quicksort  Memory: 2672kB
                                                                                             ->  Hash Join  (cost=56.32..330.51 rows=326 width=28) (actual time=0.087..13.668 rows=24360 loops=1)
                                                                                                   Hash Cond: (exec.user_id = queue.user_id)
                                                                                                   ->  Index Scan using batch_spec_workspace_execution_jobs_state on batch_spec_workspace_execution_jobs exec  (cost=0.42..273.75 rows=326 width=20) (actual time=0.022..9.687 rows=24360 loops=1)
                                                                                                         Index Cond: (state = 'queued'::text)
                                                                                                   ->  Hash  (cost=30.40..30.40 rows=2040 width=12) (actual time=0.049..0.050 rows=24 loops=1)
                                                                                                         Buckets: 2048  Batches: 1  Memory Usage: 18kB
                                                                                                         ->  Seq Scan on batch_spec_workspace_execution_last_dequeues queue  (cost=0.00..30.40 rows=2040 width=12) (actual time=0.029..0.031 rows=24 loops=1)
                     ->  Index Scan using batch_spec_workspace_execution_jobs_pkey on batch_spec_workspace_execution_jobs  (cost=0.42..2.64 rows=1 width=14) (actual time=0.002..0.002 rows=1 loops=50)
                           Index Cond: (id = pc.candidate_id)
                           Filter: (state = ANY ('{queued,errored}'::text[]))
 Planning Time: 0.664 ms
 Execution Time: 75.104 ms
(41 rows)
```



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
