### PR TITLE
[SG-39076] thenify before 3.3.1 made use of unsafe calls to eval.

### DIFF
--- a/package.json
+++ b/package.json
@@ -490,6 +490,7 @@
     "webpack": "5",
     "tslib": "2.1.0",
     "prettier": "2.2.1",
-    "jsprim": "1.4.2"
+    "jsprim": "1.4.2",
+    "thenify": "3.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23522,10 +23522,10 @@ thenify-all@^1.0.0:
   dependencies:
     thenify ">= 3.1.0 < 4"
 
-"thenify@>= 3.1.0 < 4":
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
-  integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
+thenify@3.3.1, "thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
 


### PR DESCRIPTION
## Description
Versions of `thenify` prior to 3.3.1 made use of unsafe calls to eval. Untrusted user input could thus lead to arbitrary code execution on the host. The patch in version 3.3.1 removes calls to eval.
## Success criteria
Update thenify to a non-vulnerable version
## Implementation details
The latest possible version of thenify that can be installed is 3.3.0.
The earliest fixed version is 3.3.1.
- Affected versions < 3.3.1

### Refs
[Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/39076)
[Gitstart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-39076)
## Test plan
Make sure there is no `CI` error resulting from this change 