### PR TITLE
Finish some deprecations and remove more unused routes

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -137,7 +137,6 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	})
 
 	m.Get(apirouter.ExternalServiceConfigs).Handler(trace.Route(handler(serveExternalServiceConfigs(db))))
-	m.Get(apirouter.ExternalServicesList).Handler(trace.Route(handler(serveExternalServicesList(db))))
 	m.Get(apirouter.PhabricatorRepoCreate).Handler(trace.Route(handler(servePhabricatorRepoCreate(db))))
 
 	// zoekt-indexserver endpoints
@@ -155,11 +154,6 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(indexer.serveConfiguration)))
 	m.Get(apirouter.ReposIndex).Handler(trace.Route(handler(indexer.serveList)))
 
-	m.Get(apirouter.ReposGetByName).Handler(trace.Route(handler(serveReposGetByName(db))))
-	m.Get(apirouter.SettingsGetForSubject).Handler(trace.Route(handler(serveSettingsGetForSubject(db))))
-	m.Get(apirouter.OrgsListUsers).Handler(trace.Route(handler(serveOrgsListUsers(db))))
-	m.Get(apirouter.OrgsGetByName).Handler(trace.Route(handler(serveOrgsGetByName(db))))
-	m.Get(apirouter.UserEmailsGetEmail).Handler(trace.Route(handler(serveUserEmailsGetEmail(db))))
 	m.Get(apirouter.ExternalURL).Handler(trace.Route(handler(serveExternalURL)))
 	m.Get(apirouter.SendEmail).Handler(trace.Route(handler(serveSendEmail)))
 	m.Get(apirouter.GitResolveRevision).Handler(trace.Route(handler(serveGitResolveRevision(db))))

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -10,9 +10,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
 
-	"github.com/sourcegraph/log"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -22,24 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-func serveReposGetByName(db database.DB) func(http.ResponseWriter, *http.Request) error {
-	logger := log.Scoped("serveReposGetByName", "")
-	return func(w http.ResponseWriter, r *http.Request) error {
-		repoName := api.RepoName(mux.Vars(r)["RepoName"])
-		repo, err := backend.NewRepos(logger, db).GetByName(r.Context(), repoName)
-		if err != nil {
-			return err
-		}
-		data, err := json.Marshal(repo)
-		if err != nil {
-			return err
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(data)
-		return nil
-	}
-}
 
 func servePhabricatorRepoCreate(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
@@ -112,34 +91,6 @@ func serveExternalServiceConfigs(db database.DB) func(w http.ResponseWriter, r *
 	}
 }
 
-// serveExternalServicesList serves a JSON response that is an array of all external services
-// of the given kind
-func serveExternalServicesList(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
-	return func(w http.ResponseWriter, r *http.Request) error {
-		var req api.ExternalServicesListRequest
-		err := json.NewDecoder(r.Body).Decode(&req)
-		if err != nil {
-			return err
-		}
-
-		options := database.ExternalServicesListOptions{
-			Kinds:   req.Kinds,
-			AfterID: int64(req.AfterID),
-		}
-		if req.Limit > 0 {
-			options.LimitOffset = &database.LimitOffset{
-				Limit: req.Limit,
-			}
-		}
-
-		services, err := db.ExternalServices().List(r.Context(), options)
-		if err != nil {
-			return err
-		}
-		return json.NewEncoder(w).Encode(services)
-	}
-}
-
 func serveConfiguration(w http.ResponseWriter, _ *http.Request) error {
 	raw := conf.Raw()
 	err := json.NewEncoder(w).Encode(raw)
@@ -149,89 +100,14 @@ func serveConfiguration(w http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
 
-func serveSettingsGetForSubject(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
-	return func(w http.ResponseWriter, r *http.Request) error {
-		var subject api.SettingsSubject
-		if err := json.NewDecoder(r.Body).Decode(&subject); err != nil {
-			return errors.Wrap(err, "Decode")
-		}
-		settings, err := db.Settings().GetLatest(r.Context(), subject)
-		if err != nil {
-			return errors.Wrap(err, "Settings.GetLatest")
-		}
-		if err := json.NewEncoder(w).Encode(settings); err != nil {
-			return errors.Wrap(err, "Encode")
-		}
-		return nil
-	}
-}
-
-func serveOrgsListUsers(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
-	return func(w http.ResponseWriter, r *http.Request) error {
-		var orgID int32
-		err := json.NewDecoder(r.Body).Decode(&orgID)
-		if err != nil {
-			return errors.Wrap(err, "Decode")
-		}
-		orgMembers, err := db.OrgMembers().GetByOrgID(r.Context(), orgID)
-		if err != nil {
-			return errors.Wrap(err, "OrgMembers.GetByOrgID")
-		}
-		users := make([]int32, 0, len(orgMembers))
-		for _, member := range orgMembers {
-			users = append(users, member.UserID)
-		}
-		if err := json.NewEncoder(w).Encode(users); err != nil {
-			return errors.Wrap(err, "Encode")
-		}
-		return nil
-	}
-}
-
-func serveOrgsGetByName(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
-	return func(w http.ResponseWriter, r *http.Request) error {
-		var orgName string
-		err := json.NewDecoder(r.Body).Decode(&orgName)
-		if err != nil {
-			return errors.Wrap(err, "Decode")
-		}
-		org, err := db.Orgs().GetByName(r.Context(), orgName)
-		if err != nil {
-			return errors.Wrap(err, "Orgs.GetByName")
-		}
-		if err := json.NewEncoder(w).Encode(org.ID); err != nil {
-			return errors.Wrap(err, "Encode")
-		}
-		return nil
-	}
-}
-
-func serveUserEmailsGetEmail(db database.DB) func(http.ResponseWriter, *http.Request) error {
-	return func(w http.ResponseWriter, r *http.Request) error {
-		var userID int32
-		err := json.NewDecoder(r.Body).Decode(&userID)
-		if err != nil {
-			return errors.Wrap(err, "Decode")
-		}
-		email, _, err := db.UserEmails().GetPrimaryEmail(r.Context(), userID)
-		if err != nil {
-			return errors.Wrap(err, "UserEmails.GetEmail")
-		}
-		if err := json.NewEncoder(w).Encode(email); err != nil {
-			return errors.Wrap(err, "Encode")
-		}
-		return nil
-	}
-}
-
-func serveExternalURL(w http.ResponseWriter, r *http.Request) error {
+func serveExternalURL(w http.ResponseWriter, _ *http.Request) error {
 	if err := json.NewEncoder(w).Encode(globals.ExternalURL().String()); err != nil {
 		return errors.Wrap(err, "Encode")
 	}
 	return nil
 }
 
-func serveSendEmail(w http.ResponseWriter, r *http.Request) error {
+func serveSendEmail(_ http.ResponseWriter, r *http.Request) error {
 	var msg txemail.Message
 	err := json.NewDecoder(r.Body).Decode(&msg)
 	if err != nil {

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -28,26 +28,18 @@ const (
 	BitbucketServerWebhooks = "bitbucketServer.webhooks"
 	BitbucketCloudWebhooks  = "bitbucketCloud.webhooks"
 
-	SettingsGetForSubject  = "internal.settings.get-for-subject"
-	OrgsListUsers          = "internal.orgs.list-users"
-	OrgsGetByName          = "internal.orgs.get-by-name"
-	UserEmailsGetEmail     = "internal.user-emails.get-email"
 	ExternalURL            = "internal.app-url"
 	SendEmail              = "internal.send-email"
-	Extension              = "internal.extension"
 	GitInfoRefs            = "internal.git.info-refs"
 	GitResolveRevision     = "internal.git.resolve-revision"
 	GitUploadPack          = "internal.git.upload-pack"
 	PhabricatorRepoCreate  = "internal.phabricator.repo.create"
-	ReposGetByName         = "internal.repos.get-by-name"
 	ReposInventoryUncached = "internal.repos.inventory-uncached"
 	ReposInventory         = "internal.repos.inventory"
-	ReposList              = "internal.repos.list"
 	ReposIndex             = "internal.repos.index"
 	Configuration          = "internal.configuration"
 	SearchConfiguration    = "internal.search-configuration"
 	ExternalServiceConfigs = "internal.external-services.configs"
-	ExternalServicesList   = "internal.external-services.list"
 	StreamingSearch        = "internal.stream-search"
 	Checks                 = "internal.checks"
 )
@@ -93,24 +85,16 @@ func NewInternal(base *mux.Router) *mux.Router {
 
 	base.StrictSlash(true)
 	// Internal API endpoints should only be served on the internal Handler
-	base.Path("/settings/get-for-subject").Methods("POST").Name(SettingsGetForSubject)
-	base.Path("/orgs/list-users").Methods("POST").Name(OrgsListUsers)
-	base.Path("/orgs/get-by-name").Methods("POST").Name(OrgsGetByName)
-	base.Path("/user-emails/get-email").Methods("POST").Name(UserEmailsGetEmail)
 	base.Path("/app-url").Methods("POST").Name(ExternalURL)
 	base.Path("/send-email").Methods("POST").Name(SendEmail)
-	base.Path("/extension").Methods("POST").Name(Extension)
 	base.Path("/git/{RepoName:.*}/info/refs").Methods("GET").Name(GitInfoRefs)
 	base.Path("/git/{RepoName:.*}/resolve-revision/{Spec}").Methods("GET").Name(GitResolveRevision)
 	base.Path("/git/{RepoName:.*}/git-upload-pack").Methods("GET", "POST").Name(GitUploadPack)
 	base.Path("/phabricator/repo-create").Methods("POST").Name(PhabricatorRepoCreate)
 	base.Path("/external-services/configs").Methods("POST").Name(ExternalServiceConfigs)
-	base.Path("/external-services/list").Methods("POST").Name(ExternalServicesList)
 	base.Path("/repos/inventory-uncached").Methods("POST").Name(ReposInventoryUncached)
 	base.Path("/repos/inventory").Methods("POST").Name(ReposInventory)
-	base.Path("/repos/list").Methods("POST").Name(ReposList)
 	base.Path("/repos/index").Methods("POST").Name(ReposIndex)
-	base.Path("/repos/{RepoName:.*}").Methods("POST").Name(ReposGetByName)
 	base.Path("/configuration").Methods("POST").Name(Configuration)
 	base.Path("/search/configuration").Methods("GET", "POST").Name(SearchConfiguration)
 	base.Path("/telemetry").Methods("POST").Name(Telemetry)

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -795,8 +795,13 @@ func TestServer_handleExternalServiceSync(t *testing.T) {
 			}
 			r := httptest.NewRequest("POST", "/sync-external-service", strings.NewReader(`{"ExternalService": {"ID":1,"kind":"GITHUB"}}}`))
 			w := httptest.NewRecorder()
-			s := &Server{Logger: logtest.Scoped(t), Syncer: &repos.Syncer{Sourcer: repos.NewFakeSourcer(nil, src)}}
-			s.handleExternalServiceSync(w, r)
+			s := repos.NewMockStore()
+			es := database.NewMockExternalServiceStore()
+			s.ExternalServiceStoreFunc.SetDefaultReturn(es)
+			es.GetByIDFunc.PushReturn(&types.ExternalService{ID: 1, Kind: extsvc.KindGitHub}, nil)
+
+			srv := &Server{Logger: logtest.Scoped(t), Store: s, Syncer: &repos.Syncer{Sourcer: repos.NewFakeSourcer(nil, src)}}
+			srv.handleExternalServiceSync(w, r)
 			if w.Code != test.wantErrCode {
 				t.Errorf("Code: want %v but got %v", test.wantErrCode, w.Code)
 			}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -1269,7 +1269,7 @@ func TestTriggerTestEmailAction(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	got := background.TemplateDataNewSearchResults{}
-	background.MockSendEmailForNewSearchResult = func(ctx context.Context, userID int32, data *background.TemplateDataNewSearchResults) error {
+	background.MockSendEmailForNewSearchResult = func(ctx context.Context, db database.DB, userID int32, data *background.TemplateDataNewSearchResults) error {
 		got = *data
 		return nil
 	}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -283,7 +284,7 @@ func (r *actionRunner) handleEmail(ctx context.Context, j *edb.ActionJob) error 
 		if rec.NamespaceUserID == nil {
 			return errors.New("nil recipient")
 		}
-		err = SendEmailForNewSearchResult(ctx, *rec.NamespaceUserID, data)
+		err = SendEmailForNewSearchResult(ctx, database.NewDBWith(log.Scoped("handleEmail", ""), r.CodeMonitorStore), *rec.NamespaceUserID, data)
 		if err != nil {
 			return err
 		}

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -46,7 +46,7 @@ func TestActionRunner(t *testing.T) {
 
 			// Mocks.
 			got := TemplateDataNewSearchResults{}
-			MockSendEmailForNewSearchResult = func(ctx context.Context, userID int32, data *TemplateDataNewSearchResults) error {
+			MockSendEmailForNewSearchResult = func(ctx context.Context, db database.DB, userID int32, data *TemplateDataNewSearchResults) error {
 				got = *data
 				return nil
 			}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -158,6 +158,7 @@ type Settings struct {
 }
 
 // ExternalService represents a complete external service record.
+// TODO(eseliger): Remove this post the 3.43 release.
 type ExternalService struct {
 	ID              int64
 	Kind            string

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -103,7 +103,11 @@ func (s *userEmailsStore) GetPrimaryEmail(ctx context.Context, id int32) (email 
 	if err := s.Handle().QueryRowContext(ctx, "SELECT email, verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND is_primary",
 		id,
 	).Scan(&email, &verified); err != nil {
-		return "", false, userEmailNotFoundError{[]any{fmt.Sprintf("id %d", id)}}
+		if err == sql.ErrNoRows {
+			return "", false, userEmailNotFoundError{[]any{fmt.Sprintf("id %d", id)}}
+		}
+
+		return "", false, err
 	}
 	return email, verified, nil
 }

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -239,7 +239,7 @@ func (c *Client) SyncExternalService(
 	ctx context.Context,
 	svc api.ExternalService,
 ) (*protocol.ExternalServiceSyncResult, error) {
-	req := &protocol.ExternalServiceSyncRequest{ExternalService: svc}
+	req := &protocol.ExternalServiceSyncRequest{ExternalServiceID: svc.ID, ExternalService: svc}
 	resp, err := c.httpPost(ctx, "sync-external-service", req)
 	if err != nil {
 		return nil, err
@@ -266,31 +266,6 @@ func (c *Client) SyncExternalService(
 		return nil, errors.New(result.Error)
 	}
 	return &result, nil
-}
-
-// RepoExternalServices requests the external services associated with a
-// repository with the given id.
-func (c *Client) RepoExternalServices(ctx context.Context, id api.RepoID) ([]api.ExternalService, error) {
-	req := protocol.RepoExternalServicesRequest{ID: id}
-	resp, err := c.httpPost(ctx, "repo-external-services", &req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	bs, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read response body")
-	}
-
-	var res protocol.RepoExternalServicesResponse
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return nil, errors.New(string(bs))
-	} else if err = json.Unmarshal(bs, &res); err != nil {
-		return nil, err
-	}
-
-	return res.ExternalServices, nil
 }
 
 func (c *Client) httpPost(ctx context.Context, method string, payload any) (resp *http.Response, err error) {

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -40,19 +40,6 @@ type RepoQueueState struct {
 	Priority int
 }
 
-// RepoExternalServicesRequest is a request for the external services
-// associated with a repository.
-type RepoExternalServicesRequest struct {
-	// ID of the repository being queried.
-	ID api.RepoID
-}
-
-// RepoExternalServicesResponse is returned in response to an
-// RepoExternalServicesRequest.
-type RepoExternalServicesResponse struct {
-	ExternalServices []api.ExternalService
-}
-
 // RepoLookupArgs is a request for information about a repository on repoupdater.
 type RepoLookupArgs struct {
 	// Repo is the repository name to look up.
@@ -274,7 +261,9 @@ type PermsSyncResponse struct {
 // updating an external service so that admins don't have to wait until the next sync
 // run to see their repos being synced.
 type ExternalServiceSyncRequest struct {
-	ExternalService api.ExternalService
+	// TODO(eseliger): We can remove this after the 3.43 release, it's for backwards compatibility only.
+	ExternalService   api.ExternalService
+	ExternalServiceID int64
 }
 
 // ExternalServiceSyncResult is a result type of an external service's sync request.


### PR DESCRIPTION
Removes some more dead code and starts a new deprecation for the external service API type.

## Test plan

Relying on test suite for this, also Keegan already identified these routes as unused in https://github.com/sourcegraph/sourcegraph/issues/36290.