### PR TITLE
add full semver for new tooling

### DIFF
--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -6,7 +6,7 @@ This page lists the changes that are relevant for [upgrading Sourcegraph on Dock
 
 ## Unreleased
 
-## 3.41 -> 3.42
+## 3.41 -> 3.42.0
 
 Follow the [standard upgrade procedure](upgrade_docker-compose.md) to upgrade your deployment.
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -12,7 +12,7 @@
 
 ## Unreleased
 
-## 3.41 -> 3.42
+## 3.41 -> 3.42.0
 
 Follow the [standard upgrade procedure](../deploy/kubernetes/update.md) to upgrade your deployment.
 

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -10,7 +10,7 @@ Each section comprehensively describes the changes needed in Docker images, envi
 
 ## Unreleased
 
-## 3.41 -> 3.42
+## 3.41 -> 3.42.0
 
 To upgrade, please perform the changes in the following diff: [[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/8bfd70892c1bf56c5a88db0329826800c7a1097b](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/a189e495813bc33d544b302eb98c197d70eacc87)]
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -11,7 +11,7 @@ This document describes the exact changes needed to update a single-node Sourceg
 
 ## Unreleased
 
-## 3.41 -> 3.42
+## 3.41 -> 3.42.0
 
 Follow the [standard upgrade procedure](../deploy/docker-single-container/index.md#upgrade).
 


### PR DESCRIPTION
Adds the full semver manually, in prep for new release tooling. 

Part of work on https://github.com/sourcegraph/sourcegraph/issues/31755
## Test plan

CI linting on docs. 