### PR TITLE
render-pr-preview: check that BUILDKITE_PULL_REQUEST is not false

### DIFF
--- a/dev/ci/render-pr-preview.sh
+++ b/dev/ci/render-pr-preview.sh
@@ -168,7 +168,7 @@ fi
 
 echo "Preview url: ${pr_preview_url}"
 
-if [[ -n "${github_api_key}" && -n "${pr_number}" ]]; then
+if [[ -n "${github_api_key}" && -n "${pr_number}" && "${pr_number}" != "false" ]]; then
 
   # GitHub pull request number and GitHub api token are set
   # Appending `App Preview` section into PR description if it hasn't existed yet


### PR DESCRIPTION
Turns out that `BUILDKITE_PULL_REQUEST` is either a number or `false`.


## Test plan

- CI
- Test script to confirm checks
```bash
pr_number="${BUILDKITE_PULL_REQUEST}"

if [[ -n "${pr_number}" && "${pr_number}" != "false" ]]; then
  echo "we have a PR"
else
  echo "we don't have a PR"
fi
```