### PR TITLE
conf: remove Edits

### DIFF
--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/sourcegraph/jsonx"
-
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // ConfigurationSource provides direct access to read and write to the
@@ -67,50 +64,6 @@ func (s *Server) Write(ctx context.Context, input conftypes.RawUnified) error {
 	// until this is done.
 	<-doneReading
 
-	return nil
-}
-
-// Edits describes some JSON edits to apply to site configuration.
-type Edits struct {
-	Site []jsonx.Edit
-}
-
-// Edit invokes the provided function to compute edits to the site
-// configuration. It then applies and writes them.
-//
-// The computation function is provided the current configuration, which should
-// NEVER be modified in any way. Always copy values.
-//
-// TODO(slimsag): Currently, edits may only be applied via the frontend. It may
-// make sense to allow non-frontend services to apply edits as well. To do this
-// we would need to pipe writes through the frontend's internal httpapi.
-func (s *Server) Edit(ctx context.Context, computeEdits func(current *Unified, raw conftypes.RawUnified) (Edits, error)) error {
-	// TODO@ggilmore: There is a race condition here (also present in the existing library).
-	// Current and raw could be inconsistent. Another thing to offload to configStore?
-	// Snapshot method?
-	client := DefaultClient()
-	current := client.store.LastValid()
-	raw := client.Raw()
-
-	// Compute edits.
-	edits, err := computeEdits(current, raw)
-	if err != nil {
-		return errors.Wrap(err, "computeEdits")
-	}
-
-	// Apply edits and write out new configuration.
-	newSite, err := jsonx.ApplyEdits(raw.Site, edits.Site...)
-	if err != nil {
-		return errors.Wrap(err, "jsonx.ApplyEdits Site")
-	}
-
-	// TODO@ggilmore: Another race condition (also present in the existing library). Locks
-	// aren't held between applying the edits and writing the config file,
-	// so the newConfig could be outdated.
-	err = s.Write(ctx, conftypes.RawUnified{Site: newSite})
-	if err != nil {
-		return errors.Wrap(err, "conf.Write")
-	}
 	return nil
 }
 


### PR DESCRIPTION
I couldn't find a usage of it. Tried this search and got nothing, I'm not sure if it was ever used since we open sourced:

```
type:diff \.Edit\b Edits before:2022 count:all
```

Test Plan: CI