### PR TITLE
blob: Replace history entry if next selected is close the currently selected line

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -12,7 +12,7 @@ import { addLineRangeQueryParameter, toPositionOrRangeQueryParameter } from '@so
 import { editorHeight, useCodeMirror, useCompartment } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
 
-import { BlobProps, updateBrowserHistoryIfNecessary } from './Blob'
+import { BlobProps, updateBrowserHistoryIfChanged } from './Blob'
 import { selectLines, selectableLineNumbers, SelectedLineRange } from './CodeMirrorLineNumbers'
 
 const staticExtensions: Extension = [
@@ -73,7 +73,7 @@ export const Blob: React.FunctionComponent<BlobProps> = ({
             query = toPositionOrRangeQueryParameter({ position: { line: range.line } })
         }
 
-        updateBrowserHistoryIfNecessary(
+        updateBrowserHistoryIfChanged(
             historyRef.current,
             locationRef.current,
             addLineRangeQueryParameter(parameters, query)


### PR DESCRIPTION
Closes #4816 

With this commit a new history entry for selecting a line is only added
if the newly selected line is > 10 lines away from the currently
selected line.

A new entry is always added if a line range is currently selected or
if the new selection is a line range.

A new entry is also always added when pinning the hovercard or closing
the hovercard.



## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-4816-replace-browser.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-juylnljfzd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
