### PR TITLE
Add extensions as core features feature flag

### DIFF
--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -33,6 +33,7 @@ export interface Settings {
             forNerds?: boolean
         }
         enableExtensionsDecorationsColumnView?: boolean
+        extensionsAsCoreFeatures?: boolean
     }
     [key: string]: any
 

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -59,6 +59,20 @@ export function enableExtensionsDecorationsColumnViewFromSettings(settingsCascad
 }
 
 /**
+ * Whether user wants to use default extensions functionality as core product features instead of the corresponding extensions.
+ */
+export function useExtensionsAsCoreFeaturesFromSettings(settingsCascade: SettingsCascadeOrError): boolean {
+    if (!settingsCascade.final) {
+        return false
+    }
+    if (isErrorLike(settingsCascade.final)) {
+        return false
+    }
+
+    return settingsCascade.final.experimentalFeatures?.extensionsAsCoreFeatures === true
+}
+
+/**
  * Returns undefined if the settings cannot be loaded or if the setting doesn't
  * exist.
  */

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1739,6 +1739,8 @@ type SettingsExperimentalFeatures struct {
 	EnableSearchStack *bool `json:"enableSearchStack,omitempty"`
 	// EnableSmartQuery description: REMOVED. Previously, added more syntax highlighting and hovers for queries in the web app. This behavior is active by default now.
 	EnableSmartQuery *bool `json:"enableSmartQuery,omitempty"`
+	// ExtensionsAsCoreFeatures description: Use default extensions (Git extras, Open in editor, Search export) functionality as core features instead of extensions.
+	ExtensionsAsCoreFeatures *bool `json:"extensionsAsCoreFeatures,omitempty"`
 	// FuzzyFinder description: Enables fuzzy finder with the keyboard shortcut `Cmd+K` on macOS and `Ctrl+K` on Linux/Windows.
 	FuzzyFinder *bool `json:"fuzzyFinder,omitempty"`
 	// FuzzyFinderCaseInsensitiveFileCountThreshold description: The maximum number of files a repo can have to use case-insensitive fuzzy finding

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -325,6 +325,14 @@
             "pointer": true
           }
         },
+        "extensionsAsCoreFeatures": {
+          "description": "Use default extensions (Git extras, Open in editor, Search export) functionality as core features instead of extensions.",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
+        },
         "codeInsightsCompute": {
           "description": "Enables Compute powered Code Insights",
           "type": "boolean",


### PR DESCRIPTION
Adds `extensionsAsCoreFeatures` experimental feature to rely on during the extensions sunset and default extensions migration.

## Test plan
Ensure `extensionsAsCoreFeatures` experimental feature is available.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
