### PR TITLE
remove pointer events.user_id to match database not null constraint

### DIFF
--- a/cmd/frontend/graphqlbackend/event_log.go
+++ b/cmd/frontend/graphqlbackend/event_log.go
@@ -14,15 +14,12 @@ type userEventLogResolver struct {
 }
 
 func (s *userEventLogResolver) User(ctx context.Context) (*UserResolver, error) {
-	if s.event.UserID != nil {
-		user, err := UserByIDInt32(ctx, s.db, *s.event.UserID)
-		if err != nil && errcode.IsNotFound(err) {
-			// Don't throw an error if a user has been deleted.
-			return nil, nil
-		}
-		return user, err
+	user, err := UserByIDInt32(ctx, s.db, s.event.UserID)
+	if err != nil && errcode.IsNotFound(err) {
+		// Don't throw an error if a user has been deleted.
+		return nil, nil
 	}
-	return nil, nil
+	return user, err
 }
 
 func (s *userEventLogResolver) Name() string {

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -178,7 +178,7 @@ func TestHandlerLoadsEvents(t *testing.T) {
 			{
 				ID:       1,
 				Name:     "event1",
-				UserID:   2,
+				UserID:   1,
 				Argument: "{}",
 				Source:   "test",
 				Version:  "0.0.0+dev",
@@ -210,7 +210,7 @@ func TestHandlerLoadsEvents(t *testing.T) {
 			{
 				ID:       1,
 				Name:     "event1",
-				UserID:   2,
+				UserID:   1,
 				Argument: "{}",
 				Source:   "test",
 				Version:  "0.0.0+dev",

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/hexops/autogold"
-	"github.com/hexops/valast"
-
 	"github.com/sourcegraph/sourcegraph/internal/database"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -180,7 +178,7 @@ func TestHandlerLoadsEvents(t *testing.T) {
 			{
 				ID:       1,
 				Name:     "event1",
-				UserID:   valast.Addr(int32(1)).(*int32),
+				UserID:   2,
 				Argument: "{}",
 				Source:   "test",
 				Version:  "0.0.0+dev",
@@ -188,7 +186,7 @@ func TestHandlerLoadsEvents(t *testing.T) {
 			{
 				ID:       2,
 				Name:     "event2",
-				UserID:   valast.Addr(int32(2)).(*int32),
+				UserID:   2,
 				Argument: "{}",
 				Source:   "test",
 				Version:  "0.0.0+dev",
@@ -212,7 +210,7 @@ func TestHandlerLoadsEvents(t *testing.T) {
 			{
 				ID:       1,
 				Name:     "event1",
-				UserID:   valast.Addr(int32(1)).(*int32),
+				UserID:   2,
 				Argument: "{}",
 				Source:   "test",
 				Version:  "0.0.0+dev",

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -1243,7 +1243,7 @@ func TestEventLogs_LatestPing(t *testing.T) {
 			ID:              2,
 			Name:            events[1].Name,
 			URL:             events[1].URL,
-			UserID:          &userID,
+			UserID:          userID,
 			AnonymousUserID: events[1].AnonymousUserID,
 			Version:         version.Version(),
 			Argument:        string(events[1].Argument),

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -640,7 +640,7 @@ func TestUsers_Delete(t *testing.T) {
 			eventLog := eventLogs[0]
 			if hard {
 				// Event logs should now be anonymous
-				if *eventLog.UserID != 0 {
+				if eventLog.UserID != 0 {
 					t.Error("After hard delete user id should be 0")
 				}
 				if len(eventLog.AnonymousUserID) == 0 {
@@ -648,7 +648,7 @@ func TestUsers_Delete(t *testing.T) {
 				}
 			} else {
 				// Event logs are unchanged
-				if *eventLog.UserID != user.ID {
+				if eventLog.UserID != user.ID {
 					t.Error("After soft delete user id should be non zero")
 				}
 				if len(eventLog.AnonymousUserID) != 0 {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1217,7 +1217,7 @@ type Event struct {
 	ID              int32
 	Name            string
 	URL             string
-	UserID          *int32
+	UserID          int32
 	AnonymousUserID string
 	Argument        string
 	Source          string


### PR DESCRIPTION
Updates the `types.Event.user_id` field to be non-null to match the [database schema](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/migrations/frontend/squashed.sql?L1411&utm_campaign=search&utm_source=raycast-sourcegraph).

## Test plan

Unit tests pass and started Sourcegraph (including some events scraping) and everything starts
