### PR TITLE
insights: determine if query targets a single repo

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/regexp"
 
 	searchquery "github.com/sourcegraph/sourcegraph/internal/search/query"
+	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -165,4 +166,31 @@ func (q BasicQuery) String() string {
 
 func (q ComputeInsightQuery) String() string {
 	return string(q)
+}
+
+var QueryNotSupported = errors.New("query not supported")
+
+// IsSingleRepoQuery - Returns a boolean indicating if the query provided targets only a single repo.
+// At this time only queries with a single query plan step are supported.  Queries with multiple plan steps
+// will error with `QueryNotSupported`
+func IsSingleRepoQuery(query BasicQuery) (bool, error) {
+
+	// because we are only attempting to understand if this query targets a single repo, the search type is not relevant
+	planSteps, err := searchquery.Pipeline(searchquery.Init(string(query), searchquery.SearchTypeLiteral))
+	if err != nil {
+		return false, err
+	}
+
+	if len(planSteps) > 1 {
+		return false, QueryNotSupported
+	}
+
+	for _, step := range planSteps {
+		repoFilters, _ := step.Repositories()
+		if !searchrepos.ExactlyOneRepo(repoFilters) {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestWithDefaults(t *testing.T) {
@@ -327,6 +328,100 @@ func TestComputeInsightCommandQuery(t *testing.T) {
 			if diff := cmp.Diff(test.want, string(got)); diff != "" {
 				t.Errorf("%s failed (want/got): %s", test.name, diff)
 			}
+		})
+	}
+}
+
+func TestIsSingleRepoQuery(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		inputQuery string
+		mapType    MapType
+		want       bool
+	}{
+		{
+			name:       "repo text string",
+			inputQuery: "repo:abc123@12346f fork:yes archived:yes findme",
+			mapType:    Lang,
+			want:       false,
+		},
+		{
+			name:       "repo contains",
+			inputQuery: "repo:contains.file(CHANGELOG) TEST",
+			mapType:    Lang,
+			want:       false,
+		},
+		{
+			name:       "repo or",
+			inputQuery: "repo:^(repo1|repo2)$ test",
+			mapType:    Lang,
+			want:       false,
+		},
+		{
+			name:       "repo with revision",
+			inputQuery: `repo:^github\.com/sgtest/java-langserver$@v1 test`,
+			mapType:    Lang,
+			want:       true,
+		},
+		{
+			name:       "single repo",
+			inputQuery: `repo:^github\.com/sgtest/java-langserver$ test`,
+			mapType:    Lang,
+			want:       true,
+		},
+		{
+			name:       "complex query",
+			inputQuery: `test`,
+			mapType:    Lang,
+			want:       false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := IsSingleRepoQuery(BasicQuery(test.inputQuery))
+			if err != nil {
+				t.Error(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("%s failed (want/got): %s", test.name, diff)
+			}
+
+		})
+	}
+}
+
+func TestIsSingleRepoQueryMultipleSteps(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		inputQuery string
+		mapType    MapType
+		want       error
+	}{
+		{
+			name:       "2 step query different repos",
+			inputQuery: `(repo:^github\.com/sourcegraph/sourcegraph$ OR repo:^github\.com/sourcegraph-testing/zap$) test`,
+			mapType:    Lang,
+			want:       QueryNotSupported,
+		},
+		{
+			name:       "2 step query same repo",
+			inputQuery: `(repo:^github\.com/sourcegraph/sourcegraph$ test) OR (repo:^github\.com/sourcegraph/sourcegraph$ todo)`,
+			mapType:    Lang,
+			want:       QueryNotSupported,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := IsSingleRepoQuery(BasicQuery(test.inputQuery))
+			if !errors.Is(err, test.want) {
+				t.Error(err)
+			}
+			if diff := cmp.Diff(false, got); diff != "" {
+				t.Errorf("%s failed (want/got): %s", test.name, diff)
+			}
+
 		})
 	}
 }

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -341,7 +341,7 @@ func TestIsSingleRepoQuery(t *testing.T) {
 		want       bool
 	}{
 		{
-			name:       "repo text string",
+			name:       "repo as simple text string",
 			inputQuery: "repo:abc123@12346f fork:yes archived:yes findme",
 			mapType:    Lang,
 			want:       false,
@@ -359,7 +359,7 @@ func TestIsSingleRepoQuery(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:       "repo with revision",
+			name:       "single repo with revision specified",
 			inputQuery: `repo:^github\.com/sgtest/java-langserver$@v1 test`,
 			mapType:    Lang,
 			want:       true,
@@ -371,7 +371,7 @@ func TestIsSingleRepoQuery(t *testing.T) {
 			want:       true,
 		},
 		{
-			name:       "complex query",
+			name:       "query without repo filter",
 			inputQuery: `test`,
 			mapType:    Lang,
 			want:       false,


### PR DESCRIPTION
Adds a new function to the insights query builder package that can determine if a query is targeting a single repo.  This will initially be used as one piece of criteria to determine if a search query is eligible to run additional queries to provide additional insights such as % change over time or a small preview of an insight.

Currently only supports queries with a 1 step query plan.

resolves #39241

## Test plan
added unit tests pass 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
