### PR TITLE
conf: unexport NeedRestartToApply and RedactedSecret

### DIFF
--- a/internal/conf/parse.go
+++ b/internal/conf/parse.go
@@ -63,9 +63,9 @@ var requireRestart = []string{
 	"permissions.syncUsersMaxConcurrency",
 }
 
-// NeedRestartToApply determines if a restart is needed to apply the changes
+// needRestartToApply determines if a restart is needed to apply the changes
 // between the two configurations.
-func NeedRestartToApply(before, after *Unified) bool {
+func needRestartToApply(before, after *Unified) bool {
 	// Check every option that changed to determine whether or not a server
 	// restart is required.
 	for option := range diff(before, after) {

--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -132,7 +132,7 @@ func (s *Server) Start() {
 
 				// Update global "needs restart" state.
 				newConfig := Get()
-				if NeedRestartToApply(oldConfig, newConfig) {
+				if needRestartToApply(oldConfig, newConfig) {
 					s.markNeedServerRestart()
 				}
 

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -49,7 +49,7 @@ var ignoreLegacyKubernetesFields = map[string]struct{}{
 	"useAlertManager":       {},
 }
 
-const RedactedSecret = "REDACTED"
+const redactedSecret = "REDACTED"
 
 // problemKind represents the kind of a configuration problem.
 type problemKind string
@@ -250,13 +250,13 @@ func UnredactSecrets(input string, raw conftypes.RawUnified) (string, error) {
 		return input, errors.Wrap(err, "parse new config")
 	}
 	for _, ap := range newCfg.AuthProviders {
-		if ap.Openidconnect != nil && ap.Openidconnect.ClientSecret == RedactedSecret {
+		if ap.Openidconnect != nil && ap.Openidconnect.ClientSecret == redactedSecret {
 			ap.Openidconnect.ClientSecret = oldSecrets[ap.Openidconnect.ClientID]
 		}
-		if ap.Github != nil && ap.Github.ClientSecret == RedactedSecret {
+		if ap.Github != nil && ap.Github.ClientSecret == redactedSecret {
 			ap.Github.ClientSecret = oldSecrets[ap.Github.ClientID]
 		}
-		if ap.Gitlab != nil && ap.Gitlab.ClientSecret == RedactedSecret {
+		if ap.Gitlab != nil && ap.Gitlab.ClientSecret == redactedSecret {
 			ap.Gitlab.ClientSecret = oldSecrets[ap.Gitlab.ClientID]
 		}
 	}
@@ -267,7 +267,7 @@ func UnredactSecrets(input string, raw conftypes.RawUnified) (string, error) {
 
 	for _, secret := range siteConfigSecrets {
 		v := gjson.Get(unredactedSite, secret.readPath).String()
-		if v != RedactedSecret {
+		if v != redactedSecret {
 			continue
 		}
 
@@ -292,13 +292,13 @@ func RedactSecrets(raw conftypes.RawUnified) (empty conftypes.RawUnified, err er
 
 	for _, ap := range cfg.AuthProviders {
 		if ap.Openidconnect != nil {
-			ap.Openidconnect.ClientSecret = RedactedSecret
+			ap.Openidconnect.ClientSecret = redactedSecret
 		}
 		if ap.Github != nil {
-			ap.Github.ClientSecret = RedactedSecret
+			ap.Github.ClientSecret = redactedSecret
 		}
 		if ap.Gitlab != nil {
-			ap.Gitlab.ClientSecret = RedactedSecret
+			ap.Gitlab.ClientSecret = redactedSecret
 		}
 	}
 	redactedSite, err := jsonc.Edit(raw.Site, cfg.AuthProviders, "auth.providers")
@@ -312,7 +312,7 @@ func RedactSecrets(raw conftypes.RawUnified) (empty conftypes.RawUnified, err er
 			continue
 		}
 
-		redactedSite, err = jsonc.Edit(redactedSite, RedactedSecret, secret.editPaths...)
+		redactedSite, err = jsonc.Edit(redactedSite, redactedSecret, secret.editPaths...)
 		if err != nil {
 			return empty, errors.Wrapf(err, `redact %q`, strings.Join(secret.editPaths, " > "))
 		}

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -178,20 +178,20 @@ func TestUnredactSecrets(t *testing.T) {
 		input := getTestSiteWithRedactedSecrets()
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
 		require.NoError(t, err)
-		assert.NotContains(t, unredactedSite, RedactedSecret)
+		assert.NotContains(t, unredactedSite, redactedSecret)
 		assert.Equal(t, previousSite, unredactedSite)
 	})
 
 	t.Run("unredacts secrets AND respects specified edits to secret", func(t *testing.T) {
 		input := getTestSiteWithSecrets(
 			"new"+executorsAccessToken,
-			RedactedSecret, "new"+authGitLabClientSecret, RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
+			redactedSecret, "new"+authGitLabClientSecret, redactedSecret,
+			redactedSecret,
+			redactedSecret,
+			redactedSecret,
+			redactedSecret,
+			redactedSecret,
+			redactedSecret,
 		)
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
 		require.NoError(t, err)
@@ -214,13 +214,13 @@ func TestUnredactSecrets(t *testing.T) {
 		const newEmail = "new_email@example.com"
 		input := getTestSiteWithSecrets(
 			"new"+executorsAccessToken,
-			RedactedSecret, "new"+authGitLabClientSecret, RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
-			RedactedSecret,
+			redactedSecret, "new"+authGitLabClientSecret, redactedSecret,
+			redactedSecret,
+			redactedSecret,
+			redactedSecret,
+			redactedSecret,
+			redactedSecret,
+			redactedSecret,
 			newEmail,
 		)
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
@@ -243,7 +243,7 @@ func TestUnredactSecrets(t *testing.T) {
 }
 
 func getTestSiteWithRedactedSecrets() string {
-	return getTestSiteWithSecrets(RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret)
+	return getTestSiteWithSecrets(redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret)
 }
 
 func getTestSiteWithSecrets(


### PR DESCRIPTION
These don't make sense to export nor are they used by any external packages. Just something I noticed while reading code.

Test Plan: CI