### PR TITLE
dev/sg: ops update-images -k compose only on yaml files, improve error messages

### DIFF
--- a/dev/sg/internal/images/compose.go
+++ b/dev/sg/internal/images/compose.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/docker-credential-helpers/credentials"
 	"gopkg.in/yaml.v3"
@@ -16,16 +15,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-// UpdateCompose walks all `*docker-compose.yaml` files and updates Sourcegraph images
-// in each.
+// UpdateCompose walks all `*.yaml` files assuming they are docker-compose files and
+// updates Sourcegraph images in each.
 func UpdateCompose(path string, creds credentials.Credentials, pinTag string) error {
 	var checked int
 	if err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		if d.IsDir() {
 			return nil
 		}
-		if !strings.Contains(d.Name(), "docker-compose.yaml") {
-			std.Out.WriteWarningf("%s is not a docker-compose.yaml file but we will still try to update it anyway", path)
+		if filepath.Ext(d.Name()) != ".yaml" {
+			return nil
 		}
 
 		std.Out.WriteNoticef("Checking %q", path)


### PR DESCRIPTION

<img width="699" alt="image" src="https://user-images.githubusercontent.com/23356519/180068226-90d172d9-832a-4257-a032-9c6b0c77f92e.png">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
go build -o ./sg ./dev/sg && ./sg install -f -p=false

# in ds-docker
sg ops update-images -k compose docker-compose
```

<img width="663" alt="image" src="https://user-images.githubusercontent.com/23356519/180068309-feb7ff42-0f9a-40b6-a1fe-2a365c664318.png">
