### PR TITLE
frontend: add service registry

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -145,6 +145,16 @@ func Main(enterpriseSetupHook func(database.DB, conftypes.UnifiedWatchable) ente
 	}
 	db := database.NewDB(logger, sqlDB)
 
+	servicesStore := db.Services()
+	go func() {
+		for {
+			time.Sleep(60 * time.Second)
+			if err := servicesStore.Invalidate(ctx, 90*time.Second); err != nil {
+				logger.Warn("error while invalidating service registry", sglog.Error(err))
+			}
+		}
+	}()
+
 	if os.Getenv("SRC_DISABLE_OOBMIGRATION_VALIDATION") != "" {
 		log15.Warn("Skipping out-of-band migrations check")
 	} else {

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/requestclient"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -209,6 +210,10 @@ func NewInternalHandler(
 	m.Get(apirouter.ComputeStream).Handler(trace.Route(newComputeStreamHandler()))
 
 	m.Get(apirouter.LSIFUpload).Handler(trace.Route(newCodeIntelUploadHandler(false)))
+
+	m.Get(apirouter.ServiceRegister).Handler(trace.Route(requestclient.HTTPMiddleware(http.HandlerFunc(newServiceRegisterHandler(db)))))
+	m.Get(apirouter.ServiceDeregister).Handler(trace.Route(http.HandlerFunc(newServiceDeregisterHandler(db))))
+	m.Get(apirouter.ServiceRenew).Handler(trace.Route(http.HandlerFunc(newServiceRenewHandler(db))))
 
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("API no route: %s %s from %s", r.Method, r.URL, r.Referer())

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -46,6 +46,9 @@ const (
 	RepoRank               = "internal.repo-rank"
 	DocumentRanks          = "internal.document-ranks"
 	UpdateIndexStatus      = "internal.update-index-status"
+	ServiceRegister        = "internal.service.register"
+	ServiceRenew           = "internal.service.renew"
+	ServiceDeregister      = "internal.service.deregister"
 )
 
 // New creates a new API router with route URL pattern definitions but
@@ -109,6 +112,15 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/lsif/upload").Methods("POST").Name(LSIFUpload)
 	base.Path("/search/stream").Methods("GET").Name(StreamingSearch)
 	base.Path("/compute/stream").Methods("GET", "POST").Name(ComputeStream)
+
+	// service registry
+	//
+	// instanceID is a unique id for each instance of a service. The instanceID is
+	// returned by POST when the instance registers.
+	base.Path("/services/{name}").Methods("POST").Name(ServiceRegister)
+	base.Path("/services/{name}/{instanceID}").Methods("PUT").Name(ServiceRenew)
+	base.Path("/services/{name}/{instanceID}").Methods("DELETE").Name(ServiceDeregister)
+
 	addRegistryRoute(base)
 	addGraphQLRoute(base)
 

--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -6910,6 +6910,9 @@ type MockEnterpriseDB struct {
 	// SecurityEventLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method SecurityEventLogs.
 	SecurityEventLogsFunc *EnterpriseDBSecurityEventLogsFunc
+	// ServicesFunc is an instance of a mock function object controlling the
+	// behavior of the method Services.
+	ServicesFunc *EnterpriseDBServicesFunc
 	// SettingsFunc is an instance of a mock function object controlling the
 	// behavior of the method Settings.
 	SettingsFunc *EnterpriseDBSettingsFunc
@@ -7109,6 +7112,11 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 		},
 		SecurityEventLogsFunc: &EnterpriseDBSecurityEventLogsFunc{
 			defaultHook: func() (r0 database.SecurityEventLogsStore) {
+				return
+			},
+		},
+		ServicesFunc: &EnterpriseDBServicesFunc{
+			defaultHook: func() (r0 database.ServicesStore) {
 				return
 			},
 		},
@@ -7339,6 +7347,11 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 				panic("unexpected invocation of MockEnterpriseDB.SecurityEventLogs")
 			},
 		},
+		ServicesFunc: &EnterpriseDBServicesFunc{
+			defaultHook: func() database.ServicesStore {
+				panic("unexpected invocation of MockEnterpriseDB.Services")
+			},
+		},
 		SettingsFunc: &EnterpriseDBSettingsFunc{
 			defaultHook: func() database.SettingsStore {
 				panic("unexpected invocation of MockEnterpriseDB.Settings")
@@ -7502,6 +7515,9 @@ func NewMockEnterpriseDBFrom(i EnterpriseDB) *MockEnterpriseDB {
 		},
 		SecurityEventLogsFunc: &EnterpriseDBSecurityEventLogsFunc{
 			defaultHook: i.SecurityEventLogs,
+		},
+		ServicesFunc: &EnterpriseDBServicesFunc{
+			defaultHook: i.Services,
 		},
 		SettingsFunc: &EnterpriseDBSettingsFunc{
 			defaultHook: i.Settings,
@@ -10776,6 +10792,105 @@ func (c EnterpriseDBSecurityEventLogsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EnterpriseDBSecurityEventLogsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// EnterpriseDBServicesFunc describes the behavior when the Services method
+// of the parent MockEnterpriseDB instance is invoked.
+type EnterpriseDBServicesFunc struct {
+	defaultHook func() database.ServicesStore
+	hooks       []func() database.ServicesStore
+	history     []EnterpriseDBServicesFuncCall
+	mutex       sync.Mutex
+}
+
+// Services delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockEnterpriseDB) Services() database.ServicesStore {
+	r0 := m.ServicesFunc.nextHook()()
+	m.ServicesFunc.appendCall(EnterpriseDBServicesFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Services method of
+// the parent MockEnterpriseDB instance is invoked and the hook queue is
+// empty.
+func (f *EnterpriseDBServicesFunc) SetDefaultHook(hook func() database.ServicesStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Services method of the parent MockEnterpriseDB instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *EnterpriseDBServicesFunc) PushHook(hook func() database.ServicesStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBServicesFunc) SetDefaultReturn(r0 database.ServicesStore) {
+	f.SetDefaultHook(func() database.ServicesStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBServicesFunc) PushReturn(r0 database.ServicesStore) {
+	f.PushHook(func() database.ServicesStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBServicesFunc) nextHook() func() database.ServicesStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBServicesFunc) appendCall(r0 EnterpriseDBServicesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnterpriseDBServicesFuncCall objects
+// describing the invocations of this function.
+func (f *EnterpriseDBServicesFunc) History() []EnterpriseDBServicesFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBServicesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBServicesFuncCall is an object that describes an invocation of
+// method Services on an instance of MockEnterpriseDB.
+type EnterpriseDBServicesFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.ServicesStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBServicesFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBServicesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -41,6 +41,7 @@ type DB interface {
 	RepoKVPs() RepoKVPStore
 	SavedSearches() SavedSearchStore
 	SearchContexts() SearchContextsStore
+	Services() ServicesStore
 	Settings() SettingsStore
 	SubRepoPerms() SubRepoPermsStore
 	TemporarySettings() TemporarySettingsStore
@@ -216,6 +217,10 @@ func (d *db) UserPublicRepos() UserPublicRepoStore {
 
 func (d *db) Users() UserStore {
 	return UsersWith(d.logger, d.Store)
+}
+
+func (d *db) Services() ServicesStore {
+	return ServicesWith(d.logger, d.Store)
 }
 
 func (d *db) WebhookLogs(key encryption.Key) WebhookLogStore {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -3711,6 +3711,9 @@ type MockDB struct {
 	// SecurityEventLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method SecurityEventLogs.
 	SecurityEventLogsFunc *DBSecurityEventLogsFunc
+	// ServicesFunc is an instance of a mock function object controlling the
+	// behavior of the method Services.
+	ServicesFunc *DBServicesFunc
 	// SettingsFunc is an instance of a mock function object controlling the
 	// behavior of the method Settings.
 	SettingsFunc *DBSettingsFunc
@@ -3900,6 +3903,11 @@ func NewMockDB() *MockDB {
 		},
 		SecurityEventLogsFunc: &DBSecurityEventLogsFunc{
 			defaultHook: func() (r0 SecurityEventLogsStore) {
+				return
+			},
+		},
+		ServicesFunc: &DBServicesFunc{
+			defaultHook: func() (r0 ServicesStore) {
 				return
 			},
 		},
@@ -4120,6 +4128,11 @@ func NewStrictMockDB() *MockDB {
 				panic("unexpected invocation of MockDB.SecurityEventLogs")
 			},
 		},
+		ServicesFunc: &DBServicesFunc{
+			defaultHook: func() ServicesStore {
+				panic("unexpected invocation of MockDB.Services")
+			},
+		},
 		SettingsFunc: &DBSettingsFunc{
 			defaultHook: func() SettingsStore {
 				panic("unexpected invocation of MockDB.Settings")
@@ -4276,6 +4289,9 @@ func NewMockDBFrom(i DB) *MockDB {
 		},
 		SecurityEventLogsFunc: &DBSecurityEventLogsFunc{
 			defaultHook: i.SecurityEventLogs,
+		},
+		ServicesFunc: &DBServicesFunc{
+			defaultHook: i.Services,
 		},
 		SettingsFunc: &DBSettingsFunc{
 			defaultHook: i.Settings,
@@ -7326,6 +7342,104 @@ func (c DBSecurityEventLogsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBSecurityEventLogsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBServicesFunc describes the behavior when the Services method of the
+// parent MockDB instance is invoked.
+type DBServicesFunc struct {
+	defaultHook func() ServicesStore
+	hooks       []func() ServicesStore
+	history     []DBServicesFuncCall
+	mutex       sync.Mutex
+}
+
+// Services delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockDB) Services() ServicesStore {
+	r0 := m.ServicesFunc.nextHook()()
+	m.ServicesFunc.appendCall(DBServicesFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Services method of
+// the parent MockDB instance is invoked and the hook queue is empty.
+func (f *DBServicesFunc) SetDefaultHook(hook func() ServicesStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Services method of the parent MockDB instance invokes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *DBServicesFunc) PushHook(hook func() ServicesStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBServicesFunc) SetDefaultReturn(r0 ServicesStore) {
+	f.SetDefaultHook(func() ServicesStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBServicesFunc) PushReturn(r0 ServicesStore) {
+	f.PushHook(func() ServicesStore {
+		return r0
+	})
+}
+
+func (f *DBServicesFunc) nextHook() func() ServicesStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBServicesFunc) appendCall(r0 DBServicesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBServicesFuncCall objects describing the
+// invocations of this function.
+func (f *DBServicesFunc) History() []DBServicesFuncCall {
+	f.mutex.Lock()
+	history := make([]DBServicesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBServicesFuncCall is an object that describes an invocation of method
+// Services on an instance of MockDB.
+type DBServicesFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 ServicesStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBServicesFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBServicesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -18224,6 +18224,91 @@
       "Triggers": []
     },
     {
+      "Name": "service_registry",
+      "Comment": "Records services that register with the service registry in frontend.",
+      "Columns": [
+        {
+          "Name": "hostname",
+          "Index": 3,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "ip",
+          "Index": 1,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "last_heartbeat",
+          "Index": 5,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": true,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The last time the service sent a renewal request to the service registry."
+        },
+        {
+          "Name": "port",
+          "Index": 2,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "service",
+          "Index": 4,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "service_registry_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX service_registry_pkey ON service_registry USING btree (ip, port)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (ip, port)"
+        }
+      ],
+      "Constraints": null,
+      "Triggers": []
+    },
+    {
       "Name": "settings",
       "Comment": "",
       "Columns": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2855,6 +2855,24 @@ Contains security-relevant events with a long time horizon for storage.
 
 **version**: The version of Sourcegraph which generated the event.
 
+# Table "public.service_registry"
+```
+     Column     |           Type           | Collation | Nullable | Default 
+----------------+--------------------------+-----------+----------+---------
+ ip             | text                     |           | not null | 
+ port           | integer                  |           | not null | 
+ hostname       | text                     |           | not null | 
+ service        | text                     |           | not null | 
+ last_heartbeat | timestamp with time zone |           |          | now()
+Indexes:
+    "service_registry_pkey" PRIMARY KEY, btree (ip, port)
+
+```
+
+Records services that register with the service registry in frontend.
+
+**last_heartbeat**: The last time the service sent a renewal request to the service registry.
+
 # Table "public.settings"
 ```
      Column     |           Type           | Collation | Nullable |               Default                

--- a/internal/database/service_registry.go
+++ b/internal/database/service_registry.go
@@ -1,0 +1,157 @@
+package database
+
+import (
+	"context"
+	"net/netip"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type ServiceArgs struct {
+	// We ignore the IP address for JSON marshalling because we extract it from the
+	// request and not from the JSON payload.
+	IP netip.Addr `json:"-"`
+
+	// Required
+	// Valid ports are >0.
+	Port uint16 `json:"port"`
+	// The self-reported hostname of the server.
+	Hostname string `json:"hostname"`
+}
+
+type ServicesStore interface {
+	Register(ctx context.Context, service string, args ServiceArgs) (string, error)
+	Renew(ctx context.Context, service, id string) error
+	Deregister(ctx context.Context, service, id string) error
+
+	GetByService(ctx context.Context, service string) ([]ServiceArgs, error)
+	Invalidate(ctx context.Context, age time.Duration) error
+}
+
+type servicesStore struct {
+	logger log.Logger
+	*basestore.Store
+}
+
+func ServicesWith(logger log.Logger, other basestore.ShareableStore) ServicesStore {
+	return &servicesStore{
+		logger: logger,
+		Store:  basestore.NewWithHandle(other.Handle()),
+	}
+}
+
+var _ ServicesStore = (*servicesStore)(nil)
+
+const registerFmtStr = `
+-- source: /internal/database/service_registry.go:Register
+INSERT INTO service_registry (service, ip, port, hostname)
+VALUES (%s, %s, %d, %s)`
+
+func (s servicesStore) Register(ctx context.Context, service string, args ServiceArgs) (string, error) {
+	err := s.Exec(ctx, sqlf.Sprintf(registerFmtStr, service, args.IP.String(), args.Port, args.Hostname))
+	if err != nil {
+		return "", err
+	}
+
+	// We use the combination of IP and port as instanceID. However, the ID is
+	// arbitrary as long as it is unique for each instance. By using IP and
+	// port we avoid storing an extra string field in the DB. The caller should
+	// treat the returned ID as an opaque string.
+	return netip.AddrPortFrom(args.IP, args.Port).String(), nil
+}
+
+const renewFmtStr = `
+-- source: /internal/database/service_registry.go:Renew
+UPDATE service_registry
+SET last_heartbeat = now()
+WHERE service = %s
+AND ip = %s
+AND port = %d`
+
+func (s servicesStore) Renew(ctx context.Context, service, id string) error {
+	return s.renewOrDeregister(ctx, renewFmtStr, service, id)
+}
+
+const deregisterFmtStr = `
+-- source: /internal/database/service_registry.go:Deregister
+DELETE FROM service_registry
+WHERE service = %s
+AND ip = %s
+AND port = %d`
+
+func (s servicesStore) Deregister(ctx context.Context, service, id string) error {
+	return s.renewOrDeregister(ctx, deregisterFmtStr, service, id)
+}
+
+func (s servicesStore) renewOrDeregister(ctx context.Context, queryStr, service, id string) error {
+	addrPort, err := netip.ParseAddrPort(id)
+	if err != nil {
+		return errors.Wrapf(err, "id=%q", id)
+	}
+
+	res, err := s.ExecResult(ctx, sqlf.Sprintf(queryStr, service, addrPort.Addr().String(), addrPort.Port()))
+	if err != nil {
+		return err
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return NotFoundError{errors.New("unknown service or id")}
+	}
+	return nil
+}
+
+type NotFoundError struct {
+	error
+}
+
+func (e NotFoundError) NotFound() bool {
+	return true
+}
+
+const getByServiceFmtStr = `
+-- source: /internal/database/service_registry.go:GetByService
+SELECT ip, port, hostname FROM service_registry where service = %s`
+
+func (s servicesStore) GetByService(ctx context.Context, service string) (instances []ServiceArgs, err error) {
+	rows, err := s.Query(ctx, sqlf.Sprintf(getByServiceFmtStr, service))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ipStr := ""
+	for rows.Next() {
+		instance := ServiceArgs{}
+		if err := rows.Scan(
+			&ipStr,
+			&instance.Port,
+			&instance.Hostname,
+		); err != nil {
+			return nil, err
+		}
+		instance.IP, err = netip.ParseAddr(ipStr)
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, instance)
+	}
+	return
+}
+
+const invalidateFmtStr = `
+-- source: /internal/database/service_registry.go:Invalidate
+DELETE from service_registry
+WHERE last_heartbeat < (NOW() - (%s * '1 second'::interval));`
+
+func (s servicesStore) Invalidate(ctx context.Context, age time.Duration) error {
+	return s.Exec(ctx, sqlf.Sprintf(invalidateFmtStr, int(age/time.Second)))
+}

--- a/internal/database/service_registry_test.go
+++ b/internal/database/service_registry_test.go
@@ -1,0 +1,101 @@
+package database
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestServiceRegistry(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	store := db.Services()
+	service := "zoekt-indexserver"
+
+	err := store.Renew(ctx, service, "127.0.0.1:1234")
+	if err == nil {
+		t.Fatal("the store should have complained because we cannot renew before registering")
+	}
+
+	err = store.Deregister(ctx, service, "127.0.0.1:1234")
+	if err == nil {
+		t.Fatal("the store should have complained because we cannot de-register before registering")
+	}
+
+	addr, err := netip.ParseAddr("127.0.0.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id1, err := store.Register(ctx, service, ServiceArgs{
+		IP:       addr,
+		Port:     1234,
+		Hostname: "host1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.Register(ctx, service, ServiceArgs{
+		IP:       addr,
+		Port:     1235,
+		Hostname: "host2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.Renew(ctx, service, id1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instances, err := store.GetByService(ctx, service)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(instances) != 2 {
+		t.Fatal("expected 2 instances")
+	}
+
+	err = store.Deregister(ctx, service, id1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instances, err = store.GetByService(ctx, service)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(instances) != 1 {
+		t.Fatal("expected 1 instance")
+	}
+
+	if got := instances[0].Hostname; got != "host2" {
+		t.Fatalf("want %q, got %q", "host2", got)
+	}
+
+	err = store.Invalidate(ctx, 0*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instances, err = store.GetByService(ctx, service)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(instances) != 0 {
+		t.Fatalf("instances: want=0, have=%d", len(instances))
+	}
+}

--- a/migrations/frontend/1669365596_add_table_for_service_registry/down.sql
+++ b/migrations/frontend/1669365596_add_table_for_service_registry/down.sql
@@ -1,0 +1,3 @@
+-- Undo the changes made in the up migration
+DROP TABLE IF EXISTS service_registry;
+

--- a/migrations/frontend/1669365596_add_table_for_service_registry/metadata.yaml
+++ b/migrations/frontend/1669365596_add_table_for_service_registry/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_table_for_service_registry
+parents: [1669184869]

--- a/migrations/frontend/1669365596_add_table_for_service_registry/up.sql
+++ b/migrations/frontend/1669365596_add_table_for_service_registry/up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS service_registry
+(
+    ip                text,
+    port              integer NOT NULL,
+    hostname          text    NOT NULL,
+    service           text    NOT NULL,
+    last_heartbeat    timestamp with time zone DEFAULT now(),
+    PRIMARY KEY (ip, port)
+);
+
+COMMENT ON TABLE service_registry IS 'Records services that register with the service registry in frontend.';
+
+COMMENT ON COLUMN service_registry.last_heartbeat IS 'The last time the service sent a renewal request to the service registry.';
+

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3427,6 +3427,18 @@ CREATE SEQUENCE security_event_logs_id_seq
 
 ALTER SEQUENCE security_event_logs_id_seq OWNED BY security_event_logs.id;
 
+CREATE TABLE service_registry (
+    ip text NOT NULL,
+    port integer NOT NULL,
+    hostname text NOT NULL,
+    service text NOT NULL,
+    last_heartbeat timestamp with time zone DEFAULT now()
+);
+
+COMMENT ON TABLE service_registry IS 'Records services that register with the service registry in frontend.';
+
+COMMENT ON COLUMN service_registry.last_heartbeat IS 'The last time the service sent a renewal request to the service registry.';
+
 CREATE TABLE settings (
     id integer NOT NULL,
     org_id integer,
@@ -4197,6 +4209,9 @@ ALTER TABLE ONLY search_contexts
 
 ALTER TABLE ONLY security_event_logs
     ADD CONSTRAINT security_event_logs_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY service_registry
+    ADD CONSTRAINT service_registry_pkey PRIMARY KEY (ip, port);
 
 ALTER TABLE ONLY settings
     ADD CONSTRAINT settings_pkey PRIMARY KEY (id);


### PR DESCRIPTION
This adds a tiny service registry to frontend. 

## Why?
- We want to add a "re-index" button to the index status page.
- Frontend doesn't know the addresses of the Zoekt indexservers.
- Other projects that could potentially benefit: 1-click export, health-checker

## Goals
- Create a simple but resilliant service registry
- Support all environments Sourcegraph can run on (server, docker-compose, K8S, other containerized environments) 
- Don't require open ports other than those which are already open
- Don't add another service
- Don't create too much load on frontend

## Non-goals
- Make this a general purose service registry that is useful beyond Sourcegraph

## Not part of this PR
- a client for the service registry. Once/if this is merged, we can create a separate repo (sourcegraph/registry-client) that both Sourcegraph and Zoekt can import. 

## Design
![image](https://user-images.githubusercontent.com/26413131/180753434-4208b9de-99bf-4d39-94af-f82ac0b48af7.png)

## Test plan
- local testing
```bash
# create record
 curl -v -X POST http://localhost:3090/.internal/services/foobar -d '{"port": 8119, "health_check_path": "/healthz", "hostname": "host1"}'

# renew
curl -v -X PUT http://localhost:3090/.internal/services/foobar/127.0.0.1:8119

# delete
curl -v -X DELETE http://localhost:3090/.internal/services/foobar/127.0.0.1:8119
```
- Checked that manually created entries expire if they are not renewed
- Wrote a basic client for Zoekt (not part of this PR) and verified that db records show up as expected.  




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
