### PR TITLE
Fix a bug in repo perms that would fetch public repos

### DIFF
--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1661,7 +1661,8 @@ func (s *permsStore) ReposIDsWithOldestPerms(ctx context.Context, limit int, age
 SELECT perms.repo_id, perms.synced_at FROM repo_permissions AS perms
 WHERE perms.repo_id IN
 	(SELECT repo.id FROM repo
-	 WHERE repo.deleted_at IS NULL)
+	 WHERE repo.deleted_at IS NULL
+	 AND repo.private = TRUE)
 AND %s
 ORDER BY perms.synced_at ASC NULLS FIRST
 LIMIT %s


### PR DESCRIPTION
Fixed a bug where the code that fetches the repos with the stalest permissions could return a list of public repos. This happens in a situation where a repo was once private, had permissions attached to it, and then was migrated to being public, meaning that it no longer needs permission syncing. This could theoretically cause permissions syncing to stop working ifthe # of repos that are migrated from private to public > the limit of repos fetched.

## Test plan
Existing tests pass