### PR TITLE
Graduate extensions: Sourcegraph web changes

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -36,7 +36,7 @@ import { useScrollToLocationHash } from './components/useScrollToLocationHash'
 import { GlobalContributions } from './contributions'
 import { ExtensionAreaRoute } from './extensions/extension/ExtensionArea'
 import { ExtensionAreaHeaderNavItem } from './extensions/extension/ExtensionAreaHeader'
-import { excludeExtensionsRoute } from './extensions/extensions';
+import { excludeExtensionsRoute } from './extensions/extensions'
 import { ExtensionsAreaRoute } from './extensions/ExtensionsArea'
 import { ExtensionsAreaHeaderActionButton } from './extensions/ExtensionsAreaHeader'
 import { useFeatureFlag } from './featureFlags/useFeatureFlag'
@@ -64,7 +64,7 @@ import { UserAreaRoute } from './user/area/UserArea'
 import { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
 import { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
 import { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
-import { useExtensionsAsCoreFeaturesFromSettings } from './util/settings';
+import { useExtensionsAsCoreFeaturesFromSettings } from './util/settings'
 import { parseBrowserRepoURL } from './util/url'
 
 import styles from './Layout.module.scss'
@@ -128,7 +128,7 @@ const CONTRAST_COMPLIANT_CLASSNAME = 'theme-contrast-compliant-syntax-highlighti
 export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps>> = props => {
     const extensionsAsCoreFeatures = useExtensionsAsCoreFeaturesFromSettings(props.settingsCascade)
     const routes = extensionsAsCoreFeatures ? excludeExtensionsRoute(props.routes) : props.routes
-    const routeMatch = routes.find(({path, exact}) => matchPath(props.location.pathname, {path, exact}))?.path
+    const routeMatch = routes.find(({ path, exact }) => matchPath(props.location.pathname, { path, exact }))?.path
     const isSearchRelatedPage = (routeMatch === '/:repoRevAndRest+' || routeMatch?.startsWith('/search')) ?? false
     const minimalNavLinks = routeMatch === '/cncf'
     const isSearchHomepage = props.location.pathname === '/search' && !parseSearchURLQuery(props.location.search)

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -36,6 +36,7 @@ import { useScrollToLocationHash } from './components/useScrollToLocationHash'
 import { GlobalContributions } from './contributions'
 import { ExtensionAreaRoute } from './extensions/extension/ExtensionArea'
 import { ExtensionAreaHeaderNavItem } from './extensions/extension/ExtensionAreaHeader'
+import { excludeExtensionsRoute } from './extensions/extensions';
 import { ExtensionsAreaRoute } from './extensions/ExtensionsArea'
 import { ExtensionsAreaHeaderActionButton } from './extensions/ExtensionsAreaHeader'
 import { useFeatureFlag } from './featureFlags/useFeatureFlag'
@@ -63,6 +64,7 @@ import { UserAreaRoute } from './user/area/UserArea'
 import { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
 import { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
 import { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
+import { useExtensionsAsCoreFeaturesFromSettings } from './util/settings';
 import { parseBrowserRepoURL } from './util/url'
 
 import styles from './Layout.module.scss'
@@ -124,7 +126,9 @@ export interface LayoutProps
 const CONTRAST_COMPLIANT_CLASSNAME = 'theme-contrast-compliant-syntax-highlighting'
 
 export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps>> = props => {
-    const routeMatch = props.routes.find(({ path, exact }) => matchPath(props.location.pathname, { path, exact }))?.path
+    const extensionsAsCoreFeatures = useExtensionsAsCoreFeaturesFromSettings(props.settingsCascade)
+    const routes = extensionsAsCoreFeatures ? excludeExtensionsRoute(props.routes) : props.routes
+    const routeMatch = routes.find(({path, exact}) => matchPath(props.location.pathname, {path, exact}))?.path
     const isSearchRelatedPage = (routeMatch === '/:repoRevAndRest+' || routeMatch?.startsWith('/search')) ?? false
     const minimalNavLinks = routeMatch === '/cncf'
     const isSearchHomepage = props.location.pathname === '/search' && !parseSearchURLQuery(props.location.search)
@@ -260,7 +264,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
                     }
                 >
                     <Switch>
-                        {props.routes.map(
+                        {routes.map(
                             ({ render, condition = () => true, ...route }) =>
                                 condition(context) && (
                                     <Route

--- a/client/web/src/extensions/extensions.ts
+++ b/client/web/src/extensions/extensions.ts
@@ -8,6 +8,7 @@ import { ExtensionCategory, EXTENSION_CATEGORIES } from '@sourcegraph/shared/src
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { RegistryExtensionFieldsForList } from '../graphql-operations'
+import { LayoutRouteProps } from '../routes';
 
 import { validCategories } from './extension/extension'
 import { ConfiguredExtensionCache, ExtensionsEnablement } from './ExtensionRegistry'
@@ -164,4 +165,11 @@ export function applyWIPFilter(
         // that the extension is WIP.
         return true
     })
+}
+
+export function excludeExtensionsRoute(routes: readonly LayoutRouteProps<any>[]): readonly LayoutRouteProps<any>[] {
+    const extensionsRouteIndex = routes.findIndex(route => route.path === '/extensions')
+    return (extensionsRouteIndex > -1)
+        ? [...routes.slice(0, extensionsRouteIndex), ...routes.slice(extensionsRouteIndex + 1)]
+        : routes
 }

--- a/client/web/src/extensions/extensions.ts
+++ b/client/web/src/extensions/extensions.ts
@@ -8,7 +8,7 @@ import { ExtensionCategory, EXTENSION_CATEGORIES } from '@sourcegraph/shared/src
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { RegistryExtensionFieldsForList } from '../graphql-operations'
-import { LayoutRouteProps } from '../routes';
+import { LayoutRouteProps } from '../routes'
 
 import { validCategories } from './extension/extension'
 import { ConfiguredExtensionCache, ExtensionsEnablement } from './ExtensionRegistry'
@@ -169,7 +169,7 @@ export function applyWIPFilter(
 
 export function excludeExtensionsRoute(routes: readonly LayoutRouteProps<any>[]): readonly LayoutRouteProps<any>[] {
     const extensionsRouteIndex = routes.findIndex(route => route.path === '/extensions')
-    return (extensionsRouteIndex > -1)
+    return extensionsRouteIndex > -1
         ? [...routes.slice(0, extensionsRouteIndex), ...routes.slice(extensionsRouteIndex + 1)]
         : routes
 }

--- a/client/web/src/extensions/extensions.ts
+++ b/client/web/src/extensions/extensions.ts
@@ -9,6 +9,7 @@ import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { RegistryExtensionFieldsForList } from '../graphql-operations'
 import { LayoutRouteProps } from '../routes'
+import { PageRoutes } from '../routes.constants'
 
 import { validCategories } from './extension/extension'
 import { ConfiguredExtensionCache, ExtensionsEnablement } from './ExtensionRegistry'
@@ -168,7 +169,7 @@ export function applyWIPFilter(
 }
 
 export function excludeExtensionsRoute(routes: readonly LayoutRouteProps<any>[]): readonly LayoutRouteProps<any>[] {
-    const extensionsRouteIndex = routes.findIndex(route => route.path === '/extensions')
+    const extensionsRouteIndex = routes.findIndex(route => route.path === PageRoutes.Extensions)
     return extensionsRouteIndex > -1
         ? [...routes.slice(0, extensionsRouteIndex), ...routes.slice(extensionsRouteIndex + 1)]
         : routes

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -55,6 +55,7 @@ import { useExperimentalFeatures, useNavbarQueryState } from '../stores'
 import { ThemePreferenceProps } from '../theme'
 import { userExternalServicesEnabledFromTags } from '../user/settings/cloud-ga'
 import { showDotComMarketing } from '../util/features'
+import { useExtensionsAsCoreFeaturesFromSettings } from '../util/settings'
 
 import { NavDropdown, NavDropdownItem } from './NavBar/NavDropdown'
 import { StatusMessagesNavItem } from './StatusMessagesNavItem'
@@ -200,6 +201,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext)
     const enableCodeMonitoring = useExperimentalFeatures(features => features.codeMonitoring)
     const showSearchNotebook = useExperimentalFeatures(features => features.showSearchNotebook)
+    const extensionsAsCoreFeatures = useExtensionsAsCoreFeaturesFromSettings(props.settingsCascade)
 
     useEffect(() => {
         // On a non-search related page or non-repo page, we clear the query in
@@ -311,11 +313,13 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
                             </NavLink>
                         </NavItem>
                     )}
-                    <NavItem icon={PuzzleOutlineIcon}>
-                        <NavLink variant={navLinkVariant} to="/extensions">
-                            Extensions
-                        </NavLink>
-                    </NavItem>
+                    {!extensionsAsCoreFeatures && (
+                        <NavItem icon={PuzzleOutlineIcon}>
+                            <NavLink variant={navLinkVariant} to="/extensions">
+                                Extensions
+                            </NavLink>
+                        </NavItem>
+                    )}
                     {props.activation && (
                         <NavItem>
                             <ActivationDropdown activation={props.activation} history={history} />

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -55,7 +55,6 @@ import { useExperimentalFeatures, useNavbarQueryState } from '../stores'
 import { ThemePreferenceProps } from '../theme'
 import { userExternalServicesEnabledFromTags } from '../user/settings/cloud-ga'
 import { showDotComMarketing } from '../util/features'
-import { useExtensionsAsCoreFeaturesFromSettings } from '../util/settings'
 
 import { NavDropdown, NavDropdownItem } from './NavBar/NavDropdown'
 import { StatusMessagesNavItem } from './StatusMessagesNavItem'
@@ -201,7 +200,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext)
     const enableCodeMonitoring = useExperimentalFeatures(features => features.codeMonitoring)
     const showSearchNotebook = useExperimentalFeatures(features => features.showSearchNotebook)
-    const extensionsAsCoreFeatures = useExtensionsAsCoreFeaturesFromSettings(props.settingsCascade)
+    const extensionsAsCoreFeatures = useExperimentalFeatures(features => features.extensionsAsCoreFeatures)
 
     useEffect(() => {
         // On a non-search related page or non-repo page, we clear the query in

--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -270,14 +270,10 @@ function setDiagnosticsOptions(
     jsonSchema: JSONSchema | undefined,
     extensionsAsCoreFeatures: boolean
 ): void {
-    const schema = { ...settingsSchema, properties: { ...settingsSchema.properties } }
+    let schema = settingsSchema
     if (extensionsAsCoreFeatures) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- no need to remove this key conditionally, but not from the schema
-        // @ts-ignore
-        delete schema.properties.extensions
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- no need to remove this key conditionally, but not from the schema
-        // @ts-ignore
-        delete schema.properties['extensions.activeLoggers']
+        const {'extensions.activeLoggers': ___, extensions: ____, ...properties} = schema.properties
+        schema = {...settingsSchema, properties}
     }
     editor.languages.json.jsonDefaults.setDiagnosticsOptions({
         validate: true,

--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -270,7 +270,7 @@ function setDiagnosticsOptions(
     jsonSchema: JSONSchema | undefined,
     extensionsAsCoreFeatures: boolean
 ): void {
-    const schema = { ...settingsSchema }
+    const schema = { ...settingsSchema, properties: { ...settingsSchema.properties } }
     if (extensionsAsCoreFeatures) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- no need to remove this key conditionally, but not from the schema
         // @ts-ignore

--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -43,6 +43,8 @@ export interface Props extends ThemeProps {
      * Called when the user presses the key binding for "save" (Ctrl+S/Cmd+S).
      */
     onDidSave?: () => void
+
+    extensionsAsCoreFeatures?: boolean
 }
 
 interface State {}
@@ -79,7 +81,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
         this.subscriptions.add(
             componentUpdates.pipe(distinctUntilKeyChanged('jsonSchema')).subscribe(props => {
                 if (this.monaco) {
-                    setDiagnosticsOptions(this.monaco, props.jsonSchema)
+                    setDiagnosticsOptions(this.monaco, props.jsonSchema, this.props.extensionsAsCoreFeatures || false)
                 }
             })
         )
@@ -150,7 +152,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
 
         this.disposables.push(registerRedactedHover(monaco))
 
-        setDiagnosticsOptions(monaco, this.props.jsonSchema)
+        setDiagnosticsOptions(monaco, this.props.jsonSchema, this.props.extensionsAsCoreFeatures || false)
 
         // Only listen to 1 event each to avoid receiving events from other Monaco editors on the
         // same page (if there are multiple).
@@ -263,7 +265,20 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
     }
 }
 
-function setDiagnosticsOptions(editor: typeof monaco, jsonSchema: JSONSchema | undefined): void {
+function setDiagnosticsOptions(
+    editor: typeof monaco,
+    jsonSchema: JSONSchema | undefined,
+    extensionsAsCoreFeatures: boolean
+): void {
+    const schema = { ...settingsSchema }
+    if (extensionsAsCoreFeatures) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- no need to remove this key conditionally, but not from the schema
+        // @ts-ignore
+        delete schema.properties.extensions
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- no need to remove this key conditionally, but not from the schema
+        // @ts-ignore
+        delete schema.properties['extensions.activeLoggers']
+    }
     editor.languages.json.jsonDefaults.setDiagnosticsOptions({
         validate: true,
         allowComments: true,
@@ -281,11 +296,11 @@ function setDiagnosticsOptions(editor: typeof monaco, jsonSchema: JSONSchema | u
             },
             {
                 uri: 'settings.schema.json#',
-                schema: settingsSchema,
+                schema,
             },
             {
                 uri: 'settings.schema.json',
-                schema: settingsSchema,
+                schema,
             },
         ],
     })

--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -272,8 +272,8 @@ function setDiagnosticsOptions(
 ): void {
     let schema = settingsSchema
     if (extensionsAsCoreFeatures) {
-        const {'extensions.activeLoggers': ___, extensions: ____, ...properties} = schema.properties
-        schema = {...settingsSchema, properties}
+        const { 'extensions.activeLoggers': ___, extensions: ____, ...properties } = schema.properties
+        schema = { ...settingsSchema, properties }
     }
     editor.languages.json.jsonDefaults.setDiagnosticsOptions({
         validate: true,

--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -270,10 +270,14 @@ function setDiagnosticsOptions(
     jsonSchema: JSONSchema | undefined,
     extensionsAsCoreFeatures: boolean
 ): void {
-    let schema = settingsSchema
+    const schema = settingsSchema
     if (extensionsAsCoreFeatures) {
-        const { 'extensions.activeLoggers': ___, extensions: ____, ...properties } = schema.properties
-        schema = { ...settingsSchema, properties }
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- we need to remove this key conditionally, but not from the schema
+        // @ts-ignore
+        delete schema.properties.extensions
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- we need to remove this key conditionally, but not from the schema
+        // @ts-ignore
+        delete schema.properties['extensions.activeLoggers']
     }
     editor.languages.json.jsonDefaults.setDiagnosticsOptions({
         validate: true,

--- a/client/web/src/settings/SettingsFile.tsx
+++ b/client/web/src/settings/SettingsFile.tsx
@@ -43,6 +43,8 @@ interface Props extends ThemeProps, TelemetryProps {
      * if any.
      */
     commitError?: Error
+
+    extensionsAsCoreFeatures: boolean
 }
 
 interface State {
@@ -199,6 +201,7 @@ export class SettingsFile extends React.PureComponent<Props, State> {
                         monacoRef={this.monacoRef}
                         isLightTheme={this.props.isLightTheme}
                         onDidSave={this.save}
+                        extensionsAsCoreFeatures={this.props.extensionsAsCoreFeatures}
                     />
                 </React.Suspense>
             </div>

--- a/client/web/src/settings/SettingsPage.tsx
+++ b/client/web/src/settings/SettingsPage.tsx
@@ -6,7 +6,7 @@ import { overwriteSettings } from '@sourcegraph/shared/src/settings/edit'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { useExtensionsAsCoreFeaturesFromSettings } from '../util/settings'
+import { extensionsAsCoreFeaturesEnabled } from '../util/settings'
 
 import { SettingsAreaPageProps } from './SettingsArea'
 import { SettingsFile } from './SettingsFile'
@@ -31,8 +31,7 @@ export class SettingsPage extends React.PureComponent<Props, State> {
     public state: State = {}
 
     public render(): JSX.Element | null {
-        // eslint-disable-next-line react-hooks/rules-of-hooks -- This is a function that can be called here safely
-        const extensionsAsCoreFeatures = useExtensionsAsCoreFeaturesFromSettings(this.props.settingsCascade)
+        const extensionsAsCoreFeatures = extensionsAsCoreFeaturesEnabled(this.props.settingsCascade)
 
         return (
             <SettingsFile

--- a/client/web/src/settings/SettingsPage.tsx
+++ b/client/web/src/settings/SettingsPage.tsx
@@ -6,6 +6,8 @@ import { overwriteSettings } from '@sourcegraph/shared/src/settings/edit'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
+import { useExtensionsAsCoreFeaturesFromSettings } from '../util/settings'
+
 import { SettingsAreaPageProps } from './SettingsArea'
 import { SettingsFile } from './SettingsFile'
 
@@ -29,6 +31,9 @@ export class SettingsPage extends React.PureComponent<Props, State> {
     public state: State = {}
 
     public render(): JSX.Element | null {
+        // eslint-disable-next-line react-hooks/rules-of-hooks -- This is a function that can be called here safely
+        const extensionsAsCoreFeatures = useExtensionsAsCoreFeaturesFromSettings(this.props.settingsCascade)
+
         return (
             <SettingsFile
                 settings={this.props.data.subjects[this.props.data.subjects.length - 1].latestSettings}
@@ -39,6 +44,7 @@ export class SettingsPage extends React.PureComponent<Props, State> {
                 history={this.props.history}
                 isLightTheme={this.props.isLightTheme}
                 telemetryService={this.props.telemetryService}
+                extensionsAsCoreFeatures={extensionsAsCoreFeatures}
             />
         )
     }

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -59,9 +59,16 @@ export function enableExtensionsDecorationsColumnViewFromSettings(settingsCascad
 }
 
 /**
- * Whether user wants to use default extensions functionality as core product features instead of the corresponding extensions.
+ * A hook around the function
  */
 export function useExtensionsAsCoreFeaturesFromSettings(settingsCascade: SettingsCascadeOrError): boolean {
+    return extensionsAsCoreFeaturesEnabled(settingsCascade)
+}
+
+/**
+ * Whether user wants to use default extensions functionality as core product features instead of the corresponding extensions.
+ */
+export function extensionsAsCoreFeaturesEnabled(settingsCascade: SettingsCascadeOrError): boolean {
     if (!settingsCascade.final) {
         return false
     }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39046
Closes https://github.com/sourcegraph/sourcegraph/issues/39048
Closes https://github.com/sourcegraph/sourcegraph/issues/39049
Closes https://github.com/sourcegraph/sourcegraph/issues/39050

Listed in the order of commits:

1. https://github.com/sourcegraph/sourcegraph/issues/39046

See the first commit.

Extensions page with the flag off vs on:
<img width="50%" alt="CleanShot 2022-07-26 at 13 54 18@2x" src="https://user-images.githubusercontent.com/2552265/180999905-ac67a034-6488-4e14-8e54-3223d3e89446.png"><img width="50%" alt="CleanShot 2022-07-26 at 13 55 01@2x" src="https://user-images.githubusercontent.com/2552265/181000007-75904a42-73c1-44b9-9e54-b1f3aa5708f7.png">

2. https://github.com/sourcegraph/sourcegraph/issues/39048

See the second commit.
Navbar with the flag off vs on:

<img width="857" alt="CleanShot 2022-07-26 at 13 56 04@2x" src="https://user-images.githubusercontent.com/2552265/181000159-29345974-ed9c-4826-a2d5-d6a4638ae502.png">
<img width="753" alt="CleanShot 2022-07-26 at 13 56 43@2x" src="https://user-images.githubusercontent.com/2552265/181000268-f6539ad1-28ad-40e8-9b06-608ad22276da.png">



3. https://github.com/sourcegraph/sourcegraph/issues/39049

Flag off vs on:
<img width="50%" alt="CleanShot 2022-07-21 at 18 18 52@2x" src="https://user-images.githubusercontent.com/2552265/180264000-8b43b2f6-60e9-41fb-a6f8-1a8694d2f67b.png"><img width="50%" alt="CleanShot 2022-07-21 at 18 19 52@2x" src="https://user-images.githubusercontent.com/2552265/180264142-20a256e8-f741-47a3-9e15-5bb96a3b1ef2.png">

Needed to pass down a setting two levels, which is not so nice.

We can't remove the handlers yet as we still have the features behind flags. But for easier removal later, here are their uses:
- `extensions`:
  - [useCodeMirror](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dv/remove-extensions-web/-/blob/client/shared/src/components/CodeMirrorEditor.ts?L23) and its uses plus `EditorState.create`
  - [getEnabledExtensionsForSubject](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dv/remove-extensions-web/-/blob/client/shared/src/extensions/extensions.ts?L23) and all its usages
  - [mockExtension.ts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dv/remove-extensions-web/-/blob/client/shared/src/testing/integration/mockExtension.ts)
  - [extension-registry.test.ts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dv/remove-extensions-web/-/blob/client/web/src/integration/extension-registry.test.ts)
- `extensions.activeLoggers`:
  - Has a single use [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dv/remove-extensions-web/-/blob/client/shared/src/api/extension/api/logging.ts)

4. https://github.com/sourcegraph/sourcegraph/issues/39050

This is not needed now.
We don't want to disable the back end because we still want this functionality alive for now.
We want to disable access to this endpoint on the front end if the flag is set to `false`, but for that we need no further changes because commit #1 in this PR (to fix https://github.com/sourcegraph/sourcegraph/issues/39046) already solves it.

## Test plan

I've tested everything that came to mind. Check the screenshots above.

## App preview:

- [Web](https://sg-web-dv-remove-extensions-web.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-olncsafnpl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

