### PR TITLE
oobmigration: derive subscription account number and extract license key fields

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -10,7 +10,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -61,7 +60,7 @@ func (s dbSubscriptions) Create(ctx context.Context, userID int32, username stri
 	if err = s.db.QueryRowContext(ctx, `
 INSERT INTO product_subscriptions(id, user_id, account_number) VALUES($1, $2, $3) RETURNING id
 `,
-		uuid, userID, dbutil.NewNullString(accountNumber),
+		uuid, userID, accountNumber,
 	).Scan(&id); err != nil {
 		return "", errors.Wrap(err, "insert")
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
@@ -29,7 +29,9 @@ func TestProductSubscriptions_Create(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, sub, got.ID)
 		assert.Equal(t, u.ID, got.UserID)
-		assert.Nil(t, got.AccountNumber)
+
+		require.NotNil(t, got.AccountNumber)
+		assert.Empty(t, *got.AccountNumber)
 	})
 
 	u, err := db.Users().Create(ctx, database.NewUser{Username: "u-11223344"})

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/telemetry"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/productsubscription"
 
 	"github.com/sourcegraph/log"
 
@@ -110,6 +111,10 @@ func registerEnterpriseMigrations(db database.DB, outOfBandMigrationRunner *oobm
 	}
 
 	if err := insights.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
+		return err
+	}
+
+	if err := productsubscription.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
 		return err
 	}
 

--- a/enterprise/internal/productsubscription/migrations.go
+++ b/enterprise/internal/productsubscription/migrations.go
@@ -1,0 +1,221 @@
+package productsubscription
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+const (
+	subscriptionAccountNumberMigrationID = 15
+	licenseKeyFieldsMigrationID          = 16
+)
+
+func RegisterMigrations(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) error {
+	store := basestore.NewWithHandle(db.Handle())
+	migrations := map[int]oobmigration.Migrator{
+		subscriptionAccountNumberMigrationID: &subscriptionAccountNumberMigrator{store: store},
+		licenseKeyFieldsMigrationID:          &licenseKeyFieldsMigrator{store: store},
+	}
+
+	for id, migrator := range migrations {
+		if err := outOfBandMigrationRunner.Register(id, migrator, oobmigration.MigratorOptions{Interval: 5 * time.Second}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type subscriptionAccountNumberMigrator struct {
+	store *basestore.Store
+}
+
+func (m *subscriptionAccountNumberMigrator) Progress(ctx context.Context) (float64, error) {
+	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(`
+		SELECT
+			CASE c2.count WHEN 0 THEN 1 ELSE
+				cast(c1.count as float) / cast(c2.count as float)
+			END
+		FROM
+			(SELECT count(*) as count FROM product_subscriptions WHERE account_number IS NOT NULL) c1,
+			(SELECT count(*) as count FROM product_subscriptions) c2
+	`)))
+	return progress, err
+}
+
+func (m *subscriptionAccountNumberMigrator) Up(ctx context.Context) (err error) {
+	tx, err := m.store.Transact(ctx)
+	if err != nil {
+		return errors.Wrap(err, "start transaction")
+	}
+	defer func() { err = tx.Done(err) }()
+
+	// Select and lock a single record within this transaction. This ensures
+	// that many worker instances can run the same migration concurrently
+	// without them all trying to convert the same record.
+	rows, err := tx.Query(ctx, sqlf.Sprintf(`
+SELECT
+	product_subscriptions.id,
+	users.username
+FROM product_subscriptions
+JOIN users ON product_subscriptions.user_id = users.id
+WHERE product_subscriptions.account_number IS NULL
+LIMIT %s
+FOR UPDATE SKIP LOCKED
+`,
+		500,
+	))
+	if err != nil {
+		return errors.Wrap(err, "query rows")
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	var updates []*sqlf.Query
+	for rows.Next() {
+		var subscriptionID string
+		var username string
+		if err = rows.Scan(&subscriptionID, &username); err != nil {
+			return errors.Wrap(err, "scan")
+		}
+
+		var accountNumber string
+		if i := strings.LastIndex(username, "-"); i > -1 {
+			accountNumber = username[i+1:]
+		}
+
+		updates = append(updates, sqlf.Sprintf("(%s, %s)", subscriptionID, accountNumber))
+	}
+
+	if err = tx.Exec(ctx, sqlf.Sprintf(`
+UPDATE product_subscriptions
+SET account_number = updates.account_number
+FROM (VALUES %s) AS updates(id, account_number)
+WHERE product_subscriptions.id = updates.id::uuid`,
+		sqlf.Join(updates, ", "),
+	)); err != nil {
+		return errors.Wrap(err, "update")
+	}
+
+	return nil
+}
+
+func (m *subscriptionAccountNumberMigrator) Down(_ context.Context) error {
+	// The up migration only derived new data, thus no need to have down migration.
+	return nil
+}
+
+type licenseKeyFieldsMigrator struct {
+	store *basestore.Store
+}
+
+func (m *licenseKeyFieldsMigrator) Progress(ctx context.Context) (float64, error) {
+	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(`
+		SELECT
+			CASE c2.count WHEN 0 THEN 1 ELSE
+				cast(c1.count as float) / cast(c2.count as float)
+			END
+		FROM
+			(SELECT count(*) as count FROM product_licenses WHERE license_tags IS NOT NULL) c1,
+			(SELECT count(*) as count FROM product_licenses) c2
+	`)))
+	return progress, err
+}
+
+func (m *licenseKeyFieldsMigrator) Up(ctx context.Context) (err error) {
+	tx, err := m.store.Transact(ctx)
+	if err != nil {
+		return errors.Wrap(err, "start transaction")
+	}
+	defer func() { err = tx.Done(err) }()
+
+	// Select and lock a single record within this transaction. This ensures
+	// that many worker instances can run the same migration concurrently
+	// without them all trying to convert the same record.
+	rows, err := tx.Query(ctx, sqlf.Sprintf(`
+SELECT
+	id,
+	license_key
+FROM product_licenses
+WHERE license_tags IS NULL
+LIMIT %s
+FOR UPDATE SKIP LOCKED
+`,
+		500,
+	))
+	if err != nil {
+		return errors.Wrap(err, "query rows")
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	var updates []*sqlf.Query
+	for rows.Next() {
+		var id string
+		var licenseKey string
+		if err = rows.Scan(&id, &licenseKey); err != nil {
+			return errors.Wrap(err, "scan")
+		}
+
+		decodedText, err := base64.RawURLEncoding.DecodeString(licenseKey)
+		if err != nil {
+			return errors.Wrap(err, "decode license key")
+		}
+
+		var decodedKey struct {
+			Info []byte `json:"info"`
+		}
+		if err = json.Unmarshal(decodedText, &decodedKey); err != nil {
+			return errors.Wrap(err, "unmarshal decoded text")
+		}
+
+		var info license.Info
+		if err = json.Unmarshal(decodedKey.Info, &info); err != nil {
+			return errors.Wrap(err, "unmarshal info")
+		}
+
+		var expiresAt *time.Time
+		if !info.ExpiresAt.IsZero() {
+			expiresAt = &info.ExpiresAt
+		}
+		updates = append(updates,
+			sqlf.Sprintf("(%s, %s::integer, %s::text[], %s::integer, %s::timestamptz)",
+				id,
+				dbutil.NewNullInt64(int64(1)), // license_version
+				pq.Array(info.Tags),           // license_tags
+				dbutil.NewNullInt64(int64(info.UserCount)), // license_user_count
+				dbutil.NullTime{Time: expiresAt}),          // license_expires_at
+		)
+	}
+
+	if err = tx.Exec(ctx, sqlf.Sprintf(`
+UPDATE product_licenses
+SET
+	license_version    = updates.license_version::integer,
+	license_tags       = updates.license_tags::text[],
+	license_user_count = updates.license_user_count::integer,
+	license_expires_at = updates.license_expires_at::timestamptz
+FROM (VALUES %s) AS updates(id, license_version, license_tags, license_user_count, license_expires_at)
+WHERE product_licenses.id = updates.id::uuid`,
+		sqlf.Join(updates, ", "),
+	)); err != nil {
+		return errors.Wrap(err, "update")
+	}
+
+	return nil
+}
+
+func (m *licenseKeyFieldsMigrator) Down(_ context.Context) error {
+	// The up migration only derived new data, thus no need to have down migration.
+	return nil
+}

--- a/enterprise/internal/productsubscription/migrations_test.go
+++ b/enterprise/internal/productsubscription/migrations_test.go
@@ -79,6 +79,7 @@ RETURNING id
 		subscriptionID,
 		`eyJzaWciOnsiRm9ybWF0Ijoic3NoLXJzYSIsIkJsb2IiOiIuLi4iLCJSZXN0IjpudWxsfSwiaW5mbyI6ImV5SjJJam94TENKdUlqcGJNVEk0TERrd0xESTBOaXd5TkRRc05qWXNNVFFzTWpVMUxEZ3hYU3dpZENJNld5SmtaWFlpWFN3aWRTSTZPQ3dpWlNJNklqSXdNak10TURZdE1ERlVNVFk2TWpnNk16WmFJbjA9In0`,
 	).Scan(&licenseID)
+	require.NoError(t, err)
 
 	// Ensure there is no progress before migration
 	migrator := &licenseKeyFieldsMigrator{store: basestore.NewWithHandle(db.Handle())}

--- a/enterprise/internal/productsubscription/migrations_test.go
+++ b/enterprise/internal/productsubscription/migrations_test.go
@@ -1,0 +1,112 @@
+package productsubscription
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestSubscriptionAccountNumberMigrator(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+	// Set up test data
+	alice, err := db.Users().Create(ctx, database.NewUser{Username: "alice"}) // A username without account number shouldn't fail
+	require.NoError(t, err)
+	bob, err := db.Users().Create(ctx, database.NewUser{Username: "bob-11033746"})
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `INSERT INTO product_subscriptions(id, user_id) VALUES(gen_random_uuid(), $1)`, alice.ID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO product_subscriptions(id, user_id) VALUES(gen_random_uuid(), $1)`, bob.ID)
+	require.NoError(t, err)
+
+	// Ensure there is no progress before migration
+	migrator := &subscriptionAccountNumberMigrator{store: basestore.NewWithHandle(db.Handle())}
+	progress, err := migrator.Progress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0.0, progress)
+
+	// Perform the migration and recheck the progress
+	err = migrator.Up(ctx)
+	require.NoError(t, err)
+
+	progress, err = migrator.Progress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1.0, progress)
+
+	// Ensure data are at desired states
+	var accountNumber string
+	err = db.QueryRowContext(ctx, `SELECT account_number FROM product_subscriptions WHERE user_id = $1`, alice.ID).Scan(&accountNumber)
+	require.NoError(t, err)
+	assert.Empty(t, accountNumber)
+
+	err = db.QueryRowContext(ctx, `SELECT account_number FROM product_subscriptions WHERE user_id = $1`, bob.ID).Scan(&accountNumber)
+	require.NoError(t, err)
+	assert.Equal(t, "11033746", accountNumber)
+}
+
+func TestLicenseKeyFieldsMigrator(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+	// Set up test data
+	alice, err := db.Users().Create(ctx, database.NewUser{Username: "alice"})
+	require.NoError(t, err)
+
+	var subscriptionID string
+	err = db.QueryRowContext(ctx, `INSERT INTO product_subscriptions(id, user_id) VALUES(gen_random_uuid(), $1) RETURNING id`, alice.ID).Scan(&subscriptionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, subscriptionID)
+
+	var licenseID string
+	err = db.QueryRowContext(ctx, `
+INSERT INTO product_licenses(id, product_subscription_id, license_key)
+VALUES(gen_random_uuid(), $1, $2)
+RETURNING id
+`,
+		subscriptionID,
+		`eyJzaWciOnsiRm9ybWF0Ijoic3NoLXJzYSIsIkJsb2IiOiIuLi4iLCJSZXN0IjpudWxsfSwiaW5mbyI6ImV5SjJJam94TENKdUlqcGJNVEk0TERrd0xESTBOaXd5TkRRc05qWXNNVFFzTWpVMUxEZ3hYU3dpZENJNld5SmtaWFlpWFN3aWRTSTZPQ3dpWlNJNklqSXdNak10TURZdE1ERlVNVFk2TWpnNk16WmFJbjA9In0`,
+	).Scan(&licenseID)
+
+	// Ensure there is no progress before migration
+	migrator := &licenseKeyFieldsMigrator{store: basestore.NewWithHandle(db.Handle())}
+	progress, err := migrator.Progress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0.0, progress)
+
+	// Perform the migration and recheck the progress
+	err = migrator.Up(ctx)
+	require.NoError(t, err)
+
+	progress, err = migrator.Progress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1.0, progress)
+
+	// Ensure data are at desired states
+	var licenseVersion int
+	var licenseTags []string
+	var licenseUserCount int
+	var licenseExpiresAt time.Time
+	err = db.QueryRowContext(ctx, `SELECT license_version, license_tags, license_user_count, license_expires_at FROM product_licenses WHERE id = $1`, licenseID).
+		Scan(&licenseVersion, pq.Array(&licenseTags), &licenseUserCount, &licenseExpiresAt)
+	require.NoError(t, err)
+	assert.Equal(t, 1, licenseVersion)
+	assert.Equal(t, []string{"dev"}, licenseTags)
+	assert.Equal(t, 8, licenseUserCount)
+
+	wantExpiresAt, err := time.Parse(time.RFC3339, "2023-06-01T16:28:36Z")
+	require.NoError(t, err)
+	assert.Equal(t, wantExpiresAt, licenseExpiresAt)
+}

--- a/internal/oobmigration/oobmigrations.yaml
+++ b/internal/oobmigration/oobmigrations.yaml
@@ -117,7 +117,7 @@
   non_destructive: true
   is_enterprise: true
   introduced_version_major: 3
-  introduced_version_minor: 42
+  introduced_version_minor: 43
 - id: 16
   team: iam
   component: frontend-db.product_licenses
@@ -125,4 +125,4 @@
   non_destructive: true
   is_enterprise: true
   introduced_version_major: 3
-  introduced_version_minor: 42
+  introduced_version_minor: 43

--- a/internal/oobmigration/oobmigrations.yaml
+++ b/internal/oobmigration/oobmigrations.yaml
@@ -110,3 +110,19 @@
   is_enterprise: true
   introduced_version_major: 3
   introduced_version_minor: 35
+- id: 15
+  team: iam
+  component: frontend-db.product_subscriptions
+  description: Attempt to extract account number from the associated user of subscriptions.
+  non_destructive: true
+  is_enterprise: true
+  introduced_version_major: 3
+  introduced_version_minor: 42
+- id: 16
+  team: iam
+  component: frontend-db.product_licenses
+  description: Extract license fields from the license key text and store them to dedicated columns.
+  non_destructive: true
+  is_enterprise: true
+  introduced_version_major: 3
+  introduced_version_minor: 42


### PR DESCRIPTION
This PR adds two OOB migrations:

1. Attempt to extract the account number from the associated user of subscriptions, sister PR: https://github.com/sourcegraph/sourcegraph/pull/39209
2. Extract license fields from the license key text and store them to dedicated columns, sister PR: https://github.com/sourcegraph/sourcegraph/pull/39215

## Test plan

Manually e2e tested locally.

---

Part of https://github.com/sourcegraph/sourcegraph/issues/38661