### PR TITLE
vcsPackageSyncer: remove leftover method

### DIFF
--- a/cmd/gitserver/server/vcs_packages_syncer.go
+++ b/cmd/gitserver/server/vcs_packages_syncer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 
@@ -245,10 +246,6 @@ func (s *vcsPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir G
 	}
 
 	return nil
-}
-
-func (s *vcsPackagesSyncer) downloadPackage(ctx context.Context, dep reposource.VersionedPackage) (workDir string, err error) {
-	return workDir, nil
 }
 
 // gitPushDependencyTag downloads the dependency dep and updates


### PR DESCRIPTION
Ran into this while reading through code. I think that's a leftover from refactoring.

## Test plan

- Existing tests