### PR TITLE
batches: Fix diff unavailable after step finishes

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -581,7 +581,7 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                                         {step.startedAt && (
                                             <WorkspaceStepFileDiffConnection
                                                 isLightTheme={isLightTheme}
-                                                step={step.number}
+                                                step={step}
                                                 workspaceID={workspaceID}
                                                 queryBatchSpecWorkspaceStepFileDiffs={
                                                     queryBatchSpecWorkspaceStepFileDiffs
@@ -642,7 +642,7 @@ const StepTimer: React.FunctionComponent<React.PropsWithChildren<{ startedAt: st
 
 interface WorkspaceStepFileDiffConnectionProps extends ThemeProps {
     workspaceID: Scalars['ID']
-    step: number
+    step: BatchSpecWorkspaceStepFields
     queryBatchSpecWorkspaceStepFileDiffs?: typeof _queryBatchSpecWorkspaceStepFileDiffs
 }
 
@@ -660,7 +660,7 @@ const WorkspaceStepFileDiffConnection: React.FunctionComponent<
                 after: args.after ?? null,
                 first: args.first ?? null,
                 node: workspaceID,
-                step,
+                step: step.number,
             }),
         [workspaceID, step, queryBatchSpecWorkspaceStepFileDiffs]
     )

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -642,6 +642,7 @@ const StepTimer: React.FunctionComponent<React.PropsWithChildren<{ startedAt: st
 
 interface WorkspaceStepFileDiffConnectionProps extends ThemeProps {
     workspaceID: Scalars['ID']
+    // Require the entire step instead of just the spec number to ensure the query gets called as the step changes.
     step: BatchSpecWorkspaceStepFields
     queryBatchSpecWorkspaceStepFileDiffs?: typeof _queryBatchSpecWorkspaceStepFileDiffs
 }


### PR DESCRIPTION
Closes #38600.

The callback [`queryFileDiffs`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx?L657-666) will only update if there are changes to the dependencies. When a step has a state change (for example finishes), this function does not get re-ran since none of the dependencies changed.

I decided to pass the whole `step` instead of the step number. This way, then the step has changes (for example finishes), this would cause the `useCallback` to rerun.

## Test plan

Manual testing (see video)

https://user-images.githubusercontent.com/38407415/180518420-d870fa39-6d62-41b2-a842-5a3742ca8c8f.mov



## App preview:

- [Web](https://sg-web-rc-diff-unavailable.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-txhkxnzutq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
