### PR TITLE
licenses: store version and information to dedicated columns

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -17,6 +20,10 @@ type dbLicense struct {
 	ProductSubscriptionID string // UUID
 	LicenseKey            string
 	CreatedAt             time.Time
+	LicenseVersion        *int
+	LicenseTags           []string
+	LicenseUserCount      *int
+	LicenseExpiresAt      *time.Time
 }
 
 // errLicenseNotFound occurs when a database operation expects a specific Sourcegraph
@@ -28,22 +35,23 @@ type dbLicenses struct {
 	db database.DB
 }
 
-// Create creates a new product license entry given a license key.
-func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey string) (id string, err error) {
+// Create creates a new product license entry for the given subscription.
+func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey string, version int, info license.Info) (id string, err error) {
 	if mocks.licenses.Create != nil {
 		return mocks.licenses.Create(subscriptionID, licenseKey)
 	}
 
 	uuid, err := uuid.NewRandom()
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "new UUID")
 	}
-	if err := s.db.QueryRowContext(ctx, `
-INSERT INTO product_licenses(id, product_subscription_id, license_key) VALUES($1, $2, $3) RETURNING id
+	if err = s.db.QueryRowContext(ctx, `
+INSERT INTO product_licenses(id, product_subscription_id, license_key, license_version, license_tags, license_user_count, license_expires_at)
+VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id
 `,
-		uuid, subscriptionID, licenseKey,
+		uuid, subscriptionID, licenseKey, version, pq.Array(info.Tags), info.UserCount, dbutil.NullTime{Time: &info.ExpiresAt},
 	).Scan(&id); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "insert")
 	}
 	return id, nil
 }
@@ -109,7 +117,16 @@ func (s dbLicenses) List(ctx context.Context, opt dbLicensesListOptions) ([]*dbL
 
 func (s dbLicenses) list(ctx context.Context, conds []*sqlf.Query, limitOffset *database.LimitOffset) ([]*dbLicense, error) {
 	q := sqlf.Sprintf(`
-SELECT id, product_subscription_id, license_key, created_at FROM product_licenses
+SELECT
+	id,
+	product_subscription_id,
+	license_key,
+	created_at,
+	license_version,
+	license_tags,
+	license_user_count,
+	license_expires_at
+FROM product_licenses
 WHERE (%s)
 ORDER BY created_at DESC
 %s`,
@@ -126,7 +143,7 @@ ORDER BY created_at DESC
 	var results []*dbLicense
 	for rows.Next() {
 		var v dbLicense
-		if err := rows.Scan(&v.ID, &v.ProductSubscriptionID, &v.LicenseKey, &v.CreatedAt); err != nil {
+		if err := rows.Scan(&v.ID, &v.ProductSubscriptionID, &v.LicenseKey, &v.CreatedAt, &v.LicenseVersion, pq.Array(&v.LicenseTags), &v.LicenseUserCount, &v.LicenseExpiresAt); err != nil {
 			return nil, err
 		}
 		results = append(results, &v)

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -22,6 +22,15 @@ func TestProductLicenses_Create(t *testing.T) {
 	u, err := db.Users().Create(ctx, database.NewUser{Username: "u"})
 	require.NoError(t, err)
 
+	t.Run("empty license info", func(t *testing.T) {
+		ps, err := dbSubscriptions{db: db}.Create(ctx, u.ID, u.Username)
+		require.NoError(t, err)
+
+		// This should not happen in practice but just in case to check it won't blow up
+		_, err = dbLicenses{db: db}.Create(ctx, ps, "k", 1, license.Info{})
+		require.NoError(t, err)
+	})
+
 	ps, err := dbSubscriptions{db: db}.Create(ctx, u.ID, "")
 	require.NoError(t, err)
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -27,8 +27,15 @@ func TestProductLicenses_Create(t *testing.T) {
 		require.NoError(t, err)
 
 		// This should not happen in practice but just in case to check it won't blow up
-		_, err = dbLicenses{db: db}.Create(ctx, ps, "k", 1, license.Info{})
+		pl, err := dbLicenses{db: db}.Create(ctx, ps, "k", 0, license.Info{})
 		require.NoError(t, err)
+
+		got, err := dbLicenses{db: db}.GetByID(ctx, pl)
+		require.NoError(t, err)
+		assert.Nil(t, got.LicenseVersion)
+		assert.Nil(t, got.LicenseTags)
+		assert.Nil(t, got.LicenseUserCount)
+		assert.Nil(t, got.LicenseExpiresAt)
 	})
 
 	ps, err := dbSubscriptions{db: db}.Create(ctx, u.ID, "")

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -5,9 +5,13 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestProductLicenses_Create(t *testing.T) {
@@ -16,49 +20,42 @@ func TestProductLicenses_Create(t *testing.T) {
 	ctx := context.Background()
 
 	u, err := db.Users().Create(ctx, database.NewUser{Username: "u"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	ps0, err := dbSubscriptions{db: db}.Create(ctx, u.ID, "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ps, err := dbSubscriptions{db: db}.Create(ctx, u.ID, "")
+	require.NoError(t, err)
 
-	pl0, err := dbLicenses{db: db}.Create(ctx, ps0, "k")
-	if err != nil {
-		t.Fatal(err)
+	now := timeutil.Now()
+	info := license.Info{
+		Tags:      []string{"true-up"},
+		UserCount: 10,
+		ExpiresAt: now,
 	}
+	pl, err := dbLicenses{db: db}.Create(ctx, ps, "k", 1, info)
+	require.NoError(t, err)
 
-	got, err := dbLicenses{db: db}.GetByID(ctx, pl0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := pl0; got.ID != want {
-		t.Errorf("got %v, want %v", got.ID, want)
-	}
-	if want := ps0; got.ProductSubscriptionID != want {
-		t.Errorf("got %v, want %v", got.ProductSubscriptionID, want)
-	}
-	if want := "k"; got.LicenseKey != want {
-		t.Errorf("got %q, want %q", got.LicenseKey, want)
-	}
+	got, err := dbLicenses{db: db}.GetByID(ctx, pl)
+	require.NoError(t, err)
+	assert.Equal(t, pl, got.ID)
+	assert.Equal(t, ps, got.ProductSubscriptionID)
+	assert.Equal(t, "k", got.LicenseKey)
 
-	ts, err := dbLicenses{db: db}.List(ctx, dbLicensesListOptions{ProductSubscriptionID: ps0})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := 1; len(ts) != want {
-		t.Errorf("got %d product licenses, want %d", len(ts), want)
-	}
+	require.NotNil(t, got.LicenseVersion)
+	assert.Equal(t, 1, *got.LicenseVersion)
+	require.NotNil(t, got.LicenseTags)
+	assert.Equal(t, info.Tags, got.LicenseTags)
+	require.NotNil(t, got.LicenseUserCount)
+	assert.Equal(t, int(info.UserCount), *got.LicenseUserCount)
+	require.NotNil(t, got.LicenseExpiresAt)
+	assert.Equal(t, info.ExpiresAt, *got.LicenseExpiresAt)
+
+	ts, err := dbLicenses{db: db}.List(ctx, dbLicensesListOptions{ProductSubscriptionID: ps})
+	require.NoError(t, err)
+	assert.Len(t, ts, 1)
 
 	ts, err = dbLicenses{db: db}.List(ctx, dbLicensesListOptions{ProductSubscriptionID: "69da12d5-323c-4e42-9d44-cc7951639bca" /* invalid */})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := 0; len(ts) != want {
-		t.Errorf("got %d product licenses, want %d", len(ts), want)
-	}
+	require.NoError(t, err)
+	assert.Len(t, ts, 0)
 }
 
 func TestProductLicenses_List(t *testing.T) {
@@ -83,11 +80,11 @@ func TestProductLicenses_List(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = dbLicenses{db: db}.Create(ctx, ps0, "k")
+	_, err = dbLicenses{db: db}.Create(ctx, ps0, "k", 1, license.Info{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = dbLicenses{db: db}.Create(ctx, ps0, "n1")
+	_, err = dbLicenses{db: db}.Create(ctx, ps0, "n1", 1, license.Info{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -102,15 +102,16 @@ func (r *productLicense) CreatedAt() graphqlbackend.DateTime {
 }
 
 func generateProductLicenseForSubscription(ctx context.Context, db database.DB, subscriptionID string, input *graphqlbackend.ProductLicenseInput) (id string, err error) {
-	licenseKey, err := licensing.GenerateProductLicenseKey(license.Info{
+	info := license.Info{
 		Tags:      license.SanitizeTagsList(input.Tags),
 		UserCount: uint(input.UserCount),
 		ExpiresAt: time.Unix(int64(input.ExpiresAt), 0),
-	})
+	}
+	licenseKey, version, err := licensing.GenerateProductLicenseKey(info)
 	if err != nil {
 		return "", err
 	}
-	return dbLicenses{db: db}.Create(ctx, subscriptionID, licenseKey)
+	return dbLicenses{db: db}.Create(ctx, subscriptionID, licenseKey, version, info)
 }
 
 func (r ProductSubscriptionLicensingResolver) GenerateProductLicenseForSubscription(ctx context.Context, args *graphqlbackend.GenerateProductLicenseForSubscriptionArgs) (graphqlbackend.ProductLicense, error) {

--- a/enterprise/internal/license/license.go
+++ b/enterprise/internal/license/license.go
@@ -122,20 +122,20 @@ type signedKey struct {
 
 // GenerateSignedKey generates a new signed license key with the given license information, using
 // the private key for the signature.
-func GenerateSignedKey(info Info, privateKey ssh.Signer) (string, error) {
+func GenerateSignedKey(info Info, privateKey ssh.Signer) (licenseKey string, version int, err error) {
 	encodedInfo, err := info.encode()
 	if err != nil {
-		return "", err
+		return "", 0, errors.Wrap(err, "encode")
 	}
 	sig, err := privateKey.Sign(rand.Reader, encodedInfo)
 	if err != nil {
-		return "", err
+		return "", 0, errors.Wrap(err, "sign")
 	}
 	signedKeyData, err := json.Marshal(signedKey{Signature: sig, EncodedInfo: encodedInfo})
 	if err != nil {
-		return "", err
+		return "", 0, errors.Wrap(err, "marshal")
 	}
-	return base64.RawURLEncoding.EncodeToString(signedKeyData), nil
+	return base64.RawURLEncoding.EncodeToString(signedKeyData), formatVersion, nil
 }
 
 // ParseSignedKey parses and verifies the signed license key. If parsing or verification fails, a

--- a/enterprise/internal/license/license_test.go
+++ b/enterprise/internal/license/license_test.go
@@ -104,7 +104,7 @@ func TestInfo_EncodeDecode(t *testing.T) {
 func TestGenerateParseSignedKey(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		want := infoFixture
-		text, err := GenerateSignedKey(want, privateKey)
+		text, _, err := GenerateSignedKey(want, privateKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,7 +121,7 @@ func TestGenerateParseSignedKey(t *testing.T) {
 
 	t.Run("ignores whitespace", func(t *testing.T) {
 		want := infoFixture
-		text, err := GenerateSignedKey(want, privateKey)
+		text, _, err := GenerateSignedKey(want, privateKey)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/licensing/licensing.go
+++ b/enterprise/internal/licensing/licensing.go
@@ -160,19 +160,19 @@ var licenseGenerationPrivateKey = func() ssh.Signer {
 
 // GenerateProductLicenseKey generates a product license key using the license generation private
 // key configured in site configuration.
-func GenerateProductLicenseKey(info license.Info) (string, error) {
+func GenerateProductLicenseKey(info license.Info) (licenseKey string, version int, err error) {
 	if envLicenseGenerationPrivateKey == "" {
 		const msg = "no product license generation private key was configured"
 		if env.InsecureDev {
 			// Show more helpful error message in local dev.
-			return "", errors.Errorf("%s (for testing by Sourcegraph staff: set the SOURCEGRAPH_LICENSE_GENERATION_KEY env var to the key obtained at %s)", msg, licenseGenerationPrivateKeyURL)
+			return "", 0, errors.Errorf("%s (for testing by Sourcegraph staff: set the SOURCEGRAPH_LICENSE_GENERATION_KEY env var to the key obtained at %s)", msg, licenseGenerationPrivateKeyURL)
 		}
-		return "", errors.New(msg)
+		return "", 0, errors.New(msg)
 	}
 
-	licenseKey, err := license.GenerateSignedKey(info, licenseGenerationPrivateKey)
+	licenseKey, version, err = license.GenerateSignedKey(info, licenseGenerationPrivateKey)
 	if err != nil {
-		return "", err
+		return "", 0, errors.Wrap(err, "generate signed key")
 	}
-	return licenseKey, nil
+	return licenseKey, version, nil
 }


### PR DESCRIPTION
This PR stores license _version, tags, user count and expiration_ to their dedicated columns in addition to the license key text upon license key creation. These columns would make our life much easier by being able to directly use SQL SELECT to export them to Salesforce.

Notes:
1. Existing licenses will be handled by an OOB migration that comes later.

## Test plan

CI

---

Part of https://github.com/sourcegraph/sourcegraph/issues/38661
