### PR TITLE
p4: skip integration tests for now

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -73,6 +73,10 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 }
 
 func TestSubRepoPermissionsSearch(t *testing.T) {
+	// context: https://sourcegraph.slack.com/archives/C07KZF47K/p1658178309055259
+	// But it seems that there is still an issue with P4 and they're currently timing out.
+	// cc @mollylogue
+	t.Skip("Currently broken")
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
 	createPerforceExternalService(t)


### PR DESCRIPTION
@mollylogue it seems that while your PR in https://github.com/sourcegraph/infrastructure/pull/3699 correctly made the CI to run those integrations tests, they have the side effect of also blocking the main branch as they're failing. 

By adding just a skip statement, you can keep working on this as the agents will have the env vars, but the `main` branch will be unblocked. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Should not run that particular tests. CI. 