### PR TITLE
example: useConnection complains about `first` being optional

### DIFF
--- a/client/web/src/enterprise/codeintel/lockfiles/hooks/queries.ts
+++ b/client/web/src/enterprise/codeintel/lockfiles/hooks/queries.ts
@@ -1,0 +1,34 @@
+import { gql } from '@sourcegraph/http-client'
+
+export const LOCKFILE_INDEXES_LIST = gql`
+    fragment LockfileIndexFields on LockfileIndex {
+        id
+        lockfile
+        fidelity
+        repository {
+            id
+            name
+            url
+        }
+        commit {
+            url
+            abbreviatedOID
+            oid
+        }
+    }
+    fragment LockfileIndexConnectionFields on LockfileIndexConnection {
+        nodes {
+            ...LockfileIndexFields
+        }
+        totalCount
+        pageInfo {
+            endCursor
+            hasNextPage
+        }
+    }
+    query LockfileIndexes($first: Int, $after: String) {
+        lockfileIndexes(first: $first, after: $after) {
+            ...LockfileIndexConnectionFields
+        }
+    }
+`

--- a/client/web/src/enterprise/codeintel/lockfiles/hooks/useLockfileIndexes.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/hooks/useLockfileIndexes.tsx
@@ -1,0 +1,27 @@
+import { useConnection, UseConnectionResult } from 'src/components/FilteredConnection/hooks/useConnection'
+
+import { dataOrThrowErrors } from '@sourcegraph/http-client'
+
+import { LockfileIndexesResult, LockfileIndexesVariables, LockfileIndexFields } from '../../../../graphql-operations'
+
+import { LOCKFILE_INDEXES_LIST } from './queries'
+
+export const LOCKFILES_PER_PAGE_COUNT = 50
+
+export const useLockfileIndexes = (first?: number, after?: string): UseConnectionResult<LockfileIndexFields> =>
+    useConnection<LockfileIndexesResult, LockfileIndexesVariables, LockfileIndexFields>({
+        query: LOCKFILE_INDEXES_LIST,
+        variables: {
+            first: first ?? null,
+            after: after ?? null,
+        },
+        options: {
+            useURL: false,
+            fetchPolicy: 'cache-and-network',
+        },
+        getConnection: result => {
+            const data = dataOrThrowErrors(result)
+
+            return data.lockfileIndexes
+        },
+    })


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mrn-use-connection-first-example.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

