### PR TITLE
dependencies: add GraphQL query to get LockfileIndex by ID

### DIFF
--- a/cmd/frontend/graphqlbackend/dependencies.go
+++ b/cmd/frontend/graphqlbackend/dependencies.go
@@ -13,8 +13,13 @@ type ListLockfileIndexesArgs struct {
 	After *string
 }
 
+type GetLockfileIndexArgs struct {
+	ID graphql.ID
+}
+
 type DependenciesResolver interface {
 	LockfileIndexes(ctx context.Context, args *ListLockfileIndexesArgs) (LockfileIndexConnectionResolver, error)
+	LockfileIndex(ctx context.Context, args *GetLockfileIndexArgs) (LockfileIndexResolver, error)
 }
 
 type LockfileIndexConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/dependencies.go
+++ b/cmd/frontend/graphqlbackend/dependencies.go
@@ -13,13 +13,10 @@ type ListLockfileIndexesArgs struct {
 	After *string
 }
 
-type GetLockfileIndexArgs struct {
-	ID graphql.ID
-}
-
 type DependenciesResolver interface {
 	LockfileIndexes(ctx context.Context, args *ListLockfileIndexesArgs) (LockfileIndexConnectionResolver, error)
-	LockfileIndex(ctx context.Context, args *GetLockfileIndexArgs) (LockfileIndexResolver, error)
+
+	NodeResolvers() map[string]NodeByIDFunc
 }
 
 type LockfileIndexConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -14,16 +14,6 @@ extend type Query {
         """
         after: String
     ): LockfileIndexConnection!
-
-    """
-    Looks up a lockfile index by ID.
-    """
-    lockfileIndex(
-        """
-        The ID of the lockfile index.
-        """
-        id: ID!
-    ): LockfileIndex
 }
 
 """

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -14,6 +14,16 @@ extend type Query {
         """
         after: String
     ): LockfileIndexConnection!
+
+    """
+    Looks up a lockfile index by ID.
+    """
+    lockfileIndex(
+        """
+        The ID of the lockfile index.
+        """
+        id: ID!
+    ): LockfileIndex
 }
 
 """

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -462,6 +462,10 @@ func NewSchema(
 		EnterpriseResolvers.dependenciesResolver = dependencies
 		resolver.DependenciesResolver = dependencies
 		schemas = append(schemas, dependenciesSchema)
+		// Register NodeByID handlers.
+		for kind, res := range dependencies.NodeResolvers() {
+			resolver.nodeByIDFns[kind] = res
+		}
 	}
 
 	return graphql.ParseSchema(

--- a/internal/codeintel/dependencies/mocks_test.go
+++ b/internal/codeintel/dependencies/mocks_test.go
@@ -501,6 +501,9 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// DeleteDependencyReposByID.
 	DeleteDependencyReposByIDFunc *StoreDeleteDependencyReposByIDFunc
+	// GetLockfileIndexFunc is an instance of a mock function object
+	// controlling the behavior of the method GetLockfileIndex.
+	GetLockfileIndexFunc *StoreGetLockfileIndexFunc
 	// ListDependencyReposFunc is an instance of a mock function object
 	// controlling the behavior of the method ListDependencyRepos.
 	ListDependencyReposFunc *StoreListDependencyReposFunc
@@ -540,6 +543,11 @@ func NewMockStore() *MockStore {
 	return &MockStore{
 		DeleteDependencyReposByIDFunc: &StoreDeleteDependencyReposByIDFunc{
 			defaultHook: func(context.Context, ...int) (r0 error) {
+				return
+			},
+		},
+		GetLockfileIndexFunc: &StoreGetLockfileIndexFunc{
+			defaultHook: func(context.Context, store.GetLockfileIndexOpts) (r0 shared.LockfileIndex, r1 error) {
 				return
 			},
 		},
@@ -605,6 +613,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteDependencyReposByID")
 			},
 		},
+		GetLockfileIndexFunc: &StoreGetLockfileIndexFunc{
+			defaultHook: func(context.Context, store.GetLockfileIndexOpts) (shared.LockfileIndex, error) {
+				panic("unexpected invocation of MockStore.GetLockfileIndex")
+			},
+		},
 		ListDependencyReposFunc: &StoreListDependencyReposFunc{
 			defaultHook: func(context.Context, store.ListDependencyReposOpts) ([]shared.Repo, error) {
 				panic("unexpected invocation of MockStore.ListDependencyRepos")
@@ -664,6 +677,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 	return &MockStore{
 		DeleteDependencyReposByIDFunc: &StoreDeleteDependencyReposByIDFunc{
 			defaultHook: i.DeleteDependencyReposByID,
+		},
+		GetLockfileIndexFunc: &StoreGetLockfileIndexFunc{
+			defaultHook: i.GetLockfileIndex,
 		},
 		ListDependencyReposFunc: &StoreListDependencyReposFunc{
 			defaultHook: i.ListDependencyRepos,
@@ -810,6 +826,114 @@ func (c StoreDeleteDependencyReposByIDFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreDeleteDependencyReposByIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// StoreGetLockfileIndexFunc describes the behavior when the
+// GetLockfileIndex method of the parent MockStore instance is invoked.
+type StoreGetLockfileIndexFunc struct {
+	defaultHook func(context.Context, store.GetLockfileIndexOpts) (shared.LockfileIndex, error)
+	hooks       []func(context.Context, store.GetLockfileIndexOpts) (shared.LockfileIndex, error)
+	history     []StoreGetLockfileIndexFuncCall
+	mutex       sync.Mutex
+}
+
+// GetLockfileIndex delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) GetLockfileIndex(v0 context.Context, v1 store.GetLockfileIndexOpts) (shared.LockfileIndex, error) {
+	r0, r1 := m.GetLockfileIndexFunc.nextHook()(v0, v1)
+	m.GetLockfileIndexFunc.appendCall(StoreGetLockfileIndexFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetLockfileIndex
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreGetLockfileIndexFunc) SetDefaultHook(hook func(context.Context, store.GetLockfileIndexOpts) (shared.LockfileIndex, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetLockfileIndex method of the parent MockStore instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *StoreGetLockfileIndexFunc) PushHook(hook func(context.Context, store.GetLockfileIndexOpts) (shared.LockfileIndex, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetLockfileIndexFunc) SetDefaultReturn(r0 shared.LockfileIndex, r1 error) {
+	f.SetDefaultHook(func(context.Context, store.GetLockfileIndexOpts) (shared.LockfileIndex, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetLockfileIndexFunc) PushReturn(r0 shared.LockfileIndex, r1 error) {
+	f.PushHook(func(context.Context, store.GetLockfileIndexOpts) (shared.LockfileIndex, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetLockfileIndexFunc) nextHook() func(context.Context, store.GetLockfileIndexOpts) (shared.LockfileIndex, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetLockfileIndexFunc) appendCall(r0 StoreGetLockfileIndexFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetLockfileIndexFuncCall objects
+// describing the invocations of this function.
+func (f *StoreGetLockfileIndexFunc) History() []StoreGetLockfileIndexFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetLockfileIndexFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetLockfileIndexFuncCall is an object that describes an invocation
+// of method GetLockfileIndex on an instance of MockStore.
+type StoreGetLockfileIndexFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 store.GetLockfileIndexOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 shared.LockfileIndex
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetLockfileIndexFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetLockfileIndexFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreListDependencyReposFunc describes the behavior when the

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -501,3 +501,14 @@ type ListLockfileIndexesOpts struct {
 func (s *Service) ListLockfileIndexes(ctx context.Context, opts ListLockfileIndexesOpts) ([]shared.LockfileIndex, int, error) {
 	return s.dependenciesStore.ListLockfileIndexes(ctx, store.ListLockfileIndexesOpts(opts))
 }
+
+type GetLockfileIndexOpts struct {
+	ID       int
+	RepoName string
+	Commit   string
+	Lockfile string
+}
+
+func (s *Service) GetLockfileIndexOpts(ctx context.Context, opts GetLockfileIndexOpts) (shared.LockfileIndex, error) {
+	return s.dependenciesStore.GetLockfileIndex(ctx, store.GetLockfileIndexOpts(opts))
+}

--- a/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
@@ -14,12 +14,14 @@ type LockfileIndexResolver struct {
 	commit   *graphqlbackend.GitCommitResolver
 }
 
+const lockfileIndexIDKind = "LockfileIndex"
+
 func NewLockfileIndexResolver(lockfile shared.LockfileIndex, repo *graphqlbackend.RepositoryResolver, commit *graphqlbackend.GitCommitResolver) graphqlbackend.LockfileIndexResolver {
 	return &LockfileIndexResolver{lockfile: lockfile, repo: repo, commit: commit}
 }
 
 func (e *LockfileIndexResolver) ID() graphql.ID {
-	return relay.MarshalID("LockfileIndex", (int64(e.lockfile.ID)))
+	return relay.MarshalID(lockfileIndexIDKind, (int64(e.lockfile.ID)))
 }
 
 func (e *LockfileIndexResolver) Lockfile() string {

--- a/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
@@ -37,3 +37,8 @@ func (e *LockfileIndexResolver) Commit() *graphqlbackend.GitCommitResolver {
 func (e *LockfileIndexResolver) Fidelity() string {
 	return e.lockfile.Fidelity.ToGraphQL()
 }
+
+func unmarshalLockfileIndexID(id graphql.ID) (lockfileIndexID int, err error) {
+	err = relay.UnmarshalSpec(id, &lockfileIndexID)
+	return
+}

--- a/internal/codeintel/dependencies/transport/graphql/resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/resolver.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 
+	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -28,6 +29,42 @@ func New(db database.DB, logger log.Logger) graphqlbackend.DependenciesResolver 
 		db:     db,
 		logger: logger,
 	}
+}
+
+func (r *resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {
+	return map[string]graphqlbackend.NodeByIDFunc{
+		lockfileIndexIDKind: func(ctx context.Context, id graphql.ID) (graphqlbackend.Node, error) {
+			return r.lockfileIndexByID(ctx, id)
+		},
+	}
+}
+
+func (r *resolver) lockfileIndexByID(ctx context.Context, gqlID graphql.ID) (graphqlbackend.LockfileIndexResolver, error) {
+	// 🚨 SECURITY: For now we only allow site admins to query lockfile indexes.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	id, err := unmarshalLockfileIndexID(gqlID)
+	if err != nil {
+		return nil, err
+	}
+
+	lockfileIndex, err := r.svc.GetLockfileIndexOpts(ctx, dependencies.GetLockfileIndexOpts{
+		ID: id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := backend.NewRepos(r.logger, r.db).Get(ctx, api.RepoID(lockfileIndex.RepositoryID))
+	if err != nil {
+		return nil, err
+	}
+	repoResolver := graphqlbackend.NewRepositoryResolver(r.db, repo)
+	commit := graphqlbackend.NewGitCommitResolver(r.db, repoResolver, api.CommitID(lockfileIndex.Commit), nil)
+
+	return NewLockfileIndexResolver(lockfileIndex, repoResolver, commit), nil
 }
 
 func (r *resolver) LockfileIndexes(ctx context.Context, args *graphqlbackend.ListLockfileIndexesArgs) (graphqlbackend.LockfileIndexConnectionResolver, error) {
@@ -108,32 +145,4 @@ func validateListArgs(args *graphqlbackend.ListLockfileIndexesArgs) (params, err
 	p.limit = limit
 
 	return p, nil
-}
-
-func (r *resolver) LockfileIndex(ctx context.Context, args *graphqlbackend.GetLockfileIndexArgs) (graphqlbackend.LockfileIndexResolver, error) {
-	// 🚨 SECURITY: For now we only allow site admins to query lockfile indexes.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
-		return nil, err
-	}
-
-	id, err := unmarshalLockfileIndexID(args.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	lockfileIndex, err := r.svc.GetLockfileIndexOpts(ctx, dependencies.GetLockfileIndexOpts{
-		ID: id,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	repo, err := backend.NewRepos(r.logger, r.db).Get(ctx, api.RepoID(lockfileIndex.RepositoryID))
-	if err != nil {
-		return nil, err
-	}
-	repoResolver := graphqlbackend.NewRepositoryResolver(r.db, repo)
-	commit := graphqlbackend.NewGitCommitResolver(r.db, repoResolver, api.CommitID(lockfileIndex.Commit), nil)
-
-	return NewLockfileIndexResolver(lockfileIndex, repoResolver, commit), nil
 }

--- a/internal/codeintel/dependencies/transport/graphql/resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/resolver.go
@@ -36,7 +36,7 @@ func (r *resolver) LockfileIndexes(ctx context.Context, args *graphqlbackend.Lis
 		return nil, err
 	}
 
-	p, err := validateArgs(args)
+	p, err := validateListArgs(args)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ type params struct {
 	limit int
 }
 
-func validateArgs(args *graphqlbackend.ListLockfileIndexesArgs) (params, error) {
+func validateListArgs(args *graphqlbackend.ListLockfileIndexesArgs) (params, error) {
 	var p params
 	afterCount, err := graphqlutil.DecodeIntCursor(args.After)
 	if err != nil {
@@ -108,4 +108,32 @@ func validateArgs(args *graphqlbackend.ListLockfileIndexesArgs) (params, error) 
 	p.limit = limit
 
 	return p, nil
+}
+
+func (r *resolver) LockfileIndex(ctx context.Context, args *graphqlbackend.GetLockfileIndexArgs) (graphqlbackend.LockfileIndexResolver, error) {
+	// 🚨 SECURITY: For now we only allow site admins to query lockfile indexes.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	id, err := unmarshalLockfileIndexID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	lockfileIndex, err := r.svc.GetLockfileIndexOpts(ctx, dependencies.GetLockfileIndexOpts{
+		ID: id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := backend.NewRepos(r.logger, r.db).Get(ctx, api.RepoID(lockfileIndex.RepositoryID))
+	if err != nil {
+		return nil, err
+	}
+	repoResolver := graphqlbackend.NewRepositoryResolver(r.db, repo)
+	commit := graphqlbackend.NewGitCommitResolver(r.db, repoResolver, api.CommitID(lockfileIndex.Commit), nil)
+
+	return NewLockfileIndexResolver(lockfileIndex, repoResolver, commit), nil
 }


### PR DESCRIPTION
I'll need this for the lockfile index page in the site-admin page.

Extends the store, service, GraphQL layer. Boring stuff.

## Test plan

- Existing and new tests
- Manual testing of GraphQL endpoint