### PR TITLE
batches: Add computed state value to DB

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -710,7 +710,7 @@ type ChangesetResolver interface {
 	// ExternalState returns a value of type *btypes.ChangesetExternalState.
 	ExternalState() *string
 	// State returns a value of type *btypes.ChangesetState.
-	State() (string, error)
+	State() string
 	BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
 
 	ToExternalChangeset() (ExternalChangesetResolver, bool)

--- a/dev/ci/go-backcompat/flakefiles/v3.42.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.42.0.json
@@ -28,5 +28,10 @@
     "path": "enterprise/internal/batches/store",
     "prefix": "TestIntegration",
     "reason": "New DB structure doesn't work with old test helper data."
+  },
+  {
+    "path": "enterprise/internal/batches/store",
+    "prefix": "TestCancelQueuedBatchChangeChangesets",
+    "reason": "New DB structure doesn't work with old test helper data."
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v3.42.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.42.0.json
@@ -3,5 +3,30 @@
     "path": "internal/usagestats",
     "prefix": "TestGetBatchChangesUsageStatistics",
     "reason": "Fixed up DB constraints, now the test inserts invalid test data."
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/resolvers",
+    "prefix": "TestPublishChangesets",
+    "reason": "New DB structure doesn't work with old test helper data."
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/resolvers",
+    "prefix": "TestReenqueueChangesets",
+    "reason": "New DB structure doesn't work with old test helper data."
+  },
+  {
+    "path": "enterprise/internal/batches/processor",
+    "prefix": "TestBulkProcessor",
+    "reason": "New DB structure doesn't work with old test helper data."
+  },
+  {
+    "path": "enterprise/internal/batches/service",
+    "prefix": "TestService",
+    "reason": "New DB structure doesn't work with old test helper data."
+  },
+  {
+    "path": "enterprise/internal/batches/store",
+    "prefix": "TestIntegration",
+    "reason": "New DB structure doesn't work with old test helper data."
   }
 ]

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -315,43 +315,8 @@ func (r *changesetResolver) ExternalState() *string {
 	return &state
 }
 
-func (r *changesetResolver) State() (string, error) {
-	// Note that there's an inverse version of this function in
-	// getRewirerMappingCurrentState(): if one changes, so should the other.
-
-	switch r.changeset.ReconcilerState {
-	case btypes.ReconcilerStateErrored:
-		return string(btypes.ChangesetStateRetrying), nil
-	case btypes.ReconcilerStateFailed:
-		return string(btypes.ChangesetStateFailed), nil
-	case btypes.ReconcilerStateScheduled:
-		return string(btypes.ChangesetStateScheduled), nil
-	default:
-		if r.changeset.ReconcilerState != btypes.ReconcilerStateCompleted {
-			return string(btypes.ChangesetStateProcessing), nil
-		}
-	}
-
-	if r.changeset.PublicationState == btypes.ChangesetPublicationStateUnpublished {
-		return string(btypes.ChangesetStateUnpublished), nil
-	}
-
-	switch r.changeset.ExternalState {
-	case btypes.ChangesetExternalStateDraft:
-		return string(btypes.ChangesetStateDraft), nil
-	case btypes.ChangesetExternalStateOpen:
-		return string(btypes.ChangesetStateOpen), nil
-	case btypes.ChangesetExternalStateClosed:
-		return string(btypes.ChangesetStateClosed), nil
-	case btypes.ChangesetExternalStateMerged:
-		return string(btypes.ChangesetStateMerged), nil
-	case btypes.ChangesetExternalStateDeleted:
-		return string(btypes.ChangesetStateDeleted), nil
-	case btypes.ChangesetExternalStateReadOnly:
-		return string(btypes.ChangesetStateReadOnly), nil
-	default:
-		return "", errors.Errorf("invalid ExternalState %q for state calculation", r.changeset.ExternalState)
-	}
+func (r *changesetResolver) State() string {
+	return string(r.changeset.State)
 }
 
 func (r *changesetResolver) ExternalURL() (*externallink.Resolver, error) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -863,13 +863,7 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 			return opts, false, errors.New("invalid combination of state and onlyClosable")
 		}
 
-		publicationState := btypes.ChangesetPublicationStatePublished
-		opts.ExternalStates = []btypes.ChangesetExternalState{
-			btypes.ChangesetExternalStateDraft,
-			btypes.ChangesetExternalStateOpen,
-		}
-		opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
-		opts.PublicationState = &publicationState
+		opts.States = []btypes.ChangesetState{btypes.ChangesetStateOpen, btypes.ChangesetStateDraft}
 	}
 
 	if args.State != nil {
@@ -878,58 +872,7 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 			return opts, false, errors.New("changeset state not valid")
 		}
 
-		switch state {
-		case btypes.ChangesetStateOpen:
-			externalState := btypes.ChangesetExternalStateOpen
-			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
-			opts.PublicationState = &publicationState
-		case btypes.ChangesetStateDraft:
-			externalState := btypes.ChangesetExternalStateDraft
-			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
-			opts.PublicationState = &publicationState
-		case btypes.ChangesetStateClosed:
-			externalState := btypes.ChangesetExternalStateClosed
-			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
-			opts.PublicationState = &publicationState
-		case btypes.ChangesetStateMerged:
-			externalState := btypes.ChangesetExternalStateMerged
-			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
-			opts.PublicationState = &publicationState
-		case btypes.ChangesetStateDeleted:
-			externalState := btypes.ChangesetExternalStateDeleted
-			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
-			opts.PublicationState = &publicationState
-		case btypes.ChangesetStateReadOnly:
-			externalState := btypes.ChangesetExternalStateReadOnly
-			publicationState := btypes.ChangesetPublicationStatePublished
-			opts.ExternalStates = []btypes.ChangesetExternalState{externalState}
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
-			opts.PublicationState = &publicationState
-		case btypes.ChangesetStateUnpublished:
-			publicationState := btypes.ChangesetPublicationStateUnpublished
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
-			opts.PublicationState = &publicationState
-		case btypes.ChangesetStateProcessing:
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateQueued, btypes.ReconcilerStateProcessing}
-		case btypes.ChangesetStateRetrying:
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateErrored}
-		case btypes.ChangesetStateFailed:
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateFailed}
-		case btypes.ChangesetStateScheduled:
-			opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateScheduled}
-		default:
-			return opts, false, errors.Errorf("changeset state %q not supported in filtering", state)
-		}
+		opts.States = []btypes.ChangesetState{state}
 	}
 
 	if args.ReviewState != nil {

--- a/enterprise/internal/batches/processor/bulk_processor_test.go
+++ b/enterprise/internal/batches/processor/bulk_processor_test.go
@@ -235,20 +235,24 @@ func TestBulkProcessor(t *testing.T) {
 				"imported changeset": {
 					spec: nil,
 					changeset: ct.TestChangesetOpts{
-						Repo:            repo.ID,
-						BatchChange:     batchChange.ID,
-						CurrentSpec:     0,
-						ReconcilerState: btypes.ReconcilerStateCompleted,
+						Repo:             repo.ID,
+						BatchChange:      batchChange.ID,
+						CurrentSpec:      0,
+						ReconcilerState:  btypes.ReconcilerStateCompleted,
+						PublicationState: btypes.ChangesetPublicationStatePublished,
+						ExternalState:    btypes.ChangesetExternalStateOpen,
 					},
 					wantRetryable: false,
 				},
 				"bogus changeset spec ID, dude": {
 					spec: nil,
 					changeset: ct.TestChangesetOpts{
-						Repo:            repo.ID,
-						BatchChange:     batchChange.ID,
-						CurrentSpec:     -1,
-						ReconcilerState: btypes.ReconcilerStateCompleted,
+						Repo:             repo.ID,
+						BatchChange:      batchChange.ID,
+						CurrentSpec:      -1,
+						ReconcilerState:  btypes.ReconcilerStateCompleted,
+						PublicationState: btypes.ChangesetPublicationStatePublished,
+						ExternalState:    btypes.ChangesetExternalStateOpen,
 					},
 					wantRetryable: false,
 				},
@@ -261,9 +265,10 @@ func TestBulkProcessor(t *testing.T) {
 						Published: false,
 					},
 					changeset: ct.TestChangesetOpts{
-						Repo:            repo.ID,
-						BatchChange:     batchChange.ID,
-						ReconcilerState: btypes.ReconcilerStateCompleted,
+						Repo:             repo.ID,
+						BatchChange:      batchChange.ID,
+						ReconcilerState:  btypes.ReconcilerStateCompleted,
+						PublicationState: btypes.ChangesetPublicationStateUnpublished,
 					},
 					wantRetryable: false,
 				},
@@ -321,10 +326,11 @@ func TestBulkProcessor(t *testing.T) {
 								HeadRef:   "main",
 							})
 							changeset := ct.CreateChangeset(t, ctx, bstore, ct.TestChangesetOpts{
-								Repo:            repo.ID,
-								BatchChange:     batchChange.ID,
-								CurrentSpec:     changesetSpec.ID,
-								ReconcilerState: reconcilerState,
+								Repo:             repo.ID,
+								BatchChange:      batchChange.ID,
+								CurrentSpec:      changesetSpec.ID,
+								ReconcilerState:  reconcilerState,
+								PublicationState: btypes.ChangesetPublicationStateUnpublished,
 							})
 
 							job := &types.ChangesetJob{

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -944,10 +944,12 @@ func TestService(t *testing.T) {
 			}
 			t.Run("attached changeset", func(t *testing.T) {
 				changeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
-					Repo:            rs[0].ID,
-					ReconcilerState: btypes.ReconcilerStateCompleted,
-					BatchChange:     batchChange.ID,
-					IsArchived:      false,
+					Repo:             rs[0].ID,
+					ReconcilerState:  btypes.ReconcilerStateCompleted,
+					PublicationState: btypes.ChangesetPublicationStatePublished,
+					ExternalState:    btypes.ChangesetExternalStateOpen,
+					BatchChange:      batchChange.ID,
+					IsArchived:       false,
 				})
 				_, err := svc.CreateChangesetJobs(ctx, batchChange.ID, []int64{changeset.ID}, btypes.ChangesetJobTypeDetach, btypes.ChangesetJobDetachPayload{}, store.ListChangesetsOpts{OnlyArchived: true})
 				if err != ErrChangesetsForJobNotFound {
@@ -956,9 +958,11 @@ func TestService(t *testing.T) {
 			})
 			t.Run("detached changeset", func(t *testing.T) {
 				detachedChangeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
-					Repo:            rs[2].ID,
-					ReconcilerState: btypes.ReconcilerStateCompleted,
-					BatchChanges:    []btypes.BatchChangeAssoc{},
+					Repo:             rs[2].ID,
+					ReconcilerState:  btypes.ReconcilerStateCompleted,
+					PublicationState: btypes.ChangesetPublicationStatePublished,
+					ExternalState:    btypes.ChangesetExternalStateOpen,
+					BatchChanges:     []btypes.BatchChangeAssoc{},
 				})
 				_, err := svc.CreateChangesetJobs(ctx, batchChange.ID, []int64{detachedChangeset.ID}, btypes.ChangesetJobTypeDetach, btypes.ChangesetJobDetachPayload{}, store.ListChangesetsOpts{OnlyArchived: true})
 				if err != ErrChangesetsForJobNotFound {
@@ -1104,9 +1108,10 @@ func TestService(t *testing.T) {
 			}
 
 			changeset := ct.CreateChangeset(t, adminCtx, s, ct.TestChangesetOpts{
-				Repo:            rs[0].ID,
-				ReconcilerState: btypes.ReconcilerStateCompleted,
-				BatchChange:     batchChange.ID,
+				Repo:             rs[0].ID,
+				ReconcilerState:  btypes.ReconcilerStateCompleted,
+				PublicationState: btypes.ChangesetPublicationStateUnpublished,
+				BatchChange:      batchChange.ID,
 			})
 
 			_, err := svc.CreateChangesetJobs(

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -694,9 +694,9 @@ func getRewirerMappingsQuery(opts GetRewirerMappingsOpts) (*sqlf.Query, error) {
 	detachTextSearch, viewTextSearch := getRewirerMappingTextSearch(opts.TextSearch)
 
 	// Happily, current state is simpler. Less happily, it can error.
-	currentState, err := getRewirerMappingCurrentState(opts.CurrentState)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing current state option")
+	currentState := sqlf.Sprintf("")
+	if opts.CurrentState != nil {
+		currentState = sqlf.Sprintf("AND computed_state = %s", *opts.CurrentState)
 	}
 
 	return sqlf.Sprintf(
@@ -717,51 +717,6 @@ func getRewirerMappingsQuery(opts GetRewirerMappingsOpts) (*sqlf.Query, error) {
 		currentState,
 		opts.LimitOffset.SQL(),
 	), nil
-}
-
-func getRewirerMappingCurrentState(state *btypes.ChangesetState) (*sqlf.Query, error) {
-	if state == nil {
-		return sqlf.Sprintf(""), nil
-	}
-
-	// This is essentially the reverse mapping of changesetResolver.State. Note
-	// that if one changes, so should the other.
-	var q *sqlf.Query
-	switch *state {
-	case btypes.ChangesetStateRetrying:
-		q = sqlf.Sprintf("reconciler_state = %s", btypes.ReconcilerStateErrored.ToDB())
-	case btypes.ChangesetStateFailed:
-		q = sqlf.Sprintf("reconciler_state = %s", btypes.ReconcilerStateFailed.ToDB())
-	case btypes.ChangesetStateScheduled:
-		q = sqlf.Sprintf("reconciler_state = %s", btypes.ReconcilerStateScheduled.ToDB())
-	case btypes.ChangesetStateProcessing:
-		q = sqlf.Sprintf("reconciler_state NOT IN (%s)",
-			sqlf.Join([]*sqlf.Query{
-				sqlf.Sprintf("%s", btypes.ReconcilerStateErrored.ToDB()),
-				sqlf.Sprintf("%s", btypes.ReconcilerStateFailed.ToDB()),
-				sqlf.Sprintf("%s", btypes.ReconcilerStateScheduled.ToDB()),
-				sqlf.Sprintf("%s", btypes.ReconcilerStateCompleted.ToDB()),
-			}, ","),
-		)
-	case btypes.ChangesetStateUnpublished:
-		q = sqlf.Sprintf("publication_state = %s", btypes.ChangesetPublicationStateUnpublished)
-	case btypes.ChangesetStateDraft:
-		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateDraft)
-	case btypes.ChangesetStateOpen:
-		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateOpen)
-	case btypes.ChangesetStateClosed:
-		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateClosed)
-	case btypes.ChangesetStateMerged:
-		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateMerged)
-	case btypes.ChangesetStateReadOnly:
-		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateReadOnly)
-	case btypes.ChangesetStateDeleted:
-		q = sqlf.Sprintf("external_state = %s", btypes.ChangesetExternalStateDeleted)
-	default:
-		return nil, errors.Errorf("unknown changeset state: %q", *state)
-	}
-
-	return sqlf.Sprintf("AND %s", q), nil
 }
 
 func getRewirerMappingTextSearch(terms []search.TextSearchTerm) (detachTextSearch, viewTextSearch *sqlf.Query) {

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -279,6 +279,9 @@ type Changeset struct {
 	PublicationState   ChangesetPublicationState // "unpublished", "published"
 	UiPublicationState *ChangesetUiPublicationState
 
+	// State is a computed value. Changes to this value will never be persisted to the database.
+	State ChangesetState
+
 	// All of the following fields are used by workerutil.Worker.
 	ReconcilerState  ReconcilerState
 	FailureMessage   *string

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -81,6 +81,10 @@
       "Definition": "CREATE OR REPLACE FUNCTION public.batch_spec_workspace_execution_last_dequeues_upsert()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$ BEGIN\n    INSERT INTO\n        batch_spec_workspace_execution_last_dequeues\n    SELECT\n        user_id,\n        MAX(started_at) as latest_dequeue\n    FROM\n        newtab\n    GROUP BY\n        user_id\n    ON CONFLICT (user_id) DO UPDATE SET\n        latest_dequeue = GREATEST(batch_spec_workspace_execution_last_dequeues.latest_dequeue, EXCLUDED.latest_dequeue);\n\n    RETURN NULL;\nEND $function$\n"
     },
     {
+      "Name": "changesets_computed_state_ensure",
+      "Definition": "CREATE OR REPLACE FUNCTION public.changesets_computed_state_ensure()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$ BEGIN\n\n    NEW.computed_state = CASE\n        WHEN NEW.reconciler_state = 'errored' THEN 'RETRYING'\n        WHEN NEW.reconciler_state = 'failed' THEN 'FAILED'\n        WHEN NEW.reconciler_state = 'scheduled' THEN 'SCHEDULED'\n        WHEN NEW.reconciler_state != 'completed' THEN 'PROCESSING'\n        WHEN NEW.publication_state = 'UNPUBLISHED' THEN 'UNPUBLISHED'\n        ELSE NEW.external_state\n    END AS computed_state;\n\n    RETURN NEW;\nEND $function$\n"
+    },
+    {
       "Name": "delete_batch_change_reference_on_changesets",
       "Definition": "CREATE OR REPLACE FUNCTION public.delete_batch_change_reference_on_changesets()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        UPDATE\n          changesets\n        SET\n          batch_change_ids = changesets.batch_change_ids - OLD.id::text\n        WHERE\n          changesets.batch_change_ids ? OLD.id::text;\n\n        RETURN OLD;\n    END;\n$function$\n"
     },
@@ -3442,6 +3446,19 @@
           "Comment": ""
         },
         {
+          "Name": "computed_state",
+          "Index": 42,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "created_at",
           "Index": 4,
           "TypeName": "timestamp with time zone",
@@ -3988,6 +4005,16 @@
           "ConstraintDefinition": ""
         },
         {
+          "Name": "changesets_computed_state",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX changesets_computed_state ON changesets USING btree (computed_state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "changesets_detached_at",
           "IsPrimaryKey": false,
           "IsUnique": false,
@@ -4103,7 +4130,12 @@
           "ConstraintDefinition": "CHECK (external_branch ~~ 'refs/heads/%'::text)"
         }
       ],
-      "Triggers": []
+      "Triggers": [
+        {
+          "Name": "changesets_update_computed_state",
+          "Definition": "CREATE TRIGGER changesets_update_computed_state BEFORE INSERT OR UPDATE ON changesets FOR EACH ROW EXECUTE FUNCTION changesets_computed_state_ensure()"
+        }
+      ]
     },
     {
       "Name": "cm_action_jobs",
@@ -17988,7 +18020,7 @@
     },
     {
       "Name": "branch_changeset_specs_and_changesets",
-      "Definition": " SELECT changeset_specs.id AS changeset_spec_id,\n    COALESCE(changesets.id, (0)::bigint) AS changeset_id,\n    changeset_specs.repo_id,\n    changeset_specs.batch_spec_id,\n    changesets.owned_by_batch_change_id AS owner_batch_change_id,\n    repo.name AS repo_name,\n    changeset_specs.title AS changeset_name,\n    changesets.external_state,\n    changesets.publication_state,\n    changesets.reconciler_state\n   FROM ((changeset_specs\n     LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.current_spec_id IS NOT NULL) AND (EXISTS ( SELECT 1\n           FROM changeset_specs changeset_specs_1\n          WHERE ((changeset_specs_1.id = changesets.current_spec_id) AND (changeset_specs_1.head_ref = changeset_specs.head_ref)))))))\n     JOIN repo ON ((changeset_specs.repo_id = repo.id)))\n  WHERE ((changeset_specs.external_id IS NULL) AND (repo.deleted_at IS NULL));"
+      "Definition": " SELECT changeset_specs.id AS changeset_spec_id,\n    COALESCE(changesets.id, (0)::bigint) AS changeset_id,\n    changeset_specs.repo_id,\n    changeset_specs.batch_spec_id,\n    changesets.owned_by_batch_change_id AS owner_batch_change_id,\n    repo.name AS repo_name,\n    changeset_specs.title AS changeset_name,\n    changesets.external_state,\n    changesets.publication_state,\n    changesets.reconciler_state,\n    changesets.computed_state\n   FROM ((changeset_specs\n     LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.current_spec_id IS NOT NULL) AND (EXISTS ( SELECT 1\n           FROM changeset_specs changeset_specs_1\n          WHERE ((changeset_specs_1.id = changesets.current_spec_id) AND (changeset_specs_1.head_ref = changeset_specs.head_ref)))))))\n     JOIN repo ON ((changeset_specs.repo_id = repo.id)))\n  WHERE ((changeset_specs.external_id IS NULL) AND (repo.deleted_at IS NULL));"
     },
     {
       "Name": "external_service_sync_jobs_with_next_sync_at",
@@ -18016,7 +18048,7 @@
     },
     {
       "Name": "reconciler_changesets",
-      "Definition": " SELECT c.id,\n    c.batch_change_ids,\n    c.repo_id,\n    c.queued_at,\n    c.created_at,\n    c.updated_at,\n    c.metadata,\n    c.external_id,\n    c.external_service_type,\n    c.external_deleted_at,\n    c.external_branch,\n    c.external_updated_at,\n    c.external_state,\n    c.external_review_state,\n    c.external_check_state,\n    c.diff_stat_added,\n    c.diff_stat_changed,\n    c.diff_stat_deleted,\n    c.sync_state,\n    c.current_spec_id,\n    c.previous_spec_id,\n    c.publication_state,\n    c.owned_by_batch_change_id,\n    c.reconciler_state,\n    c.failure_message,\n    c.started_at,\n    c.finished_at,\n    c.process_after,\n    c.num_resets,\n    c.closing,\n    c.num_failures,\n    c.log_contents,\n    c.execution_logs,\n    c.syncer_error,\n    c.external_title,\n    c.worker_hostname,\n    c.ui_publication_state,\n    c.last_heartbeat_at,\n    c.external_fork_namespace,\n    c.detached_at\n   FROM (changesets c\n     JOIN repo r ON ((r.id = c.repo_id)))\n  WHERE ((r.deleted_at IS NULL) AND (EXISTS ( SELECT 1\n           FROM ((batch_changes\n             LEFT JOIN users namespace_user ON ((batch_changes.namespace_user_id = namespace_user.id)))\n             LEFT JOIN orgs namespace_org ON ((batch_changes.namespace_org_id = namespace_org.id)))\n          WHERE ((c.batch_change_ids ? (batch_changes.id)::text) AND (namespace_user.deleted_at IS NULL) AND (namespace_org.deleted_at IS NULL)))));"
+      "Definition": " SELECT c.id,\n    c.batch_change_ids,\n    c.repo_id,\n    c.queued_at,\n    c.created_at,\n    c.updated_at,\n    c.metadata,\n    c.external_id,\n    c.external_service_type,\n    c.external_deleted_at,\n    c.external_branch,\n    c.external_updated_at,\n    c.external_state,\n    c.external_review_state,\n    c.external_check_state,\n    c.diff_stat_added,\n    c.diff_stat_changed,\n    c.diff_stat_deleted,\n    c.sync_state,\n    c.current_spec_id,\n    c.previous_spec_id,\n    c.publication_state,\n    c.owned_by_batch_change_id,\n    c.reconciler_state,\n    c.computed_state,\n    c.failure_message,\n    c.started_at,\n    c.finished_at,\n    c.process_after,\n    c.num_resets,\n    c.closing,\n    c.num_failures,\n    c.log_contents,\n    c.execution_logs,\n    c.syncer_error,\n    c.external_title,\n    c.worker_hostname,\n    c.ui_publication_state,\n    c.last_heartbeat_at,\n    c.external_fork_namespace,\n    c.detached_at\n   FROM (changesets c\n     JOIN repo r ON ((r.id = c.repo_id)))\n  WHERE ((r.deleted_at IS NULL) AND (EXISTS ( SELECT 1\n           FROM ((batch_changes\n             LEFT JOIN users namespace_user ON ((batch_changes.namespace_user_id = namespace_user.id)))\n             LEFT JOIN orgs namespace_org ON ((batch_changes.namespace_org_id = namespace_org.id)))\n          WHERE ((c.batch_change_ids ? (batch_changes.id)::text) AND (namespace_user.deleted_at IS NULL) AND (namespace_org.deleted_at IS NULL)))));"
     },
     {
       "Name": "site_config",
@@ -18024,7 +18056,7 @@
     },
     {
       "Name": "tracking_changeset_specs_and_changesets",
-      "Definition": " SELECT changeset_specs.id AS changeset_spec_id,\n    COALESCE(changesets.id, (0)::bigint) AS changeset_id,\n    changeset_specs.repo_id,\n    changeset_specs.batch_spec_id,\n    repo.name AS repo_name,\n    COALESCE((changesets.metadata -\u003e\u003e 'Title'::text), (changesets.metadata -\u003e\u003e 'title'::text)) AS changeset_name,\n    changesets.external_state,\n    changesets.publication_state,\n    changesets.reconciler_state\n   FROM ((changeset_specs\n     LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.external_id = changeset_specs.external_id))))\n     JOIN repo ON ((changeset_specs.repo_id = repo.id)))\n  WHERE ((changeset_specs.external_id IS NOT NULL) AND (repo.deleted_at IS NULL));"
+      "Definition": " SELECT changeset_specs.id AS changeset_spec_id,\n    COALESCE(changesets.id, (0)::bigint) AS changeset_id,\n    changeset_specs.repo_id,\n    changeset_specs.batch_spec_id,\n    repo.name AS repo_name,\n    COALESCE((changesets.metadata -\u003e\u003e 'Title'::text), (changesets.metadata -\u003e\u003e 'title'::text)) AS changeset_name,\n    changesets.external_state,\n    changesets.publication_state,\n    changesets.reconciler_state,\n    changesets.computed_state\n   FROM ((changeset_specs\n     LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.external_id = changeset_specs.external_id))))\n     JOIN repo ON ((changeset_specs.repo_id = repo.id)))\n  WHERE ((changeset_specs.external_id IS NOT NULL) AND (repo.deleted_at IS NULL));"
     }
   ]
 }

--- a/migrations/frontend/1658503913_batches_changeset_state_computed/down.sql
+++ b/migrations/frontend/1658503913_batches_changeset_state_computed/down.sql
@@ -1,0 +1,92 @@
+DROP TRIGGER IF EXISTS changesets_update_computed_state ON changesets;
+DROP FUNCTION IF EXISTS changesets_computed_state_ensure();
+
+DROP VIEW IF EXISTS branch_changeset_specs_and_changesets;
+CREATE VIEW branch_changeset_specs_and_changesets AS
+ SELECT changeset_specs.id AS changeset_spec_id,
+    COALESCE(changesets.id, (0)::bigint) AS changeset_id,
+    changeset_specs.repo_id,
+    changeset_specs.batch_spec_id,
+    changesets.owned_by_batch_change_id AS owner_batch_change_id,
+    repo.name AS repo_name,
+    changeset_specs.title AS changeset_name,
+    changesets.external_state,
+    changesets.publication_state,
+    changesets.reconciler_state
+   FROM ((changeset_specs
+     LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.current_spec_id IS NOT NULL) AND (EXISTS ( SELECT 1
+           FROM changeset_specs changeset_specs_1
+          WHERE ((changeset_specs_1.id = changesets.current_spec_id) AND (changeset_specs_1.head_ref = changeset_specs.head_ref)))))))
+     JOIN repo ON ((changeset_specs.repo_id = repo.id)))
+  WHERE ((changeset_specs.external_id IS NULL) AND (repo.deleted_at IS NULL));
+
+DROP VIEW IF EXISTS tracking_changeset_specs_and_changesets;
+CREATE VIEW tracking_changeset_specs_and_changesets AS
+ SELECT changeset_specs.id AS changeset_spec_id,
+    COALESCE(changesets.id, (0)::bigint) AS changeset_id,
+    changeset_specs.repo_id,
+    changeset_specs.batch_spec_id,
+    repo.name AS repo_name,
+    COALESCE((changesets.metadata ->> 'Title'::text), (changesets.metadata ->> 'title'::text)) AS changeset_name,
+    changesets.external_state,
+    changesets.publication_state,
+    changesets.reconciler_state
+   FROM ((changeset_specs
+     LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.external_id = changeset_specs.external_id))))
+     JOIN repo ON ((changeset_specs.repo_id = repo.id)))
+  WHERE ((changeset_specs.external_id IS NOT NULL) AND (repo.deleted_at IS NULL));
+
+DROP VIEW IF EXISTS reconciler_changesets;
+CREATE VIEW reconciler_changesets AS
+SELECT c.id,
+       c.batch_change_ids,
+       c.repo_id,
+       c.queued_at,
+       c.created_at,
+       c.updated_at,
+       c.metadata,
+       c.external_id,
+       c.external_service_type,
+       c.external_deleted_at,
+       c.external_branch,
+       c.external_updated_at,
+       c.external_state,
+       c.external_review_state,
+       c.external_check_state,
+       c.diff_stat_added,
+       c.diff_stat_changed,
+       c.diff_stat_deleted,
+       c.sync_state,
+       c.current_spec_id,
+       c.previous_spec_id,
+       c.publication_state,
+       c.owned_by_batch_change_id,
+       c.reconciler_state,
+       c.failure_message,
+       c.started_at,
+       c.finished_at,
+       c.process_after,
+       c.num_resets,
+       c.closing,
+       c.num_failures,
+       c.log_contents,
+       c.execution_logs,
+       c.syncer_error,
+       c.external_title,
+       c.worker_hostname,
+       c.ui_publication_state,
+       c.last_heartbeat_at,
+       c.external_fork_namespace,
+       c.detached_at
+FROM changesets c
+         JOIN repo r ON r.id = c.repo_id
+WHERE r.deleted_at IS NULL AND EXISTS (
+    SELECT 1
+    FROM batch_changes
+             LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
+             LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
+    WHERE c.batch_change_ids ? batch_changes.id::text AND namespace_user.deleted_at IS NULL AND namespace_org.deleted_at IS NULL
+    );
+
+
+ALTER TABLE changesets DROP COLUMN IF EXISTS computed_state;

--- a/migrations/frontend/1658503913_batches_changeset_state_computed/metadata.yaml
+++ b/migrations/frontend/1658503913_batches_changeset_state_computed/metadata.yaml
@@ -1,0 +1,2 @@
+name: batches_changeset_state_computed
+parents: [1658384388, 1653596521]

--- a/migrations/frontend/1658503913_batches_changeset_state_computed/up.sql
+++ b/migrations/frontend/1658503913_batches_changeset_state_computed/up.sql
@@ -1,0 +1,125 @@
+ALTER TABLE changesets ADD COLUMN IF NOT EXISTS computed_state TEXT;
+
+DROP TRIGGER IF EXISTS changesets_update_computed_state ON changesets;
+
+UPDATE
+    changesets
+SET
+    computed_state = CASE
+        WHEN reconciler_state = 'errored' THEN 'RETRYING'
+        WHEN reconciler_state = 'failed' THEN 'FAILED'
+        WHEN reconciler_state = 'scheduled' THEN 'SCHEDULED'
+        WHEN reconciler_state != 'completed' THEN 'PROCESSING'
+        WHEN publication_state = 'UNPUBLISHED' THEN 'UNPUBLISHED'
+        ELSE external_state
+    END;
+
+ALTER TABLE changesets ALTER COLUMN computed_state SET NOT NULL;
+
+CREATE OR REPLACE FUNCTION changesets_computed_state_ensure() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ BEGIN
+
+    NEW.computed_state = CASE
+        WHEN NEW.reconciler_state = 'errored' THEN 'RETRYING'
+        WHEN NEW.reconciler_state = 'failed' THEN 'FAILED'
+        WHEN NEW.reconciler_state = 'scheduled' THEN 'SCHEDULED'
+        WHEN NEW.reconciler_state != 'completed' THEN 'PROCESSING'
+        WHEN NEW.publication_state = 'UNPUBLISHED' THEN 'UNPUBLISHED'
+        ELSE NEW.external_state
+    END AS computed_state;
+
+    RETURN NEW;
+END $$;
+
+CREATE TRIGGER changesets_update_computed_state BEFORE INSERT OR UPDATE ON changesets FOR EACH ROW EXECUTE FUNCTION changesets_computed_state_ensure();
+
+DROP VIEW IF EXISTS branch_changeset_specs_and_changesets;
+CREATE VIEW branch_changeset_specs_and_changesets AS
+ SELECT changeset_specs.id AS changeset_spec_id,
+    COALESCE(changesets.id, (0)::bigint) AS changeset_id,
+    changeset_specs.repo_id,
+    changeset_specs.batch_spec_id,
+    changesets.owned_by_batch_change_id AS owner_batch_change_id,
+    repo.name AS repo_name,
+    changeset_specs.title AS changeset_name,
+    changesets.external_state,
+    changesets.publication_state,
+    changesets.reconciler_state,
+    changesets.computed_state
+   FROM ((changeset_specs
+     LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.current_spec_id IS NOT NULL) AND (EXISTS ( SELECT 1
+           FROM changeset_specs changeset_specs_1
+          WHERE ((changeset_specs_1.id = changesets.current_spec_id) AND (changeset_specs_1.head_ref = changeset_specs.head_ref)))))))
+     JOIN repo ON ((changeset_specs.repo_id = repo.id)))
+  WHERE ((changeset_specs.external_id IS NULL) AND (repo.deleted_at IS NULL));
+
+DROP VIEW IF EXISTS tracking_changeset_specs_and_changesets;
+CREATE VIEW tracking_changeset_specs_and_changesets AS
+ SELECT changeset_specs.id AS changeset_spec_id,
+    COALESCE(changesets.id, (0)::bigint) AS changeset_id,
+    changeset_specs.repo_id,
+    changeset_specs.batch_spec_id,
+    repo.name AS repo_name,
+    COALESCE((changesets.metadata ->> 'Title'::text), (changesets.metadata ->> 'title'::text)) AS changeset_name,
+    changesets.external_state,
+    changesets.publication_state,
+    changesets.reconciler_state,
+    changesets.computed_state
+   FROM ((changeset_specs
+     LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.external_id = changeset_specs.external_id))))
+     JOIN repo ON ((changeset_specs.repo_id = repo.id)))
+  WHERE ((changeset_specs.external_id IS NOT NULL) AND (repo.deleted_at IS NULL));
+
+DROP VIEW IF EXISTS reconciler_changesets;
+CREATE VIEW reconciler_changesets AS
+SELECT c.id,
+       c.batch_change_ids,
+       c.repo_id,
+       c.queued_at,
+       c.created_at,
+       c.updated_at,
+       c.metadata,
+       c.external_id,
+       c.external_service_type,
+       c.external_deleted_at,
+       c.external_branch,
+       c.external_updated_at,
+       c.external_state,
+       c.external_review_state,
+       c.external_check_state,
+       c.diff_stat_added,
+       c.diff_stat_changed,
+       c.diff_stat_deleted,
+       c.sync_state,
+       c.current_spec_id,
+       c.previous_spec_id,
+       c.publication_state,
+       c.owned_by_batch_change_id,
+       c.reconciler_state,
+       c.computed_state,
+       c.failure_message,
+       c.started_at,
+       c.finished_at,
+       c.process_after,
+       c.num_resets,
+       c.closing,
+       c.num_failures,
+       c.log_contents,
+       c.execution_logs,
+       c.syncer_error,
+       c.external_title,
+       c.worker_hostname,
+       c.ui_publication_state,
+       c.last_heartbeat_at,
+       c.external_fork_namespace,
+       c.detached_at
+FROM changesets c
+         JOIN repo r ON r.id = c.repo_id
+WHERE r.deleted_at IS NULL AND EXISTS (
+    SELECT 1
+    FROM batch_changes
+             LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
+             LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
+    WHERE c.batch_change_ids ? batch_changes.id::text AND namespace_user.deleted_at IS NULL AND namespace_org.deleted_at IS NULL
+    );

--- a/migrations/frontend/1658512336_batches_changeset_state_index/down.sql
+++ b/migrations/frontend/1658512336_batches_changeset_state_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS changesets_computed_state;

--- a/migrations/frontend/1658512336_batches_changeset_state_index/metadata.yaml
+++ b/migrations/frontend/1658512336_batches_changeset_state_index/metadata.yaml
@@ -1,0 +1,3 @@
+name: batches_changeset_state_index
+parents: [1658503913]
+createIndexConcurrently: true

--- a/migrations/frontend/1658512336_batches_changeset_state_index/up.sql
+++ b/migrations/frontend/1658512336_batches_changeset_state_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS changesets_computed_state ON changesets (computed_state);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -117,6 +117,22 @@ CREATE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert() RETURNS tr
     RETURN NULL;
 END $$;
 
+CREATE FUNCTION changesets_computed_state_ensure() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ BEGIN
+
+    NEW.computed_state = CASE
+        WHEN NEW.reconciler_state = 'errored' THEN 'RETRYING'
+        WHEN NEW.reconciler_state = 'failed' THEN 'FAILED'
+        WHEN NEW.reconciler_state = 'scheduled' THEN 'SCHEDULED'
+        WHEN NEW.reconciler_state != 'completed' THEN 'PROCESSING'
+        WHEN NEW.publication_state = 'UNPUBLISHED' THEN 'UNPUBLISHED'
+        ELSE NEW.external_state
+    END AS computed_state;
+
+    RETURN NEW;
+END $$;
+
 CREATE FUNCTION delete_batch_change_reference_on_changesets() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -817,6 +833,7 @@ CREATE TABLE changesets (
     queued_at timestamp with time zone DEFAULT now(),
     cancel boolean DEFAULT false NOT NULL,
     detached_at timestamp with time zone,
+    computed_state text NOT NULL,
     CONSTRAINT changesets_batch_change_ids_check CHECK ((jsonb_typeof(batch_change_ids) = 'object'::text)),
     CONSTRAINT changesets_external_id_check CHECK ((external_id <> ''::text)),
     CONSTRAINT changesets_external_service_type_not_blank CHECK ((external_service_type <> ''::text)),
@@ -857,7 +874,8 @@ CREATE VIEW branch_changeset_specs_and_changesets AS
     changeset_specs.title AS changeset_name,
     changesets.external_state,
     changesets.publication_state,
-    changesets.reconciler_state
+    changesets.reconciler_state,
+    changesets.computed_state
    FROM ((changeset_specs
      LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.current_spec_id IS NOT NULL) AND (EXISTS ( SELECT 1
            FROM changeset_specs changeset_specs_1
@@ -2669,6 +2687,7 @@ CREATE VIEW reconciler_changesets AS
     c.publication_state,
     c.owned_by_batch_change_id,
     c.reconciler_state,
+    c.computed_state,
     c.failure_message,
     c.started_at,
     c.finished_at,
@@ -2949,7 +2968,8 @@ CREATE VIEW tracking_changeset_specs_and_changesets AS
     COALESCE((changesets.metadata ->> 'Title'::text), (changesets.metadata ->> 'title'::text)) AS changeset_name,
     changesets.external_state,
     changesets.publication_state,
-    changesets.reconciler_state
+    changesets.reconciler_state,
+    changesets.computed_state
    FROM ((changeset_specs
      LEFT JOIN changesets ON (((changesets.repo_id = changeset_specs.repo_id) AND (changesets.external_id = changeset_specs.external_id))))
      JOIN repo ON ((changeset_specs.repo_id = repo.id)))
@@ -3587,6 +3607,8 @@ CREATE INDEX changesets_bitbucket_cloud_metadata_source_commit_idx ON changesets
 
 CREATE INDEX changesets_changeset_specs ON changesets USING btree (current_spec_id, previous_spec_id);
 
+CREATE INDEX changesets_computed_state ON changesets USING btree (computed_state);
+
 CREATE INDEX changesets_detached_at ON changesets USING btree (detached_at);
 
 CREATE INDEX changesets_external_state_idx ON changesets USING btree (external_state);
@@ -3860,6 +3882,8 @@ CREATE INDEX webhook_logs_status_code_idx ON webhook_logs USING btree (status_co
 CREATE TRIGGER batch_spec_workspace_execution_last_dequeues_insert AFTER INSERT ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert();
 
 CREATE TRIGGER batch_spec_workspace_execution_last_dequeues_update AFTER UPDATE ON batch_spec_workspace_execution_jobs REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION batch_spec_workspace_execution_last_dequeues_upsert();
+
+CREATE TRIGGER changesets_update_computed_state BEFORE INSERT OR UPDATE ON changesets FOR EACH ROW EXECUTE FUNCTION changesets_computed_state_ensure();
 
 CREATE TRIGGER trig_delete_batch_change_reference_on_changesets AFTER DELETE ON batch_changes FOR EACH ROW EXECUTE FUNCTION delete_batch_change_reference_on_changesets();
 


### PR DESCRIPTION
This adds a trigger that updates the new `computed_state` value on a changeset in the DB before writes. This ensures it's always up to date.
With this new column, we don't have to reverse-engineer the go logic from the resolver into SQL conditions anymore, thus making multiple places simpler to reason about and reducing the sources of truth for the logic to compute the state. This'll also make filtering extremely fast because we can now index on the state directly.

Most of the diff is actually just fixing bad state in tests that now showed up.

Closes https://github.com/sourcegraph/sourcegraph/issues/19975

## Test plan

Manually verified a bunch of workflows still work and this is also heavily tested.