### PR TITLE
vcsPackageSyncer: clearly divide different paths in Fetch

### DIFF
--- a/cmd/gitserver/server/vcs_packages_syncer_test.go
+++ b/cmd/gitserver/server/vcs_packages_syncer_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -179,16 +178,16 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	t.Run("lazy-sync error version via revspec", func(t *testing.T) {
 		// the v0.0.4 tag cannot be created on-demand because it returns a "0.0.4 not found" error
 		err := s.Fetch(ctx, remoteURL, dir, "v0.0.4^0")
-		require.NotNil(t, err)
-		// the 0.0.4 error is silently ignored, we only return the error for v0.0.1.
-		require.Equal(t, fmt.Sprint(err.Error()), "error pushing dependency {\"foo\" \"0.0.1\"}: 401 unauthorized")
+		require.Nil(t, err)
+		// // the 0.0.4 error is silently ignored, we only return the error for v0.0.1.
+		// require.Equal(t, fmt.Sprint(err.Error()), "error pushing dependency {\"foo\" \"0.0.1\"}: 401 unauthorized")
 		// the 0.0.4 dependency was not stored in the database because the download failed.
 		require.Equal(t, s.svc.(*fakeDepsService).upsertedDeps, []dependencies.Repo{})
 		// git tags are unchanged, v0.0.2 and v0.0.3 are cached.
 		s.assertRefs(t, dir, bothV2andV3Refs)
-		// We triggered downloads for v0.0.1 and v0.0.4 since they both error.
-		// No new downloads were triggered for cached versions.
-		s.assertDownloadCounts(t, depsSource, map[string]int{"foo@0.0.1": 4, "foo@0.0.2": 2, "foo@0.0.3": 1, "foo@0.0.4": 1})
+		// We triggered downloads only for v0.0.4.
+		// No new downloads were triggered for cached or other errored versions.
+		s.assertDownloadCounts(t, depsSource, map[string]int{"foo@0.0.1": 3, "foo@0.0.2": 2, "foo@0.0.3": 1, "foo@0.0.4": 1})
 	})
 
 	depsSource.download["org.springframework.boot:spring-boot:3.0"] = notFoundError{errors.New("Please contact Josh Long")}


### PR DESCRIPTION
Attempt nr. 2 after #39020. I think this adds a bit more clarity to the code, but it is, granted, more polish than refactoring, just like @olafurpg predicted.

What I like is that it clearly separates the different paths, depending on whether a revspec was given or not. It also doesn't try to sync all existing versions again in the request path, if the revspec given is invalid (which is why I had to adjust the test). Previously a user could request version `foobar` and we'd send a request to the package host to try to re-download a version that has maybe been removed but we still have in `git tags` or in the database.

## Test plan

- Existing and modified tests