### PR TITLE
ci: on release branch builds, never cache client bundle

### DIFF
--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -5,8 +5,14 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/../../..
 
 echo "--- (enterprise) pre-build frontend"
 
-if [[ ! "$BUILDKITE" == "true" ]]; then
+if [[ "$BUILDKITE" != "true" || "${SERVER_NO_CLIENT_BUNDLE_CACHE:-}" == "true" ]]; then
   # Not-in-buildkite simple install.
+  #
+  # Or When we are building a release, we do not want to cache the client bundle.
+  #
+  # This is a defensive measure, as caching the client bundle is tricky when it comes to invalidating it.
+  # This makes sure that we're running integration tests on a fresh bundle and, the image
+  # that 99% of our customers are using is exactly the same as the other deployments.
   ./enterprise/cmd/frontend/pre-build.sh
 else
   # set the buildkite cache access keys

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -66,6 +66,12 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	// On release branches Percy must compare to the previous commit of the release branch, not main.
 	if c.RunType.Is(runtype.ReleaseBranch) {
 		env["PERCY_TARGET_BRANCH"] = c.Branch
+		// When we are building a release, we do not want to cache the client bundle.
+		//
+		// This is a defensive measure, as caching the client bundle is tricky when it comes to invalidating it.
+		// This makes sure that we're running integration tests on a fresh bundle and, the image
+		// that 99% of our customers are using is exactly the same as the other deployments.
+		env["SERVER_NO_CLIENT_BUNDLE_CACHE"] = "true"
 	}
 
 	// Build options for pipeline operations that spawn more build steps


### PR DESCRIPTION
Follow up to @eseliger's great suggestion here https://github.com/sourcegraph/sourcegraph/pull/39031#pullrequestreview-1043381407

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 