### PR TITLE
insights: remove interval step reset when toggling all repos during creation

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
@@ -83,8 +83,6 @@ export const CaptureGroupCreationContent: FC<CaptureGroupCreationContentProps> =
             // Reset form values in case if All repos mode was activated
             if (checked) {
                 repositories.input.onChange('')
-                step.input.onChange('months')
-                stepValue.input.onChange('1')
             }
         },
     })

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/use-insight-creation-form.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/use-insight-creation-form.ts
@@ -69,8 +69,6 @@ export function useInsightCreationForm(props: UseInsightCreationFormProps): Insi
             // Reset form values in case if All repos mode was activated
             if (checked) {
                 repositories.input.onChange('')
-                step.input.onChange('months')
-                stepValue.input.onChange('1')
             }
         },
     })


### PR DESCRIPTION
During insight creation removes the changes to the step between data points when the user switches from scoped to all repos.

resolves https://github.com/sourcegraph/sourcegraph/issues/39103
## Test plan
In Search Insight creation:

- enter an repo and search query
- update interval to 4 weeks
- preview loads 
- check `all repos` 
- validate that time interval remains at 4 weeks

In Detect and Track Insight creation:

- enter an repo and search query
- update interval to 4 weeks
- preview loads 
- check `all repos` 
- validate that time interval remains at 4 weeks


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
