### PR TITLE
oobmigration: Add utilities for scheduling upgrades

### DIFF
--- a/internal/oobmigration/upgrade.go
+++ b/internal/oobmigration/upgrade.go
@@ -1,0 +1,96 @@
+package oobmigration
+
+import "sort"
+
+type MigrationInterrupt struct {
+	Version      Version
+	MigrationIDs []int
+}
+
+// ScheduleMigrationInterrupts returns the set of versions during an instance upgrade that
+// have out-of-band migration completion requirements.
+func ScheduleMigrationInterrupts() ([]MigrationInterrupt, error) {
+	return scheduleMigrationInterrupts(yamlMigrations)
+}
+
+func scheduleMigrationInterrupts(migrations []yamlMigration) ([]MigrationInterrupt, error) {
+	type migrationInterval struct {
+		id         int
+		introduced Version
+		deprecated Version
+	}
+
+	// First, extract the intervals on which the given out of band migrations are defined. If
+	// the interval hasn't been deprecated, it's still "open" and does not need to complete for
+	// the instance upgrade operation to be successful.
+
+	intervals := make([]migrationInterval, 0, len(migrations))
+	for _, m := range migrations {
+		if m.DeprecatedVersionMajor == nil {
+			continue
+		}
+
+		intervals = append(intervals, migrationInterval{
+			m.ID,
+			Version{m.IntroducedVersionMajor, m.IntroducedVersionMinor},
+			Version{*m.DeprecatedVersionMajor, *m.DeprecatedVersionMinor},
+		})
+	}
+
+	// Choose a minimal set of versions that intersect all migration intervals. These will be the
+	// points in the upgrade where we need to wait for an out of band migration to finish before
+	// proceeding to subsequent versions.
+	//
+	// The following greedy algorithm chooses the optimal number of versions with a single scan
+	// over the intervals:
+	//
+	//   (1) Order intervals by increasing upper bound
+	//   (2) For each interval, choose a new version equal to the interval's upper bound if
+	//       no previously chosen version falls within the interval.
+
+	sort.Slice(intervals, func(i, j int) bool {
+		return compareVersions(intervals[i].deprecated, intervals[j].deprecated) == VersionOrderBefore
+	})
+
+	points := make([]Version, 0, len(intervals))
+	for _, interval := range intervals {
+		if len(points) == 0 || compareVersions(points[len(points)-1], interval.introduced) == VersionOrderBefore {
+			points = append(points, interval.deprecated)
+		}
+	}
+
+	// Finally, we reconstruct the return value, which pairs each of our chosen versions with the
+	// set of migrations that need to finish prior to continuing the upgrade process. When an interval
+	// contains multiple chosen versions, we add it only to the largest version so that we delay
+	// completion as long as possible (hence the reversal of the points slice).
+
+	coveringSet := make(map[Version][]int, len(intervals))
+
+	for i, j := 0, len(points)-1; i < j; i, j = i+1, j-1 {
+		points[i], points[j] = points[j], points[i]
+	}
+
+outer:
+	for _, interval := range intervals {
+		for _, point := range points {
+			// check for intersection
+			if pointIntersectsInterval(interval.introduced, interval.deprecated, point) {
+				coveringSet[point] = append(coveringSet[point], interval.id)
+				continue outer
+			}
+		}
+
+		panic("unreachable: input interval not covered in output")
+	}
+
+	interupts := make([]MigrationInterrupt, 0, len(coveringSet))
+	for version, ids := range coveringSet {
+		sort.Ints(ids)
+		interupts = append(interupts, MigrationInterrupt{version, ids})
+	}
+	sort.Slice(interupts, func(i, j int) bool {
+		return compareVersions(interupts[i].Version, interupts[j].Version) == VersionOrderBefore
+	})
+
+	return interupts, nil
+}

--- a/internal/oobmigration/upgrade_test.go
+++ b/internal/oobmigration/upgrade_test.go
@@ -1,0 +1,88 @@
+package oobmigration
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestScheduleMigrationInterrupts(t *testing.T) {
+	migration := func(id, iMajor, iMinor, jMajor, jMinor int) yamlMigration {
+		return yamlMigration{
+			ID:                     id,
+			IntroducedVersionMajor: iMajor, IntroducedVersionMinor: iMinor,
+			DeprecatedVersionMajor: &jMajor, DeprecatedVersionMinor: &jMinor,
+		}
+	}
+
+	for _, testCase := range []struct {
+		name       string
+		migrations []yamlMigration
+		interrupts []MigrationInterrupt
+	}{
+		{
+			name:       "empty",
+			migrations: []yamlMigration{},
+			interrupts: []MigrationInterrupt{},
+		},
+		{
+			name: "non-overlapping",
+			migrations: []yamlMigration{
+				// 1: [------]
+				// 2: .      . [------]
+				// 3: .      . .      . [------]
+				// 4: .      . .      . .      . [------]
+				//    32 33 34 35 36 37 38 39 40 41 42 43
+				//          **       **       **       **
+
+				migration(1 /* introduced = */, 3, 32 /* deprecated = */, 3, 34),
+				migration(2 /* introduced = */, 3, 35 /* deprecated = */, 3, 37),
+				migration(3 /* introduced = */, 3, 38 /* deprecated = */, 3, 40),
+				migration(4 /* introduced = */, 3, 41 /* deprecated = */, 3, 43),
+			},
+			interrupts: []MigrationInterrupt{
+				{Version: Version{3, 34}, MigrationIDs: []int{1}},
+				{Version: Version{3, 37}, MigrationIDs: []int{2}},
+				{Version: Version{3, 40}, MigrationIDs: []int{3}},
+				{Version: Version{3, 43}, MigrationIDs: []int{4}},
+			},
+		},
+		{
+			name: "overlapping",
+			migrations: []yamlMigration{
+				// 1: [------]
+				// 2: .  [------]
+				// 3: .  .   .  . [---------------]
+				// 4: .  .   .  . .  [---]        .
+				// 5: .  .   .  . .  .   . [---]  .
+				// 6: .  .   .  . .  .   . .   .  . [---]
+				//    .  .   .  . .  .   . .   .  . .   .
+				//    32 33 34 35 36 37 38 39 40 41 42 43
+				//          **          **    **       **
+
+				migration(1 /* introduced = */, 3, 32 /* deprecated = */, 3, 34),
+				migration(2 /* introduced = */, 3, 33 /* deprecated = */, 3, 35),
+				migration(3 /* introduced = */, 3, 36 /* deprecated = */, 3, 41),
+				migration(4 /* introduced = */, 3, 37 /* deprecated = */, 3, 38),
+				migration(5 /* introduced = */, 3, 39 /* deprecated = */, 3, 40),
+				migration(6 /* introduced = */, 3, 42 /* deprecated = */, 3, 43),
+			},
+			interrupts: []MigrationInterrupt{
+				{Version: Version{3, 34}, MigrationIDs: []int{1, 2}},
+				{Version: Version{3, 38}, MigrationIDs: []int{4}},
+				{Version: Version{3, 40}, MigrationIDs: []int{3, 5}},
+				{Version: Version{3, 43}, MigrationIDs: []int{6}},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			interrupts, err := scheduleMigrationInterrupts(testCase.migrations)
+			if err != nil {
+				t.Fatalf("falied to schedule upgrade: %s", err)
+			}
+			if diff := cmp.Diff(testCase.interrupts, interrupts); diff != "" {
+				t.Fatalf("unexpected interrupts (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -42,3 +42,8 @@ func compareVersions(a, b Version) VersionOrder {
 
 	return VersionOrderEqual
 }
+
+// pointIntersectsInterval returns true if point falls within the interval [lower, upper].
+func pointIntersectsInterval(lower, upper, point Version) bool {
+	return compareVersions(point, lower) != VersionOrderBefore && compareVersions(upper, point) != VersionOrderBefore
+}


### PR DESCRIPTION
Add basic utilities to determine at what versions need oobmigrations to complete.

## Test plan

New unit tests included in this PR.