### PR TITLE
sg: make buildkite URL more readable in 'sg ci build' output

### DIFF
--- a/dev/sg/internal/bk/bk.go
+++ b/dev/sg/internal/bk/bk.go
@@ -68,7 +68,7 @@ func retrieveToken(ctx context.Context, out *std.Output) (string, error) {
 
 // getTokenFromUser prompts the user for a slack OAuth token.
 func getTokenFromUser(out *std.Output) (string, error) {
-	out.WriteLine(output.Linef(output.EmojiLightbulb, output.StylePending, `Please create and copy a new token from https://buildkite.com/user/api-access-tokens with the following scopes:
+	out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion, `Please create and copy a new token from %shttps://buildkite.com/user/api-access-tokens%s with the following scopes:
 
 - Organization access to %q
 - read_artifacts
@@ -78,7 +78,7 @@ func getTokenFromUser(out *std.Output) (string, error) {
 - (optional) write_builds
 
 To use functionality that manipulates builds, you must also have the 'write_builds' scope.
-`, BuildkiteOrg))
+`, output.StyleOrange, output.StyleSuggestion, BuildkiteOrg))
 	return out.PromptPasswordf(os.Stdin, "Paste your token here:")
 }
 


### PR DESCRIPTION
@oleggromov  pointed this out to me: the URL is really hard to read in the blue
text when using default colors in iTerm2.

This fixes it.

## before
<img width="661" alt="screenshot_2022-07-21_16 34 06@2x" src="https://user-images.githubusercontent.com/1185253/180240962-e5c5ce93-673a-4131-aff5-ff3f574f90f5.png">

## after

<img width="665" alt="screenshot_2022-07-21_16 34 40@2x" src="https://user-images.githubusercontent.com/1185253/180240970-7382ebbf-e256-45d0-a498-6ee516c2a61e.png">


## Test plan

- Manual testing
