### PR TITLE
sg: fix typo in cmd description

### DIFF
--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -72,7 +72,7 @@ sg db add-user -name=foo
 			},
 			{
 				Name:        "add-user",
-				Usage:       "Create an admin sourcegrah user",
+				Usage:       "Create an admin sourcegraph user",
 				Description: `Run 'sg db add-user -username bob' to create an admin user whose email is bob@sourcegraph.com. The password will be printed if the operation succeeds`,
 				Flags: []cli.Flag{
 					&cli.StringFlag{

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -432,7 +432,7 @@ $ sg db reset-redis
 
 ### sg db add-user
 
-Create an admin sourcegrah user.
+Create an admin sourcegraph user.
 
 Run 'sg db add-user -username bob' to create an admin user whose email is bob@sourcegraph.com. The password will be printed if the operation succeeds
 


### PR DESCRIPTION
Fix a typo

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a, doc change 