### PR TITLE
search ui: hide unnecessary panels and split dynamic filters into their own panels by kind

### DIFF
--- a/client/search-ui/src/results/sidebar/FilterLink.test.tsx
+++ b/client/search-ui/src/results/sidebar/FilterLink.test.tsx
@@ -83,7 +83,7 @@ describe('FilterLink', () => {
         const filters: Filter[] = [repoFilter1, langFilter1, repoFilter2, langFilter2, fileFilter]
         const onFilterChosen = sinon.stub()
 
-        const links = getDynamicFilterLinks(filters, onFilterChosen)
+        const links = getDynamicFilterLinks(filters, ['file', 'lang', 'utility'], onFilterChosen)
         expect(links).toHaveLength(3)
         expect(renderWithBrandedContext(<>{links}</>).asFragment()).toMatchSnapshot()
     })
@@ -92,7 +92,7 @@ describe('FilterLink', () => {
         const filters: Filter[] = [repoFilter1, repoFilter2]
         const onFilterChosen = sinon.stub()
 
-        const links = getDynamicFilterLinks(filters, onFilterChosen)
+        const links = getDynamicFilterLinks(filters, ['file', 'lang', 'utility'], onFilterChosen)
         expect(links).toHaveLength(0)
     })
 

--- a/client/search-ui/src/results/sidebar/FilterLink.tsx
+++ b/client/search-ui/src/results/sidebar/FilterLink.tsx
@@ -98,16 +98,20 @@ export const getRepoFilterLinks = (
 
 export const getDynamicFilterLinks = (
     filters: Filter[] | undefined,
-    onFilterChosen: (value: string, kind?: string) => void
+    kinds: Filter['kind'][],
+    onFilterChosen: (value: string, kind?: string) => void,
+    ariaLabelTransform: (label: string, value: string) => string = label => `${label}`,
+    labelTransform: (label: string, value: string) => string = label => `${label}`
 ): React.ReactElement[] =>
     (filters || [])
-        .filter(filter => filter.kind !== 'repo')
+        .filter(filter => kinds.includes(filter.kind))
         .map(filter => (
             <FilterLink
                 {...filter}
+                label={labelTransform(filter.label, filter.value)}
+                ariaLabel={ariaLabelTransform(filter.label, filter.value)}
                 key={`${filter.label}-${filter.value}`}
                 onFilterChosen={onFilterChosen}
-                ariaLabel={`Filter by ${filter.label}`}
             />
         ))
 

--- a/client/search-ui/src/results/sidebar/SearchSidebar.story.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.story.tsx
@@ -142,12 +142,12 @@ const filters: Filter[] = [
         kind: 'file',
     },
 
-    ...['typescript', 'javascript', 'c++', 'c', 'c#', 'python', 'ruby', 'haskell', 'java'].map(lang => ({
-        label: `lang:${lang}`,
-        value: `lang:${lang}`,
+    ...['TypeScript', 'JavaScript', 'C++', 'C', 'C#', 'Python', 'Ruby', 'Haskell', 'Java'].map(lang => ({
+        label: lang,
+        value: `lang:${lang.toLowerCase()}`,
         count: 10,
         limitHit: true,
-        kind: 'lang',
+        kind: 'lang' as Filter['kind'],
     })),
 ]
 

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -135,6 +135,8 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
         repoFilters,
         onDynamicFilterClicked,
     ])
+    const showReposSection = repoFilterLinks.length > 1
+
     const langFilterLinks = useMemo(
         () => getDynamicFilterLinks(props.filters, ['lang'], onDynamicFilterClicked, label => `Search ${label} files`),
         [props.filters, onDynamicFilterClicked]
@@ -204,7 +206,7 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                         {langFilterLinks}
                     </SearchSidebarSection>
                 )}
-                {repoFilterLinks.length > 0 && (
+                {showReposSection && (
                     <SearchSidebarSection
                         sectionId={SectionID.REPOSITORIES}
                         className={styles.item}

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -19,6 +19,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { SectionID } from '@sourcegraph/shared/src/settings/temporary/searchSidebar'
 import { TemporarySettings } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Code, Icon } from '@sourcegraph/wildcard'
 
@@ -76,6 +77,7 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
     const history = useHistory()
     const [collapsedSections, setCollapsedSections] = useTemporarySetting('search.collapsedSidebarSections', {})
     const [, setSelectedTab] = useTemporarySetting('search.sidebar.selectedTab', 'filters')
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
 
     // The zustand store for search query state is referenced through context
     // because there may be different global stores across clients
@@ -133,11 +135,29 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
         repoFilters,
         onDynamicFilterClicked,
     ])
-    const dynamicFilterLinks = useMemo(() => getDynamicFilterLinks(props.filters, onDynamicFilterClicked), [
+    const langFilterLinks = useMemo(
+        () => getDynamicFilterLinks(props.filters, ['lang'], onDynamicFilterClicked, label => `Search ${label} files`),
+        [props.filters, onDynamicFilterClicked]
+    )
+    const fileFilterLinks = useMemo(() => getDynamicFilterLinks(props.filters, ['file'], onDynamicFilterClicked), [
         props.filters,
         onDynamicFilterClicked,
     ])
-    const showReposSection = repoFilterLinks.length > 1
+    const utilityFilterLinks = useMemo(
+        () => getDynamicFilterLinks(props.filters, ['utility'], onDynamicFilterClicked),
+        [props.filters, onDynamicFilterClicked]
+    )
+    const dynamicFilterLinks = useMemo(
+        () =>
+            getDynamicFilterLinks(
+                props.filters,
+                ['lang', 'file', 'utility'],
+                onDynamicFilterClicked,
+                (label, value) => `Filter by ${value}`,
+                (label, value) => value
+            ),
+        [props.filters, onDynamicFilterClicked]
+    )
 
     let body
 
@@ -162,16 +182,29 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                         forceButton: props.forceButton,
                     })}
                 </SearchSidebarSection>
-                <SearchSidebarSection
-                    sectionId={SectionID.DYNAMIC_FILTERS}
-                    className={styles.item}
-                    header="Dynamic filters"
-                    startCollapsed={collapsedSections?.[SectionID.DYNAMIC_FILTERS]}
-                    onToggle={persistToggleState}
-                >
-                    {dynamicFilterLinks}
-                </SearchSidebarSection>
-                {showReposSection ? (
+                {!coreWorkflowImprovementsEnabled && dynamicFilterLinks.length > 0 && (
+                    <SearchSidebarSection
+                        sectionId={SectionID.DYNAMIC_FILTERS}
+                        className={styles.item}
+                        header="Dynamic Filters"
+                        startCollapsed={collapsedSections?.[SectionID.DYNAMIC_FILTERS]}
+                        onToggle={persistToggleState}
+                    >
+                        {dynamicFilterLinks}
+                    </SearchSidebarSection>
+                )}
+                {coreWorkflowImprovementsEnabled && langFilterLinks.length > 0 && (
+                    <SearchSidebarSection
+                        sectionId={SectionID.LANGUAGES}
+                        className={styles.item}
+                        header="Languages"
+                        startCollapsed={collapsedSections?.[SectionID.LANGUAGES]}
+                        onToggle={persistToggleState}
+                    >
+                        {langFilterLinks}
+                    </SearchSidebarSection>
+                )}
+                {repoFilterLinks.length > 0 && (
                     <SearchSidebarSection
                         sectionId={SectionID.REPOSITORIES}
                         className={styles.item}
@@ -188,7 +221,29 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                     >
                         {repoFilterLinks}
                     </SearchSidebarSection>
-                ) : null}
+                )}
+                {coreWorkflowImprovementsEnabled && fileFilterLinks.length > 0 && (
+                    <SearchSidebarSection
+                        sectionId={SectionID.FILE_TYPES}
+                        className={styles.item}
+                        header="File types"
+                        startCollapsed={collapsedSections?.[SectionID.FILE_TYPES]}
+                        onToggle={persistToggleState}
+                    >
+                        {fileFilterLinks}
+                    </SearchSidebarSection>
+                )}
+                {coreWorkflowImprovementsEnabled && utilityFilterLinks.length > 0 && (
+                    <SearchSidebarSection
+                        sectionId={SectionID.OTHER}
+                        className={styles.item}
+                        header="Other"
+                        startCollapsed={collapsedSections?.[SectionID.OTHER]}
+                        onToggle={persistToggleState}
+                    >
+                        {utilityFilterLinks}
+                    </SearchSidebarSection>
+                )}
                 {props.getRevisions && repoName ? (
                     <SearchSidebarSection
                         sectionId={SectionID.REVISIONS}
@@ -202,22 +257,24 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                         {props.getRevisions({ repoName, onFilterClick: submitQueryWithProps })}
                     </SearchSidebarSection>
                 ) : null}
-                <SearchSidebarSection
-                    sectionId={SectionID.SEARCH_REFERENCE}
-                    className={styles.item}
-                    header="Search reference"
-                    showSearch={true}
-                    startCollapsed={collapsedSections?.[SectionID.SEARCH_REFERENCE]}
-                    onToggle={onSearchReferenceToggle}
-                    // search reference should always preserve the filter
-                    // (false is just an arbitrary but static value)
-                    clearSearchOnChange={false}
-                >
-                    {getSearchReferenceFactory({
-                        telemetryService: props.telemetryService,
-                        setQueryState,
-                    })}
-                </SearchSidebarSection>
+                {!coreWorkflowImprovementsEnabled && (
+                    <SearchSidebarSection
+                        sectionId={SectionID.SEARCH_REFERENCE}
+                        className={styles.item}
+                        header="Search reference"
+                        showSearch={true}
+                        startCollapsed={collapsedSections?.[SectionID.SEARCH_REFERENCE]}
+                        onToggle={onSearchReferenceToggle}
+                        // search reference should always preserve the filter
+                        // (false is just an arbitrary but static value)
+                        clearSearchOnChange={false}
+                    >
+                        {getSearchReferenceFactory({
+                            telemetryService: props.telemetryService,
+                            setQueryState,
+                        })}
+                    </SearchSidebarSection>
+                )}
                 <SearchSidebarSection
                     sectionId={SectionID.SEARCH_SNIPPETS}
                     className={styles.item}
@@ -227,15 +284,17 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
                 >
                     {getSearchSnippetLinks(props.settingsCascade, onSnippetClicked)}
                 </SearchSidebarSection>
-                <SearchSidebarSection
-                    sectionId={SectionID.QUICK_LINKS}
-                    className={styles.item}
-                    header="Quicklinks"
-                    startCollapsed={collapsedSections?.[SectionID.QUICK_LINKS]}
-                    onToggle={persistToggleState}
-                >
-                    {getQuickLinks(props.settingsCascade)}
-                </SearchSidebarSection>
+                {!coreWorkflowImprovementsEnabled && (
+                    <SearchSidebarSection
+                        sectionId={SectionID.QUICK_LINKS}
+                        className={styles.item}
+                        header="Quicklinks"
+                        startCollapsed={collapsedSections?.[SectionID.QUICK_LINKS]}
+                        onToggle={persistToggleState}
+                    >
+                        {getQuickLinks(props.settingsCascade)}
+                    </SearchSidebarSection>
+                )}
             </>
         )
     }

--- a/client/search-ui/src/results/sidebar/SearchSidebarSection.test.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebarSection.test.tsx
@@ -23,7 +23,7 @@ describe('SearchSidebarSection', () => {
     it('should render all items initially', () => {
         render(
             <SearchSidebarSection sectionId="id" header="Dynamic filters" showSearch={true}>
-                {getDynamicFilterLinks(filters, onFilterChosen)}
+                {getDynamicFilterLinks(filters, ['file', 'lang', 'utility'], onFilterChosen)}
             </SearchSidebarSection>
         )
 
@@ -35,7 +35,7 @@ describe('SearchSidebarSection', () => {
     it('should filter items based on search', () => {
         render(
             <SearchSidebarSection sectionId="id" header="Dynamic filters" showSearch={true}>
-                {getDynamicFilterLinks(filters, onFilterChosen)}
+                {getDynamicFilterLinks(filters, ['file', 'lang', 'utility'], onFilterChosen)}
             </SearchSidebarSection>
         )
 
@@ -47,7 +47,7 @@ describe('SearchSidebarSection', () => {
     it('should clear search when items change', () => {
         const { rerender } = render(
             <SearchSidebarSection sectionId="id" header="Dynamic filters" showSearch={true}>
-                {getDynamicFilterLinks(filters, onFilterChosen)}
+                {getDynamicFilterLinks(filters, ['file', 'lang', 'utility'], onFilterChosen)}
             </SearchSidebarSection>
         )
 
@@ -55,7 +55,11 @@ describe('SearchSidebarSection', () => {
 
         rerender(
             <SearchSidebarSection sectionId="id" header="Dynamic filters" showSearch={true}>
-                {getDynamicFilterLinks([filters[0], filters[5], filters[3]], onFilterChosen)}
+                {getDynamicFilterLinks(
+                    [filters[0], filters[5], filters[3]],
+                    ['file', 'lang', 'utility'],
+                    onFilterChosen
+                )}
             </SearchSidebarSection>
         )
 
@@ -67,7 +71,7 @@ describe('SearchSidebarSection', () => {
     it('should not show search if only one item in list', () => {
         render(
             <SearchSidebarSection sectionId="id" header="Dynamic filters" showSearch={true}>
-                {getDynamicFilterLinks([filters[2]], onFilterChosen)}
+                {getDynamicFilterLinks([filters[2]], ['file', 'lang', 'utility'], onFilterChosen)}
             </SearchSidebarSection>
         )
 
@@ -79,7 +83,7 @@ describe('SearchSidebarSection', () => {
     it('should not show search if showSearch is false', () => {
         render(
             <SearchSidebarSection sectionId="id" header="Dynamic filters">
-                {getDynamicFilterLinks(filters, onFilterChosen)}
+                {getDynamicFilterLinks(filters, ['file', 'lang', 'utility'], onFilterChosen)}
             </SearchSidebarSection>
         )
 

--- a/client/search-ui/src/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
+++ b/client/search-ui/src/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FilterLink should have correct links for dynamic filters 1`] = `
 <DocumentFragment>
   <button
-    aria-label="Filter by lang:go, At least 500 results match this filter."
+    aria-label="lang:go, At least 500 results match this filter."
     class="btn btnLink sidebarSectionListItem"
     data-testid="filter-link"
     type="button"
@@ -40,7 +40,7 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
     </span>
   </button>
   <button
-    aria-label="Filter by lang:typescript, At least 241 results match this filter."
+    aria-label="lang:typescript, At least 241 results match this filter."
     class="btn btnLink sidebarSectionListItem"
     data-testid="filter-link"
     type="button"
@@ -77,7 +77,7 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
     </span>
   </button>
   <button
-    aria-label="Filter by -file:_test\\\\.go$, At least 1 result matches this filter."
+    aria-label="-file:_test\\\\.go$, At least 1 result matches this filter."
     class="btn btnLink sidebarSectionListItem"
     data-testid="filter-link"
     type="button"

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -213,7 +213,7 @@ export interface Filter {
     label: string
     count: number
     limitHit: boolean
-    kind: string
+    kind: 'file' | 'repo' | 'lang' | 'utility'
 }
 
 export type AlertKind = 'lucky-search-queries'

--- a/client/shared/src/settings/temporary/searchSidebar.ts
+++ b/client/shared/src/settings/temporary/searchSidebar.ts
@@ -1,8 +1,11 @@
 export enum SectionID {
     SEARCH_REFERENCE = 'reference',
     SEARCH_TYPES = 'types',
-    DYNAMIC_FILTERS = 'filters',
+    DYNAMIC_FILTERS = 'filters', // Deprecated
+    LANGUAGES = 'languages',
     REPOSITORIES = 'repositories',
+    FILE_TYPES = 'file-types',
+    OTHER = 'other',
     SEARCH_SNIPPETS = 'snippets',
     QUICK_LINKS = 'quicklinks',
     REVISIONS = 'revisions',

--- a/client/shared/src/testing/searchTestHelpers.ts
+++ b/client/shared/src/testing/searchTestHelpers.ts
@@ -120,8 +120,8 @@ export const SEARCH_RESULT: AggregateStreamingSearchResults = {
         skipped: [],
     },
     filters: [
-        { value: 'file:\\.yml$', label: 'file:\\.yml$', count: 1, limitHit: false, kind: 'file' },
-        { value: 'case:yes', label: 'case:yes', count: 0, limitHit: false, kind: 'case' },
+        { value: 'file:\\.yml$', label: 'YAML', count: 1, limitHit: false, kind: 'file' },
+        { value: 'case:yes', label: 'Make search case sensitive', count: 0, limitHit: false, kind: 'utility' },
         {
             value: 'repo:^github\\.com/golang/oauth2$',
             label: 'github.com/golang/oauth2',

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -33,8 +33,8 @@ const mockDefaultStreamEvents: SearchEvent[] = [
     {
         type: 'filters',
         data: [
-            { label: 'archived:yes', value: 'archived:yes', count: 5, kind: 'generic', limitHit: true },
-            { label: 'fork:yes', value: 'fork:yes', count: 46, kind: 'generic', limitHit: true },
+            { label: 'archived:yes', value: 'archived:yes', count: 5, kind: 'utility', limitHit: true },
+            { label: 'fork:yes', value: 'fork:yes', count: 46, kind: 'utility', limitHit: true },
             // Two repo filters to trigger the repository sidebar section
             {
                 label: 'github.com/Algorilla/manta-ray',


### PR DESCRIPTION
**Review with "hide whitespace" on**

Closes #38564
Closes #38229

- Backend now sends more descriptive labels for dynamic filter suggestions
- With "simple UI" toggle on, frontend search sidebar:
  - Renders different kinds of filters in their own panels, using the new descriptive label sent by the backend
  - Hides the "Search Reference" and "Quicklinks" panel
- With "simple UI" toggle off, frontend search sidebar still renders all non-repo dynamic filters in the same section, using the value as the label

![image](https://user-images.githubusercontent.com/206864/179850879-1c059e6b-c7ae-4fa0-907f-0090b974709e.png)


## Test plan

Verified manually. No visual tests should show changes.
