### PR TITLE
remove seriesCount limit from filters

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -50,7 +50,6 @@ const insightsWithManyLines: SearchBasedInsight[] = [
         isFrozen: false,
         seriesDisplayOptions: {},
         dashboards: [],
-        seriesCount: 1,
     },
     {
         id: 'searchInsights.insight.Backend_2',
@@ -65,7 +64,6 @@ const insightsWithManyLines: SearchBasedInsight[] = [
         isFrozen: false,
         seriesDisplayOptions: {},
         dashboards: [],
-        seriesCount: 0,
     },
     {
         id: 'searchInsights.insight.Backend_3',
@@ -87,7 +85,6 @@ const insightsWithManyLines: SearchBasedInsight[] = [
         isFrozen: false,
         seriesDisplayOptions: {},
         dashboards: [],
-        seriesCount: 6,
     },
     {
         id: 'searchInsights.insight.Backend_4',
@@ -102,7 +99,6 @@ const insightsWithManyLines: SearchBasedInsight[] = [
         isFrozen: false,
         seriesDisplayOptions: {},
         dashboards: [],
-        seriesCount: 1,
     },
     {
         id: 'searchInsights.insight.Backend_5',
@@ -138,7 +134,6 @@ const insightsWithManyLines: SearchBasedInsight[] = [
         isFrozen: false,
         seriesDisplayOptions: {},
         dashboards: [],
-        seriesCount: 20,
     },
     {
         id: 'searchInsights.insight.Backend_6',
@@ -153,7 +148,6 @@ const insightsWithManyLines: SearchBasedInsight[] = [
         isFrozen: false,
         seriesDisplayOptions: {},
         dashboards: [],
-        seriesCount: 1,
     },
     {
         id: 'searchInsights.insight.Backend_7',
@@ -168,7 +162,6 @@ const insightsWithManyLines: SearchBasedInsight[] = [
         isFrozen: false,
         seriesDisplayOptions: {},
         dashboards: [],
-        seriesCount: 1,
     },
 ]
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -66,7 +66,6 @@ const INSIGHT_CONFIGURATION_MOCK: SearchBasedInsight = {
         },
     },
     dashboards: [],
-    seriesCount: 2,
 }
 
 interface BackendInsightDatum {
@@ -275,7 +274,6 @@ const COMPONENT_MIGRATION_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     isFrozen: false,
     repositories: [],
     dashboards: [],
-    seriesCount: 3,
 }
 
 const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBasedInsight = {
@@ -305,7 +303,6 @@ const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     isFrozen: false,
     repositories: [],
     dashboards: [],
-    seriesCount: 3,
 }
 
 const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
@@ -331,7 +328,6 @@ const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
     dashboardReferenceCount: 0,
     isFrozen: false,
     dashboards: [],
-    seriesCount: 0,
 }
 
 const BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK: MockedResponse<GetInsightViewResult> = {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -206,7 +206,6 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                             anchor={insightCardReference}
                             initialFiltersValue={filters}
                             originalFiltersValue={originalInsightFilters}
-                            insight={insight}
                             onFilterChange={setFilters}
                             onFilterSave={handleFilterSave}
                             onInsightCreate={handleInsightFilterCreation}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
@@ -4,7 +4,7 @@ import { Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../../../../../../../components/WebStory'
 import { SeriesSortDirection, SeriesSortMode } from '../../../../../../../../graphql-operations'
-import { BackendInsight, InsightExecutionType, InsightFilters, InsightType } from '../../../../../../core'
+import { InsightFilters } from '../../../../../../core'
 import { DrillDownFiltersPopover } from '../drill-down-filters-popover/DrillDownFiltersPopover'
 
 const defaultStory: Meta = {
@@ -28,20 +28,6 @@ export const DrillDownPopover: Story = () => {
             },
         },
     }
-    const insight: BackendInsight = {
-        id: 'example',
-        title: 'Example Insight',
-        repositories: [],
-        type: InsightType.CaptureGroup,
-        executionType: InsightExecutionType.Backend,
-        step: {},
-        isFrozen: false,
-        query: '',
-        filters: initialFiltersValue,
-        dashboardReferenceCount: 0,
-        dashboards: [],
-        seriesCount: 0,
-    }
 
     return (
         <DrillDownFiltersPopover
@@ -49,7 +35,6 @@ export const DrillDownPopover: Story = () => {
             anchor={exampleReference}
             initialFiltersValue={initialFiltersValue}
             originalFiltersValue={initialFiltersValue}
-            insight={insight}
             onFilterChange={log('onFilterChange')}
             onFilterSave={log('onFilterSave')}
             onInsightCreate={log('onInsightCreate')}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
@@ -117,7 +117,6 @@ export const DrillDownFiltersShowcase: Story = () => (
             onFiltersChange={console.log}
             onFilterSave={console.log}
             onCreateInsightRequest={console.log}
-            seriesCount={20}
         />
     </MockedTestProvider>
 )
@@ -135,7 +134,6 @@ export const DrillDownFiltersHorizontalMode: Story = () => {
                 onFiltersChange={console.log}
                 onFilterSave={console.log}
                 onCreateInsightRequest={console.log}
-                seriesCount={20}
             />
         </MockedTestProvider>
     )

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -56,8 +56,6 @@ interface DrillDownInsightFilters {
 
     className?: string
 
-    seriesCount: number
-
     /** Fires whenever the user changes filter value in any form input. */
     onFiltersChange: (filters: FormChangeEvent<DrillDownFiltersFormValues>) => void
 
@@ -83,7 +81,6 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
         onCreateInsightRequest,
         onVisualModeChange = noop,
         onFilterValuesChange = noop,
-        seriesCount,
     } = props
 
     const [activeSection, setActiveSection] = useState<FilterSection | null>(FilterSection.RegularExpressions)
@@ -207,7 +204,6 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                     <SortFilterSeriesPanel
                         value={seriesDisplayOptionsField.input.value}
                         onChange={seriesDisplayOptionsField.input.onChange}
-                        seriesCount={seriesCount}
                     />
                 </FilterCollapseSection>
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.test.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.test.ts
@@ -23,7 +23,7 @@ const PARSED_TEST_SERIES_DISPLAY_OPTIONS: SeriesDisplayOptionsInputRequired = {
 describe('BackendInsight', () => {
     describe('parseSeriesDisplayOptions', () => {
         it('returns given object when provided complete values', () => {
-            const parsed = parseSeriesDisplayOptions(10, TEST_SERIES_DISPLAY_OPTIONS)
+            const parsed = parseSeriesDisplayOptions(TEST_SERIES_DISPLAY_OPTIONS)
             expect(parsed).toEqual(PARSED_TEST_SERIES_DISPLAY_OPTIONS)
         })
     })

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
@@ -81,18 +81,16 @@ export function getSerializedSearchContextFilter(
 /**
  * Returns a SeriesDisplayOptionsInput object with default values
  *
- * @param seriesCount The total series available for this insight. Used to set the max limit value
  * @param options series display options
  */
 export const parseSeriesDisplayOptions = (
-    seriesCount: number,
     options?: SeriesDisplayOptions | SeriesDisplayOptionsInput | DrillDownFiltersFormValues['seriesDisplayOptions']
 ): SeriesDisplayOptionsInputRequired => {
     if (!options) {
-        return { ...DEFAULT_SERIES_DISPLAY_OPTIONS, limit: Math.min(seriesCount, MAX_NUMBER_OF_SERIES) }
+        return { ...DEFAULT_SERIES_DISPLAY_OPTIONS, limit: MAX_NUMBER_OF_SERIES }
     }
 
-    const limit = Math.min(parseSeriesLimit(options?.limit) || seriesCount, seriesCount)
+    const limit = parseSeriesLimit(options?.limit) || MAX_NUMBER_OF_SERIES
     const sortOptions = options.sortOptions || DEFAULT_SERIES_DISPLAY_OPTIONS.sortOptions
 
     return {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 
 import { Button, createRectangle, Popover, PopoverContent, PopoverTrigger, Position, Icon } from '@sourcegraph/wildcard'
 
-import { Insight, InsightFilters } from '../../../../../../core'
+import { InsightFilters } from '../../../../../../core'
 import { FormChangeEvent, SubmissionResult } from '../../../../../form/hooks/useForm'
 import {
     DrillDownInsightCreationForm,
@@ -24,7 +24,6 @@ interface DrillDownFiltersPopoverProps {
     initialFiltersValue: InsightFilters
     originalFiltersValue: InsightFilters
     anchor: React.RefObject<HTMLElement>
-    insight: Insight
     onFilterChange: (filters: InsightFilters) => void
     onFilterSave: (filters: InsightFilters) => void
     onInsightCreate: (values: DrillDownInsightCreationFormValues) => SubmissionResult
@@ -51,7 +50,6 @@ export const DrillDownFiltersPopover: React.FunctionComponent<
     const {
         isOpen,
         anchor,
-        insight,
         initialFiltersValue,
         originalFiltersValue,
         onVisibilityChange,
@@ -113,7 +111,6 @@ export const DrillDownFiltersPopover: React.FunctionComponent<
                         initialValues={initialFiltersValue}
                         originalValues={originalFiltersValue}
                         visualMode={FilterSectionVisualMode.CollapseSections}
-                        seriesCount={insight.seriesCount}
                         onFiltersChange={handleFilterChange}
                         onFilterSave={onFilterSave}
                         onCreateInsightRequest={() => setStep(DrillDownFiltersStep.ViewCreation)}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.story.tsx
@@ -30,7 +30,7 @@ export const Primary: Story = () => {
     return (
         <div className="d-flex">
             <div className={styles.container}>
-                <SortFilterSeriesPanel seriesCount={20} value={value} onChange={setValue} />
+                <SortFilterSeriesPanel value={value} onChange={setValue} />
             </div>
             <pre className="p-4">{JSON.stringify(value, null, 2)}</pre>
         </div>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
@@ -13,19 +13,14 @@ interface SortFilterSeriesPanelProps {
         limit: string
         sortOptions: SeriesSortOptionsInput
     }
-    seriesCount: number
     onChange: (parameter: DrillDownFiltersFormValues['seriesDisplayOptions']) => void
 }
 
-export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPanelProps> = ({
-    value,
-    seriesCount,
-    onChange,
-}) => {
-    // It is possible to have N number of series, but we need to have maximum to render in UI
-    // or else it gets too cluttered to view
-    const maxLimit = Math.min(seriesCount, MAX_NUMBER_OF_SERIES)
+// It is possible to have N number of series, but we need to have maximum to render in UI
+// or else it gets too cluttered to view
+const maxLimit = MAX_NUMBER_OF_SERIES
 
+export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPanelProps> = ({ value, onChange }) => {
     const handleToggle = (sortOptions: SeriesSortOptionsInput): void => {
         onChange({ ...value, sortOptions })
     }

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
@@ -27,11 +27,10 @@ export const createInsightView = (insight: InsightViewNode): Insight => {
         title: insight.presentation.title,
         isFrozen: insight.isFrozen,
         dashboardReferenceCount: insight.dashboardReferenceCount,
-        seriesDisplayOptions: parseSeriesDisplayOptions(insight.seriesCount, insight.appliedSeriesDisplayOptions),
+        seriesDisplayOptions: parseSeriesDisplayOptions(insight.appliedSeriesDisplayOptions),
         dashboards: insight.dashboards?.nodes ?? [],
         appliedSeriesDisplayOptions: insight.appliedSeriesDisplayOptions,
         defaultSeriesDisplayOptions: insight.defaultSeriesDisplayOptions,
-        seriesCount: insight.seriesCount,
     }
 
     switch (insight.presentation.__typename) {

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsights.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsights.ts
@@ -68,7 +68,6 @@ export const INSIGHT_VIEW_FRAGMENT = gql`
                 title
             }
         }
-        seriesCount
         ...InsightViewSeries
     }
 

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
@@ -55,8 +55,7 @@ export function getCaptureGroupInsightCreateInput(
         options: { title: insight.title },
         viewControls: {
             seriesDisplayOptions:
-                insight.seriesDisplayOptions ||
-                parseSeriesDisplayOptions(insight.seriesCount, insight.appliedSeriesDisplayOptions),
+                insight.seriesDisplayOptions || parseSeriesDisplayOptions(insight.appliedSeriesDisplayOptions),
             filters: {
                 excludeRepoRegex: insight.filters.excludeRepoRegexp,
                 includeRepoRegex: insight.filters.includeRepoRegexp,

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/serializators.ts
@@ -23,7 +23,7 @@ export function getSearchInsightUpdateInput(insight: MinimalSearchBasedInsightDa
         searchContexts: insight.filters.context ? [insight.filters.context] : [],
     }
 
-    const seriesDisplayOptions = parseSeriesDisplayOptions(insight.seriesCount, insight.seriesDisplayOptions)
+    const seriesDisplayOptions = parseSeriesDisplayOptions(insight.seriesDisplayOptions)
 
     return {
         dataSeries: insight.series.map<LineChartSearchInsightDataSeriesInput>(series => ({
@@ -49,7 +49,7 @@ export function getCaptureGroupInsightUpdateInput(
     const { step, filters, query, title, repositories, seriesDisplayOptions } = insight
     const [unit, value] = getStepInterval(step)
 
-    const _seriesDisplayOptions = parseSeriesDisplayOptions(insight.seriesCount, seriesDisplayOptions)
+    const _seriesDisplayOptions = parseSeriesDisplayOptions(seriesDisplayOptions)
 
     return {
         dataSeries: [

--- a/client/web/src/enterprise/insights/core/types/insight/common.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/common.ts
@@ -56,7 +56,6 @@ export interface BaseInsight {
     dashboardReferenceCount: number
     dashboards: InsightDashboardReference[]
     isFrozen: boolean
-    seriesCount: number
 
     // TODO: move these fields out of base insight since they are
     // specific to the search based and capture group insights only

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-group-insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-group-insight-sanitizer.ts
@@ -30,7 +30,6 @@ export function getSanitizedCaptureGroupInsight(values: CaptureGroupFormFields):
         },
         dashboards: [],
         seriesDisplayOptions: {},
-        seriesCount: 0,
     }
 }
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/utils/insight-sanitaizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/utils/insight-sanitaizer.ts
@@ -27,5 +27,4 @@ export const getSanitizedComputeInsight = (values: CreateComputeInsightFormField
             },
         },
     },
-    seriesCount: 0,
 })

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/utils/insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/utils/insight-sanitizer.ts
@@ -12,5 +12,4 @@ export const getSanitizedLangStatsInsight = (values: LangStatsCreationFormFields
     otherThreshold: values.threshold / 100,
     seriesDisplayOptions: {},
     dashboards: [],
-    seriesCount: 0,
 })

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
@@ -30,7 +30,6 @@ export function getSanitizedSearchInsight(rawInsight: CreateInsightFormFields): 
                     },
                 },
             },
-            seriesCount: 0,
         }
     }
 
@@ -54,6 +53,5 @@ export function getSanitizedSearchInsight(rawInsight: CreateInsightFormFields): 
                 },
             },
         },
-        seriesCount: 0,
     }
 }

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditCaptureGroupInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditCaptureGroupInsight.tsx
@@ -47,7 +47,6 @@ export const EditCaptureGroupInsight: React.FunctionComponent<
             ...sanitizedInsight,
             filters: insight.filters,
             seriesDisplayOptions: insight.seriesDisplayOptions,
-            seriesCount: insight.seriesCount,
         })
     }
 

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
@@ -42,7 +42,6 @@ export const EditSearchBasedInsight: FC<EditSearchBasedInsightProps> = props => 
             ...sanitizedInsight,
             filters: insight.filters,
             seriesDisplayOptions: insight.seriesDisplayOptions,
-            seriesCount: insight.seriesCount,
         })
     }
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -166,7 +166,6 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
                         onFiltersChange={handleFilterChange}
                         onFilterSave={handleFilterSave}
                         onCreateInsightRequest={() => setStep(DrillDownFiltersStep.ViewCreation)}
-                        seriesCount={insight.seriesCount}
                     />
                 )}
 

--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -171,7 +171,7 @@ describe('Code insight create insight page', () => {
                             },
                             dashboardReferenceCount: 0,
                             dashboards: { nodes: [] },
-                            seriesCount: 2,
+
                             presentation: {
                                 __typename: 'LineChartInsightViewPresentation',
                                 title: 'Test insight title',

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -126,7 +126,7 @@ describe('Backend insight drill down filters', () => {
                 excludeRepoRegex: 'github.com/sourcegraph/sourcegraph',
             },
             seriesDisplayOptions: {
-                limit: 2,
+                limit: 20,
                 sortOptions: {
                     direction: 'DESC',
                     mode: 'RESULT_COUNT',
@@ -267,7 +267,7 @@ describe('Backend insight drill down filters', () => {
                     excludeRepoRegex: 'github.com/sourcegraph/sourcegraph',
                 },
                 seriesDisplayOptions: {
-                    limit: 2,
+                    limit: 20,
                     sortOptions: {
                         direction: 'DESC',
                         mode: 'RESULT_COUNT',

--- a/client/web/src/integration/insights/edit-search-insights.test.ts
+++ b/client/web/src/integration/insights/edit-search-insights.test.ts
@@ -238,7 +238,7 @@ describe('Code insight edit insight page', () => {
                         searchContexts: [],
                     },
                     seriesDisplayOptions: {
-                        limit: 2,
+                        limit: 20,
                         sortOptions: {
                             direction: 'DESC',
                             mode: 'RESULT_COUNT',

--- a/client/web/src/integration/insights/fixtures/insights-metadata.ts
+++ b/client/web/src/integration/insights/fixtures/insights-metadata.ts
@@ -27,7 +27,7 @@ export const createJITMigrationToGQLInsightMetadataFixture = (options: InsightOp
         excludeRepoRegex: '',
     },
     dashboards: { nodes: [] },
-    seriesCount: 2,
+
     presentation: {
         __typename: 'LineChartInsightViewPresentation',
         title: 'Migration to new GraphQL TS types',
@@ -91,7 +91,7 @@ export const STORYBOOK_GROWTH_INSIGHT_METADATA_FIXTURE: InsightViewNode = {
     defaultSeriesDisplayOptions: DEFAULT_SERIES_DISPLAY_OPTIONS,
     dashboardReferenceCount: 0,
     dashboards: { nodes: [] },
-    seriesCount: 1,
+
     isFrozen: false,
     appliedFilters: {
         __typename: 'InsightViewFilters',
@@ -139,7 +139,7 @@ export const SOURCEGRAPH_LANG_STATS_INSIGHT_METADATA_FIXTURE: InsightViewNode = 
     defaultSeriesDisplayOptions: DEFAULT_SERIES_DISPLAY_OPTIONS,
     dashboardReferenceCount: 0,
     dashboards: { nodes: [] },
-    seriesCount: 1,
+
     isFrozen: false,
     appliedFilters: {
         __typename: 'InsightViewFilters',


### PR DESCRIPTION
Remove `seriesCount` from GQL request, and from the series display options.

This was causing a bug in capture group insights where the series was being limited to 1. This is because capture groups update over time.

Secondarily this request was causing time outs due to how heavy a request this is on the backend.

## Test plan

- Open all dashboards page. Should not time out.
- Filter any dashboard by series limit. Should not cause any errors.
- Should be able to set series limit higher than actual series count: i.e. if insight has only 5 series, should be able to set limit to 20
- Series should still have hard limit of 20

## App preview:

- [Web](https://sg-web-insights-remove-series-count.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bpexpjhcsa.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
