### PR TITLE
[Admin Analytics] export search stats

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
@@ -3,7 +3,7 @@ import React, { useMemo, useState, useEffect } from 'react'
 import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 
-import { useQuery } from '@sourcegraph/http-client'
+import { useQuery, useLazyQuery } from '@sourcegraph/http-client'
 import { Card, H3, Text, LoadingSpinner, AnchorLink, H4 } from '@sourcegraph/wildcard'
 
 import { LineChart, Series } from '../../../charts'
@@ -11,13 +11,14 @@ import { AnalyticsDateRange, SearchStatisticsResult, SearchStatisticsVariables }
 import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { ChartContainer } from '../components/ChartContainer'
+import { ExportButton } from '../components/ExportButton'
 import { HorizontalSelect } from '../components/HorizontalSelect'
 import { TimeSavedCalculatorGroup } from '../components/TimeSavedCalculatorGroup'
 import { ToggleSelect } from '../components/ToggleSelect'
 import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
 import { StandardDatum } from '../utils'
 
-import { SEARCH_STATISTICS } from './queries'
+import { SEARCH_STATISTICS, EXPORT_STATISTICS } from './queries'
 
 import styles from './index.module.scss'
 
@@ -29,9 +30,11 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
             dateRange,
         },
     })
+
     useEffect(() => {
         eventLogger.logPageView('AdminAnalyticsSearch')
     }, [])
+
     const [stats, legends] = useMemo(() => {
         if (!data) {
             return []
@@ -161,7 +164,17 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
 
     return (
         <>
-            <AnalyticsPageTitle>Analytics / Search</AnalyticsPageTitle>
+            <div className="d-flex justify-content-between align-items-end">
+                <AnalyticsPageTitle>Analytics / Search</AnalyticsPageTitle>
+                <div className="mb-4">
+                    <ExportButton
+                        query={EXPORT_STATISTICS}
+                        variables={{ dateRange }}
+                        path="site.analytics.search.exportCSV"
+                        fileName="search_analytics"
+                    />
+                </div>
+            </div>
 
             <Card className="p-3">
                 <div className="d-flex justify-content-end align-items-stretch mb-2">

--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
@@ -3,11 +3,17 @@ import React, { useMemo, useState, useEffect } from 'react'
 import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 
-import { useQuery, useLazyQuery } from '@sourcegraph/http-client'
+import { useQuery } from '@sourcegraph/http-client'
 import { Card, H3, Text, LoadingSpinner, AnchorLink, H4 } from '@sourcegraph/wildcard'
 
 import { LineChart, Series } from '../../../charts'
-import { AnalyticsDateRange, SearchStatisticsResult, SearchStatisticsVariables } from '../../../graphql-operations'
+import {
+    AnalyticsDateRange,
+    SearchStatisticsResult,
+    SearchStatisticsVariables,
+    ExportSearchStatisticsResult,
+    ExportSearchStatisticsVariables,
+} from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { ChartContainer } from '../components/ChartContainer'
@@ -167,7 +173,7 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
             <div className="d-flex justify-content-between align-items-end">
                 <AnalyticsPageTitle>Analytics / Search</AnalyticsPageTitle>
                 <div className="mb-4">
-                    <ExportButton
+                    <ExportButton<ExportSearchStatisticsResult, ExportSearchStatisticsVariables>
                         query={EXPORT_STATISTICS}
                         variables={{ dateRange }}
                         path="site.analytics.search.exportCSV"

--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/queries.ts
@@ -37,3 +37,15 @@ export const SEARCH_STATISTICS = gql`
     }
     ${analyticsStatItemFragment}
 `
+
+export const EXPORT_STATISTICS = gql`
+    query ExportSearchStatistics($dateRange: AnalyticsDateRange!) {
+        site {
+            analytics {
+                search(dateRange: $dateRange) {
+                    exportCSV
+                }
+            }
+        }
+    }
+`

--- a/client/web/src/site-admin/analytics/components/ExportButton.tsx
+++ b/client/web/src/site-admin/analytics/components/ExportButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import _ from 'lodash'
+import { mdiDownload } from '@mdi/js'
+
+import { useLazyQuery } from '@sourcegraph/http-client'
+import { Button, Icon } from '@sourcegraph/wildcard'
+
+interface IProps<IQuery, IVariables> {
+    query: string
+    variables: IVariables
+    path: string
+    fileName: string
+}
+
+export const ExportButton = <IQuery, IVariables>({ query, variables, path, fileName }: IProps<IQuery, IVariables>) => {
+    const [fetchCSV] = useLazyQuery<IQuery, IVariables>(query, {
+        variables,
+        onCompleted: data => {
+            let element = document.createElement('a')
+            element.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(_.get(data, path)))
+            element.setAttribute('download', `${fileName}.csv`)
+            element.style.display = 'none'
+            document.body.appendChild(element)
+            element.click()
+            document.body.removeChild(element)
+        },
+    })
+
+    return (
+        <Button variant="primary" onClick={() => fetchCSV()}>
+            <Icon className="mr-1" color="var(--white)" svgPath={mdiDownload} size="sm" aria-label="Download icon" />{' '}
+            Export
+        </Button>
+    )
+}

--- a/client/web/src/site-admin/analytics/components/ExportButton.tsx
+++ b/client/web/src/site-admin/analytics/components/ExportButton.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
-import _ from 'lodash'
 import { mdiDownload } from '@mdi/js'
+import lodash from 'lodash'
 
 import { useLazyQuery } from '@sourcegraph/http-client'
 import { Button, Icon } from '@sourcegraph/wildcard'
@@ -12,17 +11,22 @@ interface IProps<IQuery, IVariables> {
     fileName: string
 }
 
-export const ExportButton = <IQuery, IVariables>({ query, variables, path, fileName }: IProps<IQuery, IVariables>) => {
+export function ExportButton<IQuery, IVariables>({
+    query,
+    variables,
+    path,
+    fileName,
+}: IProps<IQuery, IVariables>): JSX.Element {
     const [fetchCSV] = useLazyQuery<IQuery, IVariables>(query, {
         variables,
         onCompleted: data => {
-            let element = document.createElement('a')
-            element.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(_.get(data, path)))
+            const element = document.createElement('a')
+            element.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(lodash.get(data, path)))
             element.setAttribute('download', `${fileName}.csv`)
             element.style.display = 'none'
-            document.body.appendChild(element)
+            document.body.append(element)
             element.click()
-            document.body.removeChild(element)
+            element.remove()
         },
     })
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6081,6 +6081,10 @@ type AnalyticsSearchResult {
     File open analytics
     """
     fileOpens: AnalyticsStatItem!
+    """
+    CSV export
+    """
+    exportCSV: String
 }
 
 """

--- a/internal/adminanalytics/fetcher.go
+++ b/internal/adminanalytics/fetcher.go
@@ -65,10 +65,6 @@ func (f *AnalyticsFetcher) Nodes(ctx context.Context) ([]*AnalyticsNode, error) 
 		nodes = append(nodes, &AnalyticsNode{data})
 	}
 
-	if _, err := setArrayToCache(cacheKey, nodes); err != nil {
-		return nil, err
-	}
-
 	now := time.Now()
 	to := now
 	daysOffset := 1
@@ -106,6 +102,10 @@ func (f *AnalyticsFetcher) Nodes(ctx context.Context) ([]*AnalyticsNode, error) 
 		}
 
 		allNodes = append(allNodes, node)
+	}
+
+	if _, err := setArrayToCache(cacheKey, allNodes); err != nil {
+		return nil, err
 	}
 
 	return allNodes, nil

--- a/internal/adminanalytics/search.go
+++ b/internal/adminanalytics/search.go
@@ -117,22 +117,23 @@ func (s *Search) ExportCSV(ctx context.Context) (*string, error) {
 	}
 
 	for _, event := range events {
-		if fetcher, err := event.Fetcher(); err == nil {
-			if nodes, err := fetcher.Nodes(ctx); err == nil {
-				for _, node := range nodes {
-					rows = append(rows, fmt.Sprintf("%s,Total Events,%s,%v", event.Name, node.Date(), node.Count()))
-					rows = append(rows, fmt.Sprintf("%s,Unique Users,%s,%v", event.Name, node.Date(), node.UniqueUsers()))
-				}
-			} else {
-				return nil, err
-			}
-		} else {
+		fetcher, err := event.Fetcher()
+		if err != nil {
 			return nil, err
 		}
 
+		nodes, err := fetcher.Nodes(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, node := range nodes {
+			rows = append(rows, fmt.Sprintf("%s,Total Events,%s,%v", event.Name, node.Date(), node.Count()))
+			rows = append(rows, fmt.Sprintf("%s,Unique Users,%s,%v", event.Name, node.Date(), node.UniqueUsers()))
+		}
 	}
 
-	csv := strings.Join(rows[:], "\n")
+	csv := strings.Join(rows, "\n")
 
 	return &csv, nil
 }


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/39325
Add a button to Export Admin Analytics Search Stats in CSV format.

[search_analytics.csv](https://github.com/sourcegraph/sourcegraph/files/9189066/search_analytics.csv)

https://www.loom.com/share/226904d6fd824e7e814402bb8e2e33dc

## Test plan
<img width="933" alt="CleanShot 2022-07-26 at 16 25 28@2x" src="https://user-images.githubusercontent.com/22571395/180990034-de14e7b8-2af0-4466-a381-b496096c6335.png">
