### PR TITLE
add displayName to components

### DIFF
--- a/client/shared/src/components/LinkOrSpan.tsx
+++ b/client/shared/src/components/LinkOrSpan.tsx
@@ -13,7 +13,8 @@ type Props = React.PropsWithChildren<
  * The LinkOrSpan component renders a <Link> if the "to" property is a non-empty string; otherwise it renders the
  * text in a <span> (with no link).
  */
-export const LinkOrSpan = React.forwardRef(({ to, className = '', children, ...otherProps }: Props, reference) => {
+// eslint-disable-next-line react/display-name
+const LinkOrSpan = React.forwardRef(({ to, className = '', children, ...otherProps }: Props, reference) => {
     if (to) {
         return (
             <Link ref={reference} to={to} className={className} {...otherProps}>
@@ -28,3 +29,7 @@ export const LinkOrSpan = React.forwardRef(({ to, className = '', children, ...o
         </span>
     )
 }) as ForwardReferenceComponent<typeof Link, Props>
+
+LinkOrSpan.displayName = 'LinkOrSpan'
+
+export { LinkOrSpan }

--- a/client/web/src/repo/blob/LineDecorator.tsx
+++ b/client/web/src/repo/blob/LineDecorator.tsx
@@ -28,7 +28,7 @@ export interface LineDecoratorProps extends ThemeProps {
 /**
  * Component that decorates lines of code and appends line attachments set by extensions
  */
-export const LineDecorator = React.memo<LineDecoratorProps>(
+const LineDecorator = React.memo<LineDecoratorProps>(
     ({ getCodeElementFromLineNumber, line, decorations, portalID, isLightTheme, codeViewElements }) => {
         const [portalNode, setPortalNode] = React.useState<HTMLDivElement | null>(null)
 
@@ -172,3 +172,7 @@ export const LineDecorator = React.memo<LineDecoratorProps>(
         )
     }
 )
+
+LineDecorator.displayName = 'LineDecorator'
+
+export { LineDecorator }


### PR DESCRIPTION
Add displayName to the following components:

- LinkOrSpan
- LineDecorator

## Test plan

Open any blob page
Use react dev tools to inspect a line of code
Should see LineDecorator and LinkOrSpan instead of anonymous in the components listing

## App preview:

- [Web](https://sg-web-jdb-add-displayname-linedecorator.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xaysqkmrxo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
