### PR TITLE
subscriptions: attempt to extract account number from username upon creation

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -20,7 +20,7 @@ func TestProductLicenses_Create(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ps0, err := dbSubscriptions{db: db}.Create(ctx, u.ID)
+	ps0, err := dbSubscriptions{db: db}.Create(ctx, u.ID, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,11 +74,11 @@ func TestProductLicenses_List(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ps0, err := dbSubscriptions{db: db}.Create(ctx, u1.ID)
+	ps0, err := dbSubscriptions{db: db}.Create(ctx, u1.ID, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ps1, err := dbSubscriptions{db: db}.Create(ctx, u1.ID)
+	ps1, err := dbSubscriptions{db: db}.Create(ctx, u1.ID, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -3,6 +3,7 @@ package productsubscription
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -20,6 +21,7 @@ type dbSubscription struct {
 	BillingSubscriptionID *string // this subscription's ID in the billing system
 	CreatedAt             time.Time
 	ArchivedAt            *time.Time
+	AccountNumber         *string
 }
 
 var emailQueries = sqlf.Sprintf(`all_primary_emails AS (
@@ -38,22 +40,29 @@ type dbSubscriptions struct {
 	db database.DB
 }
 
-// Create creates a new product subscription entry given a license key.
-func (s dbSubscriptions) Create(ctx context.Context, userID int32) (id string, err error) {
+// Create creates a new product subscription entry for the given user. It also
+// attempts to extract the Salesforce account number from the username following
+// the format "<name>-<account number>".
+func (s dbSubscriptions) Create(ctx context.Context, userID int32, username string) (id string, err error) {
 	if mocks.subscriptions.Create != nil {
 		return mocks.subscriptions.Create(userID)
 	}
 
+	var accountNumber string
+	if i := strings.LastIndex(username, "-"); i > -1 {
+		accountNumber = username[i+1:]
+	}
+
 	uuid, err := uuid.NewRandom()
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "new UUID")
 	}
-	if err := s.db.QueryRowContext(ctx, `
-INSERT INTO product_subscriptions(id, user_id) VALUES($1, $2) RETURNING id
+	if err = s.db.QueryRowContext(ctx, `
+INSERT INTO product_subscriptions(id, user_id, account_number) VALUES($1, $2, $3) RETURNING id
 `,
-		uuid, userID,
+		uuid, userID, accountNumber,
 	).Scan(&id); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "insert")
 	}
 	return id, nil
 }
@@ -109,7 +118,13 @@ func (s dbSubscriptions) List(ctx context.Context, opt dbSubscriptionsListOption
 func (s dbSubscriptions) list(ctx context.Context, conds []*sqlf.Query, limitOffset *database.LimitOffset) ([]*dbSubscription, error) {
 	q := sqlf.Sprintf(`
 WITH %s
-SELECT product_subscriptions.id, product_subscriptions.user_id, billing_subscription_id, product_subscriptions.created_at, product_subscriptions.archived_at
+SELECT
+	product_subscriptions.id,
+	product_subscriptions.user_id,
+	billing_subscription_id,
+	product_subscriptions.created_at,
+	product_subscriptions.archived_at,
+	product_subscriptions.account_number
 FROM product_subscriptions
 LEFT OUTER JOIN users ON product_subscriptions.user_id = users.id
 LEFT OUTER JOIN primary_emails ON users.id = primary_emails.user_id
@@ -130,7 +145,7 @@ ORDER BY archived_at DESC NULLS FIRST, created_at DESC
 	var results []*dbSubscription
 	for rows.Next() {
 		var v dbSubscription
-		if err := rows.Scan(&v.ID, &v.UserID, &v.BillingSubscriptionID, &v.CreatedAt, &v.ArchivedAt); err != nil {
+		if err := rows.Scan(&v.ID, &v.UserID, &v.BillingSubscriptionID, &v.CreatedAt, &v.ArchivedAt, &v.AccountNumber); err != nil {
 			return nil, err
 		}
 		results = append(results, &v)

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -60,7 +61,7 @@ func (s dbSubscriptions) Create(ctx context.Context, userID int32, username stri
 	if err = s.db.QueryRowContext(ctx, `
 INSERT INTO product_subscriptions(id, user_id, account_number) VALUES($1, $2, $3) RETURNING id
 `,
-		uuid, userID, accountNumber,
+		uuid, userID, dbutil.NewNullString(accountNumber),
 	).Scan(&id); err != nil {
 		return "", errors.Wrap(err, "insert")
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -16,45 +18,28 @@ func TestProductSubscriptions_Create(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	ctx := context.Background()
 
-	u, err := db.Users().Create(ctx, database.NewUser{Username: "u"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	u, err := db.Users().Create(ctx, database.NewUser{Username: "u-11223344"})
+	require.NoError(t, err)
 
-	sub0, err := dbSubscriptions{db: db}.Create(ctx, u.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sub0, err := dbSubscriptions{db: db}.Create(ctx, u.ID, u.Username)
+	require.NoError(t, err)
 
 	got, err := dbSubscriptions{db: db}.GetByID(ctx, sub0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := sub0; got.ID != want {
-		t.Errorf("got %v, want %v", got.ID, want)
-	}
-	if want := u.ID; got.UserID != want {
-		t.Errorf("got %v, want %v", got.UserID, want)
-	}
-	if got.BillingSubscriptionID != nil {
-		t.Errorf("got %v, want nil", got.BillingSubscriptionID)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, sub0, got.ID)
+	assert.Equal(t, u.ID, got.UserID)
+	assert.Nil(t, got.BillingSubscriptionID)
+
+	require.NotNil(t, got.AccountNumber)
+	assert.Equal(t, "11223344", *got.AccountNumber)
 
 	ts, err := dbSubscriptions{db: db}.List(ctx, dbSubscriptionsListOptions{UserID: u.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := 1; len(ts) != want {
-		t.Errorf("got %d product subscriptions, want %d", len(ts), want)
-	}
+	require.NoError(t, err)
+	assert.Len(t, ts, 1)
 
 	ts, err = dbSubscriptions{db: db}.List(ctx, dbSubscriptionsListOptions{UserID: 123 /* invalid */})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := 0; len(ts) != want {
-		t.Errorf("got %d product subscriptions, want %d", len(ts), want)
-	}
+	require.NoError(t, err)
+	assert.Len(t, ts, 0)
 }
 
 func TestProductSubscriptions_List(t *testing.T) {
@@ -71,11 +56,11 @@ func TestProductSubscriptions_List(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = dbSubscriptions{db: db}.Create(ctx, u1.ID)
+	_, err = dbSubscriptions{db: db}.Create(ctx, u1.ID, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = dbSubscriptions{db: db}.Create(ctx, u1.ID)
+	_, err = dbSubscriptions{db: db}.Create(ctx, u1.ID, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +116,7 @@ func TestProductSubscriptions_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sub0, err := dbSubscriptions{db: db}.Create(ctx, u.ID)
+	sub0, err := dbSubscriptions{db: db}.Create(ctx, u.ID, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
@@ -18,15 +18,29 @@ func TestProductSubscriptions_Create(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	ctx := context.Background()
 
+	t.Run("no account number", func(t *testing.T) {
+		u, err := db.Users().Create(ctx, database.NewUser{Username: "u"})
+		require.NoError(t, err)
+
+		sub, err := dbSubscriptions{db: db}.Create(ctx, u.ID, u.Username)
+		require.NoError(t, err)
+
+		got, err := dbSubscriptions{db: db}.GetByID(ctx, sub)
+		require.NoError(t, err)
+		assert.Equal(t, sub, got.ID)
+		assert.Equal(t, u.ID, got.UserID)
+		assert.Nil(t, got.AccountNumber)
+	})
+
 	u, err := db.Users().Create(ctx, database.NewUser{Username: "u-11223344"})
 	require.NoError(t, err)
 
-	sub0, err := dbSubscriptions{db: db}.Create(ctx, u.ID, u.Username)
+	sub, err := dbSubscriptions{db: db}.Create(ctx, u.ID, u.Username)
 	require.NoError(t, err)
 
-	got, err := dbSubscriptions{db: db}.GetByID(ctx, sub0)
+	got, err := dbSubscriptions{db: db}.GetByID(ctx, sub)
 	require.NoError(t, err)
-	assert.Equal(t, sub0, got.ID)
+	assert.Equal(t, sub, got.ID)
 	assert.Equal(t, u.ID, got.UserID)
 	assert.Nil(t, got.BillingSubscriptionID)
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -198,7 +198,7 @@ func (r ProductSubscriptionLicensingResolver) CreateProductSubscription(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	id, err := dbSubscriptions{db: r.DB}.Create(ctx, user.DatabaseID())
+	id, err := dbSubscriptions{db: r.DB}.Create(ctx, user.DatabaseID(), user.Username())
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +268,7 @@ func (r ProductSubscriptionLicensingResolver) CreatePaidProductSubscription(ctx 
 
 	// Create the subscription in our database first, before processing payment. If payment fails,
 	// users can retry payment on the already created subscription.
-	subID, err := dbSubscriptions{db: r.DB}.Create(ctx, user.DatabaseID())
+	subID, err := dbSubscriptions{db: r.DB}.Create(ctx, user.DatabaseID(), user.Username())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CEs are currently (as the convention) including a Salesforce account number in the username (e.g. `XYZ-11223344`) that a product subscription is associated with. This PR adds the logic to attempt extracting this account number whenever possible and save it to the `product_subscriptions.account_number` column.

The value of the column will then be used to link up dotcom license keys and Salesforce accounts.

Notes:
1. Existing subscriptions will be handled by an OOB migration that comes later.
2. The IAM team has the plan to move off license management completely out of dotcom instance, therefore minimal effort to make existing license workflow easier.

## Test plan

CI

---

Part of https://github.com/sourcegraph/sourcegraph/issues/38661
