### PR TITLE
docs: Mention enabling the IAM API for GCP executors

### DIFF
--- a/doc/admin/deploy_executors.md
+++ b/doc/admin/deploy_executors.md
@@ -71,6 +71,8 @@ Two variables must be supplied to the module in order for it to contact your Sou
 - `sourcegraph_external_url` ([Google](https://sourcegraph.com/search?q=context:global+repo:%5Egithub.com/sourcegraph/terraform-google-executors%24+variable+%22sourcegraph_external_url%22&patternType=literal); [AWS](https://sourcegraph.com/search?q=context:global+repo:%5Egithub.com/sourcegraph/terraform-aws-executors%24+variable+%22sourcegraph_external_url%22&patternType=literal)): The **public** URL of your Sourcegraph instance. This corresponds to the `externalURL` value in your Sourcegraph instance's site-config and must be resolvable from the provisioned executor compute resources.
 - `sourcegraph_executor_proxy_password` ([Google](https://sourcegraph.com/search?q=context:global+repo:%5Egithub.com/sourcegraph/terraform-google-executors%24+variable+%22sourcegraph_executor_proxy_password%22&patternType=literal); [AWS](https://sourcegraph.com/search?q=context:global+repo:%5Egithub.com/sourcegraph/terraform-aws-executors%24+variable+%22sourcegraph_executor_proxy_password%22&patternType=literal)): The access token chosen and configured above.
 
+For Google Cloud, make sure the [IAM API](https://console.cloud.google.com/apis/api/iam.googleapis.com/overview) is enabled.
+
 Additional values may need to be supplied for a specific cloud provider. Refer to the relevant Terraform module documentation for specifics.
 
 To deploy executor compute resources defined in the Terraform file above, simply run `terraform apply`.


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/issues/27878

## Test plan

N/A
