### PR TITLE
lib: use ReplaceAll instead of Replace(,,,-1)

### DIFF
--- a/lib/batches/schema/stringdata.go
+++ b/lib/batches/schema/stringdata.go
@@ -48,5 +48,5 @@ func main() {
 }
 
 func backtickStringLiteral(data string) string {
-	return "`" + strings.Replace(data, "`", "` + \"`\" + `", -1) + "`"
+	return "`" + strings.ReplaceAll(data, "`", "` + \"`\" + `") + "`"
 }


### PR DESCRIPTION
Replaced a call to `strings.Replace(x, y, z, -1)` with `strings.ReplaceAll(x, y, z)`, which does the same thing but is more straightforward.

## Test plan

This is a simple cleanup and no specifics actions other than CI should be necessary.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
