### PR TITLE
doc: cleanup whitespace in kubernetes dir

### DIFF
--- a/doc/admin/deploy/kubernetes/configure.md
+++ b/doc/admin/deploy/kubernetes/configure.md
@@ -1,6 +1,6 @@
 # Configure Sourcegraph with Kubernetes
 
-> WARNING: This guide applies exclusively to a Kubernetes deployment **without** Helm. If using Helm, please go to [Configuration in the Helm guide](helm.md#configuration). 
+> WARNING: This guide applies exclusively to a Kubernetes deployment **without** Helm. If using Helm, please go to [Configuration in the Helm guide](helm.md#configuration).
 > If you have not deployed Sourcegraph yet, it is higly recommended to use Helm as it simplifies the configuration and greatly simplifies the later upgrade process. See our [Helm guide](helm.md) for more information.
 
 Configuring a [Sourcegraph Kubernetes cluster](./index.md) without Helm is done by applying manifest files and with simple
@@ -41,17 +41,17 @@ We **strongly** recommend you fork the [Sourcegraph with Kubernetes reference re
 > NOTE: We do not recommend storing secrets in the repository itself - instead, consider leveraging [Kubernetes's Secret objects](https://kubernetes.io/docs/concepts/configuration/secret).
 
 ### Create a fork or private duplicate
-  
+
   [Create a public fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository) of the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) repository.
 
   Alternatively, create a [private duplicate](https://docs.github.com/en/repositories/creating-and-managing-repositories/duplicating-a-repository#mirroring-a-repository) of the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) repository as follows:
 
-  Create an [empty private repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository), for example `<you/private-repository>` in GitHub, then bare clone the reference repository. 
+  Create an [empty private repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository), for example `<you/private-repository>` in GitHub, then bare clone the reference repository.
 
 ```bash
 git clone --bare https://github.com/sourcegraph/deploy-sourcegraph/
 ```
-  
+
 Navigate to the bare clone and mirror push it to your private repository.
 
 ```bash
@@ -59,7 +59,7 @@ cd deploy-sourcegraph.git
 git push --mirror https://github.com/<you/private-repository>.git
 ```
 
-Remove your local bare clone. 
+Remove your local bare clone.
 ```bash
   cd ..
   rm -rf deploy-sourcegraph.git
@@ -394,7 +394,7 @@ We recommend utilizing an external database when deploying Sourcegraph to provid
 
 Simply edit the relevant PostgreSQL environment variables (e.g. PGHOST, PGPORT, PGUSER, [etc.](http://www.postgresql.org/docs/current/static/libpq-envars.html)) in [base/frontend/sourcegraph-frontend.Deployment.yaml](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/frontend/sourcegraph-frontend.Deployment.yaml) to point to your existing PostgreSQL instance.
 
-If you do not have an external database available, configuration is provided to deploy PostgreSQL on Kubernetes. 
+If you do not have an external database available, configuration is provided to deploy PostgreSQL on Kubernetes.
 
 
 ## Configure repository cloning via SSH
@@ -486,7 +486,7 @@ Sourcegraph supports specifying a custom Redis server for:
 - caching information (specified via the `REDIS_CACHE_ENDPOINT` environment variable)
 - storing information (session data and job queues) (specified via the `REDIS_STORE_ENDPOINT` environment variable)
 
-If these are not set, they will [default](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24++REDIS_CACHE_ENDPOINT+AND+REDIS_STORE_ENDPOINT+-file:doc+file:internal&patternType=literal) to `redis-cache:6379` & `redis-store:6379` 
+If these are not set, they will [default](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24++REDIS_CACHE_ENDPOINT+AND+REDIS_STORE_ENDPOINT+-file:doc+file:internal&patternType=literal) to `redis-cache:6379` & `redis-store:6379`
 
 If you want to specify a custom Redis server, you'll need specify the corresponding environment variable for each of the following deployments:
 
@@ -515,7 +515,6 @@ spec:
             value: "<REDIS_CACHE_DSN>"
           - name: REDIS_STORE_ENDPOINT
             value: "<REDIS_STORE_DSN>"
-    
 ```
 
 ## Connect to an external Jaeger instance

--- a/doc/admin/deploy/kubernetes/helm.md
+++ b/doc/admin/deploy/kubernetes/helm.md
@@ -20,7 +20,7 @@
 
 ## Why use Helm
 
-Our Helm chart has a lot of sensible defaults baked into the values.yaml. Not only does this make customizations much easier (than either using Kustomize or manually editing Sourcegraph's manifest files) it also means that, when an override file is used to make the changes, you _never_ have to deal with merge conflicts during upgrades (see more about customizations in the [configuration](#configuration) section). 
+Our Helm chart has a lot of sensible defaults baked into the values.yaml. Not only does this make customizations much easier (than either using Kustomize or manually editing Sourcegraph's manifest files) it also means that, when an override file is used to make the changes, you _never_ have to deal with merge conflicts during upgrades (see more about customizations in the [configuration](#configuration) section).
 
 
 ## High-level overview of how to use Helm with Sourcegraph
@@ -281,8 +281,8 @@ If you have access to the ssh keys locally, you can run the command below to cre
 
 ```sh
 kubectl create secret generic gitserver-ssh \
-	    --from-file id_rsa=${HOME}/.ssh/id_rsa \
-	    --from-file known_hosts=${HOME}/.ssh/known_hosts
+      --from-file id_rsa=${HOME}/.ssh/id_rsa \
+      --from-file known_hosts=${HOME}/.ssh/known_hosts
 ```
 
 Alternatively, you may manually create the secret from a manifest file.
@@ -517,7 +517,7 @@ frontend:
 storageClass:
   create: true
   type: gp2 # This configures SSDs (recommended).
-#  provisioner: ebs.csi.aws.com # use this provisioner if using the self-managed Amazon EBS Container Storage Interface driver 
+#  provisioner: ebs.csi.aws.com # use this provisioner if using the self-managed Amazon EBS Container Storage Interface driver
 #  provisioner: kubernetes.io/aws-ebs # use this provisioner if using the Amazon EKS add-on
   volumeBindingMode: WaitForFirstConsumer
   reclaimPolicy: Retain

--- a/doc/admin/deploy/kubernetes/index.md
+++ b/doc/admin/deploy/kubernetes/index.md
@@ -77,7 +77,7 @@ Sourcegraph for Kubernetes is configured using our [`sourcegraph/deploy-sourcegr
   kubectl port-forward svc/sourcegraph-frontend 3080:30080
   ```
 
-- Open http://localhost:3080 in your browser and you will see a setup page. Congratulations, you have Sourcegraph up and running! 🎉 
+- Open http://localhost:3080 in your browser and you will see a setup page. Congratulations, you have Sourcegraph up and running! 🎉
 
 > NOTE: If you previously [set up an `ingress-controller`](./configure.md#ingress-controller-recommended), you can now also access your deployment via the ingress.
 
@@ -87,8 +87,8 @@ Sourcegraph for Kubernetes is configured using our [`sourcegraph/deploy-sourcegr
 > or other secure network that restricts unauthenticated access from the public Internet. You can later expose the
 > necessary ports via an
 > [Internet Gateway](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Internet_Gateway.html) or equivalent
-> mechanism. Note that SG must expose port 443 for outbound traffic to codehosts and to enable [telemetry](https://docs.sourcegraph.com/admin/pings) with 
-> Sourcegraph.com. Additionally port 22 may be opened to enable git SSH cloning by Sourcegraph. Take care to secure your cluster in a manner that meets your 
+> mechanism. Note that SG must expose port 443 for outbound traffic to codehosts and to enable [telemetry](https://docs.sourcegraph.com/admin/pings) with
+> Sourcegraph.com. Additionally port 22 may be opened to enable git SSH cloning by Sourcegraph. Take care to secure your cluster in a manner that meets your
 > organization's security requirements.
 
 Follow the instructions linked in the table below to provision a Kubernetes cluster for the

--- a/doc/admin/deploy/kubernetes/kustomize.md
+++ b/doc/admin/deploy/kubernetes/kustomize.md
@@ -1,7 +1,7 @@
 # Kustomize
 
-> WARNING: Kustomize can be used **with** Helm to configure Sourcegraph (see [this guidance](helm.md#integrate-kustomize-with-helm-chart)) but this is only recommended as a temporary workaround while Sourcegraph adds to the Helm chart to support previously unsupported customizations. 
-> If you have yet to deploy Sourcegraph, it is highly recommended to us Helm for the deployment and configuration ([Using Helm with Sourcegraph](helm.md)). 
+> WARNING: Kustomize can be used **with** Helm to configure Sourcegraph (see [this guidance](helm.md#integrate-kustomize-with-helm-chart)) but this is only recommended as a temporary workaround while Sourcegraph adds to the Helm chart to support previously unsupported customizations.
+> If you have yet to deploy Sourcegraph, it is highly recommended to us Helm for the deployment and configuration ([Using Helm with Sourcegraph](helm.md)).
 
 Sourcegraph supports the use of [Kustomize](https://kustomize.io) to modify and customize our Kubernetes manifests. Kustomize is a template-free way to customize configuration with a simple configuration file.
 
@@ -29,7 +29,7 @@ See the [overlays guide](#overlays) to learn about the [overlays we provide](#pr
 
 ## Overlays
 
-An [*overlay*](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays) specifies customizations for a base directory of Kubernetes manifests, in this case the `base/` directory in the [reference repository](#reference-repository). 
+An [*overlay*](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays) specifies customizations for a base directory of Kubernetes manifests, in this case the `base/` directory in the [reference repository](#reference-repository).
 
 Overlays can:
 
@@ -89,7 +89,7 @@ Overlays provided out-of-the-box are in the subdirectories of [`deploy-sourcegra
 This overlay adds a namespace declaration to all the manifests.
 
 1. Change the namespace by replacing `ns-sourcegraph` to the name of your choice everywhere within the
-[overlays/namespaced/](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/overlays/namespaced/) directory. 
+[overlays/namespaced/](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/overlays/namespaced/) directory.
 
 1. Generate the overlay by running this command from the `root` directory:
 
@@ -118,7 +118,7 @@ This overlay adds a namespace declaration to all the manifests.
 
 #### Storageclass
 
-By default Sourcegraph is configured to use a storage class called `sourcegraph`. If you wish to use an alternate name, you can use this overlay to change all `storageClass` references in the manifests. 
+By default Sourcegraph is configured to use a storage class called `sourcegraph`. If you wish to use an alternate name, you can use this overlay to change all `storageClass` references in the manifests.
 
 You need to create the storageclass if it doesn't exist yet. See [these docs](./configure.md#configure-a-storage-class) for more instructions.
 
@@ -135,7 +135,7 @@ You need to create the storageclass if it doesn't exist yet. See [these docs](./
 kubectl apply --prune -l deploy=sourcegraph -f generated-cluster --recursive
 ```
 
-1. Ensure the persistent volumes have been created in the correct storage class by running the following command and inspecting the output: 
+1. Ensure the persistent volumes have been created in the correct storage class by running the following command and inspecting the output:
 
 ```shell script
 kubectl get pvc
@@ -184,7 +184,7 @@ If you are starting a fresh installation use the overlay `non-privileged-create-
 If you already are running a Sourcegraph instance using user `root` and want to convert to running with non-root user then
 you need to apply a migration step that will change the permissions of all persistent volumes so that the volumes can be
 used by the non-root user. This migration is provided as overlay `migrate-to-nonprivileged`. After the migration you can use
-overlay `non-privileged`. If you have previously deployed your cluster in a non-default namespace, be sure to edit the `kustomization.yaml` file in the overlays directly to ensure the files are generated with the correct namespace. 
+overlay `non-privileged`. If you have previously deployed your cluster in a non-default namespace, be sure to edit the `kustomization.yaml` file in the overlays directly to ensure the files are generated with the correct namespace.
 
 This kustomization injects initContainers in all pods with persistent volumes to transfer ownership of directories to specified non-root users. It is used for migrating existing installations to a non-privileged environment.
 

--- a/doc/admin/deploy/kubernetes/operations.md
+++ b/doc/admin/deploy/kubernetes/operations.md
@@ -224,7 +224,7 @@ Ensure the `sourcegraph_db.out` and `codeintel_db.out` files are moved to a safe
 
 #### Restoring Sourcegraph databases into a new environment
 
-The following instructions apply only if you are restoring your databases into a new deployment of Sourcegraph ie: a new virtual machine 
+The following instructions apply only if you are restoring your databases into a new deployment of Sourcegraph ie: a new virtual machine
 
 If you are restoring a previously running environment, see the instructions for [restoring a previously running deployment](#restoring-sourcegraph-databases-into-an-existing-environment)
 
@@ -282,7 +282,7 @@ kubectl delete deployment sourcegraph-frontend
 ```
 
 B. Remove any existing volumes for the databases in the existing deployment
- 
+
 ```bash
 kubectl delete pvc pgsql
 kubectl delete pvc codeintel-db

--- a/doc/admin/deploy/kubernetes/troubleshoot.md
+++ b/doc/admin/deploy/kubernetes/troubleshoot.md
@@ -110,6 +110,4 @@ livenessProbe:
 Git command [git rev-parse HEAD] failed (stderr: ""): strconv.Atoi: parsing "": invalid syntax
 ```
 
-This error occurs when the service mesh, like istio, drops the [Trailer response header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer) for http1 by default. Enable trailers in your instance to resolve this issue. See our `envoy` examples in [Kubernetes with Helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples) and [Kubernetes without Helm](https://github.com/sourcegraph/deploy-sourcegraph/tree/master/overlays) for details. 
-
-
+This error occurs when the service mesh, like istio, drops the [Trailer response header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer) for http1 by default. Enable trailers in your instance to resolve this issue. See our `envoy` examples in [Kubernetes with Helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples) and [Kubernetes without Helm](https://github.com/sourcegraph/deploy-sourcegraph/tree/master/overlays) for details.

--- a/doc/admin/deploy/kubernetes/update.md
+++ b/doc/admin/deploy/kubernetes/update.md
@@ -1,6 +1,6 @@
 # Updating Sourcegraph with Kubernetes
 
-> WARNING: This guide applies exclusively to a Kubernetes deployment **without** Helm. If using Helm, please go to [Updating Sourcegraph in the Helm guide](helm.md#upgrading-sourcegraph). 
+> WARNING: This guide applies exclusively to a Kubernetes deployment **without** Helm. If using Helm, please go to [Updating Sourcegraph in the Helm guide](helm.md#upgrading-sourcegraph).
 > If you have not deployed Sourcegraph yet, it is higly recommended to use Helm as it simplifies the configuration and greatly simplifies the upgrade process. See our [Helm guide](helm.md) for more information.
 
 A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) for release announcements.


### PR DESCRIPTION
This is a minor nit I am doing. This removes trailing whitespace. It should not effect how the markdown is rendered. I accomplished this by running (cleanup-whitespace) in emacs.

Test Plan: n/a
