### PR TITLE
Syntax highlighting for CodeMirror based blob view

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -156,15 +156,21 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                         if (blob === null) {
                             return blob
                         }
+                        console.log(blob)
 
                         // Replace html with lsif generated HTML, if available
                         if (blob.highlight.lsif && blob.highlight.lsif !== '{}') {
                             blob.highlight.html = renderLsifHtml(blob.highlight.lsif, blob.content)
                         }
 
-                        const blobInfo: BlobInfo & { richHTML: string; aborted: boolean } = {
+                        const blobInfo: BlobInfo & {
+                            richHTML: string
+                            aborted: boolean
+                            data: [number, number, string][]
+                        } = {
                             content: blob.content,
-                            html: blob.highlight.html,
+                            //html: blob.highlight.html,
+                            data: JSON.parse(blob.highlight.html).sort((a, b) => a[0] - b[0]),
                             repoName,
                             revision,
                             commitID,

--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -413,6 +413,7 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 		Tracer:           ot.GetTracer(ctx),
 		LineLengthLimit:  maxLineLength,
 		CSS:              true,
+		OnlyRanges:       true,
 	}
 
 	// Set the Filetype part of the command if:

--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -406,6 +406,8 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 		maxLineLength = 2000
 	}
 
+	useTreesitter := filetypeQuery.Engine == EngineTreeSitter
+
 	query := &gosyntect.Query{
 		Code:             code,
 		Filepath:         p.Filepath,
@@ -413,7 +415,7 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 		Tracer:           ot.GetTracer(ctx),
 		LineLengthLimit:  maxLineLength,
 		CSS:              true,
-		OnlyRanges:       true,
+		UseTreesitter:    useTreesitter,
 	}
 
 	// Set the Filetype part of the command if:
@@ -422,11 +424,11 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 	//       whatever we were calculating before)
 	//    2. We are using treesitter. Always have syntect use the language provided in that
 	//       case to make sure that we have normalized the names of the language by then.
-	if filetypeQuery.LanguageOverride || filetypeQuery.Engine == EngineTreeSitter {
+	if filetypeQuery.LanguageOverride || useTreesitter {
 		query.Filetype = filetypeQuery.Language
 	}
 
-	resp, err := client.Highlight(ctx, query, filetypeQuery.Engine == EngineTreeSitter)
+	resp, err := client.Highlight(ctx, query)
 
 	unhighlightedCode := func(err error, code string) (*HighlightedCode, bool, error) {
 		errCollector.Collect(&err)

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_syntect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_syntect.rs
@@ -194,8 +194,11 @@ fn close_row(s: &mut String) {
 pub struct RangesGenerator<'a> {
     syntax_set: &'a SyntaxSet,
     parse_state: ParseState,
+    // This keeps track of the start position of a scope. When the scope is removed from the stack,
+    // we can generate an entry in data with (start, end, scope)
     position_stack: Vec<(Scope, usize)>,
     stack: ScopeStack,
+    // A list of (start, end, scope) tuples
     data: Vec<(usize, usize, Scope)>,
     code: &'a str,
     max_line_len: Option<usize>,
@@ -224,8 +227,8 @@ impl<'a> RangesGenerator<'a> {
         let mut file_offset = 0;
         for (_i, line) in LinesWithEndings::from(self.code).enumerate() {
             if self.max_line_len.map_or(false, |n| line.len() > n) {
-                // TODO: Not sure what should happen here... close all open
-                // scopes?
+                // TODO: Not sure what should happen here... maybe close all open scopes? But that
+                // could mess up the position information for scopes following that line.
             } else {
                 self.write_data_for_tokens(line, file_offset);
             }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_syntect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_syntect.rs
@@ -232,7 +232,7 @@ impl<'a> RangesGenerator<'a> {
             } else {
                 self.write_data_for_tokens(line, file_offset);
             }
-            file_offset += line.len()
+            file_offset += line.chars().count()
         }
         self.data
     }
@@ -249,10 +249,10 @@ impl<'a> RangesGenerator<'a> {
             let mut stack = self.stack.clone();
             stack.apply_with_hook(op, |basic_op, _| match basic_op {
                 BasicScopeStackOp::Push(scope) => {
-                    self.open_scope(&scope, file_offset + i);
+                    self.open_scope(&scope, file_offset + unsafe { line.get_unchecked(0..i).chars().count() });
                 }
                 BasicScopeStackOp::Pop => {
-                    self.close_scope(file_offset + i);
+                    self.close_scope(file_offset + unsafe { line.get_unchecked(0..i).chars().count() });
                 }
             });
             self.stack = stack;

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_syntect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_syntect.rs
@@ -191,33 +191,30 @@ fn close_row(s: &mut String) {
     s.push_str("</div></td></tr>");
 }
 
-pub struct JSONGenerator<'a> {
+pub struct RangesGenerator<'a> {
     syntax_set: &'a SyntaxSet,
     parse_state: ParseState,
     position_stack: Vec<(Scope, usize)>,
     stack: ScopeStack,
     data: Vec<(usize, usize, Scope)>,
-    style: ClassStyle,
     code: &'a str,
     max_line_len: Option<usize>,
 }
 
-impl<'a> JSONGenerator<'a> {
+impl<'a> RangesGenerator<'a> {
     pub fn new(
         ss: &'a SyntaxSet,
         sr: &SyntaxReference,
         code: &'a str,
         max_line_len: Option<usize>,
-        style: ClassStyle,
     ) -> Self {
-        JSONGenerator {
+        RangesGenerator {
             code,
             syntax_set: ss,
             parse_state: ParseState::new(sr),
             stack: ScopeStack::new(),
             data: vec![],
             position_stack: vec![],
-            style,
             max_line_len,
         }
     }
@@ -225,9 +222,10 @@ impl<'a> JSONGenerator<'a> {
     // generate takes ownership of self so that it can't be re-used
     pub fn generate(mut self) -> Vec<(usize, usize, Scope)> {
         let mut file_offset = 0;
-        for (i, line) in LinesWithEndings::from(self.code).enumerate() {
+        for (_i, line) in LinesWithEndings::from(self.code).enumerate() {
             if self.max_line_len.map_or(false, |n| line.len() > n) {
-                // TODO
+                // TODO: Not sure what should happen here... close all open
+                // scopes?
             } else {
                 self.write_data_for_tokens(line, file_offset);
             }
@@ -332,6 +330,7 @@ mod tests {
             extension: String::new(),
             theme: String::new(),
             css: true,
+            onlyranges: false,
         };
         let expected = "<table>\
                             <tbody>\
@@ -362,6 +361,7 @@ mod tests {
             extension: String::new(),
             theme: String::new(),
             css: true,
+            onlyranges: false,
         };
         let expected = "<table>\
                             <tbody>\
@@ -411,6 +411,7 @@ mod tests {
             extension: String::new(),
             theme: String::new(),
             css: true,
+            onlyranges: false,
         };
         let expected = "<table>\
                             <tbody>\

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
@@ -108,7 +108,7 @@ pub fn jsonify_err(e: impl ToString) -> JsonValue {
     json!({"error": e.to_string()})
 }
 
-pub fn lsif_highlight(q: SourcegraphQuery) -> Result<JsonValue, JsonValue> {
+pub fn scip_treesitter_highlight(q: SourcegraphQuery) -> Result<JsonValue, JsonValue> {
     let filetype = q
         .filetype
         .ok_or_else(|| json!({"error": "Must pass a filetype for /lsif" }))?
@@ -176,13 +176,13 @@ pub fn index_language_with_config(
     emitter.render(highlights, &code, &get_syntax_kind_for_hl)
 }
 
-struct OffsetManager {
+pub struct OffsetManager {
     source: String,
     offsets: Vec<usize>,
 }
 
 impl OffsetManager {
-    fn new(s: &str) -> Result<Self, Error> {
+    pub fn new(s: &str) -> Result<Self, Error> {
         if s.is_empty() {
             // TODO: Make an error here
             // Error(
@@ -204,7 +204,7 @@ impl OffsetManager {
         Ok(Self { source, offsets })
     }
 
-    fn line_and_col(&self, offset_byte: usize) -> (usize, usize) {
+    pub fn line_and_col(&self, offset_byte: usize) -> (usize, usize) {
         // let offset_char = self.source.bytes
         let mut line = 0;
         for window in self.offsets.windows(2) {
@@ -231,7 +231,7 @@ impl OffsetManager {
     }
 
     // range takes in start and end offsets and returns start/end line/column.
-    fn range(&self, start_byte: usize, end_byte: usize) -> Vec<i32> {
+    pub fn range(&self, start_byte: usize, end_byte: usize) -> Vec<i32> {
         let start_pos = self.line_and_col(start_byte);
         let end_pos = self.line_and_col(end_byte);
 

--- a/docker-images/syntax-highlighter/src/main.rs
+++ b/docker-images/syntax-highlighter/src/main.rs
@@ -6,7 +6,7 @@ extern crate rocket;
 use rocket::serde::json::{json, Json, Value as JsonValue};
 use sg_syntax::SourcegraphQuery;
 
-#[post("/", format = "application/json", data = "<q>")]
+#[post("/html", format = "application/json", data = "<q>")]
 fn syntect(q: Json<SourcegraphQuery>) -> JsonValue {
     // TODO(slimsag): In an ideal world we wouldn't be relying on catch_unwind
     // and instead Syntect would return Result types when failures occur. This
@@ -19,11 +19,20 @@ fn syntect(q: Json<SourcegraphQuery>) -> JsonValue {
     }
 }
 
-#[post("/lsif", format = "application/json", data = "<q>")]
+#[post("/scip", format = "application/json", data = "<q>")]
 fn lsif(q: Json<SourcegraphQuery>) -> JsonValue {
-    match sg_syntax::lsif_highlight(q.into_inner()) {
-        Ok(v) => v,
-        Err(err) => err,
+    let query = q.into_inner();
+
+    if q.usetreesitter {
+        match sg_syntax::scip_syntect_highlight(query) {
+            Ok(v) => v,
+            Err(err) => err,
+        }
+    } else {
+        match sg_syntax::scip_treesitter_highlight(query) {
+            Ok(v) => v,
+            Err(err) => err,
+        }
     }
 }
 

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -42,9 +42,7 @@ type Query struct {
 	// have any use case for these anymore (and haven't for awhile).
 	CSS bool `json:"css"`
 
-	// If set to true instructs the syntax highlight to not return HTML but to
-	// include a list of [start, end, class] tuples.
-	OnlyRanges bool `json:"onlyranges"`
+	UseTreesitter bool `json:"usetreesitter"`
 
 	// LineLengthLimit is the maximum length of line that will be highlighted if set.
 	// Defaults to no max if zero.
@@ -153,9 +151,10 @@ func (c *Client) IsTreesitterSupported(filetype string) bool {
 // automatically do this via the query or something else. It feels a bit goofy
 // to be a separate param. But I need to clean up these other deprecated
 // options later, so it's OK for the first iteration.
-func (c *Client) Highlight(ctx context.Context, q *Query, useTreeSitter bool) (*Response, error) {
+func (c *Client) Highlight(ctx context.Context, q *Query) (*Response, error) {
 	// Normalize filetype
 	q.Filetype = normalizeFiletype(q.Filetype)
+	useTreeSitter := q.UseTreesitter
 
 	if useTreeSitter && !c.IsTreesitterSupported(q.Filetype) {
 		return nil, errors.New("Not a valid treesitter filetype")
@@ -169,7 +168,7 @@ func (c *Client) Highlight(ctx context.Context, q *Query, useTreeSitter bool) (*
 
 	var url string
 	if useTreeSitter {
-		url = "/lsif"
+		url = "/scip"
 	} else {
 		url = "/"
 	}

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -94,7 +94,7 @@ var (
 
 type response struct {
 	// Successful response fields.
-	Data      string `json:"data"`
+	Data      [][]interface{} `json:"data"`
 	Plaintext bool   `json:"plaintext"`
 
 	// Error response fields.
@@ -221,8 +221,9 @@ func (c *Client) Highlight(ctx context.Context, q *Query, useTreeSitter bool) (*
 		}
 		return nil, errors.Wrap(err, c.syntectServer)
 	}
+	res, err := json.Marshal(r.Data)
 	return &Response{
-		Data:      r.Data,
+		Data:      string(res),
 		Plaintext: r.Plaintext,
 	}, nil
 }

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -110,6 +110,7 @@ type rangesresponse struct {
 	response
 
 	// Successful response fields.
+	// This is a list of [number, number, string] tuples
 	Data      [][]interface{} `json:"data"`
 }
 


### PR DESCRIPTION
With the CodeMirror-based blob view we don't need syntax highlighting as annotated HTML, we need the raw token ranges so that we can created CodeMirror decorations from them.

Comparison of of current view (left) vs CodeMirror (right) when opening a ~15k line document: 

https://user-images.githubusercontent.com/179026/179994205-ae92d3c9-5832-4d48-abc2-0e89a9a84821.mp4



**CAVEAT**: I have no idea what I'm doing because I'm not familiar with these parts of the code base and I'm not familiar with Rust.

This PR adds a new query parameter that informs the syntax highlighter to return the ranges only. At the moment the response is returned in the same HTML field, which is not great. Also there is no way to let the client set the query parameter (it's hardcoded).

I've implemented syntax highlighting by only creating decorations for the lines that are currently rendered. Compared to creating all decorations up-front I feel like the "on demand" version loads a tad faster when opening a ~15k line file.

- [ ] Extend GraphQL to allow passing the parameter (unless there is a better way)
- [ ] Extend the response type to include token ranges directly (vs piggybacking on the `html` field)
- [ ] Fix tests (where necessary)
- [ ] Fix ranges (there seems to be an issue with ranges following a line that contains a unicode character; see screenshot)

<img width="658" alt="2022-07-20_14-00" src="https://user-images.githubusercontent.com/179026/179986257-9900464c-628d-4a4e-aba3-00ac22a59a5b.png">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
