### PR TITLE
codemirror blob: Restructure syntax extension to share blob info

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -13,7 +13,7 @@ import { editorHeight, useCodeMirror, useCompartment } from '@sourcegraph/shared
 import { parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
 
 import { BlobProps, updateBrowserHistoryIfChanged } from './Blob'
-import { syntaxHighlight } from './codemirror/highlight'
+import { blob, syntaxHighlight } from './codemirror/highlight'
 import { selectLines, selectableLineNumbers, SelectedLineRange } from './codemirror/linenumbers'
 
 const staticExtensions: Extension = [
@@ -29,6 +29,7 @@ const staticExtensions: Extension = [
             backgroundColor: 'var(--code-selection-bg)',
         },
     }),
+    syntaxHighlight(),
 ]
 
 export const Blob: React.FunctionComponent<BlobProps> = ({
@@ -82,12 +83,7 @@ export const Blob: React.FunctionComponent<BlobProps> = ({
     }, [])
 
     const extensions = useMemo(
-        () => [
-            staticExtensions,
-            settingsCompartment,
-            selectableLineNumbers({ onSelection }),
-            syntaxHighlight(blobInfo.lsif),
-        ],
+        () => [staticExtensions, settingsCompartment, selectableLineNumbers({ onSelection }), blob(blobInfo)],
         [settingsCompartment, onSelection, blobInfo]
     )
 

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -1,7 +1,8 @@
-import { Extension, RangeSetBuilder, StateEffect, StateField } from '@codemirror/state'
+import { Extension, Facet, RangeSetBuilder, StateEffect, StateField } from '@codemirror/state'
 import { Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view'
 
 import { JsonDocument, JsonOccurrence, SyntaxKind } from '../../../lsif/lsif-typed'
+import { BlobInfo } from '../Blob'
 
 /**
  * This data structure combines the syntax highlighting data received from the
@@ -54,107 +55,115 @@ function createHighlightTable(json: string | undefined): HighlightIndex {
     }
 }
 
+export const setBlob = StateEffect.define<BlobInfo>()
 /**
- * Set JSON encoded SCIP highlighting data
+ * Stores information about the current blob to make it accessible to other
+ * extensions.
  */
-export const setSCIPData = StateEffect.define<string>()
+export const blobField = StateField.define<BlobInfo | null>({
+    create: () => null,
+
+    update(value, transaction) {
+        for (const effect of transaction.effects) {
+            if (effect.is(setBlob)) {
+                return effect.value
+            }
+        }
+        return value
+    },
+})
+
+export function blob(initialBlobInfo: BlobInfo): Extension {
+    return blobField.init(() => initialBlobInfo)
+}
 
 /**
+ * Extensions
  * Extension to convert SCIP-encoded highlighting information to decorations.
  * The SCIP data should be set/updated via the `setSCIPData` effect.
  */
-export function syntaxHighlight(initialSCIPJSON: string | undefined): Extension {
-    return StateField.define<HighlightIndex>({
-        create: () => createHighlightTable(initialSCIPJSON),
-
-        update(value, transaction) {
-            let newSCIPData = ''
-
-            for (const effect of transaction.effects) {
-                if (effect.is(setSCIPData)) {
-                    newSCIPData = effect.value
-                    break
-                }
-            }
-
-            return newSCIPData ? createHighlightTable(newSCIPData) : value
-        },
-
-        provide: field =>
-            ViewPlugin.fromClass(
-                class {
-                    private decorationCache: Partial<Record<SyntaxKind, Decoration>> = {}
-                    public decorations: DecorationSet = Decoration.none
-
-                    constructor(view: EditorView) {
-                        this.decorations = this.computeDecorations(view)
-                    }
-
-                    public update(update: ViewUpdate): void {
-                        if (update.viewportChanged) {
-                            this.decorations = this.computeDecorations(update.view)
-                        }
-                    }
-
-                    private computeDecorations(view: EditorView): DecorationSet {
-                        const { from, to } = view.viewport
-
-                        // Determine the start and end lines of the current viewport
-                        const fromLine = view.state.doc.lineAt(from)
-                        const toLine = view.state.doc.lineAt(to)
-
-                        const { occurrences, lineIndex } = view.state.field(field)
-
-                        // Find index of first relevant token
-                        let startIndex: number | undefined
-                        {
-                            let line = fromLine.number - 1
-                            do {
-                                startIndex = lineIndex[line++]
-                            } while (startIndex === undefined && line < lineIndex.length)
-                        }
-
-                        const builder = new RangeSetBuilder<Decoration>()
-
-                        // Cache current line object
-                        let line = fromLine
-
-                        if (startIndex !== undefined) {
-                            // Iterate over the rendered line (numbers) and get the
-                            // corresponding occurrences from the highlighting table.
-                            for (let index = startIndex; index < occurrences.length; index++) {
-                                const occurrence = occurrences[index]
-
-                                if (occurrence.range[0] > toLine.number) {
-                                    break
-                                }
-
-                                if (occurrence.syntaxKind === undefined) {
-                                    continue
-                                }
-
-                                // Fetch new line information if necessary
-                                if (line.number !== occurrence.range[0] + 1) {
-                                    line = view.state.doc.line(occurrence.range[0] + 1)
-                                }
-
-                                builder.add(
-                                    line.from + occurrence.range[1],
-                                    occurrence.range.length === 3
-                                        ? line.from + occurrence.range[2]
-                                        : view.state.doc.line(occurrence.range[2] + 1).from + occurrence.range[3],
-                                    this.decorationCache[occurrence.syntaxKind] ||
-                                        (this.decorationCache[occurrence.syntaxKind] = Decoration.mark({
-                                            class: `hl-typed-${SyntaxKind[occurrence.syntaxKind]}`,
-                                        }))
-                                )
-                            }
-                        }
-
-                        return builder.finish()
-                    }
-                },
-                { decorations: plugin => plugin.decorations }
-            ),
+export function syntaxHighlight(): Extension {
+    const syntaxHighlight = Facet.define<BlobInfo, HighlightIndex>({
+        combine: blobInfos =>
+            blobInfos[0]?.lsif ? createHighlightTable(blobInfos[0].lsif) : { occurrences: [], lineIndex: [] },
     })
+
+    return [
+        syntaxHighlight.from(blobField),
+        ViewPlugin.fromClass(
+            class {
+                private decorationCache: Partial<Record<SyntaxKind, Decoration>> = {}
+                public decorations: DecorationSet = Decoration.none
+
+                constructor(view: EditorView) {
+                    this.decorations = this.computeDecorations(view)
+                }
+
+                public update(update: ViewUpdate): void {
+                    if (update.viewportChanged) {
+                        this.decorations = this.computeDecorations(update.view)
+                    }
+                }
+
+                private computeDecorations(view: EditorView): DecorationSet {
+                    const { from, to } = view.viewport
+
+                    // Determine the start and end lines of the current viewport
+                    const fromLine = view.state.doc.lineAt(from)
+                    const toLine = view.state.doc.lineAt(to)
+
+                    const { occurrences, lineIndex } = view.state.facet(syntaxHighlight)
+
+                    // Find index of first relevant token
+                    let startIndex: number | undefined
+                    {
+                        let line = fromLine.number - 1
+                        do {
+                            startIndex = lineIndex[line++]
+                        } while (startIndex === undefined && line < lineIndex.length)
+                    }
+
+                    const builder = new RangeSetBuilder<Decoration>()
+
+                    // Cache current line object
+                    let line = fromLine
+
+                    if (startIndex !== undefined) {
+                        // Iterate over the rendered line (numbers) and get the
+                        // corresponding occurrences from the highlighting table.
+                        for (let index = startIndex; index < occurrences.length; index++) {
+                            const occurrence = occurrences[index]
+
+                            if (occurrence.range[0] > toLine.number) {
+                                break
+                            }
+
+                            if (occurrence.syntaxKind === undefined) {
+                                continue
+                            }
+
+                            // Fetch new line information if necessary
+                            if (line.number !== occurrence.range[0] + 1) {
+                                line = view.state.doc.line(occurrence.range[0] + 1)
+                            }
+
+                            builder.add(
+                                line.from + occurrence.range[1],
+                                occurrence.range.length === 3
+                                    ? line.from + occurrence.range[2]
+                                    : view.state.doc.line(occurrence.range[2] + 1).from + occurrence.range[3],
+                                this.decorationCache[occurrence.syntaxKind] ||
+                                    (this.decorationCache[occurrence.syntaxKind] = Decoration.mark({
+                                        class: `hl-typed-${SyntaxKind[occurrence.syntaxKind]}`,
+                                    }))
+                            )
+                        }
+                    }
+
+                    return builder.finish()
+                }
+            },
+            { decorations: plugin => plugin.decorations }
+        ),
+    ]
 }


### PR DESCRIPTION
Best reviewed with white-space difference turned off.

This commit refactors the syntax extension to provide a "blob" field
that holds the information about the current blob and derives syntax
highlighting information from that field via a facet instead.

This way the blob field can be used by other extensions, e.g. for hovercards.

## Test plan

Syntax highlighting works as before.

## App preview:

- [Web](https://sg-web-fkling-cm-blob-info.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dkduudxzox.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
