### PR TITLE
worker: change ext svc type and ID for granting pending permissions

### DIFF
--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -284,8 +284,8 @@ func (h *bitbucketProjectPermissionsHandler) setRepoPermissions(ctx context.Cont
 	defer func() { err = txs.Done(err) }()
 
 	accounts := &extsvc.Accounts{
-		ServiceType: extsvc.KindToType(svc.Kind),
-		ServiceID:   strconv.FormatInt(svc.ID, 10),
+		ServiceType: authz.SourcegraphServiceType,
+		ServiceID:   authz.SourcegraphServiceID,
 		AccountIDs:  pendingBindIDs,
 	}
 

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -170,8 +170,8 @@ func TestSetPermissionsForUsers(t *testing.T) {
 
 		for _, bindID := range bindIDs {
 			userPerms := &authz.UserPendingPermissions{
-				ServiceType: extsvc.TypeBitbucketServer,
-				ServiceID:   "1",
+				ServiceType: authz.SourcegraphServiceType,
+				ServiceID:   authz.SourcegraphServiceID,
 				BindID:      bindID,
 				Perm:        authz.Read,
 				Type:        authz.PermRepos,


### PR DESCRIPTION
Fix the ext svc type for granting pending permissions during Bitbucket Projects repo sync

## Test plan
existing tests should pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
