### PR TITLE
Create simple page for lockfile index

### DIFF
--- a/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.module.scss
+++ b/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.module.scss
@@ -1,7 +1,9 @@
 .separator {
-    display: block;
-    width: 100%;
-    margin-top: 1rem;
-    padding-bottom: 1rem;
+    // Make it full width in the current row.
+    grid-column: 1 / -1;
     border-top: 1px solid var(--border-color-2);
+    @media (--xs-breakpoint-down) {
+        margin-top: 1rem;
+        padding-bottom: 1rem;
+    }
 }

--- a/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/components/CodeIntelLockfileIndexNode.tsx
@@ -1,6 +1,8 @@
 import React, { FunctionComponent } from 'react'
 
-import { Link, H3, Code } from '@sourcegraph/wildcard'
+import { mdiChevronRight } from '@mdi/js'
+
+import { Link, H3, Code, Icon } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../../components/time/Timestamp'
 import { LockfileIndexFields } from '../../../../graphql-operations'
@@ -44,5 +46,11 @@ export const CodeIntelLockfileNode: FunctionComponent<React.PropsWithChildren<Co
                 </small>
             </div>
         </div>
+
+        <span className="d-none d-md-inline">
+            <Link to={`./lockfiles/${node.id}`}>
+                <Icon svgPath={mdiChevronRight} inline={false} aria-label="View more information" />
+            </Link>
+        </span>
     </>
 )

--- a/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilePage.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilePage.tsx
@@ -1,0 +1,92 @@
+import { FunctionComponent, useEffect } from 'react'
+
+import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
+import { RouteComponentProps } from 'react-router'
+
+import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Code, Container, H2, H3, Icon, Link, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
+
+import { HeroPage } from '../../../../components/HeroPage'
+import { PageTitle } from '../../../../components/PageTitle'
+import { Timestamp } from '../../../../components/time/Timestamp'
+import { LockfileIndexResult, LockfileIndexVariables } from '../../../../graphql-operations'
+
+import { LOCKFILE_INDEX } from './queries'
+
+export interface CodeIntelLockfilePageProps extends RouteComponentProps<{ id: string }>, TelemetryProps {}
+
+export const CodeIntelLockfilePage: FunctionComponent<React.PropsWithChildren<CodeIntelLockfilePageProps>> = ({
+    match: {
+        params: { id },
+    },
+    telemetryService,
+}) => {
+    useEffect(() => telemetryService.logPageView('CodeIntelLockfile'), [telemetryService])
+
+    const { data, loading, error } = useQuery<LockfileIndexResult, LockfileIndexVariables>(LOCKFILE_INDEX, {
+        variables: { id },
+        fetchPolicy: 'cache-first',
+    })
+
+    // If we're loading and haven't received any data yet
+    if (loading && !data) {
+        return (
+            <div className="w-100 text-center">
+                <Icon aria-label="Loading" className="m-2" as={LoadingSpinner} />
+            </div>
+        )
+    }
+    // If we received an error before we successfully received any data
+    if (error && !data) {
+        throw new Error(error.message)
+    }
+    // If there weren't any errors and we just didn't receive any data
+    if (!data?.node || data.node.__typename !== 'LockfileIndex') {
+        return <HeroPage icon={AlertCircleIcon} title="Lockfile index not found" />
+    }
+
+    const node = data.node
+    const title = `Index of ${node.lockfile} in ${node.repository.name}@${node.commit.abbreviatedOID}`
+
+    return (
+        <div className="code-intel-lockfiles">
+            <PageTitle title={title} />
+            <PageHeader
+                headingElement="h1"
+                path={[{ text: 'Lockfile index' }]}
+                description="Lockfile index created by lockfile-indexing"
+                className="mb-3"
+            />
+
+            <Container>
+                <H2>Overview</H2>
+                <div className="m-0">
+                    <H3 className="m-0 d-block d-md-inline">
+                        <Link to={node.repository.url}>{node.repository.name}</Link>
+                    </H3>
+                </div>
+
+                <div>
+                    <span className="mr-2 d-block d-mdinline-block">
+                        Lockfile <Code>{node.lockfile}</Code> indexed at commit{' '}
+                        <Link to={node.commit.url}>
+                            <Code>{node.commit.abbreviatedOID}</Code>
+                        </Link>
+                        . Dependency graph fidelity: {node.fidelity}.
+                    </span>
+
+                    <small className="text-mute">
+                        Indexed <Timestamp date={node.createdAt} />.{' '}
+                        {node.createdAt !== node.updatedAt && (
+                            <>
+                                Updated <Timestamp date={node.updatedAt} />{' '}
+                            </>
+                        )}
+                        .
+                    </small>
+                </div>
+            </Container>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.module.scss
+++ b/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.module.scss
@@ -1,0 +1,12 @@
+.grid {
+    display: grid;
+    grid-template-columns: [info] minmax(auto, 1fr) [state] min-content [caret] min-content [end];
+    row-gap: 1rem;
+    column-gap: 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
+    @media (--sm-breakpoint-down) {
+        row-gap: 0.5rem;
+        column-gap: 0.5rem;
+    }
+}

--- a/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.tsx
@@ -47,7 +47,7 @@ export const CodeIntelLockfilesPage: FunctionComponent<React.PropsWithChildren<C
             return data.lockfileIndexes
         },
         options: {
-            fetchPolicy: 'cache-first',
+            fetchPolicy: 'cache-and-network',
         },
     })
 

--- a/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.tsx
+++ b/client/web/src/enterprise/codeintel/lockfiles/pages/CodeIntelLockfilesPage.tsx
@@ -22,6 +22,8 @@ import { CodeIntelLockfileNode } from '../components/CodeIntelLockfileIndexNode'
 
 import { LOCKFILE_INDEXES_LIST } from './queries'
 
+import styles from './CodeIntelLockfilesPage.module.scss'
+
 export interface CodeIntelLockfilesPageProps extends RouteComponentProps<{}>, TelemetryProps {}
 
 const DEFAULT_LOCKFILE_INDEXES_PAGE_SIZE = 50
@@ -64,7 +66,7 @@ export const CodeIntelLockfilesPage: FunctionComponent<React.PropsWithChildren<C
                     <ConnectionContainer>
                         {error && <ConnectionError errors={[error.message]} />}
                         {connection && (
-                            <ConnectionList>
+                            <ConnectionList className={styles.grid}>
                                 {connection.nodes.map(node => (
                                     <CodeIntelLockfileNode key={node.id} node={node} />
                                 ))}
@@ -79,7 +81,6 @@ export const CodeIntelLockfilesPage: FunctionComponent<React.PropsWithChildren<C
                                     noun="lockfile index"
                                     pluralNoun="lockfile indexes"
                                     hasNextPage={hasNextPage}
-                                    // connectionQuery={query}
                                     noSummaryIfAllNodesVisible={true}
                                     compact={true}
                                 />

--- a/client/web/src/enterprise/codeintel/lockfiles/pages/queries.ts
+++ b/client/web/src/enterprise/codeintel/lockfiles/pages/queries.ts
@@ -1,6 +1,6 @@
 import { gql } from '@sourcegraph/http-client'
 
-export const LOCKFILE_INDEXES_LIST = gql`
+const LOCKFILE_INDEX_FIELDS = gql`
     fragment LockfileIndexFields on LockfileIndex {
         id
         lockfile
@@ -21,6 +21,10 @@ export const LOCKFILE_INDEXES_LIST = gql`
         updatedAt
         createdAt
     }
+`
+
+export const LOCKFILE_INDEXES_LIST = gql`
+    ${LOCKFILE_INDEX_FIELDS}
 
     fragment LockfileIndexConnectionFields on LockfileIndexConnection {
         nodes {
@@ -36,6 +40,18 @@ export const LOCKFILE_INDEXES_LIST = gql`
     query LockfileIndexes($first: Int, $after: String) {
         lockfileIndexes(first: $first, after: $after) {
             ...LockfileIndexConnectionFields
+        }
+    }
+`
+
+export const LOCKFILE_INDEX = gql`
+    ${LOCKFILE_INDEX_FIELDS}
+
+    query LockfileIndex($id: ID!) {
+        node(id: $id) {
+            ... on LockfileIndex {
+                ...LockfileIndexFields
+            }
         }
     }
 `

--- a/client/web/src/enterprise/codeintel/lockfiles/pages/queries.ts
+++ b/client/web/src/enterprise/codeintel/lockfiles/pages/queries.ts
@@ -55,3 +55,11 @@ export const LOCKFILE_INDEX = gql`
         }
     }
 `
+
+export const DELETE_LOCKFILE_INDEX = gql`
+    mutation DeleteLockfileIndex($id: ID!) {
+        deleteLockfileIndex(lockfileIndex: $id) {
+            alwaysNil
+        }
+    }
+`

--- a/client/web/src/enterprise/site-admin/routes.tsx
+++ b/client/web/src/enterprise/site-admin/routes.tsx
@@ -147,6 +147,15 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
         condition: () => Boolean(window.context?.codeIntelLockfileIndexingEnabled),
     },
+    {
+        path: '/code-graph/lockfiles/:id',
+        render: lazyComponent(
+            () => import('../codeintel/lockfiles/pages/CodeIntelLockfilePage'),
+            'CodeIntelLockfilePage'
+        ),
+        exact: true,
+        condition: () => Boolean(window.context?.codeIntelLockfileIndexingEnabled),
+    },
 
     // Code graph configuration
     {

--- a/cmd/frontend/graphqlbackend/dependencies.go
+++ b/cmd/frontend/graphqlbackend/dependencies.go
@@ -13,8 +13,13 @@ type ListLockfileIndexesArgs struct {
 	After *string
 }
 
+type DeleteLockfileIndexArgs struct {
+	LockfileIndex graphql.ID
+}
+
 type DependenciesResolver interface {
 	LockfileIndexes(ctx context.Context, args *ListLockfileIndexesArgs) (LockfileIndexConnectionResolver, error)
+	DeleteLockfileIndex(ctx context.Context, args *DeleteLockfileIndexArgs) (*EmptyResponse, error)
 
 	NodeResolvers() map[string]NodeByIDFunc
 }

--- a/cmd/frontend/graphqlbackend/dependencies.graphql
+++ b/cmd/frontend/graphqlbackend/dependencies.graphql
@@ -16,6 +16,14 @@ extend type Query {
     ): LockfileIndexConnection!
 }
 
+extend type Mutation {
+    """
+    Deletes the lockfile index. All associated data will be deleted, except for
+    package repos that were added to the instance as a result of indexing.
+    """
+    deleteLockfileIndex(lockfileIndex: ID!): EmptyResponse!
+}
+
 """
 A list of lockfile indexes.
 """

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -827,7 +827,7 @@ func (s *store) GetLockfileIndex(ctx context.Context, opts GetLockfileIndexOpts)
 		getLockfileIndexQuery,
 		sqlf.Join(conds, "AND"),
 	)))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return index, ErrLockfileIndexNotFound
 	}
 	return index, err
@@ -889,7 +889,7 @@ func (s *store) DeleteLockfileIndexByID(ctx context.Context, id int) (err error)
 	)
 	err = tx.QueryRow(ctx, sqlf.Sprintf(deleteLockfileIndexByIDQuery, id)).Scan(&repoID, &commit, &lockfile)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return ErrLockfileIndexNotFound
 		}
 		return err

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -36,6 +36,7 @@ type Store interface {
 	DeleteDependencyReposByID(ctx context.Context, ids ...int) (err error)
 	ListLockfileIndexes(ctx context.Context, opts ListLockfileIndexesOpts) (indexes []shared.LockfileIndex, totalCount int, err error)
 	GetLockfileIndex(ctx context.Context, opts GetLockfileIndexOpts) (index shared.LockfileIndex, err error)
+	DeleteLockfileIndexByID(ctx context.Context, id int) (err error)
 }
 
 // store manages the database tables for package dependencies.
@@ -865,6 +866,56 @@ func makeGetLockfileIndexConds(opts GetLockfileIndexOpts) ([]*sqlf.Query, error)
 
 	return conds, nil
 }
+
+// DeleteLockfileIndexByID deletes the lockfile index with the given ID.
+func (s *store) DeleteLockfileIndexByID(ctx context.Context, id int) (err error) {
+	ctx, _, endObservation := s.operations.getLockfileIndex.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("id", id),
+	}})
+	defer func() {
+		endObservation(1, observation.Args{LogFields: []log.Field{}})
+	}()
+
+	if id == 0 {
+		return nil
+	}
+
+	tx, err := s.db.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	var (
+		repoID   int
+		commit   dbutil.CommitBytea
+		lockfile string
+	)
+	err = tx.QueryRow(ctx, sqlf.Sprintf(deleteLockfileIndexByIDQuery, id)).Scan(&repoID, &commit, &lockfile)
+	if err != nil {
+		return err
+	}
+
+	return tx.Exec(ctx, sqlf.Sprintf(deleteLockfileReferencesQuery, repoID, commit, lockfile))
+}
+
+const deleteLockfileIndexByIDQuery = `
+-- source: internal/codeintel/dependencies/internal/store/store.go:DeleteLockfileIndexByID
+DELETE FROM codeintel_lockfiles
+WHERE id = %s
+RETURNING repository_id, commit_bytea, lockfile
+`
+
+const deleteLockfileReferencesQuery = `
+-- source: internal/codeintel/dependencies/internal/store/store.go:DeleteLockfileIndexByID
+DELETE FROM codeintel_lockfile_references
+WHERE
+	resolution_repository_id = %s
+AND
+	resolution_commit_bytea = %s
+AND
+	resolution_lockfile = %s
+`
 
 // UpsertDependencyRepos creates the given dependency repos if they don't yet exist. The values
 // that did not exist previously are returned.

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -876,10 +876,6 @@ func (s *store) DeleteLockfileIndexByID(ctx context.Context, id int) (err error)
 		endObservation(1, observation.Args{LogFields: []log.Field{}})
 	}()
 
-	if id == 0 {
-		return nil
-	}
-
 	tx, err := s.db.Transact(ctx)
 	if err != nil {
 		return err

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -802,7 +802,7 @@ type GetLockfileIndexOpts struct {
 	Lockfile string
 }
 
-var ErrLockfileIndexNotFound = errors.New("lockfile index matching conditions not found")
+var ErrLockfileIndexNotFound = errors.New("lockfile index not found")
 
 // GetLockfileIndex returns a lockfile index.
 func (s *store) GetLockfileIndex(ctx context.Context, opts GetLockfileIndexOpts) (index shared.LockfileIndex, err error) {
@@ -893,6 +893,9 @@ func (s *store) DeleteLockfileIndexByID(ctx context.Context, id int) (err error)
 	)
 	err = tx.QueryRow(ctx, sqlf.Sprintf(deleteLockfileIndexByIDQuery, id)).Scan(&repoID, &commit, &lockfile)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return ErrLockfileIndexNotFound
+		}
 		return err
 	}
 

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strconv"
 	"testing"
@@ -1408,8 +1409,8 @@ func TestDeleteLockfileIndexByID(t *testing.T) {
 
 		// Delete again
 		err = store.DeleteLockfileIndexByID(ctx, index.ID)
-		if err != ErrLockfileIndexNotFound {
-			t.Fatalf("wrong error: %s", err)
+		if !errors.Is(err, ErrLockfileIndexNotFound) {
+			t.Fatalf("wrong error: %s (%T)", err, err)
 		}
 	})
 
@@ -1447,7 +1448,7 @@ func TestDeleteLockfileIndexByID(t *testing.T) {
 
 		// Delete again
 		err = store.DeleteLockfileIndexByID(ctx, index.ID)
-		if err != ErrLockfileIndexNotFound {
+		if !errors.Is(err, ErrLockfileIndexNotFound) {
 			t.Fatalf("wrong error: %s", err)
 		}
 	})

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -1405,6 +1405,12 @@ func TestDeleteLockfileIndexByID(t *testing.T) {
 		if len(names) != 0 {
 			t.Fatalf("references not inserted")
 		}
+
+		// Delete again
+		err = store.DeleteLockfileIndexByID(ctx, index.ID)
+		if err != ErrLockfileIndexNotFound {
+			t.Fatalf("wrong error: %s", err)
+		}
 	})
 
 	t.Run("without any dependencies", func(t *testing.T) {
@@ -1437,6 +1443,12 @@ func TestDeleteLockfileIndexByID(t *testing.T) {
 		_, err = store.GetLockfileIndex(ctx, GetLockfileIndexOpts{ID: index.ID})
 		if err != ErrLockfileIndexNotFound {
 			t.Fatalf("unexpected error: %s", err)
+		}
+
+		// Delete again
+		err = store.DeleteLockfileIndexByID(ctx, index.ID)
+		if err != ErrLockfileIndexNotFound {
+			t.Fatalf("wrong error: %s", err)
 		}
 	})
 }

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -1341,3 +1341,102 @@ func TestListAndGetLockfileIndexes(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
+
+func TestDeleteLockfileIndexByID(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(db, &observation.TestContext)
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo')`); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	t.Run("with dependencies", func(t *testing.T) {
+		packageA := shared.TestPackageDependencyLiteral("A", "1", "2", "pkg-A", "4")
+		packageB := shared.TestPackageDependencyLiteral("B", "2", "3", "pkg-B", "5")
+		packageC := shared.TestPackageDependencyLiteral("C", "3", "4", "pkg-C", "6")
+
+		deps := []shared.PackageDependency{packageA, packageB, packageC}
+		graph := shared.TestDependencyGraphLiteral(
+			[]shared.PackageDependency{packageA},
+			false,
+			[][]shared.PackageDependency{{packageA, packageB}, {packageA, packageC}},
+		)
+		commit := "cafebabe"
+
+		// Insert and check everything's been inserted
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, "lock.file", deps, graph); err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		index, err := store.GetLockfileIndex(ctx, GetLockfileIndexOpts{RepoName: "foo", Commit: commit, Lockfile: "lock.file"})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		names, err := queryLockfileReferences(t, ctx, store, "foo", commit)
+		if err != nil {
+			t.Fatalf("database query error: %s", err)
+		}
+		if len(names) != 3 {
+			t.Fatalf("references not inserted")
+		}
+
+		// Delete
+		err = store.DeleteLockfileIndexByID(ctx, index.ID)
+		if err != nil {
+			t.Fatalf("failed to delete: %s", err)
+		}
+
+		// Query again to make sure it's deleted
+		_, err = store.GetLockfileIndex(ctx, GetLockfileIndexOpts{ID: index.ID})
+		if err != ErrLockfileIndexNotFound {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		// Query references again to make sure they're deleted
+		names, err = queryLockfileReferences(t, ctx, store, "foo", commit)
+		if err != nil {
+			t.Fatalf("database query error: %s", err)
+		}
+		if len(names) != 0 {
+			t.Fatalf("references not inserted")
+		}
+	})
+
+	t.Run("without any dependencies", func(t *testing.T) {
+		deps := []shared.PackageDependency{}
+		commit := "d34db30f"
+
+		// Insert and check everything's been inserted
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, "lock.file", deps, nil); err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		index, err := store.GetLockfileIndex(ctx, GetLockfileIndexOpts{RepoName: "foo", Commit: commit, Lockfile: "lock.file"})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		names, err := queryLockfileReferences(t, ctx, store, "foo", commit)
+		if err != nil {
+			t.Fatalf("database query error: %s", err)
+		}
+		if len(names) != 0 {
+			t.Fatalf("references not inserted")
+		}
+
+		// Delete
+		err = store.DeleteLockfileIndexByID(ctx, index.ID)
+		if err != nil {
+			t.Fatalf("failed to delete: %s", err)
+		}
+
+		// Query again to make sure it's deleted
+		_, err = store.GetLockfileIndex(ctx, GetLockfileIndexOpts{ID: index.ID})
+		if err != ErrLockfileIndexNotFound {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	})
+}

--- a/internal/codeintel/dependencies/mocks_test.go
+++ b/internal/codeintel/dependencies/mocks_test.go
@@ -501,6 +501,9 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// DeleteDependencyReposByID.
 	DeleteDependencyReposByIDFunc *StoreDeleteDependencyReposByIDFunc
+	// DeleteLockfileIndexByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method DeleteLockfileIndexByID.
+	DeleteLockfileIndexByIDFunc *StoreDeleteLockfileIndexByIDFunc
 	// GetLockfileIndexFunc is an instance of a mock function object
 	// controlling the behavior of the method GetLockfileIndex.
 	GetLockfileIndexFunc *StoreGetLockfileIndexFunc
@@ -543,6 +546,11 @@ func NewMockStore() *MockStore {
 	return &MockStore{
 		DeleteDependencyReposByIDFunc: &StoreDeleteDependencyReposByIDFunc{
 			defaultHook: func(context.Context, ...int) (r0 error) {
+				return
+			},
+		},
+		DeleteLockfileIndexByIDFunc: &StoreDeleteLockfileIndexByIDFunc{
+			defaultHook: func(context.Context, int) (r0 error) {
 				return
 			},
 		},
@@ -613,6 +621,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteDependencyReposByID")
 			},
 		},
+		DeleteLockfileIndexByIDFunc: &StoreDeleteLockfileIndexByIDFunc{
+			defaultHook: func(context.Context, int) error {
+				panic("unexpected invocation of MockStore.DeleteLockfileIndexByID")
+			},
+		},
 		GetLockfileIndexFunc: &StoreGetLockfileIndexFunc{
 			defaultHook: func(context.Context, store.GetLockfileIndexOpts) (shared.LockfileIndex, error) {
 				panic("unexpected invocation of MockStore.GetLockfileIndex")
@@ -677,6 +690,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 	return &MockStore{
 		DeleteDependencyReposByIDFunc: &StoreDeleteDependencyReposByIDFunc{
 			defaultHook: i.DeleteDependencyReposByID,
+		},
+		DeleteLockfileIndexByIDFunc: &StoreDeleteLockfileIndexByIDFunc{
+			defaultHook: i.DeleteLockfileIndexByID,
 		},
 		GetLockfileIndexFunc: &StoreGetLockfileIndexFunc{
 			defaultHook: i.GetLockfileIndex,
@@ -825,6 +841,112 @@ func (c StoreDeleteDependencyReposByIDFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreDeleteDependencyReposByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// StoreDeleteLockfileIndexByIDFunc describes the behavior when the
+// DeleteLockfileIndexByID method of the parent MockStore instance is
+// invoked.
+type StoreDeleteLockfileIndexByIDFunc struct {
+	defaultHook func(context.Context, int) error
+	hooks       []func(context.Context, int) error
+	history     []StoreDeleteLockfileIndexByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// DeleteLockfileIndexByID delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) DeleteLockfileIndexByID(v0 context.Context, v1 int) error {
+	r0 := m.DeleteLockfileIndexByIDFunc.nextHook()(v0, v1)
+	m.DeleteLockfileIndexByIDFunc.appendCall(StoreDeleteLockfileIndexByIDFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// DeleteLockfileIndexByID method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreDeleteLockfileIndexByIDFunc) SetDefaultHook(hook func(context.Context, int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DeleteLockfileIndexByID method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreDeleteLockfileIndexByIDFunc) PushHook(hook func(context.Context, int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreDeleteLockfileIndexByIDFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreDeleteLockfileIndexByIDFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int) error {
+		return r0
+	})
+}
+
+func (f *StoreDeleteLockfileIndexByIDFunc) nextHook() func(context.Context, int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreDeleteLockfileIndexByIDFunc) appendCall(r0 StoreDeleteLockfileIndexByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreDeleteLockfileIndexByIDFuncCall
+// objects describing the invocations of this function.
+func (f *StoreDeleteLockfileIndexByIDFunc) History() []StoreDeleteLockfileIndexByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreDeleteLockfileIndexByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreDeleteLockfileIndexByIDFuncCall is an object that describes an
+// invocation of method DeleteLockfileIndexByID on an instance of MockStore.
+type StoreDeleteLockfileIndexByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreDeleteLockfileIndexByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreDeleteLockfileIndexByIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -535,3 +535,7 @@ type GetLockfileIndexOpts struct {
 func (s *Service) GetLockfileIndexOpts(ctx context.Context, opts GetLockfileIndexOpts) (shared.LockfileIndex, error) {
 	return s.dependenciesStore.GetLockfileIndex(ctx, store.GetLockfileIndexOpts(opts))
 }
+
+func (s *Service) DeleteLockfileIndexByID(ctx context.Context, id int) error {
+	return s.dependenciesStore.DeleteLockfileIndexByID(ctx, id)
+}

--- a/internal/codeintel/dependencies/transport/graphql/resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/resolver.go
@@ -146,3 +146,18 @@ func validateListArgs(args *graphqlbackend.ListLockfileIndexesArgs) (params, err
 
 	return p, nil
 }
+
+func (r *resolver) DeleteLockfileIndex(ctx context.Context, args *graphqlbackend.DeleteLockfileIndexArgs) (*graphqlbackend.EmptyResponse, error) {
+	// 🚨 SECURITY: For now we only allow site admins to query lockfile indexes.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	id, err := unmarshalLockfileIndexID(args.LockfileIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.svc.DeleteLockfileIndexByID(ctx, id)
+	return &graphqlbackend.EmptyResponse{}, err
+}


### PR DESCRIPTION
This adds a detail page for a single lockfile index and a mutation to delete them.

Of course there should/will be more information on that page, but baby steps.

## Test plan

- Manual testing

https://user-images.githubusercontent.com/1185253/181040493-be4f7413-f00d-4c65-9c9a-fb9ebdd26b1d.mp4



## App preview:

- [Web](https://sg-web-mrn-lockfile-index-page.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-trqgzmsgiu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

