### PR TITLE
core workflow: First pass on inlining symbols in the file tree

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -31,6 +31,7 @@ import { Tree } from '../tree/Tree'
 import { RepoRevisionSidebarSymbols } from './RepoRevisionSidebarSymbols'
 
 import styles from './RepoRevisionSidebar.module.scss'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 
 interface Props extends AbsoluteRepoFile, ExtensionsControllerProps, ThemeProps, TelemetryProps {
     repoID: Scalars['ID']
@@ -58,6 +59,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
 
     const isWideScreen = useMatchMedia('(min-width: 768px)', false)
     const [isVisible, setIsVisible] = useState(persistedIsVisible && isWideScreen)
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
 
     const handleSidebarToggle = useCallback(
         (value: boolean) => {
@@ -101,9 +103,13 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
                     isAuthenticated={!!props.authenticatedUser}
                     isSourcegraphDotCom={props.isSourcegraphDotCom}
                 />
+                {/* `key` is used to force rerendering the Tabs component when the UI
+                    setting changes. This is necessary to force registering Tabs and
+                    TabPanels properly. */}
                 <Tabs
+                    key={`ui-${coreWorkflowImprovementsEnabled}`}
                     className="w-100 test-repo-revision-sidebar pr-3 h-25 d-flex flex-column flex-grow-1"
-                    defaultIndex={persistedTabIndex}
+                    defaultIndex={coreWorkflowImprovementsEnabled ? 0 : persistedTabIndex}
                     onChange={setPersistedTabIndex}
                     lazy={true}
                 >
@@ -127,9 +133,11 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
                         <Tab data-tab-content="files">
                             <span className="tablist-wrapper--tab-label">Files</span>
                         </Tab>
-                        <Tab data-tab-content="symbols">
-                            <span className="tablist-wrapper--tab-label">Symbols</span>
-                        </Tab>
+                        {!coreWorkflowImprovementsEnabled && (
+                            <Tab data-tab-content="symbols">
+                                <span className="tablist-wrapper--tab-label">Symbols</span>
+                            </Tab>
+                        )}
                     </TabList>
                     <div className={classNames('flex w-100 overflow-auto explorer', styles.tabpanels)} tabIndex={-1}>
                         <TabPanels>
@@ -137,6 +145,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
                                 <Tree
                                     key="files"
                                     repoName={props.repoName}
+                                    repoID={props.repoID}
                                     revision={props.revision}
                                     commitID={props.commitID}
                                     history={props.history}
@@ -150,15 +159,17 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
                                     telemetryService={props.telemetryService}
                                 />
                             </TabPanel>
-                            <TabPanel>
-                                <RepoRevisionSidebarSymbols
-                                    key="symbols"
-                                    repoID={props.repoID}
-                                    revision={props.revision}
-                                    activePath={props.filePath}
-                                    onHandleSymbolClick={handleSymbolClick}
-                                />
-                            </TabPanel>
+                            {!coreWorkflowImprovementsEnabled && (
+                                <TabPanel>
+                                    <RepoRevisionSidebarSymbols
+                                        key="symbols"
+                                        repoID={props.repoID}
+                                        revision={props.revision}
+                                        activePath={props.filePath}
+                                        onHandleSymbolClick={handleSymbolClick}
+                                    />
+                                </TabPanel>
+                            )}
                         </TabPanels>
                     </div>
                 </Tabs>

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -6,6 +6,7 @@ import * as H from 'history'
 
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { AbsoluteRepoFile } from '@sourcegraph/shared/src/util/url'
@@ -31,7 +32,6 @@ import { Tree } from '../tree/Tree'
 import { RepoRevisionSidebarSymbols } from './RepoRevisionSidebarSymbols'
 
 import styles from './RepoRevisionSidebar.module.scss'
-import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 
 interface Props extends AbsoluteRepoFile, ExtensionsControllerProps, ThemeProps, TelemetryProps {
     repoID: Scalars['ID']

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -33,6 +33,7 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
         expandedTrees: props.expandedTrees,
         parent: props.parent,
         repoName: props.repoName,
+        repoID: props.repoID,
         revision: props.revision,
         onToggleExpand: props.onToggleExpand,
         onHover: props.onHover,

--- a/client/web/src/tree/File.module.scss
+++ b/client/web/src/tree/File.module.scss
@@ -1,0 +1,34 @@
+.symbols {
+    background-color: var(--color-bg-2);
+    color: var(--gray-06);
+
+    ul {
+        width: 100%;
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        // Used to prevent margin collapse
+        display: flex;
+        flex-direction: column;
+
+        li {
+            margin: 0.25rem 0%;
+        }
+    }
+
+    .link {
+        display: block;
+        padding: 0.25rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        &--active,
+        &:hover {
+            background-color: var(--color-bg-3);
+            text-decoration: none;
+            color: var(--body-color);
+            border-radius: var(--border-radius);
+        }
+    }
+}

--- a/client/web/src/tree/File.module.scss
+++ b/client/web/src/tree/File.module.scss
@@ -12,7 +12,7 @@
         flex-direction: column;
 
         li {
-            margin: 0.25rem 0%;
+            margin: 0.25rem 0;
         }
     }
 

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -1,11 +1,13 @@
 /* eslint jsx-a11y/click-events-have-key-events: warn, jsx-a11y/no-static-element-interactions: warn */
 import * as React from 'react'
+import * as H from 'history'
 
 import { mdiSourceRepository } from '@mdi/js'
 import { FileDecoration } from 'sourcegraph'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, LoadingSpinner } from '@sourcegraph/wildcard'
+import { gql, useQuery } from '@sourcegraph/http-client'
 
 import {
     TreeLayerCell,
@@ -19,6 +21,17 @@ import {
 } from './components'
 import { FileDecorator } from './FileDecorator'
 import { maxEntries, TreeEntryInfo, treePadding } from './util'
+import { TreeLayerProps } from './TreeLayer'
+import { escapeRegExp, isEqual } from 'lodash'
+
+import { InlineSymbolsResult, Scalars } from '../graphql-operations'
+import { NavLink } from 'react-router-dom'
+import classNames from 'classnames'
+import { SymbolTag } from '@sourcegraph/shared/src/symbols/SymbolTag'
+import { parseBrowserRepoURL } from '../util/url'
+import styles from './File.module.scss'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
+import { useEffect, useState } from 'react'
 
 interface FileProps extends ThemeProps {
     fileDecorations?: FileDecoration[]
@@ -32,9 +45,16 @@ interface FileProps extends ThemeProps {
     linkRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
     isActive: boolean
     isSelected: boolean
+
+    // For core workflow inline symbols redesign
+    repoID: Scalars['ID']
+    revision: string
+    location: H.Location
 }
 
 export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> = props => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+
     const renderedFileDecorations = (
         <FileDecorator
             // If component is not specified, or it is 'sidebar', render it.
@@ -44,73 +64,226 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
         />
     )
 
+    const padding = treePadding(props.depth, false)
+
     return (
-        <TreeRow
-            key={props.entryInfo.path}
-            className={props.className}
-            isActive={props.isActive}
-            isSelected={props.isSelected}
-        >
-            <TreeLayerCell className="test-sidebar-file-decorable">
-                {props.entryInfo.submodule ? (
-                    props.entryInfo.url ? (
+        <>
+            <TreeRow
+                key={props.entryInfo.path}
+                className={props.className}
+                isActive={props.isActive}
+                isSelected={props.isSelected}
+            >
+                <TreeLayerCell className="test-sidebar-file-decorable">
+                    {props.entryInfo.submodule ? (
+                        props.entryInfo.url ? (
+                            <TreeLayerRowContentsLink
+                                to={props.entryInfo.url}
+                                onClick={props.linkRowClick}
+                                draggable={false}
+                                title={'Submodule: ' + props.entryInfo.submodule.url}
+                                data-tree-path={props.entryInfo.path}
+                            >
+                                <TreeLayerRowContentsText>
+                                    {/* TODO Improve accessibility: https://github.com/sourcegraph/sourcegraph/issues/12916 */}
+                                    <TreeRowIcon style={treePadding(props.depth, true)} onClick={props.noopRowClick}>
+                                        <Icon aria-hidden={true} svgPath={mdiSourceRepository} />
+                                    </TreeRowIcon>
+                                    <TreeRowLabel className="test-file-decorable-name">
+                                        {props.entryInfo.name} @ {props.entryInfo.submodule.commit.slice(0, 7)}
+                                    </TreeRowLabel>
+                                    {renderedFileDecorations}
+                                </TreeLayerRowContentsText>
+                            </TreeLayerRowContentsLink>
+                        ) : (
+                            <TreeLayerRowContents title={'Submodule: ' + props.entryInfo.submodule.url}>
+                                <TreeLayerRowContentsText>
+                                    <TreeRowIcon style={treePadding(props.depth, true)}>
+                                        <Icon aria-hidden={true} svgPath={mdiSourceRepository} />
+                                    </TreeRowIcon>
+                                    <TreeRowLabel className="test-file-decorable-name">
+                                        {props.entryInfo.name} @ {props.entryInfo.submodule.commit.slice(0, 7)}
+                                    </TreeRowLabel>
+                                    {renderedFileDecorations}
+                                </TreeLayerRowContentsText>
+                            </TreeLayerRowContents>
+                        )
+                    ) : (
                         <TreeLayerRowContentsLink
+                            className="test-tree-file-link"
                             to={props.entryInfo.url}
                             onClick={props.linkRowClick}
-                            draggable={false}
-                            title={'Submodule: ' + props.entryInfo.submodule.url}
                             data-tree-path={props.entryInfo.path}
+                            draggable={false}
+                            title={props.entryInfo.path}
+                            // needed because of dynamic styling
+                            style={padding}
+                            tabIndex={-1}
                         >
-                            <TreeLayerRowContentsText>
-                                {/* TODO Improve accessibility: https://github.com/sourcegraph/sourcegraph/issues/12916 */}
-                                <TreeRowIcon style={treePadding(props.depth, true)} onClick={props.noopRowClick}>
-                                    <Icon aria-hidden={true} svgPath={mdiSourceRepository} />
-                                </TreeRowIcon>
-                                <TreeRowLabel className="test-file-decorable-name">
-                                    {props.entryInfo.name} @ {props.entryInfo.submodule.commit.slice(0, 7)}
-                                </TreeRowLabel>
+                            <TreeLayerRowContentsText className="d-flex flex-row flex-1 justify-content-between">
+                                <span className="test-file-decorable-name">{props.entryInfo.name}</span>
                                 {renderedFileDecorations}
                             </TreeLayerRowContentsText>
                         </TreeLayerRowContentsLink>
-                    ) : (
-                        <TreeLayerRowContents title={'Submodule: ' + props.entryInfo.submodule.url}>
-                            <TreeLayerRowContentsText>
-                                <TreeRowIcon style={treePadding(props.depth, true)}>
-                                    <Icon aria-hidden={true} svgPath={mdiSourceRepository} />
-                                </TreeRowIcon>
-                                <TreeRowLabel className="test-file-decorable-name">
-                                    {props.entryInfo.name} @ {props.entryInfo.submodule.commit.slice(0, 7)}
-                                </TreeRowLabel>
-                                {renderedFileDecorations}
-                            </TreeLayerRowContentsText>
-                        </TreeLayerRowContents>
-                    )
-                ) : (
-                    <TreeLayerRowContentsLink
-                        className="test-tree-file-link"
-                        to={props.entryInfo.url}
-                        onClick={props.linkRowClick}
-                        data-tree-path={props.entryInfo.path}
-                        draggable={false}
-                        title={props.entryInfo.path}
-                        // needed because of dynamic styling
-                        style={treePadding(props.depth, false)}
-                        tabIndex={-1}
-                    >
-                        <TreeLayerRowContentsText className="d-flex flex-row flex-1 justify-content-between">
-                            <span className="test-file-decorable-name">{props.entryInfo.name}</span>
-                            {renderedFileDecorations}
-                        </TreeLayerRowContentsText>
-                    </TreeLayerRowContentsLink>
-                )}
-                {props.index === maxEntries - 1 && (
-                    <TreeRowAlert
-                        variant="warning"
-                        style={treePadding(props.depth, true)}
-                        error="Too many entries. Use search to find a specific file."
-                    />
-                )}
-            </TreeLayerCell>
-        </TreeRow>
+                    )}
+                    {props.index === maxEntries - 1 && (
+                        <TreeRowAlert
+                            variant="warning"
+                            style={treePadding(props.depth, true)}
+                            error="Too many entries. Use search to find a specific file."
+                        />
+                    )}
+                </TreeLayerCell>
+            </TreeRow>
+            {coreWorkflowImprovementsEnabled && props.isActive && (
+                <Symbols
+                    repoID={props.repoID}
+                    revision={props.revision}
+                    activePath={props.entryInfo.path}
+                    location={props.location}
+                    style={padding}
+                />
+            )}
+        </>
     )
+}
+
+export const SYMBOLS_QUERY = gql`
+    query InlineSymbols($repo: ID!, $revision: String!, $includePatterns: [String!]) {
+        node(id: $repo) {
+            __typename
+            ... on Repository {
+                commit(rev: $revision) {
+                    symbols(first: 1000, query: "", includePatterns: $includePatterns) {
+                        ...InlineSymbolConnectionFields
+                    }
+                }
+            }
+        }
+    }
+
+    fragment InlineSymbolConnectionFields on SymbolConnection {
+        __typename
+        nodes {
+            ...InlineSymbolNodeFields
+        }
+    }
+
+    fragment InlineSymbolNodeFields on Symbol {
+        __typename
+        name
+        containerName
+        kind
+        language
+        location {
+            resource {
+                path
+            }
+            range {
+                start {
+                    line
+                    character
+                }
+                end {
+                    line
+                    character
+                }
+            }
+        }
+        url
+    }
+`
+
+interface SymbolsProps
+    extends Pick<TreeLayerProps, 'repoID' | 'revision' | 'activePath' | 'location'>,
+        Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> {}
+
+const Symbols: React.FunctionComponent<SymbolsProps> = ({ repoID, revision, activePath, location, style }) => {
+    const { data, loading, error } = useQuery<InlineSymbolsResult>(SYMBOLS_QUERY, {
+        variables: {
+            repo: repoID,
+            revision,
+            // `includePatterns` expects regexes, so first escape the path.
+            includePatterns: ['^' + escapeRegExp(activePath)],
+        },
+    })
+
+    const currentLocation = parseBrowserRepoURL(H.createPath(location))
+    const isSymbolActive = (symbolUrl: string): boolean => {
+        const symbolLocation = parseBrowserRepoURL(symbolUrl)
+        return (
+            currentLocation.repoName === symbolLocation.repoName &&
+            currentLocation.revision === symbolLocation.revision &&
+            currentLocation.filePath === symbolLocation.filePath &&
+            isEqual(currentLocation.position, symbolLocation.position)
+        )
+    }
+
+    if (loading) {
+        return (
+            <Delay timeout={800}>
+                <TreeRow className={styles.symbols}>
+                    <TreeLayerCell>
+                        <TreeLayerRowContents className="d-flex" style={style}>
+                            <LoadingSpinner /> Loading symbol data...
+                        </TreeLayerRowContents>
+                    </TreeLayerCell>
+                </TreeRow>
+            </Delay>
+        )
+    }
+
+    let content = null
+
+    if (error) {
+        content = 'Unable to load symbol data.'
+    }
+
+    if (data && data.node?.__typename === 'Repository') {
+        // Only consider top-level symbols
+        const symbols = data.node.commit?.symbols.nodes.filter(symbol => !symbol.containerName) ?? []
+        if (symbols.length > 0) {
+            content = (
+                <ul>
+                    {symbols.map(symbol => (
+                        <li className={''}>
+                            <NavLink
+                                to={symbol.url}
+                                isActive={() => isSymbolActive(symbol.url)}
+                                className={classNames('test-symbol-link', styles.link)}
+                                activeClassName={styles.linkActive}
+                            >
+                                <SymbolTag kind={symbol.kind} className="mr-1 test-symbol-icon" />
+                                <span className={classNames('test-symbol-name')}>{symbol.name}</span>
+                            </NavLink>
+                        </li>
+                    ))}
+                </ul>
+            )
+        } else {
+            content = 'No symbols found.'
+        }
+    }
+
+    if (content) {
+        return (
+            <TreeRow className={styles.symbols}>
+                <TreeLayerCell>
+                    <TreeLayerRowContents style={style}>{content}</TreeLayerRowContents>
+                </TreeLayerCell>
+            </TreeRow>
+        )
+    }
+    return null
+}
+
+const Delay: React.FunctionComponent<{ timeout: number; children: React.ReactElement }> = ({ timeout, children }) => {
+    const [show, setShow] = useState(false)
+
+    useEffect(() => {
+        const id = setTimeout(() => setShow(true), timeout)
+        return () => clearTimeout(id)
+    }, [timeout])
+
+    return show ? children : null
 }

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -1,13 +1,22 @@
 /* eslint jsx-a11y/click-events-have-key-events: warn, jsx-a11y/no-static-element-interactions: warn */
 import * as React from 'react'
-import * as H from 'history'
+import { useEffect, useState } from 'react'
 
 import { mdiSourceRepository } from '@mdi/js'
+import classNames from 'classnames'
+import * as H from 'history'
+import { escapeRegExp, isEqual } from 'lodash'
+import { NavLink } from 'react-router-dom'
 import { FileDecoration } from 'sourcegraph'
 
+import { gql, useQuery } from '@sourcegraph/http-client'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
+import { SymbolTag } from '@sourcegraph/shared/src/symbols/SymbolTag'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Icon, LoadingSpinner } from '@sourcegraph/wildcard'
-import { gql, useQuery } from '@sourcegraph/http-client'
+
+import { InlineSymbolsResult, Scalars } from '../graphql-operations'
+import { parseBrowserRepoURL } from '../util/url'
 
 import {
     TreeLayerCell,
@@ -20,18 +29,10 @@ import {
     TreeRow,
 } from './components'
 import { FileDecorator } from './FileDecorator'
-import { maxEntries, TreeEntryInfo, treePadding } from './util'
 import { TreeLayerProps } from './TreeLayer'
-import { escapeRegExp, isEqual } from 'lodash'
+import { maxEntries, TreeEntryInfo, treePadding } from './util'
 
-import { InlineSymbolsResult, Scalars } from '../graphql-operations'
-import { NavLink } from 'react-router-dom'
-import classNames from 'classnames'
-import { SymbolTag } from '@sourcegraph/shared/src/symbols/SymbolTag'
-import { parseBrowserRepoURL } from '../util/url'
 import styles from './File.module.scss'
-import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
-import { useEffect, useState } from 'react'
 
 interface FileProps extends ThemeProps {
     fileDecorations?: FileDecoration[]
@@ -246,7 +247,7 @@ const Symbols: React.FunctionComponent<SymbolsProps> = ({ repoID, revision, acti
             content = (
                 <ul>
                     {symbols.map(symbol => (
-                        <li className={''}>
+                        <li key={symbol.url}>
                             <NavLink
                                 to={symbol.url}
                                 isActive={() => isSymbolActive(symbol.url)}

--- a/client/web/src/tree/Tree.tsx
+++ b/client/web/src/tree/Tree.tsx
@@ -19,6 +19,7 @@ import { TreeRoot } from './TreeRoot'
 import { getDomElement, scrollIntoView } from './util'
 
 import styles from './Tree.module.scss'
+import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 
 interface Props extends AbsoluteRepo, ExtensionsControllerProps, ThemeProps, TelemetryProps {
     history: H.History
@@ -32,6 +33,7 @@ interface Props extends AbsoluteRepo, ExtensionsControllerProps, ThemeProps, Tel
     activePathIsDir: boolean
     /** The localStorage key that stores the current size of the (resizable) RepoRevisionSidebar. */
     sizeKey: string
+    repoID: Scalars['ID']
 }
 
 interface State {
@@ -325,6 +327,7 @@ export class Tree extends React.PureComponent<Props, State> {
                     activePath={this.props.activePath}
                     depth={0}
                     location={this.props.location}
+                    repoID={this.props.repoID}
                     repoName={this.props.repoName}
                     revision={this.props.revision}
                     commitID={this.props.commitID}

--- a/client/web/src/tree/Tree.tsx
+++ b/client/web/src/tree/Tree.tsx
@@ -9,6 +9,7 @@ import { Key } from 'ts-key-enum'
 
 import { formatSearchParameters } from '@sourcegraph/common'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
+import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { AbsoluteRepo } from '@sourcegraph/shared/src/util/url'
@@ -19,7 +20,6 @@ import { TreeRoot } from './TreeRoot'
 import { getDomElement, scrollIntoView } from './util'
 
 import styles from './Tree.module.scss'
-import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 
 interface Props extends AbsoluteRepo, ExtensionsControllerProps, ThemeProps, TelemetryProps {
     history: H.History

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -18,7 +18,7 @@ import { FileDecoration } from 'sourcegraph'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { FileDecorationsByPath } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { fetchTreeEntries } from '@sourcegraph/shared/src/backend/repo'
-import { TreeFields } from '@sourcegraph/shared/src/graphql-operations'
+import { Scalars, TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 
 import { getFileDecorations } from '../backend/features'
 import { requestGraphQL } from '../backend/graphql'
@@ -43,6 +43,7 @@ export interface TreeLayerProps extends Omit<TreeRootProps, 'sizeKey'> {
     entryInfo: TreeEntryInfo
     fileDecorations?: FileDecoration[]
     onHover: (filePath: string) => void
+    repoID: Scalars['ID']
 }
 
 const LOADING = 'loading' as const
@@ -329,6 +330,9 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                 linkRowClick={this.linkRowClick}
                                 isActive={isActive}
                                 isSelected={isSelected}
+                                repoID={this.props.repoID}
+                                revision={this.props.revision}
+                                location={this.props.location}
                             />
                         )}
                     </tbody>

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -19,7 +19,7 @@ import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { FileDecorationsByPath } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { fetchTreeEntries } from '@sourcegraph/shared/src/backend/repo'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { TreeFields } from '@sourcegraph/shared/src/graphql-operations'
+import { Scalars, TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { AbsoluteRepo } from '@sourcegraph/shared/src/util/url'
@@ -56,6 +56,7 @@ export interface TreeRootProps extends AbsoluteRepo, ExtensionsControllerProps, 
     onToggleExpand: (path: string, expanded: boolean, node: TreeNode) => void
     setChildNodes: (node: TreeNode, index: number) => void
     setActiveNode: (node: TreeNode) => void
+    repoID: Scalars['ID']
 }
 
 const LOADING = 'loading' as const


### PR DESCRIPTION
Addresses #38662

This builds on top of Rok's symbol tag work.

It's a very rudimentary first pass to inline symbols. I basically
duplicated the logic for the symbols sidebar with some changes:

- No pagination, I'm requesting a high number of symbols from the server
  and hope that this will suffice to load all symbols.
- Only show top level symbols. I don't know how reliable the
  `containerName` data is but if its set I assume it's not a top level
  symbol.

I had to thread some additional values through to the File component to
be able to fetch symbols (I guess another alternative would be to also
ask for symbol information when we fetch the file information in the
first place, but that feels very wasteful).

It takes a moment to load the data, but I found it too distracting to
immediately show a loading indicator. I added some logic to only show it
after 800ms. If there are no symbols or there is an error a
corresponding message will be shown.

A big drawback of this first solution is that it will show "No symbols
found." for files that _cannot_ have symbol information, such as
Markdown files. This feels weird, but I don't know of a good way to
handle that.

Lastly I'm currently keep using the Tab component because that allows me
to keep using the "sidebar collapse" button without additional changes.



https://user-images.githubusercontent.com/179026/180432432-cad4fee9-0ad3-409f-b340-f70715c70a82.mp4

**CAVEAT:** Our symbol data is very low quality for some files, and 
using single character labels doesn't improve that either in this case
(additional [Slack](https://sourcegraph.slack.com/archives/C07KZF47K/p1658487725681349) thread).


## Test plan

Open file, enable core workflow simple UI. See inline symbols.

## App preview:

- [Web](https://sg-web-fkling-38662-symbol-treeview.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-avmowzbsuc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
