### PR TITLE
sg: ignore config overwrite when generating reference for docs

### DIFF
--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -17,7 +17,6 @@ import (
 	"github.com/jackc/pgx/v4"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/check"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/usershell"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
@@ -232,7 +231,7 @@ func checkSourcegraphDatabase(ctx context.Context) error {
 	// This check runs only in the `sourcegraph/sourcegraph` repository, so
 	// we try to parse the globalConf and use its `Env` to configure the
 	// Postgres connection.
-	config, _ := sgconf.Get(configFile, configOverwriteFile)
+	config, _ := getConfig()
 	if config == nil {
 		return errors.New("failed to read sg.config.yaml. This step of `sg setup` needs to be run in the `sourcegraph` repository")
 	}

--- a/dev/sg/dependencies/dependencies.go
+++ b/dev/sg/dependencies/dependencies.go
@@ -12,6 +12,7 @@ type CheckArgs struct {
 
 	ConfigFile          string
 	ConfigOverwriteFile string
+	DisableOverwrite    bool
 }
 
 type category = check.Category[CheckArgs]

--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -191,7 +191,12 @@ func checkSourcegraphDatabase(ctx context.Context, out *std.Output, args CheckAr
 	// This check runs only in the `sourcegraph/sourcegraph` repository, so
 	// we try to parse the globalConf and use its `Env` to configure the
 	// Postgres connection.
-	config, _ := sgconf.Get(args.ConfigFile, args.ConfigOverwriteFile)
+	var config *sgconf.Config
+	if args.DisableOverwrite {
+		config, _ = sgconf.GetWithoutOverwrites(args.ConfigFile)
+	} else {
+		config, _ = sgconf.Get(args.ConfigFile, args.ConfigOverwriteFile)
+	}
 	if config == nil {
 		return errors.New("failed to read sg.config.yaml. This step of `sg setup` needs to be run in the `sourcegraph` repository")
 	}

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/db"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
@@ -97,7 +96,7 @@ func dbAddUserAction(cmd *cli.Context) error {
 	logger := log.Scoped("dbAddUserAction", "")
 
 	// Read the configuration.
-	conf, _ := sgconf.Get(configFile, configOverwriteFile)
+	conf, _ := getConfig()
 	if conf == nil {
 		return errors.New("failed to read sg.config.yaml. This command needs to be run in the `sourcegraph` repository")
 	}
@@ -150,7 +149,7 @@ func dbAddUserAction(cmd *cli.Context) error {
 
 func dbResetRedisExec(ctx *cli.Context) error {
 	// Read the configuration.
-	config, _ := sgconf.Get(configFile, configOverwriteFile)
+	config, _ := getConfig()
 	if config == nil {
 		return errors.New("failed to read sg.config.yaml. This command needs to be run in the `sourcegraph` repository")
 	}
@@ -173,7 +172,7 @@ func dbResetRedisExec(ctx *cli.Context) error {
 
 func dbResetPGExec(ctx *cli.Context) error {
 	// Read the configuration.
-	config, _ := sgconf.Get(configFile, configOverwriteFile)
+	config, _ := getConfig()
 	if config == nil {
 		return errors.New("failed to read sg.config.yaml. This command needs to be run in the `sourcegraph` repository")
 	}

--- a/dev/sg/sg_insights.go
+++ b/dev/sg/sg_insights.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -68,7 +67,7 @@ func getInsightSeriesIDsAction(cmd *cli.Context) error {
 	logger := log.Scoped("getInsightSeriesIDsAction", "")
 
 	// Read the configuration.
-	conf, err := sgconf.Get(configFile, configOverwriteFile)
+	conf, err := getConfig()
 	if err != nil {
 		return err
 	}

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/db"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/migration"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
@@ -172,7 +171,7 @@ func makeRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, erro
 	// Try to read the `sg` configuration so we can read ENV vars from the
 	// configuration and use process env as fallback.
 	var getEnv func(string) string
-	config, _ := sgconf.Get(configFile, configOverwriteFile)
+	config, _ := getConfig()
 	logger := log.Scoped("migrations.runner", "migration runner")
 	if config != nil {
 		getEnv = config.GetEnv

--- a/dev/sg/sg_run.go
+++ b/dev/sg/sg_run.go
@@ -9,7 +9,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -40,7 +39,7 @@ sg run gitserver frontend repo-updater
 	Flags:    []cli.Flag{},
 	Action:   runExec,
 	BashComplete: completeOptions(func() (options []string) {
-		config, _ := sgconf.Get(configFile, configOverwriteFile)
+		config, _ := getConfig()
 		if config == nil {
 			return
 		}
@@ -52,7 +51,7 @@ sg run gitserver frontend repo-updater
 }
 
 func runExec(ctx *cli.Context) error {
-	config, err := sgconf.Get(configFile, configOverwriteFile)
+	config, err := getConfig()
 	if err != nil {
 		return err
 	}
@@ -81,7 +80,7 @@ func constructRunCmdLongHelp() string {
 
 	fmt.Fprintf(&out, "Runs the given command. If given a whitespace-separated list of commands it runs the set of commands.\n")
 
-	config, err := sgconf.Get(configFile, configOverwriteFile)
+	config, err := getConfig()
 	if err != nil {
 		out.Write([]byte("\n"))
 		// Do not treat error message as a format string

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -55,6 +55,7 @@ var setupCommand = &cli.Command{
 			Teammate:            !cmd.Bool("oss"),
 			ConfigFile:          configFile,
 			ConfigOverwriteFile: configOverwriteFile,
+			DisableOverwrite:    disableOverwrite,
 		}
 
 		switch {

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -87,7 +87,7 @@ sg start --debug=gitserver --error=enterprise-worker,enterprise-frontend enterpr
 			},
 		},
 		BashComplete: completeOptions(func() (options []string) {
-			config, _ := sgconf.Get(configFile, configOverwriteFile)
+			config, _ := getConfig()
 			if config == nil {
 				return
 			}
@@ -105,7 +105,7 @@ func constructStartCmdLongHelp() string {
 
 	fmt.Fprintf(&out, `Use this to start your Sourcegraph environment!`)
 
-	config, err := sgconf.Get(configFile, configOverwriteFile)
+	config, err := getConfig()
 	if err != nil {
 		out.Write([]byte("\n"))
 		std.NewOutput(&out, false).WriteWarningf(err.Error())
@@ -133,7 +133,7 @@ func constructStartCmdLongHelp() string {
 }
 
 func startExec(ctx *cli.Context) error {
-	config, err := sgconf.Get(configFile, configOverwriteFile)
+	config, err := getConfig()
 	if err != nil {
 		return err
 	}

--- a/dev/sg/sg_tests.go
+++ b/dev/sg/sg_tests.go
@@ -9,7 +9,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -40,7 +39,7 @@ sg test backend-integration -run TestSearch
 `,
 	Category: CategoryDev,
 	BashComplete: completeOptions(func() (options []string) {
-		config, _ := sgconf.Get(configFile, configOverwriteFile)
+		config, _ := getConfig()
 		if config == nil {
 			return
 		}
@@ -53,7 +52,7 @@ sg test backend-integration -run TestSearch
 }
 
 func testExec(ctx *cli.Context) error {
-	config, err := sgconf.Get(configFile, configOverwriteFile)
+	config, err := getConfig()
 	if err != nil {
 		return err
 	}
@@ -80,7 +79,7 @@ func constructTestCmdLongHelp() string {
 
 	// Attempt to parse config to list available testsuites, but don't fail on
 	// error, because we should never error when the user wants --help output.
-	config, err := sgconf.Get(configFile, configOverwriteFile)
+	config, err := getConfig()
 	if err != nil {
 		out.Write([]byte("\n"))
 		// Do not treat error message as a format string

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -15,6 +15,7 @@ Global flags:
 * `--config, -c="<value>"`: load sg configuration from `file` (default: sg.config.yaml)
 * `--disable-analytics`: disable event logging (logged to '~/.sourcegraph/events')
 * `--disable-output-detection`: use fixed output configuration instead of detecting terminal capabilities
+* `--disable-overwrite`: disable loading additional sg configuration from overwrite file (see -overwrite)
 * `--overwrite, -o="<value>"`: load sg configuration from `file` that is gitignored and can be used to, for example, add credentials (default: sg.config.overwrite.yaml)
 * `--skip-auto-update`: prevent sg from automatically updating itself
 * `--verbose, -v`: toggle verbose mode


### PR DESCRIPTION
Finally fixing this after it made me say "ah! oh no" one too many times
in the past few weeks.

Here's what previously happened on THORSTEN & SG GENERATE:

1. Thorsten has a custom commandset named `horsegraph` in `sg.config.overwrite.yaml`, along with some other custom commands.
2. Thorsten creates a database migration/GraphQL schema addition/...
3. Thorsten runs `sg generate`
4. Thorsten commits and pushes commit
5. Thorsten sees that he pushed commit in which `sg`'s reference in the
   documentation now contains `"horsegraph"` as an official commandset
   to be used with `sg start`
6. Thorsten says "ah! oh no" and undoes changes

... multiple times.

So what this does here is introduce a `disable-overwrite` flag that
causes only the standard config to be read.

It's then used in the `go:generate` directive that runs `sg help`.

## Test plan

- See steps above. I tested this manually. This PR contains an updated reference (to include `-disable-overwrite`) but no custom commands.