### PR TITLE
search: Improve search reference panel rendering

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -440,49 +440,51 @@ const SearchReferenceEntry = <T extends SearchReferenceInfo>({
                     </CollapseHeader>
                 </span>
                 <CollapsePanel>
-                    <div className={styles.description}>
-                        {searchReference.description && (
-                            <Markdown dangerousInnerHTML={renderMarkdown(searchReference.description)} />
-                        )}
-                        {searchReference.alias && (
-                            <Text>
-                                Alias:{' '}
-                                <span className="text-code search-filter-keyword">
-                                    {searchReference.alias}
-                                    {isFilterInfo(searchReference) ? ':' : ''}
-                                </span>
-                            </Text>
-                        )}
-                        {isFilterInfo(searchReference) && isNegatableFilter(searchReference.field) && (
-                            <Text>
-                                Negation:{' '}
-                                <span className="test-code search-filter-keyword">-{searchReference.field}:</span>
-                                {searchReference.alias && (
-                                    <>
-                                        {' '}
-                                        |{' '}
-                                        <span className="test-code search-filter-keyword">
-                                            -{searchReference.alias}:
-                                        </span>
-                                    </>
-                                )}
-                                <br />
-                                <span className={styles.placeholder}>(opt + click filter in reference list)</span>
-                            </Text>
-                        )}
-                        {searchReference.examples && (
-                            <>
-                                <div className="font-weight-medium">Examples</div>
-                                <div className={classNames('text-code', styles.examples)}>
-                                    {searchReference.examples.map(example => (
-                                        <Text key={example}>
-                                            <SearchReferenceExample example={example} onClick={onExampleClick} />
-                                        </Text>
-                                    ))}
-                                </div>
-                            </>
-                        )}
-                    </div>
+                    {!collapsed && (
+                        <div className={styles.description}>
+                            {searchReference.description && (
+                                <Markdown dangerousInnerHTML={renderMarkdown(searchReference.description)} />
+                            )}
+                            {searchReference.alias && (
+                                <Text>
+                                    Alias:{' '}
+                                    <span className="text-code search-filter-keyword">
+                                        {searchReference.alias}
+                                        {isFilterInfo(searchReference) ? ':' : ''}
+                                    </span>
+                                </Text>
+                            )}
+                            {isFilterInfo(searchReference) && isNegatableFilter(searchReference.field) && (
+                                <Text>
+                                    Negation:{' '}
+                                    <span className="test-code search-filter-keyword">-{searchReference.field}:</span>
+                                    {searchReference.alias && (
+                                        <>
+                                            {' '}
+                                            |{' '}
+                                            <span className="test-code search-filter-keyword">
+                                                -{searchReference.alias}:
+                                            </span>
+                                        </>
+                                    )}
+                                    <br />
+                                    <span className={styles.placeholder}>(opt + click filter in reference list)</span>
+                                </Text>
+                            )}
+                            {searchReference.examples && (
+                                <>
+                                    <div className="font-weight-medium">Examples</div>
+                                    <div className={classNames('text-code', styles.examples)}>
+                                        {searchReference.examples.map(example => (
+                                            <Text key={example}>
+                                                <SearchReferenceExample example={example} onClick={onExampleClick} />
+                                            </Text>
+                                        ))}
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    )}
                 </CollapsePanel>
             </Collapse>
         </li>


### PR DESCRIPTION
This commits improves rendering the reference panel by not rendering the
filter information when the filter isn't openend. This shaves off at
least 40ms from rendering the search results page (profiling revealed
that rendering the search reference panel can sometimes take up to 120
ms).

Before (SearchSidebarSection for 60ms): 
<img width="731" alt="2022-07-19_12-01" src="https://user-images.githubusercontent.com/179026/179767981-8a9568a3-839e-4cb0-a926-34bb961b4b86.png">


After SearchSidebarSection for 18ms):
<img width="953" alt="2022-07-19_15-52" src="https://user-images.githubusercontent.com/179026/179768009-68ccfc09-a2c6-4a2d-98bb-07351163e719.png">


## Test plan

Filter information is shown when clicking on a filter in the reference panel.

## App preview:

- [Web](https://sg-web-fkling-search-reference-panel.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-voewhtuecn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
