### PR TITLE
gqltest: remove skipping TestBitbucketProjectsPermsSync_SetPermissionsUnrestricted

### DIFF
--- a/dev/gqltest/bitbucket_projects_perms_sync_test.go
+++ b/dev/gqltest/bitbucket_projects_perms_sync_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestBitbucketProjectsPermsSync_SetPermissionsUnrestricted(t *testing.T) {
-	t.Skipf("disabling broken test to unblock main")
 	if len(*bbsURL) == 0 || len(*bbsToken) == 0 || len(*bbsUsername) == 0 {
 		t.Skip("Environment variable BITBUCKET_SERVER_URL, BITBUCKET_SERVER_TOKEN, or BITBUCKET_SERVER_USERNAME is not set")
 	}
@@ -73,6 +72,10 @@ func TestBitbucketProjectsPermsSync_SetPermissionsUnrestricted(t *testing.T) {
 		status, err := client.GetLastBitbucketProjectPermissionJob(projectKey)
 		if err != nil || status == "" {
 			t.Fatal("Error during getting the status of a Bitbucket Permissions job")
+		}
+
+		if status == "errored" || status == "failed" {
+			t.Fatalf("Bitbucket Permissions job failed with status: '%s'", status)
 		}
 
 		if status == "completed" {


### PR DESCRIPTION
After successful local retests I am returning this test.
Current commit adds clarity whether the job has failed or just hasn't finished in a 30 second frame. Which will be useful for further understanding if this test will fail again.

I think there must have been some issues with the database or the code host for the build that failed at that time, because the error in the [failed build](https://buildkite.com/sourcegraph/sourcegraph/builds/162722#018226e1-881e-4777-b4dc-8dcf5215a644) showed that basically either:
- 2 one-row INSERTs into the DB weren't able to finish in 30-ish seconds
- there were some error while interacting with `bitbucket.sgdev.org`

Also, this test passed for me locally during development, and both PR and `main` builds passed when I was merging the commit with this test.

## Test plan
Test should run successfully.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
