### PR TITLE
gqltest: add initial test for Bitbucket Project repos permission sync

### DIFF
--- a/dev/gqltest/bitbucket_projects_perms_sync_test.go
+++ b/dev/gqltest/bitbucket_projects_perms_sync_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestBitbucketProjectsPermsSync_SetPermissionsUnrestricted(t *testing.T) {
+	if len(*bbsURL) == 0 || len(*bbsToken) == 0 || len(*bbsUsername) == 0 {
+		t.Skip("Environment variable BITBUCKET_SERVER_URL, BITBUCKET_SERVER_TOKEN, or BITBUCKET_SERVER_USERNAME is not set")
+	}
+
+	// Set up external service
+	esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
+		Kind:        extsvc.KindBitbucketServer,
+		DisplayName: "gqltest-bitbucket-server",
+		Config: mustMarshalJSONString(struct {
+			URL                   string   `json:"url"`
+			Token                 string   `json:"token"`
+			Username              string   `json:"username"`
+			Repos                 []string `json:"repos"`
+			RepositoryPathPattern string   `json:"repositoryPathPattern"`
+		}{
+			URL:                   *bbsURL,
+			Token:                 *bbsToken,
+			Username:              *bbsUsername,
+			Repos:                 []string{"SOURCEGRAPH/jsonrpc2"},
+			RepositoryPathPattern: "bbs/{projectKey}/{repositorySlug}",
+		}),
+	})
+
+	// The repo-updater might not be up yet, but it will eventually catch up for the
+	// external service we just added, thus it is OK to ignore this transient error.
+	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := client.DeleteExternalService(esID, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	const repoName = "bbs/SOURCEGRAPH/jsonrpc2"
+	err = client.WaitForReposToBeCloned(repoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setting unrestricted permissions to all repos of SOURCEGRAPH Bitbucket
+	// project SG has only bbs/SOURCEGRAPH/jsonrpc2 repo cloned -- this repo should
+	// be unrestricted
+	unrestricted := true
+	const projectKey = "SOURCEGRAPH"
+	err = client.SetRepositoryPermissionsForBitbucketProject(gqltestutil.BitbucketProjectPermsSyncArgs{
+		ProjectKey:      projectKey,
+		CodeHost:        esID,
+		UserPermissions: make([]types.UserPermission, 0),
+		Unrestricted:    &unrestricted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait up to 30 seconds for worker to finish the permissions sync.
+	err = gqltestutil.Retry(30*time.Second, func() error {
+		status, err := client.GetLastBitbucketProjectPermissionJob(projectKey)
+		if err != nil || status == "" {
+			t.Fatal("Error during getting the status of a Bitbucket Permissions job")
+		}
+
+		if status == "completed" {
+			return nil
+		}
+		return gqltestutil.ErrContinueRetry
+	})
+	if err != nil {
+		t.Fatal("Waiting for repository permissions to be synced:", err)
+	}
+
+	// Checking that unrestricted permission is set to bbs/SOURCEGRAPH/jsonrpc2
+	permissionsInfo, err := client.RepositoryPermissionsInfo(repoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if permissionsInfo.Permissions[0] != "READ" {
+		t.Fatal("READ permission hasn't been set:", err)
+	}
+
+	if !permissionsInfo.Unrestricted {
+		t.Fatal("unrestricted permission hasn't been set:", err)
+	}
+}

--- a/internal/gqltestutil/permissions.go
+++ b/internal/gqltestutil/permissions.go
@@ -1,6 +1,11 @@
 package gqltestutil
 
-import "github.com/sourcegraph/sourcegraph/lib/errors"
+import (
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
 
 // ScheduleRepositoryPermissionsSync schedules a permissions syncing request for
 // the given repository.
@@ -20,4 +25,81 @@ mutation ScheduleRepositoryPermissionsSync($repository: ID!) {
 		return errors.Wrap(err, "request GraphQL")
 	}
 	return nil
+}
+
+type BitbucketProjectPermsSyncArgs struct {
+	ProjectKey      string
+	CodeHost        string
+	UserPermissions []types.UserPermission
+	Unrestricted    *bool
+}
+
+type UserPermission struct {
+	BindID     string `json:"bindID"`
+	Permission string `json:"permission"`
+}
+
+// SetRepositoryPermissionsForBitbucketProject requests to set repo permissions for given Bitbucket Project and users.
+func (c *Client) SetRepositoryPermissionsForBitbucketProject(args BitbucketProjectPermsSyncArgs) error {
+	const query = `
+mutation SetRepositoryPermissionsForBitbucketProject($projectKey: String!, $codeHost: ID!, $userPermissions: [UserPermissionInput!]!, $unrestricted: Boolean) {
+	setRepositoryPermissionsForBitbucketProject(
+		projectKey: $projectKey
+		codeHost: $codeHost
+		userPermissions: $userPermissions
+		unrestricted: $unrestricted
+	) {
+		alwaysNil
+	}
+}
+`
+	variables := map[string]any{
+		"projectKey":      args.ProjectKey,
+		"codeHost":        graphql.ID(args.CodeHost),
+		"userPermissions": args.UserPermissions,
+		"unrestricted":    args.Unrestricted,
+	}
+	err := c.GraphQL("", query, variables, nil)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+	return nil
+}
+
+// GetLastBitbucketProjectPermissionJob returns a status of the most recent
+// BitbucketProjectPermissionJob for given projectKey
+func (c *Client) GetLastBitbucketProjectPermissionJob(projectKey string) (string, error) {
+	const query = `
+query BitbucketProjectPermissionJobs($projectKeys: [String!], $status: String, $count: Int) {
+	bitbucketProjectPermissionJobs(projectKeys: $projectKeys, status: $status, count: $count) {
+		totalCount,
+   		nodes {
+			State
+   		}
+	}
+}
+`
+	variables := map[string]any{
+		"projectKeys": []string{projectKey},
+	}
+	var resp struct {
+		Data struct {
+			Jobs struct {
+				TotalCount int `json:"totalCount"`
+				Nodes      []struct {
+					State string `json:"state"`
+				} `json:"nodes"`
+			} `json:"bitbucketProjectPermissionJobs"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return "", errors.Wrap(err, "request GraphQL")
+	}
+
+	if resp.Data.Jobs.TotalCount < 1 {
+		return "", nil
+	} else {
+		return resp.Data.Jobs.Nodes[0].State, nil
+	}
 }

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -213,7 +213,10 @@ query Repository($name: String!) {
 // PermissionsInfo contains permissions information of a repository from
 // GraphQL.
 type PermissionsInfo struct {
-	SyncedAt time.Time
+	SyncedAt     time.Time
+	UpdatedAt    time.Time
+	Permissions  []string
+	Unrestricted bool
 }
 
 // RepositoryPermissionsInfo returns permissions information of the given
@@ -228,6 +231,7 @@ query RepositoryPermissionsInfo($name: String!) {
 			syncedAt
 			updatedAt
 			permissions
+			unrestricted
 		}
 	}
 }


### PR DESCRIPTION
This and future tests will use `bitbucket.sgdev.org` Bitbucket Server instance and intended to cover all (or most) cases of using Bitbucket Projects permissions sync API.

## Test plan
New int tests are added 😅 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
