### PR TITLE
dev/sg: support update custom compose file

### DIFF
--- a/dev/sg/internal/images/compose.go
+++ b/dev/sg/internal/images/compose.go
@@ -25,7 +25,7 @@ func UpdateCompose(path string, creds credentials.Credentials, pinTag string) er
 			return nil
 		}
 		if !strings.Contains(d.Name(), "docker-compose.yaml") {
-			return nil
+			std.Out.WriteWarningf("%s is not a docker-compose.yaml file but we will still try to update it anyway", path)
 		}
 
 		std.Out.WriteNoticef("Checking %q", path)


### PR DESCRIPTION
use case:

I want to be able to use `sg` to update non docker-compose.yaml docker-compose files. For example, for MI, I can use `sg` to pin unreleased images

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Create

```sh
curl -o docker-compose.insiders.yaml https://raw.githubusercontent.com/sourcegraph/deploy-sourcegraph-docker/3.41.0/docker-compose/docker-compose.yaml
```

```sh
sg ops update-images -kind compose docker-compose.insiders.yaml
```

the file should be updated to the latest unreleae images