### PR TITLE
search: Show diagnostics for patterns starting/ending with quotes

### DIFF
--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -640,4 +640,173 @@ describe('getDiagnostics()', () => {
             ).toMatchInlineSnapshot('[]')
         })
     })
+
+    describe('patterns with quotation marks', () => {
+        test('detects patterns starting or ending with a quotation mark', () => {
+            expect(parseAndDiagnose(`"test 'test test" test'`, SearchPatternType.literal)).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": "info",
+                    "message": "This pattern is interpreted literally, including the quotation marks.",
+                    "range": {
+                      "start": 0,
+                      "end": 5
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove quotation marks",
+                        "change": {
+                          "from": 0,
+                          "to": 5,
+                          "insert": "test"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "severity": "info",
+                    "message": "This pattern is interpreted literally, including the quotation marks.",
+                    "range": {
+                      "start": 6,
+                      "end": 11
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove quotation marks",
+                        "change": {
+                          "from": 6,
+                          "to": 11,
+                          "insert": "test"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "severity": "info",
+                    "message": "This pattern is interpreted literally, including the quotation marks.",
+                    "range": {
+                      "start": 12,
+                      "end": 17
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove quotation marks",
+                        "change": {
+                          "from": 12,
+                          "to": 17,
+                          "insert": "test"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "severity": "info",
+                    "message": "This pattern is interpreted literally, including the quotation marks.",
+                    "range": {
+                      "start": 18,
+                      "end": 23
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove quotation marks",
+                        "change": {
+                          "from": 18,
+                          "to": 23,
+                          "insert": "test"
+                        }
+                      }
+                    ]
+                  }
+                ]
+            `)
+        })
+
+        test('detects patterns starting and ending with a quotation mark', () => {
+            expect(parseAndDiagnose(`"test" 'test' "test'`, SearchPatternType.literal)).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": "info",
+                    "message": "This pattern is interpreted literally, including the quotation marks. Use the \`content:\` filter if you want to \\"escape\\" terms that would otherwise be interpreted as query keywords.",
+                    "range": {
+                      "start": 0,
+                      "end": 6
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove quotation marks",
+                        "change": {
+                          "from": 0,
+                          "to": 6,
+                          "insert": "test"
+                        }
+                      },
+                      {
+                        "label": "Replace with content:\\"...\\"",
+                        "change": {
+                          "from": 0,
+                          "to": 6,
+                          "insert": "content:\\"test\\""
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "severity": "info",
+                    "message": "This pattern is interpreted literally, including the quotation marks. Use the \`content:\` filter if you want to \\"escape\\" terms that would otherwise be interpreted as query keywords.",
+                    "range": {
+                      "start": 7,
+                      "end": 13
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove quotation marks",
+                        "change": {
+                          "from": 7,
+                          "to": 13,
+                          "insert": "test"
+                        }
+                      },
+                      {
+                        "label": "Replace with content:\\"...\\"",
+                        "change": {
+                          "from": 7,
+                          "to": 13,
+                          "insert": "content:'test'"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "severity": "info",
+                    "message": "This pattern is interpreted literally, including the quotation marks.",
+                    "range": {
+                      "start": 14,
+                      "end": 20
+                    },
+                    "actions": [
+                      {
+                        "label": "Remove quotation marks",
+                        "change": {
+                          "from": 14,
+                          "to": 20,
+                          "insert": "test"
+                        }
+                      }
+                    ]
+                  }
+                ]
+            `)
+        })
+
+        test('ignores patterns containing a quotation mark', () => {
+            expect(parseAndDiagnose(`no'match no"match`, SearchPatternType.literal)).toMatchInlineSnapshot(`[]`)
+        })
+
+        test('ignores patterns in regexp or structural modes', () => {
+            expect(parseAndDiagnose(`"test 'test test" test'`, SearchPatternType.regexp)).toMatchInlineSnapshot(`[]`)
+            expect(parseAndDiagnose(`"test 'test test" test'`, SearchPatternType.structural)).toMatchInlineSnapshot(
+                `[]`
+            )
+        })
+    })
 })


### PR DESCRIPTION
Follow up on #39147 

This commit adds diagnostics for patterns that start or end with a
quotation mark, including a quick fix action to replace the quote, but
only if we are in literal or lucky mode.

If the pattern is completely enclosed in quotes it can also be replaced
with the `content:` filter. The assumption here is that the user used
quotes as a way to "escape" the query.

Not sure about the copy text, let me know what you think!


https://user-images.githubusercontent.com/179026/180444735-45dd57bd-e8f8-47d9-b0e7-f416e49a90f2.mp4



## Test plan

Enter search query with patterns that beginning or end with a quote. Verify that quick fix action work as expected. Verify that diagnostic is not shown for patterns that contain a quote at a position other than the beginning or end.

## App preview:

- [Web](https://sg-web-fkling-quotes-info.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zjxryivvmm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
