### PR TITLE
Wildcard: Improve `<Icon />` docs

### DIFF
--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -43,6 +43,19 @@ interface HiddenIconProps extends BaseIconProps {
 
 export type IconProps = HiddenIconProps | ScreenReaderIconProps
 
+/**
+ * Renders an Icon.
+ *
+ * We have two types of icons:
+ * - [Material design icons](https://materialdesignicons.com): These should be imported from `@mdi/js` and used as the `svgPath` prop.
+ * Example: `<Icon svgPath={mdiIcon} />`
+ *
+ * - Custom icons: We can use this directly by passing the icon component as the `as` prop.
+ * Example: `<Icon as={SourcegraphLogo} />`
+ *
+ * Note: In order to be accessible, we enforce that either an `aria-label` OR an `aria-hidden` prop is provided.
+ * If the icon is not decorative, and adds value to the users journey, we should use a descriptive `aria-label`.
+ */
 // eslint-disable-next-line react/display-name
 export const Icon = React.memo(
     React.forwardRef(function Icon({ children, className, size, role = 'img', inline = true, ...props }, reference) {


### PR DESCRIPTION
## Description

Adds a `JSDoc` comment to our `Icon` component will some additional information

We're pretty close to removing `mdi-react` so I haven't included that here.

## Test plan

N/A - Docs only.

## App preview:

- [Web](https://sg-web-tr-improve-icon-docs.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-onyaajhckq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
