### PR TITLE
search: log lucky search events

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -41,7 +41,7 @@ import { GettingStartedTour } from '../../tour/GettingStartedTour'
 import { SearchUserNeedsCodeHost } from '../../user/settings/codeHosts/OrgUserNeedsCodeHost'
 import { submitSearch } from '../helpers'
 import { DidYouMean } from '../suggestion/DidYouMean'
-import { LuckySearch } from '../suggestion/LuckySearch'
+import { LuckySearch, luckySearchEvent } from '../suggestion/LuckySearch'
 
 import { SearchAlert } from './SearchAlert'
 import { useCachedSearchResults } from './SearchResultsCacheProvider'
@@ -164,6 +164,19 @@ export const StreamingSearchResults: React.FunctionComponent<
             telemetryService.log('SearchResultsFetchFailed', {
                 code_search: { error_message: asError(results.error).message },
             })
+        }
+    }, [results, telemetryService])
+
+    // Log lucky search events
+    useEffect(() => {
+        if (results?.alert?.kind === 'lucky-search-queries' && results?.alert?.title && results.alert.proposedQueries) {
+            const events = luckySearchEvent(
+                results.alert.title,
+                results.alert.proposedQueries.map(entry => entry.description || '')
+            )
+            for (const event of events) {
+                telemetryService.log(event)
+            }
         }
     }, [results, telemetryService])
 

--- a/client/web/src/search/suggestion/LuckySearch.tsx
+++ b/client/web/src/search/suggestion/LuckySearch.tsx
@@ -49,3 +49,28 @@ export const LuckySearch: React.FunctionComponent<React.PropsWithChildren<LuckyS
             </ul>
         </div>
     )
+
+export const luckySearchEvent = (alertTitle: string, descriptions: string[]): string[] => {
+    const rules = descriptions.map(entry => {
+        if (entry.match(/patterns as regular expressions/)) {
+            return 'Regexp'
+        }
+        if (entry.match(/unquote patterns/)) {
+            return 'Unquote'
+        }
+        if (entry.match(/AND patterns together/)) {
+            return 'And'
+        }
+        return 'Other'
+    })
+
+    const prefix = alertTitle.match(/No results for original query/)
+        ? 'SearchResultsAutoPure'
+        : 'SearchResultsAutoAdded'
+
+    const events = []
+    for (const rule of rules) {
+        events.push(`${prefix}${rule}`)
+    }
+    return events
+}


### PR DESCRIPTION
Adds logging for events I'm interested in tracking in amplitude. This is temporary and will go away in about ~two releases from now. Later I might add additional logging for results clicked, but that can wait.

## Test plan
No changes in functionality. Manually checked log events.