### PR TITLE
notebooks: improvements to the read-only mode

### DIFF
--- a/client/web/src/notebooks/blocks/NotebookBlock.module.scss
+++ b/client/web/src/notebooks/blocks/NotebookBlock.module.scss
@@ -11,6 +11,10 @@
     &:hover {
         border: 1px solid var(--border-color);
     }
+
+    :global(.is-read-only-notebook) &:hover {
+        border: 1px solid transparent;
+    }
 }
 
 .selected {

--- a/client/web/src/notebooks/blocks/NotebookBlock.module.scss
+++ b/client/web/src/notebooks/blocks/NotebookBlock.module.scss
@@ -13,7 +13,7 @@
     }
 
     :global(.is-read-only-notebook) &:hover {
-        border: 1px solid transparent;
+        border-color: transparent;
     }
 }
 

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.module.scss
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.module.scss
@@ -4,12 +4,20 @@
 
 .highlighted-file-wrapper {
     padding: 0.25rem 1rem 1rem 1rem;
+
+    :global(.is-read-only-notebook) & {
+        padding-bottom: 0.25rem;
+    }
 }
 
 .header {
     display: flex;
     align-items: center;
     padding: 1rem 1rem 0.25rem 1rem;
+
+    :global(.is-read-only-notebook) & {
+        padding-top: 0.25rem;
+    }
 }
 
 .separator {

--- a/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.module.scss
+++ b/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.module.scss
@@ -65,6 +65,12 @@
 
 .output {
     padding: 1rem;
+    // Taken from https://www.smashingmagazine.com/2020/07/css-techniques-legibility/
+    line-height: calc(1ex / 0.32);
+
+    :global(.is-read-only-notebook) & {
+        padding: 0.25rem 1rem;
+    }
 }
 
 .markdown {

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.module.scss
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.module.scss
@@ -1,5 +1,9 @@
 .block {
     padding: 1rem;
+
+    :global(.is-read-only-notebook) & {
+        padding: 0.25rem 1rem;
+    }
 }
 
 .content {

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.module.scss
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.module.scss
@@ -4,12 +4,20 @@
 
 .highlighted-file-wrapper {
     padding: 0.25rem 1rem 1rem 1rem;
+
+    :global(.is-read-only-notebook) & {
+        padding-bottom: 0.25rem;
+    }
 }
 
 .header {
     display: flex;
     align-items: center;
     padding: 1rem 1rem 0.25rem 1rem;
+
+    :global(.is-read-only-notebook) & {
+        padding-top: 0.25rem;
+    }
 }
 
 .separator {


### PR DESCRIPTION
Improvements:

* Line height property is now proportional to the font size in Markdown blocks
* Blocks are not selectable/hoverable in read-only mode
* Reduced vertical padding between blocks in read-only mode

## Screenshots

### Current read-only mode:
<img width="1004" alt="Screenshot 2022-07-26 at 09 46 20" src="https://user-images.githubusercontent.com/6417322/180952976-64b096d0-e106-4595-8f32-45f5bf50ffa8.png">

### New read-only mode:
<img width="1014" alt="Screenshot 2022-07-26 at 09 46 12" src="https://user-images.githubusercontent.com/6417322/180952987-49e6b7e3-1d61-43d1-80ff-664a2ead2552.png">


## Demo

*Left - new read-only mode, Right - old read-only mode*

https://user-images.githubusercontent.com/6417322/180952934-f9a2734c-08d7-4ae7-bdf1-888766f3b41b.mp4


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Open a notebook with permissions to edit
* Notebook should still be editable
* Open a read-only notebook
* Blocks should not be selectable
* Blocks should not have a border on hover

## App preview:

- [Web](https://sg-web-rn-notebook-read-only-improvements.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-migcvthjtn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

