### PR TITLE
gqltest: add failure message when Bitbucket Permissions job failed to run

### DIFF
--- a/dev/gqltest/bitbucket_projects_perms_sync_test.go
+++ b/dev/gqltest/bitbucket_projects_perms_sync_test.go
@@ -197,13 +197,13 @@ func TestBitbucketProjectsPermsSync(t *testing.T) {
 
 			// Wait up to 30 seconds for worker to finish the permissions sync.
 			err = gqltestutil.Retry(30*time.Second, func() error {
-				status, err := client.GetLastBitbucketProjectPermissionJob(projectKey)
+				status, failureMessage, err := client.GetLastBitbucketProjectPermissionJob(projectKey)
 				if err != nil || status == "" {
 					t.Fatal("Error during getting the status of a Bitbucket Permissions job")
 				}
 
 				if status == "errored" || status == "failed" {
-					t.Fatalf("Bitbucket Permissions job failed with status: '%s'", status)
+					t.Fatalf("Bitbucket Permissions job failed with status: '%s' and failure message: '%s'", status, failureMessage)
 				}
 
 				if status == "completed" {

--- a/internal/gqltestutil/permissions.go
+++ b/internal/gqltestutil/permissions.go
@@ -68,7 +68,7 @@ mutation SetRepositoryPermissionsForBitbucketProject($projectKey: String!, $code
 
 // GetLastBitbucketProjectPermissionJob returns a status of the most recent
 // BitbucketProjectPermissionJob for given projectKey
-func (c *Client) GetLastBitbucketProjectPermissionJob(projectKey string) (string, string, error) {
+func (c *Client) GetLastBitbucketProjectPermissionJob(projectKey string) (state string, failureMessage string, err error) {
 	const query = `
 query BitbucketProjectPermissionJobs($projectKeys: [String!], $status: String, $count: Int) {
 	bitbucketProjectPermissionJobs(projectKeys: $projectKeys, status: $status, count: $count) {
@@ -94,7 +94,7 @@ query BitbucketProjectPermissionJobs($projectKeys: [String!], $status: String, $
 			} `json:"bitbucketProjectPermissionJobs"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", query, variables, &resp)
+	err = c.GraphQL("", query, variables, &resp)
 	if err != nil {
 		return "", "", errors.Wrap(err, "request GraphQL")
 	}

--- a/internal/gqltestutil/permissions.go
+++ b/internal/gqltestutil/permissions.go
@@ -102,7 +102,8 @@ query BitbucketProjectPermissionJobs($projectKeys: [String!], $status: String, $
 	if resp.Data.Jobs.TotalCount < 1 {
 		return "", "", nil
 	} else {
-		return resp.Data.Jobs.Nodes[0].State, resp.Data.Jobs.Nodes[0].FailureMessage, nil
+		job := resp.Data.Jobs.Nodes[0]
+		return job.State, job.FailureMessage, nil
 	}
 }
 

--- a/internal/gqltestutil/permissions.go
+++ b/internal/gqltestutil/permissions.go
@@ -68,13 +68,14 @@ mutation SetRepositoryPermissionsForBitbucketProject($projectKey: String!, $code
 
 // GetLastBitbucketProjectPermissionJob returns a status of the most recent
 // BitbucketProjectPermissionJob for given projectKey
-func (c *Client) GetLastBitbucketProjectPermissionJob(projectKey string) (string, error) {
+func (c *Client) GetLastBitbucketProjectPermissionJob(projectKey string) (string, string, error) {
 	const query = `
 query BitbucketProjectPermissionJobs($projectKeys: [String!], $status: String, $count: Int) {
 	bitbucketProjectPermissionJobs(projectKeys: $projectKeys, status: $status, count: $count) {
 		totalCount,
    		nodes {
 			State
+			FailureMessage
    		}
 	}
 }
@@ -87,20 +88,21 @@ query BitbucketProjectPermissionJobs($projectKeys: [String!], $status: String, $
 			Jobs struct {
 				TotalCount int `json:"totalCount"`
 				Nodes      []struct {
-					State string `json:"state"`
+					State          string `json:"state"`
+					FailureMessage string `json:"failureMessage"`
 				} `json:"nodes"`
 			} `json:"bitbucketProjectPermissionJobs"`
 		} `json:"data"`
 	}
 	err := c.GraphQL("", query, variables, &resp)
 	if err != nil {
-		return "", errors.Wrap(err, "request GraphQL")
+		return "", "", errors.Wrap(err, "request GraphQL")
 	}
 
 	if resp.Data.Jobs.TotalCount < 1 {
-		return "", nil
+		return "", "", nil
 	} else {
-		return resp.Data.Jobs.Nodes[0].State, nil
+		return resp.Data.Jobs.Nodes[0].State, resp.Data.Jobs.Nodes[0].FailureMessage, nil
 	}
 }
 


### PR DESCRIPTION
This will add clarity to understanding the root cause of a failure.

## Test plan
Existing tests should pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
