### PR TITLE
search: fetch repo metadata during repo resolution

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -291,6 +291,13 @@ func TestSearchResultsHydration(t *testing.T) {
 		}
 		return []types.MinimalRepo{{ID: repoWithIDs.ID, Name: repoWithIDs.Name}}, nil
 	})
+	repos.MetadataFunc.SetDefaultHook(func(ctx context.Context, repoIDs ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error) {
+		res := make(map[api.RepoID]*types.SearchedRepo, len(repoIDs))
+		for _, id := range repoIDs {
+			res[id] = &types.SearchedRepo{ID: id}
+		}
+		return res, nil
+	})
 	repos.CountFunc.SetDefaultReturn(0, nil)
 	db.ReposFunc.SetDefaultReturn(repos)
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -27171,7 +27171,7 @@ func NewMockRepoStore() *MockRepoStore {
 			},
 		},
 		MetadataFunc: &RepoStoreMetadataFunc{
-			defaultHook: func(context.Context, ...api.RepoID) (r0 []*types.SearchedRepo, r1 error) {
+			defaultHook: func(context.Context, ...api.RepoID) (r0 map[api.RepoID]*types.SearchedRepo, r1 error) {
 				return
 			},
 		},
@@ -27273,7 +27273,7 @@ func NewStrictMockRepoStore() *MockRepoStore {
 			},
 		},
 		MetadataFunc: &RepoStoreMetadataFunc{
-			defaultHook: func(context.Context, ...api.RepoID) ([]*types.SearchedRepo, error) {
+			defaultHook: func(context.Context, ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error) {
 				panic("unexpected invocation of MockRepoStore.Metadata")
 			},
 		},
@@ -28881,15 +28881,15 @@ func (c RepoStoreListMinimalReposFuncCall) Results() []interface{} {
 // RepoStoreMetadataFunc describes the behavior when the Metadata method of
 // the parent MockRepoStore instance is invoked.
 type RepoStoreMetadataFunc struct {
-	defaultHook func(context.Context, ...api.RepoID) ([]*types.SearchedRepo, error)
-	hooks       []func(context.Context, ...api.RepoID) ([]*types.SearchedRepo, error)
+	defaultHook func(context.Context, ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error)
+	hooks       []func(context.Context, ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error)
 	history     []RepoStoreMetadataFuncCall
 	mutex       sync.Mutex
 }
 
 // Metadata delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockRepoStore) Metadata(v0 context.Context, v1 ...api.RepoID) ([]*types.SearchedRepo, error) {
+func (m *MockRepoStore) Metadata(v0 context.Context, v1 ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error) {
 	r0, r1 := m.MetadataFunc.nextHook()(v0, v1...)
 	m.MetadataFunc.appendCall(RepoStoreMetadataFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -28897,7 +28897,7 @@ func (m *MockRepoStore) Metadata(v0 context.Context, v1 ...api.RepoID) ([]*types
 
 // SetDefaultHook sets function that is called when the Metadata method of
 // the parent MockRepoStore instance is invoked and the hook queue is empty.
-func (f *RepoStoreMetadataFunc) SetDefaultHook(hook func(context.Context, ...api.RepoID) ([]*types.SearchedRepo, error)) {
+func (f *RepoStoreMetadataFunc) SetDefaultHook(hook func(context.Context, ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error)) {
 	f.defaultHook = hook
 }
 
@@ -28905,7 +28905,7 @@ func (f *RepoStoreMetadataFunc) SetDefaultHook(hook func(context.Context, ...api
 // Metadata method of the parent MockRepoStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *RepoStoreMetadataFunc) PushHook(hook func(context.Context, ...api.RepoID) ([]*types.SearchedRepo, error)) {
+func (f *RepoStoreMetadataFunc) PushHook(hook func(context.Context, ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -28913,20 +28913,20 @@ func (f *RepoStoreMetadataFunc) PushHook(hook func(context.Context, ...api.RepoI
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *RepoStoreMetadataFunc) SetDefaultReturn(r0 []*types.SearchedRepo, r1 error) {
-	f.SetDefaultHook(func(context.Context, ...api.RepoID) ([]*types.SearchedRepo, error) {
+func (f *RepoStoreMetadataFunc) SetDefaultReturn(r0 map[api.RepoID]*types.SearchedRepo, r1 error) {
+	f.SetDefaultHook(func(context.Context, ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *RepoStoreMetadataFunc) PushReturn(r0 []*types.SearchedRepo, r1 error) {
-	f.PushHook(func(context.Context, ...api.RepoID) ([]*types.SearchedRepo, error) {
+func (f *RepoStoreMetadataFunc) PushReturn(r0 map[api.RepoID]*types.SearchedRepo, r1 error) {
+	f.PushHook(func(context.Context, ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error) {
 		return r0, r1
 	})
 }
 
-func (f *RepoStoreMetadataFunc) nextHook() func(context.Context, ...api.RepoID) ([]*types.SearchedRepo, error) {
+func (f *RepoStoreMetadataFunc) nextHook() func(context.Context, ...api.RepoID) (map[api.RepoID]*types.SearchedRepo, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -28967,7 +28967,7 @@ type RepoStoreMetadataFuncCall struct {
 	Arg1 []api.RepoID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []*types.SearchedRepo
+	Result0 map[api.RepoID]*types.SearchedRepo
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -593,8 +593,8 @@ func TestRepoStore_Metadata(t *testing.T) {
 	gr := db.GitserverRepos()
 	require.NoError(t, gr.Upsert(ctx, gitserverRepos...))
 
-	expected := []*types.SearchedRepo{
-		{
+	expected := map[api.RepoID]*types.SearchedRepo{
+		1: {
 			ID:          1,
 			Name:        "foo",
 			Description: "foo 1",
@@ -604,7 +604,7 @@ func TestRepoStore_Metadata(t *testing.T) {
 			Stars:       10,
 			LastFetched: &d1,
 		},
-		{
+		2: {
 			ID:          2,
 			Name:        "bar",
 			Description: "bar 2",
@@ -618,5 +618,7 @@ func TestRepoStore_Metadata(t *testing.T) {
 
 	md, err := r.Metadata(ctx, 1, 2)
 	require.NoError(t, err)
-	require.ElementsMatch(t, expected, md)
+	if diff := cmp.Diff(expected, md, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("mismatch (-want +have):\n%s", diff)
+	}
 }

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -71,7 +71,7 @@ func (j *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 		onMatches := func(in []protocol.CommitMatch) {
 			res := make([]result.Match, 0, len(in))
 			for _, protocolMatch := range in {
-				res = append(res, protocolMatchToCommitMatch(repoRev.Repo, j.Diff, protocolMatch))
+				res = append(res, protocolMatchToCommitMatch(repoRev.Repo, repoRev.RepoMetadata, j.Diff, protocolMatch))
 			}
 			stream.Send(streaming.SearchEvent{
 				Results: res,
@@ -332,7 +332,7 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 	return newPred
 }
 
-func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.CommitMatch) *result.CommitMatch {
+func protocolMatchToCommitMatch(repo types.MinimalRepo, repoMetadata *types.SearchedRepo, diff bool, in protocol.CommitMatch) *result.CommitMatch {
 	var diffPreview, messagePreview *result.MatchedString
 	if diff {
 		diffPreview = &in.Diff
@@ -356,9 +356,10 @@ func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.C
 			Message: gitdomain.Message(in.Message.Content),
 			Parents: in.Parents,
 		},
-		Repo:           repo,
-		DiffPreview:    diffPreview,
-		MessagePreview: messagePreview,
-		ModifiedFiles:  in.ModifiedFiles,
+		Repo:               repo,
+		RepositoryMetadata: repoMetadata,
+		DiffPreview:        diffPreview,
+		MessagePreview:     messagePreview,
+		ModifiedFiles:      in.ModifiedFiles,
 	}
 }

--- a/internal/search/job/jobutil/select_test.go
+++ b/internal/search/job/jobutil/select_test.go
@@ -47,11 +47,13 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("dedupe paths for select:file.directory", `[
   {
     "Path": "pokeman/",
+    "RepositoryMetadata": null,
     "ChunkMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/",
+    "RepositoryMetadata": null,
     "ChunkMatches": null,
     "LimitHit": false
   }
@@ -60,16 +62,19 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("dedupe paths select:file", `[
   {
     "Path": "pokeman/charmandar",
+    "RepositoryMetadata": null,
     "ChunkMatches": null,
     "LimitHit": false
   },
   {
     "Path": "pokeman/bulbosaur",
+    "RepositoryMetadata": null,
     "ChunkMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/ummm",
+    "RepositoryMetadata": null,
     "ChunkMatches": null,
     "LimitHit": false
   }
@@ -78,6 +83,7 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("don't dedupe file matches for select:content", `[
   {
     "Path": "pokeman/charmandar",
+    "RepositoryMetadata": null,
     "ChunkMatches": [
       {
         "Content": "",
@@ -128,6 +134,7 @@ func TestWithSelect(t *testing.T) {
   },
   {
     "Path": "pokeman/charmandar",
+    "RepositoryMetadata": null,
     "ChunkMatches": [
       {
         "Content": "",
@@ -156,6 +163,7 @@ func TestWithSelect(t *testing.T) {
   },
   {
     "Path": "pokeman/bulbosaur",
+    "RepositoryMetadata": null,
     "ChunkMatches": [
       {
         "Content": "",
@@ -184,6 +192,7 @@ func TestWithSelect(t *testing.T) {
   },
   {
     "Path": "digiman/ummm",
+    "RepositoryMetadata": null,
     "ChunkMatches": [
       {
         "Content": "",

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -53,16 +53,18 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 // globs.  If no revspecs and no ref globs are specified, then the
 // repository's default branch is used.
 type RepositoryRevisions struct {
-	Repo types.MinimalRepo
-	Revs []string
+	Repo         types.MinimalRepo
+	Revs         []string
+	RepoMetadata *types.SearchedRepo
 }
 
 func (r *RepositoryRevisions) Copy() *RepositoryRevisions {
 	revs := make([]string, len(r.Revs))
 	copy(revs, r.Revs)
 	return &RepositoryRevisions{
-		Repo: r.Repo,
-		Revs: revs,
+		Repo:         r.Repo,
+		Revs:         revs,
+		RepoMetadata: r.RepoMetadata,
 	}
 }
 

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -262,6 +262,9 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolv
 	}
 	tr.LazyPrintf("finished contains filtering")
 
+	// Fetching metadata should only happen after all filters have been applied.
+	// If additional filtering operations are added to repo resolution in the future, they should be applied
+	// before fetching metadata so that we are only fetching metadata for repos that will actually be searched.
 	tr.LazyPrintf("fetching repo metadata")
 	repoRevsWithMetadata, err := r.fetchRepoRevsMetadata(ctx, filteredRepoRevs)
 	if err != nil {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -263,7 +263,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolv
 	tr.LazyPrintf("finished contains filtering")
 
 	tr.LazyPrintf("fetching repo metadata")
-	repoRevsWithMetadata, err := r.hydrateRepoRevsMetadata(ctx, filteredRepoRevs)
+	repoRevsWithMetadata, err := r.fetchRepoRevsMetadata(ctx, filteredRepoRevs)
 	if err != nil {
 		return Resolved{}, errors.Wrap(err, "fetch metadata from db")
 	}
@@ -286,9 +286,9 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolv
 	}, err
 }
 
-// hydrateRepoRevsMetadata fetches additional repo metadata from the db for each repo in repoRevs and populates the
+// fetchRepoRevsMetadata fetches additional repo metadata from the db for each repo in repoRevs and populates the
 // RepoMetadata field on each element in repoRevs.
-func (r *Resolver) hydrateRepoRevsMetadata(ctx context.Context, repoRevs []*search.RepositoryRevisions) (_ []*search.RepositoryRevisions, err error) {
+func (r *Resolver) fetchRepoRevsMetadata(ctx context.Context, repoRevs []*search.RepositoryRevisions) (_ []*search.RepositoryRevisions, err error) {
 	repoIDs := make([]api.RepoID, 0, len(repoRevs))
 	for _, repoRev := range repoRevs {
 		repoIDs = append(repoIDs, repoRev.Repo.ID)

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -13,8 +13,9 @@ import (
 )
 
 type CommitMatch struct {
-	Commit gitdomain.Commit
-	Repo   types.MinimalRepo
+	Commit             gitdomain.Commit
+	Repo               types.MinimalRepo
+	RepositoryMetadata *types.SearchedRepo
 
 	// Refs is a set of git references that point to this commit. For example,
 	// for a search like `repo:sourcegraph@abcd123`, if the `refs/heads/main`
@@ -74,6 +75,10 @@ func (cm *CommitMatch) ResultCount() int {
 
 func (cm *CommitMatch) RepoName() types.MinimalRepo {
 	return cm.Repo
+}
+
+func (cm *CommitMatch) RepoMetadata() *types.SearchedRepo {
+	return cm.RepositoryMetadata
 }
 
 func (cm *CommitMatch) Limit(limit int) int {
@@ -257,10 +262,11 @@ func (r *CommitMatch) CommitToDiffMatches() []*CommitDiffMatch {
 	for _, diff := range fileDiffs {
 		diff := diff
 		matches = append(matches, &CommitDiffMatch{
-			Commit:   r.Commit,
-			Repo:     r.Repo,
-			Preview:  r.DiffPreview,
-			DiffFile: &diff,
+			Commit:             r.Commit,
+			Repo:               r.Repo,
+			RepositoryMetadata: r.RepositoryMetadata,
+			Preview:            r.DiffPreview,
+			DiffFile:           &diff,
 		})
 	}
 	return matches

--- a/internal/search/result/commit_diff.go
+++ b/internal/search/result/commit_diff.go
@@ -13,14 +13,19 @@ import (
 )
 
 type CommitDiffMatch struct {
-	Commit  gitdomain.Commit
-	Repo    types.MinimalRepo
-	Preview *MatchedString
+	Commit             gitdomain.Commit
+	Repo               types.MinimalRepo
+	RepositoryMetadata *types.SearchedRepo
+	Preview            *MatchedString
 	*DiffFile
 }
 
 func (cd *CommitDiffMatch) RepoName() types.MinimalRepo {
 	return cd.Repo
+}
+
+func (cd *CommitDiffMatch) RepoMetadata() *types.SearchedRepo {
+	return cd.RepositoryMetadata
 }
 
 // Path returns a nonempty path associated with a diff. This value is the usual

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -42,6 +42,7 @@ func (f *File) URL() *url.URL {
 // - A result representing the whole file (len(Symbols) == 0 && len(LineMatches) == 0)
 type FileMatch struct {
 	File
+	RepositoryMetadata *types.SearchedRepo
 
 	ChunkMatches ChunkMatches
 	Symbols      []*SymbolMatch `json:"-"`
@@ -51,6 +52,10 @@ type FileMatch struct {
 
 func (fm *FileMatch) RepoName() types.MinimalRepo {
 	return fm.File.Repo
+}
+
+func (fm *FileMatch) RepoMetadata() *types.SearchedRepo {
+	return fm.RepositoryMetadata
 }
 
 func (fm *FileMatch) searchResultMarker() {}

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -20,6 +20,7 @@ type Match interface {
 
 	Select(filter.SelectPath) Match
 	RepoName() types.MinimalRepo
+	RepoMetadata() *types.SearchedRepo
 
 	// Key returns a key which uniquely identifies this match.
 	Key() Key

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -14,6 +14,8 @@ type RepoMatch struct {
 
 	// rev optionally specifies a revision to go to for search results.
 	Rev string
+
+	RepositoryMetadata *types.SearchedRepo
 }
 
 func (r RepoMatch) RepoName() types.MinimalRepo {
@@ -21,6 +23,10 @@ func (r RepoMatch) RepoName() types.MinimalRepo {
 		Name: r.Name,
 		ID:   r.ID,
 	}
+}
+
+func (r RepoMatch) RepoMetadata() *types.SearchedRepo {
+	return r.RepositoryMetadata
 }
 
 func (r RepoMatch) Limit(limit int) int {

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -63,9 +63,10 @@ func repoRevsToRepoMatches(repos []*search.RepositoryRevisions) []result.Match {
 	for _, r := range repos {
 		for _, rev := range r.Revs {
 			matches = append(matches, &result.RepoMatch{
-				Name: r.Repo.Name,
-				ID:   r.Repo.ID,
-				Rev:  rev,
+				Name:               r.Repo.Name,
+				ID:                 r.Repo.ID,
+				Rev:                rev,
+				RepositoryMetadata: r.RepoMetadata,
 			})
 		}
 	}

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -90,6 +90,8 @@ func (s *TextSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 	g.Go(func() error {
 		for _, repoAllRevs := range s.Repos {
 			repo := repoAllRevs.Repo // capture repo
+			// Capture repoMetadata to make sure we populate each repo with the correct metadata in `searchFilesInRepo()`
+			repoMetadata := repoAllRevs.RepoMetadata
 			if len(repoAllRevs.Revs) == 0 {
 				continue
 			}
@@ -105,7 +107,7 @@ func (s *TextSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 					ctx, done := limitCtx, limitDone
 					defer done()
 
-					repoLimitHit, err := s.searchFilesInRepo(ctx, clients.DB, clients.SearcherURLs, repo, repo.Name, rev, repoAllRevs.RepoMetadata, s.Indexed, s.PatternInfo, fetchTimeout, stream)
+					repoLimitHit, err := s.searchFilesInRepo(ctx, clients.DB, clients.SearcherURLs, repo, repo.Name, rev, repoMetadata, s.Indexed, s.PatternInfo, fetchTimeout, stream)
 					if err != nil {
 						tr.LogFields(otlog.String("repo", string(repo.Name)), otlog.Error(err), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
 						clients.Logger.Warn("searchFilesInRepo failed", log.Error(err), log.String("repo", string(repo.Name)))

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -115,7 +115,7 @@ func (rb *IndexedRepoRevs) BranchRepos() []zoektquery.BranchRepos {
 	return brs
 }
 
-// getRepoInputRev returns the repo and inputRev associated with file.
+// getRepoInputRev returns the repo, repo metadata, and inputRev associated with file.
 func (rb *IndexedRepoRevs) getRepoInputRev(file *zoekt.FileMatch) (repo types.MinimalRepo, repoMetadata *types.SearchedRepo, inputRevs []string) {
 	repoRev, ok := rb.RepoRevs[api.RepoID(file.RepositoryID)]
 

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -99,7 +99,7 @@ func (s *GlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	s.ZoektArgs.Query = s.GlobalZoektQuery.Generate()
 
 	// always search for symbols in indexed repositories when searching the repo universe.
-	err = DoZoektSearchGlobal(ctx, clients.Zoekt, s.ZoektArgs, stream)
+	err = DoZoektSearchGlobal(ctx, clients.Zoekt, clients.DB, s.ZoektArgs, stream)
 	if err != nil {
 		tr.LogFields(log.Error(err))
 		// Only record error if we haven't timed out.

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -134,4 +134,4 @@ func ResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k
 
 // repoRevFunc is a function which maps repository names returned from Zoekt
 // into the Sourcegraph's resolved repository revisions for the search.
-type repoRevFunc func(file *zoekt.FileMatch) (repo types.MinimalRepo, revs []string)
+type repoRevFunc func(file *zoekt.FileMatch) (repo types.MinimalRepo, repoMetadata *types.SearchedRepo, revs []string)


### PR DESCRIPTION
Currently, we're fetching repo metadata for matches at the API layer, right before returning a streaming search event. This means we're not able to enhance the types in the `result` package by matching against that metadata during result construction, which means we can't compute match ranges for things like repo description, which means we can't do things like highlight them in the UI (which is the main motivation for this change).

This PR moves fetching repo metadata from `frontend` into the `repos.Resolve()` method in the search backend, which makes that metadata available to each search job to populate as a field on each `result.Match` type. We end up making more db calls, but the tradeoff is that we are now able to work with repo metadata at the job level across the entire search backend.

Sorry for the large number of files changed, doing this required touching a lot of files and it was easier to do it all at once than to try to break it up somehow.

## Test plan
Backend integration tests pass
Existing unit tests pass
Manually verify via traces that metadata is fetched during job execution
Manually run a few typical queries to feel good about end user experience being unaffected 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
