### PR TITLE
ci: include more files in checksum generation

### DIFF
--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -22,7 +22,6 @@ function checksum_client_code {
 function generate_cache_desc {
   echo -e "- Generated from commit: \`$(git rev-parse HEAD)\`"
   echo -e "- Created at: \`$(date)\`"
-  echo -e "- Filename: \`$cache_file\`"
 }
 
 echo "--- (enterprise) pre-build frontend"

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -46,7 +46,7 @@ else
   cache_file="cache-client-bundle-$checksum.tar.gz"
   cache_desc_file="cache-client-bundle-$checksum.txt"
   cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
-  cache_desc_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
+  cache_desc_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_desc_file"
 
   echo -e "~~~ ClientBundle 🔍 Locating cache: $cache_key"
   if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" --key "$cache_key"; then

--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -20,9 +20,9 @@ function checksum_client_code {
 }
 
 function generate_cache_desc {
-  echo -e "Generated from commit: \`$(git rev-parse HEAD)\`"
-  echo -e "Created at: \`$(date)\`"
-  echo -e "Filename: \`$cache_file\`"
+  echo -e "- Generated from commit: \`$(git rev-parse HEAD)\`"
+  echo -e "- Created at: \`$(date)\`"
+  echo -e "- Filename: \`$cache_file\`"
 }
 
 echo "--- (enterprise) pre-build frontend"
@@ -58,7 +58,7 @@ else
 
     # Retrieving the cache description
     aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_desc_key" "./"
-    echo -e "## ClientBundle 🔥 Cache hit: $cache_key\n$(cat "$cache_desc_file")" | ./enterprise/dev/ci/scripts/annotate.sh -m -t info
+    echo -e "ClientBundle 🔥 Cache hit: \`$cache_key\`\n\n$(cat "$cache_desc_file")" | ./enterprise/dev/ci/scripts/annotate.sh -m -t info
     rm "$cache_desc_file"
   else
     echo -e "~~~ ClientBundle 🚨 Cache miss: $cache_key"


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/sourcegraph/pull/38940 

We had a quick sync with @valerybugakov and we agreed that it would be safer to: 

- cover the missing files that weren't used to build up the index
- add a banner making it explicit that the bundle has been cached for the build

<img width="1209" alt="CleanShot 2022-07-19 at 14 37 02@2x" src="https://user-images.githubusercontent.com/10151/179751956-f0e054de-5ca8-477a-9052-4857c332b09e.png">

On his side, @valerybugakov will add in https://github.com/sourcegraph/sourcegraph/issues/39034 a way to check if the bundle came from the cache or not, so we could quickly see if that's the case or not. 

💡 Keep in mind that the cache we're seeing here, **only applies to the server image**, all others are not using the cache. This limits the blast radius of a possible issue with this optimization.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested in CI again (cache miss + hit)

