### PR TITLE
Tree: add "go up" the tree button

### DIFF
--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -489,12 +489,14 @@ describe('Repository', () => {
             )
             await driver.page.waitForSelector('.test-tree-file-link')
             assert.strictEqual(
-                await driver.page.evaluate(() => document.querySelector('.test-tree-file-link')?.textContent),
+                await driver.page.evaluate(() => document.querySelectorAll('.test-tree-file-link')?.[1].textContent),
                 fileName
             )
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement
-            await driver.page.$eval('.test-tree-file-link', linkElement => (linkElement as HTMLElement).click())
+            await driver.page.$eval('.test-tree-file-link', (linkElements: HTMLElement[]) => {
+                linkElements[1].click()
+            })
             await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             await driver.page.waitForSelector('.test-breadcrumb')
@@ -1000,9 +1002,8 @@ describe('Repository', () => {
                                             return {
                                                 uri: file.uri,
                                                 after: {
-                                                    contentText: `${
-                                                        name.split('').filter(char => vowels.includes(char)).length
-                                                    } vowels`,
+                                                    contentText: `${name.split('').filter(char => vowels.includes(char)).length
+                                                        } vowels`,
                                                     color: file.isDirectory ? 'red' : 'blue',
                                                 },
                                                 meter: {

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -451,6 +451,8 @@ describe('Repository', () => {
             const fileName = '% token.4288249258.sql'
             const directoryName = "Geoffrey's random queries.32r242442bf"
             const filePath = path.posix.join(directoryName, fileName)
+            const fileUrl =
+                '/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql'
 
             testContext.overrideGraphQL({
                 ...commonWebGraphQlResults,
@@ -472,8 +474,7 @@ describe('Repository', () => {
                                         name: fileName,
                                         path: filePath,
                                         isDirectory: false,
-                                        url:
-                                            '/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql',
+                                        url: fileUrl,
                                         submodule: null,
                                         isSingleChild: false,
                                     },
@@ -484,19 +485,19 @@ describe('Repository', () => {
                 }),
             })
 
+            const fileSelector = `.test-tree-file-link[href="${fileUrl}"]`
+
             await driver.page.goto(
                 `${driver.sourcegraphBaseUrl}/github.com/ggilmore/q-test/-/tree/Geoffrey's%20random%20queries.32r242442bf`
             )
-            await driver.page.waitForSelector('.test-tree-file-link')
+            await driver.page.waitForSelector(fileSelector)
             assert.strictEqual(
-                await driver.page.evaluate(() => document.querySelectorAll('.test-tree-file-link')?.[1].textContent),
+                await driver.page.evaluate(() => document.querySelector(fileSelector)?.textContent),
                 fileName
             )
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement
-            await driver.page.$eval('.test-tree-file-link', (linkElements: HTMLElement[]) => {
-                linkElements[1].click()
-            })
+            await driver.page.$eval(fileSelector, linkElement => (linkElement as HTMLElement).click())
             await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             await driver.page.waitForSelector('.test-breadcrumb')
@@ -1002,8 +1003,9 @@ describe('Repository', () => {
                                             return {
                                                 uri: file.uri,
                                                 after: {
-                                                    contentText: `${name.split('').filter(char => vowels.includes(char)).length
-                                                        } vowels`,
+                                                    contentText: `${
+                                                        name.split('').filter(char => vowels.includes(char)).length
+                                                    } vowels`,
                                                     color: file.isDirectory ? 'red' : 'blue',
                                                 },
                                                 meter: {

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -485,19 +485,17 @@ describe('Repository', () => {
                 }),
             })
 
-            const fileSelector = `.test-tree-file-link[href="${fileUrl}"]`
-
             await driver.page.goto(
                 `${driver.sourcegraphBaseUrl}/github.com/ggilmore/q-test/-/tree/Geoffrey's%20random%20queries.32r242442bf`
             )
-            await driver.page.waitForSelector(fileSelector)
+            await driver.page.waitForSelector('.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql]')
             assert.strictEqual(
-                await driver.page.evaluate(() => document.querySelector(fileSelector)?.textContent),
+                await driver.page.evaluate(() => document.querySelector('.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql]')?.textContent),
                 fileName
             )
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement
-            await driver.page.$eval(fileSelector, linkElement => (linkElement as HTMLElement).click())
+            await driver.page.$eval('.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql]', linkElement => (linkElement as HTMLElement).click())
             await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             await driver.page.waitForSelector('.test-breadcrumb')
@@ -1003,9 +1001,8 @@ describe('Repository', () => {
                                             return {
                                                 uri: file.uri,
                                                 after: {
-                                                    contentText: `${
-                                                        name.split('').filter(char => vowels.includes(char)).length
-                                                    } vowels`,
+                                                    contentText: `${name.split('').filter(char => vowels.includes(char)).length
+                                                        } vowels`,
                                                     color: file.isDirectory ? 'red' : 'blue',
                                                 },
                                                 meter: {

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -488,14 +488,22 @@ describe('Repository', () => {
             await driver.page.goto(
                 `${driver.sourcegraphBaseUrl}/github.com/ggilmore/q-test/-/tree/Geoffrey's%20random%20queries.32r242442bf`
             )
-            await driver.page.waitForSelector('.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql]')
+            await driver.page.waitForSelector('.test-tree-file-link')
             assert.strictEqual(
-                await driver.page.evaluate(() => document.querySelector('.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql]')?.textContent),
+                await driver.page.evaluate(
+                    () =>
+                        document.querySelector(
+                            '.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql"]'
+                        )?.textContent
+                ),
                 fileName
             )
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement
-            await driver.page.$eval('.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql]', linkElement => (linkElement as HTMLElement).click())
+            await driver.page.$eval(
+                '.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql"]',
+                linkElement => (linkElement as HTMLElement).click()
+            )
             await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             await driver.page.waitForSelector('.test-breadcrumb')

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -451,8 +451,6 @@ describe('Repository', () => {
             const fileName = '% token.4288249258.sql'
             const directoryName = "Geoffrey's random queries.32r242442bf"
             const filePath = path.posix.join(directoryName, fileName)
-            const fileUrl =
-                '/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql'
 
             testContext.overrideGraphQL({
                 ...commonWebGraphQlResults,
@@ -474,7 +472,8 @@ describe('Repository', () => {
                                         name: fileName,
                                         path: filePath,
                                         isDirectory: false,
-                                        url: fileUrl,
+                                        url:
+                                            '/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql',
                                         submodule: null,
                                         isSingleChild: false,
                                     },
@@ -1009,8 +1008,9 @@ describe('Repository', () => {
                                             return {
                                                 uri: file.uri,
                                                 after: {
-                                                    contentText: `${name.split('').filter(char => vowels.includes(char)).length
-                                                        } vowels`,
+                                                    contentText: `${
+                                                        name.split('').filter(char => vowels.includes(char)).length
+                                                    } vowels`,
                                                     color: file.isDirectory ? 'red' : 'blue',
                                                 },
                                                 meter: {

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -5,8 +5,10 @@ import { FileDecorationsByPath } from '@sourcegraph/shared/src/api/extension/ext
 import { dirname } from '../util/path'
 
 import { TreeLayerTable } from './components'
+import { GO_UP_TREE_LABEL } from './constants'
 import { File } from './File'
 import { SingleChildTreeLayer } from './SingleChildTreeLayer'
+import { TreeContext } from './TreeContext'
 import { TreeLayer } from './TreeLayer'
 import { TreeRootProps } from './TreeRoot'
 import { hasSingleChild, SingleChildGitTree, TreeEntryInfo } from './util'
@@ -20,7 +22,6 @@ interface ChildTreeLayerProps extends Pick<TreeRootProps, Exclude<keyof TreeRoot
     /** The children entries of a SingleChildTreeLayer. Will be undefined if there is no SingleChildTreeLayer to render. */
     childrenEntries?: SingleChildGitTree[]
     onHover: (filePath: string) => void
-    treeUrl: string
 }
 
 /**
@@ -60,24 +61,28 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                         <tr>
                             <td>
                                 <TreeLayerTable>
-                                    <File
-                                        entryInfo={{
-                                            name: '..',
-                                            path: props.parentPath as string,
-                                            isDirectory: false,
-                                            url: dirname(props.treeUrl),
-                                            isSingleChild: false,
-                                            submodule: null,
-                                        }}
-                                        depth={sharedProps.depth}
-                                        index={0}
-                                        isLightTheme={sharedProps.isLightTheme}
-                                        handleTreeClick={() => undefined}
-                                        noopRowClick={() => undefined}
-                                        linkRowClick={() => props.telemetryService.log('FileTreeClick')}
-                                        isActive={false}
-                                        isSelected={false}
-                                    />
+                                    <TreeContext.Consumer>
+                                        {treeContext => (
+                                            <File
+                                                entryInfo={{
+                                                    name: GO_UP_TREE_LABEL,
+                                                    path: props.parentPath as string,
+                                                    isDirectory: false,
+                                                    url: dirname(treeContext.rootTreeUrl),
+                                                    isSingleChild: false,
+                                                    submodule: null,
+                                                }}
+                                                depth={sharedProps.depth}
+                                                index={0}
+                                                isLightTheme={sharedProps.isLightTheme}
+                                                handleTreeClick={() => undefined}
+                                                noopRowClick={() => undefined}
+                                                linkRowClick={() => props.telemetryService.log('FileTreeClick')}
+                                                isActive={false}
+                                                isSelected={false}
+                                            />
+                                        )}
+                                    </TreeContext.Consumer>
                                 </TreeLayerTable>
                             </td>
                         </tr>
@@ -96,7 +101,6 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                     fileDecorationsByPath={props.fileDecorationsByPath}
                                     fileDecorations={props.fileDecorationsByPath[props.singleChildTreeEntry.path]}
                                     telemetryService={props.telemetryService}
-                                    treeUrl={props.treeUrl}
                                 />
                             ) : (
                                 props.entries.map((item, index) => (
@@ -109,7 +113,6 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                         entryInfo={item}
                                         fileDecorations={props.fileDecorationsByPath[item.path]}
                                         telemetryService={props.telemetryService}
-                                        treeUrl={props.treeUrl}
                                     />
                                 ))
                             )}

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -8,7 +8,7 @@ import { TreeLayerTable } from './components'
 import { GO_UP_TREE_LABEL } from './constants'
 import { File } from './File'
 import { SingleChildTreeLayer } from './SingleChildTreeLayer'
-import { TreeContext } from './TreeContext'
+import { TreeRootContext } from './TreeContext'
 import { TreeLayer } from './TreeLayer'
 import { TreeRootProps } from './TreeRoot'
 import { hasSingleChild, SingleChildGitTree, TreeEntryInfo } from './util'
@@ -61,14 +61,14 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                         <tr>
                             <td>
                                 <TreeLayerTable>
-                                    <TreeContext.Consumer>
-                                        {treeContext => (
+                                    <TreeRootContext.Consumer>
+                                        {treeRootContext => (
                                             <File
                                                 entryInfo={{
                                                     name: GO_UP_TREE_LABEL,
                                                     path: props.parentPath as string,
                                                     isDirectory: false,
-                                                    url: dirname(treeContext.rootTreeUrl),
+                                                    url: dirname(treeRootContext.rootTreeUrl),
                                                     isSingleChild: false,
                                                     submodule: null,
                                                 }}
@@ -82,7 +82,7 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                                 isSelected={false}
                                             />
                                         )}
-                                    </TreeContext.Consumer>
+                                    </TreeRootContext.Consumer>
                                 </TreeLayerTable>
                             </td>
                         </tr>

--- a/client/web/src/tree/Directory.tsx
+++ b/client/web/src/tree/Directory.tsx
@@ -15,6 +15,7 @@ import {
     TreeRowLabelLink,
     TreeRow,
 } from './components'
+import { MAX_TREE_ENTRIES } from './constants'
 import { FileDecorator } from './FileDecorator'
 import { TreeEntryInfo, treePadding } from './util'
 
@@ -24,7 +25,6 @@ interface DirectoryProps extends ThemeProps {
     className?: string
     entryInfo: TreeEntryInfo
     isExpanded: boolean
-    maxEntries: number
     loading: boolean
     handleTreeClick: () => void
     noopRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
@@ -88,7 +88,7 @@ export const Directory: React.FunctionComponent<React.PropsWithChildren<Director
                     </div>
                 )}
             </TreeLayerRowContents>
-            {props.index === props.maxEntries - 1 && (
+            {props.index === MAX_TREE_ENTRIES - 1 && (
                 <TreeRowAlert
                     variant="warning"
                     style={treePadding(props.depth, true, true)}

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -17,8 +17,9 @@ import {
     TreeRowLabel,
     TreeRow,
 } from './components'
+import { MAX_TREE_ENTRIES } from './constants'
 import { FileDecorator } from './FileDecorator'
-import { maxEntries, TreeEntryInfo, treePadding } from './util'
+import { TreeEntryInfo, treePadding } from './util'
 
 interface FileProps extends ThemeProps {
     fileDecorations?: FileDecoration[]
@@ -26,7 +27,6 @@ interface FileProps extends ThemeProps {
     depth: number
     index: number
     className?: string
-    maxEntries: number
     handleTreeClick: () => void
     noopRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
     linkRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
@@ -103,7 +103,7 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
                         </TreeLayerRowContentsText>
                     </TreeLayerRowContentsLink>
                 )}
-                {props.index === maxEntries - 1 && (
+                {props.index === MAX_TREE_ENTRIES - 1 && (
                     <TreeRowAlert
                         variant="warning"
                         style={treePadding(props.depth, true)}

--- a/client/web/src/tree/SingleChildTreeLayer.tsx
+++ b/client/web/src/tree/SingleChildTreeLayer.tsx
@@ -10,7 +10,7 @@ import { TreeLayerTable } from './components'
 import { Directory } from './Directory'
 import { TreeNode } from './Tree'
 import { TreeLayerProps } from './TreeLayer'
-import { maxEntries, SingleChildGitTree } from './util'
+import { SingleChildGitTree } from './util'
 
 interface SingleChildTreeLayerProps extends TreeLayerProps {
     childrenEntries: SingleChildGitTree[]
@@ -134,7 +134,6 @@ export class SingleChildTreeLayer extends React.Component<SingleChildTreeLayerPr
                             depth={this.props.depth}
                             index={this.props.index}
                             isLightTheme={this.props.isLightTheme}
-                            maxEntries={maxEntries}
                             loading={false}
                             handleTreeClick={this.handleTreeClick}
                             noopRowClick={this.noopRowClick}

--- a/client/web/src/tree/Tree.tsx
+++ b/client/web/src/tree/Tree.tsx
@@ -213,7 +213,6 @@ export class Tree extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props)
 
-        const parentPath = dotPathAsUndefined(props.activePathIsDir ? props.activePath : dirname(props.activePath))
         this.node = {
             index: 0,
             parent: null,
@@ -223,7 +222,7 @@ export class Tree extends React.PureComponent<Props, State> {
         }
 
         this.state = {
-            parentPath,
+            parentPath: dotPathAsUndefined(props.activePathIsDir ? props.activePath : dirname(props.activePath)),
             resolveTo: [],
             selectedNode: this.node,
             activeNode: this.node,

--- a/client/web/src/tree/TreeContext.tsx
+++ b/client/web/src/tree/TreeContext.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
-export interface TreeContext {
+export interface TreeRootContext {
     rootTreeUrl: string
 }
 
-export const TreeContext = React.createContext<TreeContext>({
+export const TreeRootContext = React.createContext<TreeRootContext>({
     rootTreeUrl: '',
 })

--- a/client/web/src/tree/TreeContext.tsx
+++ b/client/web/src/tree/TreeContext.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export interface TreeContext {
+    rootTreeUrl: string
+}
+
+export const TreeContext = React.createContext<TreeContext>({
+    rootTreeUrl: '',
+})

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -43,7 +43,6 @@ export interface TreeLayerProps extends Omit<TreeRootProps, 'sizeKey'> {
     entryInfo: TreeEntryInfo
     fileDecorations?: FileDecoration[]
     onHover: (filePath: string) => void
-    treeUrl: string
 }
 
 const LOADING = 'loading' as const

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -25,6 +25,7 @@ import { requestGraphQL } from '../backend/graphql'
 
 import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeLayerCell, TreeLayerTable, TreeRowAlert } from './components'
+import { MAX_TREE_ENTRIES } from './constants'
 import { Directory } from './Directory'
 import { File } from './File'
 import { TreeNode } from './Tree'
@@ -32,7 +33,6 @@ import { TreeRootProps } from './TreeRoot'
 import {
     compareTreeProps,
     hasSingleChild,
-    maxEntries,
     singleChildEntriesToGitTree,
     SingleChildGitTree,
     TreeEntryInfo,
@@ -43,6 +43,7 @@ export interface TreeLayerProps extends Omit<TreeRootProps, 'sizeKey'> {
     entryInfo: TreeEntryInfo
     fileDecorations?: FileDecoration[]
     onHover: (filePath: string) => void
+    treeUrl: string
 }
 
 const LOADING = 'loading' as const
@@ -86,7 +87,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                     revision: props.revision,
                     commitID: props.commitID,
                     filePath: props.parentPath || '',
-                    first: maxEntries,
+                    first: MAX_TREE_ENTRIES,
                     requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                 }).pipe(
                     catchError(error => [asError(error)]),
@@ -149,7 +150,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                             revision: this.props.revision,
                             commitID: this.props.commitID,
                             filePath: path,
-                            first: maxEntries,
+                            first: MAX_TREE_ENTRIES,
                             requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                         }).pipe(catchError(error => [asError(error)]))
                     )
@@ -279,7 +280,6 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                     depth={this.props.depth}
                                     index={this.props.index}
                                     isLightTheme={this.props.isLightTheme}
-                                    maxEntries={maxEntries}
                                     loading={treeOrError === LOADING}
                                     handleTreeClick={this.handleTreeClick}
                                     noopRowClick={this.noopRowClick}
@@ -323,7 +323,6 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                 depth={this.props.depth}
                                 index={this.props.index}
                                 isLightTheme={this.props.isLightTheme}
-                                maxEntries={maxEntries}
                                 handleTreeClick={this.handleTreeClick}
                                 noopRowClick={this.noopRowClick}
                                 linkRowClick={this.linkRowClick}

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -27,20 +27,12 @@ import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { getFileDecorations } from '../backend/features'
 import { requestGraphQL } from '../backend/graphql'
-import { dirname } from '../util/path'
 
 import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeLayerTable, TreeLayerCell, TreeRowAlert } from './components'
+import { MAX_TREE_ENTRIES } from './constants'
 import { TreeNode } from './Tree'
-import {
-    hasSingleChild,
-    compareTreeProps,
-    singleChildEntriesToGitTree,
-    SingleChildGitTree,
-    prependGoUpOnce,
-} from './util'
-
-const maxEntries = 2500
+import { hasSingleChild, compareTreeProps, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
 
 const errorWidth = (width?: string): { width: string } => ({
     width: width ? `${width}px` : 'auto',
@@ -104,7 +96,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                     revision: props.revision,
                     commitID: props.commitID,
                     filePath: props.parentPath || '',
-                    first: maxEntries,
+                    first: MAX_TREE_ENTRIES,
                     requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                 }).pipe(
                     catchError(error => [asError(error)]),
@@ -117,15 +109,6 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
         this.subscriptions.add(
             treeOrErrors.subscribe(
                 treeOrError => {
-                    // Append '..'
-                    if (treeOrError && treeOrError !== LOADING && !isErrorLike(treeOrError)) {
-                        treeOrError = prependGoUpOnce(
-                            treeOrError,
-                            dirname(this.props.parentPath ?? ''),
-                            dirname(treeOrError.url)
-                        )
-                    }
-
                     // clear file decorations before latest file decorations come
                     this.setState({ treeOrError, fileDecorationsByPath: {} })
                 },
@@ -166,7 +149,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                             revision: this.props.revision,
                             commitID: this.props.commitID,
                             filePath: path,
-                            first: maxEntries,
+                            first: MAX_TREE_ENTRIES,
                             requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                         }).pipe(catchError(error => [asError(error)]))
                     )
@@ -229,6 +212,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                                                 parent={this.node}
                                                 depth={-1 as number}
                                                 entries={treeOrError.entries}
+                                                treeUrl={treeOrError.url}
                                                 singleChildTreeEntry={singleChildTreeEntry}
                                                 childrenEntries={singleChildTreeEntry.children}
                                                 onHover={this.fetchChildContents}

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -27,11 +27,18 @@ import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { getFileDecorations } from '../backend/features'
 import { requestGraphQL } from '../backend/graphql'
+import { dirname } from '../util/path'
 
 import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeLayerTable, TreeLayerCell, TreeRowAlert } from './components'
 import { TreeNode } from './Tree'
-import { hasSingleChild, compareTreeProps, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
+import {
+    hasSingleChild,
+    compareTreeProps,
+    singleChildEntriesToGitTree,
+    SingleChildGitTree,
+    prependGoUpOnce,
+} from './util'
 
 const maxEntries = 2500
 
@@ -110,6 +117,15 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
         this.subscriptions.add(
             treeOrErrors.subscribe(
                 treeOrError => {
+                    // Append '..'
+                    if (treeOrError && treeOrError !== LOADING && !isErrorLike(treeOrError)) {
+                        treeOrError = prependGoUpOnce(
+                            treeOrError,
+                            dirname(this.props.parentPath ?? ''),
+                            dirname(treeOrError.url)
+                        )
+                    }
+
                     // clear file decorations before latest file decorations come
                     this.setState({ treeOrError, fileDecorationsByPath: {} })
                 },

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -32,7 +32,7 @@ import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeLayerTable, TreeLayerCell, TreeRowAlert } from './components'
 import { MAX_TREE_ENTRIES } from './constants'
 import { TreeNode } from './Tree'
-import { TreeContext } from './TreeContext'
+import { TreeRootContext } from './TreeContext'
 import { hasSingleChild, compareTreeProps, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
 
 const errorWidth = (width?: string): { width: string } => ({
@@ -208,7 +208,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                                         </div>
                                     ) : (
                                         treeOrError && (
-                                            <TreeContext.Provider
+                                            <TreeRootContext.Provider
                                                 value={{
                                                     rootTreeUrl: treeOrError.url,
                                                 }}
@@ -224,7 +224,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                                                     setChildNodes={this.setChildNode}
                                                     fileDecorationsByPath={this.state.fileDecorationsByPath}
                                                 />
-                                            </TreeContext.Provider>
+                                            </TreeRootContext.Provider>
                                         )
                                     )}
                                 </TreeLayerCell>

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -32,6 +32,7 @@ import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeLayerTable, TreeLayerCell, TreeRowAlert } from './components'
 import { MAX_TREE_ENTRIES } from './constants'
 import { TreeNode } from './Tree'
+import { TreeContext } from './TreeContext'
 import { hasSingleChild, compareTreeProps, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
 
 const errorWidth = (width?: string): { width: string } => ({
@@ -207,18 +208,23 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                                         </div>
                                     ) : (
                                         treeOrError && (
-                                            <ChildTreeLayer
-                                                {...this.props}
-                                                parent={this.node}
-                                                depth={-1 as number}
-                                                entries={treeOrError.entries}
-                                                treeUrl={treeOrError.url}
-                                                singleChildTreeEntry={singleChildTreeEntry}
-                                                childrenEntries={singleChildTreeEntry.children}
-                                                onHover={this.fetchChildContents}
-                                                setChildNodes={this.setChildNode}
-                                                fileDecorationsByPath={this.state.fileDecorationsByPath}
-                                            />
+                                            <TreeContext.Provider
+                                                value={{
+                                                    rootTreeUrl: treeOrError.url,
+                                                }}
+                                            >
+                                                <ChildTreeLayer
+                                                    {...this.props}
+                                                    parent={this.node}
+                                                    depth={-1 as number}
+                                                    entries={treeOrError.entries}
+                                                    singleChildTreeEntry={singleChildTreeEntry}
+                                                    childrenEntries={singleChildTreeEntry.children}
+                                                    onHover={this.fetchChildContents}
+                                                    setChildNodes={this.setChildNode}
+                                                    fileDecorationsByPath={this.state.fileDecorationsByPath}
+                                                />
+                                            </TreeContext.Provider>
                                         )
                                     )}
                                 </TreeLayerCell>

--- a/client/web/src/tree/constants.ts
+++ b/client/web/src/tree/constants.ts
@@ -1,2 +1,4 @@
 // Used in requests and components
 export const MAX_TREE_ENTRIES = 2500
+
+export const GO_UP_TREE_LABEL = '..'

--- a/client/web/src/tree/constants.ts
+++ b/client/web/src/tree/constants.ts
@@ -1,0 +1,2 @@
+// Used in requests and components
+export const MAX_TREE_ENTRIES = 2500

--- a/client/web/src/tree/util.tsx
+++ b/client/web/src/tree/util.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 
-import { cloneDeep } from 'lodash'
-
-import { TreeEntryFields, TreeFields } from '@sourcegraph/shared/src/graphql-operations'
+import { TreeEntryFields } from '@sourcegraph/shared/src/graphql-operations'
 
 import { TreeRootProps } from './TreeRoot'
 
@@ -52,8 +50,6 @@ export const treePadding = (depth: number, isTree: boolean, isDirectory = false)
     marginLeft: `${depth * 12 + (isTree ? 0 : 12) + (isDirectory ? 0 : 8)}px`,
     paddingRight: '1rem',
 })
-
-export const maxEntries = 2500
 
 // Utility functions to handle single-child directories:
 
@@ -107,27 +103,4 @@ export function compareTreeProps(a: ComparisonTreeRootProps, b: ComparisonTreeRo
         a.isExpanded === b.isExpanded &&
         a.location === b.location
     )
-}
-
-export function prependGoUpOnce(tree: TreeFields, goUpPath: string, goUpUrl: string): TreeFields {
-    if (!tree.isRoot) {
-        const firstEntryPath = tree.entries?.[0].path ?? null
-        if (firstEntryPath !== goUpPath) {
-            const newTree = cloneDeep(tree)
-            newTree.entries = [
-                {
-                    name: '..',
-                    path: goUpPath,
-                    isDirectory: false,
-                    url: goUpUrl,
-                    isSingleChild: !tree.entries.length,
-                    submodule: null,
-                },
-                ...tree.entries,
-            ]
-            return newTree
-        }
-    }
-
-    return tree
 }

--- a/client/web/src/tree/util.tsx
+++ b/client/web/src/tree/util.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
-import { TreeEntryFields } from '@sourcegraph/shared/src/graphql-operations'
+import { cloneDeep } from 'lodash'
+
+import { TreeEntryFields, TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 
 import { TreeRootProps } from './TreeRoot'
 
@@ -94,7 +96,7 @@ export function hasSingleChild(tree: TreeEntryInfo[]): boolean {
     return tree[0]?.isSingleChild
 }
 
-interface ComparisonTreeRootProps extends Omit<TreeRootProps, 'sizeKey'> {}
+interface ComparisonTreeRootProps extends Omit<TreeRootProps, 'sizeKey'> { }
 
 export function compareTreeProps(a: ComparisonTreeRootProps, b: ComparisonTreeRootProps): boolean {
     return (
@@ -105,4 +107,27 @@ export function compareTreeProps(a: ComparisonTreeRootProps, b: ComparisonTreeRo
         a.isExpanded === b.isExpanded &&
         a.location === b.location
     )
+}
+
+export function prependGoUpOnce(tree: TreeFields, goUpPath: string, goUpUrl: string): TreeFields {
+    if (!tree.isRoot) {
+        const firstEntryPath = tree.entries?.[0].path ?? null
+        if (firstEntryPath !== goUpPath) {
+            const newTree = cloneDeep(tree)
+            newTree.entries = [
+                {
+                    name: '..',
+                    path: goUpPath,
+                    isDirectory: false,
+                    url: goUpUrl,
+                    isSingleChild: !tree.entries.length,
+                    submodule: null,
+                },
+                ...tree.entries,
+            ]
+            return newTree
+        }
+    }
+
+    return tree
 }

--- a/client/web/src/tree/util.tsx
+++ b/client/web/src/tree/util.tsx
@@ -92,7 +92,7 @@ export function hasSingleChild(tree: TreeEntryInfo[]): boolean {
     return tree[0]?.isSingleChild
 }
 
-interface ComparisonTreeRootProps extends Omit<TreeRootProps, 'sizeKey'> { }
+interface ComparisonTreeRootProps extends Omit<TreeRootProps, 'sizeKey'> {}
 
 export function compareTreeProps(a: ComparisonTreeRootProps, b: ComparisonTreeRootProps): boolean {
     return (


### PR DESCRIPTION
## Description
Part of the [Tree improvements](https://github.com/sourcegraph/sourcegraph/issues/38667), it adds the option to [navigate up the tree](https://github.com/sourcegraph/sourcegraph/issues/38663).

The tree still retains the "confusing behaviour", which is the inconsistency between:

1. Navigating to the root of the repo - which opens up the entire tree at root, as expected
2. Going to a deeply nested file, which only opens the subtree - which is confusing

This part will be fixed later on, with a bigger refactoring of the entire `Tree` component, including data fetching, tree processing, and rendering.

## Test plan
1. Check out the branch
4. Open up a few repos:
    1. A regular one with lots of subfolders: https://sourcegraph.test:3443/github.com/sourcegraph/code-intel-extensions
    2. Something with a deeply nested single children: https://sourcegraph.test:3443/github.com/sgtest/java-pom-with-deps-javaconfig/-/blob/src/main/java/com/sourcegraph/depuser/ApacheCommonsUser.java
    5. A single-file one: https://sourcegraph.test:3443/github.com/sgtest/head-branch/-/blob/foo
3. Make sure that ".." is shown and navigates up the tree
6. Make sure that tests are passing


https://user-images.githubusercontent.com/2196347/180196529-e712b6cb-2fef-4185-8079-2b12a328b4fb.mov



## App preview:

- [Web](https://sg-web-og-tree-nav-up.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yudpsyqufg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
