### PR TITLE
[Admin Analytics] remove browser extension installs metric

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -231,7 +231,7 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                             <AnchorLink to="/help/integration/browser_extension" target="_blank">
                                 browser extension
                             </AnchorLink>{' '}
-                            to increase value.
+                            to add code intelligence to your code hosts.
                         </Text>
                         {repos && (
                             <Text as="li">

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -163,8 +163,6 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
     }
 
     const repos = data?.site.analytics.repos
-    const browserExtensionInstalls =
-        data?.site.analytics.codeIntel.browserExtensionInstalls.summary.totalRegisteredUsers || 0
 
     return (
         <>
@@ -229,11 +227,11 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                     <div className={classNames(styles.border, 'mb-3')} />
                     <ul className="mb-3 pl-3">
                         <Text as="li">
-                            <b>{browserExtensionInstalls}</b> {browserExtensionInstalls === 1 ? 'user' : 'users'} have
-                            installed the browser extension.{' '}
+                            Promote installation of the{' '}
                             <AnchorLink to="/help/integration/browser_extension" target="_blank">
-                                Promote installation of the browser extesion to increase value.
-                            </AnchorLink>
+                                browser extension
+                            </AnchorLink>{' '}
+                            to increase value.
                         </Text>
                         {repos && (
                             <Text as="li">

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
@@ -39,11 +39,6 @@ export const CODEINTEL_STATISTICS = gql`
                             totalCount
                         }
                     }
-                    browserExtensionInstalls {
-                        summary {
-                            totalRegisteredUsers
-                        }
-                    }
                     searchBasedEvents {
                         summary {
                             totalCount

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6065,10 +6065,6 @@ type AnalyticsCodeIntelResult {
     """
     codeHostEvents: AnalyticsStatItem!
     """
-    Browser extension installs
-    """
-    browserExtensionInstalls: AnalyticsStatItem!
-    """
     Search based events
     """
     searchBasedEvents: AnalyticsStatItem!

--- a/internal/adminanalytics/codeintel.go
+++ b/internal/adminanalytics/codeintel.go
@@ -79,22 +79,6 @@ func (s *CodeIntel) CodeHostEvents() (*AnalyticsFetcher, error) {
 	}, nil
 }
 
-func (s *CodeIntel) BrowserExtensionInstalls() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, []string{"BrowserExtensionInstalled"})
-	if err != nil {
-		return nil, err
-	}
-
-	return &AnalyticsFetcher{
-		db:           s.DB,
-		dateRange:    s.DateRange,
-		nodesQuery:   nodesQuery,
-		summaryQuery: summaryQuery,
-		group:        "CodeIntel:BrowserExtensionInstalls",
-		cache:        s.Cache,
-	}, nil
-}
-
 func (s *CodeIntel) SearchBasedEvents() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, []string{
 		"codeintel.searchDefinitions",
@@ -162,7 +146,8 @@ func (s *CodeIntel) CacheAll(ctx context.Context) error {
 	fetcherBuilders := []func() (*AnalyticsFetcher, error){
 		s.DefinitionClicks,
 		s.ReferenceClicks,
-		s.BrowserExtensionInstalls,
+		s.InAppEvents,
+		s.CodeHostEvents,
 		s.SearchBasedEvents,
 		s.PreciseEvents,
 		s.CrossRepoEvents,


### PR DESCRIPTION
Remove browser extension installs metric from admin analytics code intel page.

## Test plan
<img width="1014" alt="CleanShot 2022-07-19 at 20 34 08@2x" src="https://user-images.githubusercontent.com/22571395/179783605-5d7b9e96-f56e-4296-8971-c75576a6b8f7.png">

Check PR. 

## App preview:

- [Web](https://sg-web-naman-admin-analytics-fix-bext.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-slvkpwzgju.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
