### PR TITLE
Search: Fix error when passing double-anchored, single-word arguments to repo:has.description

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1576,7 +1576,11 @@ func parseDescriptionPattern(tr *trace.Trace, p string) ([]*sqlf.Query, error) {
 		} else {
 			// NOTE: We add anchors to each element of `exact`, store the resulting contents in `exactWithAnchors`,
 			// then pass `exactWithAnchors` into the query condition, because using `~* ANY (%s)` is more efficient
-			// than `IN (%s)`.
+			// than `IN (%s)` as it uses the trigram index on `description`.
+			// Equality support for `gin_trgm_ops` was added in Postgres v14, we are currently on v12. If we upgrade our
+			//  min pg version, then this block should be able to be simplified to just pass `exact` directly into
+			// `lower(description) IN (%s)`.
+			// Discussion: https://github.com/sourcegraph/sourcegraph/pull/39117#discussion_r925131158
 			exactWithAnchors := make([]string, len(exact))
 			for i, v := range exact {
 				exactWithAnchors[i] = "^" + v + "$"

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1558,19 +1558,29 @@ func parsePattern(tr *trace.Trace, p string, caseSensitive bool) ([]*sqlf.Query,
 }
 
 func parseDescriptionPattern(tr *trace.Trace, p string) ([]*sqlf.Query, error) {
-	// parseIncludePattern won't ever return exact string matches for patterns passed to repo:description(...)
-	// because they are transformed into fuzzy regexps during job creation
-	_, like, pattern, err := parseIncludePattern(p)
+	exact, like, pattern, err := parseIncludePattern(p)
 	if err != nil {
 		return nil, err
 	}
 
 	tr.LogFields(
 		otlog.String("parseDescriptionPattern", p),
+		trace.Strings("exact", exact),
 		trace.Strings("like", like),
 		otlog.String("pattern", pattern))
 
 	var conds []*sqlf.Query
+	if exact != nil {
+		if len(exact) == 0 || (len(exact) == 1 && exact[0] == "") {
+			conds = append(conds, sqlf.Sprintf("TRUE"))
+		} else {
+			exactWithAnchors := make([]string, len(exact))
+			for i, v := range exact {
+				exactWithAnchors[i] = "^" + v + "$"
+			}
+			conds = append(conds, sqlf.Sprintf("lower(description) ~* ANY (%s)", pq.Array(exactWithAnchors)))
+		}
+	}
 	for _, v := range like {
 		conds = append(conds, sqlf.Sprintf(`lower(description) LIKE %s`, strings.ToLower(v)))
 	}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1574,6 +1574,9 @@ func parseDescriptionPattern(tr *trace.Trace, p string) ([]*sqlf.Query, error) {
 		if len(exact) == 0 || (len(exact) == 1 && exact[0] == "") {
 			conds = append(conds, sqlf.Sprintf("TRUE"))
 		} else {
+			// NOTE: We add anchors to each element of `exact`, store the resulting contents in `exactWithAnchors`,
+			// then pass `exactWithAnchors` into the query condition, because using `~* ANY (%s)` is more efficient
+			// than `IN (%s)`.
 			exactWithAnchors := make([]string, len(exact))
 			for i, v := range exact {
 				exactWithAnchors[i] = "^" + v + "$"


### PR DESCRIPTION
Currently, passing a double-anchored regex pattern without any spaces (e.g. `^foo$`) to `repo:has.description` causes a SQL error because within `parseDescriptionPattern()` the `exact` return value from `parseIncludePattern()` is always ignored, which results in a malformed SQL query when `exact` is non-nil. This was the result of an incorrect assumption by me that because regex patterns passed to `repo:has.description` are always "fuzzed" there will never be an exact string match. However, if the given pattern is something like `^foo$` then the fuzzed pattern will be `(?:^foo$)`, which does have an exact string match. This PR fixes the error by: 
1. Not ignoring the value for `exact` returned by `parseIncludePattern()`
2. Adding start and end anchors to each element of `exact`, then adding the resulting array to the database query condition, if `exact` is non-nil.

Example: `repo:has.description(^foo$)` will now _only_ match repo descriptions that are an _exact_ match of the string `foo`. Currently this query will result in a SQL error.

NOTE: Patterns that are double-anchored but containing spaces currently do not cause an error, because we are fuzzing the pattern passed to `repo:has.description` up-front -- basically we replace spaces with `.*?`. For `repo:has.description(^foo bar$)`, the pattern `^foo bar$` is actually parsed as `(?:^foo).*?(?:bar$)`, and `exact` will be `nil` for this pattern, which is why it doesn't cause an error. If you search for [`repo:has.description(^foo bar$)`](https://sourcegraph.com/search?q=context:global+repo:has.description%28%5Efoo+bar%24%29&patternType=lucky) you'll get repo descriptions that start with `foo` and end with `bar`, with an indeterminate number of characters in between. I'm not yet sure if that is the exact behavior we want, but regex search appears to work similarly: check out the results for [`^foo bar$`](https://sourcegraph.com/search?q=context:global+%5Efoo+bar%24&patternType=regexp). 

In any case this fixes the very obvious and visible bug, and behavior can continue to be refined.

## Test plan
Manually verify in traces that the argument passed to the db query condition for patterns like `^foo$` (double-anchored, single-word) is correct. Relying on existing unit tests for `parseIncludePattern()`.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
