### PR TITLE
[SG-36581] Accessibility: It is time-consuming to navigate back from the ref panel to the file content pane

### DIFF
--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
@@ -257,6 +257,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                                         storageKey={`hierarchical-locations-view-resizable:${group.name}`}
                                         minSize={100}
                                         defaultSize={group.defaultSize}
+                                        ariaLabel="Hierarchical locations sidebar"
                                     >
                                         <div
                                             data-testid="hierarchical-locations-view-list"

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -209,7 +209,9 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
       data-testid="hierarchical-locations-view"
     >
       <div
+        aria-label="Hierarchical locations sidebar"
         class="panel panelLeft panelRelative"
+        role="region"
         style="width: 200px;"
       >
         <div

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -280,7 +280,13 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
             </ErrorBoundary>
             {parseQueryAndHash(props.location.search, props.location.hash).viewState &&
                 props.location.pathname !== PageRoutes.SignIn && (
-                    <Panel className={styles.panel} position="bottom" defaultSize={350} storageKey="panel-size">
+                    <Panel
+                        className={styles.panel}
+                        position="bottom"
+                        defaultSize={350}
+                        storageKey="panel-size"
+                        ariaLabel="References panel"
+                    >
                         <TabbedPanelContent
                             {...props}
                             {...themeProps}

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewPanel.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewPanel.tsx
@@ -26,6 +26,7 @@ export const WorkspacesPreviewPanel: React.FunctionComponent<React.PropsWithChil
             maxSize={0.45 * width}
             position="right"
             storageKey={WORKSPACES_PREVIEW_SIZE}
+            ariaLabel="Workspaces preview sidebar"
         >
             <div className={styles.container}>
                 <WorkspacesPreview isReadOnly={isReadOnly} />

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesPanel.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesPanel.tsx
@@ -18,7 +18,14 @@ export const WorkspacesPanel: React.FunctionComponent<React.PropsWithChildren<Wo
             <Workspaces {...props} />
         </div>
     ) : (
-        <Panel defaultSize={500} minSize={405} maxSize={0.45 * width} position="left" storageKey={WORKSPACES_LIST_SIZE}>
+        <Panel
+            defaultSize={500}
+            minSize={405}
+            maxSize={0.45 * width}
+            position="left"
+            storageKey={WORKSPACES_LIST_SIZE}
+            ariaLabel="Execution workspaces sidebar"
+        >
             <Workspaces {...props} />
         </Panel>
     )

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -93,7 +93,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
     }
 
     return (
-        <Panel defaultSize={256} position="left" storageKey={SIZE_STORAGE_KEY}>
+        <Panel defaultSize={256} position="left" storageKey={SIZE_STORAGE_KEY} ariaLabel="File sidebar">
             <div className="d-flex flex-column h-100 w-100">
                 <GettingStartedTour
                     className="mr-3"

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -122,6 +122,8 @@ export interface BlobProps
     // If set, nav is called when a user clicks on a token highlighted by
     // WebHoverOverlay
     nav?: (url: string) => void
+    role?: string
+    ariaLabel?: string
 }
 
 export interface BlobInfo extends AbsoluteRepoFile, ModeSpec {
@@ -204,6 +206,8 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
         blobInfo,
         platformContext,
         settingsCascade,
+        role,
+        ariaLabel,
         'data-testid': dataTestId,
     } = props
 
@@ -797,6 +801,8 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                 className={classNames(props.className, styles.blob)}
                 ref={nextBlobElement}
                 tabIndex={-1}
+                role={role}
+                aria-label={ariaLabel}
             >
                 <Code
                     className={classNames('test-blob', styles.blobCode, props.wrapCode && styles.blobCodeWrapped)}

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -380,6 +380,8 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                     location={props.location}
                     disableStatusBar={false}
                     disableDecorations={false}
+                    role="region"
+                    ariaLabel="File blob"
                 />
             )}
         </>

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -30,7 +30,14 @@ const staticExtensions: Extension = [
     }),
 ]
 
-export const Blob: React.FunctionComponent<BlobProps> = ({ className, blobInfo, wrapCode, isLightTheme }) => {
+export const Blob: React.FunctionComponent<BlobProps> = ({
+    className,
+    blobInfo,
+    wrapCode,
+    isLightTheme,
+    ariaLabel,
+    role,
+}) => {
     const [container, setContainer] = useState<HTMLDivElement | null>(null)
 
     const dynamicExtensions = useMemo(
@@ -101,5 +108,5 @@ export const Blob: React.FunctionComponent<BlobProps> = ({ className, blobInfo, 
         // logic whenever the content changes
     }, [editor, position, blobInfo])
 
-    return <div ref={setContainer} className={`${className} overflow-hidden`} />
+    return <div ref={setContainer} aria-label={ariaLabel} role={role} className={`${className} overflow-hidden`} />
 }

--- a/client/wildcard/src/components/Panel/Panel.test.tsx
+++ b/client/wildcard/src/components/Panel/Panel.test.tsx
@@ -4,6 +4,6 @@ import { Panel } from './Panel'
 
 describe('Panel', () => {
     it('renders correctly positioned at page bottom', () => {
-        expect(render(<Panel />).asFragment()).toMatchSnapshot()
+        expect(render(<Panel ariaLabel="Test panel" />).asFragment()).toMatchSnapshot()
     })
 })

--- a/client/wildcard/src/components/Panel/Panel.tsx
+++ b/client/wildcard/src/components/Panel/Panel.tsx
@@ -20,6 +20,7 @@ export interface PanelProps extends Omit<UseResizablePanelParameters, 'panelRef'
      */
     handleClassName?: string
     className?: string
+    ariaLabel: string
 }
 
 export const Panel: React.FunctionComponent<React.PropsWithChildren<PanelProps>> = ({
@@ -32,6 +33,7 @@ export const Panel: React.FunctionComponent<React.PropsWithChildren<PanelProps>>
     handleClassName,
     minSize,
     maxSize,
+    ariaLabel,
 }) => {
     const handleReference = useRef<HTMLDivElement | null>(null)
     const panelReference = useRef<HTMLDivElement | null>(null)
@@ -57,6 +59,8 @@ export const Panel: React.FunctionComponent<React.PropsWithChildren<PanelProps>>
                 getDisplayStyle({ isFloating })
             )}
             ref={panelReference}
+            role="region"
+            aria-label={ariaLabel}
         >
             <div
                 ref={handleReference}

--- a/client/wildcard/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/client/wildcard/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`Panel renders correctly positioned at page bottom 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Test panel"
     class="panel panelBottom panelRelative"
+    role="region"
     style="height: 200px;"
   >
     <div

--- a/client/wildcard/src/components/Panel/story/Panel.story.tsx
+++ b/client/wildcard/src/components/Panel/story/Panel.story.tsx
@@ -105,7 +105,7 @@ export const Simple: Story = () => {
                 defaultSize={200}
                 storageKey={`size-cache-${position}`}
                 className={styles.panel}
-                ariaLabel="Sorybook panel"
+                ariaLabel="Storybook panel"
             >
                 <PanelBodyContent position={position}>
                     <b>{position}</b> panel content

--- a/client/wildcard/src/components/Panel/story/Panel.story.tsx
+++ b/client/wildcard/src/components/Panel/story/Panel.story.tsx
@@ -105,6 +105,7 @@ export const Simple: Story = () => {
                 defaultSize={200}
                 storageKey={`size-cache-${position}`}
                 className={styles.panel}
+                ariaLabel="Sorybook panel"
             >
                 <PanelBodyContent position={position}>
                     <b>{position}</b> panel content
@@ -123,7 +124,7 @@ export const WithChildren: Story = (props = {}) => {
     const closePanel = () => setTabIndex(-1)
 
     return (
-        <Panel {...props}>
+        <Panel {...props} ariaLabel="Storybook panel">
             <Tabs index={tabIndex} size="small">
                 <div className={classNames('tablist-wrapper d-flex justify-content-between sticky-top')}>
                     <TabList>


### PR DESCRIPTION
### Audit type
Screen reader navigation

### User journey audit issue
[#33510](https://github.com/sourcegraph/sourcegraph/issues/33510)

### Problem description
After the focus has moved to the ref panel, navigating the focus back to the blob view is quite time-consuming (hold Shift + Tab for long or lots of key presses). This makes using the ref panel tedious.

(This point applies to keyboard navigation too.)

### Expected behavior
I think we should modify the tab hierarchy or the page structure so that one can quickly navigate back from the ref panel to the blob view, perhaps to the specific part where the code intel popover was triggered.

### Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/36581)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-36581)

### Test Plan
- Run app on feature branch / preview link
- visit the blob page.
- Verify that all regions are appropriately shown.
- Sample below

<img width="445" alt="Screenshot 2022-07-20 at 11 41 20 AM" src="https://user-images.githubusercontent.com/89894075/179963376-8637ad5e-83f0-4970-aac5-0c6be22ce7ee.png">

 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-contractors-sg-36581.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ubvhbuufta.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
