### PR TITLE
Search backend: add diff formatting function

### DIFF
--- a/internal/search/result/commit_diff.go
+++ b/internal/search/result/commit_diff.go
@@ -2,6 +2,7 @@ package result
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -110,6 +111,30 @@ func (cm *CommitDiffMatch) Select(path filter.SelectPath) Match {
 }
 
 func (cm *CommitDiffMatch) searchResultMarker() {}
+
+// FormatDiffFiles inverts ParseDiffString
+func FormatDiffFiles(res []DiffFile) string {
+	var buf strings.Builder
+	for _, diffFile := range res {
+		buf.WriteString(diffFile.OrigName)
+		buf.WriteByte(' ')
+		buf.WriteString(diffFile.NewName)
+		buf.WriteByte('\n')
+		for _, hunk := range diffFile.Hunks {
+			fmt.Fprintf(&buf, "@@ -%d,%d +%d,%d @@", hunk.OldStart, hunk.OldCount, hunk.NewStart, hunk.NewCount)
+			if hunk.Header != "" {
+				// Only add a space before the header if the header is non-empty
+				fmt.Fprintf(&buf, " %s", hunk.Header)
+			}
+			buf.WriteByte('\n')
+			for _, line := range hunk.Lines {
+				buf.WriteString(line)
+				buf.WriteByte('\n')
+			}
+		}
+	}
+	return buf.String()
+}
 
 func ParseDiffString(diff string) (res []DiffFile, err error) {
 	const (

--- a/internal/search/result/commit_diff_test.go
+++ b/internal/search/result/commit_diff_test.go
@@ -3,6 +3,8 @@ package result
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hexops/autogold"
 )
 
@@ -46,6 +48,10 @@ func TestParseDiffString(t *testing.T) {
 		panic(err)
 	}
 	autogold.Equal(t, res)
+
+	formatted := FormatDiffFiles(res)
+	require.Equal(t, input, formatted)
+
 }
 
 func TestCommitDiffMatch(t *testing.T) {

--- a/internal/search/result/testdata/TestParseDiffString.golden
+++ b/internal/search/result/testdata/TestParseDiffString.golden
@@ -2,6 +2,22 @@
 	{
 		OrigName: "client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss",
 		NewName:  "client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss",
+		Hunks: []result.Hunk{{
+			OldStart: 1,
+			NewStart: 1,
+			OldCount: 2,
+			NewCount: 6,
+			Header:   "... +1",
+			Lines: []string{
+				"+.badge-wrapper {",
+				"+    font-size: 0.75rem;",
+				"+}",
+				"+",
+				" .telemetric-redirect {",
+				"-    display: inline !important;",
+				"+    font-size: 0.75rem;",
+			},
+		}},
 	},
 	{
 		OrigName: "client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx",
@@ -14,13 +30,6 @@
 				NewCount: 3,
 				Header:   "export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({",
 				Lines: []string{
-					"+.badge-wrapper {",
-					"+    font-size: 0.75rem;",
-					"+}",
-					"+",
-					" .telemetric-redirect {",
-					"-    display: inline !important;",
-					"+    font-size: 0.75rem;",
 					"     return (",
 					`-        <div className="px-2 py-1">`,
 					"+        <div className={classNames('px-2 py-1', styles.badgeWrapper)}>",
@@ -40,6 +49,36 @@
 					"                             Enabled",
 				},
 			},
+			{
+				OldStart: 65,
+				NewStart: 65,
+				OldCount: 3,
+				NewCount: 3,
+				Header:   "export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({",
+				Lines: []string{
+					"                     ) : summary.indexer?.url ? (",
+					`-                        <Badge variant="secondary" className={className}>`,
+					`+                        <Badge variant="secondary" small={true} className={className}>`,
+					"                             Configurable",
+				},
+			},
 		},
+	},
+	{
+		OrigName: "client/web/src/enterprise/codeintel/badge/components/RequestLink.module.scss",
+		NewName:  "client/web/src/enterprise/codeintel/badge/components/RequestLink.module.scss",
+		Hunks: []result.Hunk{{
+			OldStart: 1,
+			NewStart: 1,
+			OldCount: 3,
+			NewCount: 5,
+			Lines: []string{
+				" .language-request {",
+				"+    font-size: 0.75rem;",
+				"     font-weight: normal;",
+				"+    display: inline !important;",
+				" }",
+			},
+		}},
 	},
 }


### PR DESCRIPTION
Adds a formatting function to invert ParseDiffString. I'd like to save the structured form of diff on the result type, but I want to be able to easily get the original format back. 

Stacked on https://github.com/sourcegraph/sourcegraph/pull/39378

## Test plan

Added an assertion that round-trip reformatting works as expected. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
