### PR TITLE
migration: normalize license key fields and record subscription account number

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -14106,10 +14106,62 @@
           "Comment": ""
         },
         {
+          "Name": "license_expires_at",
+          "Index": 8,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "license_key",
           "Index": 3,
           "TypeName": "text",
           "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "license_tags",
+          "Index": 6,
+          "TypeName": "text[]",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "license_user_count",
+          "Index": 7,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "license_version",
+          "Index": 5,
+          "TypeName": "integer",
+          "IsNullable": true,
           "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,
@@ -14159,6 +14211,19 @@
       "Name": "product_subscriptions",
       "Comment": "",
       "Columns": [
+        {
+          "Name": "account_number",
+          "Index": 7,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
         {
           "Name": "archived_at",
           "Index": 6,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2173,6 +2173,10 @@ Indexes:
  product_subscription_id | uuid                     |           | not null | 
  license_key             | text                     |           | not null | 
  created_at              | timestamp with time zone |           | not null | now()
+ license_version         | integer                  |           |          | 
+ license_tags            | text[]                   |           |          | 
+ license_user_count      | integer                  |           |          | 
+ license_expires_at      | timestamp with time zone |           |          | 
 Indexes:
     "product_licenses_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -2190,6 +2194,7 @@ Foreign-key constraints:
  created_at              | timestamp with time zone |           | not null | now()
  updated_at              | timestamp with time zone |           | not null | now()
  archived_at             | timestamp with time zone |           |          | 
+ account_number          | text                     |           |          | 
 Indexes:
     "product_subscriptions_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:

--- a/migrations/frontend/1658384388_normalize_product_licenseslicense_key_fields/down.sql
+++ b/migrations/frontend/1658384388_normalize_product_licenseslicense_key_fields/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE product_licenses DROP COLUMN IF EXISTS license_version;
+ALTER TABLE product_licenses DROP COLUMN IF EXISTS license_tags;
+ALTER TABLE product_licenses DROP COLUMN IF EXISTS license_user_count;
+ALTER TABLE product_licenses DROP COLUMN IF EXISTS license_expires_at;
+ALTER TABLE product_subscriptions DROP COLUMN IF EXISTS account_number;

--- a/migrations/frontend/1658384388_normalize_product_licenseslicense_key_fields/metadata.yaml
+++ b/migrations/frontend/1658384388_normalize_product_licenseslicense_key_fields/metadata.yaml
@@ -1,0 +1,2 @@
+name: normalize product_licenses.license_key fields
+parents: [1658255432]

--- a/migrations/frontend/1658384388_normalize_product_licenseslicense_key_fields/up.sql
+++ b/migrations/frontend/1658384388_normalize_product_licenseslicense_key_fields/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE product_licenses ADD COLUMN IF NOT EXISTS license_version INT;
+ALTER TABLE product_licenses ADD COLUMN IF NOT EXISTS license_tags TEXT[];
+ALTER TABLE product_licenses ADD COLUMN IF NOT EXISTS license_user_count INT;
+ALTER TABLE product_licenses ADD COLUMN IF NOT EXISTS license_expires_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE product_subscriptions ADD COLUMN IF NOT EXISTS account_number TEXT;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2594,7 +2594,11 @@ CREATE TABLE product_licenses (
     id uuid NOT NULL,
     product_subscription_id uuid NOT NULL,
     license_key text NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    license_version integer,
+    license_tags text[],
+    license_user_count integer,
+    license_expires_at timestamp with time zone
 );
 
 CREATE TABLE product_subscriptions (
@@ -2603,7 +2607,8 @@ CREATE TABLE product_subscriptions (
     billing_subscription_id text,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    archived_at timestamp with time zone
+    archived_at timestamp with time zone,
+    account_number text
 );
 
 CREATE TABLE query_runner_state (


### PR DESCRIPTION
We want to use Polytomic to pull license data from our Postgres to Salesforce, but we currently only store the encoded license key which then requires on-the-fly decoding during the data transmission that can not be easily supported (only SQL is allowed, and for some reasons we used `base64.RawURLEncoding.EncodeString` which doesn't have padding that the Postgres base64 decoder would expect).

This PR adds columns needed to normalize the license tags, user count and expiration date as dedicated columns to be populated later (update the write path + OOB migration).

We currently also optionally include a Salesforce account number in the user name (e.g. `XYZ-11223344`) that a product subscription is associated with (as a hack, due to lack of this column), thus adding the `product_subscriptions.account_number` column as well.

## Test plan

CI

---

Part of https://github.com/sourcegraph/sourcegraph/issues/38661