### PR TITLE
Search backend: increase repo page size from 500 to 4096

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -783,7 +783,10 @@ func (s *repoStore) StreamMinimalRepos(ctx context.Context, opt ReposListOptions
 
 // ListMinimalRepos returns a list of repositories names and ids.
 func (s *repoStore) ListMinimalRepos(ctx context.Context, opt ReposListOptions) (results []types.MinimalRepo, err error) {
-	preallocSize := opt.Limit
+	preallocSize := 128
+	if opt.LimitOffset != nil {
+		preallocSize = opt.Limit
+	}
 	if preallocSize > 4096 {
 		preallocSize = 4096
 	}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -783,6 +783,11 @@ func (s *repoStore) StreamMinimalRepos(ctx context.Context, opt ReposListOptions
 
 // ListMinimalRepos returns a list of repositories names and ids.
 func (s *repoStore) ListMinimalRepos(ctx context.Context, opt ReposListOptions) (results []types.MinimalRepo, err error) {
+	preallocSize := opt.Limit
+	if preallocSize > 4096 {
+		preallocSize = 4096
+	}
+	results = make([]types.MinimalRepo, 0, preallocSize)
 	return results, s.StreamMinimalRepos(ctx, opt, func(r *types.MinimalRepo) {
 		results = append(results, *r)
 	})

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -1364,14 +1364,14 @@ func TestRepos_ListMinimalRepos_fork(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assertJSONEqual(t, nil, repos)
+		assertJSONEqual(t, []types.MinimalRepo{}, repos)
 	}
 	{
 		repos, err := db.Repos().ListMinimalRepos(ctx, ReposListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		assertJSONEqual(t, append(append([]types.MinimalRepo(nil), mine...), yours...), repos)
+		assertJSONEqual(t, append(append([]types.MinimalRepo{}, mine...), yours...), repos)
 	}
 }
 
@@ -1395,8 +1395,8 @@ func TestRepos_ListMinimalRepos_cloned(t *testing.T) {
 	}{
 		{"OnlyCloned", ReposListOptions{OnlyCloned: true}, yours},
 		{"NoCloned", ReposListOptions{NoCloned: true}, mine},
-		{"NoCloned && OnlyCloned", ReposListOptions{NoCloned: true, OnlyCloned: true}, nil},
-		{"Default", ReposListOptions{}, append(append([]types.MinimalRepo(nil), mine...), yours...)},
+		{"NoCloned && OnlyCloned", ReposListOptions{NoCloned: true, OnlyCloned: true}, []types.MinimalRepo{}},
+		{"Default", ReposListOptions{}, append(append([]types.MinimalRepo{}, mine...), yours...)},
 	}
 
 	for _, test := range tests {
@@ -1824,7 +1824,7 @@ func TestRepos_ListMinimalRepos_externalServiceID(t *testing.T) {
 	}{
 		{"Some", ReposListOptions{ExternalServiceIDs: []int64{service1.ID}}, repoNamesFromRepos(mine)},
 		{"Default", ReposListOptions{}, repoNamesFromRepos(append(mine, yours...))},
-		{"NonExistant", ReposListOptions{ExternalServiceIDs: []int64{1000}}, nil},
+		{"NonExistant", ReposListOptions{ExternalServiceIDs: []int64{1000}}, []types.MinimalRepo{}},
 	}
 
 	for _, test := range tests {
@@ -2151,7 +2151,7 @@ func TestRepos_ListMinimalRepos_externalRepoContains(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			want: []types.MinimalRepo{},
 		},
 	}
 

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -83,7 +83,7 @@ func (r *Resolver) Paginate(ctx context.Context, opts search.RepoOptions, handle
 	}()
 
 	if opts.Limit == 0 {
-		opts.Limit = 500
+		opts.Limit = 4096
 	}
 
 	var errs error


### PR DESCRIPTION
When doing a search that has any `repo:` filters, we resolve repos a page at a time before searching that page. We do this to 1) limit the up-front cost of resolving all repos before starting the search, and 2) limit the memory overhead of holding all searchable repos in memory. 

However, at the scale of something like sourcegraph.com, paging through repos 500 at a time is very slow, even for searches that execute fast (indexed search) because we pay the overhead of resolving a page of repos 5000000 / 500 = 10000 times, and this overhead happens serially. For example, even a simple search like `type:repo count:all` takes a very long time on sourcegraph.com.

This bumps the page size up by 8x, which I expect to increase the speed of non-global repo paging by approximately 8x. 

This will hopefully fix https://github.com/sourcegraph/sourcegraph/issues/39392

Risks:
- Larger page size increases latency for expensive repo resolve steps like `repo:contains.commit.after()`
- Larger page sizes increase memory pressure on the `frontend` instance. In practice, I expect this to increase the memory cost of a page from ~31KB to ~256KB. I think that will be okay. 

If this doesn't help, we can try increasing it further, but I'm hesitant to go too high given our regular memory woes with `frontend`. Another thing we could try would be to resolve the next page concurrent to executing the search. This should be a fairly easy change and it would allow us to partially deserialize these steps. 

## Test plan

I can't test this well locally because I can't realistically clone millions of repos. However, I think this is a low-risk change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
