### PR TITLE
search: Fix search results page flickering

### DIFF
--- a/client/web/src/search/SearchPageWrapper.tsx
+++ b/client/web/src/search/SearchPageWrapper.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 
+import { useLocation } from 'react-router'
+
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { LayoutRouteComponentProps } from '../routes'
-import { useLocation } from 'react-router'
+
 import { parseSearchURLQuery } from '.'
 
 const SearchPage = lazyComponent(() => import('./home/SearchPage'), 'SearchPage')

--- a/client/web/src/search/SearchPageWrapper.tsx
+++ b/client/web/src/search/SearchPageWrapper.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { LayoutRouteComponentProps } from '../routes'
-import { useNavbarQueryState } from '../stores'
+import { useLocation } from 'react-router'
+import { parseSearchURLQuery } from '.'
 
 const SearchPage = lazyComponent(() => import('./home/SearchPage'), 'SearchPage')
 const StreamingSearchResults = lazyComponent(() => import('./results/StreamingSearchResults'), 'StreamingSearchResults')
@@ -15,7 +16,8 @@ const StreamingSearchResults = lazyComponent(() => import('./results/StreamingSe
 export const SearchPageWrapper: React.FunctionComponent<
     React.PropsWithChildren<LayoutRouteComponentProps<any>>
 > = props => {
-    const hasSearchQuery = useNavbarQueryState(state => state.searchQueryFromURL !== '')
+    const location = useLocation()
+    const hasSearchQuery = parseSearchURLQuery(location.search)
 
     return hasSearchQuery ? <StreamingSearchResults {...props} /> : <SearchPage {...props} />
 }


### PR DESCRIPTION
Fixes #38928 

This commit introduces a simple fix to prevent the search homepage from
being shown for a split second when navigating back to search results.

As the issue points out, the reason for the flicker is that the component
rerenders before the query state was updated.

Medium term we should look into how/when the query state is updated, but
considering there is a release cut today, we should get this fix in asap.


https://user-images.githubusercontent.com/179026/179728525-766baee7-e166-4faa-9627-49b7c30a772b.mp4



## Test plan

Navigated back from a file to search results, didn't see the search homepage
flash.

## App preview:

- [Web](https://sg-web-fkling-38928-search-results.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uhgvjoyulz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
