### PR TITLE
Wildcard [Popover]: Add default padding to the tether (tooltip position engine)

### DIFF
--- a/client/wildcard/src/components/Popover/components/floating-panel/FloatingPanel.tsx
+++ b/client/wildcard/src/components/Popover/components/floating-panel/FloatingPanel.tsx
@@ -5,9 +5,11 @@ import { createPortal } from 'react-dom'
 import { useCallbackRef, useMergeRefs } from 'use-callback-ref'
 
 import { ForwardReferenceComponent } from '../../../../types'
-import { createTether, Flipping, Overlapping, Position, Strategy, Tether } from '../../tether'
+import { createTether, Flipping, Overlapping, Padding, Position, Strategy, Tether } from '../../tether'
 
 import styles from './FloatingPanel.module.scss'
+
+const DEFAULT_PADDING: Padding = { top: 8, right: 8, bottom: 8, left: 8 }
 
 export interface FloatingPanelProps extends Omit<Tether, 'target' | 'element'>, React.HTMLAttributes<HTMLDivElement> {
     /**
@@ -40,7 +42,7 @@ export const FloatingPanel = forwardRef((props, reference) => {
         constrainToScrollParents = true,
         overflowToScrollParents = true,
         strategy = Strategy.Fixed,
-        windowPadding,
+        windowPadding = DEFAULT_PADDING,
         constraintPadding,
         targetPadding,
         constraint,


### PR DESCRIPTION
## Background

This PR simply adds default padding values (8px) for `windowPadding` prop of the tether engine. See how floating UI (code insights filter panel) doesn't stick with window borders as on the image before.

| Before  | After |
| ------------- | ------------- |
| <img width="1136" alt="Screenshot 2022-07-19 at 16 22 08" src="https://user-images.githubusercontent.com/18492575/179761087-1557b633-1482-4033-821c-fafae4c04025.png"> |  <img width="1158" alt="Screenshot 2022-07-19 at 16 21 48" src="https://user-images.githubusercontent.com/18492575/179761112-bd32d980-71fe-48fe-aea6-25dc3d6bbccf.png">  |

## Test plan
- Make sure that most of the floating elements look good (but honestly, I don't see any reasons why this change will break anything) 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-default-padding-to-popover.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jramocgahp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
