### PR TITLE
Jdb/poc-inline-insights

### DIFF
--- a/client/extension-api-types/src/textDocument.d.ts
+++ b/client/extension-api-types/src/textDocument.d.ts
@@ -19,7 +19,7 @@ export interface InsightDecoration
     range: Range
 
     /** The raw html to render in line. */
-    content: string
+    content: JSX.Element
 
     /** The JSX Element to render in the popover */
     popover: JSX.Element

--- a/client/extension-api-types/src/textDocument.d.ts
+++ b/client/extension-api-types/src/textDocument.d.ts
@@ -12,3 +12,17 @@ export interface TextDocumentDecoration
     /** The range that the decoration applies to. */
     range: Range
 }
+
+export interface InsightDecoration
+    extends Pick<sourcegraph.TextDocumentDecoration, Exclude<keyof sourcegraph.TextDocumentDecoration, 'range'>> {
+    /** The range that the decoration applies to. */
+    range: Range
+
+    /** The raw html to render in line. */
+    content: string
+
+    /** The JSX Element to render in the popover */
+    popover: JSX.Element
+
+    trigger?: 'hover' | 'click'
+}

--- a/client/shared/src/api/extension/api/decorations.ts
+++ b/client/shared/src/api/extension/api/decorations.ts
@@ -8,7 +8,7 @@ import {
 } from 'sourcegraph'
 
 import { hasProperty } from '@sourcegraph/common'
-import { TextDocumentDecoration } from '@sourcegraph/extension-api-types'
+import { InsightDecoration, TextDocumentDecoration } from '@sourcegraph/extension-api-types'
 
 // LINE AND COLUMN DECORATIONS
 
@@ -46,7 +46,7 @@ export function decorationAttachmentStyleForTheme(
     return { ...base, ...overrides }
 }
 
-export type DecorationMapByLine = ReadonlyMap<number, TextDocumentDecoration[]>
+export type DecorationMapByLine = ReadonlyMap<number, TextDocumentDecoration[] | InsightDecoration[]>
 
 /**
  * @returns Map from 1-based line number to non-empty array of TextDocumentDecoration for that line

--- a/client/shared/src/api/extension/api/decorations.ts
+++ b/client/shared/src/api/extension/api/decorations.ts
@@ -53,8 +53,10 @@ export type DecorationMapByLine = ReadonlyMap<number, TextDocumentDecoration[] |
  *
  * @todo this does not handle decorations that span multiple lines
  */
-export const groupDecorationsByLine = (decorations: TextDocumentDecoration[] | null): DecorationMapByLine => {
-    const grouped = new Map<number, TextDocumentDecoration[]>()
+export const groupDecorationsByLine = (
+    decorations: (TextDocumentDecoration | InsightDecoration)[] | null
+): DecorationMapByLine => {
+    const grouped = new Map<number, (TextDocumentDecoration | InsightDecoration)[]>()
     for (const decoration of decorations || []) {
         const lineNumber = decoration.range.start.line + 1
         const decorationsForLine = grouped.get(lineNumber)

--- a/client/web/src/insights/components/InsightDecorationContent.module.scss
+++ b/client/web/src/insights/components/InsightDecorationContent.module.scss
@@ -1,0 +1,5 @@
+.insight-decoration-content {
+    background-color: var(--primary-4);
+    padding: 1px 3px;
+    cursor: pointer;
+}

--- a/client/web/src/insights/components/InsightDecorationContent.tsx
+++ b/client/web/src/insights/components/InsightDecorationContent.tsx
@@ -1,0 +1,11 @@
+import { forwardRef, PropsWithChildren } from 'react'
+
+import styles from './InsightDecorationContent.module.scss'
+
+export const InsightDecorationContent = forwardRef<HTMLSpanElement, PropsWithChildren<{}>>(({ children }, ref) => (
+    <span ref={ref} className={styles.insightDecorationContent}>
+        {children}
+    </span>
+))
+
+InsightDecorationContent.displayName = 'InsightDecorationContent'

--- a/client/web/src/insights/components/InsightDecorationPopover.module.scss
+++ b/client/web/src/insights/components/InsightDecorationPopover.module.scss
@@ -1,0 +1,28 @@
+.insight-decoration-popover {
+    background-color: var(--color-bg-1);
+    padding: 12px;
+    border-radius: 4px;
+    border: solid 1px var(--border-color);
+    box-shadow: var(--dropdown-shadow);
+}
+
+.insight-decoration-line-ref {
+    color: var(--text-muted);
+    font-size: 0.625rem;
+    font-weight: 400;
+}
+
+.insight-decoration-link {
+    font-size: 0.75rem;
+    font-weight: 400;
+}
+
+.insight-decoration-row {
+    padding-left: 16px;
+    margin-left: 4px;
+    border-left: solid 2px var(--border-color-2);
+}
+
+.insight-decoration-section {
+    margin-bottom: 8px;
+}

--- a/client/web/src/insights/components/InsightDecorationPopover.module.scss
+++ b/client/web/src/insights/components/InsightDecorationPopover.module.scss
@@ -15,6 +15,7 @@
 .insight-decoration-link {
     font-size: 0.75rem;
     font-weight: 400;
+    cursor: pointer;
 }
 
 .insight-decoration-row {

--- a/client/web/src/insights/components/InsightDecorationPopover.tsx
+++ b/client/web/src/insights/components/InsightDecorationPopover.tsx
@@ -1,0 +1,48 @@
+import { FC } from 'react'
+
+import classNames from 'classnames'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
+
+import { Link } from '@sourcegraph/wildcard'
+
+import styles from './InsightDecorationPopover.module.scss'
+
+interface TokenInsight {
+    id: string
+    name: string
+    url: string
+}
+
+interface Token {
+    name: string
+    insights: TokenInsight[]
+}
+
+interface InsightDecorationPopoverProps {
+    tokens: Token[]
+}
+
+export const InsightDecorationPopover: FC<InsightDecorationPopoverProps> = ({ tokens }) => (
+    <div className={styles.insightDecorationPopover}>
+        {tokens.map(token => (
+            <div key={token.name} className={styles.insightDecorationSection}>
+                <div>
+                    <span>{'{}'}</span>
+                    <small className="ml-2">
+                        <strong>{token.name}</strong>
+                    </small>
+                </div>
+                <div className={classNames(styles.insightDecorationRow, styles.insightDecorationLineRef)}>
+                    Insights referencing this line ({token.insights.length})
+                </div>
+                {token.insights.map(insight => (
+                    <div key={insight.id} className={classNames(styles.insightDecorationRow)}>
+                        <Link to={insight.url} className={styles.insightDecorationLink}>
+                            {insight.name} <OpenInNewIcon size={12} />
+                        </Link>
+                    </div>
+                ))}
+            </div>
+        ))}
+    </div>
+)

--- a/client/web/src/insights/components/InsightDecorationPopover.tsx
+++ b/client/web/src/insights/components/InsightDecorationPopover.tsx
@@ -14,7 +14,7 @@ interface TokenInsight {
 }
 
 interface Token {
-    name: string
+    token: string
     insights: TokenInsight[]
 }
 
@@ -25,11 +25,11 @@ interface InsightDecorationPopoverProps {
 export const InsightDecorationPopover: FC<InsightDecorationPopoverProps> = ({ tokens }) => (
     <div className={styles.insightDecorationPopover}>
         {tokens.map(token => (
-            <div key={token.name} className={styles.insightDecorationSection}>
+            <div key={token.token} className={styles.insightDecorationSection}>
                 <div>
                     <span>{'{}'}</span>
                     <small className="ml-2">
-                        <strong>{token.name}</strong>
+                        <strong>{token.token}</strong>
                     </small>
                 </div>
                 <div className={classNames(styles.insightDecorationRow, styles.insightDecorationLineRef)}>

--- a/client/web/src/insights/hooks/useCodeInsightsData.ts
+++ b/client/web/src/insights/hooks/useCodeInsightsData.ts
@@ -1,0 +1,37 @@
+import { QueryResult } from '@apollo/client'
+
+import { gql, useQuery } from '@sourcegraph/http-client'
+
+import { GetRelatedInsightsInlineResult } from '../../graphql-operations'
+
+const RELATED_INSIGHTS_INLINE_QUERY = gql`
+    query GetRelatedInsightsInline($input: RelatedInsightsInput!) {
+        relatedInsightsInline(input: $input) {
+            viewId
+            title
+            lineNumbers
+            text
+        }
+    }
+`
+
+interface UseCodeInsightsDataInput {
+    file: string
+    revision: string
+    repo: string
+}
+
+export const useCodeInsightsData = ({
+    file,
+    revision,
+    repo,
+}: UseCodeInsightsDataInput): QueryResult<GetRelatedInsightsInlineResult> =>
+    useQuery(RELATED_INSIGHTS_INLINE_QUERY, {
+        variables: {
+            input: {
+                file,
+                revision,
+                repo,
+            },
+        },
+    })

--- a/client/web/src/repo/blob/Blob.module.scss
+++ b/client/web/src/repo/blob/Blob.module.scss
@@ -124,38 +124,3 @@
     background-color: var(--body-bg);
     color: var(--body-color);
 }
-
-.insight-decoration-content {
-    background-color: var(--primary-4);
-    padding: 1px 3px;
-    cursor: pointer;
-}
-
-.insight-decoration-popover {
-    background-color: var(--color-bg-1);
-    padding: 12px;
-    border-radius: 4px;
-    border: solid 1px var(--border-color);
-    box-shadow: var(--dropdown-shadow);
-}
-
-.insight-decoration-line-ref {
-    color: var(--text-muted);
-    font-size: 0.625rem;
-    font-weight: 400;
-}
-
-.insight-decoration-link {
-    font-size: 0.75rem;
-    font-weight: 400;
-}
-
-.insight-decoration-row {
-    padding-left: 16px;
-    margin-left: 4px;
-    border-left: solid 2px var(--border-color-2);
-}
-
-.insight-decoration-section {
-    margin-bottom: 8px;
-}

--- a/client/web/src/repo/blob/Blob.module.scss
+++ b/client/web/src/repo/blob/Blob.module.scss
@@ -124,3 +124,38 @@
     background-color: var(--body-bg);
     color: var(--body-color);
 }
+
+.insight-decoration-content {
+    background-color: var(--primary-4);
+    padding: 1px 3px;
+    cursor: pointer;
+}
+
+.insight-decoration-popover {
+    background-color: var(--color-bg-1);
+    padding: 12px;
+    border-radius: 4px;
+    border: solid 1px var(--border-color);
+    box-shadow: var(--dropdown-shadow);
+}
+
+.insight-decoration-line-ref {
+    color: var(--text-muted);
+    font-size: 0.625rem;
+    font-weight: 400;
+}
+
+.insight-decoration-link {
+    font-size: 0.75rem;
+    font-weight: 400;
+}
+
+.insight-decoration-row {
+    padding-left: 16px;
+    margin-left: 4px;
+    border-left: solid 2px var(--border-color-2);
+}
+
+.insight-decoration-section {
+    margin-bottom: 8px;
+}

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -55,7 +55,7 @@ import {
     addLineRangeQueryParameter,
     formatSearchParameters,
 } from '@sourcegraph/common'
-import { TextDocumentDecoration } from '@sourcegraph/extension-api-types'
+import { InsightDecoration, TextDocumentDecoration } from '@sourcegraph/extension-api-types'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
@@ -176,6 +176,20 @@ const domFunctions = {
 
 const STATUS_BAR_HORIZONTAL_GAP_VAR = '--blob-status-bar-horizontal-gap'
 const STATUS_BAR_VERTICAL_GAP_VAR = '--blob-status-bar-vertical-gap'
+
+const decoration: InsightDecoration = {
+    range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 0 },
+    },
+    content: '<b>TEST:</b>Inline insight test',
+    popover: (
+        <span>
+            Hey look I'm a <b>React Component</b>
+        </span>
+    ),
+    trigger: 'click',
+}
 
 /**
  * Renders a code view augmented by Sourcegraph extensions
@@ -307,8 +321,12 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
     }, [blobInfo, nextBlobInfoChange, viewerUpdates])
 
     const [decorationsOrError, setDecorationsOrError] = useState<
-        [TextDocumentDecorationType, TextDocumentDecoration[]][] | Error | undefined
+        [TextDocumentDecorationType, (TextDocumentDecoration | InsightDecoration)[]][] | Error | undefined
     >()
+    const [insightDecorations, setInsightsDecorations] = useState<InsightDecoration[]>([])
+
+    // TODO: Update this to an API call
+    useEffect(() => setInsightsDecorations([decoration]), [])
 
     const popoverCloses = useMemo(() => new Subject<void>(), [])
     const nextPopoverClose = useCallback((click: void) => popoverCloses.next(click), [popoverCloses])
@@ -868,6 +886,17 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                         )
                     })
                     .toArray()}
+                {insightDecorations.map((insightDecoration, index) => (
+                    <LineDecorator
+                        key={index}
+                        isLightTheme={isLightTheme}
+                        portalID={toPortalID(1)}
+                        getCodeElementFromLineNumber={domFunctions.getCodeElementFromLineNumber}
+                        line={1}
+                        decorations={[insightDecoration]}
+                        codeViewElements={codeViewElements}
+                    />
+                ))}
             </div>
             {!props.disableStatusBar && (
                 <StatusBar

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -468,10 +468,6 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
         }, [] as InsightDecoration[])
     }
 
-    console.log(
-        '🚀 ~ file: Blob.tsx ~ line 467 ~ insightDecorationsData=Object.entries ~ insightDecorationsData',
-        insightDecorationsData
-    )
     useEffect(() => setInsightsDecorations(groupDecorationsByLine(insightDecorationsData)), [insightDecorationsData])
     // TODO: Update this to an API call
     // useEffect(() => setInsightsDecorations(groupDecorationsByLine([decoration])), [])

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -1,11 +1,10 @@
-import React, { FC, forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 import { Remote } from 'comlink'
 import * as H from 'history'
 import iterate from 'iterare'
 import { isEqual, sortBy } from 'lodash'
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import {
     BehaviorSubject,
     combineLatest,
@@ -83,11 +82,13 @@ import {
     toURIWithPath,
     parseQueryAndHash,
 } from '@sourcegraph/shared/src/util/url'
-import { Code, Link, useObservable } from '@sourcegraph/wildcard'
+import { Code, useObservable } from '@sourcegraph/wildcard'
 
 import { getHover, getDocumentHighlights } from '../../backend/features'
 import { WebHoverOverlay } from '../../components/shared'
 import { StatusBar } from '../../extensions/components/StatusBar'
+import { InsightDecorationContent } from '../../insights/components/InsightDecorationContent'
+import { InsightDecorationPopover } from '../../insights/components/InsightDecorationPopover'
 import { enableExtensionsDecorationsColumnViewFromSettings } from '../../util/settings'
 import { HoverThresholdProps } from '../RepoContainer'
 
@@ -178,75 +179,61 @@ const domFunctions = {
 const STATUS_BAR_HORIZONTAL_GAP_VAR = '--blob-status-bar-horizontal-gap'
 const STATUS_BAR_VERTICAL_GAP_VAR = '--blob-status-bar-vertical-gap'
 
-const InsightDecorationContent = forwardRef<HTMLSpanElement>((props, ref) => (
-    <span ref={ref} className={styles.insightDecorationContent}>
-        Referenced in <strong>5 insights</strong> 📈
-    </span>
-))
-
-InsightDecorationContent.displayName = 'InsightDecorationContent'
-
-const InsightDecorationPopover: FC = () => (
-    <div className={styles.insightDecorationPopover}>
-        <div className={styles.insightDecorationSection}>
-            <div>
-                <span>{'{}'}</span>
-                <small className="ml-2">
-                    <strong>AuthURLPrefix</strong>
-                </small>
-            </div>
-            <div className={classNames(styles.insightDecorationRow, styles.insightDecorationLineRef)}>
-                Insights referencing this line (3)
-            </div>
-            <div className={classNames(styles.insightDecorationRow)}>
-                <Link to="/insights" className={styles.insightDecorationLink}>
-                    Track Middleware <OpenInNewIcon size={12} />
-                </Link>
-            </div>
-            <div className={classNames(styles.insightDecorationRow)}>
-                <Link to="/insights" className={styles.insightDecorationLink}>
-                    API Middleware <OpenInNewIcon size={12} />
-                </Link>
-            </div>
-            <div className={classNames(styles.insightDecorationRow)}>
-                <Link to="/insights" className={styles.insightDecorationLink}>
-                    API Tracking <OpenInNewIcon size={12} />
-                </Link>
-            </div>
-        </div>
-        <div className={styles.insightDecorationSection}>
-            <div>
-                <span>{'{}'}</span>
-                <small className="ml-2">
-                    <strong>""./auth"</strong>
-                </small>
-            </div>
-            <div className={classNames(styles.insightDecorationRow, styles.insightDecorationLineRef)}>
-                Insights referencing this line (2)
-            </div>
-            <div className={classNames(styles.insightDecorationRow)}>
-                <Link to="/insights" className={styles.insightDecorationLink}>
-                    Auth protocols <OpenInNewIcon size={12} />
-                </Link>
-            </div>
-            <div className={classNames(styles.insightDecorationRow)}>
-                <Link to="/insights" className={styles.insightDecorationLink}>
-                    Auth Middleware <OpenInNewIcon size={12} />
-                </Link>
-            </div>
-        </div>
-    </div>
-)
+// BEGIN STATIC CODE INSIGHTS TEST DATA
+const insightTokens = [
+    {
+        name: 'AuthURLPrefix',
+        insights: [
+            {
+                id: 'foo',
+                name: 'Track Middleware',
+                url: '/insights/foo',
+            },
+            {
+                id: 'bar',
+                name: 'API Middleware',
+                url: '/insights/bar',
+            },
+            {
+                id: 'baz',
+                name: 'API Tracking',
+                url: '/insights/baz',
+            },
+        ],
+    },
+    {
+        name: '"/.auth"',
+        insights: [
+            {
+                id: 'foo',
+                name: 'Auth Middleware',
+                url: '/insights/foo',
+            },
+            {
+                id: 'bar',
+                name: 'Auth APIs',
+                url: '/insights/bar',
+            },
+        ],
+    },
+]
 
 const decoration: InsightDecoration = {
     range: {
         start: { line: 0, character: 0 },
         end: { line: 0, character: 0 },
     },
-    content: <InsightDecorationContent />,
-    popover: <InsightDecorationPopover />,
+    content: (
+        <InsightDecorationContent>
+            <>
+                Referenced in <strong>5 insights</strong> 📈
+            </>
+        </InsightDecorationContent>
+    ),
+    popover: <InsightDecorationPopover tokens={insightTokens} />,
     trigger: 'click',
 }
+// END STATIC CODE INSIGHTS TEST DATA
 
 /**
  * Renders a code view augmented by Sourcegraph extensions

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { FC, forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 import { Remote } from 'comlink'
 import * as H from 'history'
 import iterate from 'iterare'
 import { isEqual, sortBy } from 'lodash'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import {
     BehaviorSubject,
     combineLatest,
@@ -82,7 +83,7 @@ import {
     toURIWithPath,
     parseQueryAndHash,
 } from '@sourcegraph/shared/src/util/url'
-import { Code, useObservable } from '@sourcegraph/wildcard'
+import { Code, Link, useObservable } from '@sourcegraph/wildcard'
 
 import { getHover, getDocumentHighlights } from '../../backend/features'
 import { WebHoverOverlay } from '../../components/shared'
@@ -177,21 +178,73 @@ const domFunctions = {
 const STATUS_BAR_HORIZONTAL_GAP_VAR = '--blob-status-bar-horizontal-gap'
 const STATUS_BAR_VERTICAL_GAP_VAR = '--blob-status-bar-vertical-gap'
 
+const InsightDecorationContent = forwardRef<HTMLSpanElement>((props, ref) => (
+    <span ref={ref} className={styles.insightDecorationContent}>
+        Referenced in <strong>5 insights</strong> 📈
+    </span>
+))
+
+InsightDecorationContent.displayName = 'InsightDecorationContent'
+
+const InsightDecorationPopover: FC = () => (
+    <div className={styles.insightDecorationPopover}>
+        <div className={styles.insightDecorationSection}>
+            <div>
+                <span>{'{}'}</span>
+                <small className="ml-2">
+                    <strong>AuthURLPrefix</strong>
+                </small>
+            </div>
+            <div className={classNames(styles.insightDecorationRow, styles.insightDecorationLineRef)}>
+                Insights referencing this line (3)
+            </div>
+            <div className={classNames(styles.insightDecorationRow)}>
+                <Link to="/insights" className={styles.insightDecorationLink}>
+                    Track Middleware <OpenInNewIcon size={12} />
+                </Link>
+            </div>
+            <div className={classNames(styles.insightDecorationRow)}>
+                <Link to="/insights" className={styles.insightDecorationLink}>
+                    API Middleware <OpenInNewIcon size={12} />
+                </Link>
+            </div>
+            <div className={classNames(styles.insightDecorationRow)}>
+                <Link to="/insights" className={styles.insightDecorationLink}>
+                    API Tracking <OpenInNewIcon size={12} />
+                </Link>
+            </div>
+        </div>
+        <div className={styles.insightDecorationSection}>
+            <div>
+                <span>{'{}'}</span>
+                <small className="ml-2">
+                    <strong>""./auth"</strong>
+                </small>
+            </div>
+            <div className={classNames(styles.insightDecorationRow, styles.insightDecorationLineRef)}>
+                Insights referencing this line (2)
+            </div>
+            <div className={classNames(styles.insightDecorationRow)}>
+                <Link to="/insights" className={styles.insightDecorationLink}>
+                    Auth protocols <OpenInNewIcon size={12} />
+                </Link>
+            </div>
+            <div className={classNames(styles.insightDecorationRow)}>
+                <Link to="/insights" className={styles.insightDecorationLink}>
+                    Auth Middleware <OpenInNewIcon size={12} />
+                </Link>
+            </div>
+        </div>
+    </div>
+)
+
 const decoration: InsightDecoration = {
     range: {
         start: { line: 0, character: 0 },
         end: { line: 0, character: 0 },
     },
-    content: (
-        <span>
-            Referenced in <strong>5 insights</strong>
-        </span>
-    ),
-    popover: (
-        <span>
-            Hey look I'm a <b>React Component</b>
-        </span>
-    ),
+    content: <InsightDecorationContent />,
+    popover: <InsightDecorationPopover />,
     trigger: 'click',
 }
 

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -182,7 +182,11 @@ const decoration: InsightDecoration = {
         start: { line: 0, character: 0 },
         end: { line: 0, character: 0 },
     },
-    content: '<b>TEST:</b>Inline insight test',
+    content: (
+        <span>
+            Referenced in <strong>5 insights</strong>
+        </span>
+    ),
     popover: (
         <span>
             Hey look I'm a <b>React Component</b>

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -220,8 +220,8 @@ const insightTokens = [
 
 const decoration: InsightDecoration = {
     range: {
-        start: { line: 0, character: 0 },
-        end: { line: 0, character: 0 },
+        start: { line: 2, character: 0 },
+        end: { line: 2, character: 0 },
     },
     content: (
         <InsightDecorationContent>
@@ -367,10 +367,10 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
     const [decorationsOrError, setDecorationsOrError] = useState<
         [TextDocumentDecorationType, (TextDocumentDecoration | InsightDecoration)[]][] | Error | undefined
     >()
-    const [insightDecorations, setInsightsDecorations] = useState<InsightDecoration[]>([])
+    const [insightDecorations, setInsightsDecorations] = useState<DecorationMapByLine>(new Map())
 
     // TODO: Update this to an API call
-    useEffect(() => setInsightsDecorations([decoration]), [])
+    useEffect(() => setInsightsDecorations(groupDecorationsByLine([decoration])), [])
 
     const popoverCloses = useMemo(() => new Subject<void>(), [])
     const nextPopoverClose = useCallback((click: void) => popoverCloses.next(click), [popoverCloses])
@@ -930,17 +930,22 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                         )
                     })
                     .toArray()}
-                {insightDecorations.map((insightDecoration, index) => (
-                    <LineDecorator
-                        key={index}
-                        isLightTheme={isLightTheme}
-                        portalID={toPortalID(1)}
-                        getCodeElementFromLineNumber={domFunctions.getCodeElementFromLineNumber}
-                        line={1}
-                        decorations={[insightDecoration]}
-                        codeViewElements={codeViewElements}
-                    />
-                ))}
+                {iterate(insightDecorations)
+                    .map(([line, items]) => {
+                        const portalID = toPortalID(line)
+                        return (
+                            <LineDecorator
+                                key={`${portalID}-${blobInfo.filePath}`}
+                                isLightTheme={isLightTheme}
+                                portalID={toPortalID(3)}
+                                getCodeElementFromLineNumber={domFunctions.getCodeElementFromLineNumber}
+                                line={line}
+                                decorations={items}
+                                codeViewElements={codeViewElements}
+                            />
+                        )
+                    })
+                    .toArray()}
             </div>
             {!props.disableStatusBar && (
                 <StatusBar

--- a/client/web/src/repo/blob/LineDecorator.tsx
+++ b/client/web/src/repo/blob/LineDecorator.tsx
@@ -175,7 +175,7 @@ const LineDecorator = React.memo<LineDecoratorProps>(
                 // Content is only available on Insight decorations
                 if ('content' in decoration && isDefined(decoration.content)) {
                     return (
-                        <Tippy content={decoration.popover} trigger={decoration.trigger}>
+                        <Tippy content={decoration.popover} trigger={decoration.trigger} hideOnClick="toggle">
                             {decoration.content}
                         </Tippy>
                     )

--- a/client/web/src/repo/blob/LineDecorator.tsx
+++ b/client/web/src/repo/blob/LineDecorator.tsx
@@ -176,7 +176,7 @@ const LineDecorator = React.memo<LineDecoratorProps>(
                 if ('content' in decoration && isDefined(decoration.content)) {
                     return (
                         <Tippy content={decoration.popover} trigger={decoration.trigger}>
-                            <span dangerouslySetInnerHTML={{ __html: decoration.content }} />
+                            {decoration.content}
                         </Tippy>
                     )
                 }

--- a/client/web/src/repo/blob/LineDecorator.tsx
+++ b/client/web/src/repo/blob/LineDecorator.tsx
@@ -175,7 +175,12 @@ const LineDecorator = React.memo<LineDecoratorProps>(
                 // Content is only available on Insight decorations
                 if ('content' in decoration && isDefined(decoration.content)) {
                     return (
-                        <Tippy content={decoration.popover} trigger={decoration.trigger} hideOnClick="toggle">
+                        <Tippy
+                            key={decoration.content.key}
+                            content={decoration.popover}
+                            trigger={decoration.trigger}
+                            hideOnClick="toggle"
+                        >
                             {decoration.content}
                         </Tippy>
                     )

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -474,13 +474,13 @@ type RelatedInsightsRepoInput struct {
 }
 
 type RelatedInsightsInlineResolver interface {
-	ViewID() string
+	ViewID() graphql.ID
 	Title() string
 	LineNumbers() []int32
 	Text() []string
 }
 
 type RelatedInsightsResolver interface {
-	ViewID() string
+	ViewID() graphql.ID
 	Title() string
 }

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -477,6 +477,7 @@ type RelatedInsightsInlineResolver interface {
 	ViewID() string
 	Title() string
 	LineNumbers() []int32
+	OffsetAndLengths() [][]int32
 }
 
 type RelatedInsightsResolver interface {

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -477,7 +477,7 @@ type RelatedInsightsInlineResolver interface {
 	ViewID() string
 	Title() string
 	LineNumbers() []int32
-	OffsetAndLengths() [][]int32
+	Text() []string
 }
 
 type RelatedInsightsResolver interface {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -265,7 +265,7 @@ type RelatedInsightInline {
     """
     Insight view id
     """
-    viewId: String!
+    viewId: ID!
     """
     Insight title
     """
@@ -287,7 +287,7 @@ type RelatedInsight {
     """
     Insight view id
     """
-    viewId: String!
+    viewId: ID!
     """
     Insight title
     """

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -275,9 +275,9 @@ type RelatedInsightInline {
     """
     lineNumbers: [Int!]!
     """
-    The offsets and lengths of the matches
+    The text that was matched
     """
-    offsetAndLengths: [[Int!]!]!
+    text: [String!]!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -274,6 +274,10 @@ type RelatedInsightInline {
     An array of line numbers where matches are found
     """
     lineNumbers: [Int!]!
+    """
+    The offsets and lengths of the matches
+    """
+    offsetAndLengths: [[Int!]!]!
 }
 
 """

--- a/enterprise/internal/insights/query/streaming/decoder.go
+++ b/enterprise/internal/insights/query/streaming/decoder.go
@@ -123,8 +123,6 @@ func MetadataDecoder() (streamhttp.FrontendStreamDecoder, *MetadataResult) {
 		OnMatches: func(matches []streamhttp.EventMatch) {
 			for _, match := range matches {
 				switch match := match.(type) {
-				// Right now we only care about inline matches.
-				// Should be extended when we care about repo and file results.
 				case *streamhttp.EventContentMatch:
 					mr.Matches = append(mr.Matches, &SearchMatch{LineMatches: match.LineMatches})
 				case *streamhttp.EventPathMatch:

--- a/enterprise/internal/insights/resolvers/related_insights_resolvers.go
+++ b/enterprise/internal/insights/resolvers/related_insights_resolvers.go
@@ -60,6 +60,7 @@ func (r *Resolver) RelatedInsightsInline(ctx context.Context, args graphqlbacken
 					seriesMatches[series.UniqueID] = &relatedInsightInlineMetadata{title: series.Title, lineNumbers: []int32{lineMatch.LineNumber}, offsetAndLengths: lineMatch.OffsetAndLengths}
 				} else if !containsInt(seriesMatches[series.UniqueID].lineNumbers, lineMatch.LineNumber) {
 					seriesMatches[series.UniqueID].lineNumbers = append(seriesMatches[series.UniqueID].lineNumbers, lineMatch.LineNumber)
+					seriesMatches[series.UniqueID].offsetAndLengths = append(seriesMatches[series.UniqueID].offsetAndLengths, lineMatch.OffsetAndLengths...)
 				}
 			}
 		}

--- a/enterprise/internal/insights/resolvers/related_insights_resolvers.go
+++ b/enterprise/internal/insights/resolvers/related_insights_resolvers.go
@@ -57,7 +57,7 @@ func (r *Resolver) RelatedInsightsInline(ctx context.Context, args graphqlbacken
 		for _, match := range mr.Matches {
 			for _, lineMatch := range match.LineMatches {
 				if seriesMatches[series.UniqueID] == nil {
-					seriesMatches[series.UniqueID] = &relatedInsightInlineMetadata{title: series.Title, lineNumbers: []int32{lineMatch.LineNumber}}
+					seriesMatches[series.UniqueID] = &relatedInsightInlineMetadata{title: series.Title, lineNumbers: []int32{lineMatch.LineNumber}, offsetAndLengths: lineMatch.OffsetAndLengths}
 				} else if !containsInt(seriesMatches[series.UniqueID].lineNumbers, lineMatch.LineNumber) {
 					seriesMatches[series.UniqueID].lineNumbers = append(seriesMatches[series.UniqueID].lineNumbers, lineMatch.LineNumber)
 				}
@@ -70,20 +70,27 @@ func (r *Resolver) RelatedInsightsInline(ctx context.Context, args graphqlbacken
 		sort.SliceStable(metadata.lineNumbers, func(i, j int) bool {
 			return metadata.lineNumbers[i] < metadata.lineNumbers[j]
 		})
-		resolvers = append(resolvers, &relatedInsightsInlineResolver{viewID: insightId, title: metadata.title, lineNumbers: metadata.lineNumbers})
+		resolvers = append(resolvers, &relatedInsightsInlineResolver{
+			viewID:           insightId,
+			title:            metadata.title,
+			lineNumbers:      metadata.lineNumbers,
+			offsetAndLengths: metadata.offsetAndLengths,
+		})
 	}
 	return resolvers, nil
 }
 
 type relatedInsightInlineMetadata struct {
-	title       string
-	lineNumbers []int32
+	title            string
+	lineNumbers      []int32
+	offsetAndLengths [][2]int32
 }
 
 type relatedInsightsInlineResolver struct {
-	viewID      string
-	title       string
-	lineNumbers []int32
+	viewID           string
+	title            string
+	lineNumbers      []int32
+	offsetAndLengths [][2]int32
 
 	baseInsightResolver
 }
@@ -98,6 +105,14 @@ func (r *relatedInsightsInlineResolver) Title() string {
 
 func (r *relatedInsightsInlineResolver) LineNumbers() []int32 {
 	return r.lineNumbers
+}
+
+func (r *relatedInsightsInlineResolver) OffsetAndLengths() [][]int32 {
+	converted := [][]int32{}
+	for i := range r.offsetAndLengths {
+		converted = append(converted, r.offsetAndLengths[i][:])
+	}
+	return converted
 }
 
 func (r *Resolver) RelatedInsightsForFile(ctx context.Context, args graphqlbackend.RelatedInsightsArgs) ([]graphqlbackend.RelatedInsightsResolver, error) {

--- a/enterprise/internal/insights/resolvers/related_insights_resolvers.go
+++ b/enterprise/internal/insights/resolvers/related_insights_resolvers.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -101,8 +103,8 @@ type relatedInsightsInlineResolver struct {
 	baseInsightResolver
 }
 
-func (r *relatedInsightsInlineResolver) ViewID() string {
-	return r.viewID
+func (r *relatedInsightsInlineResolver) ViewID() graphql.ID {
+	return relay.MarshalID("insight_view", r.viewID)
 }
 
 func (r *relatedInsightsInlineResolver) Title() string {
@@ -232,8 +234,8 @@ type relatedInsightsResolver struct {
 	baseInsightResolver
 }
 
-func (r *relatedInsightsResolver) ViewID() string {
-	return r.viewID
+func (r *relatedInsightsResolver) ViewID() graphql.ID {
+	return relay.MarshalID("insight_view", r.viewID)
 }
 
 func (r *relatedInsightsResolver) Title() string {

--- a/package.json
+++ b/package.json
@@ -385,6 +385,7 @@
     "@sourcegraph/extension-api-classes": "^1.1.0",
     "@stripe/react-stripe-js": "^1.8.0-0",
     "@stripe/stripe-js": "^1.29.0",
+    "@tippyjs/react": "^4.2.6",
     "@visx/annotation": "^2.10.0",
     "@visx/axis": "^2.10.0",
     "@visx/glyph": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3363,6 +3363,11 @@
     qs "^6.7.0"
     url-parse "^1.4.7"
 
+"@popperjs/core@^2.9.0":
+  version "2.11.5"
+  resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
+  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
+
 "@radix-ui/popper@0.1.0":
   version "0.1.0"
   resolved "https://registry.npmjs.org/@radix-ui/popper/-/popper-0.1.0.tgz#c387a38f31b7799e1ea0d2bb1ca0c91c2931b063"
@@ -5232,6 +5237,13 @@
   integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+"@tippyjs/react@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz#971677a599bf663f20bb1c60a62b9555b749cc71"
+  integrity sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==
+  dependencies:
+    tippy.js "^6.3.1"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -23620,6 +23632,13 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+tippy.js@^6.3.1:
+  version "6.3.7"
+  resolved "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz#8ccfb651d642010ed9a32ff29b0e9e19c5b8c61c"
+  integrity sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==
+  dependencies:
+    "@popperjs/core" "^2.9.0"
 
 title-case@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39112

Related BE PR: https://github.com/sourcegraph/sourcegraph/pull/39475

To set up pick any file. I've been using this one: https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/enterprise/internal/insights/query/querybuilder/builder.go?L24

Then create an insight with any keyword in that file. You should see the line decoration for that file. Clicking the decoration should open the popover. Clicking it again should close the popover.

Known Issues:

- [ ] Links aren't clickable. Popover seems to render beneath code.
- [ ] To keep the popover from closing when mousing away from the decoration, I set `hideOnClick="toggle"` in `LineDecorator`. This works but also means the popover doesn't close when you click outside the popover. Which is not great.

Remaining Items:

- [ ] Fix the above. Probably clean up how we pull data. (I am so sorry)
- [ ] Build the dropdown for the file at the top of the blob view. You should be able to reuse the popover component I already built.
- [ ] Extract all of the logic building the decorations in `Blob.tsx` to a utility so that we don't clutter up Blob anymore.
- [ ] Make sure all of this is feature flagged default off

### Note

Felix recommended breaking this up into 3 separate issues. I've stubbed them out below. I would take the code in this PR and pull what you need into brand new feature branches to build these one at a time.

For example: Grab the popover component and build the file drop-down first.

Here are the issues in order of what makes sense so that they build on each other:

1. https://github.com/sourcegraph/sourcegraph/issues/39550
2. https://github.com/sourcegraph/sourcegraph/issues/39551
3. https://github.com/sourcegraph/sourcegraph/issues/39552

### Note 2

@Joelkw actually wants item 3 above done first, but it doesn't make sense to build it this way. (Sorry Joel). I recommended breaking this up into smaller pieces and getting them reviewed/merged separately.

## Test plan

N/A This is just a spike

## App preview:

- [Web](https://sg-web-jdb-poc-inline-insights.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

