### PR TITLE
cmd/server: use annotations API on build, allow all build/prebuild scripts to generate annotations

### DIFF
--- a/enterprise/cmd/server/pre-build.sh
+++ b/enterprise/cmd/server/pre-build.sh
@@ -13,7 +13,7 @@ function checksum_client_code {
     find . -maxdepth 1 -type f -name "*.js" -exec sha1sum {} \;
     find . -maxdepth 1 -type f -name "*.ts" -exec sha1sum {} \;
     find . -maxdepth 1 -type f -name "*.json" -exec sha1sum {} \;
-  }>> "$tmpfile"
+  } >>"$tmpfile"
 
   # We know for sure that renovate has nothing to do with the client files.
   grep -v "renovate.json" <"$tmpfile" | sort -k 2 | sha1sum | awk '{print $1}'
@@ -63,7 +63,7 @@ else
 
     # Retrieving the cache description
     aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_desc_key" "./"
-    echo -e "ClientBundle 🔥 Cache hit: \`$cache_key\`\n\n$(cat "$cache_desc_file")" | ./enterprise/dev/ci/scripts/annotate.sh -m -t info
+    echo -e "\`$cache_key\`\n\n$(cat "$cache_desc_file")" >>"./annotations/🔥 Client bundle cache hit.md"
     rm "$cache_desc_file"
   else
     echo -e "~~~ ClientBundle 🚨 Cache miss: $cache_key"
@@ -76,7 +76,7 @@ else
     rm "$cache_file"
 
     # Building the bundle description
-    generate_cache_desc > "$cache_desc_file"
+    generate_cache_desc >"$cache_desc_file"
     aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "$cache_desc_file" "s3://sourcegraph_buildkite_cache/$cache_desc_key"
     rm "$cache_desc_file"
   fi

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -251,11 +251,11 @@ func Cmd(command string) StepOpt {
 type AnnotationType string
 
 const (
-	// We opt not to allow 'success' and 'info' type annotations for now to encourage
-	// steps to only provide annotations that help debug failure cases. In the future
-	// we can revisit this if there is a need.
+	// We opt not to allow 'success' type annotations for now to encourage steps to only
+	// provide annotations that help debug failure cases. In the future we can revisit
+	// this if there is a need.
 	// AnnotationTypeSuccess AnnotationType = "success"
-	// AnnotationTypeInfo    AnnotationType = "info"
+	AnnotationTypeInfo    AnnotationType = "info"
 	AnnotationTypeWarning AnnotationType = "warning"
 	AnnotationTypeError   AnnotationType = "error"
 )


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/sourcegraph/pull/39031

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main-dry-run/use-annotations-api-for-server

<img width="1184" alt="image" src="https://user-images.githubusercontent.com/23356519/179846590-95cd9f88-7d0d-4de6-b3c9-75d069b308a7.png">
