### PR TITLE
compute: output command uses chunk matches

### DIFF
--- a/enterprise/internal/compute/output_command_test.go
+++ b/enterprise/internal/compute/output_command_test.go
@@ -60,6 +60,14 @@ func fileMatch(content string) result.Match {
 			Repo: types.MinimalRepo{Name: "my/awesome/repo"},
 			Path: "my/awesome/path.ml",
 		},
+		ChunkMatches: result.ChunkMatches{{
+			Content:      content,
+			ContentStart: result.Location{Offset: 0, Line: 1, Column: 0},
+			Ranges: result.Ranges{{
+				Start: result.Location{Offset: 0, Line: 1, Column: 0},
+				End:   result.Location{Offset: len(content), Line: 1, Column: len(content)},
+			}},
+		}},
 	}
 }
 


### PR DESCRIPTION
Compute `output` command no longer fetches files. Locally tested this has a 4x speedup for some simple examples. Will test and share more broadly when live on Sourcegraph.com

## Test plan
Semantics-preserving with respect to tested behavior
