### PR TITLE
insights: stop polling when we are no longer waiting on data

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -113,7 +113,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
     // polling is disabled ignore all
     if (enablePolling) {
         // not on the screen so stop polling if we are - multiple stop calls are safe
-        if (error || !isVisible) {
+        if (error || !isVisible || !isFetchingHistoricalData) {
             isPolling.current = false
             stopPolling()
         } else if (isFetchingHistoricalData && !isPolling.current) {


### PR DESCRIPTION
stopping polling was missing 1 condition which is to stop when a previously processing insight is no longer processing
## Test plan
Create a new scoped insight
Watch network requests, ensure they stop when insight is no longer processing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cw-stop-polling.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mqodnrhjab.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
