### PR TITLE
Search backend: move privateReposForActor to package where it's used

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -13,14 +13,17 @@ import (
 	"github.com/sourcegraph/log"
 	"go.uber.org/atomic"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -653,7 +656,7 @@ func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClient
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, t)
 	defer func() { finish(alert, err) }()
 
-	userPrivateRepos := searchrepos.PrivateReposForActor(ctx, clients.Logger, clients.DB, t.RepoOpts)
+	userPrivateRepos := privateReposForActor(ctx, clients.Logger, clients.DB, t.RepoOpts)
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	t.ZoektArgs.Query = t.GlobalZoektQuery.Generate()
 
@@ -686,3 +689,42 @@ func (t *GlobalTextSearchJob) Fields(v job.Verbosity) (res []otlog.Field) {
 
 func (t *GlobalTextSearchJob) Children() []job.Describer       { return nil }
 func (t *GlobalTextSearchJob) MapChildren(job.MapFunc) job.Job { return t }
+
+// Get all private repos for the the current actor. On sourcegraph.com, those are
+// only the repos directly added by the user. Otherwise it's all repos the user has
+// access to on all connected code hosts / external services.
+func privateReposForActor(ctx context.Context, logger log.Logger, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
+	tr, ctx := trace.New(ctx, "privateReposForActor", "")
+	defer tr.Finish()
+
+	userID := int32(0)
+	if envvar.SourcegraphDotComMode() {
+		if a := actor.FromContext(ctx); a.IsAuthenticated() {
+			userID = a.UID
+		} else {
+			tr.LazyPrintf("skipping private repo resolution for unauthed user")
+			return nil
+		}
+	}
+	tr.LogFields(otlog.Int32("userID", userID))
+
+	// TODO: We should use repos.Resolve here. However, the logic for
+	// UserID is different to repos.Resolve, so we need to work out how
+	// best to address that first.
+	userPrivateRepos, err := db.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
+		UserID:         userID, // Zero valued when not in sourcegraph.com mode
+		OnlyPrivate:    true,
+		LimitOffset:    &database.LimitOffset{Limit: limits.SearchLimits(conf.Get()).MaxRepos + 1},
+		OnlyForks:      repoOptions.OnlyForks,
+		NoForks:        repoOptions.NoForks,
+		OnlyArchived:   repoOptions.OnlyArchived,
+		NoArchived:     repoOptions.NoArchived,
+		ExcludePattern: query.UnionRegExps(repoOptions.MinusRepoFilters),
+	})
+
+	if err != nil {
+		logger.Error("doResults: failed to list user private repos", log.Error(err), log.Int32("user-id", userID))
+		tr.LazyPrintf("error resolving user private repos: %v", err)
+	}
+	return userPrivateRepos
+}

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
-	"github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -95,7 +94,7 @@ func (s *GlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	userPrivateRepos := repos.PrivateReposForActor(ctx, clients.Logger, clients.DB, s.RepoOpts)
+	userPrivateRepos := privateReposForActor(ctx, clients.Logger, clients.DB, s.RepoOpts)
 	s.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	s.ZoektArgs.Query = s.GlobalZoektQuery.Generate()
 


### PR DESCRIPTION
PrivateReposForActors is only used by zoekt code, and it's causing circular import issues blocking https://github.com/sourcegraph/sourcegraph/pull/38988. This just moves the function to where it's used.

Pulled out of #38988

## Test plan

Semantics-preserving.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
