### PR TITLE
Code Ownership: Pass db to code ownership filter job 

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -605,7 +605,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 		if err != nil {
 			return nil, err
 		}
-		j, err := jobutil.NewBasicJob(r.SearchInputs, b)
+		j, err := jobutil.NewBasicJob(r.SearchInputs, b, r.db)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -48,7 +48,7 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, 
 			srs.err = err
 			return
 		}
-		j, err := jobutil.NewBasicJob(srs.sr.SearchInputs, b)
+		j, err := jobutil.NewBasicJob(srs.sr.SearchInputs, b, srs.sr.db)
 		if err != nil {
 			srs.err = err
 			return

--- a/internal/search/codeownership/job.go
+++ b/internal/search/codeownership/job.go
@@ -6,6 +6,7 @@ import (
 
 	otlog "github.com/opentracing/opentracing-go/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -13,19 +14,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func New(child job.Job, includeOwners, excludeOwners []string) job.Job {
+func New(child job.Job, includeOwners, excludeOwners []string, db database.DB) job.Job {
 	return &codeownershipJob{
 		child:         child,
 		includeOwners: includeOwners,
 		excludeOwners: excludeOwners,
+		db:            db,
 	}
 }
 
 type codeownershipJob struct {
-	child job.Job
-
+	child         job.Job
 	includeOwners []string
 	excludeOwners []string
+	db            database.DB
 }
 
 func (s *codeownershipJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	codeownershipjob "github.com/sourcegraph/sourcegraph/internal/search/codeownership"
@@ -35,7 +36,7 @@ import (
 func NewPlanJob(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
 	children := make([]job.Job, 0, len(plan))
 	for _, q := range plan {
-		child, err := NewBasicJob(inputs, q)
+		child, err := NewBasicJob(inputs, q, inputs.DB)
 		if err != nil {
 			return nil, err
 		}
@@ -46,7 +47,7 @@ func NewPlanJob(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
 
 	if inputs.PatternType == query.SearchTypeLucky {
 		newJob := func(b query.Basic) (job.Job, error) {
-			return NewBasicJob(inputs, b)
+			return NewBasicJob(inputs, b, inputs.DB)
 		}
 		jobTree = lucky.NewFeelingLuckySearchJob(jobTree, newJob, plan)
 	}
@@ -55,7 +56,7 @@ func NewPlanJob(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
 }
 
 // NewBasicJob converts a query.Basic into its job tree representation.
-func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
+func NewBasicJob(inputs *run.SearchInputs, b query.Basic, db database.DB) (job.Job, error) {
 	var children []job.Job
 	addJob := func(j job.Job) {
 		children = append(children, j)
@@ -164,7 +165,7 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 
 	{ // Apply code ownership post-search filter
 		if includeOwners, excludeOwners := b.FileHasOwner(); len(includeOwners) > 0 || len(excludeOwners) > 0 {
-			basicJob = codeownershipjob.New(basicJob, includeOwners, excludeOwners)
+			basicJob = codeownershipjob.New(basicJob, includeOwners, excludeOwners, db)
 		}
 	}
 

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -26,6 +26,7 @@ type SearchInputs struct {
 	OnSourcegraphDotCom bool
 	Features            *featureflag.FlagSet
 	Protocol            search.Protocol
+	DB                  database.DB
 }
 
 // MaxResults computes the limit for the query.
@@ -97,6 +98,7 @@ func NewSearchInputs(
 		Features:            featureflag.FromContext(ctx),
 		PatternType:         searchType,
 		Protocol:            protocol,
+		DB:                  db,
 	}
 
 	tr.LazyPrintf("Parsed query: %s", inputs.Query)


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39157

To filter by code ownership information in our post-search job, we need a way to find out the ownership information of a file. To do this, we need access to the `DB` (to do git server file readings at first and maybe postgres lookups later).

I am not sure if adding it to the `SearchInputs` struct makes conceptual sense but this seemed to have been the least invasive method and it worked for me in my prototype. 🙈 

What are your thoughts @camdencheek / @rvantonder?

## Test plan

I’m happy if tests are still green and it compiles.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
