### PR TITLE
gitserver: Remove Client.Addrs

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -64,13 +64,6 @@ var ClientMocks, emptyClientMocks struct {
 	LocalGitCommandReposDir string
 }
 
-// AddrsMock is a mock for Addrs() function. It is separated from ClientMocks
-// because it is not intended to be cleared when other mocks should be.
-// This mock should be initialized during tests initialization so that
-// gitserver client always contain address of a local machine during tests
-// and tests which use gitserver client can pass successfully
-var AddrsMock func() []string
-
 // ResetClientMocks clears the mock functions set on Mocks (so that subsequent
 // tests don't inadvertently use them).
 func ResetClientMocks() {
@@ -167,10 +160,6 @@ type BatchLogCallback func(repoCommit api.RepoCommit, gitLogResult RawBatchLogRe
 type Client interface {
 	// AddrForRepo returns the gitserver address to use for the given repo name.
 	AddrForRepo(context.Context, api.RepoName) (string, error)
-
-	// Addrs returns the addresses for gitservers. It is safe for concurrent
-	// use. It may return different results at different times.
-	Addrs() []string
 
 	// Archive produces an archive from a Git repository.
 	Archive(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error)
@@ -414,9 +403,6 @@ type Client interface {
 }
 
 func (c *ClientImplementor) Addrs() []string {
-	if AddrsMock != nil {
-		return AddrsMock()
-	}
 	return c.addrs()
 }
 

--- a/internal/gitserver/integration_tests/commits_test.go
+++ b/internal/gitserver/integration_tests/commits_test.go
@@ -3,6 +3,7 @@ package inttests
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -76,7 +77,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewClient(db).GetCommits(ctx, repoCommits, true, nil)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses).GetCommits(ctx, repoCommits, true, nil)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -114,7 +115,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewClient(db).GetCommits(ctx, repoCommits, true, getTestSubRepoPermsChecker("file1", "file3"))
+		commits, err := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses).GetCommits(ctx, repoCommits, true, getTestSubRepoPermsChecker("file1", "file3"))
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -162,7 +163,7 @@ func mustParseDate(s string, t *testing.T) *time.Time {
 }
 
 func TestHead(t *testing.T) {
-	client := gitserver.NewClient(database.NewMockDB())
+	client := gitserver.NewTestClient(http.DefaultClient, database.NewMockDB(), gitserverAddresses)
 	t.Run("basic", func(t *testing.T) {
 		gitCommands := []string{
 			"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",

--- a/internal/gitserver/integration_tests/main_test.go
+++ b/internal/gitserver/integration_tests/main_test.go
@@ -31,6 +31,7 @@ var root string
 // This is a default gitserver test client currently used for RequestRepoUpdate
 // gitserver calls during invocation of MakeGitRepository function
 var testGitserverClient gitserver.Client
+var gitserverAddresses []string
 
 func TestMain(m *testing.M) {
 	flag.Parse()
@@ -84,9 +85,7 @@ func init() {
 
 	serverAddress := l.Addr().String()
 	testGitserverClient = gitserver.NewTestClient(httpcli.InternalDoer, database.NewMockDB(), []string{serverAddress})
-	gitserver.AddrsMock = func() []string {
-		return []string{serverAddress}
-	}
+	gitserverAddresses = []string{serverAddress}
 }
 
 var Times = []string{

--- a/internal/gitserver/integration_tests/main_test.go
+++ b/internal/gitserver/integration_tests/main_test.go
@@ -137,14 +137,6 @@ func MakeGitRepository(t testing.TB, cmds ...string) api.RepoName {
 	return repo
 }
 
-func MustParseTime(layout, value string) time.Time {
-	tm, err := time.Parse(layout, value)
-	if err != nil {
-		panic(err.Error())
-	}
-	return tm
-}
-
 func AppleTime(t string) string {
 	ti, _ := time.Parse(time.RFC3339, t)
 	return ti.Local().Format("200601021504.05")

--- a/internal/gitserver/integration_tests/object_test.go
+++ b/internal/gitserver/integration_tests/object_test.go
@@ -2,6 +2,7 @@ package inttests
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -34,7 +35,7 @@ func TestGetObject(t *testing.T) {
 
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
-			obj, err := gitserver.NewClient(database.NewMockDB()).GetObject(context.Background(), test.repo, test.objectName)
+			obj, err := gitserver.NewTestClient(http.DefaultClient, database.NewMockDB(), gitserverAddresses).GetObject(context.Background(), test.repo, test.objectName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/gitserver/integration_tests/tree_test.go
+++ b/internal/gitserver/integration_tests/tree_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -59,7 +60,7 @@ func TestReadDir_SubRepoFiltering(t *testing.T) {
 	}
 
 	db := database.NewMockDB()
-	client := gitserver.NewClient(db)
+	client := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses)
 	files, err := client.ReadDir(ctx, checker, repo, commitID, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -111,7 +112,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewClient(db)
+	client := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses)
 	for label, test := range tests {
 		// notafile should not exist.
 		if _, err := client.Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "notafile"); !os.IsNotExist(err) {
@@ -137,7 +138,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		if got, want := "ab771ba54f5571c99ffdae54f44acc7993d9f115", dir1Info.Sys().(gitdomain.ObjectInfo).OID().String(); got != want {
 			t.Errorf("%s: got dir1 OID %q, want %q", label, got, want)
 		}
-		client := gitserver.NewClient(db)
+		client := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses)
 
 		// dir1 should contain one entry: file1.
 		dir1Entries, err := client.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "dir1", false)
@@ -304,7 +305,7 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewClient(db)
+	client := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {
@@ -365,7 +366,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewClient(db)
+	client := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -29,9 +29,6 @@ type MockClient struct {
 	// AddrForRepoFunc is an instance of a mock function object controlling
 	// the behavior of the method AddrForRepo.
 	AddrForRepoFunc *ClientAddrForRepoFunc
-	// AddrsFunc is an instance of a mock function object controlling the
-	// behavior of the method Addrs.
-	AddrsFunc *ClientAddrsFunc
 	// ArchiveFunc is an instance of a mock function object controlling the
 	// behavior of the method Archive.
 	ArchiveFunc *ClientArchiveFunc
@@ -205,11 +202,6 @@ func NewMockClient() *MockClient {
 	return &MockClient{
 		AddrForRepoFunc: &ClientAddrForRepoFunc{
 			defaultHook: func(context.Context, api.RepoName) (r0 string, r1 error) {
-				return
-			},
-		},
-		AddrsFunc: &ClientAddrsFunc{
-			defaultHook: func() (r0 []string) {
 				return
 			},
 		},
@@ -500,11 +492,6 @@ func NewStrictMockClient() *MockClient {
 				panic("unexpected invocation of MockClient.AddrForRepo")
 			},
 		},
-		AddrsFunc: &ClientAddrsFunc{
-			defaultHook: func() []string {
-				panic("unexpected invocation of MockClient.Addrs")
-			},
-		},
 		ArchiveFunc: &ClientArchiveFunc{
 			defaultHook: func(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error) {
 				panic("unexpected invocation of MockClient.Archive")
@@ -790,9 +777,6 @@ func NewMockClientFrom(i Client) *MockClient {
 		AddrForRepoFunc: &ClientAddrForRepoFunc{
 			defaultHook: i.AddrForRepo,
 		},
-		AddrsFunc: &ClientAddrsFunc{
-			defaultHook: i.Addrs,
-		},
 		ArchiveFunc: &ClientArchiveFunc{
 			defaultHook: i.Archive,
 		},
@@ -1066,104 +1050,6 @@ func (c ClientAddrForRepoFuncCall) Args() []interface{} {
 // invocation.
 func (c ClientAddrForRepoFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// ClientAddrsFunc describes the behavior when the Addrs method of the
-// parent MockClient instance is invoked.
-type ClientAddrsFunc struct {
-	defaultHook func() []string
-	hooks       []func() []string
-	history     []ClientAddrsFuncCall
-	mutex       sync.Mutex
-}
-
-// Addrs delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockClient) Addrs() []string {
-	r0 := m.AddrsFunc.nextHook()()
-	m.AddrsFunc.appendCall(ClientAddrsFuncCall{r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the Addrs method of the
-// parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientAddrsFunc) SetDefaultHook(hook func() []string) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Addrs method of the parent MockClient instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *ClientAddrsFunc) PushHook(hook func() []string) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ClientAddrsFunc) SetDefaultReturn(r0 []string) {
-	f.SetDefaultHook(func() []string {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientAddrsFunc) PushReturn(r0 []string) {
-	f.PushHook(func() []string {
-		return r0
-	})
-}
-
-func (f *ClientAddrsFunc) nextHook() func() []string {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ClientAddrsFunc) appendCall(r0 ClientAddrsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ClientAddrsFuncCall objects describing the
-// invocations of this function.
-func (f *ClientAddrsFunc) History() []ClientAddrsFuncCall {
-	f.mutex.Lock()
-	history := make([]ClientAddrsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ClientAddrsFuncCall is an object that describes an invocation of method
-// Addrs on an instance of MockClient.
-type ClientAddrsFuncCall struct {
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []string
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ClientAddrsFuncCall) Args() []interface{} {
-	return []interface{}{}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ClientAddrsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // ClientArchiveFunc describes the behavior when the Archive method of the


### PR DESCRIPTION
This is an implementation detail that shouldn't exist on the public
interface.

## Test plan

All tests still pass