### PR TITLE
`lib/group`: fix race condition in test

### DIFF
--- a/lib/group/result_test.go
+++ b/lib/group/result_test.go
@@ -98,6 +98,7 @@ func TestResultErrorGroup(t *testing.T) {
 		synchronizer := make(chan struct{})
 		g.Go(func() (int, error) {
 			<-synchronizer
+			time.Sleep(100 * time.Millisecond)
 			return 0, err1
 		})
 		g.Go(func() (int, error) {

--- a/lib/group/result_test.go
+++ b/lib/group/result_test.go
@@ -98,6 +98,13 @@ func TestResultErrorGroup(t *testing.T) {
 		synchronizer := make(chan struct{})
 		g.Go(func() (int, error) {
 			<-synchronizer
+			// This test has an intrinsic race condition that can be reproduced
+			// by adding a `defer time.Sleep(time.Second)` before the `defer
+			// close(synchronizer)`. We cannot guarantee that the group processes
+			// the return value of the second goroutine before the first goroutine
+			// exits in response to synchronizer, so we add a sleep here to make
+			// this race condition vanishingly unlikely. Note that this is a race
+			// in the test, not in the library.
 			time.Sleep(100 * time.Millisecond)
 			return 0, err1
 		})


### PR DESCRIPTION
This test has a race condition. It can be triggered consistently by
adding a `defer func() { time.Sleep(100 * time.Millisecond) }()` before
the `defer close(synchronizer)`. Unfortunately, I don't think it's
possible to completely remove the race condition without extending the
API of the group, so in this commit I resort to adding a sleep that
makes hitting the race condition vanishingly unlikely.

## Test plan

Tested that the race condition is not hit with an added sleep. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
