### PR TITLE
grafana: upgrade ncurses

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -43,7 +43,14 @@ RUN mkdir /sg_config_grafana/provisioning/plugins && chown grafana:root /sg_conf
 
 # @FIXME: Update redis image
 # Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965
-RUN apk add --upgrade --no-cache 'apk-tools>=2.12' 'krb5-libs>=1.18.4' 'libssl1.1>=1.1.1l' 'openssl>=1.1.1l' 'busybox>=1.32.1'
+RUN apk add --upgrade --no-cache \
+    'apk-tools>=2.12' \
+    'krb5-libs>=1.18.4' \
+    'libssl1.1>=1.1.1l' \
+    'openssl>=1.1.1l' \
+    'busybox>=1.32.1' \
+    'ncurses-libs>=6.2_p20210109-r1' \
+    'ncurses-terminfo-base>=6.2_p20210109-r1'
 
 EXPOSE 3370
 USER grafana


### PR DESCRIPTION
This is for CVE-2022-29458. We already have addressed this in our base alpine image but it seems we missed grafana.

Test Plan: CI