### PR TITLE
JetBrains: Remove com.intellij.modules.lang dependency

### DIFF
--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -3,10 +3,6 @@
     <name>Sourcegraph</name>
     <vendor email="hi@sourcegraph.com" url="https://sourcegraph.com">Sourcegraph</vendor>
 
-    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
-         on how to target different products -->
-    <depends>com.intellij.modules.lang</depends>
-
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="com.sourcegraph.config.SourcegraphProjectService"/>
         <projectService serviceImplementation="com.sourcegraph.config.SettingsChangeListener"/>


### PR DESCRIPTION
I was looking into JetBrains Gateway product support and noticed that according to the JetBrains web UI, the `com.intellij.modules.lang` module is not supported by that product.

I tried removing it from the definition file but it seems that the product still works without any issues, so let's remove it.

## Test plan

Manual testing and hoping that the Java CI steps pass:

![Screenshot 2022-07-25 at 12 00 06](https://user-images.githubusercontent.com/458591/180751241-3787f1a9-dac8-4f92-9676-2f2ef5a87141.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-remove-lang-module.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-leweskdyfv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
