### PR TITLE
tools: upgrade trivy to v0.30.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -7,7 +7,7 @@ shellcheck 0.7.1
 kubectl 1.21.7
 github-cli 2.0.0
 packer 1.7.10
-trivy 0.20.0
+trivy 0.30.3
 kustomize 4.0.5
 awscli 2.4.7
 python system


### PR DESCRIPTION
I'm currently unable to install 0.20.0 locally - it seems it has no distribution for M1 macs - but the latest version, 0.30.3, works fine for me.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Main dry run to build and scan the images: https://buildkite.com/sourcegraph/sourcegraph/builds/163111