### PR TITLE
core workflow: fix symbols loading

### DIFF
--- a/client/search-ui/src/components/CodeExcerpt.test.tsx
+++ b/client/search-ui/src/components/CodeExcerpt.test.tsx
@@ -31,7 +31,6 @@ describe('CodeExcerpt', () => {
         className: 'file-match__item-code-excerpt',
         fetchHighlightedFileRangeLines: () =>
             of(HIGHLIGHTED_FILE_LINES_SIMPLE).pipe(map(ranges => ranges[0].slice(startLine, endLine))),
-        isFirst: false,
     }
 
     it('renders correct number of rows', () => {

--- a/client/search-ui/src/components/CodeExcerpt.tsx
+++ b/client/search-ui/src/components/CodeExcerpt.tsx
@@ -35,12 +35,10 @@ interface Props extends Repo {
     startLine: number
     /** The 0-based (exclusive) line number that this code excerpt ends at */
     endLine: number
-    /** Whether or not this is the first result being shown or not. */
-    isFirst: boolean
     className?: string
     /** A function to fetch the range of lines this code excerpt will display. It will be provided
      * the same start and end lines properties that were provided as component props */
-    fetchHighlightedFileRangeLines: (isFirst: boolean, startLine: number, endLine: number) => Observable<string[]>
+    fetchHighlightedFileRangeLines: (startLine: number, endLine: number) => Observable<string[]>
     blobLines?: string[]
 
     viewerUpdates?: Observable<{ viewerId: ViewerId } & HoverContext>
@@ -104,7 +102,6 @@ const visibilitySensorOffset = { bottom: -500 }
 export const CodeExcerpt: React.FunctionComponent<Props> = ({
     blobLines,
     fetchHighlightedFileRangeLines,
-    isFirst,
     startLine,
     endLine,
     highlightRanges,
@@ -133,13 +130,13 @@ export const CodeExcerpt: React.FunctionComponent<Props> = ({
     useEffect(() => {
         let subscription: Subscription | undefined
         if (isVisible) {
-            const observable = blobLines ? of(blobLines) : fetchHighlightedFileRangeLines(isFirst, startLine, endLine)
+            const observable = blobLines ? of(blobLines) : fetchHighlightedFileRangeLines(startLine, endLine)
             subscription = observable.pipe(catchError(error => [asError(error)])).subscribe(blobLinesOrError => {
                 setBlobLinesOrError(blobLinesOrError)
             })
         }
         return () => subscription?.unsubscribe()
-    }, [blobLines, endLine, fetchHighlightedFileRangeLines, isFirst, isVisible, startLine])
+    }, [blobLines, endLine, fetchHighlightedFileRangeLines, isVisible, startLine])
 
     // Highlight the search matches
     useLayoutEffect(() => {

--- a/client/search-ui/src/components/SearchResult.module.scss
+++ b/client/search-ui/src/components/SearchResult.module.scss
@@ -113,6 +113,6 @@
 }
 
 .symbols {
-    border: none;
-    padding: 0;
+    border: none !important;
+    padding: 0 !important;
 }

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
@@ -225,7 +225,6 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
                             highlightRanges={[]}
                             startLine={input.lineRange?.startLine ?? 0}
                             endLine={input.lineRange?.endLine ?? 1}
-                            isFirst={false}
                             fetchHighlightedFileRangeLines={() => of([])}
                             hoverifier={hoverifier}
                             viewerUpdates={viewerUpdates}

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
@@ -221,7 +221,6 @@ export const NotebookSymbolBlock: React.FunctionComponent<
                             blobLines={symbolOutput.highlightedLines}
                             highlightRanges={[symbolOutput.highlightSymbolRange]}
                             {...symbolOutput.highlightLineRange}
-                            isFirst={false}
                             fetchHighlightedFileRangeLines={() => of([])}
                             hoverifier={hoverifier}
                             viewerUpdates={viewerUpdates}


### PR DESCRIPTION
Fixes symbols code loading when optimized highlighting is turned on. I also took the opportunity to remove the `isFirst` prop that was not useful anymore.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Turn on optimized highlighting
* Turn on Simple UI
* Symbols code should load

## App preview:

- [Web](https://sg-web-rn-core-workflow-symbols-fixes.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-aqzyghjqvh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
