### PR TITLE
core workflow: symbol improvements

### DIFF
--- a/client/search-ui/src/components/FileMatchChildren.module.scss
+++ b/client/search-ui/src/components/FileMatchChildren.module.scss
@@ -15,6 +15,36 @@
     }
 }
 
+.symbols {
+    background-color: var(--body-bg) !important;
+}
+
+.symbol {
+    display: flex;
+    align-items: center;
+    background-color: var(--color-bg-2);
+    padding: 0.25rem;
+    border-radius: var(--border-radius);
+    cursor: pointer;
+
+    &:not(:last-child) {
+        margin-bottom: 0.5rem;
+    }
+
+    &-tag {
+        width: 5.75rem;
+    }
+
+    &-code-excerpt {
+        flex: 1;
+
+        :global(.code) {
+            white-space: pre-line !important;
+            overflow-wrap: anywhere;
+        }
+    }
+}
+
 .item {
     display: flex;
     align-items: center;

--- a/client/search-ui/src/components/FileMatchChildren.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.tsx
@@ -21,7 +21,9 @@ import { HoverContext } from '@sourcegraph/shared/src/hover/HoverOverlay.types'
 import { IHighlightLineRange } from '@sourcegraph/shared/src/schema'
 import { ContentMatch, SymbolMatch, PathMatch, getFileMatchUrl } from '@sourcegraph/shared/src/search/stream'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { SymbolIcon } from '@sourcegraph/shared/src/symbols/SymbolIcon'
+import { SymbolTag } from '@sourcegraph/shared/src/symbols/SymbolTag'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 import { useCodeIntelViewerUpdates } from '@sourcegraph/shared/src/util/useCodeIntelViewerUpdates'
@@ -148,6 +150,7 @@ function navigateToFileOnMiddleMouseButtonClick(event: MouseEvent<HTMLElement>):
 }
 
 export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<FileMatchProps>> = props => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
     // If optimizeHighlighting is enabled, compile a list of the highlighted file ranges we want to
     // fetch (instead of the entire file.)
     const optimizeHighlighting =
@@ -273,7 +276,10 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
     const openInNewTabProps = props.openInNewTab ? { target: '_blank', rel: 'noopener noreferrer' } : undefined
 
     return (
-        <div className={styles.fileMatchChildren} data-testid="file-match-children">
+        <div
+            className={classNames(styles.fileMatchChildren, result.type === 'symbol' && styles.symbols)}
+            data-testid="file-match-children"
+        >
             {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
             {/* Path */}
             {result.type === 'path' && (
@@ -283,7 +289,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             )}
 
             {/* Symbols */}
-            {((result.type === 'symbol' && result.symbols) || []).map(symbol => (
+            {((!coreWorkflowImprovementsEnabled && result.type === 'symbol' && result.symbols) || []).map(symbol => (
                 <Link
                     to={symbol.url}
                     className={classNames('test-file-match-children-item', styles.item)}
@@ -297,6 +303,40 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
                         {symbol.containerName && <span className="text-muted">{symbol.containerName}</span>}
                     </Code>
                 </Link>
+            ))}
+
+            {((coreWorkflowImprovementsEnabled && result.type === 'symbol' && result.symbols) || []).map(symbol => (
+                <div
+                    key={`symbol:${symbol.name}${String(symbol.containerName)}${symbol.url}`}
+                    className={styles.symbol}
+                >
+                    <div className={classNames('mr-1 flex-shrink-0', styles.symbolTag)}>
+                        <SymbolTag kind={symbol.kind} />
+                    </div>
+                    <div
+                        className={styles.symbolCodeExcerpt}
+                        data-href={symbol.url}
+                        onClick={navigateToFile}
+                        onMouseUp={navigateToFileOnMiddleMouseButtonClick}
+                        onKeyDown={navigateToFile}
+                        role="link"
+                        tabIndex={0}
+                    >
+                        <CodeExcerpt
+                            repoName={result.repository}
+                            commitID={result.commit || ''}
+                            filePath={result.path}
+                            startLine={symbol.line - 1}
+                            endLine={symbol.line}
+                            fetchHighlightedFileRangeLines={fetchHighlightedFileRangeLines}
+                            viewerUpdates={viewerUpdates}
+                            hoverifier={props.hoverifier}
+                            onCopy={logEventOnCopy}
+                            highlightRanges={[]}
+                            isFirst={false}
+                        />
+                    </div>
+                </div>
             ))}
 
             {/* Line matches */}

--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -211,6 +211,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
         repoLastFetched: result.repoLastFetched,
         onResultClicked: props.onSelect,
         className: props.containerClassName,
+        resultsClassName: props.result.type === 'symbol' ? styles.symbols : undefined,
         resultType: result.type,
     }
 

--- a/client/search-ui/src/components/LastSyncedIcon.module.scss
+++ b/client/search-ui/src/components/LastSyncedIcon.module.scss
@@ -5,5 +5,4 @@
     height: 1rem;
     isolation: isolate;
     z-index: 1;
-    background-color: inherit;
 }

--- a/client/search-ui/src/components/ResultContainer.tsx
+++ b/client/search-ui/src/components/ResultContainer.tsx
@@ -108,6 +108,8 @@ export interface ResultContainerProps {
      */
     className?: string
 
+    resultsClassName?: string
+
     as?: React.ElementType
     index: number
 }
@@ -132,6 +134,7 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
     repoStars,
     onResultClicked,
     className,
+    resultsClassName,
     resultType,
     as: Component = 'div',
     index,
@@ -243,7 +246,12 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
                         </span>
                     )}
                 </div>
-                <div className={classNames(coreWorkflowImprovementsEnabled && styles.collapsibleResults)}>
+                <div
+                    className={classNames(
+                        coreWorkflowImprovementsEnabled && styles.collapsibleResults,
+                        resultsClassName
+                    )}
+                >
                     <div>{expanded ? expandedChildren : collapsedChildren}</div>
                     {coreWorkflowImprovementsEnabled && collapsible && (
                         <button

--- a/client/search-ui/src/components/SearchResult.module.scss
+++ b/client/search-ui/src/components/SearchResult.module.scss
@@ -111,3 +111,8 @@
         }
     }
 }
+
+.symbols {
+    border: none;
+    padding: 0;
+}

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -95,6 +95,7 @@ export interface MatchedSymbol {
     name: string
     containerName: string
     kind: SymbolKind
+    line: number
 }
 
 type MarkdownText = string

--- a/client/shared/src/symbols/SymbolTag.module.scss
+++ b/client/shared/src/symbols/SymbolTag.module.scss
@@ -1,0 +1,35 @@
+.tag {
+    font-size: 0.75rem;
+    padding: 0.0625rem 0.25rem;
+    border-radius: var(--border-radius);
+    color: var(--white);
+    background-color: #000;
+}
+
+.class-tag {
+    background-color: #6b47d6;
+}
+
+.function-tag {
+    background-color: #6b1515;
+}
+
+.field-tag {
+    background-color: #b8e3e8;
+}
+
+.module-tag {
+    background-color: #f59f00;
+}
+
+.package-tag {
+    background-color: #fbd999;
+}
+
+.method-tag {
+    background-color: #37b24d;
+}
+
+.struct-tag {
+    background-color: #845ef7;
+}

--- a/client/shared/src/symbols/SymbolTag.story.tsx
+++ b/client/shared/src/symbols/SymbolTag.story.tsx
@@ -1,0 +1,36 @@
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+
+// eslint-disable-next-line no-restricted-imports
+import { WebStory } from '@sourcegraph/web/src/components/WebStory'
+
+import { SymbolKind } from '../graphql-operations'
+
+import { SymbolTag } from './SymbolTag'
+
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'client/shared/src/symbols/SymbolTag',
+    parameters: {
+        chromatic: { disableSnapshots: false },
+    },
+    decorators: [decorator],
+}
+
+export default config
+
+const symbolKinds = Object.values(SymbolKind)
+
+export const Default: Story = () => (
+    <WebStory>
+        {() => (
+            <div>
+                {symbolKinds.map(symbolKind => (
+                    <div key={symbolKind}>
+                        <SymbolTag kind={symbolKind} />
+                    </div>
+                ))}
+            </div>
+        )}
+    </WebStory>
+)

--- a/client/shared/src/symbols/SymbolTag.tsx
+++ b/client/shared/src/symbols/SymbolTag.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react'
+
+import classNames from 'classnames'
+
+import { SymbolKind } from '../graphql-operations'
+
+import styles from './SymbolTag.module.scss'
+
+const getSymbolTag = (kind: SymbolKind): string => {
+    switch (kind) {
+        case 'FILE':
+            return 'file'
+        case 'MODULE':
+            return 'module'
+        case 'NAMESPACE':
+            return 'namespace'
+        case 'PACKAGE':
+            return 'package'
+        case 'CLASS':
+            return 'class'
+        case 'METHOD':
+            return 'method'
+        case 'PROPERTY':
+            return 'property'
+        case 'FIELD':
+            return 'field'
+        case 'CONSTRUCTOR':
+            return 'constructor'
+        case 'ENUM':
+            return 'enum'
+        case 'INTERFACE':
+            return 'interface'
+        case 'FUNCTION':
+            return 'function'
+        case 'VARIABLE':
+            return 'var'
+        case 'CONSTANT':
+            return 'const'
+        case 'STRING':
+            return 'string'
+        case 'NUMBER':
+            return 'number'
+        case 'BOOLEAN':
+            return 'bool'
+        case 'ARRAY':
+            return 'array'
+        case 'OBJECT':
+            return 'object'
+        case 'KEY':
+            return 'key'
+        case 'NULL':
+            return 'null'
+        case 'ENUMMEMBER':
+            return 'enum member'
+        case 'STRUCT':
+            return 'struct'
+        case 'EVENT':
+            return 'event'
+        case 'OPERATOR':
+            return 'operator'
+        case 'TYPEPARAMETER':
+            return 'type param'
+        case 'UNKNOWN':
+        default:
+            return 'unknown'
+    }
+}
+
+interface SymbolTagProps {
+    kind: SymbolKind
+    className?: string
+}
+
+function getSymbolIconClassName(kind: SymbolKind): string | undefined {
+    return (styles as Record<string, string>)[`${kind.toLowerCase()}Tag`]
+}
+
+export const SymbolTag: React.FunctionComponent<React.PropsWithChildren<SymbolTagProps>> = ({ kind, className }) => (
+    <span
+        className={classNames(getSymbolIconClassName(kind), className, styles.tag)}
+        aria-label={`Symbol kind ${kind.toLowerCase()}`}
+    >
+        {getSymbolTag(kind)}
+    </span>
+)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -422,6 +422,7 @@ func fromSymbolMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Searc
 			Name:          sym.Symbol.Name,
 			ContainerName: sym.Symbol.Parent,
 			Kind:          kindString,
+			Line:          int32(sym.Symbol.Line),
 		})
 	}
 

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -129,6 +129,7 @@ type Symbol struct {
 	Name          string `json:"name"`
 	ContainerName string `json:"containerName"`
 	Kind          string `json:"kind"`
+	Line          int32  `json:"line"`
 }
 
 // EventCommitMatch is the generic results interface from GQL. There is a lot


### PR DESCRIPTION
Fixes #38810

## Screenshots

<img width="1489" alt="Screenshot 2022-07-19 at 10 05 44" src="https://user-images.githubusercontent.com/6417322/179699840-8cf45695-5142-4b67-b726-0546cf36878e.png">
<img width="1384" alt="Screenshot 2022-07-19 at 10 05 36" src="https://user-images.githubusercontent.com/6417322/179699851-a63bc694-7c6d-4781-8e83-cc34b5301239.png">


## Test plan
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Enable core workflow improvements
* Search with `type:symbol`
* See new design

## TODO

* The colors for symbol tags are not finalized.
