### PR TITLE
Revert "[SG-37461]: logging(gitstart): migrate internal/repos to sourcegraph/log"

### DIFF
--- a/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
+++ b/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/inconshreveable/log15"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -84,7 +82,7 @@ func (a *affiliatedRepositoriesConnection) getNodesAndErrors(ctx context.Context
 		)
 		for _, svc := range svcs {
 			svcsByID[svc.ID] = svc
-			src, err := repos.NewSource(ctx, log.Scoped("repos.Source", ""), a.db, svc, cf)
+			src, err := repos.NewSource(ctx, a.db, svc, cf)
 			if err != nil {
 				a.err = err
 				return
@@ -192,7 +190,6 @@ type codeHostRepositoryResolver struct {
 	repo     *types.CodeHostRepository
 	codeHost *types.ExternalService
 	db       database.DB
-	logger   log.Logger
 }
 
 func (r *codeHostRepositoryResolver) Name() string {
@@ -205,7 +202,6 @@ func (r *codeHostRepositoryResolver) Private() bool {
 
 func (r *codeHostRepositoryResolver) CodeHost(ctx context.Context) *externalServiceResolver {
 	return &externalServiceResolver{
-		logger:          r.logger,
 		db:              r.db,
 		externalService: r.codeHost,
 	}

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -49,7 +49,7 @@ func externalServiceByID(ctx context.Context, db database.DB, gqlID graphql.ID) 
 	if err := backend.CheckExternalServiceAccess(ctx, db, es.NamespaceUserID, es.NamespaceOrgID); err != nil {
 		return nil, err
 	}
-	return &externalServiceResolver{logger: log.Scoped("externalServiceResolver", ""), db: db, externalService: es}, nil
+	return &externalServiceResolver{db: db, externalService: es}, nil
 }
 
 func MarshalExternalServiceID(id int64) graphql.ID {
@@ -187,7 +187,7 @@ func (r *externalServiceResolver) NextSyncAt() *DateTime {
 var scopeCache = rcache.New("extsvc_token_scope")
 
 func (r *externalServiceResolver) GrantedScopes(ctx context.Context) (*[]string, error) {
-	scopes, err := repos.GrantedScopes(ctx, r.logger.Scoped("GrantedScopes", ""), scopeCache, r.db, r.externalService)
+	scopes, err := repos.GrantedScopes(ctx, scopeCache, r.db, r.externalService)
 	if err != nil {
 		// It's possible that we fail to fetch scope from the code host, in this case we
 		// don't want the entire resolver to fail.

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -14,8 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -111,7 +109,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 		return nil, err
 	}
 
-	res := &externalServiceResolver{logger: r.logger.Scoped("externalServiceResolver", ""), db: r.db, externalService: externalService}
+	res := &externalServiceResolver{db: r.db, externalService: externalService}
 	if err = backend.SyncExternalService(ctx, externalService, syncExternalServiceTimeout, r.repoupdaterClient); err != nil {
 		res.warning = fmt.Sprintf("External service created, but we encountered a problem while validating the external service: %s", err)
 	}
@@ -175,7 +173,7 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 		return nil, err
 	}
 
-	res := &externalServiceResolver{logger: r.logger.Scoped("externalServiceResolver", ""), db: r.db, externalService: es}
+	res := &externalServiceResolver{db: r.db, externalService: es}
 
 	if oldConfig != es.Config {
 		err = backend.SyncExternalService(ctx, es, syncExternalServiceTimeout, r.repoupdaterClient)
@@ -324,7 +322,7 @@ func (r *externalServiceConnectionResolver) Nodes(ctx context.Context) ([]*exter
 	}
 	resolvers := make([]*externalServiceResolver, 0, len(externalServices))
 	for _, externalService := range externalServices {
-		resolvers = append(resolvers, &externalServiceResolver{logger: log.Scoped("externalServiceResolver", ""), db: r.db, externalService: externalService})
+		resolvers = append(resolvers, &externalServiceResolver{db: r.db, externalService: externalService})
 	}
 	return resolvers, nil
 }
@@ -381,7 +379,7 @@ func (r *computedExternalServiceConnectionResolver) Nodes(ctx context.Context) [
 	}
 	resolvers := make([]*externalServiceResolver, 0, len(svcs))
 	for _, svc := range svcs {
-		resolvers = append(resolvers, &externalServiceResolver{logger: log.Scoped("externalServiceResolver", ""), db: r.db, externalService: svc})
+		resolvers = append(resolvers, &externalServiceResolver{db: r.db, externalService: svc})
 	}
 	return resolvers
 }

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -3,8 +3,6 @@ package graphqlbackend
 import (
 	"context"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -83,5 +81,5 @@ func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalS
 		return nil, err
 	}
 
-	return &externalServiceResolver{logger: log.Scoped("externalServiceResolver", ""), db: r.db, externalService: externalService}, nil
+	return &externalServiceResolver{db: r.db, externalService: externalService}, nil
 }

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -354,7 +354,7 @@ func getRemoteURLFunc(
 				}
 			}
 		}
-		return repos.CloneURL(log.Scoped("repos.CloneURL", ""), svc.Kind, svc.Config, r)
+		return repos.CloneURL(svc.Kind, svc.Config, r)
 	}
 	return "", errors.Errorf("no sources for %q", repo)
 }
@@ -394,7 +394,7 @@ func editGitHubAppExternalServiceConfigToken(
 
 	client := github.NewV3Client(logger, svc.URN(), apiURL, auther, cli)
 
-	token, err := repos.GetOrRenewGitHubAppInstallationAccessToken(ctx, log.Scoped("GetOrRenewGitHubAppInstallationAccessToken", ""), externalServiceStore, svc, client, installationID)
+	token, err := repos.GetOrRenewGitHubAppInstallationAccessToken(ctx, externalServiceStore, svc, client, installationID)
 	if err != nil {
 		return "", errors.Wrap(err, "get or renew GitHub App installation access token")
 	}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -200,7 +200,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	if sourcer = s.Sourcer; sourcer == nil {
 		db := database.NewDBWith(logger, s)
 		depsSvc := livedependencies.GetService(db, nil)
-		sourcer = repos.NewSourcer(s.Logger.Scoped("repos.Sourcer", ""), db, httpcli.ExternalClientFactory, repos.WithDependenciesService(depsSvc))
+		sourcer = repos.NewSourcer(db, httpcli.ExternalClientFactory, repos.WithDependenciesService(depsSvc))
 	}
 	src, err := sourcer(ctx, &types.ExternalService{
 		ID:              req.ExternalService.ID,

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -120,7 +120,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	// bit more to do in this method, though, and the process will be marked ready
 	// further down this function.
 
-	repos.MustRegisterMetrics(log.Scoped("MustRegisterMetrics", ""), db, envvar.SourcegraphDotComMode())
+	repos.MustRegisterMetrics(db, envvar.SourcegraphDotComMode())
 
 	store := repos.NewStore(logger.Scoped("store", "repo store"), db)
 	{
@@ -138,7 +138,7 @@ func Main(enterpriseInit EnterpriseInit) {
 
 		depsSvc := livedependencies.GetService(db, nil)
 		obsLogger := logger.Scoped("ObservedSource", "")
-		src = repos.NewSourcer(logger.Scoped("repos.Sourcer", ""), db, cf, repos.WithDependenciesService(depsSvc), repos.ObservedSource(obsLogger, m))
+		src = repos.NewSourcer(db, cf, repos.WithDependenciesService(depsSvc), repos.ObservedSource(obsLogger, m))
 	}
 
 	updateScheduler := repos.NewUpdateScheduler(logger, db)
@@ -194,14 +194,14 @@ func Main(enterpriseInit EnterpriseInit) {
 		go syncer.RunSyncReposWithLastErrorsWorker(ctx, rateLimiter)
 	}
 
-	go repos.RunPhabricatorRepositorySyncWorker(ctx, log.Scoped("PhabricatorRepositorySyncWorker", ""), store)
+	go repos.RunPhabricatorRepositorySyncWorker(ctx, store)
 
 	// git-server repos purging thread
 	var purgeTTL time.Duration
 	if envvar.SourcegraphDotComMode() {
 		purgeTTL = 14 * 24 * time.Hour // two weeks
 	}
-	go repos.RunRepositoryPurgeWorker(ctx, log.Scoped("RepositoryPurgeWorker", ""), db, purgeTTL)
+	go repos.RunRepositoryPurgeWorker(ctx, db, purgeTTL)
 
 	// Git fetches scheduler
 	go repos.RunScheduler(ctx, logger, updateScheduler)
@@ -361,7 +361,7 @@ func manualPurgeHandler(db database.DB) http.HandlerFunc {
 				return
 			}
 		}
-		err = repos.PurgeOldestRepos(log.Scoped("PurgeOldestRepos", ""), db, limit, perSecond)
+		err = repos.PurgeOldestRepos(db, limit, perSecond)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("starting manual purge: %v", err), http.StatusInternalServerError)
 			return

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -104,7 +104,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		t.Fatalf("Failed to Upsert external service: %s", err)
 	}
 
-	githubSrc, err := repos.NewGithubSource(logger, db.ExternalServices(), githubExtSvc, cf)
+	githubSrc, err := repos.NewGithubSource(db.ExternalServices(), githubExtSvc, cf)
 	if err != nil {
 		t.Fatal(t)
 	}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/syncer"
@@ -75,7 +73,7 @@ func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 			t.Fatal(t)
 		}
 
-		bitbucketSource, err := repos.NewBitbucketServerSource(logtest.Scoped(t), extSvc, cf)
+		bitbucketSource, err := repos.NewBitbucketServerSource(extSvc, cf)
 		if err != nil {
 			t.Fatal(t)
 		}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	gh "github.com/google/go-github/v43/github"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -75,7 +73,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			t.Fatal(t)
 		}
 
-		githubSrc, err := repos.NewGithubSource(logtest.Scoped(t), db.ExternalServices(), extSvc, cf)
+		githubSrc, err := repos.NewGithubSource(db.ExternalServices(), extSvc, cf)
 		if err != nil {
 			t.Fatal(t)
 		}

--- a/enterprise/internal/authz/github/app.go
+++ b/enterprise/internal/authz/github/app.go
@@ -47,7 +47,7 @@ func newAppProvider(
 		urn:      urn,
 		codeHost: extsvc.NewCodeHost(baseURL, extsvc.TypeGitHub),
 		client: func() (client, error) {
-			token, err := repos.GetOrRenewGitHubAppInstallationAccessToken(context.Background(), log.Scoped("GetOrRenewGitHubAppInstallationAccessToken", ""), externalServicesStore, svc, appClient, installationID)
+			token, err := repos.GetOrRenewGitHubAppInstallationAccessToken(context.Background(), externalServicesStore, svc, appClient, installationID)
 			if err != nil {
 				return nil, errors.Wrap(err, "get or renew GitHub App installation access token")
 			}

--- a/enterprise/internal/batches/sources/sources.go
+++ b/enterprise/internal/batches/sources/sources.go
@@ -6,8 +6,6 @@ import (
 	"net/url"
 	"sort"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -441,7 +439,7 @@ func extractCloneURL(ctx context.Context, s database.ExternalServiceStore, repo 
 	for _, svc := range svcs {
 		// build the clone url using the external service config instead of using
 		// the source CloneURL field
-		cloneURL, err := repos.CloneURL(log.Scoped("CloneURL", ""), svc.Kind, svc.Config, repo)
+		cloneURL, err := repos.CloneURL(svc.Kind, svc.Config, repo)
 		if err != nil {
 			return "", err
 		}

--- a/internal/extsvc/versions/sync.go
+++ b/internal/extsvc/versions/sync.go
@@ -46,7 +46,7 @@ func (j *syncingJob) Routines(_ context.Context, logger log.Logger) ([]goroutine
 	}
 
 	cf := httpcli.ExternalClientFactory
-	sourcer := repos.NewSourcer(logger.Scoped("repos.Sourcer", ""), database.NewDB(logger, db), cf)
+	sourcer := repos.NewSourcer(database.NewDB(logger, db), cf)
 
 	store := database.NewDB(logger, db).ExternalServices()
 	handler := goroutine.NewHandlerWithErrorMessage("sync versions of external services", func(ctx context.Context) error {

--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"sync"
 
-	"github.com/sourcegraph/log"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -27,21 +27,20 @@ type BitbucketCloudSource struct {
 	config  *schema.BitbucketCloudConnection
 	exclude excludeFunc
 	client  bitbucketcloud.Client
-	logger  log.Logger
 }
 
 var _ UserSource = &BitbucketCloudSource{}
 
 // NewBitbucketCloudSource returns a new BitbucketCloudSource from the given external service.
-func NewBitbucketCloudSource(logger log.Logger, svc *types.ExternalService, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
+func NewBitbucketCloudSource(svc *types.ExternalService, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
 	var c schema.BitbucketCloudConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
-	return newBitbucketCloudSource(logger, svc, &c, cf)
+	return newBitbucketCloudSource(svc, &c, cf)
 }
 
-func newBitbucketCloudSource(logger log.Logger, svc *types.ExternalService, c *schema.BitbucketCloudConnection, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
+func newBitbucketCloudSource(svc *types.ExternalService, c *schema.BitbucketCloudConnection, cf *httpcli.Factory) (*BitbucketCloudSource, error) {
 	if cf == nil {
 		cf = httpcli.ExternalClientFactory
 	}
@@ -72,7 +71,6 @@ func newBitbucketCloudSource(logger log.Logger, svc *types.ExternalService, c *s
 		config:  c,
 		exclude: exclude,
 		client:  client,
-		logger:  logger,
 	}, nil
 }
 
@@ -142,7 +140,7 @@ func (s *BitbucketCloudSource) remoteURL(repo *bitbucketcloud.Repo) string {
 
 	httpsURL, err := repo.Links.Clone.HTTPS()
 	if err != nil {
-		s.logger.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", log.String("url", fmt.Sprintf("%v", repo.Links.Clone)), log.Error(err))
+		log15.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", "url", repo.Links.Clone, "error", err)
 		return fallbackURL
 	}
 	return httpsURL

--- a/internal/repos/bitbucketcloud_test.go
+++ b/internal/repos/bitbucketcloud_test.go
@@ -10,8 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
-	"github.com/sourcegraph/log/logtest"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
@@ -81,12 +80,15 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 			cf, save := newClientFactory(t, tc.name)
 			defer save(t)
 
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
 			svc := &types.ExternalService{
 				Kind:   extsvc.KindBitbucketCloud,
 				Config: marshalJSON(t, tc.conf),
 			}
 
-			bbcSrc, err := newBitbucketCloudSource(logtest.Scoped(t), svc, tc.conf, cf)
+			bbcSrc, err := newBitbucketCloudSource(svc, tc.conf, cf)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -148,7 +150,7 @@ func TestBitbucketCloudSource_makeRepo(t *testing.T) {
 	for _, test := range tests {
 		test.name = "BitbucketCloudSource_makeRepo_" + test.name
 		t.Run(test.name, func(t *testing.T) {
-			s, err := newBitbucketCloudSource(logtest.Scoped(t), &svc, test.schema, nil)
+			s, err := newBitbucketCloudSource(&svc, test.schema, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -219,7 +221,7 @@ func TestBitbucketCloudSource_Exclude(t *testing.T) {
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
-			s, err := newBitbucketCloudSource(logtest.Scoped(t), &svc, config, nil)
+			s, err := newBitbucketCloudSource(&svc, config, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -54,7 +52,7 @@ func TestBitbucketServerSource_MakeRepo(t *testing.T) {
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
-			s, err := newBitbucketServerSource(logtest.Scoped(t), &svc, config, nil)
+			s, err := newBitbucketServerSource(&svc, config, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -127,7 +125,7 @@ func TestBitbucketServerSource_Exclude(t *testing.T) {
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
-			s, err := newBitbucketServerSource(logtest.Scoped(t), &svc, config, nil)
+			s, err := newBitbucketServerSource(&svc, config, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -164,7 +162,7 @@ func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 		}),
 	}
 
-	bbsSrc, err := NewBitbucketServerSource(logtest.Scoped(t), svc, nil)
+	bbsSrc, err := NewBitbucketServerSource(svc, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +232,7 @@ func TestBitbucketServerSource_ListByReposOnly(t *testing.T) {
 	cases, svc := GetConfig(t, server.URL, "secret")
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
-			s, err := newBitbucketServerSource(logtest.Scoped(t), &svc, config, nil)
+			s, err := newBitbucketServerSource(&svc, config, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -337,7 +335,7 @@ func TestBitbucketServerSource_ListByRepositoryQuery(t *testing.T) {
 		tc := tc
 		for name, config := range cases {
 			t.Run(name, func(t *testing.T) {
-				s, err := newBitbucketServerSource(logtest.Scoped(t), &svc, config, nil)
+				s, err := newBitbucketServerSource(&svc, config, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -399,7 +397,7 @@ func TestBitbucketServerSource_ListByProjectKeyMock(t *testing.T) {
 	cases, svc := GetConfig(t, server.URL, "secret")
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
-			s, err := newBitbucketServerSource(logtest.Scoped(t), &svc, config, nil)
+			s, err := newBitbucketServerSource(&svc, config, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -429,7 +427,7 @@ func TestBitbucketServerSource_ListByProjectKeyAuthentic(t *testing.T) {
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
-			s, err := newBitbucketServerSource(logtest.Scoped(t), &svc, config, nil)
+			s, err := newBitbucketServerSource(&svc, config, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/sourcegraph/log"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -27,7 +27,7 @@ import (
 // CloneURL builds a cloneURL for the given repo based on the external service
 // configuration. If authentication information is found in the configuration, it
 // returns an authenticated URL for the selected code host.
-func CloneURL(logger log.Logger, kind, config string, repo *types.Repo) (string, error) {
+func CloneURL(kind, config string, repo *types.Repo) (string, error) {
 	parsed, err := extsvc.ParseConfig(kind, config)
 	if err != nil {
 		return "", errors.Wrap(err, "loading service configuration")
@@ -36,7 +36,7 @@ func CloneURL(logger log.Logger, kind, config string, repo *types.Repo) (string,
 	switch t := parsed.(type) {
 	case *schema.AWSCodeCommitConnection:
 		if r, ok := repo.Metadata.(*awscodecommit.Repository); ok {
-			return awsCodeCloneURL(logger, r, t), nil
+			return awsCodeCloneURL(r, t), nil
 		}
 	case *schema.BitbucketServerConnection:
 		if r, ok := repo.Metadata.(*bitbucketserver.Repo); ok {
@@ -44,19 +44,19 @@ func CloneURL(logger log.Logger, kind, config string, repo *types.Repo) (string,
 		}
 	case *schema.BitbucketCloudConnection:
 		if r, ok := repo.Metadata.(*bitbucketcloud.Repo); ok {
-			return bitbucketCloudCloneURL(logger, r, t), nil
+			return bitbucketCloudCloneURL(r, t), nil
 		}
 	case *schema.GerritConnection:
 		if r, ok := repo.Metadata.(*gerrit.Project); ok {
-			return gerritCloneURL(logger, r, t), nil
+			return gerritCloneURL(r, t), nil
 		}
 	case *schema.GitHubConnection:
 		if r, ok := repo.Metadata.(*github.Repository); ok {
-			return githubCloneURL(logger, r, t)
+			return githubCloneURL(r, t)
 		}
 	case *schema.GitLabConnection:
 		if r, ok := repo.Metadata.(*gitlab.Project); ok {
-			return gitlabCloneURL(logger, r, t), nil
+			return gitlabCloneURL(r, t), nil
 		}
 	case *schema.GitoliteConnection:
 		if r, ok := repo.Metadata.(*gitolite.Repo); ok {
@@ -68,7 +68,7 @@ func CloneURL(logger log.Logger, kind, config string, repo *types.Repo) (string,
 		}
 	case *schema.PhabricatorConnection:
 		if r, ok := repo.Metadata.(*phabricator.Repo); ok {
-			return phabricatorCloneURL(logger, r, t), nil
+			return phabricatorCloneURL(r, t), nil
 		}
 	case *schema.PagureConnection:
 		if r, ok := repo.Metadata.(*pagure.Project); ok {
@@ -98,10 +98,10 @@ func CloneURL(logger log.Logger, kind, config string, repo *types.Repo) (string,
 	return "", errors.Errorf("unknown repo.Metadata type %T for repo %d", repo.Metadata, repo.ID)
 }
 
-func awsCodeCloneURL(logger log.Logger, repo *awscodecommit.Repository, cfg *schema.AWSCodeCommitConnection) string {
+func awsCodeCloneURL(repo *awscodecommit.Repository, cfg *schema.AWSCodeCommitConnection) string {
 	u, err := url.Parse(repo.HTTPCloneURL)
 	if err != nil {
-		logger.Warn("Error adding authentication to AWS CodeCommit repository Git remote URL.", log.String("url", repo.HTTPCloneURL), log.Error(err))
+		log15.Warn("Error adding authentication to AWS CodeCommit repository Git remote URL.", "url", repo.HTTPCloneURL, "error", err)
 		return repo.HTTPCloneURL
 	}
 
@@ -137,7 +137,7 @@ func bitbucketServerCloneURL(repo *bitbucketserver.Repo, cfg *schema.BitbucketSe
 
 // bitbucketCloudCloneURL returns the repository's Git remote URL with the configured
 // Bitbucket Cloud app password inserted in the URL userinfo.
-func bitbucketCloudCloneURL(logger log.Logger, repo *bitbucketcloud.Repo, cfg *schema.BitbucketCloudConnection) string {
+func bitbucketCloudCloneURL(repo *bitbucketcloud.Repo, cfg *schema.BitbucketCloudConnection) string {
 	if cfg.GitURLType == "ssh" {
 		return fmt.Sprintf("git@%s:%s.git", cfg.Url, repo.FullName)
 	}
@@ -150,12 +150,12 @@ func bitbucketCloudCloneURL(logger log.Logger, repo *bitbucketcloud.Repo, cfg *s
 
 	httpsURL, err := repo.Links.Clone.HTTPS()
 	if err != nil {
-		logger.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", log.String("url", fmt.Sprintf("%v", repo.Links.Clone)), log.Error(err))
+		log15.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", "url", repo.Links.Clone, "error", err)
 		return fallbackURL
 	}
 	u, err := url.Parse(httpsURL)
 	if err != nil {
-		logger.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", log.String("url", httpsURL), log.Error(err))
+		log15.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", "url", httpsURL, "error", err)
 		return fallbackURL
 	}
 
@@ -163,7 +163,7 @@ func bitbucketCloudCloneURL(logger log.Logger, repo *bitbucketcloud.Repo, cfg *s
 	return u.String()
 }
 
-func githubCloneURL(logger log.Logger, repo *github.Repository, cfg *schema.GitHubConnection) (string, error) {
+func githubCloneURL(repo *github.Repository, cfg *schema.GitHubConnection) (string, error) {
 	if cfg.GitURLType == "ssh" {
 		baseURL, err := url.Parse(cfg.Url)
 		if err != nil {
@@ -183,7 +183,7 @@ func githubCloneURL(logger log.Logger, repo *github.Repository, cfg *schema.GitH
 	}
 	u, err := url.Parse(repo.URL)
 	if err != nil {
-		logger.Warn("Error adding authentication to GitHub repository Git remote URL.", log.String("url", repo.URL), log.Error(err))
+		log15.Warn("Error adding authentication to GitHub repository Git remote URL.", "url", repo.URL, "error", err)
 		return repo.URL, nil
 	}
 
@@ -197,7 +197,7 @@ func githubCloneURL(logger log.Logger, repo *github.Repository, cfg *schema.GitH
 
 // authenticatedRemoteURL returns the GitLab project's Git remote URL with the
 // configured GitLab personal access token inserted in the URL userinfo.
-func gitlabCloneURL(logger log.Logger, repo *gitlab.Project, cfg *schema.GitLabConnection) string {
+func gitlabCloneURL(repo *gitlab.Project, cfg *schema.GitLabConnection) string {
 	if cfg.GitURLType == "ssh" {
 		return repo.SSHURLToRepo // SSH authentication must be provided out-of-band
 	}
@@ -206,7 +206,7 @@ func gitlabCloneURL(logger log.Logger, repo *gitlab.Project, cfg *schema.GitLabC
 	}
 	u, err := url.Parse(repo.HTTPURLToRepo)
 	if err != nil {
-		logger.Warn("Error adding authentication to GitLab repository Git remote URL.", log.String("url", repo.HTTPURLToRepo), log.Error(err))
+		log15.Warn("Error adding authentication to GitLab repository Git remote URL.", "url", repo.HTTPURLToRepo, "error", err)
 		return repo.HTTPURLToRepo
 	}
 	username := "git"
@@ -217,10 +217,10 @@ func gitlabCloneURL(logger log.Logger, repo *gitlab.Project, cfg *schema.GitLabC
 	return u.String()
 }
 
-func gerritCloneURL(logger log.Logger, project *gerrit.Project, cfg *schema.GerritConnection) string {
+func gerritCloneURL(project *gerrit.Project, cfg *schema.GerritConnection) string {
 	u, err := url.Parse(cfg.Url)
 	if err != nil {
-		logger.Warn("Error adding authentication to Gerrit project remote URL.", log.String("url", cfg.Url), log.Error(err))
+		log15.Warn("Error adding authentication to Gerrit project remote URL.", "url", cfg.Url, "error", err)
 		return cfg.Url
 	}
 	u.User = url.UserPassword(cfg.Username, cfg.Password)
@@ -244,7 +244,7 @@ func perforceCloneURL(depot *perforce.Depot, cfg *schema.PerforceConnection) str
 	return cloneURL.String()
 }
 
-func phabricatorCloneURL(logger log.Logger, repo *phabricator.Repo, _ *schema.PhabricatorConnection) string {
+func phabricatorCloneURL(repo *phabricator.Repo, _ *schema.PhabricatorConnection) string {
 	var external []*phabricator.URI
 	builtin := make(map[string]*phabricator.URI)
 
@@ -288,7 +288,7 @@ func phabricatorCloneURL(logger log.Logger, repo *phabricator.Repo, _ *schema.Ph
 	}
 
 	if cloneURL == "" {
-		logger.Warn("unable to construct clone URL for repo", log.String("name", name), log.String("phabricator_id", repo.PHID))
+		log15.Warn("unable to construct clone URL for repo", "name", name, "phabricator_id", repo.PHID)
 	}
 
 	return cloneURL

--- a/internal/repos/clone_url_test.go
+++ b/internal/repos/clone_url_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -43,7 +41,7 @@ func TestAWSCodeCloneURLs(t *testing.T) {
 		},
 	}
 
-	got := awsCodeCloneURL(logtest.Scoped(t), repo, &cfg)
+	got := awsCodeCloneURL(repo, &cfg)
 	want := "https://username:password@git-codecommit.us-west-1.amazonaws.com/v1/repos/stripe-go"
 	if got != want {
 		t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
@@ -113,7 +111,6 @@ func TestBitbucketServerCloneURLs(t *testing.T) {
 }
 
 func TestBitbucketCloudCloneURLs(t *testing.T) {
-	logger := logtest.Scoped(t)
 	repo := &bitbucketcloud.Repo{
 		FullName: "sg/sourcegraph",
 	}
@@ -132,7 +129,7 @@ func TestBitbucketCloudCloneURLs(t *testing.T) {
 	t.Run("ssh", func(t *testing.T) {
 		cfg.GitURLType = "ssh"
 
-		got := bitbucketCloudCloneURL(logger, repo, &cfg)
+		got := bitbucketCloudCloneURL(repo, &cfg)
 		want := "git@bitbucket.org:sg/sourcegraph.git"
 		if got != want {
 			t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
@@ -142,7 +139,7 @@ func TestBitbucketCloudCloneURLs(t *testing.T) {
 	t.Run("http", func(t *testing.T) {
 		cfg.GitURLType = "http"
 
-		got := bitbucketCloudCloneURL(logger, repo, &cfg)
+		got := bitbucketCloudCloneURL(repo, &cfg)
 		want := "https://username:password@bitbucket.org/sg/sourcegraph.git"
 		if got != want {
 			t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
@@ -151,9 +148,8 @@ func TestBitbucketCloudCloneURLs(t *testing.T) {
 }
 
 func TestGitHubCloneURLs(t *testing.T) {
-	logger := logtest.Scoped(t)
 	t.Run("empty repo.URL", func(t *testing.T) {
-		_, err := githubCloneURL(logger, &github.Repository{}, &schema.GitHubConnection{})
+		_, err := githubCloneURL(&github.Repository{}, &schema.GitHubConnection{})
 		got := fmt.Sprintf("%v", err)
 		want := "empty repo.URL"
 		if diff := cmp.Diff(want, got); diff != "" {
@@ -186,7 +182,7 @@ func TestGitHubCloneURLs(t *testing.T) {
 
 			repo.URL = test.RepoURL
 
-			got, err := githubCloneURL(logger, &repo, &cfg)
+			got, err := githubCloneURL(&repo, &cfg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -228,7 +224,7 @@ func TestGitLabCloneURLs(t *testing.T) {
 				GitURLType: test.GitURLType,
 			}
 
-			got := gitlabCloneURL(logtest.Scoped(t), repo, &cfg)
+			got := gitlabCloneURL(repo, &cfg)
 			if got != test.Want {
 				t.Fatalf("wrong cloneURL, got: %q, want: %q", got, test.Want)
 			}
@@ -247,7 +243,7 @@ func TestGerritCloneURL(t *testing.T) {
 		ID: "test-project",
 	}
 
-	got := gerritCloneURL(logtest.Scoped(t), project, &cfg)
+	got := gerritCloneURL(project, &cfg)
 	want := "https://admin:pa$$word@gerrit.com/test-project"
 	if got != want {
 		t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
@@ -345,7 +341,7 @@ func TestPhabricatorCloneURL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := phabricatorCloneURL(logtest.Scoped(t), repo, nil)
+	got := phabricatorCloneURL(repo, nil)
 	want := "ssh://git@phabricator.sgdev.org/diffusion/8/test.git"
 
 	if want != got {

--- a/internal/repos/gerrit_test.go
+++ b/internal/repos/gerrit_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
@@ -17,6 +19,9 @@ func TestGerritSource_ListRepos(t *testing.T) {
 	}
 	cf, save := newClientFactory(t, t.Name(), httpcli.GerritUnauthenticateMiddleware)
 	defer save(t)
+
+	lg := log15.New()
+	lg.SetHandler(log15.DiscardHandler())
 
 	svc := &types.ExternalService{
 		Kind:   extsvc.KindGerrit,

--- a/internal/repos/main_test.go
+++ b/internal/repos/main_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
+
+	"github.com/inconshreveable/log15"
 )
 
 var updateRegex = flag.String("update", "", "Update testdata of tests matching the given regex")
@@ -23,6 +25,7 @@ func update(name string) bool {
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if !testing.Verbose() {
+		log15.Root().SetHandler(log15.DiscardHandler())
 		logtest.InitWithLevel(m, log.LevelNone)
 	} else {
 		logtest.Init(m)

--- a/internal/repos/pagure_test.go
+++ b/internal/repos/pagure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -18,6 +19,9 @@ func TestPagureSource_ListRepos(t *testing.T) {
 	}
 	cf, save := newClientFactory(t, t.Name())
 	defer save(t)
+
+	lg := log15.New()
+	lg.SetHandler(log15.DiscardHandler())
 
 	svc := &types.ExternalService{
 		Kind:   extsvc.KindPagure,

--- a/internal/repos/perforce_test.go
+++ b/internal/repos/perforce_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
@@ -59,6 +60,9 @@ func TestPerforceSource_ListRepos(t *testing.T) {
 		tc := tc
 		tc.name = "PERFORCE-LIST-REPOS/" + tc.name
 		t.Run(tc.name, func(t *testing.T) {
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
 			svc := &types.ExternalService{
 				Kind:   extsvc.KindPerforce,
 				Config: marshalJSON(t, tc.conf),

--- a/internal/repos/purge.go
+++ b/internal/repos/purge.go
@@ -7,9 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/inconshreveable/log15"
 	"golang.org/x/time/rate"
-
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -21,14 +20,13 @@ import (
 // RunRepositoryPurgeWorker is a worker which deletes repos which are present on
 // gitserver, but not enabled/present in our repos table. ttl, should be >= 0 and
 // specifies how long ago a repo must be deleted before it is purged.
-func RunRepositoryPurgeWorker(ctx context.Context, logger log.Logger, db database.DB, ttl time.Duration) {
-	sglogError := log.Error
-
+func RunRepositoryPurgeWorker(ctx context.Context, db database.DB, ttl time.Duration) {
+	log := log15.Root().New("worker", "repo-purge")
 	limiter := ratelimit.NewInstrumentedLimiter("PurgeRepoWorker", rate.NewLimiter(10, 1))
 
 	// Temporary escape hatch if this feature proves to be dangerous
 	if disabled, _ := strconv.ParseBool(os.Getenv("DISABLE_REPO_PURGE")); disabled {
-		logger.Info("repository purger is disabled via env DISABLE_REPO_PURGE")
+		log.Info("repository purger is disabled via env DISABLE_REPO_PURGE")
 		return
 	}
 
@@ -42,12 +40,12 @@ func RunRepositoryPurgeWorker(ctx context.Context, logger log.Logger, db databas
 			randSleep(10*time.Minute, 1*time.Minute)
 			continue
 		}
-		if err := purge(ctx, logger, db, database.IteratePurgableReposOptions{
+		if err := purge(ctx, db, log, database.IteratePurgableReposOptions{
 			Limit:         5000,
 			Limiter:       limiter,
 			DeletedBefore: now.Add(-ttl),
 		}); err != nil {
-			logger.Error("failed to run repository clone purge", sglogError(err))
+			log.Error("failed to run repository clone purge", "error", err)
 		}
 		randSleep(1*time.Minute, 10*time.Second)
 	}
@@ -56,27 +54,26 @@ func RunRepositoryPurgeWorker(ctx context.Context, logger log.Logger, db databas
 // PurgeOldestRepos will start a go routine to purge the oldest repos limited by
 // limit. The repos are ordered by when they were deleted. limit must be greater
 // than zero.
-func PurgeOldestRepos(logger log.Logger, db database.DB, limit int, perSecond float64) error {
+func PurgeOldestRepos(db database.DB, limit int, perSecond float64) error {
 	if limit <= 0 {
 		return errors.Errorf("limit must be greater than zero, got %d", limit)
 	}
-	sglogError := log.Error
-
+	log := log15.Root().New("request", "repo-purge")
 	go func() {
 		limiter := ratelimit.NewInstrumentedLimiter("PurgeOldestRepos", rate.NewLimiter(rate.Limit(perSecond), 1))
 		// Use a background routine so that we don't time out based on the http context.
-		if err := purge(context.Background(), logger, db, database.IteratePurgableReposOptions{
+		if err := purge(context.Background(), db, log, database.IteratePurgableReposOptions{
 			Limit:   limit,
 			Limiter: limiter,
 		}); err != nil {
-			logger.Error("Purging old repos", sglogError(err))
+			log.Error("Purging old repos", "error", err)
 		}
 	}()
 	return nil
 }
 
 // purge purges repos, returning the number of repos that were successfully purged
-func purge(ctx context.Context, logger log.Logger, db database.DB, options database.IteratePurgableReposOptions) error {
+func purge(ctx context.Context, db database.DB, log log15.Logger, options database.IteratePurgableReposOptions) error {
 	start := time.Now()
 	gitserverClient := gitserver.NewClient(db)
 	var (
@@ -95,7 +92,7 @@ func purge(ctx context.Context, logger log.Logger, db database.DB, options datab
 		total++
 		if err := gitserverClient.Remove(ctx, repo); err != nil {
 			// Do not fail at this point, just log so we can remove other repos.
-			logger.Warn("failed to remove repository", log.String("repo", string(repo)), log.Error(err))
+			log.Warn("failed to remove repository", "repo", repo, "error", err)
 			purgeFailed.Inc()
 			failed++
 			return nil
@@ -105,11 +102,11 @@ func purge(ctx context.Context, logger log.Logger, db database.DB, options datab
 		return nil
 	})
 	// If we did something we log with a higher level.
-	statusLogger := logger.Info
+	statusLogger := log.Info
 	if failed > 0 {
-		statusLogger = logger.Warn
+		statusLogger = log.Warn
 	}
-	statusLogger("repository purge finished", log.Int("total", total), log.Int("removed", success), log.Int("failed", failed), log.Duration("duration", time.Since(start)))
+	statusLogger("repository purge finished", "total", total, "removed", success, "failed", failed, "duration", time.Since(start))
 	return errors.Wrap(err, "iterating purgeable repos")
 }
 

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -621,7 +621,7 @@ func TestSources_ListRepos(t *testing.T) {
 
 				logger := logtest.Scoped(t)
 				obs := ObservedSource(logger, NewSourceMetrics())
-				src, err := NewSourcer(logtest.Scoped(t), database.NewMockDB(), cf, obs)(tc.ctx, svc)
+				src, err := NewSourcer(database.NewMockDB(), cf, obs)(tc.ctx, svc)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/internal/repos/sync_worker_test.go
+++ b/internal/repos/sync_worker_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -52,7 +51,7 @@ func testSyncWorkerPlumbing(repoStore repos.Store) func(t *testing.T) {
 		h := &fakeRepoSyncHandler{
 			jobChan: jobChan,
 		}
-		worker, resetter := repos.NewSyncWorker(ctx, logtest.Scoped(t), repoStore.Handle(), h, repos.SyncWorkerOptions{
+		worker, resetter := repos.NewSyncWorker(ctx, repoStore.Handle(), h, repos.SyncWorkerOptions{
 			NumHandlers:    1,
 			WorkerInterval: 1 * time.Millisecond,
 		})

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -80,7 +80,7 @@ func (s *Syncer) Run(ctx context.Context, store Store, opts RunOptions) error {
 		s.initialUnmodifiedDiffFromStore(ctx, store)
 	}
 
-	worker, resetter := NewSyncWorker(ctx, s.Logger.Scoped("syncWorker", ""), store.Handle(), &syncHandler{
+	worker, resetter := NewSyncWorker(ctx, store.Handle(), &syncHandler{
 		syncer:          s,
 		store:           store,
 		minSyncInterval: opts.MinSyncInterval,

--- a/internal/repos/types.go
+++ b/internal/repos/types.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -136,12 +134,12 @@ type ScopeCache interface {
 //
 // Currently only GitHub and GitLab external services with user or org namespace are supported,
 // other code hosts will simply return an empty slice
-func GrantedScopes(ctx context.Context, logger log.Logger, cache ScopeCache, db database.DB, svc *types.ExternalService) ([]string, error) {
+func GrantedScopes(ctx context.Context, cache ScopeCache, db database.DB, svc *types.ExternalService) ([]string, error) {
 	externalServicesStore := db.ExternalServices()
 	if svc.IsSiteOwned() || (svc.Kind != extsvc.KindGitHub && svc.Kind != extsvc.KindGitLab) {
 		return nil, nil
 	}
-	src, err := NewSource(ctx, logger.Scoped("Source", ""), db, svc, nil)
+	src, err := NewSource(ctx, db, svc, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating source")
 	}
@@ -161,7 +159,7 @@ func GrantedScopes(ctx context.Context, logger log.Logger, cache ScopeCache, db 
 		}
 
 		// Slow path
-		src, err := NewGithubSource(logger.Scoped("GithubSource", ""), externalServicesStore, svc, nil)
+		src, err := NewGithubSource(externalServicesStore, svc, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating source")
 		}
@@ -190,7 +188,7 @@ func GrantedScopes(ctx context.Context, logger log.Logger, cache ScopeCache, db 
 		}
 
 		// Slow path
-		src, err := NewGitLabSource(ctx, logger.Scoped("GitLabSource", ""), db, svc, nil)
+		src, err := NewGitLabSource(ctx, db, svc, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating source")
 		}

--- a/internal/repos/types_test.go
+++ b/internal/repos/types_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -165,7 +163,6 @@ func (m MockExternalServicesLister) List(ctx context.Context, args database.Exte
 }
 
 func TestGrantedScopes(t *testing.T) {
-	logger := logtest.Scoped(t)
 	rcache.SetupForTest(t)
 	cache := rcache.New("TestGrantedScopes")
 	ctx := context.Background()
@@ -179,7 +176,7 @@ func TestGrantedScopes(t *testing.T) {
 		svc := &types.ExternalService{Kind: extsvc.KindGitHub, Config: `{"token": "abc"}`, NamespaceUserID: 123}
 		// Run twice to use cache
 		for i := 0; i < 2; i++ {
-			have, err := GrantedScopes(ctx, logger, cache, database.NewMockDB(), svc)
+			have, err := GrantedScopes(ctx, cache, database.NewMockDB(), svc)
 			if err != nil {
 				t.Fatal(i, err)
 			}
@@ -193,7 +190,7 @@ func TestGrantedScopes(t *testing.T) {
 		svc := &types.ExternalService{Kind: extsvc.KindGitHub, Config: `{"token": "abc"}`, NamespaceOrgID: 42}
 		// Run twice to use cache
 		for i := 0; i < 2; i++ {
-			have, err := GrantedScopes(ctx, logger, cache, database.NewMockDB(), svc)
+			have, err := GrantedScopes(ctx, cache, database.NewMockDB(), svc)
 			if err != nil {
 				t.Fatal(i, err)
 			}


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#37603

We're really close to the next release, let's wait for it to be done before merging this. 

Test-Plan: This is a revert 