### PR TITLE
executors: Tweak wording on config page

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/IndexingPolicyDescription.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/IndexingPolicyDescription.tsx
@@ -17,5 +17,5 @@ export const IndexingPolicyDescription: FunctionComponent<
             .
         </>
     ) : (
-        <span className="text-muted">Auto-indexing disabled.</span>
+        <span className="text-muted">Auto-indexing is disabled for this policy.</span>
     )


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/issues/29095

Updates wording from

> Auto-indexing disabled.

to

> Auto-indexing is disabled for this policy.

## Test plan

Ran locally.

## App preview:

- [Web](https://sg-web-executors-tweak-wording.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sahbhczana.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
