### PR TITLE
flake: disable TestSearch/repo:deps in gqltest

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -97,6 +97,8 @@ func TestSearch(t *testing.T) {
 	// Adding and deleting the dependency repos external services in between all other tests is
 	// flaky since deleting an external service doesn't cancel a running external
 	// service sync job for it.
+
+	// 2022-07-22 - This test is skipped as it is flakey
 	t.Run("repo:deps", testDependenciesSearch(client, streamClient))
 }
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1370,6 +1370,8 @@ func enableGlobalLockfileIndexing(t *testing.T) {
 
 func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) {
 	return func(t *testing.T) {
+		t.Skipf("Skipping test as it suspected to be flakey")
+
 		t.Helper()
 
 		// Setup global lockfile indexing


### PR DESCRIPTION
[Offending build](https://buildkite.com/sourcegraph/sourcegraph/builds/162711#018226aa-3eab-4a76-9138-c7689e3c3403)
[Loki Query](https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22buildkite%5C%22,%20branch%3D%5C%22main%5C%22,%20state%3D%5C%22failed%5C%22%7D%20%7C%3D%20%5C%22FAIL:%20TestSearch%2Frepo:deps%5C%22%5Cn%22%7D%5D,%22range%22:%7B%22from%22:%22now-20d%22,%22to%22:%22now%22%7D%7D)
![image](https://user-images.githubusercontent.com/1001709/180487363-7caa57e6-d18b-4b46-9daa-ba7ddbe22542.png)

## Test plan
Disabling test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
