### PR TITLE
Icon: Fix React warning for `svgPath={undefined}`

### DIFF
--- a/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
+++ b/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
@@ -42,8 +42,7 @@ export const Breadcrumb: React.FunctionComponent<BreadcrumbProps> = ({
                     <Icon
                         inline={false}
                         className={styles.icon}
-                        svgPath={typeof icon === 'string' ? icon : undefined}
-                        as={typeof icon !== 'string' ? icon : undefined}
+                        {...(typeof icon === 'string' ? { svgPath: icon } : { as: icon })}
                         {...(iconHidden ? { 'aria-hidden': true } : { 'aria-label': ariaLabel })}
                     />
                 )}


### PR DESCRIPTION
## Description

Previous code meant that it was possible to pass the `svgPath` prop down as a DOM attribute.

![image](https://user-images.githubusercontent.com/9516420/180239083-98c4d033-c6db-4f66-b1b8-752efe9189ad.png)

## Test plan

Tested locally at https://sourcegraph.test:3443/users/jeff.wayman/batch-changes/deploy-docs-folder-links-rename/executions/QmF0Y2hTcGVjOiI2WEtUUnRSd0Z3eSI=/execution/workspaces/QmF0Y2hTcGVjV29ya3NwYWNlOjk5MjAyMw==?visible=15

## App preview:

- [Web](https://sg-web-tr-fix-icon-warning.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fxhzhbfeoo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
