### PR TITLE
search: lucky search does not unquote aliased patterns

### DIFF
--- a/internal/search/lucky/rules.go
+++ b/internal/search/lucky/rules.go
@@ -65,7 +65,7 @@ func unquotePatterns(b query.Basic) *query.Basic {
 
 	changed := false // track whether we've successfully changed any pattern, which means this rule applies.
 	newParseTree := query.MapPattern(rawParseTree, func(value string, negated bool, annotation query.Annotation) query.Node {
-		if annotation.Labels.IsSet(query.Quoted) {
+		if annotation.Labels.IsSet(query.Quoted) && !annotation.Labels.IsSet(query.IsAlias) {
 			changed = true
 			annotation.Labels.Unset(query.Quoted)
 			annotation.Labels.Set(query.Literal)

--- a/internal/search/lucky/rules_test.go
+++ b/internal/search/lucky/rules_test.go
@@ -36,6 +36,7 @@ func Test_unquotePatterns(t *testing.T) {
 	cases := []string{
 		`"monitor"`,
 		`repo:^github\.com/sourcegraph/sourcegraph$ "monitor" "*Monitor"`,
+		`content:"not quoted"`,
 	}
 
 	for _, c := range cases {

--- a/internal/search/lucky/testdata/Test_unquotePatterns/unquote_patterns#02.golden
+++ b/internal/search/lucky/testdata/Test_unquotePatterns/unquote_patterns#02.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "content:\"not quoted\"",
+  "Query": "DOES NOT APPLY"
+}


### PR DESCRIPTION
The unquote rule would fire for `content:"xyz"` syntax since `xyz` is quoted. It's true that the pattern is quoted (as opposed to `content:xyz`), but lucky search isn't meant to try unquote _that_ syntax, because the quotes on patterns on fields like `content` are never searched literally. This updates the `unquote` rule to only apply to quoted patterns that do not have `content:` in front of them (i.e., not aliased).

## Test plan
Adds test.
