### PR TITLE
cmd/gitserver: Conditionally update clone_status

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -219,6 +219,7 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 		if !s.hostnameMatch(addr) {
 			wrongShardRepoCount++
 			wrongShardRepoSize += size
+
 			if knownGitServerShard && wrongShardReposDeleteLimit > 0 && wrongShardReposDeleted < int64(wrongShardReposDeleteLimit) {
 				s.Logger.Info(
 					"removing repo cloned on the wrong shard",
@@ -227,7 +228,7 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 					log.String("current-shard", s.Hostname),
 					log.Int64("size-bytes", size),
 				)
-				if err := s.removeRepoDirectory(dir); err != nil {
+				if err := s.removeRepoDirectory(dir, false); err != nil {
 					return false, err
 				}
 				wrongShardReposDeleted++
@@ -262,7 +263,7 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 		}
 
 		s.Logger.Info("removing corrupt repo", log.String("repo", string(dir)), log.String("reason", reason))
-		if err := s.removeRepoDirectory(dir); err != nil {
+		if err := s.removeRepoDirectory(dir, true); err != nil {
 			return true, err
 		}
 		reposRemoved.WithLabelValues(reason).Inc()
@@ -693,7 +694,7 @@ func (s *Server) freeUpSpace(howManyBytesToFree int64) error {
 			return nil
 		}
 		delta := dirSize(d.Path("."))
-		if err := s.removeRepoDirectory(d); err != nil {
+		if err := s.removeRepoDirectory(d, true); err != nil {
 			return errors.Wrap(err, "removing repo directory")
 		}
 		spaceFreed += delta
@@ -774,7 +775,7 @@ func dirSize(d string) int64 {
 // the directory.
 //
 // Additionally, it removes parent empty directories up until s.ReposDir.
-func (s *Server) removeRepoDirectory(gitDir GitDir) error {
+func (s *Server) removeRepoDirectory(gitDir GitDir, updateCloneStatus bool) error {
 	ctx := context.Background()
 	dir := string(gitDir)
 
@@ -797,8 +798,10 @@ func (s *Server) removeRepoDirectory(gitDir GitDir) error {
 	// Everything after this point is just cleanup, so any error that occurs
 	// should not be returned, just logged.
 
-	// Set as not_cloned in the database
-	s.setCloneStatusNonFatal(ctx, s.name(gitDir), types.CloneStatusNotCloned)
+	// Set as not_cloned in the database.
+	if updateCloneStatus {
+		s.setCloneStatusNonFatal(ctx, s.name(gitDir), types.CloneStatusNotCloned)
+	}
 
 	// Cleanup empty parent directories. We just attempt to remove and if we
 	// have a failure we assume it's due to the directory having other

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -741,7 +741,7 @@ func TestRemoveRepoDirectory(t *testing.T) {
 		"github.com/bam/bam/.git",
 		"example.com/repo/.git",
 	} {
-		if err := s.removeRepoDirectory(GitDir(filepath.Join(root, d))); err != nil {
+		if err := s.removeRepoDirectory(GitDir(filepath.Join(root, d)), true); err != nil {
 			t.Fatalf("failed to remove %s: %s", d, err)
 		}
 	}
@@ -752,7 +752,7 @@ func TestRemoveRepoDirectory(t *testing.T) {
 		"github.com/bam/bam/.git",
 		"example.com/repo/.git",
 	} {
-		if err := s.removeRepoDirectory(GitDir(filepath.Join(root, d))); err != nil {
+		if err := s.removeRepoDirectory(GitDir(filepath.Join(root, d)), true); err != nil {
 			t.Fatalf("failed to remove %s: %s", d, err)
 		}
 	}
@@ -796,13 +796,66 @@ func TestRemoveRepoDirectory_Empty(t *testing.T) {
 		ReposDir: root,
 	}
 
-	if err := s.removeRepoDirectory(GitDir(filepath.Join(root, "github.com/foo/baz/.git"))); err != nil {
+	if err := s.removeRepoDirectory(GitDir(filepath.Join(root, "github.com/foo/baz/.git")), true); err != nil {
 		t.Fatal(err)
 	}
 
 	assertPaths(t, root,
 		".tmp",
 	)
+}
+
+func TestRemoveRepoDirectory_UpdateCloneStatus(t *testing.T) {
+	logger := logtest.Scoped(t)
+
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	repo := &types.Repo{
+		Name: api.RepoName("github.com/foo/baz/"),
+	}
+	if err := db.Repos().Create(ctx, repo); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.GitserverRepos().Upsert(ctx, &types.GitserverRepo{
+		RepoID:      repo.ID,
+		ShardID:     "test",
+		CloneStatus: types.CloneStatusCloned,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	mkFiles(t, root, "github.com/foo/baz/.git/HEAD")
+	s := &Server{
+		Logger:   logtest.Scoped(t),
+		ReposDir: root,
+		DB:       db,
+		ctx:      ctx,
+	}
+
+	if err := s.removeRepoDirectory(GitDir(filepath.Join(root, "github.com/foo/baz/.git")), false); err != nil {
+		t.Fatal(err)
+	}
+
+	assertPaths(t, root, ".tmp")
+
+	r, err := db.Repos().GetByName(ctx, repo.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gsRepo, err := db.GitserverRepos().GetByID(ctx, r.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gsRepo.CloneStatus != types.CloneStatusCloned {
+		t.Fatalf("Expected clone_status to be %s, but got %s", types.CloneStatusCloned, gsRepo.CloneStatus)
+	}
 }
 
 func TestHowManyBytesToFree(t *testing.T) {

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -162,7 +162,7 @@ func (s *Server) handleRepoDelete(w http.ResponseWriter, r *http.Request) {
 func (s *Server) deleteRepo(ctx context.Context, repo api.RepoName) error {
 	// The repo may be deleted in the database, in this case we need to get the
 	// original name in order to find it on disk
-	err := s.removeRepoDirectory(s.dir(api.UndeletedRepoName(repo)))
+	err := s.removeRepoDirectory(s.dir(api.UndeletedRepoName(repo)), true)
 	if err != nil {
 		return errors.Wrap(err, "removing repo directory")
 	}


### PR DESCRIPTION
In the cleanup task maybeDeleteWrongShardRepos, we delete the repo
from disk in the wrong shard and also end up updating the clone status
to `not_cloned`.

This is an unintended side effect. The wrong shard should perform no
DB state changes and ultimately it is the responsibility of the
correct shard. In the most likely scenario, this repo is already
cloned and owned by the correct gitserver shard and this task should
only care about freeing up the disk space in it's own home.

First reported in https://github.com/sourcegraph/customer/issues/1127. 


## Test plan

Added new test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
