### PR TITLE
Tree: add "go up" the tree button (second merge)

### DIFF
--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -190,7 +190,7 @@ describe('Repository component', () => {
         test('selects the current file', async () => {
             await driver.page.goto(
                 sourcegraphBaseUrl +
-                    '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/blob/async.go'
+                '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/blob/async.go'
             )
             await driver.page.waitForSelector('[data-tree-row-active="true"] [data-tree-path="async.go"]', {
                 visible: true,
@@ -200,12 +200,12 @@ describe('Repository component', () => {
         test('shows partial tree when opening directory', async () => {
             await driver.page.goto(
                 sourcegraphBaseUrl +
-                    '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/tree/websocket'
+                '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/tree/websocket'
             )
             await driver.page.waitForSelector('[data-testid="tree-row"]', { visible: true })
             expect(
                 await driver.page.evaluate(() => document.querySelectorAll('[data-testid="tree-row"]').length)
-            ).toEqual(1)
+            ).toEqual(2)
         })
 
         test('responds to keyboard shortcuts', async () => {
@@ -218,7 +218,7 @@ describe('Repository component', () => {
             }
             await driver.page.goto(
                 sourcegraphBaseUrl +
-                    '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/.travis.yml'
+                '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/.travis.yml'
             )
             await driver.page.waitForSelector('[data-testid="tree-row"]', { visible: true }) // waitForSelector for tree to render
 
@@ -499,7 +499,7 @@ describe('Repository component', () => {
             test('gets displayed and updates URL when hovering over a token', async () => {
                 await driver.page.goto(
                     sourcegraphBaseUrl +
-                        '/github.com/gorilla/mux@15a353a636720571d19e37b34a14499c3afa9991/-/blob/mux.go'
+                    '/github.com/gorilla/mux@15a353a636720571d19e37b34a14499c3afa9991/-/blob/mux.go'
                 )
                 await driver.page.waitForSelector(blobTableSelector)
 
@@ -521,7 +521,7 @@ describe('Repository component', () => {
                 test('noops when on the definition', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6'
+                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6'
                     )
                     await clickHoverJ2D(29, 6)
                     await driver.assertWindowLocation(
@@ -532,7 +532,7 @@ describe('Repository component', () => {
                 test('does navigation (same repo, same file)', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L25:10'
+                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L25:10'
                     )
                     await clickHoverJ2D(25, 10)
                     await driver.assertWindowLocation(
@@ -543,7 +543,7 @@ describe('Repository component', () => {
                 test.skip('does navigation (same repo, different file)', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/print.go?L13:31'
+                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/print.go?L13:31'
                     )
                     await clickHoverJ2D(13, 31)
                     await driver.assertWindowLocation(
@@ -564,7 +564,7 @@ describe('Repository component', () => {
                 test.skip('does navigation (external repo)', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                            '/github.com/sourcegraph/vcsstore@267289226b15e5b03adedc9746317455be96e44c/-/blob/server/diff.go?L27:30'
+                        '/github.com/sourcegraph/vcsstore@267289226b15e5b03adedc9746317455be96e44c/-/blob/server/diff.go?L27:30'
                     )
                     await clickHoverJ2D(27, 30)
                     await driver.assertWindowLocation(
@@ -581,7 +581,7 @@ describe('Repository component', () => {
 
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6'
+                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6'
                     )
                     await clickHoverFindReferences(29, 6)
                     await driver.assertWindowLocation(
@@ -620,7 +620,7 @@ describe('Repository component', () => {
                 test.skip('opens widget and fetches external references', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L32:16#tab=references'
+                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L32:16#tab=references'
                     )
 
                     // verify some external refs are fetched (we cannot assert how many, but we can check that the matched results

--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -190,7 +190,7 @@ describe('Repository component', () => {
         test('selects the current file', async () => {
             await driver.page.goto(
                 sourcegraphBaseUrl +
-                '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/blob/async.go'
+                    '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/blob/async.go'
             )
             await driver.page.waitForSelector('[data-tree-row-active="true"] [data-tree-path="async.go"]', {
                 visible: true,
@@ -200,7 +200,7 @@ describe('Repository component', () => {
         test('shows partial tree when opening directory', async () => {
             await driver.page.goto(
                 sourcegraphBaseUrl +
-                '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/tree/websocket'
+                    '/github.com/sourcegraph/jsonrpc2@c6c7b9aa99fb76ee5460ccd3912ba35d419d493d/-/tree/websocket'
             )
             await driver.page.waitForSelector('[data-testid="tree-row"]', { visible: true })
             expect(
@@ -218,7 +218,7 @@ describe('Repository component', () => {
             }
             await driver.page.goto(
                 sourcegraphBaseUrl +
-                '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/.travis.yml'
+                    '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/.travis.yml'
             )
             await driver.page.waitForSelector('[data-testid="tree-row"]', { visible: true }) // waitForSelector for tree to render
 
@@ -499,7 +499,7 @@ describe('Repository component', () => {
             test('gets displayed and updates URL when hovering over a token', async () => {
                 await driver.page.goto(
                     sourcegraphBaseUrl +
-                    '/github.com/gorilla/mux@15a353a636720571d19e37b34a14499c3afa9991/-/blob/mux.go'
+                        '/github.com/gorilla/mux@15a353a636720571d19e37b34a14499c3afa9991/-/blob/mux.go'
                 )
                 await driver.page.waitForSelector(blobTableSelector)
 
@@ -521,7 +521,7 @@ describe('Repository component', () => {
                 test('noops when on the definition', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6'
+                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6'
                     )
                     await clickHoverJ2D(29, 6)
                     await driver.assertWindowLocation(
@@ -532,7 +532,7 @@ describe('Repository component', () => {
                 test('does navigation (same repo, same file)', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L25:10'
+                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L25:10'
                     )
                     await clickHoverJ2D(25, 10)
                     await driver.assertWindowLocation(
@@ -543,7 +543,7 @@ describe('Repository component', () => {
                 test.skip('does navigation (same repo, different file)', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/print.go?L13:31'
+                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/print.go?L13:31'
                     )
                     await clickHoverJ2D(13, 31)
                     await driver.assertWindowLocation(
@@ -564,7 +564,7 @@ describe('Repository component', () => {
                 test.skip('does navigation (external repo)', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                        '/github.com/sourcegraph/vcsstore@267289226b15e5b03adedc9746317455be96e44c/-/blob/server/diff.go?L27:30'
+                            '/github.com/sourcegraph/vcsstore@267289226b15e5b03adedc9746317455be96e44c/-/blob/server/diff.go?L27:30'
                     )
                     await clickHoverJ2D(27, 30)
                     await driver.assertWindowLocation(
@@ -581,7 +581,7 @@ describe('Repository component', () => {
 
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6'
+                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6'
                     )
                     await clickHoverFindReferences(29, 6)
                     await driver.assertWindowLocation(
@@ -620,7 +620,7 @@ describe('Repository component', () => {
                 test.skip('opens widget and fetches external references', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
-                        '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L32:16#tab=references'
+                            '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L32:16#tab=references'
                     )
 
                     // verify some external refs are fetched (we cannot assert how many, but we can check that the matched results

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -489,12 +489,20 @@ describe('Repository', () => {
             )
             await driver.page.waitForSelector('.test-tree-file-link')
             assert.strictEqual(
-                await driver.page.evaluate(() => document.querySelector('.test-tree-file-link')?.textContent),
+                await driver.page.evaluate(
+                    () =>
+                        document.querySelector(
+                            '.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql"]'
+                        )?.textContent
+                ),
                 fileName
             )
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement
-            await driver.page.$eval('.test-tree-file-link', linkElement => (linkElement as HTMLElement).click())
+            await driver.page.$eval(
+                '.test-tree-file-link[href="/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql"]',
+                linkElement => (linkElement as HTMLElement).click()
+            )
             await driver.page.waitForSelector('[data-testid="repo-blob"]')
 
             await driver.page.waitForSelector('.test-breadcrumb')

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -73,6 +73,9 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                                     isSingleChild: false,
                                                     submodule: null,
                                                 }}
+                                                location={props.location}
+                                                repoID={props.repoID}
+                                                revision={props.revision}
                                                 depth={sharedProps.depth}
                                                 index={0}
                                                 isLightTheme={sharedProps.isLightTheme}

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -2,8 +2,13 @@ import React from 'react'
 
 import { FileDecorationsByPath } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 
+import { dirname } from '../util/path'
+
 import { TreeLayerTable } from './components'
+import { GO_UP_TREE_LABEL } from './constants'
+import { File } from './File'
 import { SingleChildTreeLayer } from './SingleChildTreeLayer'
+import { TreeRootContext } from './TreeContext'
 import { TreeLayer } from './TreeLayer'
 import { TreeRootProps } from './TreeRoot'
 import { hasSingleChild, SingleChildGitTree, TreeEntryInfo } from './util'
@@ -46,17 +51,50 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
         isLightTheme: props.isLightTheme,
     }
 
+    // Only show ".." (go up) for non-root file trees
+    const shouldShowGoUp = props.depth === -1 && props.parentPath
+
     return (
         <div>
             <TreeLayerTable>
                 <tbody>
+                    {shouldShowGoUp && (
+                        <tr>
+                            <td>
+                                <TreeLayerTable>
+                                    <TreeRootContext.Consumer>
+                                        {treeRootContext => (
+                                            <File
+                                                entryInfo={{
+                                                    name: GO_UP_TREE_LABEL,
+                                                    path: props.parentPath as string,
+                                                    isDirectory: false,
+                                                    url: dirname(treeRootContext.rootTreeUrl),
+                                                    isSingleChild: false,
+                                                    submodule: null,
+                                                }}
+                                                depth={sharedProps.depth}
+                                                index={0}
+                                                isLightTheme={sharedProps.isLightTheme}
+                                                handleTreeClick={() => undefined}
+                                                noopRowClick={() => undefined}
+                                                linkRowClick={() => props.telemetryService.log('FileTreeClick')}
+                                                isActive={false}
+                                                isSelected={false}
+                                            />
+                                        )}
+                                    </TreeRootContext.Consumer>
+                                </TreeLayerTable>
+                            </td>
+                        </tr>
+                    )}
                     <tr>
                         <td>
                             {hasSingleChild(props.entries) ? (
                                 <SingleChildTreeLayer
                                     {...sharedProps}
                                     key={props.singleChildTreeEntry.path}
-                                    index={0}
+                                    index={shouldShowGoUp ? 1 : 0}
                                     isExpanded={props.expandedTrees.includes(props.singleChildTreeEntry.path)}
                                     parentPath={props.singleChildTreeEntry.path}
                                     entryInfo={props.singleChildTreeEntry}
@@ -70,7 +108,7 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                     <TreeLayer
                                         {...sharedProps}
                                         key={item.path}
-                                        index={index}
+                                        index={shouldShowGoUp ? index + 1 : index}
                                         isExpanded={props.expandedTrees.includes(item.path)}
                                         parentPath={item.path}
                                         entryInfo={item}

--- a/client/web/src/tree/Directory.tsx
+++ b/client/web/src/tree/Directory.tsx
@@ -15,6 +15,7 @@ import {
     TreeRowLabelLink,
     TreeRow,
 } from './components'
+import { MAX_TREE_ENTRIES } from './constants'
 import { FileDecorator } from './FileDecorator'
 import { TreeEntryInfo, treePadding } from './util'
 
@@ -24,7 +25,6 @@ interface DirectoryProps extends ThemeProps {
     className?: string
     entryInfo: TreeEntryInfo
     isExpanded: boolean
-    maxEntries: number
     loading: boolean
     handleTreeClick: () => void
     noopRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
@@ -88,7 +88,7 @@ export const Directory: React.FunctionComponent<React.PropsWithChildren<Director
                     </div>
                 )}
             </TreeLayerRowContents>
-            {props.index === props.maxEntries - 1 && (
+            {props.index === MAX_TREE_ENTRIES - 1 && (
                 <TreeRowAlert
                     variant="warning"
                     style={treePadding(props.depth, true, true)}

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -197,7 +197,7 @@ export const SYMBOLS_QUERY = gql`
 
 interface SymbolsProps
     extends Pick<TreeLayerProps, 'repoID' | 'revision' | 'activePath' | 'location'>,
-    Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> { }
+        Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> {}
 
 const Symbols: React.FunctionComponent<SymbolsProps> = ({ repoID, revision, activePath, location, style }) => {
     const { data, loading, error } = useQuery<InlineSymbolsResult>(SYMBOLS_QUERY, {

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -28,9 +28,10 @@ import {
     TreeRowLabel,
     TreeRow,
 } from './components'
+import { MAX_TREE_ENTRIES } from './constants'
 import { FileDecorator } from './FileDecorator'
 import { TreeLayerProps } from './TreeLayer'
-import { maxEntries, TreeEntryInfo, treePadding } from './util'
+import { TreeEntryInfo, treePadding } from './util'
 
 import styles from './File.module.scss'
 
@@ -40,7 +41,6 @@ interface FileProps extends ThemeProps {
     depth: number
     index: number
     className?: string
-    maxEntries: number
     handleTreeClick: () => void
     noopRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
     linkRowClick: (event: React.MouseEvent<HTMLAnchorElement>) => void
@@ -127,7 +127,7 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
                             </TreeLayerRowContentsText>
                         </TreeLayerRowContentsLink>
                     )}
-                    {props.index === maxEntries - 1 && (
+                    {props.index === MAX_TREE_ENTRIES - 1 && (
                         <TreeRowAlert
                             variant="warning"
                             style={treePadding(props.depth, true)}
@@ -197,7 +197,7 @@ export const SYMBOLS_QUERY = gql`
 
 interface SymbolsProps
     extends Pick<TreeLayerProps, 'repoID' | 'revision' | 'activePath' | 'location'>,
-        Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> {}
+    Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> { }
 
 const Symbols: React.FunctionComponent<SymbolsProps> = ({ repoID, revision, activePath, location, style }) => {
     const { data, loading, error } = useQuery<InlineSymbolsResult>(SYMBOLS_QUERY, {

--- a/client/web/src/tree/SingleChildTreeLayer.tsx
+++ b/client/web/src/tree/SingleChildTreeLayer.tsx
@@ -10,7 +10,7 @@ import { TreeLayerTable } from './components'
 import { Directory } from './Directory'
 import { TreeNode } from './Tree'
 import { TreeLayerProps } from './TreeLayer'
-import { maxEntries, SingleChildGitTree } from './util'
+import { SingleChildGitTree } from './util'
 
 interface SingleChildTreeLayerProps extends TreeLayerProps {
     childrenEntries: SingleChildGitTree[]
@@ -134,7 +134,6 @@ export class SingleChildTreeLayer extends React.Component<SingleChildTreeLayerPr
                             depth={this.props.depth}
                             index={this.props.index}
                             isLightTheme={this.props.isLightTheme}
-                            maxEntries={maxEntries}
                             loading={false}
                             handleTreeClick={this.handleTreeClick}
                             noopRowClick={this.noopRowClick}

--- a/client/web/src/tree/Tree.module.scss
+++ b/client/web/src/tree/Tree.module.scss
@@ -1,3 +1,5 @@
+$row-vertical-spacing: 0.25rem;
+
 .tree {
     isolation: isolate;
     flex: 1 1 auto;
@@ -28,8 +30,8 @@
     display: flex;
     color: inherit;
     align-items: center;
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
+    padding-top: $row-vertical-spacing;
+    padding-bottom: $row-vertical-spacing;
     cursor: pointer;
 }
 
@@ -98,4 +100,11 @@
 .row-label {
     margin-left: 0.25rem;
     color: inherit;
+}
+
+.tree-loading-spinner {
+    display: flex;
+    align-items: center;
+    padding-top: $row-vertical-spacing;
+    padding-bottom: $row-vertical-spacing;
 }

--- a/client/web/src/tree/Tree.tsx
+++ b/client/web/src/tree/Tree.tsx
@@ -215,7 +215,6 @@ export class Tree extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props)
 
-        const parentPath = dotPathAsUndefined(props.activePathIsDir ? props.activePath : dirname(props.activePath))
         this.node = {
             index: 0,
             parent: null,
@@ -225,7 +224,7 @@ export class Tree extends React.PureComponent<Props, State> {
         }
 
         this.state = {
-            parentPath,
+            parentPath: dotPathAsUndefined(props.activePathIsDir ? props.activePath : dirname(props.activePath)),
             resolveTo: [],
             selectedNode: this.node,
             activeNode: this.node,

--- a/client/web/src/tree/TreeContext.tsx
+++ b/client/web/src/tree/TreeContext.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export interface TreeRootContext {
+    rootTreeUrl: string
+}
+
+export const TreeRootContext = React.createContext<TreeRootContext>({
+    rootTreeUrl: '',
+})

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -25,6 +25,7 @@ import { requestGraphQL } from '../backend/graphql'
 
 import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeLayerCell, TreeLayerTable, TreeRowAlert } from './components'
+import { MAX_TREE_ENTRIES } from './constants'
 import { Directory } from './Directory'
 import { File } from './File'
 import { TreeNode } from './Tree'
@@ -32,7 +33,6 @@ import { TreeRootProps } from './TreeRoot'
 import {
     compareTreeProps,
     hasSingleChild,
-    maxEntries,
     singleChildEntriesToGitTree,
     SingleChildGitTree,
     TreeEntryInfo,
@@ -87,7 +87,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                     revision: props.revision,
                     commitID: props.commitID,
                     filePath: props.parentPath || '',
-                    first: maxEntries,
+                    first: MAX_TREE_ENTRIES,
                     requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                 }).pipe(
                     catchError(error => [asError(error)]),
@@ -150,7 +150,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                             revision: this.props.revision,
                             commitID: this.props.commitID,
                             filePath: path,
-                            first: maxEntries,
+                            first: MAX_TREE_ENTRIES,
                             requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                         }).pipe(catchError(error => [asError(error)]))
                     )
@@ -280,7 +280,6 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                     depth={this.props.depth}
                                     index={this.props.index}
                                     isLightTheme={this.props.isLightTheme}
-                                    maxEntries={maxEntries}
                                     loading={treeOrError === LOADING}
                                     handleTreeClick={this.handleTreeClick}
                                     noopRowClick={this.noopRowClick}
@@ -324,7 +323,6 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                 depth={this.props.depth}
                                 index={this.props.index}
                                 isLightTheme={this.props.isLightTheme}
-                                maxEntries={maxEntries}
                                 handleTreeClick={this.handleTreeClick}
                                 noopRowClick={this.noopRowClick}
                                 linkRowClick={this.linkRowClick}

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -30,10 +30,10 @@ import { requestGraphQL } from '../backend/graphql'
 
 import { ChildTreeLayer } from './ChildTreeLayer'
 import { TreeLayerTable, TreeLayerCell, TreeRowAlert } from './components'
+import { MAX_TREE_ENTRIES } from './constants'
 import { TreeNode } from './Tree'
+import { TreeRootContext } from './TreeContext'
 import { hasSingleChild, compareTreeProps, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
-
-const maxEntries = 2500
 
 const errorWidth = (width?: string): { width: string } => ({
     width: width ? `${width}px` : 'auto',
@@ -98,7 +98,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                     revision: props.revision,
                     commitID: props.commitID,
                     filePath: props.parentPath || '',
-                    first: maxEntries,
+                    first: MAX_TREE_ENTRIES,
                     requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                 }).pipe(
                     catchError(error => [asError(error)]),
@@ -151,7 +151,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                             revision: this.props.revision,
                             commitID: this.props.commitID,
                             filePath: path,
-                            first: maxEntries,
+                            first: MAX_TREE_ENTRIES,
                             requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
                         }).pipe(catchError(error => [asError(error)]))
                     )
@@ -209,17 +209,23 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                                         </div>
                                     ) : (
                                         treeOrError && (
-                                            <ChildTreeLayer
-                                                {...this.props}
-                                                parent={this.node}
-                                                depth={-1 as number}
-                                                entries={treeOrError.entries}
-                                                singleChildTreeEntry={singleChildTreeEntry}
-                                                childrenEntries={singleChildTreeEntry.children}
-                                                onHover={this.fetchChildContents}
-                                                setChildNodes={this.setChildNode}
-                                                fileDecorationsByPath={this.state.fileDecorationsByPath}
-                                            />
+                                            <TreeRootContext.Provider
+                                                value={{
+                                                    rootTreeUrl: treeOrError.url,
+                                                }}
+                                            >
+                                                <ChildTreeLayer
+                                                    {...this.props}
+                                                    parent={this.node}
+                                                    depth={-1 as number}
+                                                    entries={treeOrError.entries}
+                                                    singleChildTreeEntry={singleChildTreeEntry}
+                                                    childrenEntries={singleChildTreeEntry.children}
+                                                    onHover={this.fetchChildContents}
+                                                    setChildNodes={this.setChildNode}
+                                                    fileDecorationsByPath={this.state.fileDecorationsByPath}
+                                                />
+                                            </TreeRootContext.Provider>
                                         )
                                     )}
                                 </TreeLayerCell>

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -35,6 +35,8 @@ import { TreeNode } from './Tree'
 import { TreeRootContext } from './TreeContext'
 import { hasSingleChild, compareTreeProps, singleChildEntriesToGitTree, SingleChildGitTree } from './util'
 
+import styles from './Tree.module.scss'
+
 const errorWidth = (width?: string): { width: string } => ({
     width: width ? `${width}px` : 'auto',
 })
@@ -203,7 +205,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                             <tr>
                                 <TreeLayerCell>
                                     {treeOrError === LOADING ? (
-                                        <div className="d-flex">
+                                        <div className={styles.treeLoadingSpinner}>
                                             <LoadingSpinner className="tree-page__entries-loader mr-2" />
                                             Loading tree
                                         </div>

--- a/client/web/src/tree/constants.ts
+++ b/client/web/src/tree/constants.ts
@@ -1,0 +1,4 @@
+// Used in requests and components
+export const MAX_TREE_ENTRIES = 2500
+
+export const GO_UP_TREE_LABEL = '..'

--- a/client/web/src/tree/util.tsx
+++ b/client/web/src/tree/util.tsx
@@ -51,8 +51,6 @@ export const treePadding = (depth: number, isTree: boolean, isDirectory = false)
     paddingRight: '1rem',
 })
 
-export const maxEntries = 2500
-
 // Utility functions to handle single-child directories:
 
 /**


### PR DESCRIPTION
As the [previous merge](https://github.com/sourcegraph/sourcegraph/pull/39138) was [reverted](https://github.com/sourcegraph/sourcegraph/pull/39234), I am making the new one.

## Description
Part of the [Tree improvements](https://github.com/sourcegraph/sourcegraph/issues/38667), it adds the option to [navigate up the tree](https://github.com/sourcegraph/sourcegraph/issues/38663).

The tree still retains the "confusing behaviour", which is the inconsistency between:

1. Navigating to the root of the repo - which opens up the entire tree at root, as expected
2. Going to a deeply nested file, which only opens the subtree - which is confusing

This part will be fixed later on, with a bigger refactoring of the entire `Tree` component, including data fetching, tree processing, and rendering.

## Test plan
1. Check out the branch
4. Open up a few repos:
    1. A regular one with lots of subfolders: https://sourcegraph.test:3443/github.com/sourcegraph/code-intel-extensions
    2. Something with a deeply nested single children: https://sourcegraph.test:3443/github.com/sgtest/java-pom-with-deps-javaconfig/-/blob/src/main/java/com/sourcegraph/depuser/ApacheCommonsUser.java
    5. A single-file one: https://sourcegraph.test:3443/github.com/sgtest/head-branch/-/blob/foo
3. Make sure that ".." is shown and navigates up the tree
6. Make sure that tests are passing


https://user-images.githubusercontent.com/2196347/180196529-e712b6cb-2fef-4185-8079-2b12a328b4fb.mov



## App preview:

- [Web](https://sg-web-og-tree-nav-up.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hjmdhwxsqg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
