### PR TITLE
`mapfs`: _Never use a temp directory again_

### DIFF
--- a/internal/mapfs/directory.go
+++ b/internal/mapfs/directory.go
@@ -1,0 +1,62 @@
+package mapfs
+
+import (
+	"io"
+	"io/fs"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type mapFSDirectory struct {
+	name    string
+	entries []string
+	offset  int
+}
+
+func (d *mapFSDirectory) Stat() (fs.FileInfo, error) {
+	return &mapFSDirectoryEntry{name: d.name}, nil
+}
+
+func (d *mapFSDirectory) ReadDir(count int) ([]fs.DirEntry, error) {
+	n := len(d.entries) - d.offset
+	if n == 0 {
+		if count <= 0 {
+			return nil, nil
+		}
+		return nil, io.EOF
+	}
+	if count > 0 && n > count {
+		n = count
+	}
+
+	list := make([]fs.DirEntry, 0, n)
+	for i := 0; i < n; i++ {
+		name := d.entries[d.offset]
+		list = append(list, &mapFSDirectoryEntry{name: name})
+		d.offset++
+	}
+
+	return list, nil
+}
+
+func (d *mapFSDirectory) Read(_ []byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: d.name, Err: errors.New("is a directory")}
+}
+
+func (d *mapFSDirectory) Close() error {
+	return nil
+}
+
+type mapFSDirectoryEntry struct {
+	name string
+}
+
+func (e *mapFSDirectoryEntry) Name() string               { return e.name }
+func (e *mapFSDirectoryEntry) Size() int64                { return 0 }
+func (e *mapFSDirectoryEntry) Mode() fs.FileMode          { return fs.ModeDir }
+func (e *mapFSDirectoryEntry) ModTime() time.Time         { return time.Time{} }
+func (e *mapFSDirectoryEntry) IsDir() bool                { return e.Mode().IsDir() }
+func (e *mapFSDirectoryEntry) Sys() any                   { return nil }
+func (e *mapFSDirectoryEntry) Type() fs.FileMode          { return fs.ModeDir }
+func (e *mapFSDirectoryEntry) Info() (fs.FileInfo, error) { return e, nil }

--- a/internal/mapfs/file.go
+++ b/internal/mapfs/file.go
@@ -1,0 +1,35 @@
+package mapfs
+
+import (
+	"io"
+	"io/fs"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type mapFSFile struct {
+	name string
+	size int64
+	io.ReadCloser
+}
+
+func (f *mapFSFile) Stat() (fs.FileInfo, error) {
+	return &mapFSFileEntry{name: f.name, size: f.size}, nil
+}
+
+func (d *mapFSFile) ReadDir(count int) ([]fs.DirEntry, error) {
+	return nil, &fs.PathError{Op: "read", Path: d.name, Err: errors.New("not a directory")}
+}
+
+type mapFSFileEntry struct {
+	name string
+	size int64
+}
+
+func (e *mapFSFileEntry) Name() string       { return e.name }
+func (e *mapFSFileEntry) Size() int64        { return e.size }
+func (e *mapFSFileEntry) Mode() fs.FileMode  { return fs.ModePerm }
+func (e *mapFSFileEntry) ModTime() time.Time { return time.Time{} }
+func (e *mapFSFileEntry) IsDir() bool        { return e.Mode().IsDir() }
+func (e *mapFSFileEntry) Sys() any           { return nil }

--- a/internal/mapfs/mapfs.go
+++ b/internal/mapfs/mapfs.go
@@ -1,0 +1,60 @@
+package mapfs
+
+import (
+	"io"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type mapFS struct {
+	contents map[string]string
+}
+
+// New creates an fs.FS from the given map, where the keys are filenames and values
+// are file contents. Intermediate directories do not need to be explicitly represented
+// in the given map.
+func New(contents map[string]string) fs.FS {
+	return &mapFS{contents}
+}
+
+func (fs *mapFS) Open(name string) (fs.File, error) {
+	if name == "." || name == "/" {
+		name = ""
+	}
+	if contents, ok := fs.contents[name]; ok {
+		return &mapFSFile{
+			name:       name,
+			size:       int64(len(contents)),
+			ReadCloser: io.NopCloser(strings.NewReader(contents)),
+		}, nil
+	}
+
+	prefix := name
+	if prefix != "" && !strings.HasSuffix(prefix, string(filepath.Separator)) {
+		prefix += string(filepath.Separator)
+	}
+
+	entryMap := make(map[string]struct{}, len(fs.contents))
+	for key := range fs.contents {
+		if !strings.HasPrefix(key, name) {
+			continue
+		}
+
+		// Collect direct child of any matching descendant paths
+		entryMap[strings.Split(key[len(prefix):], string(filepath.Separator))[0]] = struct{}{}
+	}
+
+	// Flatten the map into a sorted slice
+	entries := make([]string, 0, len(entryMap))
+	for key := range entryMap {
+		entries = append(entries, key)
+	}
+	sort.Strings(entries)
+
+	return &mapFSDirectory{
+		name:    name,
+		entries: entries,
+	}, nil
+}

--- a/internal/mapfs/mapfs_test.go
+++ b/internal/mapfs/mapfs_test.go
@@ -1,0 +1,72 @@
+package mapfs
+
+import (
+	"io"
+	"io/fs"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMapFS(t *testing.T) {
+	mapFS := New(map[string]string{
+		"src/java/main/foo.java":                      "code",
+		"src/scala/main/bar.scala":                    "better code",
+		"test/java/main/baz.java":                     "qa",
+		"test/scala/main/bonk.scala":                  "better qa",
+		"business/slidedeck_2022_final~2_(1).pdf.bak": "stonks",
+	})
+
+	assertFile(t, mapFS, "src/scala/main/bar.scala", "better code")
+	assertFile(t, mapFS, "test/scala/main/bonk.scala", "better qa")
+
+	assertDirectory(t, mapFS, "", []string{"business", "src", "test"})
+	assertDirectory(t, mapFS, "src", []string{"java", "scala"})
+	assertDirectory(t, mapFS, "test", []string{"java", "scala"})
+	assertDirectory(t, mapFS, "src/java", []string{"main"})
+	assertDirectory(t, mapFS, "src/java/main", []string{"foo.java"})
+}
+
+func assertFile(t *testing.T, mapFS fs.FS, filename string, expectedContents string) {
+	file, err := mapFS.Open(filename)
+	if err != nil {
+		t.Fatalf("failed to open file %q: %s", filename, err)
+	}
+
+	contents, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("failed to read file: %s", err)
+	}
+
+	if diff := cmp.Diff(expectedContents, string(contents)); diff != "" {
+		t.Fatalf("mismatched contents for file %q (-have, +want): %s", filename, diff)
+	}
+}
+
+func assertDirectory(t *testing.T, mapFS fs.FS, directory string, expectedEntries []string) {
+	file, err := mapFS.Open(directory)
+	if err != nil {
+		t.Fatalf("failed to open directory %q: %s", directory, err)
+	}
+
+	rdf, ok := file.(fs.ReadDirFile)
+	if !ok {
+		t.Fatalf("failed to read directory: bad type %T", file)
+	}
+
+	entries, err := rdf.ReadDir(-1)
+	if err != nil {
+		t.Fatalf("failed to read directory %q: %s", directory, err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+
+	if diff := cmp.Diff(expectedEntries, names); diff != "" {
+		t.Fatalf("mismatched entries for directory %q (-have, +want): %s", directory, diff)
+	}
+}


### PR DESCRIPTION
Extracted from #36319. This PR adds the `internal/mapfs` package that presents a dictionary from filenames to file contents as an `fs.FS` interface.

## Test plan

Additional unit tests in this PR.