### PR TITLE
build: Rename Sentry auth token's environment variable

### DIFF
--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -42,8 +42,8 @@ export const ENVIRONMENT_CONFIG = {
     RELEASE_CANDIDATE_VERSION: process.env.RELEASE_CANDIDATE_VERSION,
     // Should sourcemaps be uploaded to Sentry.
     SENTRY_UPLOAD_SOURCE_MAPS: getEnvironmentBoolean('SENTRY_UPLOAD_SOURCE_MAPS'),
-    // Sentry authentication token
-    SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
+    // Sentry's Dotcom project's authentication token
+    SENTRY_DOT_COM_AUTH_TOKEN: process.env.SENTRY_DOT_COM_AUTH_TOKEN,
     // Sentry organization
     SENTRY_ORGANIZATION: process.env.SENTRY_ORGANIZATION,
     // Sentry project

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -46,7 +46,7 @@ const {
   SENTRY_UPLOAD_SOURCE_MAPS,
   COMMIT_SHA,
   RELEASE_CANDIDATE_VERSION,
-  SENTRY_AUTH_TOKEN,
+  SENTRY_DOT_COM_AUTH_TOKEN,
   SENTRY_ORGANIZATION,
   SENTRY_PROJECT,
 } = ENVIRONMENT_CONFIG
@@ -189,7 +189,7 @@ const config = {
       new SentryWebpackPlugin({
         org: SENTRY_ORGANIZATION,
         project: SENTRY_PROJECT,
-        authToken: SENTRY_AUTH_TOKEN,
+        authToken: SENTRY_DOT_COM_AUTH_TOKEN,
         release: `frontend@${RELEASE_CANDIDATE_VERSION}`,
         include: path.join(STATIC_ASSETS_PATH, 'scripts'),
       }),


### PR DESCRIPTION
Renaming `SENTRY_AUTH_TOKEN` to `SENTRY_DOT_COM_AUTH_TOKEN` in the Webpack config. [[ref](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1658327994814869?thread_ts=1658129158.954509&cid=C01N83PS4TU)]

## Test plan

Just renaming variables, can be tested in the next release!

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mihir-webpack-env-var-rename.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dmadtqlcnf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
