### PR TITLE
internal/gitserver: Improvement  to RepoInfo method

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1234,7 +1234,13 @@ func (c *ClientImplementor) RepoInfo(ctx context.Context, repos ...api.RepoName)
 					msg = fmt.Sprintf("%s, failed to read response body, error: %v", msg, err)
 				}
 
-				msg = fmt.Sprintf("%s, body: %q", msg, string(content))
+				// strings.TrimSpace is needed to remove trailing \n characters that is added by the
+				// server. We use http.Error in the server which in turn uses fmt.Fprintln to format
+				// the error message. And in translation that newline gets escapted into a \n
+				// character.  For what the error message would look in the UI without
+				// strings.TrimSpace, see attached screenshots in this pull request:
+				// https://github.com/sourcegraph/sourcegraph/pull/39358.
+				msg = fmt.Sprintf("%s, reason: %q", msg, strings.TrimSpace(string(content)))
 
 				o.err = &url.Error{
 					URL: resp.Request.URL.String(),

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1189,8 +1189,8 @@ func (c *ClientImplementor) RepoInfo(ctx context.Context, repos ...api.RepoName)
 		return ClientMocks.RepoInfo(ctx, repos...)
 	}
 
-	numPossibleShards := len(c.Addrs())
-	shards := make(map[string]*protocol.RepoInfoRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
+	totalShards := len(c.Addrs())
+	shards := make(map[string]*protocol.RepoInfoRequest, totalShards)
 
 	for _, r := range repos {
 		addr, err := c.AddrForRepo(ctx, r)

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -38,6 +38,104 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+func TestClient_RepoInfo(t *testing.T) {
+	repos := []api.RepoName{
+		"github.com/sourcegraph/sourcegraph", // Address of this repo hashes to 172.16.8.1:8080, DO NOT CHANGE THE NAME.
+		"gitlab.com/foo/baz",                 // Address of this repo hashes to 172.16.8.2:8080, DO NOT CHANGE THE NAME.
+	}
+	addrs := []string{"172.16.8.1:8080", "172.16.8.2:8080"}
+
+	t.Run("200 status code", func(t *testing.T) {
+		cli := gitserver.NewTestClient(
+			httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					Request:    r,
+					StatusCode: 200,
+					Body: io.NopCloser(bytes.NewBufferString(`
+{
+  "Results": {
+    "github.com/sourcegraph/sourcegraph": {
+      "URL": "github.com/sourcegraph/sourcegraph",
+      "Cloned": true
+    },
+    "gitlab.com/foo/baz": {
+      "URL": "gitlab.com/foo/baz",
+      "Cloned": true
+    }
+  }
+}
+`,
+					)),
+				}, nil
+			}),
+			database.NewMockDB(),
+			addrs,
+		)
+
+		resp, err := cli.RepoInfo(context.Background(), repos...)
+		if err != nil {
+			t.Errorf("expected nil, but got err: %v", err)
+		}
+
+		l := len(resp.Results)
+		if l != 2 {
+			t.Fatalf("expected length of RepoInfoResponse.Results to be 2, but got %d", l)
+		}
+
+		for _, repo := range repos {
+			repoInfo, ok := resp.Results[repo]
+			if !ok {
+				t.Fatalf("expected repoInfo for repo %q, but found none", repo)
+			}
+
+			if repoInfo.URL != string(repo) {
+				t.Errorf("expected repoInfo.URL to be %q, but got %q", repo, repoInfo.URL)
+			}
+
+			if !repoInfo.Cloned {
+				t.Error("expected repoInfo.Cloned to be true, but got false")
+			}
+		}
+	})
+
+	t.Run("500 status code", func(t *testing.T) {
+		cli := gitserver.NewTestClient(
+			httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					Request:    r,
+					StatusCode: 500,
+					Body:       io.NopCloser(bytes.NewBufferString("test error message")),
+				}, nil
+			}),
+			database.NewMockDB(),
+			addrs,
+		)
+
+		resp, err := cli.RepoInfo(context.Background(), repos...)
+		if err == nil {
+			t.Error("expected err, but got nil")
+		}
+
+		_ = "RepoInfo \"http://172.16.8.1:8080/repos\": RepoInfo: http status code: 500, body: \"test error message\""
+
+		expected := `
+2 errors occurred:
+		* RepoInfo "http://172.16.8.2:8080/repos": RepoInfo: http status code: 500, body: "test error message"
+		* RepoInfo "http://172.16.8.1:8080/repos": RepoInfo: http status code: 500, body: "test error message"
+`
+
+		// expected := `RepoInfo "http://172.16.8.1:8080/repos": RepoInfo: http status code: 500, body: "test error message"`
+		if cmp.Equal(expected, err.Error()) {
+			t.Errorf("mismatch in error message (-want +got):\n%s", cmp.Diff(expected, err.Error()))
+		}
+
+		l := len(resp.Results)
+		if l != 0 {
+			t.Fatalf("expected length of RepoInfoResponse.Results to be 0, but got %d", l)
+		}
+	})
+}
+
 func TestClient_RequestRepoMigrate(t *testing.T) {
 	repo := api.RepoName("github.com/sourcegraph/sourcegraph")
 	addrs := []string{"172.16.8.1:8080", "172.16.8.2:8080"}

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -116,15 +116,12 @@ func TestClient_RepoInfo(t *testing.T) {
 			t.Error("expected err, but got nil")
 		}
 
-		_ = "RepoInfo \"http://172.16.8.1:8080/repos\": RepoInfo: http status code: 500, body: \"test error message\""
-
 		expected := `
 2 errors occurred:
 		* RepoInfo "http://172.16.8.2:8080/repos": RepoInfo: http status code: 500, body: "test error message"
 		* RepoInfo "http://172.16.8.1:8080/repos": RepoInfo: http status code: 500, body: "test error message"
 `
 
-		// expected := `RepoInfo "http://172.16.8.1:8080/repos": RepoInfo: http status code: 500, body: "test error message"`
 		if cmp.Equal(expected, err.Error()) {
 			t.Errorf("mismatch in error message (-want +got):\n%s", cmp.Diff(expected, err.Error()))
 		}


### PR DESCRIPTION
This PR makes two functional improvements to the RepoInfo client method and a semantic one. 

The functional improvements are:

1. Limit length of map to max number of shards
2. Do not hide response body for failed HTTP reqs

The semantic improvement is:

1. Add comment and rename shard -> repoInfoReq

**Note to reviewers**

It's recommended to look at each commit sequentially to view the changes in an isolated way. This should make it easier to understand the changes in this PR vs looking at the entire diff at the same time.

The pain point with no response body for non 200 errors was first observer in this [customer issue](https://github.com/sourcegraph/customer/issues/1049) which also led to the other improvements as I was reading and understanding this code.

## Test plan

- Added tests. 
- Did end to end UI testing. Applied the following diff to the code to simulate 500 HTTP response.

![image](https://user-images.githubusercontent.com/2682729/181237359-aa9ef51f-d740-4731-91de-5a76496b762a.png)


**UI should now look like this:**

![image](https://user-images.githubusercontent.com/2682729/181236681-efcbb4ba-67f8-429c-a34b-5cfb67d989be.png)

**VS current behaviour without this PR:**

![image](https://user-images.githubusercontent.com/2682729/181237723-4c7268c2-a791-4dd0-b8db-a442ca29867b.png)



## Note for time travellers

**Without strings.TrimSpace**

![image](https://user-images.githubusercontent.com/2682729/181236836-46c5caf5-aa5f-4cde-877e-f9327d0e8c68.png)

**With strings.TrimSpace**


![image](https://user-images.githubusercontent.com/2682729/181236743-7cd00176-1d0a-4843-b4f9-e7f878ea3d38.png)



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
