### PR TITLE
search: Add experimental feature to select search query input suggestions with "Enter"

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -121,7 +121,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
                 isSourcegraphDotCom,
                 applyOnEnter: applySuggestionsOnEnter,
             }),
-        [selectedSearchContextSpec, globbing, isSourcegraphDotCom, fetchStreamSuggestions]
+        [selectedSearchContextSpec, globbing, isSourcegraphDotCom, fetchStreamSuggestions, applySuggestionsOnEnter]
     )
 
     const extensions = useMemo(() => {

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -85,6 +85,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
     placeholder,
     editorOptions,
     ariaLabel = 'Search query',
+    applySuggestionsOnEnter,
     // Used by the VSCode extension (which doesn't use this component directly,
     // but added for future compatibility)
     fetchStreamSuggestions = defaultFetchStreamSuggestions,
@@ -118,6 +119,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
                     fetchStreamSuggestions(appendContextFilter(query, selectedSearchContextSpec)),
                 globbing,
                 isSourcegraphDotCom,
+                applyOnEnter: applySuggestionsOnEnter,
             }),
         [selectedSearchContextSpec, globbing, isSourcegraphDotCom, fetchStreamSuggestions]
     )

--- a/client/search-ui/src/input/MonacoQueryInput.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.tsx
@@ -97,6 +97,15 @@ export interface MonacoQueryInputProps
     ariaLabel?: string
 
     editorClassName?: string
+
+    // CodeMirror specific
+    /**
+     * If set suggestions can be applied by pressing enter. In the past we
+     * didn't enable this behavior because it interfered with loading
+     * suggestions asynchronously, but CodeMirror allows us to disable selecting
+     * a suggestion by default. This is currently an experimental feature.
+     */
+    applySuggestionsOnEnter?: boolean
 }
 
 /**

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -22,7 +22,7 @@ export interface SearchBoxProps
         SearchContextInputProps,
         TelemetryProps,
         PlatformContextProps<'requestGraphQL'>,
-        Pick<LazyMonacoQueryInputProps, 'editorComponent'> {
+        Pick<LazyMonacoQueryInputProps, 'editorComponent' | 'applySuggestionsOnEnter'> {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean // significant for query suggestions
     showSearchContext: boolean
@@ -125,6 +125,7 @@ export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBo
                         patternType={props.patternType}
                         queryState={props.queryState}
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
+                        applySuggestionsOnEnter={props.applySuggestionsOnEnter}
                     />
                     <Toggles
                         patternType={props.patternType}

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -133,7 +133,7 @@ type SuggestionSource<R, C extends SuggestionContext> = (
  */
 export function searchQueryAutocompletion(
     sources: SuggestionSource<CompletionResult | null, SuggestionContext>[],
-    // By default we do not enabel suggestion selection with enter because that
+    // By default we do not enable suggestion selection with enter because that
     // interferes with the query submission logic.
     applyOnEnter = false
 ): Extension {

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -8,6 +8,8 @@ import {
     Completion,
     snippet,
     CompletionSource,
+    acceptCompletion,
+    CompletionContext,
 } from '@codemirror/autocomplete'
 import { Extension, Prec } from '@codemirror/state'
 import { keymap, EditorView } from '@codemirror/view'
@@ -130,7 +132,10 @@ type SuggestionSource<R, C extends SuggestionContext> = (
  * provided suggestion sources.
  */
 export function searchQueryAutocompletion(
-    sources: SuggestionSource<CompletionResult | null, SuggestionContext>[]
+    sources: SuggestionSource<CompletionResult | null, SuggestionContext>[],
+    // By default we do not enabel suggestion selection with enter because that
+    // interferes with the query submission logic.
+    applyOnEnter = false
 ): Extension {
     const override: CompletionSource[] = sources.map(source => context => {
         const position = context.pos
@@ -143,14 +148,48 @@ export function searchQueryAutocompletion(
         )
     })
 
+    // Customizing how completion items are rendered
+    const addToOptions: NonNullable<Parameters<typeof autocompletion>[0]>['addToOptions'] = [
+        // This renders the completion icon
+        {
+            render(completion) {
+                return createIcon(
+                    completion.type && completion.type in typeIconMap
+                        ? typeIconMap[completion.type as CompletionType]
+                        : typeIconMap[SymbolKind.UNKNOWN]
+                )
+            },
+            // Per CodeMirror documentation, 20 is the default icon
+            // position
+            position: 20,
+        },
+    ]
+
+    if (!applyOnEnter) {
+        // This renders the "Tab" indicator after the details text. It's
+        // only visible for the currently selected suggestion (handled
+        // by CSS).
+        addToOptions.push({
+            render() {
+                const node = document.createElement('span')
+                node.classList.add('completion-hint', styles.tabStyle)
+                node.textContent = 'Tab'
+                return node
+            },
+            position: 200,
+        })
+    }
+
     return [
         // Uses the default keymapping but changes accepting suggestions from Enter
         // to Tab
         Prec.highest(
             keymap.of(
-                completionKeymap.map(keybinding =>
-                    keybinding.key === 'Enter' ? { ...keybinding, key: 'Tab' } : keybinding
-                )
+                applyOnEnter
+                    ? [...completionKeymap, { key: 'Tab', run: acceptCompletion }]
+                    : completionKeymap.map(keybinding =>
+                          keybinding.key === 'Enter' ? { ...keybinding, key: 'Tab' } : keybinding
+                      )
             )
         ),
         EditorView.theme({
@@ -187,33 +226,8 @@ export function searchQueryAutocompletion(
             optionClass: completionItem => 'completion-type-' + (completionItem.type ?? ''),
             icons: false,
             closeOnBlur: true,
-            addToOptions: [
-                // This renders the completion icon
-                {
-                    render(completion) {
-                        return createIcon(
-                            completion.type && completion.type in typeIconMap
-                                ? typeIconMap[completion.type as CompletionType]
-                                : typeIconMap[SymbolKind.UNKNOWN]
-                        )
-                    },
-                    // Per CodeMirror documentation, 20 is the default icon
-                    // position
-                    position: 20,
-                },
-                // This renders the "Tab" indicator after the details text. It's
-                // only visible for the currently selected suggestion (handled
-                // by CSS).
-                {
-                    render() {
-                        const node = document.createElement('span')
-                        node.classList.add('completion-hint', styles.tabStyle)
-                        node.textContent = 'Tab'
-                        return node
-                    },
-                    position: 200,
-                },
-            ],
+            selectOnOpen: !applyOnEnter,
+            addToOptions,
         }),
     ]
 }

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -9,7 +9,6 @@ import {
     snippet,
     CompletionSource,
     acceptCompletion,
-    CompletionContext,
 } from '@codemirror/autocomplete'
 import { Extension, Prec } from '@codemirror/state'
 import { keymap, EditorView } from '@codemirror/view'

--- a/client/search-ui/src/input/extensions/index.ts
+++ b/client/search-ui/src/input/extensions/index.ts
@@ -61,12 +61,14 @@ export const createDefaultSuggestions = ({
     fetchSuggestions,
     disableFilterCompletion,
     disableSymbolCompletion,
+    applyOnEnter,
 }: {
     isSourcegraphDotCom: boolean
     globbing: boolean
     fetchSuggestions: (query: string) => Observable<SearchMatch[]>
     disableSymbolCompletion?: true
     disableFilterCompletion?: true
+    applyOnEnter?: boolean
 }): Extension => [
     searchQueryAutocompletion(
         createDefaultSuggestionSources({
@@ -75,7 +77,8 @@ export const createDefaultSuggestions = ({
             isSourcegraphDotCom,
             disableSymbolCompletion,
             disableFilterCompletion,
-        })
+        }),
+        applyOnEnter
     ),
     loadingIndicator(),
 ]

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -128,6 +128,9 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
     const [queryState, setQueryState] = useState<QueryState>({ query: query || '' })
 
     const editorComponent = useExperimentalFeatures(features => features.editor ?? 'monaco')
+    const applySuggestionsOnEnter = useExperimentalFeatures(
+        features => features.applySearchQuerySuggestionOnEnter ?? false
+    )
 
     useEffect(() => {
         const value = queryState.query
@@ -246,6 +249,7 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                                     globbing={false}
                                     preventNewLine={true}
                                     autoFocus={true}
+                                    applySuggestionsOnEnter={applySuggestionsOnEnter}
                                 />
                             </div>
                             <div className={styles.queryInputPreviewLink}>

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
@@ -85,6 +85,9 @@ export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props
 
     const { enhancedThemePreference } = useTheme()
     const editorComponent = useExperimentalFeatures(features => features.editor ?? 'codemirror6')
+    const applySuggestionsOnEnter = useExperimentalFeatures(
+        features => features.applySearchQuerySuggestionOnEnter ?? false
+    )
     const monacoOptions = useMemo(() => ({ ...MONACO_OPTIONS, readOnly: disabled }), [disabled])
 
     return (
@@ -108,6 +111,7 @@ export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props
             editorClassName={classNames(styles.editor, { [styles.editorWithPlaceholder]: !value })}
             autoFocus={autoFocus}
             onBlur={onBlur}
+            applySuggestionsOnEnter={applySuggestionsOnEnter}
         />
     )
 })

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -152,6 +152,9 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
     } = props
     const history = useHistory()
     const editorComponent = useExperimentalFeatures(features => features.editor ?? 'codemirror6')
+    const applySuggestionsOnEnter = useExperimentalFeatures(
+        features => features.applySearchQuerySuggestionOnEnter ?? false
+    )
 
     const [name, setName] = useState(searchContext ? searchContext.name : '')
     const [description, setDescription] = useState(searchContext ? searchContext.description : '')
@@ -459,6 +462,7 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                                 onChange={setQueryState}
                                 globbing={false}
                                 preventNewLine={false}
+                                applySuggestionsOnEnter={applySuggestionsOnEnter}
                             />
                         </div>
                         <div className={classNames(styles.searchContextFormQueryLabel, 'text-muted')}>

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -74,6 +74,9 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
         features => features.showSearchContextManagement ?? false
     )
     const editorComponent = useExperimentalFeatures(features => features.editor ?? 'codemirror6')
+    const applySuggestionsOnEnter = useExperimentalFeatures(
+        features => features.applySearchQuerySuggestionOnEnter ?? false
+    )
 
     useEffect(() => {
         setUserQueryState({ query: props.queryPrefix || '' })
@@ -147,6 +150,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         autoFocus={!isTouchOnlyDevice && props.autoFocus !== false}
                         isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
+                        applySuggestionsOnEnter={applySuggestionsOnEnter}
                     />
                 </div>
                 <QuickLinks quickLinks={quickLinks} className={styles.inputSubContainer} />

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -67,6 +67,9 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
     )
     const editorComponent = useExperimentalFeatures(features => features.editor ?? 'codemirror6')
     const fuzzyFinderShortcut = useKeyboardShortcut('fuzzyFinder')
+    const applySuggestionsOnEnter = useExperimentalFeatures(
+        features => features.applySearchQuerySuggestionOnEnter ?? false
+    )
 
     const submitSearchOnChange = useCallback(
         (parameters: Partial<SubmitSearchParameters> = {}) => {
@@ -111,6 +114,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
             <SearchBox
                 {...props}
                 editorComponent={editorComponent}
+                applySuggestionsOnEnter={applySuggestionsOnEnter}
                 showSearchContext={showSearchContext}
                 showSearchContextManagement={showSearchContextManagement}
                 caseSensitive={searchCaseSensitivity}

--- a/package.json
+++ b/package.json
@@ -362,7 +362,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.5.0",
-    "@codemirror/autocomplete": "^6.0.4",
+    "@codemirror/autocomplete": "^6.1.0",
     "@codemirror/commands": "^6.0.1",
     "@codemirror/lang-json": "^6.0.0",
     "@codemirror/lang-markdown": "^6.0.0",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1746,6 +1746,8 @@ type Settings struct {
 type SettingsExperimentalFeatures struct {
 	// ApiDocs description: Deprecated.
 	ApiDocs *bool `json:"apiDocs,omitempty"`
+	// ApplySearchQuerySuggestionOnEnter description: This changes the behavior of the autocompletion feature in the search query input. If set the first suggestion won't be selected by default and a selected suggestion can be selected by pressing Enter (application by pressing Tab continues to work)
+	ApplySearchQuerySuggestionOnEnter *bool `json:"applySearchQuerySuggestionOnEnter,omitempty"`
 	// BatchChangesExecution description: Enables/disables the Batch Changes server side execution feature.
 	BatchChangesExecution *bool `json:"batchChangesExecution,omitempty"`
 	// ClientSearchResultRanking description: How to rank search results in the client

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -356,6 +356,14 @@
           "!go": {
             "pointer": true
           }
+        },
+        "applySearchQuerySuggestionOnEnter": {
+          "description": "This changes the behavior of the autocompletion feature in the search query input. If set the first suggestion won't be selected by default and a selected suggestion can be selected by pressing Enter (application by pressing Tab continues to work)",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
         }
       },
       "group": "Experimental"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,17 +1470,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@codemirror/autocomplete@^6.0.0":
-  version "6.0.4"
-  resolved "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.0.4.tgz#90a9c81cfddac528b9e9dc07415a7c6554dbe85c"
-  integrity sha512-uP7UodCRykPNwSAN+wYa/AS9gJI/V47echCAXUYgCgBXy3l19nwO7W/d29COtG/dfAsjBOhMDeh3Ms8Y5VZbrA==
-  dependencies:
-    "@codemirror/language" "^6.0.0"
-    "@codemirror/state" "^6.0.0"
-    "@codemirror/view" "^6.0.0"
-    "@lezer/common" "^1.0.0"
-
-"@codemirror/autocomplete@^6.1.0":
+"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.1.0":
   version "6.1.0"
   resolved "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.1.0.tgz#7d3ca6d49e3a71cfd366c0af16172f5c128376eb"
   integrity sha512-wtO4O5WDyXhhCd4q4utDIDZxnQfmJ++3dGBCG9LMtI79+92OcA1DVk/n7BEupKmjIr8AzvptDz7YQ9ud6OkU+A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,10 +1470,20 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.0.4":
+"@codemirror/autocomplete@^6.0.0":
   version "6.0.4"
   resolved "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.0.4.tgz#90a9c81cfddac528b9e9dc07415a7c6554dbe85c"
   integrity sha512-uP7UodCRykPNwSAN+wYa/AS9gJI/V47echCAXUYgCgBXy3l19nwO7W/d29COtG/dfAsjBOhMDeh3Ms8Y5VZbrA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/autocomplete@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.1.0.tgz#7d3ca6d49e3a71cfd366c0af16172f5c128376eb"
+  integrity sha512-wtO4O5WDyXhhCd4q4utDIDZxnQfmJ++3dGBCG9LMtI79+92OcA1DVk/n7BEupKmjIr8AzvptDz7YQ9ud6OkU+A==
   dependencies:
     "@codemirror/language" "^6.0.0"
     "@codemirror/state" "^6.0.0"


### PR DESCRIPTION
This commit adds the ability to select search query input suggestions
with "Enter". Previous attempts at this didn't work reliably/satisfactory
because both CodeMirror and Monaco would always select the first
suggestion. If suggestions took a while to load and would juuuust appear
when you where pressing Enter to _submit the query_ you would insert the
first suggestion instead.

@codemirror/autocomplete v6.1 introduces the option to _not_ select the
first suggestion by default, avoiding this problem.
However, since this changes how the query input works (users have to
explicitly select an item before it be inserted), I'm putting this
behind a feature flag.
I'm also removing the "Tab" label from the selected suggestion.

Demo (you can't tell but I'm pressing Enter):

https://user-images.githubusercontent.com/179026/180072870-91f663bd-4f1d-4fee-8b83-e3a53b02c17a.mp4

Use "Tab" to select still works as before. However I noticed an issue if
multiple suggestions are shown, none is selected and "Tab" is pressed:
The suggestions popover closes, neither is a cursor visible nor is the
next button selected. It looks like `<body>` receives the focus which is
weird. The user can't easily go back to the input, only by clicking into
it. Even worse, the query input still appears to be focused.
I can't replicate this on https://codemirror.net/try/ so maybe it's some
something weird with our setup.
Given that the feature is behind a flag, I think it's still safe to
continue with this.

Demo (you can't tell but I'm pressing Tab and then I'm very confused): 

https://user-images.githubusercontent.com/179026/180072970-04df1495-9e69-4d5a-b65b-766446984cbc.mp4


## Test plan

Manual testing. Enter search query, notice that suggestions are not selected by default. Pressing enter submits the query. Selecting a suggestions and then pressing Enter (or Tab) inserts the suggestion.