### PR TITLE
worker: change the way of fetching repos by name

### DIFF
--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -344,7 +344,7 @@ func (h *bitbucketProjectPermissionsHandler) repoExists(ctx context.Context, rep
 
 // newBitbucketProjectPermissionsWorker creates a worker that reads the explicit_permissions_bitbucket_projects_jobs table and
 // executes the jobs.
-func newBitbucketProjectPermissionsWorker(rootContext context.Context, db edb.EnterpriseDB, cfg *config, metrics bitbucketProjectPermissionsMetrics) *workerutil.Worker {
+func newBitbucketProjectPermissionsWorker(ctx context.Context, db edb.EnterpriseDB, cfg *config, metrics bitbucketProjectPermissionsMetrics) *workerutil.Worker {
 	options := workerutil.WorkerOptions{
 		Name:              "explicit_permissions_bitbucket_projects_jobs_worker",
 		NumHandlers:       cfg.WorkerConcurrency,
@@ -353,7 +353,7 @@ func newBitbucketProjectPermissionsWorker(rootContext context.Context, db edb.En
 		Metrics:           metrics.workerMetrics,
 	}
 
-	return dbworker.NewWorker(rootContext, createBitbucketProjectPermissionsStore(db, cfg), &bitbucketProjectPermissionsHandler{db: db}, options)
+	return dbworker.NewWorker(ctx, createBitbucketProjectPermissionsStore(db, cfg), &bitbucketProjectPermissionsHandler{db: db}, options)
 }
 
 // newBitbucketProjectPermissionsResetter implements resetter for the explicit_permissions_bitbucket_projects_jobs table.

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
@@ -13,13 +14,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -110,13 +111,13 @@ func (h *bitbucketProjectPermissionsHandler) Handle(ctx context.Context, logger 
 	projectKey := workerJob.ProjectKey
 
 	// These repos are fetched from Bitbucket, therefore their IDs are Bitbucket IDs
-	// and we need to search for these repos in frontend DB using the name
+	// and we need to search for these repos in frontend DB to get Sourcegraph internal IDs
 	bitbucketRepos, err := client.ProjectRepos(ctx, projectKey)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list repositories of Bitbucket Project %q", projectKey)
 	}
 
-	repoIDs, err := h.getRepoIDsByNames(ctx, svc, projectKey, bitbucketRepos)
+	repoIDs, err := h.getRepoIDsByNames(ctx, svc, bitbucketRepos)
 	if err != nil {
 		return errors.Wrap(err, "failed to get gitserver repos from the database")
 	}
@@ -179,14 +180,17 @@ func (h *bitbucketProjectPermissionsHandler) setReposUnrestricted(ctx context.Co
 	return nil
 }
 
-// getRepoIDsByNames queries repo IDs from frontend database using repo names fetched from
+// getRepoIDsByNames queries repo IDs from frontend database using external repo IDs fetched from
 // Bitbucket code host.
-func (h *bitbucketProjectPermissionsHandler) getRepoIDsByNames(ctx context.Context, svc *types.ExternalService, projectKey string, repos []*bitbucketserver.Repo) ([]api.RepoID, error) {
+func (h *bitbucketProjectPermissionsHandler) getRepoIDsByNames(ctx context.Context, svc *types.ExternalService, repos []*bitbucketserver.Repo) ([]api.RepoID, error) {
 	count := len(repos)
 	IDs := make([]api.RepoID, 0, count)
 	if count == 0 {
 		return IDs, nil
 	}
+
+	specs := make([]api.ExternalRepoSpec, 0, count)
+	extSvcType := extsvc.KindToType(svc.Kind)
 
 	// unmarshalling external service config
 	var cfg schema.BitbucketServerConnection
@@ -199,31 +203,27 @@ func (h *bitbucketProjectPermissionsHandler) getRepoIDsByNames(ctx context.Conte
 	if err != nil {
 		return nil, errors.Errorf("error during parsing external service URL", err)
 	}
-	hostname := parsedURL.Hostname()
 
-	names := make([]api.RepoName, 0, count)
+	extSvcID := extsvc.NormalizeBaseURL(parsedURL).String()
 	for _, repo := range repos {
-		// this is how repo names are composed before creating repos in `repo` table
-		// we are reconstructing this name for successful pattern matching
-		name := reposource.BitbucketServerRepoName(
-			cfg.RepositoryPathPattern,
-			hostname,
-			projectKey,
-			repo.Slug,
-		)
+		// using external ID, external service type and external service ID of the repo to find it
+		spec := api.ExternalRepoSpec{
+			ID:          strconv.Itoa(repo.ID),
+			ServiceType: extSvcType,
+			ServiceID:   extSvcID,
+		}
 
-		names = append(names, name)
+		specs = append(specs, spec)
 	}
 
-	// searching for repos by names
-	gitserverRepos, err := h.db.GitserverRepos().GetByNames(ctx, names...)
+	foundRepos, err := h.db.Repos().List(ctx, database.ReposListOptions{ExternalRepos: specs})
 	if err != nil {
 		return nil, err
 	}
 
 	// mapping repos to repo IDs
-	for _, gitserverRepo := range gitserverRepos {
-		IDs = append(IDs, gitserverRepo.RepoID)
+	for _, foundRepo := range foundRepos {
+		IDs = append(IDs, foundRepo.ID)
 	}
 
 	return IDs, nil

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -40,18 +39,6 @@ func TestStore(t *testing.T) {
 	count, err := store.QueuedCount(ctx, true)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
-}
-
-func intPtr(v int) *int              { return &v }
-func stringPtr(v string) *string     { return &v }
-func timePtr(v time.Time) *time.Time { return &v }
-
-func mustParseTime(v string) time.Time {
-	t, err := time.Parse("2006-01-02", v)
-	if err != nil {
-		panic(err)
-	}
-	return t
 }
 
 func TestGetBitbucketClient(t *testing.T) {
@@ -342,14 +329,23 @@ func TestHandleRestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, name, fork)
+	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork)
 	VALUES
-		(1, 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false)
+		(1, 10060, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/go', false),
+		(2, 10056, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
+		(3, 10061, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/mux', false),
+		(4, 10058, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sentry', false),
+		(5, 10059, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
+		(6, 10072, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+
+	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
+	VALUES
+		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go'),
+		(1, 2, 'bitbucket.sgdev.org/SGDEMO/jenkins'),
+		(1, 3, 'bitbucket.sgdev.org/SGDEMO/mux'),
+		(1, 4, 'bitbucket.sgdev.org/SGDEMO/sentry'),
+		(1, 5, 'bitbucket.sgdev.org/SGDEMO/sinatra'),
+		(1, 6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph');
 `)
 	require.NoError(t, err)
 
@@ -442,14 +438,23 @@ func TestHandleUnrestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, name, fork)
+	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork)
 	VALUES
-		(1, 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+		(1, 10060, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/go', false),
+		(2, 10056, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
+		(3, 10061, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/mux', false),
+		(4, 10058, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sentry', false),
+		(5, 10059, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
+		(6, 10072, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+
+	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
+	VALUES
+		(1, 1, 'bitbucket.sgdev.org/SGDEMO/go'),
+		(1, 2, 'bitbucket.sgdev.org/SGDEMO/jenkins'),
+		(1, 3, 'bitbucket.sgdev.org/SGDEMO/mux'),
+		(1, 4, 'bitbucket.sgdev.org/SGDEMO/sentry'),
+		(1, 5, 'bitbucket.sgdev.org/SGDEMO/sinatra'),
+		(1, 6, 'bitbucket.sgdev.org/SGDEMO/sourcegraph');
 
 	INSERT INTO repo_permissions (repo_id, permission, updated_at)
 	VALUES

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -329,14 +329,14 @@ func TestHandleRestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork)
+	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork, private)
 	VALUES
-		(1, 10060, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 10056, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 10061, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 10058, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 10059, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 10072, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+		(1, 10060, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/go', false, true),
+		(2, 10056, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/jenkins', false, true),
+		(3, 10061, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/mux', false, true),
+		(4, 10058, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sentry', false, true),
+		(5, 10059, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sinatra', false, true),
+		(6, 10072, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false, true);
 
 	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
 	VALUES
@@ -438,14 +438,14 @@ func TestHandleUnrestricted(t *testing.T) {
 
 	// create 6 repos
 	_, err = db.ExecContext(ctx, `--sql
-	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork)
+	INSERT INTO repo (id, external_id, external_service_type, external_service_id, name, fork, private)
 	VALUES
-		(1, 10060, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/go', false),
-		(2, 10056, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/jenkins', false),
-		(3, 10061, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/mux', false),
-		(4, 10058, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sentry', false),
-		(5, 10059, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sinatra', false),
-		(6, 10072, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false);
+		(1, 10060, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/go', false, true),
+		(2, 10056, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/jenkins', false, true),
+		(3, 10061, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/mux', false, true),
+		(4, 10058, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sentry', false, true),
+		(5, 10059, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sinatra', false, true),
+		(6, 10072, 'bitbucketServer', 'https://bitbucket.sgdev.org/', 'bitbucket.sgdev.org/SGDEMO/sourcegraph', false, true);
 
 	INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
 	VALUES


### PR DESCRIPTION
Previously we were fetching repos using only repo the name which is okay for 99% cases, but the unique constraint in `repo` table consists of `external_service_type`, `external_service_id` and `external_id` columns.

This commit uses a combination of these 3 properties for fully deterministic searches without possible repo name collisions.

## Test plan
Unit tests updated and should pass.
Manual tests to confirm that repo permissions are granted for projects on `bitbucket.sgdev.org`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
