### PR TITLE
frontend: Remove unused resolve-revision handler

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -156,7 +156,6 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 
 	m.Get(apirouter.ExternalURL).Handler(trace.Route(handler(serveExternalURL)))
 	m.Get(apirouter.SendEmail).Handler(trace.Route(handler(serveSendEmail)))
-	m.Get(apirouter.GitResolveRevision).Handler(trace.Route(handler(serveGitResolveRevision(db))))
 	gitService := &gitServiceHandler{
 		Gitserver: gitserver.NewClient(db),
 	}

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -31,7 +31,6 @@ const (
 	ExternalURL            = "internal.app-url"
 	SendEmail              = "internal.send-email"
 	GitInfoRefs            = "internal.git.info-refs"
-	GitResolveRevision     = "internal.git.resolve-revision"
 	GitUploadPack          = "internal.git.upload-pack"
 	PhabricatorRepoCreate  = "internal.phabricator.repo.create"
 	ReposIndex             = "internal.repos.index"
@@ -86,7 +85,6 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/app-url").Methods("POST").Name(ExternalURL)
 	base.Path("/send-email").Methods("POST").Name(SendEmail)
 	base.Path("/git/{RepoName:.*}/info/refs").Methods("GET").Name(GitInfoRefs)
-	base.Path("/git/{RepoName:.*}/resolve-revision/{Spec}").Methods("GET").Name(GitResolveRevision)
 	base.Path("/git/{RepoName:.*}/git-upload-pack").Methods("GET", "POST").Name(GitUploadPack)
 	base.Path("/phabricator/repo-create").Methods("POST").Name(PhabricatorRepoCreate)
 	base.Path("/external-services/configs").Methods("POST").Name(ExternalServiceConfigs)


### PR DESCRIPTION
Instrumentation showed it is not being used anymore.

Part of https://github.com/sourcegraph/sourcegraph/issues/36290

## Test plan

Test still pass