### PR TITLE
ci: wrap yarn into a retrying loop

### DIFF
--- a/cmd/frontend/pre-build.sh
+++ b/cmd/frontend/pre-build.sh
@@ -8,7 +8,7 @@ echo "--- yarn"
 if [[ -z "${CI}" ]]; then
   yarn --mutex network
 else
-  yarn --mutex network --frozen-lockfile --network-timeout 60000
+  ./dev/ci/yarn-install-with-retry.sh
 fi
 
 echo "--- yarn run build-web"

--- a/dev/check/yarn-deduplicate.sh
+++ b/dev/check/yarn-deduplicate.sh
@@ -5,8 +5,7 @@ echo "--- check yarn.lock for duplicates"
 
 # Prevent duplicates in yarn.lock/node_modules that lead to errors and bloated bundle sizes
 
-# mutex is necessary since CI runs various yarn installs in parallel
-yarn --mutex network --frozen-lockfile --ignore-scripts
+./dev/ci/yarn-install-with-retry.sh
 
 echo "Checking for duplicate dependencies in yarn.lock"
 yarn run -s yarn-deduplicate --fail --list --strategy fewer ./yarn.lock || {

--- a/dev/ci/yarn-build.sh
+++ b/dev/ci/yarn-build.sh
@@ -7,8 +7,7 @@ echo "NODE_ENV=$NODE_ENV"
 echo "# Note: NODE_ENV only used for build command"
 
 echo "--- Yarn install in root"
-# mutex is necessary since CI runs various yarn installs in parallel
-NODE_ENV='' yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent
+NODE_ENV='' ./dev/ci/yarn-install-with-retry.sh
 
 cd "$1"
 echo "--- browserslist"

--- a/dev/ci/yarn-install-with-retry.sh
+++ b/dev/ci/yarn-install-with-retry.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-MAX_DURATION_IN_SECONDS=60 # seconds
+MAX_DURATION_IN_SECONDS=600 # seconds
 
 tmp_log=$(mktemp)
 trap 'rm -f ${tmp_log}' EXIT

--- a/dev/ci/yarn-install-with-retry.sh
+++ b/dev/ci/yarn-install-with-retry.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+MAX_DURATION_IN_SECONDS=60 # seconds
+
+tmp_log=$(mktemp)
+trap 'rm -f ${tmp_log}' EXIT
+
+while : ; do
+  if [ "$SECONDS" -gt "$MAX_DURATION_IN_SECONDS" ]; then
+    echo "--- ✂️ timeout reached, aborting".
+    exit 1
+  fi
+  if yarn --mutex network --frozen-lockfile --ignore-scripts --network-timeout 30000 --silent "$@" 2> >(tee "$tmp_log">&2); then
+    break
+  fi
+
+  if grep -q "An unexpected error occurred" < "$tmp_log"; then
+    echo "--- 🔌 possible transient error found, trying again..." 
+  else
+    break
+  fi
+done

--- a/dev/ci/yarn-run.sh
+++ b/dev/ci/yarn-run.sh
@@ -3,9 +3,8 @@
 set -e
 
 echo "--- yarn"
-# mutex is necessary since CI runs various yarn installs in parallel
-yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent
-yarn --mutex network --cwd dev/release --frozen-lockfile --network-timeout 60000 --silent
+./dev/ci/yarn-install-with-retry.sh
+./dev/ci/yarn-install-with-retry.sh --cwd dev/release
 
 echo "--- generate"
 yarn gulp generate

--- a/dev/ci/yarn-test-separate.sh
+++ b/dev/ci/yarn-test-separate.sh
@@ -3,13 +3,15 @@
 set -e
 
 echo "--- yarn in root"
-# mutex is necessary since CI runs various yarn installs in parallel
-yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent
+./dev/ci/yarn-install-with-retry.sh
+
+# Save the absolute path to the script before changing directories.
+abs_yarn="$(pwd)/dev/ci/yarn-install-with-retry.sh"
 
 cd "$1"
 echo "--- yarn"
 # mutex is necessary since CI runs various yarn installs in parallel
-yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent
+"$abs_yarn"
 
 echo "--- test"
 

--- a/dev/ci/yarn-test-separate.sh
+++ b/dev/ci/yarn-test-separate.sh
@@ -10,7 +10,6 @@ abs_yarn="$(pwd)/dev/ci/yarn-install-with-retry.sh"
 
 cd "$1"
 echo "--- yarn"
-# mutex is necessary since CI runs various yarn installs in parallel
 "$abs_yarn"
 
 echo "--- test"

--- a/dev/ci/yarn-test.sh
+++ b/dev/ci/yarn-test.sh
@@ -3,8 +3,7 @@
 set -e
 
 echo "--- yarn in root"
-# mutex is necessary since CI runs various yarn installs in parallel
-yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent
+./dev/ci/yarn-install-with-retry.sh
 
 echo "--- generate"
 yarn gulp generate

--- a/dev/ci/yarn-web-integration.sh
+++ b/dev/ci/yarn-web-integration.sh
@@ -7,8 +7,7 @@ buildkite-agent artifact download 'client.tar.gz' . --step 'puppeteer:prep'
 tar -xf client.tar.gz -C .
 
 echo "--- Yarn install in root"
-# mutex is necessary since CI runs various yarn installs in parallel
-yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent
+./dev/ci/yarn-install-with-retry.sh
 
 echo "--- Run integration test suite"
 yarn percy exec --quiet -- yarn _cover-integration "$@"

--- a/dev/licenses.sh
+++ b/dev/licenses.sh
@@ -28,7 +28,6 @@ trap cleanup EXIT
 # prepare dependencies
 go mod tidy
 go mod vendor # go mod download does not work with license_finder
-yarn --mutex network --frozen-lockfile
 ./dev/ci/yarn-install-with-retry.sh
 
 # report license_finder configuration

--- a/dev/licenses.sh
+++ b/dev/licenses.sh
@@ -29,6 +29,7 @@ trap cleanup EXIT
 go mod tidy
 go mod vendor # go mod download does not work with license_finder
 yarn --mutex network --frozen-lockfile
+./dev/ci/yarn-install-with-retry.sh
 
 # report license_finder configuration
 license_finder permitted_licenses list

--- a/enterprise/cmd/frontend/pre-build.sh
+++ b/enterprise/cmd/frontend/pre-build.sh
@@ -11,7 +11,7 @@ echo "--- yarn root"
 # mutex is necessary since frontend and the management-console can
 # run concurrent "yarn" installs
 # TODO: This is no longer needed since the management console was removed.
-yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent
+./dev/ci/yarn-install-with-retry.sh
 
 MAYBE_TIME_PREFIX=""
 if [[ "${CI_DEBUG_PROFILE:-"false"}" == "true" ]]; then

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -365,7 +365,7 @@ func clientChromaticTests(opts CoreTestOperationsOptions) operations.Operation {
 		stepOpts := []bk.StepOpt{
 			withYarnCache(),
 			bk.AutomaticRetry(3),
-			bk.Cmd("yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent"),
+			bk.Cmd("./dev/ci/yarn-install-with-retry.sh"),
 			bk.Cmd("yarn gulp generate"),
 			bk.Env("MINIFY", "1"),
 		}


### PR DESCRIPTION
_Behold, duct tape to the rescue._

This wraps `yarn install` commands within a loop that check for the presence of "unexpected errors ..." that are announcing that some network / 500 error / whatever happened when requesting stuff on the registry. 

If such an error is found, the script will run yarn again. If we did not find such an error, the script will simply exit, like it would do without the loop. 

If we go over `$MAX_TIMEOUT_IN_SECONDS` the script will simply abort. 

@sourcegraph/frontend-platform  I know that a possible fix is coming in a few weeks, but this could at least stop the bleeding until then. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

main-dry-run

To test this locally, I botched the registry url in `yarn.lock` to reproduce the kind of errors we've been seeing in CI. Remember to wipe your `./node_modules` folder before doing so, otherwise it won't be taken in account. 