### PR TITLE
Code Insights: Fix minor problems with compute v1 before the 3.42 release

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useMemo } from 'react'
 
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
@@ -58,6 +58,7 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
     const hasEnoughXSpace = width >= MINIMAL_HORIZONTAL_LAYOUT_WIDTH
 
     const isHorizontalMode = hasViewManySeries && hasEnoughXSpace
+    const isNonEmptyDataset = useMemo(() => hasNoData(data), [data])
 
     return (
         <div ref={ref} className={classNames(className, styles.root, { [styles.rootHorizontal]: isHorizontalMode })}>
@@ -71,7 +72,7 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                         {parent => (
                             <>
                                 <BackendAlertOverlay
-                                    hasNoData={hasData(data)}
+                                    hasNoData={isNonEmptyDataset}
                                     isFetchingHistoricalData={isFetchingHistoricalData}
                                     className={styles.alertOverlay}
                                 />
@@ -116,12 +117,16 @@ const isManyKeysInsight = (data: InsightContent<any>): boolean => {
     return data.content.data.length > MINIMAL_SERIES_FOR_ASIDE_LEGEND
 }
 
-const hasData = (data: InsightContent<any>): boolean => {
+const hasNoData = (data: InsightContent<any>): boolean => {
     if (data.type === InsightContentType.Series) {
         return data.content.series.every(series => series.data.length === 0)
     }
 
-    return data.content.data.length === 0
+    // If all datum have zero matches render no data layout. We need to
+    // handle it explicitly on the frontend since backend returns manually
+    // defined series with empty points in case of no matches for generated
+    // series.
+    return data.content.data.every(datum => datum.value === 0)
 }
 
 interface SeriesLegendsProps {

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -64,7 +64,7 @@ export interface CodeInsightsBackend {
      *
      * @param ids - list of insight ids
      */
-    getInsights: (input: { dashboardId: string }) => Observable<Insight[]>
+    getInsights: (input: { dashboardId: string; withCompute: boolean }) => Observable<Insight[]>
 
     getAccessibleInsightsList: () => Observable<AccessibleInsightInfo[]>
 

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/deserializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/deserializators.ts
@@ -15,10 +15,13 @@ export const createBackendInsightData = (insight: BackendInsight, response: Insi
 
     if (isComputeInsight(insight)) {
         return {
-            isFetchingHistoricalData,
+            // We have to tweak original logic around historical data since compute powered and
+            // capture group insights have problem with data series generation tracking
+            // see https://github.com/sourcegraph/sourcegraph/issues/38893
+            isFetchingHistoricalData: isFetchingHistoricalData || seriesData.some(series => !series.label),
             data: {
                 type: InsightContentType.Categorical,
-                content: createCategoricalChart(insight, seriesData),
+                content: createCategoricalChart(seriesData),
             },
         }
     }

--- a/client/web/src/enterprise/insights/core/backend/utils/create-categorical-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-categorical-content.ts
@@ -1,7 +1,6 @@
 import { groupBy } from 'lodash'
 
 import { InsightDataSeries } from '../../../../../graphql-operations'
-import { ComputeInsight } from '../../types'
 import { CategoricalChartContent } from '../code-insights-backend-types'
 
 import { DATA_SERIES_COLORS_LIST } from './create-line-chart-content'
@@ -12,11 +11,11 @@ interface CategoricalDatum {
     value: number
 }
 
-export function createCategoricalChart(
-    insight: ComputeInsight,
-    seriesData: InsightDataSeries[]
-): CategoricalChartContent<CategoricalDatum> {
-    const seriesGroups = groupBy(seriesData, series => series.label)
+export function createCategoricalChart(seriesData: InsightDataSeries[]): CategoricalChartContent<CategoricalDatum> {
+    const seriesGroups = groupBy(
+        seriesData.filter(series => series.label),
+        series => series.label
+    )
 
     // Group series result by seres name and sum up series value with the same name
     const groups = Object.keys(seriesGroups).map((key, index) =>

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useMemo } from 'react'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
+import { useExperimentalFeatures } from '../../../../../../../../../stores'
 import { SmartInsightsViewGrid, InsightContext } from '../../../../../../../components'
 import { CodeInsightsBackendContext, InsightDashboard } from '../../../../../../../core'
 import { EmptyInsightDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
@@ -18,9 +19,17 @@ export const DashboardInsights: React.FunctionComponent<React.PropsWithChildren<
     const { telemetryService, currentDashboard, dashboards, className, onAddInsightRequest } = props
 
     const { getInsights } = useContext(CodeInsightsBackendContext)
+    const { codeInsightsCompute = false } = useExperimentalFeatures()
 
     const insights = useObservable(
-        useMemo(() => getInsights({ dashboardId: currentDashboard.id }), [getInsights, currentDashboard.id])
+        useMemo(
+            () =>
+                getInsights({
+                    dashboardId: currentDashboard.id,
+                    withCompute: codeInsightsCompute,
+                }),
+            [getInsights, codeInsightsCompute, currentDashboard.id]
+        )
     )
 
     const insightContextValue = useMemo(() => ({ currentDashboard, dashboards }), [currentDashboard, dashboards])

--- a/client/web/src/enterprise/insights/pages/insights/creation/ComputeLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/ComputeLivePreview.tsx
@@ -117,12 +117,8 @@ export const ComputeLivePreview: React.FunctionComponent<ComputeLivePreviewProps
 
                 {state.status === StateStatus.Data && (
                     <LegendList className="mt-3">
-                        {state.data.series.map(series => (
-                            <LegendItem
-                                key={series.id}
-                                color={getComputeSeriesColor(series)}
-                                name={getComputeSeriesName(series)}
-                            />
+                        {mapSeriesToCompute(state.data.series).map(series => (
+                            <LegendItem key={series.name} color={series.fill} name={series.name} />
                         ))}
                     </LegendList>
                 )}
@@ -132,7 +128,10 @@ export const ComputeLivePreview: React.FunctionComponent<ComputeLivePreviewProps
 }
 
 const mapSeriesToCompute = (series: Series<BackendInsightDatum>[]): LanguageUsageDatum[] => {
-    const seriesGroups = groupBy(series, series => series.name)
+    const seriesGroups = groupBy(
+        series.filter(series => series.name),
+        series => series.name
+    )
 
     // Group series result by seres name and sum up series value with the same name
     return Object.keys(seriesGroups).map(key =>

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightMapPicker.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightMapPicker.tsx
@@ -26,25 +26,27 @@ export const ComputeInsightMapPicker: FC<ComputeInsightMapPickerProps> = props =
         onChange(pickedValue)
     }
 
-    const hasTypeDiffOrCommit = useMemo(
-        () =>
-            series.every(({ query }) => {
-                const tokens = scanSearchQuery(query)
+    const hasTypeDiffOrCommit = useMemo(() => {
+        if (series.length === 0) {
+            return false
+        }
 
-                if (tokens.type === 'success') {
-                    return tokens.term
-                        .filter((token): token is Filter => token.type === 'filter')
-                        .some(
-                            filter =>
-                                resolveFilter(filter.field.value)?.type === FilterType.type &&
-                                (filter.value?.value === 'diff' || filter.value?.value === 'commit')
-                        )
-                }
+        return series.every(({ query }) => {
+            const tokens = scanSearchQuery(query)
 
-                return false
-            }),
-        [series]
-    )
+            if (tokens.type === 'success') {
+                return tokens.term
+                    .filter((token): token is Filter => token.type === 'filter')
+                    .some(
+                        filter =>
+                            resolveFilter(filter.field.value)?.type === FilterType.type &&
+                            (filter.value?.value === 'diff' || filter.value?.value === 'commit')
+                    )
+            }
+
+            return false
+        })
+    }, [series])
 
     useEffect(() => {
         if (!hasTypeDiffOrCommit && (value === GroupByField.AUTHOR || value === GroupByField.DATE)) {


### PR DESCRIPTION

This PR fixes 
- Appearance compute insights on the dashboard page if they were created before the experimental feature flag was disabled (case: enable feature flag → create compute insight → disable feature flag) 
- Bad empty loading state for compute powered insight right after creation  
- Improve group selection control on the compute creation UI page
- Group legend labels if we have more than 1 data series in compute. 

[Related slack thread](https://sourcegraph.slack.com/archives/C02KE7E9GMR/p1658175512739239)

## Test plan
- Go to the compute creation page and create compute insight
- See that after creation, you can see in progress compute insight with historical data overlay (data on the chart may look like wrong, but this is related to the bigger problem with API, and it wouldn't be resolved in this version) 
- See that after some time and page refreshing, you can see the right dataset on the chart)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
