### PR TITLE
Revert "Tree: add "go up" the tree button (#39138)"

### DIFF
--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -489,20 +489,12 @@ describe('Repository', () => {
             )
             await driver.page.waitForSelector('.test-tree-file-link')
             assert.strictEqual(
-                await driver.page.evaluate(
-                    () =>
-                        document.querySelector(
-                            '.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql"]'
-                        )?.textContent
-                ),
+                await driver.page.evaluate(() => document.querySelector('.test-tree-file-link')?.textContent),
                 fileName
             )
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement
-            await driver.page.$eval(
-                '.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql"]',
-                linkElement => (linkElement as HTMLElement).click()
-            )
+            await driver.page.$eval('.test-tree-file-link', linkElement => (linkElement as HTMLElement).click())
             await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             await driver.page.waitForSelector('.test-breadcrumb')

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -2,13 +2,8 @@ import React from 'react'
 
 import { FileDecorationsByPath } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 
-import { dirname } from '../util/path'
-
 import { TreeLayerTable } from './components'
-import { GO_UP_TREE_LABEL } from './constants'
-import { File } from './File'
 import { SingleChildTreeLayer } from './SingleChildTreeLayer'
-import { TreeRootContext } from './TreeContext'
 import { TreeLayer } from './TreeLayer'
 import { TreeRootProps } from './TreeRoot'
 import { hasSingleChild, SingleChildGitTree, TreeEntryInfo } from './util'
@@ -50,50 +45,17 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
         isLightTheme: props.isLightTheme,
     }
 
-    // Only show ".." (go up) for non-root file trees
-    const shouldShowGoUp = props.depth === -1 && props.parentPath
-
     return (
         <div>
             <TreeLayerTable>
                 <tbody>
-                    {shouldShowGoUp && (
-                        <tr>
-                            <td>
-                                <TreeLayerTable>
-                                    <TreeRootContext.Consumer>
-                                        {treeRootContext => (
-                                            <File
-                                                entryInfo={{
-                                                    name: GO_UP_TREE_LABEL,
-                                                    path: props.parentPath as string,
-                                                    isDirectory: false,
-                                                    url: dirname(treeRootContext.rootTreeUrl),
-                                                    isSingleChild: false,
-                                                    submodule: null,
-                                                }}
-                                                depth={sharedProps.depth}
-                                                index={0}
-                                                isLightTheme={sharedProps.isLightTheme}
-                                                handleTreeClick={() => undefined}
-                                                noopRowClick={() => undefined}
-                                                linkRowClick={() => props.telemetryService.log('FileTreeClick')}
-                                                isActive={false}
-                                                isSelected={false}
-                                            />
-                                        )}
-                                    </TreeRootContext.Consumer>
-                                </TreeLayerTable>
-                            </td>
-                        </tr>
-                    )}
                     <tr>
                         <td>
                             {hasSingleChild(props.entries) ? (
                                 <SingleChildTreeLayer
                                     {...sharedProps}
                                     key={props.singleChildTreeEntry.path}
-                                    index={shouldShowGoUp ? 1 : 0}
+                                    index={0}
                                     isExpanded={props.expandedTrees.includes(props.singleChildTreeEntry.path)}
                                     parentPath={props.singleChildTreeEntry.path}
                                     entryInfo={props.singleChildTreeEntry}
@@ -107,7 +69,7 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                     <TreeLayer
                                         {...sharedProps}
                                         key={item.path}
-                                        index={shouldShowGoUp ? index + 1 : index}
+                                        index={index}
                                         isExpanded={props.expandedTrees.includes(item.path)}
                                         parentPath={item.path}
                                         entryInfo={item}

--- a/client/web/src/tree/Directory.tsx
+++ b/client/web/src/tree/Directory.tsx
@@ -15,7 +15,6 @@ import {
     TreeRowLabelLink,
     TreeRow,
 } from './components'
-import { MAX_TREE_ENTRIES } from './constants'
 import { FileDecorator } from './FileDecorator'
 import { TreeEntryInfo, treePadding } from './util'
 
@@ -25,6 +24,7 @@ interface DirectoryProps extends ThemeProps {
     className?: string
     entryInfo: TreeEntryInfo
     isExpanded: boolean
+    maxEntries: number
     loading: boolean
     handleTreeClick: () => void
     noopRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
@@ -88,7 +88,7 @@ export const Directory: React.FunctionComponent<React.PropsWithChildren<Director
                     </div>
                 )}
             </TreeLayerRowContents>
-            {props.index === MAX_TREE_ENTRIES - 1 && (
+            {props.index === props.maxEntries - 1 && (
                 <TreeRowAlert
                     variant="warning"
                     style={treePadding(props.depth, true, true)}

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -17,9 +17,8 @@ import {
     TreeRowLabel,
     TreeRow,
 } from './components'
-import { MAX_TREE_ENTRIES } from './constants'
 import { FileDecorator } from './FileDecorator'
-import { TreeEntryInfo, treePadding } from './util'
+import { maxEntries, TreeEntryInfo, treePadding } from './util'
 
 interface FileProps extends ThemeProps {
     fileDecorations?: FileDecoration[]
@@ -27,6 +26,7 @@ interface FileProps extends ThemeProps {
     depth: number
     index: number
     className?: string
+    maxEntries: number
     handleTreeClick: () => void
     noopRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
     linkRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
@@ -103,7 +103,7 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
                         </TreeLayerRowContentsText>
                     </TreeLayerRowContentsLink>
                 )}
-                {props.index === MAX_TREE_ENTRIES - 1 && (
+                {props.index === maxEntries - 1 && (
                     <TreeRowAlert
                         variant="warning"
                         style={treePadding(props.depth, true)}

--- a/client/web/src/tree/SingleChildTreeLayer.tsx
+++ b/client/web/src/tree/SingleChildTreeLayer.tsx
@@ -10,7 +10,7 @@ import { TreeLayerTable } from './components'
 import { Directory } from './Directory'
 import { TreeNode } from './Tree'
 import { TreeLayerProps } from './TreeLayer'
-import { SingleChildGitTree } from './util'
+import { maxEntries, SingleChildGitTree } from './util'
 
 interface SingleChildTreeLayerProps extends TreeLayerProps {
     childrenEntries: SingleChildGitTree[]
@@ -134,6 +134,7 @@ export class SingleChildTreeLayer extends React.Component<SingleChildTreeLayerPr
                             depth={this.props.depth}
                             index={this.props.index}
                             isLightTheme={this.props.isLightTheme}
+                            maxEntries={maxEntries}
                             loading={false}
                             handleTreeClick={this.handleTreeClick}
                             noopRowClick={this.noopRowClick}

--- a/client/web/src/tree/Tree.tsx
+++ b/client/web/src/tree/Tree.tsx
@@ -213,6 +213,7 @@ export class Tree extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props)
 
+        const parentPath = dotPathAsUndefined(props.activePathIsDir ? props.activePath : dirname(props.activePath))
         this.node = {
             index: 0,
             parent: null,
@@ -222,7 +223,7 @@ export class Tree extends React.PureComponent<Props, State> {
         }
 
         this.state = {
-            parentPath: dotPathAsUndefined(props.activePathIsDir ? props.activePath : dirname(props.activePath)),
+            parentPath,
             resolveTo: [],
             selectedNode: this.node,
             activeNode: this.node,

--- a/client/web/src/tree/TreeContext.tsx
+++ b/client/web/src/tree/TreeContext.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-export interface TreeRootContext {
-    rootTreeUrl: string
-}
-
-export const TreeRootContext = React.createContext<TreeRootContext>({
-    rootTreeUrl: '',
-})

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -25,7 +25,6 @@ import { requestGraphQL } from '../backend/graphql'
 
 import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeLayerCell, TreeLayerTable, TreeRowAlert } from './components'
-import { MAX_TREE_ENTRIES } from './constants'
 import { Directory } from './Directory'
 import { File } from './File'
 import { TreeNode } from './Tree'
@@ -33,6 +32,7 @@ import { TreeRootProps } from './TreeRoot'
 import {
     compareTreeProps,
     hasSingleChild,
+    maxEntries,
     singleChildEntriesToGitTree,
     SingleChildGitTree,
     TreeEntryInfo,
@@ -86,7 +86,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                     revision: props.revision,
                     commitID: props.commitID,
                     filePath: props.parentPath || '',
-                    first: MAX_TREE_ENTRIES,
+                    first: maxEntries,
                     requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                 }).pipe(
                     catchError(error => [asError(error)]),
@@ -149,7 +149,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                             revision: this.props.revision,
                             commitID: this.props.commitID,
                             filePath: path,
-                            first: MAX_TREE_ENTRIES,
+                            first: maxEntries,
                             requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                         }).pipe(catchError(error => [asError(error)]))
                     )
@@ -279,6 +279,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                     depth={this.props.depth}
                                     index={this.props.index}
                                     isLightTheme={this.props.isLightTheme}
+                                    maxEntries={maxEntries}
                                     loading={treeOrError === LOADING}
                                     handleTreeClick={this.handleTreeClick}
                                     noopRowClick={this.noopRowClick}
@@ -322,6 +323,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                 depth={this.props.depth}
                                 index={this.props.index}
                                 isLightTheme={this.props.isLightTheme}
+                                maxEntries={maxEntries}
                                 handleTreeClick={this.handleTreeClick}
                                 noopRowClick={this.noopRowClick}
                                 linkRowClick={this.linkRowClick}

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -30,10 +30,10 @@ import { requestGraphQL } from '../backend/graphql'
 
 import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeLayerTable, TreeLayerCell, TreeRowAlert } from './components'
-import { MAX_TREE_ENTRIES } from './constants'
 import { TreeNode } from './Tree'
-import { TreeRootContext } from './TreeContext'
 import { hasSingleChild, compareTreeProps, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
+
+const maxEntries = 2500
 
 const errorWidth = (width?: string): { width: string } => ({
     width: width ? `${width}px` : 'auto',
@@ -97,7 +97,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                     revision: props.revision,
                     commitID: props.commitID,
                     filePath: props.parentPath || '',
-                    first: MAX_TREE_ENTRIES,
+                    first: maxEntries,
                     requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                 }).pipe(
                     catchError(error => [asError(error)]),
@@ -150,7 +150,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                             revision: this.props.revision,
                             commitID: this.props.commitID,
                             filePath: path,
-                            first: MAX_TREE_ENTRIES,
+                            first: maxEntries,
                             requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                         }).pipe(catchError(error => [asError(error)]))
                     )
@@ -208,23 +208,17 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                                         </div>
                                     ) : (
                                         treeOrError && (
-                                            <TreeRootContext.Provider
-                                                value={{
-                                                    rootTreeUrl: treeOrError.url,
-                                                }}
-                                            >
-                                                <ChildTreeLayer
-                                                    {...this.props}
-                                                    parent={this.node}
-                                                    depth={-1 as number}
-                                                    entries={treeOrError.entries}
-                                                    singleChildTreeEntry={singleChildTreeEntry}
-                                                    childrenEntries={singleChildTreeEntry.children}
-                                                    onHover={this.fetchChildContents}
-                                                    setChildNodes={this.setChildNode}
-                                                    fileDecorationsByPath={this.state.fileDecorationsByPath}
-                                                />
-                                            </TreeRootContext.Provider>
+                                            <ChildTreeLayer
+                                                {...this.props}
+                                                parent={this.node}
+                                                depth={-1 as number}
+                                                entries={treeOrError.entries}
+                                                singleChildTreeEntry={singleChildTreeEntry}
+                                                childrenEntries={singleChildTreeEntry.children}
+                                                onHover={this.fetchChildContents}
+                                                setChildNodes={this.setChildNode}
+                                                fileDecorationsByPath={this.state.fileDecorationsByPath}
+                                            />
                                         )
                                     )}
                                 </TreeLayerCell>

--- a/client/web/src/tree/constants.ts
+++ b/client/web/src/tree/constants.ts
@@ -1,4 +1,0 @@
-// Used in requests and components
-export const MAX_TREE_ENTRIES = 2500
-
-export const GO_UP_TREE_LABEL = '..'

--- a/client/web/src/tree/util.tsx
+++ b/client/web/src/tree/util.tsx
@@ -51,6 +51,8 @@ export const treePadding = (depth: number, isTree: boolean, isDirectory = false)
     paddingRight: '1rem',
 })
 
+export const maxEntries = 2500
+
 // Utility functions to handle single-child directories:
 
 /**


### PR DESCRIPTION
This reverts commit 1ce169689a648fd6f76e76d5430ab219c1e51097 introduced in https://github.com/sourcegraph/sourcegraph/pull/39138 because it broke the build and locked `main`.

Failures:

- https://buildkite.com/sourcegraph/sourcegraph/builds/162391#01822069-d4f1-49c8-8e44-c19b7f3f4512
- https://buildkite.com/sourcegraph/sourcegraph/builds/162402#018220bc-b488-4371-ad2a-bf98e69ae411
- https://buildkite.com/sourcegraph/sourcegraph/builds/162403#018220c1-7215-416b-a327-e412c051e77f
- https://buildkite.com/sourcegraph/sourcegraph/builds/162404#018220f5-f5e8-4877-aeff-d14b4685ef0e

## Test plan

- N/A