### PR TITLE
opentelemetry-collector: use full contrib distribution

### DIFF
--- a/docker-images/opentelemetry-collector/Dockerfile
+++ b/docker-images/opentelemetry-collector/Dockerfile
@@ -1,5 +1,5 @@
 ARG OTEL_COLLECTOR_VERSION
-FROM otel/opentelemetry-collector:${OTEL_COLLECTOR_VERSION}
+FROM otel/opentelemetry-collector-contrib:${OTEL_COLLECTOR_VERSION}
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -11,6 +11,6 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL org.opencontainers.image.url=https://sourcegraph.com/
 LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
-LABEL com.sourcegraph.opentelemetry-collector.version=${OTEL_COLLECTOR_VERSION}
+LABEL com.sourcegraph.opentelemetry-collector-contrib.version=${OTEL_COLLECTOR_VERSION}
 
 COPY ./configs /etc/otel-collector/configs

--- a/docker-images/opentelemetry-collector/README.md
+++ b/docker-images/opentelemetry-collector/README.md
@@ -1,6 +1,6 @@
 # Sourcegraph OpenTelemetry collector
 
-This distribution of the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/) provides some basic collector configuration that can be used out-of-the-box in `/etc/otel-collector/configs` with the `--config` flag.
+This distribution of the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/)'s [full `contrib` distribution](https://github.com/open-telemetry/opentelemetry-collector-contrib#opentelemetry-collector-contrib) provides some basic collector configuration that can be used out-of-the-box in `/etc/otel-collector/configs` with the `--config` flag.
 You can also mount your own configuration to provide to the `--config` flag.
 
 In the out-of-the-box configurations, debug pages ("zPages") are available at port 55679 by default - see [Exposed zPages routes](https://github.com/open-telemetry/opentelemetry-collector/blob/main/extension/zpagesextension/README.md#exposed-zpages-routes).

--- a/docker-images/opentelemetry-collector/build.sh
+++ b/docker-images/opentelemetry-collector/build.sh
@@ -5,7 +5,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 export OTEL_COLLECTOR_VERSION="${OTEL_COLLECTOR_VERSION:-0.54.0}"
 
-docker build --no-cache -t "${IMAGE:-sourcegraph/opentelemetry-collector}" . \
+docker build -t "${IMAGE:-sourcegraph/opentelemetry-collector}" . \
   --build-arg OTEL_COLLECTOR_VERSION \
   --build-arg COMMIT_SHA \
   --build-arg DATE \


### PR DESCRIPTION
Most crucially, the contrib distribution includes the gcloud exporter we want to trial, and in the grand scheme of things we want to maximize out-of-the-box usability for potential customers that use this so I think it best we just use the full contrib distribution of the collector.

Since this is a significantly larger image, I've removed the `--no-cache` argument from the build script. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

build locally, `sg start otel`