### PR TITLE
disable Bitbucket perm sync test

### DIFF
--- a/dev/gqltest/bitbucket_projects_perms_sync_test.go
+++ b/dev/gqltest/bitbucket_projects_perms_sync_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestBitbucketProjectsPermsSync_SetPermissionsUnrestricted(t *testing.T) {
+	t.Skipf("disabling broken test to unblock main")
 	if len(*bbsURL) == 0 || len(*bbsToken) == 0 || len(*bbsUsername) == 0 {
 		t.Skip("Environment variable BITBUCKET_SERVER_URL, BITBUCKET_SERVER_TOKEN, or BITBUCKET_SERVER_USERNAME is not set")
 	}


### PR DESCRIPTION
test is broken on main - timing out
See builds:
* https://buildkite.com/sourcegraph/sourcegraph/builds/162722#018226e1-881e-4777-b4dc-8dcf5215a644
* https://buildkite.com/sourcegraph/sourcegraph/builds/162711#018226aa-3eab-4a76-9138-c7689e3c3403
## Test plan
none - disabling test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
