### PR TITLE
search frontend: do not surface quote notice

### DIFF
--- a/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
+++ b/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 
-import { mdiFormatQuoteOpen, mdiBookmarkOutline, mdiLink } from '@mdi/js'
+import { mdiBookmarkOutline, mdiLink } from '@mdi/js'
 import classNames from 'classnames'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
@@ -55,27 +55,6 @@ const ExperimentalActionButton: React.FunctionComponent<
         </button>
     )
 }
-
-/**
- * A notice for when the user is searching literally and has quotes in their
- * query, in which case it is possible that they think their query `"foobar"`
- * will be searching literally for `foobar` (without quotes). This notice
- * informs them that this may be the case to avoid confusion.
- */
-const QuotesInterpretedLiterallyNotice: React.FunctionComponent<
-    React.PropsWithChildren<SearchResultsInfoBarProps>
-> = props =>
-    props.patternType === SearchPatternType.literal && props.fullQuery && props.fullQuery.includes('"') ? (
-        <small
-            className={styles.notice}
-            data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
-        >
-            <span>
-                <Icon aria-hidden={true} className="mr-1" svgPath={mdiFormatQuoteOpen} />
-                Searching literally <strong>(including quotes)</strong>
-            </span>
-        </small>
-    ) : null
 
 export const SearchResultsInfoBar: React.FunctionComponent<
     React.PropsWithChildren<SearchResultsInfoBarProps>
@@ -232,7 +211,6 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         <div className={classNames('flex-grow-1 my-2', styles.searchResultsInfoBar)} data-testid="results-info-bar">
             <div className={styles.row}>
                 {stats}
-                <QuotesInterpretedLiterallyNotice {...props} />
                 <div className={styles.expander} />
                 <ul className="nav align-items-center">
                     {createCodeMonitorButton}

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -1,14 +1,6 @@
 import React, { useMemo, useState } from 'react'
 
-import {
-    mdiFormatQuoteOpen,
-    mdiBookmarkOutline,
-    mdiMenu,
-    mdiMenuDown,
-    mdiMenuUp,
-    mdiArrowExpandDown,
-    mdiArrowCollapseUp,
-} from '@mdi/js'
+import { mdiBookmarkOutline, mdiMenu, mdiMenuDown, mdiMenuUp, mdiArrowExpandDown, mdiArrowCollapseUp } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 
@@ -25,7 +17,6 @@ import { Button, ButtonLink, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { BookmarkRadialGradientIcon, CodeMonitorRadialGradientIcon } from '../../components/CtaIcons'
-import { SearchPatternType } from '../../graphql-operations'
 
 import { ButtonDropdownCta, ButtonDropdownCtaProps } from './ButtonDropdownCta'
 import {
@@ -113,26 +104,6 @@ const ExperimentalActionButton: React.FunctionComponent<
         </ButtonLink>
     )
 }
-
-/**
- * A notice for when the user is searching literally and has quotes in their
- * query, in which case it is possible that they think their query `"foobar"`
- * will be searching literally for `foobar` (without quotes). This notice
- * informs them that this may be the case to avoid confusion.
- */
-const QuotesInterpretedLiterallyNotice: React.FunctionComponent<
-    React.PropsWithChildren<SearchResultsInfoBarProps>
-> = props =>
-    props.patternType === SearchPatternType.literal && props.query && props.query.includes('"') ? (
-        <Tooltip content="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search.">
-            <small className={styles.notice}>
-                <span>
-                    <Icon aria-hidden={true} svgPath={mdiFormatQuoteOpen} />
-                    Searching literally <strong>(including quotes)</strong>
-                </span>
-            </small>
-        </Tooltip>
-    ) : null
 
 /**
  * The info bar shown over the search results list that displays metadata
@@ -315,8 +286,6 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                 </Button>
 
                 {props.stats}
-
-                <QuotesInterpretedLiterallyNotice {...props} />
 
                 <div className={styles.expander} />
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/22628

Our UI will report "searching literally including quotes" even when that doesn't apply to a pattern, but rather just some filter (and so, we are not actually searching for quotes). This notice was introduced at a time when search behavior transitioned and the transition was really painful https://github.com/sourcegraph/sourcegraph/pull/6090. 

Today, the behavior has been around for a while _and_ we should now prefer to surface potential issues using our diagnostics framework/Codemirror directly. We also have lucky search in the works to help with the behavior. All in all this notification is adding more confusion than clarity, and not worth fixing in the existing component since we should find better ways to deal with this in the query bar, e.g., with diagnostics.

## Test plan
Removes functionality and there are no existing tests, so confirmed manually.

## App preview:

- [Web](https://sg-web-rvt-no-quote-notice.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ldswzimwuz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
