### PR TITLE
refactor: Move Sentry source maps upload to Docker build step

### DIFF
--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -38,8 +38,8 @@ export const ENVIRONMENT_CONFIG = {
 
     // The commit SHA the client bundle was built with.
     COMMIT_SHA: process.env.COMMIT_SHA,
-    // New release candidate version.
-    RELEASE_CANDIDATE_VERSION: process.env.RELEASE_CANDIDATE_VERSION,
+    // The current Docker image version, use to associate builds with Sentry's source maps.
+    VERSION: process.env.VERSION,
     // Should sourcemaps be uploaded to Sentry.
     SENTRY_UPLOAD_SOURCE_MAPS: getEnvironmentBoolean('SENTRY_UPLOAD_SOURCE_MAPS'),
     // Sentry's Dotcom project's authentication token

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -45,7 +45,7 @@ const {
   WEBPACK_USE_NAMED_CHUNKS,
   SENTRY_UPLOAD_SOURCE_MAPS,
   COMMIT_SHA,
-  RELEASE_CANDIDATE_VERSION,
+  VERSION,
   SENTRY_DOT_COM_AUTH_TOKEN,
   SENTRY_ORGANIZATION,
   SENTRY_PROJECT,
@@ -59,7 +59,6 @@ const RUNTIME_ENV_VARIABLES = {
   ENABLE_MONITORING,
   INTEGRATION_TESTS,
   COMMIT_SHA,
-  RELEASE_CANDIDATE_VERSION,
   ...(WEBPACK_SERVE_INDEX && { SOURCEGRAPH_API_URL }),
 }
 
@@ -184,13 +183,12 @@ const config = {
          */
         threshold: 10240,
       }),
-    RELEASE_CANDIDATE_VERSION &&
-      SENTRY_UPLOAD_SOURCE_MAPS &&
+    SENTRY_UPLOAD_SOURCE_MAPS &&
       new SentryWebpackPlugin({
         org: SENTRY_ORGANIZATION,
         project: SENTRY_PROJECT,
         authToken: SENTRY_DOT_COM_AUTH_TOKEN,
-        release: `frontend@${RELEASE_CANDIDATE_VERSION}`,
+        release: `frontend@${VERSION as string}`,
         include: path.join(STATIC_ASSETS_PATH, 'scripts'),
       }),
   ].filter(Boolean),

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -142,7 +142,6 @@ Base pipeline (more steps might be included based on branch changes):
 - **CI script tests**: test-trace-command.sh
 - **Integration tests**: Backend integration tests, Code Intel QA
 - **End-to-end tests**: Sourcegraph E2E, Sourcegraph QA, Sourcegraph Cluster (deploy-sourcegraph) QA, Sourcegraph Upgrade
-- Build and upload sourcemaps to Sentry
 - **Publish images**: alpine-3.14, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, jaeger-agent, jaeger-all-in-one, minio, postgres-12-alpine, postgres_exporter, precise-code-intel-worker, prometheus, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, symbols, syntax-highlighter, worker, migrator, executor, opentelemetry-collector, server, sg, Publish executor image, Publish docker registry mirror image
 - Upload build trace
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -216,24 +216,6 @@ func addWebApp(pipeline *bk.Pipeline) {
 		bk.Cmd("dev/ci/codecov.sh -c -F typescript -F unit"))
 }
 
-// Adds steps for building webapp with the Sentry Webpack plugin enabled to upload sourcemaps
-// Only builds webapp without ENTERPRISE=1, no tests are performed. Should only run on release branches.
-func buildWebAppWithSentrySourcemaps(version string) operations.Operation {
-	return func(pipeline *bk.Pipeline) {
-		// Webapp build with Sentry's webpack plugin enabled
-		pipeline.AddStep(":webpack::globe_with_meridians: Build and upload sourcemaps to Sentry",
-			withYarnCache(),
-			bk.Cmd("dev/ci/yarn-build.sh client/web"),
-			bk.Env("NODE_ENV", "production"),
-			bk.Env("ENTERPRISE", ""),
-			bk.Env("SENTRY_UPLOAD_SOURCE_MAPS", "1"),
-			bk.Env("SENTRY_ORGANIZATION", "sourcegraph"),
-			bk.Env("SENTRY_PROJECT", "sourcegraph-dot-com"),
-			bk.Env("RELEASE_CANDIDATE_VERSION", version),
-		)
-	}
-}
-
 var browsers = []string{"chrome"}
 
 func getParallelTestCount(webParallelTestCount int) int {
@@ -683,7 +665,7 @@ func candidateImageStepKey(app string) string {
 // tags once the e2e tests pass.
 //
 // Version is the actual version of the code, and
-func buildCandidateDockerImage(app, version, tag string) operations.Operation {
+func buildCandidateDockerImage(app, version, tag string, pipelineRuntype runtype.RunType) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		image := strings.ReplaceAll(app, "/", "-")
 		localImage := "sourcegraph/" + image + ":" + version
@@ -694,6 +676,16 @@ func buildCandidateDockerImage(app, version, tag string) operations.Operation {
 			bk.Env("DOCKER_BUILDKIT", "1"),
 			bk.Env("IMAGE", localImage),
 			bk.Env("VERSION", version),
+		}
+
+		// Add Sentry environment variables if we are building off main branch
+		// to enable building the webapp with source maps enabled
+		if pipelineRuntype.Is(runtype.MainBranch) {
+			cmds = append(cmds,
+				bk.Env("SENTRY_UPLOAD_SOURCE_MAPS", "1"),
+				bk.Env("SENTRY_ORGANIZATION", "sourcegraph"),
+				bk.Env("SENTRY_PROJECT", "sourcegraph-dot-com"),
+			)
 		}
 
 		// Allow all build scripts to emit info annotations

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -120,7 +120,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			testBuilds := operations.NewNamedSet("Test builds")
 			scanBuilds := operations.NewNamedSet("Scan test builds")
 			for _, image := range images.SourcegraphDockerImages {
-				testBuilds.Append(buildCandidateDockerImage(image, c.Version, c.candidateImageTag()))
+				testBuilds.Append(buildCandidateDockerImage(image, c.Version, c.candidateImageTag(), c.RunType))
 				scanBuilds.Append(trivyScanCandidateImage(image, c.candidateImageTag()))
 			}
 			ops.Merge(testBuilds)
@@ -132,7 +132,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 	case runtype.BackendIntegrationTests:
 		ops.Append(
-			buildCandidateDockerImage("server", c.Version, c.candidateImageTag()),
+			buildCandidateDockerImage("server", c.Version, c.candidateImageTag(), c.RunType),
 			backendIntegrationTests(c.candidateImageTag()))
 
 		// always include very backend-oriented changes in this set of tests
@@ -190,7 +190,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		}
 
 		ops = operations.NewSet(
-			buildCandidateDockerImage(patchImage, c.Version, c.candidateImageTag()),
+			buildCandidateDockerImage(patchImage, c.Version, c.candidateImageTag(), c.RunType),
 			trivyScanCandidateImage(patchImage, c.candidateImageTag()))
 		// Test images
 		ops.Merge(CoreTestOperations(changed.All, CoreTestOperationsOptions{
@@ -211,14 +211,14 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			panic(fmt.Sprintf("no image %q found", patchImage))
 		}
 		ops = operations.NewSet(
-			buildCandidateDockerImage(patchImage, c.Version, c.candidateImageTag()),
+			buildCandidateDockerImage(patchImage, c.Version, c.candidateImageTag(), c.RunType),
 			wait,
 			publishFinalDockerImage(c, patchImage))
 
 	case runtype.CandidatesNoTest:
 		for _, dockerImage := range images.SourcegraphDockerImages {
 			ops.Append(
-				buildCandidateDockerImage(dockerImage, c.Version, c.candidateImageTag()))
+				buildCandidateDockerImage(dockerImage, c.Version, c.candidateImageTag(), c.RunType))
 		}
 
 	case runtype.ExecutorPatchNoTest:
@@ -237,7 +237,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// Slow image builds
 		imageBuildOps := operations.NewNamedSet("Image builds")
 		for _, dockerImage := range images.SourcegraphDockerImages {
-			imageBuildOps.Append(buildCandidateDockerImage(dockerImage, c.Version, c.candidateImageTag()))
+			imageBuildOps.Append(buildCandidateDockerImage(dockerImage, c.Version, c.candidateImageTag(), c.RunType))
 		}
 		// Executor VM image
 		skipHashCompare := c.MessageFlags.SkipHashCompare || c.RunType.Is(runtype.ReleaseBranch)
@@ -289,9 +289,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			publishOps.Append(publishExecutor(c.Version, skipHashCompare))
 			if c.RunType.Is(runtype.ReleaseBranch) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
 				publishOps.Append(publishExecutorDockerMirror(c.Version))
-			}
-			if c.RunType.Is(runtype.ReleaseBranch) {
-				ops.Append(buildWebAppWithSentrySourcemaps(c.Version))
 			}
 		}
 		ops.Merge(publishOps)


### PR DESCRIPTION
- refactor: Move Sentry source maps upload to Docker build step
- doc: remove sentry sourcemaps step from publish images



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
