### PR TITLE
Search backend: fix issue with fetching indexed branches from zoekt

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -71,13 +71,13 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 
 		for _, branch := range repo.Branches {
 			if branch.Name == rev {
-				branches = append(branches, inputRev)
+				branches = append(branches, branch.Name)
 				found = true
 				break
 			}
 			// Check if rev is an abbrev commit SHA
 			if len(rev) >= 4 && strings.HasPrefix(branch.Version, rev) {
-				branches = append(branches, inputRev)
+				branches = append(branches, branch.Name)
 				found = true
 				break
 			}


### PR DESCRIPTION
This fixes an issue where searching a repository with multiple indexed revisions will return duplicate results for each of the indexed revisions. 

Slack Context: https://sourcegraph.slack.com/archives/CHEKCRWKV/p1658245598739289

## Test plan

Added unit tests to cover this case. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
