### PR TITLE
Add lazy sync support for Rust packages

### DIFF
--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -15,7 +15,7 @@ type CodeHost struct {
 
 func (c *CodeHost) IsPackageHost() bool {
 	switch c.ServiceType {
-	case TypeNpmPackages, TypeJVMPackages, TypeGoModules, TypePythonPackages:
+	case TypeNpmPackages, TypeJVMPackages, TypeGoModules, TypePythonPackages, TypeRustPackages:
 		return true
 	}
 	return false
@@ -41,6 +41,9 @@ var (
 	PythonURL      = &url.URL{Host: "python"}
 	PythonPackages = NewCodeHost(PythonURL, TypePythonPackages)
 
+	RustURL      = &url.URL{Host: "crates"}
+	RustPackages = NewCodeHost(RustURL, TypeRustPackages)
+
 	PublicCodeHosts = []*CodeHost{
 		GitHubDotCom,
 		GitLabDotCom,
@@ -48,6 +51,7 @@ var (
 		NpmPackages,
 		GoModules,
 		PythonPackages,
+		RustPackages,
 	}
 )
 


### PR DESCRIPTION
Previously, Sourcegraph returned 404 when visiting the correct URL of an Rust package with a concrete version that wasn't tracked. This commit fixes that issue so that Sourcegraph lazy syncs the package+version and returns a 200 instead of 404.

This already worked for other package hosts like npm/pypi, this PR only adds the same support for Rust packages.

Fixes https://github.com/sourcegraph/sourcegraph/issues/37921
## Test plan

The change was manually tested with the command
```
SOURCEGRAPHDOTCOM_MODE=true sg start
```
and then visiting the URL of a crate that has not been tracked locally, for example https://sourcegraph.test:3443/crates/xquo@v0.1.1


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
