### PR TITLE
[SG-37916] Repo header nav bar doesn't show up in Safari even at wide window widths

### DIFF
--- a/client/web/src/util/dom.ts
+++ b/client/web/src/util/dom.ts
@@ -74,12 +74,13 @@ export function useBreakpoint(size: keyof typeof breakpoints, debounceMs = 50): 
                     debounceTime(debounceMs),
                     map(entry => {
                         const borderBoxSize = normalizeResizeObserverSize(entry?.borderBoxSize)
+                        const width = borderBoxSize?.inlineSize ?? entry?.contentRect.width
 
-                        if (!borderBoxSize) {
+                        if (!width) {
                             return false
                         }
 
-                        return borderBoxSize.inlineSize >= breakpoint
+                        return width >= breakpoint
                     }),
                     // TODO: debug log.
                     // On error, be conservative and report that the screen is smaller than the breakpoint

--- a/client/web/src/util/dom.ts
+++ b/client/web/src/util/dom.ts
@@ -74,6 +74,7 @@ export function useBreakpoint(size: keyof typeof breakpoints, debounceMs = 50): 
                     debounceTime(debounceMs),
                     map(entry => {
                         const borderBoxSize = normalizeResizeObserverSize(entry?.borderBoxSize)
+                        // contentRect used as fallback for versions of safari that does not support borderBoxSize
                         const width = borderBoxSize?.inlineSize ?? entry?.contentRect.width
 
                         if (!width) {


### PR DESCRIPTION
### Description
Repo Header nav bar fixed for safari

### Problem description

Works fine in Chrome:

![](https://user-images.githubusercontent.com/93103176/176384396-c7a5de84-7f1a-4abc-ba5d-b34554e87a6a.png)

Works fine in Firefox:

![](https://user-images.githubusercontent.com/93103176/176384524-79264512-7d75-489f-8580-1274475cb579.png)

Is compressed in Safari:

![](https://user-images.githubusercontent.com/93103176/176384610-7f689954-8c6d-4305-90c8-51abb9637f33.png)

### Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/37916)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-37916)

### Steps to reproduce

Open any Sourcegraph URL in Safari. I hadn't logged in. Tested with Safari Version 15.3 (17612.4.9.1.8) on macOS 12.2.1 (21D62). ([example file that I used](https://sourcegraph.com/github.com/abpframework/abp/-/blob/npm/ng-packs/packages/core/src/lib/tokens/options.token.ts))

### Test Plan
1) Run app with changes on this PR
2) Go to a repo page.
3) View page on large screen size device.
4) Repo header action items should be visible instead of being collapsed and visible only on dropdown trigger.

Note: The existing issue occurs on <v14 safari, preferably test should be carried out using those Safari versions


## App preview:

- [Web](https://sg-web-contractors-sg-37916.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cdkbpflixe.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

