### PR TITLE
Fix missing button in code nav policy config in small browser window

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.module.scss
@@ -20,8 +20,7 @@
     }
 }
 
-.name,
-.button {
+.name {
     @media (--xs-breakpoint-down) {
         grid-column: 1 / -1;
     }

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -206,10 +206,8 @@ export const PoliciesNode: FunctionComponent<React.PropsWithChildren<PoliciesNod
             </div>
         </div>
 
-        <span className={classNames(styles.button, 'd-none d-md-inline')}>
-            <Link to={`./configuration/${policy.id}`} className="p-0">
-                <Icon svgPath={mdiChevronRight} inline={false} aria-label="Configure" />
-            </Link>
-        </span>
+        <Link to={`./configuration/${policy.id}`} className="p-0">
+            <Icon svgPath={mdiChevronRight} inline={false} aria-label="Configure" />
+        </Link>
     </>
 )


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/issues/29097

![CleanShot 2022-07-19 at 16 28 59](https://user-images.githubusercontent.com/1387653/179860617-c3fbc3d1-8dda-4483-a414-bade3011ae80.png)

## Test plan

Ran locally.

## App preview:

- [Web](https://sg-web-fix-chevron-disappearing.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xarzhcjgjl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
