### PR TITLE
Revert "worker: change the way of fetching repos by name (#38800)"

### DIFF
--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -39,6 +40,18 @@ func TestStore(t *testing.T) {
 	count, err := store.QueuedCount(ctx, true)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
+}
+
+func intPtr(v int) *int              { return &v }
+func stringPtr(v string) *string     { return &v }
+func timePtr(v time.Time) *time.Time { return &v }
+
+func mustParseTime(v string) time.Time {
+	t, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }
 
 func TestGetBitbucketClient(t *testing.T) {
@@ -329,23 +342,14 @@ func TestHandleRestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork)
+	INSERT INTO repo (id, name, fork)
 	VALUES
-		(1, 10060, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 10056, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 10061, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 10058, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 10059, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 10072, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
-
-	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
-	VALUES
-		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go'),
-		(1, 2, 'bitbucket.sgdev.org/SGDEMO/jenkins'),
-		(1, 3, 'bitbucket.sgdev.org/SGDEMO/mux'),
-		(1, 4, 'bitbucket.sgdev.org/SGDEMO/sentry'),
-		(1, 5, 'bitbucket.sgdev.org/SGDEMO/sinatra'),
-		(1, 6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph');
+		(1, 'bitbucket.sgdev.org/SGDEMO/go', false),
+		(2, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
+		(3, 'bitbucket.sgdev.org/SGDEMO/mux', false),
+		(4, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
+		(5, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
+		(6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false)
 `)
 	require.NoError(t, err)
 
@@ -438,23 +442,14 @@ func TestHandleUnrestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork)
+	INSERT INTO repo (id, name, fork)
 	VALUES
-		(1, 10060, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 10056, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 10061, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 10058, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 10059, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 10072, 'bitbucketServer', 1, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
-
-	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
-	VALUES
-		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go'),
-		(1, 2, 'bitbucket.sgdev.org/SGDEMO/jenkins'),
-		(1, 3, 'bitbucket.sgdev.org/SGDEMO/mux'),
-		(1, 4, 'bitbucket.sgdev.org/SGDEMO/sentry'),
-		(1, 5, 'bitbucket.sgdev.org/SGDEMO/sinatra'),
-		(1, 6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph');
+		(1, 'bitbucket.sgdev.org/SGDEMO/go', false),
+		(2, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
+		(3, 'bitbucket.sgdev.org/SGDEMO/mux', false),
+		(4, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
+		(5, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
+		(6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
 
 	INSERT INTO repo_permissions (repo_id, permission, updated_at)
 	VALUES


### PR DESCRIPTION
This reverts commit 57520dd2ad3769375f7e93a2c4a6898376403f5f. The value used for "ServiceID"/"extSvcID" was incorrect. It isn't the sourcegraph database ID, but rather something like the URL. EG for my local setup the value is "http://bitbucket:7990/".

In all my testing today I was testing against the 3.41 branch which doesn't contain this commit. I did some testing on main today and noticed this issue.

Test Plan: The explicit bitbucket API works again.
