### PR TITLE
fix headings

### DIFF
--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -4,13 +4,13 @@ This page lists the changes that are relevant for [upgrading Sourcegraph on Dock
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+## Unreleased
+
 ## 3.41 -> 3.42
 
 Follow the [standard upgrade procedure](upgrade_docker-compose.md) to upgrade your deployment.
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.41).*
-
-## Unreleased
 
 ## 3.40 -> 3.41
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -10,13 +10,13 @@
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+## Unreleased
+
 ## 3.41 -> 3.42
 
 Follow the [standard upgrade procedure](../deploy/kubernetes/update.md) to upgrade your deployment.
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.41).*
-
-## Unreleased
 
 ## 3.40 -> 3.41
 

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -8,13 +8,13 @@ Each section comprehensively describes the changes needed in Docker images, envi
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+## Unreleased
+
 ## 3.41 -> 3.42
 
 To upgrade, please perform the changes in the following diff: [[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/8bfd70892c1bf56c5a88db0329826800c7a1097b](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/a189e495813bc33d544b302eb98c197d70eacc87)]
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.41).*
-
-## Unreleased
 
 ## 3.40.2 -> 3.41.0
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -9,6 +9,8 @@ This document describes the exact changes needed to update a single-node Sourceg
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 
+## Unreleased
+
 ## 3.41 -> 3.42
 
 Follow the [standard upgrade procedure](../deploy/docker-single-container/index.md#upgrade).


### PR DESCRIPTION
Fixes the position of the unreleased heading in the guides. Looks like these got jumbled up during the last release. 

## Test plan

CI linting. 