### PR TITLE
db: Faster SQL cleanup of cm_trigger_jobs

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -5322,6 +5322,16 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
+          "Name": "cm_trigger_jobs_finished_at",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX cm_trigger_jobs_finished_at ON cm_trigger_jobs USING btree (finished_at)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "cm_trigger_jobs_state_idx",
           "IsPrimaryKey": false,
           "IsUnique": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -614,6 +614,7 @@ Slack webhook actions configured on code monitors
  queued_at         | timestamp with time zone |           |          | now()
 Indexes:
     "cm_trigger_jobs_pkey" PRIMARY KEY, btree (id)
+    "cm_trigger_jobs_finished_at" btree (finished_at)
     "cm_trigger_jobs_state_idx" btree (state)
 Check constraints:
     "search_results_is_array" CHECK (jsonb_typeof(search_results) = 'array'::text)

--- a/migrations/frontend/1658225452_fast_cm_trigger_jobs_delete/down.sql
+++ b/migrations/frontend/1658225452_fast_cm_trigger_jobs_delete/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS cm_trigger_jobs_finished_at;

--- a/migrations/frontend/1658225452_fast_cm_trigger_jobs_delete/metadata.yaml
+++ b/migrations/frontend/1658225452_fast_cm_trigger_jobs_delete/metadata.yaml
@@ -1,0 +1,3 @@
+name: fast_cm_trigger_jobs_delete
+parents: [1657635365]
+createIndexConcurrently: true

--- a/migrations/frontend/1658225452_fast_cm_trigger_jobs_delete/up.sql
+++ b/migrations/frontend/1658225452_fast_cm_trigger_jobs_delete/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS cm_trigger_jobs_finished_at ON cm_trigger_jobs (finished_at ASC);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3558,6 +3558,8 @@ CREATE INDEX cm_action_jobs_state_idx ON cm_action_jobs USING btree (state);
 
 CREATE INDEX cm_slack_webhooks_monitor ON cm_slack_webhooks USING btree (monitor);
 
+CREATE INDEX cm_trigger_jobs_finished_at ON cm_trigger_jobs USING btree (finished_at);
+
 CREATE INDEX cm_trigger_jobs_state_idx ON cm_trigger_jobs USING btree (state);
 
 CREATE INDEX cm_webhooks_monitor ON cm_webhooks USING btree (monitor);


### PR DESCRIPTION
Found on demo, this used to be slow.

Before
```
QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------
 Delete on cm_trigger_jobs  (cost=0.00..130427.12 rows=233 width=6) (actual time=999.059..999.060 rows=0 loops=1)
   ->  Seq Scan on cm_trigger_jobs  (cost=0.00..130427.12 rows=233 width=6) (actual time=999.058..999.058 rows=0 loops=1)
         Filter: (finished_at < (now() - '100 years'::interval))
         Rows Removed by Filter: 2325550
 Planning Time: 0.059 ms
 Execution Time: 999.080 ms
(6 rows)
```

After
```
                                                                       QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on cm_trigger_jobs  (cost=0.43..1.71 rows=1 width=6) (actual time=0.005..0.005 rows=0 loops=1)
   ->  Index Scan using cm_trigger_jobs_finished_at_idx1 on cm_trigger_jobs  (cost=0.43..1.71 rows=1 width=6) (actual time=0.004..0.004 rows=0 loops=1)
         Index Cond: (finished_at < (now() - '100 years'::interval))
 Planning Time: 0.253 ms
 Execution Time: 0.024 ms
 ```



## Test plan

Just an index, proof it is good is above. Tests will tell if this can break anything.