### PR TITLE
Remove link to repo from the opengraph "description" field

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"context"
-	"fmt"
 	"html/template"
 	"log"
 	"net/http"
@@ -264,7 +263,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 
 		common.Metadata.ShowPreview = true
 		common.Metadata.PreviewImage = getBlobPreviewImageURL(envvar.OpenGraphPreviewServiceURL(), r.URL.Path, lineRange)
-		common.Metadata.Description = fmt.Sprintf("%s/%s", globals.ExternalURL(), mux.Vars(r)["Repo"])
+		common.Metadata.Description = ""
 		common.Metadata.Title = getBlobPreviewTitle(blobPath, lineRange, symbolResult)
 	}
 


### PR DESCRIPTION
Motivation https://sourcegraph.slack.com/archives/C03CSAER9LK/p1658236268361789



## Test plan

I haven't tested this change, just implemented the suggestion from @novoselrok 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
