### PR TITLE
Search UI: Truncate repo descriptions in search results to first 500 characters

### DIFF
--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -104,7 +104,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                         <div className={styles.dividerVertical} />
                         <div>
                             <small>
-                                <em>{result.description}</em>
+                                <em>{result.description.length > 500 ? (result.description.slice(0, 500) + ' ...') : result.description}</em>
                             </small>
                         </div>
                     </>


### PR DESCRIPTION
This change is meant to reduce noise and improve usability on the search results page, as some repositories on GitHub have very long descriptions. Repo descriptions are still displayed in full on the repo page.



## Test plan
Visually verify repo descriptions are now truncated on the search results page.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
