### PR TITLE
gqltest: add test cases to TestBitbucketProjectsPermsSync

### DIFF
--- a/dev/gqltest/bitbucket_projects_perms_sync_test.go
+++ b/dev/gqltest/bitbucket_projects_perms_sync_test.go
@@ -5,12 +5,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func TestBitbucketProjectsPermsSync_SetPermissionsUnrestricted(t *testing.T) {
+func TestBitbucketProjectsPermsSync(t *testing.T) {
 	if len(*bbsURL) == 0 || len(*bbsToken) == 0 || len(*bbsUsername) == 0 {
 		t.Skip("Environment variable BITBUCKET_SERVER_URL, BITBUCKET_SERVER_TOKEN, or BITBUCKET_SERVER_USERNAME is not set")
 	}
@@ -52,52 +55,170 @@ func TestBitbucketProjectsPermsSync_SetPermissionsUnrestricted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Setting unrestricted permissions to all repos of SOURCEGRAPH Bitbucket
-	// project SG has only bbs/SOURCEGRAPH/jsonrpc2 repo cloned -- this repo should
-	// be unrestricted
-	unrestricted := true
 	const projectKey = "SOURCEGRAPH"
-	err = client.SetRepositoryPermissionsForBitbucketProject(gqltestutil.BitbucketProjectPermsSyncArgs{
-		ProjectKey:      projectKey,
-		CodeHost:        esID,
-		UserPermissions: make([]types.UserPermission, 0),
-		Unrestricted:    &unrestricted,
-	})
-	if err != nil {
-		t.Fatal(err)
+
+	tests := []struct {
+		name         string
+		projectKey   string
+		codeHost     string
+		userPerms    []types.UserPermission
+		unrestricted bool
+		checkFunc    func() error
+	}{
+		{
+			name:         "Setting unrestricted permissions",
+			projectKey:   projectKey,
+			codeHost:     esID,
+			userPerms:    make([]types.UserPermission, 0),
+			unrestricted: true,
+			checkFunc: func() error {
+				permissionsInfo, err := client.RepositoryPermissionsInfo(repoName)
+				if err != nil {
+					return err
+				}
+
+				if permissionsInfo.Permissions[0] != "READ" {
+					return errors.Wrap(err, "READ permission hasn't been set")
+				}
+
+				if !permissionsInfo.Unrestricted {
+					return errors.Wrap(err, "unrestricted permission hasn't been set:")
+				}
+				return nil
+			},
+		},
+		{
+			name:       "Setting pending permissions for non-existing users",
+			projectKey: projectKey,
+			codeHost:   esID,
+			userPerms: []types.UserPermission{
+				{
+					BindID:     "some-user-1@domain.com",
+					Permission: "READ",
+				},
+				{
+					BindID:     "some-user-2@domain.com",
+					Permission: "READ",
+				},
+				{
+					BindID:     "some-user-3@domain.com",
+					Permission: "READ",
+				},
+			},
+			unrestricted: false,
+			checkFunc: func() error {
+				pendingPerms, err := client.UsersWithPendingPermissions()
+				if err != nil {
+					return err
+				}
+
+				if len(pendingPerms) != 3 {
+					return errors.Newf("Expected 3 pending permissions entries, got: %d", len(pendingPerms))
+				}
+
+				want := []string{
+					"some-user-1@domain.com",
+					"some-user-2@domain.com",
+					"some-user-3@domain.com",
+				}
+
+				if diff := cmp.Diff(want, pendingPerms); diff != "" {
+					return errors.Newf("Pending permissions mismatch (-want +got):\n%s", diff)
+				}
+
+				return nil
+			},
+		},
+		{
+			name:       "Setting permissions for both existing and non-existing users",
+			projectKey: projectKey,
+			codeHost:   esID,
+			userPerms: []types.UserPermission{
+				{
+					BindID:     "gqltest@sourcegraph.com", // existing user
+					Permission: "READ",
+				},
+				{
+					BindID:     "some-user-2@domain.com",
+					Permission: "READ",
+				},
+				{
+					BindID:     "some-user-3@domain.com",
+					Permission: "READ",
+				},
+			},
+			unrestricted: false,
+			checkFunc: func() error {
+				// First we check pending permissions
+				pendingPerms, err := client.UsersWithPendingPermissions()
+				if err != nil {
+					return err
+				}
+
+				want := []string{
+					"some-user-2@domain.com",
+					"some-user-3@domain.com",
+				}
+
+				if diff := cmp.Diff(want, pendingPerms); diff != "" {
+					return errors.Newf("Pending permissions mismatch (-want +got):\n%s", diff)
+				}
+
+				// Then we check existing user permissions
+				permissionsInfo, err := client.UserPermissions(*username)
+				if err != nil {
+					return err
+				}
+
+				if len(permissionsInfo) == 0 {
+					return errors.Newf("User '%s' has no expected permissions", *username)
+				}
+
+				if permissionsInfo[0] != "READ" {
+					return errors.Wrapf(err, "READ permission hasn't been set for user '%s'", *username)
+				}
+
+				return nil
+			},
+		},
 	}
 
-	// Wait up to 30 seconds for worker to finish the permissions sync.
-	err = gqltestutil.Retry(30*time.Second, func() error {
-		status, err := client.GetLastBitbucketProjectPermissionJob(projectKey)
-		if err != nil || status == "" {
-			t.Fatal("Error during getting the status of a Bitbucket Permissions job")
-		}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err = client.SetRepositoryPermissionsForBitbucketProject(gqltestutil.BitbucketProjectPermsSyncArgs{
+				ProjectKey:      test.projectKey,
+				CodeHost:        test.codeHost,
+				UserPermissions: test.userPerms,
+				Unrestricted:    &test.unrestricted,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		if status == "errored" || status == "failed" {
-			t.Fatalf("Bitbucket Permissions job failed with status: '%s'", status)
-		}
+			// Wait up to 30 seconds for worker to finish the permissions sync.
+			err = gqltestutil.Retry(30*time.Second, func() error {
+				status, err := client.GetLastBitbucketProjectPermissionJob(projectKey)
+				if err != nil || status == "" {
+					t.Fatal("Error during getting the status of a Bitbucket Permissions job")
+				}
 
-		if status == "completed" {
-			return nil
-		}
-		return gqltestutil.ErrContinueRetry
-	})
-	if err != nil {
-		t.Fatal("Waiting for repository permissions to be synced:", err)
-	}
+				if status == "errored" || status == "failed" {
+					t.Fatalf("Bitbucket Permissions job failed with status: '%s'", status)
+				}
 
-	// Checking that unrestricted permission is set to bbs/SOURCEGRAPH/jsonrpc2
-	permissionsInfo, err := client.RepositoryPermissionsInfo(repoName)
-	if err != nil {
-		t.Fatal(err)
-	}
+				if status == "completed" {
+					return nil
+				}
+				return gqltestutil.ErrContinueRetry
+			})
+			if err != nil {
+				t.Fatal("Waiting for repository permissions to be synced:", err)
+			}
 
-	if permissionsInfo.Permissions[0] != "READ" {
-		t.Fatal("READ permission hasn't been set:", err)
-	}
-
-	if !permissionsInfo.Unrestricted {
-		t.Fatal("unrestricted permission hasn't been set:", err)
+			// Perform checks described in the test case
+			if err = test.checkFunc(); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }

--- a/internal/gqltestutil/permissions.go
+++ b/internal/gqltestutil/permissions.go
@@ -103,3 +103,23 @@ query BitbucketProjectPermissionJobs($projectKeys: [String!], $status: String, $
 		return resp.Data.Jobs.Nodes[0].State, nil
 	}
 }
+
+// UsersWithPendingPermissions returns bind IDs of users with pending permissions
+func (c *Client) UsersWithPendingPermissions() ([]string, error) {
+	const query = `
+query {
+	usersWithPendingPermissions
+}
+`
+	var resp struct {
+		Data struct {
+			UsersWithPendingPermissions []string `json:"usersWithPendingPermissions"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, nil, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.UsersWithPendingPermissions, nil
+}

--- a/internal/gqltestutil/user.go
+++ b/internal/gqltestutil/user.go
@@ -125,3 +125,34 @@ query User($username: String) {
 	}
 	return names, nil
 }
+
+// UserPermissions returns repo permissions that given user has.
+func (c *Client) UserPermissions(username string) ([]string, error) {
+	const query = `
+query User($username: String) {
+	user(username: $username) {
+		permissionsInfo {
+			permissions
+		}
+	}
+}
+`
+	variables := map[string]any{
+		"username": username,
+	}
+	var resp struct {
+		Data struct {
+			User struct {
+				PermissionsInfo struct {
+					Permissions []string `json:"permissions"`
+				} `json:"permissionsInfo"`
+			} `json:"user"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.User.PermissionsInfo.Permissions, nil
+}


### PR DESCRIPTION
This PR adds more test cases for Bitbucket Projects perms sync functionality and also refactors the test itself.

## Test plan
New tests should pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
