### PR TITLE
sg: remove GOGC from zoekt-indexserver

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -383,7 +383,6 @@ commands:
       go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
     checkBinary: .bin/zoekt-sourcegraph-indexserver
     env: &zoektenv
-      GOGC: 25
       CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
 
   zoekt-index-0:


### PR DESCRIPTION
We only need a custom GOGC value for zoekt-webserver.

Test Plan: yolo