### PR TITLE
conf: replace any with generic in conf.Cached

### DIFF
--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var customGitFetch = conf.Cached(func() any {
+var customGitFetch = conf.Cached[map[string][]string](func() map[string][]string {
 	exp := conf.ExperimentalFeatures()
 	return buildCustomFetchMappings(exp.CustomGitFetch)
 })
@@ -30,7 +30,7 @@ func buildCustomFetchMappings(c []*schema.CustomGitFetchMapping) map[string][]st
 }
 
 func customFetchCmd(ctx context.Context, remoteURL *vcs.URL) *exec.Cmd {
-	cgm := customGitFetch().(map[string][]string)
+	cgm := customGitFetch()
 	if len(cgm) == 0 {
 		return nil
 	}

--- a/cmd/gitserver/server/customfetch_test.go
+++ b/cmd/gitserver/server/customfetch_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestEmptyCustomGitFetch(t *testing.T) {
-	customGitFetch = func() any {
+	customGitFetch = func() map[string][]string {
 		return buildCustomFetchMappings(nil)
 	}
 
@@ -66,7 +66,7 @@ func TestCustomGitFetch(t *testing.T) {
 		},
 	}
 
-	customGitFetch = func() any {
+	customGitFetch = func() map[string][]string {
 		return buildCustomFetchMappings(mappings)
 	}
 

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -102,7 +102,7 @@ type tlsConfig struct {
 	SSLCAInfo string
 }
 
-var tlsExternal = conf.Cached(func() any {
+var tlsExternal = conf.Cached[*tlsConfig](func() *tlsConfig {
 	exp := conf.ExperimentalFeatures()
 	c := exp.TlsExternal
 
@@ -143,7 +143,7 @@ func runWith(ctx context.Context, cmd *exec.Cmd, configRemoteOpts bool, progress
 		if cmd.Env == nil {
 			cmd.Env = os.Environ()
 		}
-		configureRemoteGitCommand(cmd, tlsExternal().(*tlsConfig))
+		configureRemoteGitCommand(cmd, tlsExternal())
 	}
 
 	var b interface {

--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -134,8 +134,14 @@ func Watch(f func()) {
 // will be recomputed every time the config is updated.
 //
 // IMPORTANT: The first call to wrapped will block on config initialization.
-func Cached(f func() any) (wrapped func() any) {
-	return DefaultClient().Cached(f)
+func Cached[T any](f func() T) (wrapped func() T) {
+	g := func() any {
+		return f()
+	}
+	h := DefaultClient().Cached(g)
+	return func() T {
+		return h().(T)
+	}
 }
 
 // Watch calls the given function in a separate goroutine whenever the

--- a/internal/conf/reposource/custom.go
+++ b/internal/conf/reposource/custom.go
@@ -30,7 +30,7 @@ type cloneURLResolver struct {
 
 // cloneURLResolvers is the list of clone-URL-to-repo-URI mappings, derived
 // from the site config
-var cloneURLResolvers = conf.Cached(func() any {
+var cloneURLResolvers = conf.Cached[[]*cloneURLResolver](func() []*cloneURLResolver {
 	cloneURLConfig := conf.Get().GitCloneURLToRepositoryName
 	var resolvers []*cloneURLResolver
 	for _, c := range cloneURLConfig {
@@ -51,7 +51,7 @@ var cloneURLResolvers = conf.Cached(func() any {
 // CustomCloneURLToRepoName maps from clone URL to repo name using custom mappings specified by the
 // user in site config. An empty string return value indicates no match.
 func CustomCloneURLToRepoName(cloneURL string) (repoName api.RepoName) {
-	for _, r := range cloneURLResolvers().([]*cloneURLResolver) {
+	for _, r := range cloneURLResolvers() {
 		if name := mapString(r.from, cloneURL, r.to); name != "" {
 			return api.RepoName(name)
 		}

--- a/internal/conf/reposource/custom_test.go
+++ b/internal/conf/reposource/custom_test.go
@@ -47,7 +47,7 @@ func TestCustomCloneURLToRepoName(t *testing.T) {
 	}}
 
 	for i, test := range tests {
-		cloneURLResolvers = func() any { return test.cloneURLResolvers }
+		cloneURLResolvers = func() []*cloneURLResolver { return test.cloneURLResolvers }
 		for cloneURL, expName := range test.cloneURLToRepoName {
 			if name := CustomCloneURLToRepoName(cloneURL); name != expName {
 				t.Errorf("In test case %d, expected %s -> %s, but got %s", i+1, cloneURL, expName, name)


### PR DESCRIPTION
This feels like a reasonable use of generics. It moves a potential runtime error (type casting the wrong type) to being a compile time error. Additionally the callsites are easier to read now.

Test Plan: go test