### PR TITLE
dependencies: add updated_at/created_at to LockfileIndex

### DIFF
--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -74,7 +74,7 @@ func scanLockfileIndex(s dbutil.Scanner) (shared.LockfileIndex, error) {
 		referenceIDs pq.Int32Array
 	)
 
-	err := s.Scan(&i.ID, &i.RepositoryID, &commit, &referenceIDs, &i.Lockfile, &i.Fidelity)
+	err := s.Scan(&i.ID, &i.RepositoryID, &commit, &referenceIDs, &i.Lockfile, &i.Fidelity, &i.UpdatedAt, &i.CreatedAt)
 	if err != nil {
 		return i, err
 	}

--- a/internal/codeintel/dependencies/shared/types.go
+++ b/internal/codeintel/dependencies/shared/types.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"strings"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/lockfiles"
@@ -37,6 +38,8 @@ type LockfileIndex struct {
 	LockfileReferenceIDs []int
 	Lockfile             string
 	Fidelity             IndexFidelity
+	UpdatedAt            time.Time
+	CreatedAt            time.Time
 }
 
 type Repo struct {

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -6035,6 +6035,19 @@
           "Comment": "A 40-char revhash. Note that this commit may not be resolvable in the future."
         },
         {
+          "Name": "created_at",
+          "Index": 7,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Time when lockfile was indexed"
+        },
+        {
           "Name": "fidelity",
           "Index": 6,
           "TypeName": "text",
@@ -6085,6 +6098,19 @@
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
           "Comment": ""
+        },
+        {
+          "Name": "updated_at",
+          "Index": 8,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Time when lockfile index was updated"
         }
       ],
       "Indexes": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -751,14 +751,16 @@ Tracks a lockfile dependency that might be resolvable to a specific repository-c
 
 # Table "public.codeintel_lockfiles"
 ```
-              Column              |   Type    | Collation | Nullable |                     Default                     
-----------------------------------+-----------+-----------+----------+-------------------------------------------------
- id                               | integer   |           | not null | nextval('codeintel_lockfiles_id_seq'::regclass)
- repository_id                    | integer   |           | not null | 
- commit_bytea                     | bytea     |           | not null | 
- codeintel_lockfile_reference_ids | integer[] |           | not null | 
- lockfile                         | text      |           |          | 
- fidelity                         | text      |           | not null | 'flat'::text
+              Column              |           Type           | Collation | Nullable |                     Default                     
+----------------------------------+--------------------------+-----------+----------+-------------------------------------------------
+ id                               | integer                  |           | not null | nextval('codeintel_lockfiles_id_seq'::regclass)
+ repository_id                    | integer                  |           | not null | 
+ commit_bytea                     | bytea                    |           | not null | 
+ codeintel_lockfile_reference_ids | integer[]                |           | not null | 
+ lockfile                         | text                     |           |          | 
+ fidelity                         | text                     |           | not null | 'flat'::text
+ created_at                       | timestamp with time zone |           | not null | now()
+ updated_at                       | timestamp with time zone |           | not null | now()
 Indexes:
     "codeintel_lockfiles_pkey" PRIMARY KEY, btree (id)
     "codeintel_lockfiles_repository_id_commit_bytea_lockfile" UNIQUE, btree (repository_id, commit_bytea, lockfile)
@@ -772,9 +774,13 @@ Associates a repository-commit pair with the set of repository-level dependencie
 
 **commit_bytea**: A 40-char revhash. Note that this commit may not be resolvable in the future.
 
+**created_at**: Time when lockfile was indexed
+
 **fidelity**: Fidelity of the dependency graph thats persisted, whether it is a flat list, a whole graph, circular graph, ...
 
 **lockfile**: Relative path of a lockfile in the given repository and the given commit.
+
+**updated_at**: Time when lockfile index was updated
 
 # Table "public.configuration_policies_audit_logs"
 ```

--- a/migrations/frontend/1658748822_add_timestamps_to_lockfiles/down.sql
+++ b/migrations/frontend/1658748822_add_timestamps_to_lockfiles/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE codeintel_lockfiles
+  DROP COLUMN IF EXISTS created_at,
+  DROP COLUMN IF EXISTS updated_at
+  ;

--- a/migrations/frontend/1658748822_add_timestamps_to_lockfiles/metadata.yaml
+++ b/migrations/frontend/1658748822_add_timestamps_to_lockfiles/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_timestamps_to_lockfiles
+parents: [1658512336]

--- a/migrations/frontend/1658748822_add_timestamps_to_lockfiles/up.sql
+++ b/migrations/frontend/1658748822_add_timestamps_to_lockfiles/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE codeintel_lockfiles
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT NOW(),
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT NOW()
+  ;
+
+COMMENT ON COLUMN codeintel_lockfiles.created_at IS 'Time when lockfile was indexed';
+COMMENT ON COLUMN codeintel_lockfiles.updated_at IS 'Time when lockfile index was updated';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1262,7 +1262,9 @@ CREATE TABLE codeintel_lockfiles (
     commit_bytea bytea NOT NULL,
     codeintel_lockfile_reference_ids integer[] NOT NULL,
     lockfile text,
-    fidelity text DEFAULT 'flat'::text NOT NULL
+    fidelity text DEFAULT 'flat'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 COMMENT ON TABLE codeintel_lockfiles IS 'Associates a repository-commit pair with the set of repository-level dependencies parsed from lockfiles.';
@@ -1274,6 +1276,10 @@ COMMENT ON COLUMN codeintel_lockfiles.codeintel_lockfile_reference_ids IS 'A key
 COMMENT ON COLUMN codeintel_lockfiles.lockfile IS 'Relative path of a lockfile in the given repository and the given commit.';
 
 COMMENT ON COLUMN codeintel_lockfiles.fidelity IS 'Fidelity of the dependency graph thats persisted, whether it is a flat list, a whole graph, circular graph, ...';
+
+COMMENT ON COLUMN codeintel_lockfiles.created_at IS 'Time when lockfile was indexed';
+
+COMMENT ON COLUMN codeintel_lockfiles.updated_at IS 'Time when lockfile index was updated';
 
 CREATE SEQUENCE codeintel_lockfiles_id_seq
     AS integer


### PR DESCRIPTION
More useful metadata. Without that it's really hard to make sense of the data in the site-admin UI. Follow-up PRs will add resolvers and frontend side of things.

## Test plan

- Existing unit tests
- Newly-added unit tests