### PR TITLE
Improve external services admin experience

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -98,7 +98,7 @@ export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChil
     }, [afterCreateRoute, createdExternalService, history])
 
     return (
-        <div className="mt-3">
+        <>
             <PageTitle title="Add repositories" />
             <H2>Add repositories</H2>
             {createdExternalService?.warning ? (
@@ -117,7 +117,7 @@ export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChil
                     </Alert>
                 </div>
             ) : (
-                <div>
+                <>
                     <div className="mb-3">
                         <ExternalServiceCard {...externalService} />
                     </div>
@@ -137,8 +137,8 @@ export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChil
                         loading={isCreating === true}
                         autoFocus={autoFocusForm}
                     />
-                </div>
+                </>
             )}
-        </div>
+        </>
     )
 }

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -120,7 +120,7 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
                 variant="primary"
             >
                 {loading && <LoadingSpinner />}
-                {submitName ?? (mode === 'edit' ? 'Update repositories' : 'Add repositories')}
+                {submitName ?? (mode === 'edit' ? 'Update configuration' : 'Add repositories')}
             </Button>
         </Form>
     )

--- a/client/web/src/components/externalServices/ExternalServiceNode.module.scss
+++ b/client/web/src/components/externalServices/ExternalServiceNode.module.scss
@@ -1,0 +1,14 @@
+.list-node {
+    border-left: none;
+    border-right: none;
+    border-top: none;
+    padding: 0.5rem 0;
+
+    &:first-of-type {
+        padding-top: 0;
+    }
+    &:last-of-type {
+        border-bottom: none;
+        padding-bottom: 0;
+    }
+}

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,19 +1,36 @@
-import React, { useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback, useMemo } from 'react'
 
 import * as H from 'history'
 import { parse as parseJSONC } from 'jsonc-parser'
+import { useHistory } from 'react-router'
+import { Observable, Subject } from 'rxjs'
 import { catchError } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, ErrorLike, isErrorLike, hasProperty } from '@sourcegraph/common'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { LoadingSpinner, H2 } from '@sourcegraph/wildcard'
+import { LoadingSpinner, H2, H3, Badge, Container } from '@sourcegraph/wildcard'
 
-import { ExternalServiceFields, Scalars, AddExternalServiceInput } from '../../graphql-operations'
+import {
+    ExternalServiceFields,
+    Scalars,
+    AddExternalServiceInput,
+    ExternalServiceSyncJobListFields,
+    ExternalServiceSyncJobConnectionFields,
+} from '../../graphql-operations'
+import { FilteredConnection, FilteredConnectionQueryArguments } from '../FilteredConnection'
+import { LoaderButton } from '../LoaderButton'
 import { PageTitle } from '../PageTitle'
+import { Timestamp } from '../time/Timestamp'
 
-import { isExternalService, updateExternalService, fetchExternalService as _fetchExternalService } from './backend'
+import {
+    isExternalService,
+    updateExternalService,
+    fetchExternalService as _fetchExternalService,
+    useSyncExternalService,
+    queryExternalServiceSyncJobs,
+} from './backend'
 import { ExternalServiceCard } from './ExternalServiceCard'
 import { ExternalServiceForm } from './ExternalServiceForm'
 import { defaultExternalServices, codeHostExternalServices } from './externalServices'
@@ -108,7 +125,22 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
         error = isUpdating
     }
 
+    const [
+        syncExternalService,
+        { error: syncExternalServiceError, loading: syncExternalServiceLoading },
+    ] = useSyncExternalService()
+
     const externalService = (!isErrorLike(externalServiceOrError) && externalServiceOrError) || undefined
+
+    const syncJobUpdates = useMemo(() => new Subject<void>(), [])
+    const triggerSync = useCallback(
+        () =>
+            externalService &&
+            syncExternalService({ variables: { id: externalService.id } }).then(() => {
+                syncJobUpdates.next()
+            }),
+        [externalService, syncExternalService, syncJobUpdates]
+    )
 
     let externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
     if (
@@ -141,32 +173,126 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
             ) : (
                 <PageTitle title="External service" />
             )}
-            <H2>Update synced repositories</H2>
+            <H2>Update code host connection</H2>
             {externalServiceOrError === undefined && <LoadingSpinner />}
             {isErrorLike(externalServiceOrError) && <ErrorAlert className="mb-3" error={externalServiceOrError} />}
-            {externalServiceCategory && (
-                <div className="mb-3">
-                    <ExternalServiceCard {...externalServiceCategory} namespace={externalService?.namespace} />
-                </div>
+
+            {externalService && (
+                <Container className="mb-3">
+                    {externalServiceCategory && (
+                        <div className="mb-3">
+                            <ExternalServiceCard {...externalServiceCategory} namespace={externalService?.namespace} />
+                        </div>
+                    )}
+                    {externalServiceCategory && (
+                        <ExternalServiceForm
+                            input={{ ...externalService, namespace: externalService.namespace?.id ?? null }}
+                            editorActions={externalServiceCategory.editorActions}
+                            jsonSchema={externalServiceCategory.jsonSchema}
+                            error={error}
+                            warning={externalService.warning}
+                            mode="edit"
+                            loading={isUpdating === true}
+                            onSubmit={onSubmit}
+                            onChange={onChange}
+                            history={history}
+                            isLightTheme={isLightTheme}
+                            telemetryService={telemetryService}
+                            autoFocus={autoFocusForm}
+                        />
+                    )}
+                    <LoaderButton
+                        label="Trigger manual sync"
+                        alwaysShowLabel={true}
+                        variant="secondary"
+                        onClick={triggerSync}
+                        loading={syncExternalServiceLoading}
+                        disabled={syncExternalServiceLoading}
+                    />
+                    {syncExternalServiceError && <ErrorAlert error={syncExternalServiceError} />}
+                    <ExternalServiceWebhook externalService={externalService} className="mt-3" />
+                    <ExternalServiceSyncJobsList externalServiceID={externalService.id} updates={syncJobUpdates} />
+                </Container>
             )}
-            {externalService && externalServiceCategory && (
-                <ExternalServiceForm
-                    input={{ ...externalService, namespace: externalService.namespace?.id ?? null }}
-                    editorActions={externalServiceCategory.editorActions}
-                    jsonSchema={externalServiceCategory.jsonSchema}
-                    error={error}
-                    warning={externalService.warning}
-                    mode="edit"
-                    loading={isUpdating === true}
-                    onSubmit={onSubmit}
-                    onChange={onChange}
-                    history={history}
-                    isLightTheme={isLightTheme}
-                    telemetryService={telemetryService}
-                    autoFocus={autoFocusForm}
-                />
-            )}
-            {externalService && <ExternalServiceWebhook externalService={externalService} />}
         </div>
     )
 }
+
+interface ExternalServiceSyncJobsListProps {
+    externalServiceID: Scalars['ID']
+    updates: Observable<void>
+}
+
+const ExternalServiceSyncJobsList: React.FunctionComponent<ExternalServiceSyncJobsListProps> = ({
+    externalServiceID,
+    updates,
+}) => {
+    const queryConnection = useCallback(
+        (args: FilteredConnectionQueryArguments) =>
+            queryExternalServiceSyncJobs({
+                first: args.first ?? null,
+                externalService: externalServiceID,
+            }),
+        [externalServiceID]
+    )
+
+    const history = useHistory()
+
+    return (
+        <>
+            <H3 className="mt-3">Recent sync jobs</H3>
+            <FilteredConnection<
+                ExternalServiceSyncJobListFields,
+                Omit<ExternalServiceSyncJobNodeProps, 'node'>,
+                {},
+                ExternalServiceSyncJobConnectionFields
+            >
+                className="mb-0"
+                listClassName="list-group list-group-flush mb-0"
+                noun="sync job"
+                pluralNoun="sync jobs"
+                queryConnection={queryConnection}
+                nodeComponent={ExternalServiceSyncJobNode}
+                nodeComponentProps={{}}
+                hideSearch={true}
+                noSummaryIfAllNodesVisible={true}
+                history={history}
+                updates={updates}
+                location={history.location}
+            />
+        </>
+    )
+}
+
+interface ExternalServiceSyncJobNodeProps {
+    node: ExternalServiceSyncJobListFields
+}
+
+const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJobNodeProps> = ({ node }) => (
+    <li className="list-group-item py-3">
+        <div className="d-flex align-items-center justify-content-between">
+            <div className="flex-shrink-0">
+                <Badge>{node.state}</Badge>
+            </div>
+            <div className="text-right">
+                <div>
+                    {node.startedAt === null && 'Not started yet'}
+                    {node.startedAt !== null && (
+                        <>
+                            Started <Timestamp date={node.startedAt} />
+                        </>
+                    )}
+                </div>
+                <div>
+                    {node.finishedAt === null && 'Not finished yet'}
+                    {node.finishedAt !== null && (
+                        <>
+                            Finished <Timestamp date={node.finishedAt} />
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+        {node.failureMessage && <ErrorAlert error={node.failureMessage} className="mt-2 mb-0" />}
+    </li>
+)

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -22,6 +22,7 @@ import {
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../FilteredConnection'
 import { LoaderButton } from '../LoaderButton'
 import { PageTitle } from '../PageTitle'
+import { Duration } from '../time/Duration'
 import { Timestamp } from '../time/Timestamp'
 
 import {
@@ -271,10 +272,24 @@ interface ExternalServiceSyncJobNodeProps {
 const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJobNodeProps> = ({ node }) => (
     <li className="list-group-item py-3">
         <div className="d-flex align-items-center justify-content-between">
-            <div className="flex-shrink-0">
+            <div className="flex-shrink-0 mr-2">
                 <Badge>{node.state}</Badge>
             </div>
-            <div className="text-right">
+            <div className="flex-shrink-0">
+                {node.startedAt && (
+                    <>
+                        {node.finishedAt === null && <>Running since </>}
+                        {node.finishedAt !== null && <>Ran for </>}
+                        <Duration
+                            start={node.startedAt}
+                            end={node.finishedAt ?? undefined}
+                            stableWidth={false}
+                            className="d-inline"
+                        />
+                    </>
+                )}
+            </div>
+            <div className="text-right flex-grow-1">
                 <div>
                     {node.startedAt === null && 'Not started yet'}
                     {node.startedAt !== null && (

--- a/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
@@ -7,10 +7,12 @@ import { CopyableText } from '../CopyableText'
 
 interface Props {
     externalService: Pick<ExternalServiceFields, 'kind' | 'webhookURL'>
+    className?: string
 }
 
 export const ExternalServiceWebhook: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     externalService: { kind, webhookURL },
+    className,
 }) => {
     if (!webhookURL) {
         return <></>
@@ -55,7 +57,7 @@ export const ExternalServiceWebhook: React.FunctionComponent<React.PropsWithChil
     }
 
     return (
-        <Alert variant="info">
+        <Alert variant="info" className={className}>
             <H3>Batch changes webhooks</H3>
             {description}
             <CopyableText className="mb-2" text={webhookURL} size={webhookURL.length} />

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -9,7 +9,7 @@ import { tap } from 'rxjs/operators'
 import { isErrorLike, ErrorLike } from '@sourcegraph/common'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Link, Button, Icon, H2, Text } from '@sourcegraph/wildcard'
+import { Link, Button, Icon, PageHeader, Container } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { ListExternalServiceFields, Scalars, ExternalServicesResult } from '../../graphql-operations'
@@ -87,45 +87,55 @@ export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildr
     return (
         <div className="site-admin-external-services-page">
             <PageTitle title="Manage code hosts" />
-            <div className="d-flex justify-content-between align-items-center mb-3">
-                <H2 className="mb-0">Manage code hosts</H2>
-                {!isManagingOtherUser && (
-                    <Button
-                        className="test-goto-add-external-service-page"
-                        to={`${routingPrefix}/external-services/new`}
-                        variant="primary"
-                        as={Link}
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiPlus} /> Add code host
-                    </Button>
-                )}
-            </div>
-            <Text className="mt-2">Manage code host connections to sync repositories.</Text>
-            <FilteredConnection<
-                ListExternalServiceFields,
-                Omit<ExternalServiceNodeProps, 'node'>,
-                {},
-                ExternalServicesResult['externalServices']
-            >
-                className="list-group list-group-flush mt-3"
-                noun="code host"
-                pluralNoun="code hosts"
-                queryConnection={queryConnection}
-                nodeComponent={ExternalServiceNode}
-                nodeComponentProps={{
-                    onDidUpdate: onDidUpdateExternalServices,
-                    history,
-                    routingPrefix,
-                    afterDeleteRoute,
-                }}
-                hideSearch={true}
-                noSummaryIfAllNodesVisible={true}
-                cursorPaging={true}
-                updates={updates}
-                history={history}
-                location={location}
-                onUpdate={onUpdate}
+            <PageHeader
+                path={[{ text: 'Manage code hosts' }]}
+                description="Manage code host connections to sync repositories."
+                headingElement="h2"
+                actions={
+                    <>
+                        {!isManagingOtherUser && (
+                            <Button
+                                className="test-goto-add-external-service-page"
+                                to={`${routingPrefix}/external-services/new`}
+                                variant="primary"
+                                as={Link}
+                            >
+                                <Icon aria-hidden={true} svgPath={mdiPlus} /> Add code host
+                            </Button>
+                        )}
+                    </>
+                }
+                className="mb-3"
             />
+
+            <Container className="mb-3">
+                <FilteredConnection<
+                    ListExternalServiceFields,
+                    Omit<ExternalServiceNodeProps, 'node'>,
+                    {},
+                    ExternalServicesResult['externalServices']
+                >
+                    className="mb-0"
+                    listClassName="list-group list-group-flush mb-0"
+                    noun="code host"
+                    pluralNoun="code hosts"
+                    queryConnection={queryConnection}
+                    nodeComponent={ExternalServiceNode}
+                    nodeComponentProps={{
+                        onDidUpdate: onDidUpdateExternalServices,
+                        history,
+                        routingPrefix,
+                        afterDeleteRoute,
+                    }}
+                    hideSearch={true}
+                    noSummaryIfAllNodesVisible={true}
+                    cursorPaging={true}
+                    updates={updates}
+                    history={history}
+                    location={location}
+                    onUpdate={onUpdate}
+                />
+            </Container>
         </div>
     )
 }

--- a/client/web/src/components/time/Duration.tsx
+++ b/client/web/src/components/time/Duration.tsx
@@ -57,7 +57,7 @@ export const Duration: React.FunctionComponent<React.PropsWithChildren<DurationP
     }, [end])
 
     return (
-        <div className={classNames({ [styles.stableWidth]: stableWidth, className })} {...props}>
+        <div className={classNames({ [styles.stableWidth]: stableWidth }, className)} {...props}>
             {stableWidth && (
                 // Set the width of the parent with a filler block of full-width digits,
                 // to prevent layout shift if the time changes.

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -430,7 +430,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                             key={status.message}
                             message={status.message}
                             messageHint="Your repositories may not be up-to-date."
-                            linkTo={links.viewRepositories}
+                            linkTo={links.viewRepositories + '?status=failed-fetch'}
                             linkText="Manage repositories"
                             linkOnClick={this.toggleIsOpen}
                             entryType="error"

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -558,6 +558,9 @@ func newSchemaResolver(db database.DB) *schemaResolver {
 		"Executor": func(ctx context.Context, id graphql.ID) (Node, error) {
 			return executorByID(ctx, db, id, r)
 		},
+		"ExternalServiceSyncJob": func(ctx context.Context, id graphql.ID) (Node, error) {
+			return externalServiceSyncJobByID(ctx, db, id)
+		},
 	}
 	return r
 }

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -283,3 +283,8 @@ func (r *NodeResolver) ToLockfileIndex() (LockfileIndexResolver, bool) {
 	n, ok := r.Node.(LockfileIndexResolver)
 	return n, ok
 }
+
+func (r *NodeResolver) ToExternalServiceSyncJob() (*externalServiceSyncJobResolver, bool) {
+	n, ok := r.Node.(*externalServiceSyncJobResolver)
+	return n, ok
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -753,6 +753,13 @@ type Mutation {
     Only administrators can use this API.
     """
     sendTestEmail(to: String!): String!
+
+    """
+    Enqueues a sync for the external service. It will be picked up in the background.
+
+    Site-admin or owner of the external service only.
+    """
+    syncExternalService(id: ID!): EmptyResponse!
 }
 
 """
@@ -2342,38 +2349,47 @@ type ExternalService implements Node {
     The external service's unique ID.
     """
     id: ID!
+
     """
     The kind of external service.
     """
     kind: ExternalServiceKind!
+
     """
     The display name of the external service.
     """
     displayName: String!
+
     """
     The JSON configuration of the external service.
     """
     config: JSONCString!
+
     """
     When the external service was created.
     """
     createdAt: DateTime!
+
     """
     When the external service was last updated.
     """
     updatedAt: DateTime!
+
     """
     The namespace this external service belongs to.
     """
     namespace: Namespace
+
     """
     The number of repos synced by the external service.
     """
     repoCount: Int!
+
     """
     An optional URL that will be populated when webhooks have been configured for the external service.
     """
     webhookURL: String
+
     """
     This is an optional field that's populated when we ran into errors on the
     backend side when trying to create/update an ExternalService, but the
@@ -2382,16 +2398,19 @@ type ExternalService implements Node {
     not break the API and stay backwards compatible.
     """
     warning: String
+
     """
     External services are synced with code hosts in the background. This optional field
     will contain any errors that occured during the most recent completed sync.
     """
     lastSyncError: String
+
     """
     LastSyncAt is the time the last sync job was run for this code host. Null if it
     has never been synced so far.
     """
     lastSyncAt: DateTime
+
     """
     The timestamp of the next sync job. Null if not scheduled for a re-sync.
     """
@@ -2400,6 +2419,7 @@ type ExternalService implements Node {
     """
     Returns a list of scopes granted by the code host. It is based on the token used
     when configuring the external service.
+
     NOTE: Currently only GitHub is supported and the request consumes rate limit tokens
     so it should be used sparingly.
     """
@@ -2450,6 +2470,97 @@ type ExternalService implements Node {
     reaches out to the code host directly which is wasteful if repositories are already cloned.
     """
     invitableCollaborators: [Person!]!
+
+    """
+    The list of recent sync jobs for this external service.
+    """
+    syncJobs(first: Int): ExternalServiceSyncJobConnection!
+}
+
+"""
+A list of external service sync jobs.
+"""
+type ExternalServiceSyncJobConnection {
+    """
+    A list of sync jobs.
+    """
+    nodes: [ExternalServiceSyncJob!]!
+
+    """
+    The total number of jobs in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+The possible states of an external service sync job.
+"""
+enum ExternalServiceSyncJobState {
+    """
+    Not yet started. Will be picked up by a worker eventually.
+    """
+    QUEUED
+
+    """
+    Currently syncing.
+    """
+    PROCESSING
+
+    """
+    An error occured while syncing. Will be retried eventually.
+    """
+    ERRORED
+
+    """
+    A fatal error occured while syncing. No retries will be made.
+    """
+    FAILED
+
+    """
+    Sync finished successfully.
+    """
+    COMPLETED
+}
+
+"""
+An external service sync job represents one sync with the code host. It's a background
+job that will eventually be run by the repo syncer.
+"""
+type ExternalServiceSyncJob implements Node {
+    """
+    The unique identifier of the sync job.
+    """
+    id: ID!
+
+    """
+    The current state of the sync job.
+    """
+    state: ExternalServiceSyncJobState!
+
+    """
+    When the sync job was added to the queue.
+    """
+    queuedAt: DateTime!
+
+    """
+    Set when sync begins.
+    """
+    startedAt: DateTime
+
+    """
+    Set when sync finished.
+    """
+    finishedAt: DateTime
+
+    """
+    Error message, if the sync failed.
+    """
+    failureMessage: String
 }
 
 """

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -88,8 +88,14 @@ type ExternalServiceStore interface {
 	// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service
 	GetLastSyncError(ctx context.Context, id int64) (string, error)
 
-	// GetSyncJobs gets all sync jobs
-	GetSyncJobs(ctx context.Context) ([]*types.ExternalServiceSyncJob, error)
+	// GetSyncJobs gets a sync job by its ID.
+	GetSyncJobByID(ctx context.Context, id int64) (job *types.ExternalServiceSyncJob, err error)
+
+	// GetSyncJobs gets all sync jobs.
+	GetSyncJobs(ctx context.Context, opts ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error)
+
+	// CountSyncJobs counts all sync jobs.
+	CountSyncJobs(ctx context.Context, opts ExternalServicesGetSyncJobsOptions) (int64, error)
 
 	// List returns external services under given namespace.
 	// If no namespace is given, it returns all external services.
@@ -216,6 +222,12 @@ type ExternalServiceKind struct {
 	JSONSchema string // JSON Schema for the external service's configuration
 }
 
+type ExternalServicesGetSyncJobsOptions struct {
+	ExternalServiceID int64
+
+	*LimitOffset
+}
+
 // ExternalServicesListOptions contains options for listing external services.
 type ExternalServicesListOptions struct {
 	// When specified, only include external services with the given IDs.
@@ -258,11 +270,7 @@ type ExternalServicesListOptions struct {
 func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 	conds := []*sqlf.Query{sqlf.Sprintf("deleted_at IS NULL")}
 	if len(o.IDs) > 0 {
-		ids := make([]*sqlf.Query, 0, len(o.IDs))
-		for _, id := range o.IDs {
-			ids = append(ids, sqlf.Sprintf("%s", id))
-		}
-		conds = append(conds, sqlf.Sprintf("id IN (%s)", sqlf.Join(ids, ",")))
+		conds = append(conds, sqlf.Sprintf("id = ANY(%s)", pq.Array(o.IDs)))
 	}
 
 	if o.NoNamespace {
@@ -279,11 +287,7 @@ func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 		}
 	}
 	if len(o.Kinds) > 0 {
-		kinds := make([]*sqlf.Query, 0, len(o.Kinds))
-		for _, kind := range o.Kinds {
-			kinds = append(kinds, sqlf.Sprintf("%s", kind))
-		}
-		conds = append(conds, sqlf.Sprintf("kind IN (%s)", sqlf.Join(kinds, ",")))
+		conds = append(conds, sqlf.Sprintf("kind = ANY(%s)", pq.Array(o.Kinds)))
 	}
 	if o.AfterID > 0 {
 		conds = append(conds, sqlf.Sprintf(`id < %d`, o.AfterID))
@@ -631,12 +635,31 @@ func (e *externalServiceStore) Create(ctx context.Context, confGet func() *conf.
 		return err
 	}
 
-	return e.Store.Handle().QueryRowContext(
+	return e.QueryRow(
 		ctx,
-		"INSERT INTO external_services(kind, display_name, config, encryption_key_id, created_at, updated_at, namespace_user_id, namespace_org_id, unrestricted, cloud_default, has_webhooks) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id",
-		es.Kind, es.DisplayName, config, keyID, es.CreatedAt, es.UpdatedAt, nullInt32Column(es.NamespaceUserID), nullInt32Column(es.NamespaceOrgID), es.Unrestricted, es.CloudDefault, es.HasWebhooks,
+		sqlf.Sprintf(
+			createExternalServiceQueryFmtstr,
+			es.Kind,
+			es.DisplayName,
+			config,
+			keyID,
+			es.CreatedAt,
+			es.UpdatedAt,
+			nullInt32Column(es.NamespaceUserID),
+			nullInt32Column(es.NamespaceOrgID),
+			es.Unrestricted,
+			es.CloudDefault,
+			es.HasWebhooks,
+		),
 	).Scan(&es.ID)
 }
+
+const createExternalServiceQueryFmtstr = `
+INSERT INTO external_services
+	(kind, display_name, config, encryption_key_id, created_at, updated_at, namespace_user_id, namespace_org_id, unrestricted, cloud_default, has_webhooks)
+	VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+RETURNING id
+`
 
 // maybeEncryptConfig encrypts and returns externals service config if an encryption.Key is configured
 func (e *externalServiceStore) maybeEncryptConfig(ctx context.Context, config string) (string, string, error) {
@@ -1088,39 +1111,121 @@ func (e *externalServiceStore) GetByID(ctx context.Context, id int64) (*types.Ex
 	return ess[0], nil
 }
 
-func (e *externalServiceStore) GetSyncJobs(ctx context.Context) ([]*types.ExternalServiceSyncJob, error) {
-	q := sqlf.Sprintf(`SELECT id, state, failure_message, started_at, finished_at, process_after, num_resets, external_service_id, num_failures
-FROM external_service_sync_jobs ORDER BY started_at desc
-`)
+const getSyncJobsQueryFmtstr = `
+SELECT
+	id,
+	state,
+	failure_message,
+	queued_at,
+	started_at,
+	finished_at,
+	process_after,
+	num_resets,
+	external_service_id,
+	num_failures
+FROM
+	external_service_sync_jobs
+WHERE %s
+ORDER BY
+	started_at DESC
+%s
+`
+
+func (e *externalServiceStore) GetSyncJobs(ctx context.Context, opts ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error) {
+	var preds []*sqlf.Query
+
+	if opts.ExternalServiceID != 0 {
+		preds = append(preds, sqlf.Sprintf("external_service_id = %s", opts.ExternalServiceID))
+	}
+
+	if len(preds) == 0 {
+		preds = append(preds, sqlf.Sprintf("TRUE"))
+	}
+
+	q := sqlf.Sprintf(getSyncJobsQueryFmtstr, sqlf.Join(preds, "AND"), opts.LimitOffset.SQL())
 
 	rows, err := e.Query(ctx, q)
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		err = basestore.CloseRows(rows, err)
+	}()
 
-	var jobs []*types.ExternalServiceSyncJob
+	jobs := make([]*types.ExternalServiceSyncJob, 0)
 	for rows.Next() {
 		var job types.ExternalServiceSyncJob
-		if err := rows.Scan(
-			&job.ID,
-			&job.State,
-			&dbutil.NullString{S: &job.FailureMessage},
-			&dbutil.NullTime{Time: &job.StartedAt},
-			&dbutil.NullTime{Time: &job.FinishedAt},
-			&dbutil.NullTime{Time: &job.ProcessAfter},
-			&job.NumResets,
-			&dbutil.NullInt64{N: &job.ExternalServiceID},
-			&job.NumFailures,
-		); err != nil {
+		if err := scanExternalServiceSyncJob(rows, &job); err != nil {
 			return nil, errors.Wrap(err, "scanning external service job row")
 		}
 		jobs = append(jobs, &job)
 	}
-	if rows.Err() != nil {
-		return nil, errors.Wrap(err, "row scanning error")
-	}
 
 	return jobs, nil
+}
+
+const countSyncJobsQueryFmtstr = `
+SELECT
+	COUNT(1)
+FROM
+	external_service_sync_jobs
+WHERE %s
+`
+
+func (e *externalServiceStore) CountSyncJobs(ctx context.Context, opts ExternalServicesGetSyncJobsOptions) (int64, error) {
+	var preds []*sqlf.Query
+
+	if opts.ExternalServiceID != 0 {
+		preds = append(preds, sqlf.Sprintf("external_service_id = %s", opts.ExternalServiceID))
+	}
+
+	if len(preds) == 0 {
+		preds = append(preds, sqlf.Sprintf("TRUE"))
+	}
+
+	q := sqlf.Sprintf(countSyncJobsQueryFmtstr, sqlf.Join(preds, "AND"))
+
+	count, _, err := basestore.ScanFirstInt64(e.Query(ctx, q))
+	return count, err
+}
+
+type errSyncJobNotFound struct{ id int64 }
+
+func (e errSyncJobNotFound) Error() string {
+	return fmt.Sprintf("sync job with id %d not found", e.id)
+}
+
+func (errSyncJobNotFound) NotFound() bool {
+	return true
+}
+
+func (e *externalServiceStore) GetSyncJobByID(ctx context.Context, id int64) (*types.ExternalServiceSyncJob, error) {
+	q := sqlf.Sprintf(getSyncJobsQueryFmtstr, sqlf.Sprintf("id = %s", id), (&LimitOffset{Limit: 1}).SQL())
+
+	var job types.ExternalServiceSyncJob
+	if err := scanExternalServiceSyncJob(e.QueryRow(ctx, q), &job); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &errSyncJobNotFound{id: id}
+		}
+		return nil, errors.Wrap(err, "scanning external service job row")
+	}
+
+	return &job, nil
+}
+
+func scanExternalServiceSyncJob(sc dbutil.Scanner, job *types.ExternalServiceSyncJob) error {
+	return sc.Scan(
+		&job.ID,
+		&job.State,
+		&dbutil.NullString{S: &job.FailureMessage},
+		&job.QueuedAt,
+		&dbutil.NullTime{Time: &job.StartedAt},
+		&dbutil.NullTime{Time: &job.FinishedAt},
+		&dbutil.NullTime{Time: &job.ProcessAfter},
+		&job.NumResets,
+		&dbutil.NullInt64{N: &job.ExternalServiceID},
+		&job.NumFailures,
+	)
 }
 
 func (e *externalServiceStore) GetLastSyncError(ctx context.Context, id int64) (string, error) {
@@ -1424,9 +1529,4 @@ func configurationHasWebhooks(config any) bool {
 	}
 
 	return false
-}
-
-// MockExternalServices mocks the external services store.
-type MockExternalServices struct {
-	List func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
 }

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -88,7 +88,7 @@ type ExternalServiceStore interface {
 	// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service
 	GetLastSyncError(ctx context.Context, id int64) (string, error)
 
-	// GetSyncJobs gets a sync job by its ID.
+	// GetSyncJobByID gets a sync job by its ID.
 	GetSyncJobByID(ctx context.Context, id int64) (job *types.ExternalServiceSyncJob, err error)
 
 	// GetSyncJobs gets all sync jobs.
@@ -1131,7 +1131,7 @@ ORDER BY
 %s
 `
 
-func (e *externalServiceStore) GetSyncJobs(ctx context.Context, opts ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error) {
+func (e *externalServiceStore) GetSyncJobs(ctx context.Context, opts ExternalServicesGetSyncJobsOptions) (_ []*types.ExternalServiceSyncJob, err error) {
 	var preds []*sqlf.Query
 
 	if opts.ExternalServiceID != 0 {
@@ -1166,7 +1166,7 @@ func (e *externalServiceStore) GetSyncJobs(ctx context.Context, opts ExternalSer
 
 const countSyncJobsQueryFmtstr = `
 SELECT
-	COUNT(1)
+	COUNT(*)
 FROM
 	external_service_sync_jobs
 WHERE %s

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -2033,7 +2033,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 }
 
-func TestExternalServiceStore_GetExternalServiceSyncJobs(t *testing.T) {
+func TestExternalServiceStore_GetSyncJobs(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -2076,6 +2076,107 @@ func TestExternalServiceStore_GetExternalServiceSyncJobs(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, have[0], cmpopts.IgnoreFields(types.ExternalServiceSyncJob{}, "ID", "QueuedAt")); diff != "" {
 		t.Fatal(diff)
+	}
+}
+
+func TestExternalServiceStore_CountSyncJobs(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	// Create a new external service
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+	es := &types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "GITHUB #1",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err := db.ExternalServices().Create(ctx, confGet, es)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.Handle().ExecContext(ctx, "INSERT INTO external_service_sync_jobs (external_service_id) VALUES ($1)", es.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	have, err := db.ExternalServices().CountSyncJobs(ctx, ExternalServicesGetSyncJobsOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have != 1 {
+		t.Fatalf("Expected 1 job, got %d", have)
+	}
+
+	require.Exactly(t, int64(1), have, "total count is incorrect")
+
+	have, err = db.ExternalServices().CountSyncJobs(ctx, ExternalServicesGetSyncJobsOptions{ExternalServiceID: es.ID + 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have != 0 {
+		t.Fatalf("Expected 0 jobs, got %d", have)
+	}
+
+	require.Exactly(t, int64(0), have, "total count is incorrect")
+}
+
+func TestExternalServiceStore_GetSyncJobByID(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	// Create a new external service
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+	es := &types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "GITHUB #1",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err := db.ExternalServices().Create(ctx, confGet, es)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.Handle().ExecContext(ctx, "INSERT INTO external_service_sync_jobs (id, external_service_id) VALUES (1, $1)", es.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	have, err := db.ExternalServices().GetSyncJobByID(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &types.ExternalServiceSyncJob{
+		ID:                1,
+		State:             "queued",
+		ExternalServiceID: es.ID,
+	}
+	if diff := cmp.Diff(want, have, cmpopts.IgnoreFields(types.ExternalServiceSyncJob{}, "ID", "QueuedAt")); diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Test not found:
+	_, err = db.ExternalServices().GetSyncJobByID(ctx, 2)
+	if err == nil {
+		t.Fatal("no error for not found")
+	}
+	if !errcode.IsNotFound(err) {
+		t.Fatal("wrong err code for not found")
 	}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -12306,6 +12306,9 @@ type MockExternalServiceStore struct {
 	// CountFunc is an instance of a mock function object controlling the
 	// behavior of the method Count.
 	CountFunc *ExternalServiceStoreCountFunc
+	// CountSyncJobsFunc is an instance of a mock function object
+	// controlling the behavior of the method CountSyncJobs.
+	CountSyncJobsFunc *ExternalServiceStoreCountSyncJobsFunc
 	// CreateFunc is an instance of a mock function object controlling the
 	// behavior of the method Create.
 	CreateFunc *ExternalServiceStoreCreateFunc
@@ -12327,6 +12330,9 @@ type MockExternalServiceStore struct {
 	// GetLastSyncErrorFunc is an instance of a mock function object
 	// controlling the behavior of the method GetLastSyncError.
 	GetLastSyncErrorFunc *ExternalServiceStoreGetLastSyncErrorFunc
+	// GetSyncJobByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method GetSyncJobByID.
+	GetSyncJobByIDFunc *ExternalServiceStoreGetSyncJobByIDFunc
 	// GetSyncJobsFunc is an instance of a mock function object controlling
 	// the behavior of the method GetSyncJobs.
 	GetSyncJobsFunc *ExternalServiceStoreGetSyncJobsFunc
@@ -12369,6 +12375,11 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 				return
 			},
 		},
+		CountSyncJobsFunc: &ExternalServiceStoreCountSyncJobsFunc{
+			defaultHook: func(context.Context, ExternalServicesGetSyncJobsOptions) (r0 int64, r1 error) {
+				return
+			},
+		},
 		CreateFunc: &ExternalServiceStoreCreateFunc{
 			defaultHook: func(context.Context, func() *conf.Unified, *types.ExternalService) (r0 error) {
 				return
@@ -12404,8 +12415,13 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 				return
 			},
 		},
+		GetSyncJobByIDFunc: &ExternalServiceStoreGetSyncJobByIDFunc{
+			defaultHook: func(context.Context, int64) (r0 *types.ExternalServiceSyncJob, r1 error) {
+				return
+			},
+		},
 		GetSyncJobsFunc: &ExternalServiceStoreGetSyncJobsFunc{
-			defaultHook: func(context.Context) (r0 []*types.ExternalServiceSyncJob, r1 error) {
+			defaultHook: func(context.Context, ExternalServicesGetSyncJobsOptions) (r0 []*types.ExternalServiceSyncJob, r1 error) {
 				return
 			},
 		},
@@ -12467,6 +12483,11 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 				panic("unexpected invocation of MockExternalServiceStore.Count")
 			},
 		},
+		CountSyncJobsFunc: &ExternalServiceStoreCountSyncJobsFunc{
+			defaultHook: func(context.Context, ExternalServicesGetSyncJobsOptions) (int64, error) {
+				panic("unexpected invocation of MockExternalServiceStore.CountSyncJobs")
+			},
+		},
 		CreateFunc: &ExternalServiceStoreCreateFunc{
 			defaultHook: func(context.Context, func() *conf.Unified, *types.ExternalService) error {
 				panic("unexpected invocation of MockExternalServiceStore.Create")
@@ -12502,8 +12523,13 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 				panic("unexpected invocation of MockExternalServiceStore.GetLastSyncError")
 			},
 		},
+		GetSyncJobByIDFunc: &ExternalServiceStoreGetSyncJobByIDFunc{
+			defaultHook: func(context.Context, int64) (*types.ExternalServiceSyncJob, error) {
+				panic("unexpected invocation of MockExternalServiceStore.GetSyncJobByID")
+			},
+		},
 		GetSyncJobsFunc: &ExternalServiceStoreGetSyncJobsFunc{
-			defaultHook: func(context.Context) ([]*types.ExternalServiceSyncJob, error) {
+			defaultHook: func(context.Context, ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error) {
 				panic("unexpected invocation of MockExternalServiceStore.GetSyncJobs")
 			},
 		},
@@ -12563,6 +12589,9 @@ func NewMockExternalServiceStoreFrom(i ExternalServiceStore) *MockExternalServic
 		CountFunc: &ExternalServiceStoreCountFunc{
 			defaultHook: i.Count,
 		},
+		CountSyncJobsFunc: &ExternalServiceStoreCountSyncJobsFunc{
+			defaultHook: i.CountSyncJobs,
+		},
 		CreateFunc: &ExternalServiceStoreCreateFunc{
 			defaultHook: i.Create,
 		},
@@ -12583,6 +12612,9 @@ func NewMockExternalServiceStoreFrom(i ExternalServiceStore) *MockExternalServic
 		},
 		GetLastSyncErrorFunc: &ExternalServiceStoreGetLastSyncErrorFunc{
 			defaultHook: i.GetLastSyncError,
+		},
+		GetSyncJobByIDFunc: &ExternalServiceStoreGetSyncJobByIDFunc{
+			defaultHook: i.GetSyncJobByID,
 		},
 		GetSyncJobsFunc: &ExternalServiceStoreGetSyncJobsFunc{
 			defaultHook: i.GetSyncJobs,
@@ -12722,6 +12754,117 @@ func (c ExternalServiceStoreCountFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ExternalServiceStoreCountFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ExternalServiceStoreCountSyncJobsFunc describes the behavior when the
+// CountSyncJobs method of the parent MockExternalServiceStore instance is
+// invoked.
+type ExternalServiceStoreCountSyncJobsFunc struct {
+	defaultHook func(context.Context, ExternalServicesGetSyncJobsOptions) (int64, error)
+	hooks       []func(context.Context, ExternalServicesGetSyncJobsOptions) (int64, error)
+	history     []ExternalServiceStoreCountSyncJobsFuncCall
+	mutex       sync.Mutex
+}
+
+// CountSyncJobs delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockExternalServiceStore) CountSyncJobs(v0 context.Context, v1 ExternalServicesGetSyncJobsOptions) (int64, error) {
+	r0, r1 := m.CountSyncJobsFunc.nextHook()(v0, v1)
+	m.CountSyncJobsFunc.appendCall(ExternalServiceStoreCountSyncJobsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CountSyncJobs method
+// of the parent MockExternalServiceStore instance is invoked and the hook
+// queue is empty.
+func (f *ExternalServiceStoreCountSyncJobsFunc) SetDefaultHook(hook func(context.Context, ExternalServicesGetSyncJobsOptions) (int64, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CountSyncJobs method of the parent MockExternalServiceStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExternalServiceStoreCountSyncJobsFunc) PushHook(hook func(context.Context, ExternalServicesGetSyncJobsOptions) (int64, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExternalServiceStoreCountSyncJobsFunc) SetDefaultReturn(r0 int64, r1 error) {
+	f.SetDefaultHook(func(context.Context, ExternalServicesGetSyncJobsOptions) (int64, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExternalServiceStoreCountSyncJobsFunc) PushReturn(r0 int64, r1 error) {
+	f.PushHook(func(context.Context, ExternalServicesGetSyncJobsOptions) (int64, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExternalServiceStoreCountSyncJobsFunc) nextHook() func(context.Context, ExternalServicesGetSyncJobsOptions) (int64, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExternalServiceStoreCountSyncJobsFunc) appendCall(r0 ExternalServiceStoreCountSyncJobsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExternalServiceStoreCountSyncJobsFuncCall
+// objects describing the invocations of this function.
+func (f *ExternalServiceStoreCountSyncJobsFunc) History() []ExternalServiceStoreCountSyncJobsFuncCall {
+	f.mutex.Lock()
+	history := make([]ExternalServiceStoreCountSyncJobsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExternalServiceStoreCountSyncJobsFuncCall is an object that describes an
+// invocation of method CountSyncJobs on an instance of
+// MockExternalServiceStore.
+type ExternalServiceStoreCountSyncJobsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExternalServicesGetSyncJobsOptions
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int64
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExternalServiceStoreCountSyncJobsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExternalServiceStoreCountSyncJobsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -13480,28 +13623,139 @@ func (c ExternalServiceStoreGetLastSyncErrorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// ExternalServiceStoreGetSyncJobByIDFunc describes the behavior when the
+// GetSyncJobByID method of the parent MockExternalServiceStore instance is
+// invoked.
+type ExternalServiceStoreGetSyncJobByIDFunc struct {
+	defaultHook func(context.Context, int64) (*types.ExternalServiceSyncJob, error)
+	hooks       []func(context.Context, int64) (*types.ExternalServiceSyncJob, error)
+	history     []ExternalServiceStoreGetSyncJobByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// GetSyncJobByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockExternalServiceStore) GetSyncJobByID(v0 context.Context, v1 int64) (*types.ExternalServiceSyncJob, error) {
+	r0, r1 := m.GetSyncJobByIDFunc.nextHook()(v0, v1)
+	m.GetSyncJobByIDFunc.appendCall(ExternalServiceStoreGetSyncJobByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetSyncJobByID
+// method of the parent MockExternalServiceStore instance is invoked and the
+// hook queue is empty.
+func (f *ExternalServiceStoreGetSyncJobByIDFunc) SetDefaultHook(hook func(context.Context, int64) (*types.ExternalServiceSyncJob, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetSyncJobByID method of the parent MockExternalServiceStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExternalServiceStoreGetSyncJobByIDFunc) PushHook(hook func(context.Context, int64) (*types.ExternalServiceSyncJob, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExternalServiceStoreGetSyncJobByIDFunc) SetDefaultReturn(r0 *types.ExternalServiceSyncJob, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (*types.ExternalServiceSyncJob, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExternalServiceStoreGetSyncJobByIDFunc) PushReturn(r0 *types.ExternalServiceSyncJob, r1 error) {
+	f.PushHook(func(context.Context, int64) (*types.ExternalServiceSyncJob, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExternalServiceStoreGetSyncJobByIDFunc) nextHook() func(context.Context, int64) (*types.ExternalServiceSyncJob, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExternalServiceStoreGetSyncJobByIDFunc) appendCall(r0 ExternalServiceStoreGetSyncJobByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExternalServiceStoreGetSyncJobByIDFuncCall
+// objects describing the invocations of this function.
+func (f *ExternalServiceStoreGetSyncJobByIDFunc) History() []ExternalServiceStoreGetSyncJobByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]ExternalServiceStoreGetSyncJobByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExternalServiceStoreGetSyncJobByIDFuncCall is an object that describes an
+// invocation of method GetSyncJobByID on an instance of
+// MockExternalServiceStore.
+type ExternalServiceStoreGetSyncJobByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *types.ExternalServiceSyncJob
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExternalServiceStoreGetSyncJobByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExternalServiceStoreGetSyncJobByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // ExternalServiceStoreGetSyncJobsFunc describes the behavior when the
 // GetSyncJobs method of the parent MockExternalServiceStore instance is
 // invoked.
 type ExternalServiceStoreGetSyncJobsFunc struct {
-	defaultHook func(context.Context) ([]*types.ExternalServiceSyncJob, error)
-	hooks       []func(context.Context) ([]*types.ExternalServiceSyncJob, error)
+	defaultHook func(context.Context, ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error)
+	hooks       []func(context.Context, ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error)
 	history     []ExternalServiceStoreGetSyncJobsFuncCall
 	mutex       sync.Mutex
 }
 
 // GetSyncJobs delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockExternalServiceStore) GetSyncJobs(v0 context.Context) ([]*types.ExternalServiceSyncJob, error) {
-	r0, r1 := m.GetSyncJobsFunc.nextHook()(v0)
-	m.GetSyncJobsFunc.appendCall(ExternalServiceStoreGetSyncJobsFuncCall{v0, r0, r1})
+func (m *MockExternalServiceStore) GetSyncJobs(v0 context.Context, v1 ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error) {
+	r0, r1 := m.GetSyncJobsFunc.nextHook()(v0, v1)
+	m.GetSyncJobsFunc.appendCall(ExternalServiceStoreGetSyncJobsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the GetSyncJobs method
 // of the parent MockExternalServiceStore instance is invoked and the hook
 // queue is empty.
-func (f *ExternalServiceStoreGetSyncJobsFunc) SetDefaultHook(hook func(context.Context) ([]*types.ExternalServiceSyncJob, error)) {
+func (f *ExternalServiceStoreGetSyncJobsFunc) SetDefaultHook(hook func(context.Context, ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error)) {
 	f.defaultHook = hook
 }
 
@@ -13510,7 +13764,7 @@ func (f *ExternalServiceStoreGetSyncJobsFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *ExternalServiceStoreGetSyncJobsFunc) PushHook(hook func(context.Context) ([]*types.ExternalServiceSyncJob, error)) {
+func (f *ExternalServiceStoreGetSyncJobsFunc) PushHook(hook func(context.Context, ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -13519,19 +13773,19 @@ func (f *ExternalServiceStoreGetSyncJobsFunc) PushHook(hook func(context.Context
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ExternalServiceStoreGetSyncJobsFunc) SetDefaultReturn(r0 []*types.ExternalServiceSyncJob, r1 error) {
-	f.SetDefaultHook(func(context.Context) ([]*types.ExternalServiceSyncJob, error) {
+	f.SetDefaultHook(func(context.Context, ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ExternalServiceStoreGetSyncJobsFunc) PushReturn(r0 []*types.ExternalServiceSyncJob, r1 error) {
-	f.PushHook(func(context.Context) ([]*types.ExternalServiceSyncJob, error) {
+	f.PushHook(func(context.Context, ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error) {
 		return r0, r1
 	})
 }
 
-func (f *ExternalServiceStoreGetSyncJobsFunc) nextHook() func(context.Context) ([]*types.ExternalServiceSyncJob, error) {
+func (f *ExternalServiceStoreGetSyncJobsFunc) nextHook() func(context.Context, ExternalServicesGetSyncJobsOptions) ([]*types.ExternalServiceSyncJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -13568,6 +13822,9 @@ type ExternalServiceStoreGetSyncJobsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExternalServicesGetSyncJobsOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []*types.ExternalServiceSyncJob
@@ -13579,7 +13836,7 @@ type ExternalServiceStoreGetSyncJobsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ExternalServiceStoreGetSyncJobsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -446,7 +446,7 @@ func (s *UpdateScheduler) DebugDump(ctx context.Context) any {
 	}
 
 	var err error
-	data.SyncJobs, err = s.db.ExternalServices().GetSyncJobs(ctx)
+	data.SyncJobs, err = s.db.ExternalServices().GetSyncJobs(ctx, database.ExternalServicesGetSyncJobsOptions{})
 	if err != nil {
 		s.logger.Warn("getting external service sync jobs for debug page", log.Error(err))
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -569,6 +569,7 @@ type ExternalServiceSyncJob struct {
 	ID                int64
 	State             string
 	FailureMessage    string
+	QueuedAt          time.Time
 	StartedAt         time.Time
 	FinishedAt        time.Time
 	ProcessAfter      time.Time


### PR DESCRIPTION
I've been trying to look into some issues and the pages were way too stale, also we had lots of information already fetched even that we didn't surface in the UI.
This PR mainly does 2 things:
- It adds much more context to the list page, so it's easy to see at a glance: What is working, what is not working, are we syncing?
- It adds syncer information to the external service info page, so that admins can quickly see is the error always happening, what is the error message (I don't think we surfaced that in the UI before at all?) and give them the ability to trigger another lazy sync, so that network blips can be investigated more easily.

I hope this helps a bit with admin experience and debugging.

<img width="1151" alt="Screenshot 2022-07-22 at 16 44 38@2x" src="https://user-images.githubusercontent.com/19534377/180464134-6b1363e1-bf98-4537-8e51-2f2821b8d661.png">

![Screenshot 2022-07-22 at 16 44 48@2x](https://user-images.githubusercontent.com/19534377/180464235-5dde61ed-c3de-447a-a7e8-137419306554.png)


## Test plan

Tested the flows manually pretty thoroughly. 