### PR TITLE
batches: fix workspace list display

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesListItem.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesListItem.module.scss
@@ -3,6 +3,7 @@
     background-color: var(--primary);
 
     h3,
+    h4,
     small,
     svg,
     span,

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -41,7 +41,7 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
                 </>
             ) : null}
             {workspace && (
-                <div className={classNames(styles.workspaceDetails, '.text-monospace')}>
+                <div className={classNames(styles.workspaceDetails, 'text-monospace')}>
                     {workspace.ignored && (
                         <Badge
                             className={styles.badge}


### PR DESCRIPTION
[#38784](https://github.com/sourcegraph/sourcegraph/pull/38784) added a UI regression where the repository names in the workspace list wasn't getting the right color applied to it.

[#38683](https://github.com/sourcegraph/sourcegraph/pull/38683) also contained a typo in the classname added to the `workspaceDetails` section.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Checked both light mode and dark mode to be verify the correct class is added and the branch name is in `monospace`.

<img width="966" alt="CleanShot 2022-07-19 at 00 05 02@2x" src="https://user-images.githubusercontent.com/25608335/179631473-7439fb3e-fb10-4e5a-8e98-57728d39e1a7.png">
<img width="1561" alt="CleanShot 2022-07-19 at 00 04 47@2x" src="https://user-images.githubusercontent.com/25608335/179631477-f0ece710-a81a-44f8-b367-cbe75d0b46dc.png">

## App preview:

- [Web](https://sg-web-bo-fix-workspace-list.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jzojxzbnah.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

