### PR TITLE
Alter action to move issues labeled 'design' to new board

### DIFF
--- a/.github/workflows/move-labled-issues-to-project-beta.yml
+++ b/.github/workflows/move-labled-issues-to-project-beta.yml
@@ -27,8 +27,15 @@ jobs:
           github-token: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
           labeled: team/repo-management
           label-operator: OR
-
-
+          
+      - name: Move design issues
+        uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/sourcegraph/projects/278/views/1
+          github-token: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
+          labeled: design
+          label-operator: OR
+          
 #       - name: Move team/CHANGEME issues
 #         uses: actions/add-to-project@main
 #         with:

--- a/.github/workflows/move-labled-issues-to-project-beta.yml
+++ b/.github/workflows/move-labled-issues-to-project-beta.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Move design issues
         uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/sourcegraph/projects/278/views/1
+          project-url: https://github.com/orgs/sourcegraph/projects/278
           github-token: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
           labeled: design
           label-operator: OR


### PR DESCRIPTION
This action moves issues labeled design to [a new board](https://github.com/orgs/sourcegraph/projects/278/views/1) to help automate design process.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


CI automation: it should move issues to target project