### PR TITLE
worker: Don't access DB before initialized

### DIFF
--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
@@ -15,6 +15,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/log"
+
+	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -22,13 +24,10 @@ import (
 )
 
 type telemetryJob struct {
-	db database.DB
 }
 
-func NewTelemetryJob(db database.DB) *telemetryJob {
-	return &telemetryJob{
-		db: db,
-	}
+func NewTelemetryJob() *telemetryJob {
+	return &telemetryJob{}
 }
 
 func (t *telemetryJob) Description() string {
@@ -45,7 +44,14 @@ func (t *telemetryJob) Routines(ctx context.Context, logger log.Logger) ([]gorou
 	}
 	logger.Info("Usage telemetry export enabled - initializing background routine")
 
-	eventLogStore := t.db.EventLogs()
+	sqlDB, err := workerdb.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	db := database.NewDB(log.Scoped("worker.telemetryJob", ""), sqlDB)
+
+	eventLogStore := db.EventLogs()
 
 	return []goroutine.BackgroundRoutine{
 		newBackgroundTelemetryJob(logger, eventLogStore),

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
@@ -49,8 +49,7 @@ func (t *telemetryJob) Routines(ctx context.Context, logger log.Logger) ([]gorou
 		return nil, err
 	}
 
-	db := database.NewDB(log.Scoped("worker.telemetryJob", ""), sqlDB)
-
+	db := database.NewDB(logger, sqlDB)
 	eventLogStore := db.EventLogs()
 
 	return []goroutine.BackgroundRoutine{

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -22,9 +22,10 @@ import (
 )
 
 func TestInitializeJob(t *testing.T) {
-	ctx := context.Background()
-
 	confClient = conf.MockClient()
+	defer func() {
+		confClient = conf.DefaultClient()
+	}()
 
 	tests := []struct {
 		name         string
@@ -62,20 +63,8 @@ func TestInitializeJob(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			confClient.Mock(&conf.Unified{SiteConfiguration: test.mockedConfig})
 
-			job := NewTelemetryJob()
-			routines, err := job.Routines(ctx, logtest.Scoped(t))
-			if err != nil {
-				t.Error(err)
-			}
-
-			if test.shouldInit {
-				if len(routines) != 1 {
-					t.Error("expected one routine")
-				}
-			} else {
-				if len(routines) != 0 {
-					t.Error("expected no routines")
-				}
+			if have, want := isEnabled(), test.shouldInit; have != want {
+				t.Errorf("unexpected isEnabled return value have=%t want=%t", have, want)
 			}
 		})
 	}

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -23,8 +23,6 @@ import (
 
 func TestInitializeJob(t *testing.T) {
 	ctx := context.Background()
-	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
 	confClient = conf.MockClient()
 
@@ -64,7 +62,7 @@ func TestInitializeJob(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			confClient.Mock(&conf.Unified{SiteConfiguration: test.mockedConfig})
 
-			job := NewTelemetryJob(db)
+			job := NewTelemetryJob()
 			routines, err := job.Routines(ctx, logtest.Scoped(t))
 			if err != nil {
 				t.Error(err)

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -39,11 +39,6 @@ func main() {
 	})
 	defer liblog.Sync()
 
-	db, err := workerdb.Init()
-	if err != nil {
-		return
-	}
-
 	logger := log.Scoped("worker", "worker enterprise edition")
 
 	go setAuthzProviders(logger)
@@ -60,7 +55,7 @@ func main() {
 		"executors-janitor":             executors.NewJanitorJob(),
 		"codemonitors-job":              codemonitors.NewCodeMonitorJob(),
 		"bitbucket-project-permissions": permissions.NewBitbucketProjectPermissionsJob(),
-		"export-usage-telemetry":        telemetry.NewTelemetryJob(database.NewDB(logger, db)),
+		"export-usage-telemetry":        telemetry.NewTelemetryJob(),
 
 		// fresh
 		"codeintel-upload-janitor":         freshcodeintel.NewUploadJanitorJob(),


### PR DESCRIPTION
The DB must not be retrieved before the Routines method is called, because it relies on the `conf` package and that is only initialized at that point in time.



## Test plan

Seeing worker init logs again, didn't before this change.