### PR TITLE
[Admin Analytics] add unpublished changesets

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
@@ -38,7 +38,7 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
         if (!data) {
             return []
         }
-        const { changesetsCreated, changesetsMerged } = data.site.analytics.batchChanges
+        const { changesetsCreated, changesetsMerged, unpublishedChangesets } = data.site.analytics.batchChanges
         const stats: Series<StandardDatum>[] = [
             {
                 id: 'changesets_created',
@@ -68,6 +68,20 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
                 getXValue: ({ date }) => date,
                 getYValue: ({ value }) => value,
             },
+            {
+                id: 'unpublished_changesets',
+                name: 'Unpublished changesets',
+                color: 'var(--purple)',
+                data: unpublishedChangesets.nodes.map(
+                    node => ({
+                        date: new Date(node.date),
+                        value: node.count,
+                    }),
+                    dateRange
+                ),
+                getXValue: ({ date }) => date,
+                getYValue: ({ value }) => value,
+            },
         ]
         const legends: ValueLegendListProps['items'] = [
             {
@@ -79,6 +93,11 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
                 value: changesetsMerged.summary.totalCount,
                 description: 'Changesets merged',
                 color: 'var(--cyan)',
+            },
+            {
+                value: unpublishedChangesets.summary.totalCount,
+                description: 'Unpublished changesets',
+                color: 'var(--purple)',
             },
         ]
 

--- a/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/queries.ts
@@ -23,6 +23,15 @@ export const BATCHCHANGES_STATISTICS = gql`
                             totalCount
                         }
                     }
+                    unpublishedChangesets {
+                        nodes {
+                            date
+                            count
+                        }
+                        summary {
+                            totalCount
+                        }
+                    }
                 }
             }
         }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6215,6 +6215,10 @@ type AnalyticsBatchChangesResult {
     Changesets merged
     """
     changesetsMerged: AnalyticsStatItem!
+    """
+    Unpublished changesets
+    """
+    unpublishedChangesets: AnalyticsStatItem!
 }
 
 """


### PR DESCRIPTION
Add Unpublished changesets metrics to the admin analytics batch changes page.

<img width="934" alt="CleanShot 2022-07-26 at 17 29 21@2x" src="https://user-images.githubusercontent.com/22571395/181000780-086b2e20-b662-400c-8fdc-75020e99abbf.png">

## Test plan
- visit /site-admin/analytics/batch-changes
