### PR TITLE
search: update copy for skipped files

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -112,7 +112,7 @@ const TextSearchIndexedReference: React.FunctionComponent<
                             .&nbsp;
                             <Link to={'/search?q=' + encodeURIComponent(indexedRef.skippedIndexed.query)}>
                                 {indexedRef.skippedIndexed.count} {pluralize('file', indexedRef.skippedIndexed.count)}{' '}
-                                not indexed
+                                skipped during indexing
                             </Link>
                             .
                         </span>


### PR DESCRIPTION
The current copy is misleading.

before
![image](https://user-images.githubusercontent.com/26413131/180161395-3d7c2046-b438-442a-b7d0-a62495187e5a.png)


after
![image](https://user-images.githubusercontent.com/26413131/180161327-5dc6109f-2983-4030-a611-7fc8b73d8b7d.png)

## Test plan
just a minor change of copy