### PR TITLE
[Admin Analytics] fix chart timezone issue

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
@@ -17,7 +17,7 @@ import { ChartContainer } from '../components/ChartContainer'
 import { HorizontalSelect } from '../components/HorizontalSelect'
 import { TimeSavedCalculator } from '../components/TimeSavedCalculatorGroup'
 import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
-import { StandardDatum, buildStandardDatum } from '../utils'
+import { StandardDatum } from '../utils'
 
 import { BATCHCHANGES_STATISTICS } from './queries'
 
@@ -44,11 +44,11 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
                 id: 'changesets_created',
                 name: 'Changesets created',
                 color: 'var(--orange)',
-                data: buildStandardDatum(
-                    changesetsCreated.nodes.map(node => ({
+                data: changesetsCreated.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node.count,
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -58,11 +58,11 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
                 id: 'changesets_merged',
                 name: 'Changesets merged',
                 color: 'var(--cyan)',
-                data: buildStandardDatum(
-                    changesetsMerged.nodes.map(node => ({
+                data: changesetsMerged.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node.count,
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -83,6 +83,7 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
         ]
 
         const calculatorProps = {
+            page: 'BatchChanges',
             label: 'Changesets merged',
             color: 'var(--cyan)',
             value: changesetsMerged.summary.totalCount,
@@ -111,7 +112,10 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
                     <HorizontalSelect<AnalyticsDateRange>
                         value={dateRange}
                         label="Date&nbsp;range"
-                        onChange={setDateRange}
+                        onChange={value => {
+                            setDateRange(value)
+                            eventLogger.log(`AdminAnalyticsBatchChangesDateRange${value}Selected`)
+                        }}
                         items={[
                             { value: AnalyticsDateRange.LAST_WEEK, label: 'Last week' },
                             { value: AnalyticsDateRange.LAST_MONTH, label: 'Last month' },

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -19,7 +19,7 @@ import { HorizontalSelect } from '../components/HorizontalSelect'
 import { TimeSavedCalculatorGroup } from '../components/TimeSavedCalculatorGroup'
 import { ToggleSelect } from '../components/ToggleSelect'
 import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
-import { StandardDatum, buildStandardDatum } from '../utils'
+import { StandardDatum } from '../utils'
 
 import { CODEINTEL_STATISTICS } from './queries'
 
@@ -62,11 +62,11 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                 name:
                     eventAggregation === 'count' ? '"Find references" clicked' : 'Users who clicked "Find references"',
                 color: 'var(--cyan)',
-                data: buildStandardDatum(
-                    referenceClicks.nodes.map(node => ({
+                data: referenceClicks.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node[eventAggregation],
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -79,11 +79,11 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                         ? '"Go to definition" clicked'
                         : 'Users who clicked "Go to definition"',
                 color: 'var(--orange)',
-                data: buildStandardDatum(
-                    definitionClicks.nodes.map(node => ({
+                data: definitionClicks.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node[eventAggregation],
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -105,11 +105,12 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                 value: Math.floor((crossRepoEvents.summary.totalCount * totalEvents) / totalHoverEvents || 0),
                 description: 'Cross repo events',
                 position: 'right',
-                color: 'var(--black)',
+                color: 'var(--body-color)',
             },
         ]
 
         const calculatorProps = {
+            page: 'CodeIntel',
             label: 'Intel Events',
             color: 'var(--purple)',
             description:
@@ -174,7 +175,10 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                     <HorizontalSelect<AnalyticsDateRange>
                         value={dateRange}
                         label="Date&nbsp;range"
-                        onChange={setDateRange}
+                        onChange={value => {
+                            setDateRange(value)
+                            eventLogger.log(`AdminAnalyticsCodeIntelDateRange${value}Selected`)
+                        }}
                         items={[
                             { value: AnalyticsDateRange.LAST_WEEK, label: 'Last week' },
                             { value: AnalyticsDateRange.LAST_MONTH, label: 'Last month' },
@@ -196,7 +200,12 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                         <div className="d-flex justify-content-end align-items-stretch mb-2">
                             <ToggleSelect<typeof eventAggregation>
                                 selected={eventAggregation}
-                                onChange={setEventAggregation}
+                                onChange={value => {
+                                    setEventAggregation(value)
+                                    eventLogger.log(
+                                        `AdminAnalyticsCodeIntelAgg${value === 'count' ? 'Totals' : 'Uniques'}Clicked`
+                                    )
+                                }}
                                 items={[
                                     {
                                         tooltip: 'total # of actions triggered',

--- a/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
@@ -19,7 +19,7 @@ import { HorizontalSelect } from '../components/HorizontalSelect'
 import { TimeSavedCalculator } from '../components/TimeSavedCalculatorGroup'
 import { ToggleSelect } from '../components/ToggleSelect'
 import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
-import { StandardDatum, buildStandardDatum } from '../utils'
+import { StandardDatum } from '../utils'
 
 import { NOTEBOOKS_STATISTICS } from './queries'
 
@@ -49,11 +49,11 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
                 id: 'creations',
                 name: eventAggregation === 'count' ? 'Notebooks created' : 'Users created notebooks',
                 color: 'var(--cyan)',
-                data: buildStandardDatum(
-                    creations.nodes.map(node => ({
+                data: creations.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node[eventAggregation],
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -63,11 +63,11 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
                 id: 'views',
                 name: eventAggregation === 'count' ? 'Notebook views' : 'Users viewed notebooks',
                 color: 'var(--orange)',
-                data: buildStandardDatum(
-                    views.nodes.map(node => ({
+                data: views.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node[eventAggregation],
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -94,8 +94,9 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
         ]
 
         const calculatorProps = {
+            page: 'Notebooks',
             label: 'Views',
-            color: 'var(--black)',
+            color: 'var(--body-color)',
             value: views.summary.totalCount,
             minPerItem: 5,
             description:
@@ -122,7 +123,10 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
                     <HorizontalSelect<AnalyticsDateRange>
                         value={dateRange}
                         label="Date&nbsp;range"
-                        onChange={setDateRange}
+                        onChange={value => {
+                            setDateRange(value)
+                            eventLogger.log(`AdminAnalyticsNotebooksDateRange${value}Selected`)
+                        }}
                         items={[
                             { value: AnalyticsDateRange.LAST_WEEK, label: 'Last week' },
                             { value: AnalyticsDateRange.LAST_MONTH, label: 'Last month' },
@@ -144,7 +148,12 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
                         <div className="d-flex justify-content-end align-items-stretch mb-2">
                             <ToggleSelect<typeof eventAggregation>
                                 selected={eventAggregation}
-                                onChange={setEventAggregation}
+                                onChange={value => {
+                                    setEventAggregation(value)
+                                    eventLogger.log(
+                                        `AdminAnalyticsNotebooksAgg${value === 'count' ? 'Totals' : 'Uniques'}Clicked`
+                                    )
+                                }}
                                 items={[
                                     {
                                         tooltip: 'total # of actions triggered',

--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
@@ -15,7 +15,7 @@ import { HorizontalSelect } from '../components/HorizontalSelect'
 import { TimeSavedCalculatorGroup } from '../components/TimeSavedCalculatorGroup'
 import { ToggleSelect } from '../components/ToggleSelect'
 import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
-import { StandardDatum, buildStandardDatum } from '../utils'
+import { StandardDatum } from '../utils'
 
 import { SEARCH_STATISTICS } from './queries'
 
@@ -42,11 +42,11 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
                 id: 'searches',
                 name: eventAggregation === 'count' ? 'Searches' : 'Users searched',
                 color: 'var(--cyan)',
-                data: buildStandardDatum(
-                    searches.nodes.map(node => ({
+                data: searches.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node[eventAggregation],
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -56,11 +56,11 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
                 id: 'resultClicks',
                 name: eventAggregation === 'count' ? 'Result clicks' : 'Users clicked results',
                 color: 'var(--purple)',
-                data: buildStandardDatum(
-                    resultClicks.nodes.map(node => ({
+                data: resultClicks.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node[eventAggregation],
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -70,11 +70,11 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
                 id: 'fileViews',
                 name: eventAggregation === 'count' ? 'File views' : 'Users viewed files',
                 color: 'var(--orange)',
-                data: buildStandardDatum(
-                    fileViews.nodes.map(node => ({
+                data: fileViews.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node[eventAggregation],
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -116,6 +116,7 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
 
         const totalCount = searches.summary.totalCount + fileViews.summary.totalCount
         return {
+            page: 'Search',
             label: 'Searches &<br/>file views',
             color: 'var(--blue)',
             description:
@@ -167,7 +168,10 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
                     <HorizontalSelect<AnalyticsDateRange>
                         value={dateRange}
                         label="Date&nbsp;range"
-                        onChange={setDateRange}
+                        onChange={value => {
+                            setDateRange(value)
+                            eventLogger.log(`AdminAnalyticsSearchDateRange${value}Selected`)
+                        }}
                         items={[
                             { value: AnalyticsDateRange.LAST_WEEK, label: 'Last week' },
                             { value: AnalyticsDateRange.LAST_MONTH, label: 'Last month' },
@@ -189,7 +193,12 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
                         <div className="d-flex justify-content-end align-items-stretch mb-2">
                             <ToggleSelect<typeof eventAggregation>
                                 selected={eventAggregation}
-                                onChange={setEventAggregation}
+                                onChange={value => {
+                                    setEventAggregation(value)
+                                    eventLogger.log(
+                                        `AdminAnalyticsSearchAgg${value === 'count' ? 'Totals' : 'Uniques'}Clicked`
+                                    )
+                                }}
                                 items={[
                                     {
                                         tooltip: 'total # of actions triggered',

--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
@@ -125,7 +125,7 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
             items: [
                 {
                     label: 'Complex searches',
-                    minPerItem: 5,
+                    minPerItem: 120,
                     description:
                         'Without Sourcegraph, these searches would require complex scripting. They often answer specific and valuable questions such as finding occurrences of log4j at a specific version globally.',
                     percentage: 3,
@@ -141,7 +141,7 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
                 },
                 {
                     label: 'Core workflow',
-                    minPerItem: 5,
+                    minPerItem: 0.5,
                     description:
                         'Common code search use cases are made more efficient through Sourcegraph’s advanced query language and features like syntax aware search patterns and the ability to search code, diffs, and commit messages at any revision.',
                     percentage: 75,

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -17,7 +17,7 @@ import { ChartContainer } from '../components/ChartContainer'
 import { HorizontalSelect } from '../components/HorizontalSelect'
 import { ToggleSelect } from '../components/ToggleSelect'
 import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
-import { StandardDatum, buildStandardDatum, FrequencyDatum, buildFrequencyDatum } from '../utils'
+import { StandardDatum, FrequencyDatum, buildFrequencyDatum } from '../utils'
 
 import { USERS_STATISTICS } from './queries'
 
@@ -72,11 +72,11 @@ export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>
                 id: 'activity',
                 name: eventAggregation === 'count' ? 'Activities' : 'Active users',
                 color: eventAggregation === 'count' ? 'var(--cyan)' : 'var(--purple)',
-                data: buildStandardDatum(
-                    users.activity.nodes.map(node => ({
+                data: users.activity.nodes.map(
+                    node => ({
                         date: new Date(node.date),
                         value: node[eventAggregation],
-                    })),
+                    }),
                     dateRange
                 ),
                 getXValue: ({ date }) => date,
@@ -126,7 +126,10 @@ export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>
                     <HorizontalSelect<AnalyticsDateRange>
                         label="Date&nbsp;range"
                         value={dateRange}
-                        onChange={setDateRange}
+                        onChange={value => {
+                            setDateRange(value)
+                            eventLogger.log(`AdminAnalyticsUsersDateRange${value}Selected`)
+                        }}
                         items={[
                             { value: AnalyticsDateRange.LAST_WEEK, label: 'Last week' },
                             { value: AnalyticsDateRange.LAST_MONTH, label: 'Last month' },
@@ -157,7 +160,12 @@ export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>
                         <div className="d-flex justify-content-end align-items-stretch mb-2">
                             <ToggleSelect<typeof eventAggregation>
                                 selected={eventAggregation}
-                                onChange={setEventAggregation}
+                                onChange={value => {
+                                    setEventAggregation(value)
+                                    eventLogger.log(
+                                        `AdminAnalyticsUsersAgg${value === 'count' ? 'Totals' : 'Uniques'}Clicked`
+                                    )
+                                }}
                                 items={[
                                     {
                                         tooltip: 'total # of actions triggered',

--- a/client/web/src/site-admin/analytics/utils.ts
+++ b/client/web/src/site-admin/analytics/utils.ts
@@ -1,7 +1,3 @@
-import { addDays, getDayOfYear, startOfDay, startOfWeek, sub } from 'date-fns'
-
-import { AnalyticsDateRange } from '../../graphql-operations'
-
 export interface FrequencyDatum {
     label: string
     value: number
@@ -40,29 +36,6 @@ export function buildFrequencyDatum(
     }
 
     return result
-}
-
-export function buildStandardDatum(datums: StandardDatum[], dateRange: AnalyticsDateRange): StandardDatum[] {
-    // Generates 0 value series for dates that don't exist in the original data
-    const [to, daysOffset] =
-        dateRange === AnalyticsDateRange.LAST_THREE_MONTHS
-            ? [startOfWeek(new Date(), { weekStartsOn: 1 }), 7]
-            : [startOfDay(new Date()), 1]
-    const from =
-        dateRange === AnalyticsDateRange.LAST_THREE_MONTHS
-            ? sub(to, { months: 3 })
-            : dateRange === AnalyticsDateRange.LAST_MONTH
-            ? sub(to, { months: 1 })
-            : sub(to, { weeks: 1 })
-    const newDatums: StandardDatum[] = []
-    let date = to
-    while (date >= from) {
-        const datum = datums?.find(datum => getDayOfYear(datum.date) === getDayOfYear(date))
-        newDatums.push(datum ? { ...datum, date } : { date, value: 0 })
-        date = addDays(date, -daysOffset)
-    }
-
-    return newDatums
 }
 
 export const formatNumber = (value: number): string => Intl.NumberFormat('en', { notation: 'compact' }).format(value)


### PR DESCRIPTION
- Solve charts going blank for 3 months date range due to timezone issues by moving the chart's ticks generation logic to the backend from the frontend.
- Add new events for changing calculator inputs.
- Add new events for toggling agg from totals to uniques.
-  Add new events for switching date range.
- Fix font colors from black -> body.

## Test plan

- Visit https://sourcegraph.test:3443/site-admin/analytics/code-intel in US timezone
- Select 3 months date range
- Verify chart showing correct values

---
- Visit https://sourcegraph.test:3443/site-admin/analytics/code-intel
- Turn on dark mode
- Verfiy the legend's colour to be white 