### PR TITLE
migration: Canonicalize historic queries

### DIFF
--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -28,6 +28,14 @@ type Definitions struct {
 	definitionsMap map[int]Definition
 }
 
+func NewDefinitions(migrationDefinitions []Definition) (*Definitions, error) {
+	if err := reorderDefinitions(migrationDefinitions); err != nil {
+		return nil, errors.Wrap(err, "reorderDefinitions")
+	}
+
+	return newDefinitions(migrationDefinitions), nil
+}
+
 func newDefinitions(migrationDefinitions []Definition) *Definitions {
 	definitionsMap := make(map[int]Definition, len(migrationDefinitions))
 	for _, migrationDefinition := range migrationDefinitions {


### PR DESCRIPTION
Extracted from #36319. This PR:

- Adds `canonicalizeQuery` which strips out some metadata added and removed in historic versions of our migration definition journey.
- Drive-bys:
  - Adds `NewDefinitions` to enable (later) external construction
  - Adds more information to an error message

## Test plan

Additional unit tests in this PR.