### PR TITLE
batches: Fix Diffs render incorrectly

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -565,9 +565,17 @@ func (r *DiffHunk) Highlight(ctx context.Context, args *HighlightArgs) (*highlig
 			lastMinus = i
 		}
 	}
+
+	// Lines in highlightedBase and highlightedHead are 0-indexed.
+	baseLine := r.hunk.OrigStartLine - 1
+	headLine := r.hunk.NewStartLine - 1
+
 	// Empty "-" line that's not followed by an unchanged line, so cut it out
 	if lastMinus > -1 {
 		hunkLines = append(hunkLines[:lastMinus], hunkLines[lastMinus+1:]...)
+		// Removing the empty "-" line causes a mismatch in position between hunkLines and highlightedBase. hunkLines
+		// will be behind by one line.
+		baseLine++
 	}
 
 	// Even after all the logic above, we were still hitting out-of-bounds panics:
@@ -585,9 +593,6 @@ func (r *DiffHunk) Highlight(ctx context.Context, args *HighlightArgs) (*highlig
 	}
 
 	highlightedDiffHunkLineResolvers := make([]*highlightedDiffHunkLineResolver, len(hunkLines))
-	// Lines in highlightedBase and highlightedHead are 0-indexed.
-	baseLine := r.hunk.OrigStartLine - 1
-	headLine := r.hunk.NewStartLine - 1
 	for i, hunkLine := range hunkLines {
 		highlightedDiffHunkLineResolver := highlightedDiffHunkLineResolver{}
 		if hunkLine[0] == ' ' {

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -685,7 +685,7 @@ index 4d14577..9fe9a4f 100644
 
 func TestDiffHunk4(t *testing.T) {
 	// This test exists to protect against an edge case bug illustrated in
-	// https://github.com/sourcegraph/sourcegraph/pull/####
+	// https://github.com/sourcegraph/sourcegraph/pull/39377
 
 	ctx := context.Background()
 	// Ran 'git diff --cached --no-prefix --binary' on a local repo to generate this diff (with the starting lines

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -455,6 +455,7 @@ func TestDiffHunk(t *testing.T) {
 		}
 	})
 
+	// test
 	t.Run("Highlight", func(t *testing.T) {
 		hunk.highlighter = &dummyFileHighlighter{
 			highlightedBase: []template.HTML{"B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12"},
@@ -665,6 +666,102 @@ index 4d14577..9fe9a4f 100644
 			{kind: "ADDED", html: "Wowza!"},
 			{kind: "DELETED", html: ""},
 			{kind: "UNCHANGED", html: "See [the main README](https://github.com/dominikh/go-tools#installation) for installation instructions."},
+		}
+
+		lines := body.Lines()
+		if have, want := len(lines), len(wantLines); have != want {
+			t.Fatalf("len(Highlight.Lines) is wrong. want = %d, have = %d", want, have)
+		}
+		for i, n := range lines {
+			wantedLine := wantLines[i]
+			if n.Kind() != wantedLine.kind {
+				t.Fatalf("Kind is wrong. want = %q, have = %q", wantedLine.kind, n.Kind())
+			}
+			if n.HTML() != wantedLine.html {
+				t.Fatalf("HTML is wrong. want = %q, have = %q", wantedLine.html, n.HTML())
+			}
+		}
+	})
+}
+
+func TestDiffHunk4(t *testing.T) {
+	// This test exists to protect against an edge case bug illustrated in
+	// https://github.com/sourcegraph/sourcegraph/pull/####
+
+	ctx := context.Background()
+	// Ran 'git diff --cached --no-prefix --binary' on a local repo to generate this diff (with the starting lines
+	// changes to 1)
+	filediff := `diff --git toggle.go toggle.go
+index d206c4c..bb06461 100644
+--- toggle.go
++++ toggle.go
+@@ -1,10 +1,3 @@ func AddFeatures(features map[string]bool) {
+ func AddFeature(key string, isEnabled bool) {
+        features[strings.ToLower(key)] = isEnabled
+ }
+-
+-// IsEnabled determines if the specified feature is enabled. Determining if a feature is enabled is
+-// case insensitive.
+-// If a feature is not present, it defaults to false.
+-func IsEnabled(key string) bool {
+-       return features[strings.ToLower(key)]
+-}`
+
+	dr := diff.NewMultiFileDiffReader(strings.NewReader(filediff))
+	// We only read the first file diff from testDiff
+	fileDiff, err := dr.ReadFile()
+	if err != nil && err != io.EOF {
+		t.Fatalf("parsing diff failed: %s", err)
+	}
+
+	hunk := &DiffHunk{hunk: fileDiff.Hunks[0]}
+
+	t.Run("Highlight", func(t *testing.T) {
+		hunk.highlighter = &dummyFileHighlighter{
+			// We don't care about the actual html formatting, just the number + order of
+			// the lines we get back after "applying" the diff to the highlighting.
+			highlightedBase: []template.HTML{
+				"func AddFeature(key string, isEnabled bool) {",
+				"features[strings.ToLower(key)] = isEnabled",
+				"}",
+				"",
+				"// IsEnabled determines if the specified feature is enabled. Determining if a feature is enabled is",
+				"// case insensitive.",
+				"// If a feature is not present, it defaults to false.",
+				"func IsEnabled(key string) bool {",
+				"return features[strings.ToLower(key)]",
+				"}",
+			},
+			highlightedHead: []template.HTML{
+				"func AddFeature(key string, isEnabled bool) {",
+				"features[strings.ToLower(key)] = isEnabled",
+				"}",
+			},
+		}
+
+		body, err := hunk.Highlight(ctx, &HighlightArgs{
+			DisableTimeout:     false,
+			HighlightLongLines: false,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if body.Aborted() {
+			t.Fatal("highlighting is aborted")
+		}
+
+		wantLines := []struct {
+			kind, html string
+		}{
+			{kind: "UNCHANGED", html: "features[strings.ToLower(key)] = isEnabled"},
+			{kind: "UNCHANGED", html: "}"},
+			{kind: "UNCHANGED", html: ""},
+			{kind: "DELETED", html: "// IsEnabled determines if the specified feature is enabled. Determining if a feature is enabled is"},
+			{kind: "DELETED", html: "// case insensitive."},
+			{kind: "DELETED", html: "// If a feature is not present, it defaults to false."},
+			{kind: "DELETED", html: "func IsEnabled(key string) bool {"},
+			{kind: "DELETED", html: "return features[strings.ToLower(key)]"},
+			{kind: "DELETED", html: "}"},
 		}
 
 		lines := body.Lines()

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -455,7 +455,6 @@ func TestDiffHunk(t *testing.T) {
 		}
 	})
 
-	// test
 	t.Run("Highlight", func(t *testing.T) {
 		hunk.highlighter = &dummyFileHighlighter{
 			highlightedBase: []template.HTML{"B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12"},


### PR DESCRIPTION
Closes #35492.

I removed a function at the bottom of a Go file to replicate the rendering issue. What I found was when an empty `-` line (not followed by unchanged lines) is removed, this causes the index of `highlightedBase` and `hunkLines` to be off (`hunkLines` is behind by one). This is because `highlightedBase` still includes the empty `-` line. So each `hunkLine` corresponds to the previous highlighted line.

To fix this, I simply increment `baseLine` by one if the empty `-` line is removed.

## Test plan

Added Go test

### Before

![Screen Shot 2022-07-25 at 10 47 06](https://user-images.githubusercontent.com/38407415/180832413-42a4a280-52b9-43f4-ac75-c507f5c544fb.png)

### After

![Screen Shot 2022-07-25 at 10 46 34](https://user-images.githubusercontent.com/38407415/180832436-a197d9d6-1540-49a9-8d1e-c77cea933da9.png)
