### PR TITLE
search ui: update sidebar styles

### DIFF
--- a/client/search-ui/src/results/sidebar/FilterLink.test.tsx
+++ b/client/search-ui/src/results/sidebar/FilterLink.test.tsx
@@ -53,7 +53,7 @@ describe('FilterLink', () => {
         const filters: Filter[] = [repoFilter1, langFilter1, repoFilter2, langFilter2, fileFilter]
         const onFilterChosen = sinon.stub()
 
-        const links = getRepoFilterLinks(filters, onFilterChosen)
+        const links = getRepoFilterLinks(filters, onFilterChosen, false)
         expect(links).toHaveLength(2)
         expect(renderWithBrandedContext(<>{links}</>).asFragment()).toMatchSnapshot()
     })
@@ -62,7 +62,7 @@ describe('FilterLink', () => {
         const filters: Filter[] = [repoFilter1, langFilter1, repoFilter2, langFilter2, fileFilter]
         const onFilterChosen = sinon.stub()
 
-        const links = getRepoFilterLinks(filters, onFilterChosen)
+        const links = getRepoFilterLinks(filters, onFilterChosen, false)
         expect(links).toHaveLength(2)
 
         const { asFragment } = renderWithBrandedContext(<>{links}</>)
@@ -75,7 +75,7 @@ describe('FilterLink', () => {
         const filters: Filter[] = [langFilter1, langFilter2, fileFilter]
         const onFilterChosen = sinon.stub()
 
-        const links = getRepoFilterLinks(filters, onFilterChosen)
+        const links = getRepoFilterLinks(filters, onFilterChosen, false)
         expect(links).toHaveLength(0)
     })
 
@@ -122,7 +122,7 @@ describe('FilterLink', () => {
         const filters: Filter[] = [repoFilter1]
         const onFilterChosen = sinon.spy()
 
-        const links = getRepoFilterLinks(filters, onFilterChosen)
+        const links = getRepoFilterLinks(filters, onFilterChosen, false)
         renderWithBrandedContext(<>{links}</>)
         userEvent.click(screen.getByTestId('filter-link'))
 

--- a/client/search-ui/src/results/sidebar/FilterLink.tsx
+++ b/client/search-ui/src/results/sidebar/FilterLink.tsx
@@ -49,7 +49,9 @@ export const FilterLink: React.FunctionComponent<React.PropsWithChildren<FilterL
             variant="link"
             aria-label={`${ariaLabel ?? label}${countTooltip ? `, ${countTooltip}` : ''}`}
         >
-            <span className="flex-grow-1">{labelConverter(label)}</span>
+            <span className={classNames('flex-grow-1', styles.sidebarSectionListItemLabel)}>
+                {labelConverter(label)}
+            </span>
             {count && (
                 <span className="pl-2 flex-shrink-0" data-tooltip={countTooltip}>
                     {count}
@@ -62,17 +64,23 @@ export const FilterLink: React.FunctionComponent<React.PropsWithChildren<FilterL
 
 export const getRepoFilterLinks = (
     filters: Filter[] | undefined,
-    onFilterChosen: (value: string, kind?: string) => void
+    onFilterChosen: (value: string, kind?: string) => void,
+    coreWorkflowImprovementsEnabled: boolean | undefined
 ): React.ReactElement[] => {
     function repoLabelConverter(label: string): JSX.Element {
         const Icon = CodeHostIcon({
             repoName: label,
-            className: classNames('text-muted', styles.sidebarSectionIcon),
+            className: classNames(!coreWorkflowImprovementsEnabled && 'text-muted', styles.sidebarSectionIcon),
         })
 
         return (
-            <span className={classNames('text-monospace search-query-link', styles.sidebarSectionListItemBreakWords)}>
-                <span className="search-filter-keyword">r:</span>
+            <span
+                className={classNames(
+                    !coreWorkflowImprovementsEnabled && 'text-monospace search-query-link',
+                    styles.sidebarSectionListItemBreakWords
+                )}
+            >
+                {!coreWorkflowImprovementsEnabled && <span className="search-filter-keyword">r:</span>}
                 {Icon ? (
                     <>
                         {Icon}

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -131,10 +131,10 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
 
     const repoFilters = useMemo(() => getFiltersOfKind(props.filters, FilterType.repo), [props.filters])
     const repoName = useLastRepoName(query, repoFilters)
-    const repoFilterLinks = useMemo(() => getRepoFilterLinks(repoFilters, onDynamicFilterClicked), [
-        repoFilters,
-        onDynamicFilterClicked,
-    ])
+    const repoFilterLinks = useMemo(
+        () => getRepoFilterLinks(repoFilters, onDynamicFilterClicked, coreWorkflowImprovementsEnabled),
+        [repoFilters, onDynamicFilterClicked, coreWorkflowImprovementsEnabled]
+    )
     const showReposSection = repoFilterLinks.length > 1
 
     const langFilterLinks = useMemo(

--- a/client/search-ui/src/results/sidebar/SearchSidebarSection.module.scss
+++ b/client/search-ui/src/results/sidebar/SearchSidebarSection.module.scss
@@ -49,11 +49,11 @@
 
         &:hover {
             background-color: var(--color-bg-2);
-            text-decoration: none;
+            text-decoration: none !important;
         }
 
         &:focus {
-            text-decoration: none;
+            text-decoration: none !important;
         }
 
         &:active {
@@ -65,8 +65,18 @@
         }
     }
 
+    &__list-item-label {
+        :global(.core-workflow-improvements-enabled) & {
+            color: var(--body-color);
+        }
+    }
+
     &__icon {
         margin: 0 0.125rem;
+
+        :global(.core-workflow-improvements-enabled) & {
+            margin-left: 0;
+        }
     }
 
     &__no-results {

--- a/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
+++ b/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
@@ -58,7 +58,7 @@ const SearchTypeLink: React.FunctionComponent<React.PropsWithChildren<SearchType
             className={styles.sidebarSectionListItem}
             data-testid={dataTestID}
         >
-            {children}
+            <span className={styles.sidebarSectionListItemLabel}>{children}</span>
         </Link>
     )
 }
@@ -85,7 +85,7 @@ const SearchTypeButton: React.FunctionComponent<React.PropsWithChildren<SearchTy
         variant="link"
         data-testid={dataTestID}
     >
-        {children}
+        <span className={styles.sidebarSectionListItemLabel}>{children}</span>
     </Button>
 )
 

--- a/client/search-ui/src/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
+++ b/client/search-ui/src/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
     value="lang:go"
   >
     <span
-      class="flex-grow-1"
+      class="flex-grow-1 sidebarSectionListItemLabel"
     >
       <span
         class="text-monospace search-query-link"
@@ -47,7 +47,7 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
     value="lang:typescript"
   >
     <span
-      class="flex-grow-1"
+      class="flex-grow-1 sidebarSectionListItemLabel"
     >
       <span
         class="text-monospace search-query-link"
@@ -84,7 +84,7 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
     value="-file:_test\\\\.go$"
   >
     <span
-      class="flex-grow-1"
+      class="flex-grow-1 sidebarSectionListItemLabel"
     >
       <span
         class="text-monospace search-query-link"
@@ -141,7 +141,7 @@ exports[`FilterLink should have correct links for repos 1`] = `
     value="repo:^gitlab\\\\.com/sourcegraph/sourcgreaph$"
   >
     <span
-      class="flex-grow-1"
+      class="flex-grow-1 sidebarSectionListItemLabel"
     >
       <span
         class="text-monospace search-query-link sidebarSectionListItemBreakWords"
@@ -183,7 +183,7 @@ exports[`FilterLink should have correct links for repos 1`] = `
     value="repo:^github\\\\.com/microsoft/vscode$"
   >
     <span
-      class="flex-grow-1"
+      class="flex-grow-1 sidebarSectionListItemLabel"
     >
       <span
         class="text-monospace search-query-link sidebarSectionListItemBreakWords"
@@ -230,7 +230,7 @@ exports[`FilterLink should have correct links for scopes 1`] = `
     value="repo:sourcegraph"
   >
     <span
-      class="flex-grow-1"
+      class="flex-grow-1 sidebarSectionListItemLabel"
     >
       This is a search scope with a very long name lorem ipsum dolor sit amet
     </span>
@@ -243,7 +243,7 @@ exports[`FilterLink should have correct links for scopes 1`] = `
     value="count:all"
   >
     <span
-      class="flex-grow-1"
+      class="flex-grow-1 sidebarSectionListItemLabel"
     >
       All results
     </span>
@@ -261,7 +261,7 @@ exports[`FilterLink should have show icons for repos on cloud 1`] = `
     value="repo:^gitlab\\\\.com/sourcegraph/sourcgreaph$"
   >
     <span
-      class="flex-grow-1"
+      class="flex-grow-1 sidebarSectionListItemLabel"
     >
       <span
         class="text-monospace search-query-link sidebarSectionListItemBreakWords"
@@ -303,7 +303,7 @@ exports[`FilterLink should have show icons for repos on cloud 1`] = `
     value="repo:^github\\\\.com/microsoft/vscode$"
   >
     <span
-      class="flex-grow-1"
+      class="flex-grow-1 sidebarSectionListItemLabel"
     >
       <span
         class="text-monospace search-query-link sidebarSectionListItemBreakWords"

--- a/client/web/src/search/results/sidebar/Revisions.module.scss
+++ b/client/web/src/search/results/sidebar/Revisions.module.scss
@@ -1,0 +1,3 @@
+.tabs {
+    background-color: transparent;
+}


### PR DESCRIPTION
Stacked on #39107

Updates the sidebar styles to match [Figma](https://www.figma.com/file/8MkIcpDtjv6tqgxZFcEQDt/Core-workflow-punch-list?node-id=755%3A24004) when the "simple UI" toggle is on.

![image](https://user-images.githubusercontent.com/206864/180050133-4e700436-76e7-48e8-afea-0411973ed9eb.png)
![image](https://user-images.githubusercontent.com/206864/180050171-de4e1c6e-b4cb-40b5-ac8c-1908b23fe603.png)

## Test plan

Verified by turning the "simple UI" toggle on and off. Visual tests should show no changes.

## App preview:

- [Web](https://sg-web-jp-sidebarstyle.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-itarrlpwej.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
