### PR TITLE
search: distinguish additional versus pure lucky results

### DIFF
--- a/internal/search/lucky/feeling_lucky_search_job.go
+++ b/internal/search/lucky/feeling_lucky_search_job.go
@@ -93,7 +93,13 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 		return alert, err
 	}
 
-	generated := &alertobserver.ErrLuckyQueries{ProposedQueries: []*search.ProposedQuery{}}
+	var luckyAlertType alertobserver.LuckyAlertType
+	if initialResultSetSize == 0 {
+		luckyAlertType = alertobserver.LuckyAlertPure
+	} else {
+		luckyAlertType = alertobserver.LuckyAlertAdded
+	}
+	generated := &alertobserver.ErrLuckyQueries{Type: luckyAlertType, ProposedQueries: []*search.ProposedQuery{}}
 	var autoQ *autoQuery
 	for _, next := range f.generators {
 		for {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/39260.

This communicates whether the original query found any results or not in the client. Adding primarily because it's going to be useful context to log.

<img width="1358" alt="Screen Shot 2022-07-21 at 1 38 06 PM" src="https://user-images.githubusercontent.com/888624/180311356-ceb5dbc4-2d29-41ab-bc66-20cd767cfc82.png">

vs

<img width="1206" alt="Screen Shot 2022-07-21 at 1 40 56 PM" src="https://user-images.githubusercontent.com/888624/180311343-e9d4ff4b-b897-49c7-9ec4-c22b51c6309c.png">

## Test plan
Manually tested for experimental functionality.
