### PR TITLE
compute: clean up test output

### DIFF
--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -28,6 +28,11 @@ func environment(r *MatchContext) any {
 	return env
 }
 
+type want struct {
+	Input  string
+	Result any
+}
+
 func Test_matchOnly(t *testing.T) {
 	data := &result.FileMatch{
 		File: result.File{Path: "bedge", Repo: types.MinimalRepo{
@@ -47,179 +52,25 @@ func Test_matchOnly(t *testing.T) {
 	test := func(input string, serialize serializer) string {
 		r, _ := regexp.Compile(input)
 		result := matchOnly(data, r)
-		v, _ := json.MarshalIndent(serialize(result), "", "  ")
+		w := want{Input: input, Result: result}
+		v, _ := json.MarshalIndent(w, "", "  ")
 		return string(v)
 	}
 
-	autogold.Want("compute regexp submatch empty environment", `{
-  "matches": [],
-  "path": "bedge",
-  "repositoryID": 5,
-  "repository": "codehost.com/myorg/myrepo"
-}`).Equal(t, test("nothing", match))
+	cases := []struct {
+		input      string
+		serializer serializer
+	}{
+		{input: "nothing", serializer: match},
+		{input: "(a)(?P<ThisIsNamed>b)", serializer: environment},
+		{input: "(lasvegans)|abcdefgh", serializer: environment},
+		{input: "a(b(c))(de)f(g)h", serializer: match},
+		{input: "([ag])", serializer: match},
+	}
 
-	autogold.Want("compute named regexp submatch", `{
-  "1": "a",
-  "ThisIsNamed": "b"
-}`).Equal(t, test("(a)(?P<ThisIsNamed>b)", environment))
-
-	autogold.Want("no slice out of bounds access on capture group", "{}").Equal(t, test("(lasvegans)|abcdefgh", environment))
-
-	autogold.Want("compute regexp submatch nonempty environment", `{
-  "matches": [
-    {
-      "value": "abcdefgh",
-      "range": {
-        "start": {
-          "offset": -1,
-          "line": 1,
-          "column": 0
-        },
-        "end": {
-          "offset": -1,
-          "line": 1,
-          "column": 8
-        }
-      },
-      "environment": {
-        "1": {
-          "value": "bc",
-          "range": {
-            "start": {
-              "offset": -1,
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "offset": -1,
-              "line": 1,
-              "column": 3
-            }
-          }
-        },
-        "2": {
-          "value": "c",
-          "range": {
-            "start": {
-              "offset": -1,
-              "line": 1,
-              "column": 2
-            },
-            "end": {
-              "offset": -1,
-              "line": 1,
-              "column": 3
-            }
-          }
-        },
-        "3": {
-          "value": "de",
-          "range": {
-            "start": {
-              "offset": -1,
-              "line": 1,
-              "column": 3
-            },
-            "end": {
-              "offset": -1,
-              "line": 1,
-              "column": 5
-            }
-          }
-        },
-        "4": {
-          "value": "g",
-          "range": {
-            "start": {
-              "offset": -1,
-              "line": 1,
-              "column": 6
-            },
-            "end": {
-              "offset": -1,
-              "line": 1,
-              "column": 7
-            }
-          }
-        }
-      }
-    }
-  ],
-  "path": "bedge",
-  "repositoryID": 5,
-  "repository": "codehost.com/myorg/myrepo"
-}`).Equal(t, test("a(b(c))(de)f(g)h", match))
-
-	autogold.Want("compute regexp submatch includes all matches on line", `{
-  "matches": [
-    {
-      "value": "a",
-      "range": {
-        "start": {
-          "offset": -1,
-          "line": 1,
-          "column": 0
-        },
-        "end": {
-          "offset": -1,
-          "line": 1,
-          "column": 1
-        }
-      },
-      "environment": {
-        "1": {
-          "value": "a",
-          "range": {
-            "start": {
-              "offset": -1,
-              "line": 1,
-              "column": 0
-            },
-            "end": {
-              "offset": -1,
-              "line": 1,
-              "column": 1
-            }
-          }
-        }
-      }
-    },
-    {
-      "value": "g",
-      "range": {
-        "start": {
-          "offset": -1,
-          "line": 1,
-          "column": 6
-        },
-        "end": {
-          "offset": -1,
-          "line": 1,
-          "column": 7
-        }
-      },
-      "environment": {
-        "1": {
-          "value": "g",
-          "range": {
-            "start": {
-              "offset": -1,
-              "line": 1,
-              "column": 6
-            },
-            "end": {
-              "offset": -1,
-              "line": 1,
-              "column": 7
-            }
-          }
-        }
-      }
-    }
-  ],
-  "path": "bedge",
-  "repositoryID": 5,
-  "repository": "codehost.com/myorg/myrepo"
-}`).Equal(t, test("([ag])", match))
-
+	for _, c := range cases {
+		t.Run("match_only", func(t *testing.T) {
+			autogold.Equal(t, autogold.Raw(test(c.input, c.serializer)))
+		})
+	}
 }

--- a/enterprise/internal/compute/testdata/Test_matchOnly/match_only#01.golden
+++ b/enterprise/internal/compute/testdata/Test_matchOnly/match_only#01.golden
@@ -1,0 +1,57 @@
+{
+  "Input": "(a)(?P\u003cThisIsNamed\u003eb)",
+  "Result": {
+    "matches": [
+      {
+        "value": "ab",
+        "range": {
+          "start": {
+            "offset": -1,
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "offset": -1,
+            "line": 1,
+            "column": 2
+          }
+        },
+        "environment": {
+          "1": {
+            "value": "a",
+            "range": {
+              "start": {
+                "offset": -1,
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "offset": -1,
+                "line": 1,
+                "column": 1
+              }
+            }
+          },
+          "ThisIsNamed": {
+            "value": "b",
+            "range": {
+              "start": {
+                "offset": -1,
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "offset": -1,
+                "line": 1,
+                "column": 2
+              }
+            }
+          }
+        }
+      }
+    ],
+    "path": "bedge",
+    "repositoryID": 5,
+    "repository": "codehost.com/myorg/myrepo"
+  }
+}

--- a/enterprise/internal/compute/testdata/Test_matchOnly/match_only#02.golden
+++ b/enterprise/internal/compute/testdata/Test_matchOnly/match_only#02.golden
@@ -1,0 +1,26 @@
+{
+  "Input": "(lasvegans)|abcdefgh",
+  "Result": {
+    "matches": [
+      {
+        "value": "abcdefgh",
+        "range": {
+          "start": {
+            "offset": -1,
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "offset": -1,
+            "line": 1,
+            "column": 8
+          }
+        },
+        "environment": {}
+      }
+    ],
+    "path": "bedge",
+    "repositoryID": 5,
+    "repository": "codehost.com/myorg/myrepo"
+  }
+}

--- a/enterprise/internal/compute/testdata/Test_matchOnly/match_only#03.golden
+++ b/enterprise/internal/compute/testdata/Test_matchOnly/match_only#03.golden
@@ -1,0 +1,87 @@
+{
+  "Input": "a(b(c))(de)f(g)h",
+  "Result": {
+    "matches": [
+      {
+        "value": "abcdefgh",
+        "range": {
+          "start": {
+            "offset": -1,
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "offset": -1,
+            "line": 1,
+            "column": 8
+          }
+        },
+        "environment": {
+          "1": {
+            "value": "bc",
+            "range": {
+              "start": {
+                "offset": -1,
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "offset": -1,
+                "line": 1,
+                "column": 3
+              }
+            }
+          },
+          "2": {
+            "value": "c",
+            "range": {
+              "start": {
+                "offset": -1,
+                "line": 1,
+                "column": 2
+              },
+              "end": {
+                "offset": -1,
+                "line": 1,
+                "column": 3
+              }
+            }
+          },
+          "3": {
+            "value": "de",
+            "range": {
+              "start": {
+                "offset": -1,
+                "line": 1,
+                "column": 3
+              },
+              "end": {
+                "offset": -1,
+                "line": 1,
+                "column": 5
+              }
+            }
+          },
+          "4": {
+            "value": "g",
+            "range": {
+              "start": {
+                "offset": -1,
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "offset": -1,
+                "line": 1,
+                "column": 7
+              }
+            }
+          }
+        }
+      }
+    ],
+    "path": "bedge",
+    "repositoryID": 5,
+    "repository": "codehost.com/myorg/myrepo"
+  }
+}

--- a/enterprise/internal/compute/testdata/Test_matchOnly/match_only#04.golden
+++ b/enterprise/internal/compute/testdata/Test_matchOnly/match_only#04.golden
@@ -1,0 +1,74 @@
+{
+  "Input": "([ag])",
+  "Result": {
+    "matches": [
+      {
+        "value": "a",
+        "range": {
+          "start": {
+            "offset": -1,
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "offset": -1,
+            "line": 1,
+            "column": 1
+          }
+        },
+        "environment": {
+          "1": {
+            "value": "a",
+            "range": {
+              "start": {
+                "offset": -1,
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "offset": -1,
+                "line": 1,
+                "column": 1
+              }
+            }
+          }
+        }
+      },
+      {
+        "value": "g",
+        "range": {
+          "start": {
+            "offset": -1,
+            "line": 1,
+            "column": 6
+          },
+          "end": {
+            "offset": -1,
+            "line": 1,
+            "column": 7
+          }
+        },
+        "environment": {
+          "1": {
+            "value": "g",
+            "range": {
+              "start": {
+                "offset": -1,
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "offset": -1,
+                "line": 1,
+                "column": 7
+              }
+            }
+          }
+        }
+      }
+    ],
+    "path": "bedge",
+    "repositoryID": 5,
+    "repository": "codehost.com/myorg/myrepo"
+  }
+}

--- a/enterprise/internal/compute/testdata/Test_matchOnly/match_only.golden
+++ b/enterprise/internal/compute/testdata/Test_matchOnly/match_only.golden
@@ -1,0 +1,9 @@
+{
+  "Input": "nothing",
+  "Result": {
+    "matches": [],
+    "path": "bedge",
+    "repositoryID": 5,
+    "repository": "codehost.com/myorg/myrepo"
+  }
+}


### PR DESCRIPTION
working on updating compute to use chunk matches and just want to make these test files less messy looking

## Test plan
Semantics-preserving.