### PR TITLE
dec/ci/go-backcompat: disable 3.41 flakey RunnerInteractive test

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v3.41.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.41.0.json
@@ -68,5 +68,10 @@
     "path": "internal/usagestats",
     "prefix": "TestGetBatchChangesUsageStatistics",
     "reason": "Fixed up DB constraints, now the test inserts invalid test data."
+  },
+  {
+    "path": "dev/sg/internal/check",
+    "prefix": "RunnerInteractive",
+    "reason": "Flake was only fixed after 3.41, doesn't interact with databases anyway."
   }
 ]


### PR DESCRIPTION
Following the instructions on this _beautiful_ annotation:

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/23356519/180159187-733c9a2c-0317-44c3-af96-1862a7344b4c.png">

https://buildkite.com/sourcegraph/sourcegraph/builds/162340

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a