### PR TITLE
Use centered summary for file diff filtered connections

### DIFF
--- a/client/web/src/components/diff/FileDiffConnection.tsx
+++ b/client/web/src/components/diff/FileDiffConnection.tsx
@@ -251,6 +251,7 @@ export const FileDiffConnection: React.FunctionComponent<React.PropsWithChildren
     return (
         <FilteredFileDiffConnection
             {...props}
+            withCenteredSummary={true}
             nodeComponentProps={
                 props.nodeComponentProps
                     ? {


### PR DESCRIPTION
Closes [#39220](https://github.com/sourcegraph/sourcegraph/issues/39220).

This just restores the centered "Show more" button underneath the file diff filtered connection list:

![image](https://user-images.githubusercontent.com/8942601/181046780-67ef4411-b88e-492b-80b9-9cf7b54d2046.png)

This applies the property across all instances of the connection, which outside of batch changes only includes 2 pages in the repo area.

## Test plan

Manually verified.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-center-show-more-summary.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bnnbeaqhaj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
