### PR TITLE
lockfile indexes: show timestamps in admin UI

### DIFF
--- a/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react'
 
 import { Link, H3, Code } from '@sourcegraph/wildcard'
 
+import { Timestamp } from '../../../../components/time/Timestamp'
 import { LockfileIndexFields } from '../../../../graphql-operations'
 
 import styles from './CodeIntelLockfileIndexNode.module.scss'
@@ -31,6 +32,16 @@ export const CodeIntelLockfileNode: FunctionComponent<React.PropsWithChildren<Co
                     </Link>
                     . Dependency graph fidelity: {node.fidelity}.
                 </span>
+
+                <small className="text-mute">
+                    Indexed <Timestamp date={node.createdAt} />.{' '}
+                    {node.createdAt !== node.updatedAt && (
+                        <>
+                            Updated <Timestamp date={node.updatedAt} />{' '}
+                        </>
+                    )}
+                    .
+                </small>
             </div>
         </div>
     </>

--- a/client/web/src/enterprise/codeintel/lockfiles/pages/queries.ts
+++ b/client/web/src/enterprise/codeintel/lockfiles/pages/queries.ts
@@ -17,6 +17,9 @@ export const LOCKFILE_INDEXES_LIST = gql`
             abbreviatedOID
             oid
         }
+
+        updatedAt
+        createdAt
     }
 
     fragment LockfileIndexConnectionFields on LockfileIndexConnection {

--- a/cmd/frontend/graphqlbackend/dependencies.go
+++ b/cmd/frontend/graphqlbackend/dependencies.go
@@ -31,4 +31,6 @@ type LockfileIndexResolver interface {
 	Repository() *RepositoryResolver
 	Commit() *GitCommitResolver
 	Fidelity() string
+	UpdatedAt() DateTime
+	CreatedAt() DateTime
 }

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -87,4 +87,14 @@ type LockfileIndex implements Node {
     The fidelity of the dependency graph.
     """
     fidelity: LockfileIndexFidelity!
+
+    """
+    The date and time when the lockfile index was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the lockfile index was updated.
+    """
+    updatedAt: DateTime!
 }

--- a/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/lockfile_index_resolver.go
@@ -40,6 +40,14 @@ func (e *LockfileIndexResolver) Fidelity() string {
 	return e.lockfile.Fidelity.ToGraphQL()
 }
 
+func (e *LockfileIndexResolver) CreatedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: e.lockfile.CreatedAt}
+}
+
+func (e *LockfileIndexResolver) UpdatedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: e.lockfile.UpdatedAt}
+}
+
 func unmarshalLockfileIndexID(id graphql.ID) (lockfileIndexID int, err error) {
 	err = relay.UnmarshalSpec(id, &lockfileIndexID)
 	return


### PR DESCRIPTION
Tiny change to show the newly added timestamps in the UI.

## Test plan

- Manually tested by visiting the page locally and updating timestamps.