### PR TITLE
Revert "insights: skip any search contexts that fail to load instead of erroring (#38954)"

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -468,7 +468,7 @@ func streamingSeriesJustInTime(ctx context.Context, definition types.InsightView
 	log15.Debug("just in time series", "seriesId", definition.SeriesID, "filteredRepos", matchedRepos)
 	generatedSeries, err := executor.Execute(ctx, definition.Query, definition.Label, definition.SeriesID, matchedRepos, interval)
 	if err != nil {
-		return nil, errors.Wrap(err, "CaptureGroupExecutor.Execute")
+		return nil, errors.Wrap(err, "StreamingQueryExecutor.Execute")
 	}
 
 	var resolvers []graphqlbackend.InsightSeriesResolver

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -117,9 +117,7 @@ func unwrapSearchContexts(ctx context.Context, loader SearchContextLoader, rawCo
 	for _, rawContext := range rawContexts {
 		searchContext, err := loader.GetByName(ctx, rawContext)
 		if err != nil {
-			// If this search context cannot load, we will skip it. This is a temporary measure because our
-			// resolver chain doesn't handle / propagate errors correctly. https://github.com/sourcegraph/sourcegraph/issues/38951#issuecomment-1187915821
-			continue
+			return nil, nil, err
 		}
 		if searchContext.Query != "" {
 			var plan searchquery.Plan
@@ -127,9 +125,7 @@ func unwrapSearchContexts(ctx context.Context, loader SearchContextLoader, rawCo
 				searchquery.Init(searchContext.Query, searchquery.SearchTypeRegex),
 			)
 			if err != nil {
-				// If this search context cannot parse, we will skip it. This is a temporary measure because our
-				// resolver chain doesn't handle / propagate errors correctly. https://github.com/sourcegraph/sourcegraph/issues/38951#issuecomment-1187915821
-				continue
+				return nil, nil, errors.Wrapf(err, "failed to parse search query for search context: %s", rawContext)
 			}
 			inc, exc := plan.ToQ().Repositories()
 			include = append(include, inc...)
@@ -472,7 +468,7 @@ func streamingSeriesJustInTime(ctx context.Context, definition types.InsightView
 	log15.Debug("just in time series", "seriesId", definition.SeriesID, "filteredRepos", matchedRepos)
 	generatedSeries, err := executor.Execute(ctx, definition.Query, definition.Label, definition.SeriesID, matchedRepos, interval)
 	if err != nil {
-		return nil, errors.Wrap(err, "StreamingQueryExecutor.Execute")
+		return nil, errors.Wrap(err, "CaptureGroupExecutor.Execute")
 	}
 
 	var resolvers []graphqlbackend.InsightSeriesResolver


### PR DESCRIPTION
part of #38951, reverts #38954

this doesn't close the issue linked above, just reverts a temp change that was made as part of it

## Test plan

this is a reverting change, but I confirmed that there did use to be an issue with per-insight view erroring prior to commit `b18b87a73b592b15fb1f86a3effc6cef14ecfb11` (before/after):
<img width="1840" alt="Screenshot 2022-07-25 at 14 17 08" src="https://user-images.githubusercontent.com/29406849/180787902-13bc6e41-3611-45a0-80dd-da8c72be5e06.png">

<img width="1840" alt="Screenshot 2022-07-25 at 14 19 38" src="https://user-images.githubusercontent.com/29406849/180787885-0b66bcd1-91f8-439e-8e40-6f993666aab4.png">

