### PR TITLE
batches: add close batch change link to SSBC screens

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -27,6 +27,7 @@ import { SearchTemplatesBanner } from '../../create/SearchTemplatesBanner'
 import { useInsightTemplates } from '../../create/useInsightTemplates'
 import { useSearchTemplate } from '../../create/useSearchTemplate'
 import { BatchSpecContextProvider, useBatchSpecContext, BatchSpecContextState } from '../BatchSpecContext'
+import { ActionsMenu, ActionsMenuMode } from '../execute/ActionsMenu'
 import { ActionButtons } from '../header/ActionButtons'
 import { BatchChangeHeader } from '../header/BatchChangeHeader'
 import { TabBar, TabsConfig, TabKey } from '../TabBar'
@@ -259,7 +260,13 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                     title={{ to: batchChange.url, text: batchChange.name }}
                     description={batchChange.description ?? undefined}
                 />
-                <ActionButtons>{actionButtons}</ActionButtons>
+                {activeTabKey === 'configuration' ? (
+                    <ActionButtons>
+                        <ActionsMenu defaultMode={ActionsMenuMode.ActionsOnlyClose} />
+                    </ActionButtons>
+                ) : (
+                    <ActionButtons>{actionButtons}</ActionButtons>
+                )}
             </div>
             <TabBar activeTabKey={activeTabKey} tabsConfig={tabsConfig} />
 

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.module.scss
@@ -8,12 +8,38 @@
     color: var(--danger);
 }
 
-.preview-button {
-    z-index: 1;
+.menu-button {
     position: absolute;
 }
 
 .menu-button-hidden {
     opacity: 0;
     z-index: -999;
+    visibility: hidden;
+}
+
+.dropdown-button {
+    border-left: 1px solid var(--border-primary-color);
+    padding: 0 0.25rem;
+}
+
+.actions-button {
+    display: inline-flex;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.action-label {
+    flex-grow: 1;
+    text-align: center;
+}
+
+.action-chevron {
+    // This is ugly, but it makes the styles match the true MenuButton on the
+    // preview button.
+    box-sizing: content-box;
+    border-left: 1px solid transparent;
+    border-right: 1px solid transparent;
+    padding: 0 0.25rem;
+    width: 16px;
 }

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.module.scss
@@ -8,38 +8,12 @@
     color: var(--danger);
 }
 
-.menu-button {
+.preview-button {
+    z-index: 1;
     position: absolute;
 }
 
 .menu-button-hidden {
     opacity: 0;
     z-index: -999;
-    visibility: hidden;
-}
-
-.dropdown-button {
-    border-left: 1px solid var(--border-primary-color);
-    padding: 0 0.25rem;
-}
-
-.actions-button {
-    display: inline-flex;
-    padding-left: 0;
-    padding-right: 0;
-}
-
-.action-label {
-    flex-grow: 1;
-    text-align: center;
-}
-
-.action-chevron {
-    // This is ugly, but it makes the styles match the true MenuButton on the
-    // preview button.
-    box-sizing: content-box;
-    border-left: 1px solid transparent;
-    border-right: 1px solid transparent;
-    padding: 0 0.25rem;
-    width: 1rem;
 }

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.module.scss
@@ -41,5 +41,5 @@
     border-left: 1px solid transparent;
     border-right: 1px solid transparent;
     padding: 0 0.25rem;
-    width: 16px;
+    width: 1rem;
 }

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.story.tsx
@@ -1,15 +1,10 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
-import {
-    COMPLETED_BATCH_SPEC,
-    COMPLETED_WITH_ERRORS_BATCH_SPEC,
-    EXECUTING_BATCH_SPEC,
-    mockBatchChange,
-} from '../batch-spec.mock'
+import { EXECUTING_BATCH_SPEC, mockBatchChange } from '../batch-spec.mock'
 import { BatchSpecContextProvider } from '../BatchSpecContext'
 
-import { ActionsMenu } from './ActionsMenu'
+import { ActionsMenu, ActionsMenuMode } from './ActionsMenu'
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 
@@ -20,44 +15,42 @@ const config: Meta = {
 
 export default config
 
-export const Executing: Story = () => (
+export const Preview: Story = () => (
     <WebStory>
         {() => (
             <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={EXECUTING_BATCH_SPEC}>
-                <ActionsMenu />
+                <ActionsMenu defaultMode={ActionsMenuMode.Preview} />
             </BatchSpecContextProvider>
         )}
     </WebStory>
 )
 
-export const Failed: Story = () => (
+export const Actions: Story = () => (
     <WebStory>
         {() => (
-            <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={COMPLETED_WITH_ERRORS_BATCH_SPEC}>
-                <ActionsMenu />
+            <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={EXECUTING_BATCH_SPEC}>
+                <ActionsMenu defaultMode={ActionsMenuMode.Actions} />
             </BatchSpecContextProvider>
         )}
     </WebStory>
 )
 
-export const Completed: Story = () => (
+export const ActionsOnlyClose: Story = () => (
     <WebStory>
         {() => (
-            <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={COMPLETED_BATCH_SPEC}>
-                <ActionsMenu />
+            <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={EXECUTING_BATCH_SPEC}>
+                <ActionsMenu defaultMode={ActionsMenuMode.ActionsOnlyClose} />
             </BatchSpecContextProvider>
         )}
     </WebStory>
 )
 
-export const CompletedWithErrors: Story = () => (
+export const ActionsWithPreview: Story = () => (
     <WebStory>
         {() => (
-            <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={COMPLETED_WITH_ERRORS_BATCH_SPEC}>
-                <ActionsMenu />
+            <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={EXECUTING_BATCH_SPEC}>
+                <ActionsMenu defaultMode={ActionsMenuMode.ActionsWithPreview} />
             </BatchSpecContextProvider>
         )}
     </WebStory>
 )
-
-CompletedWithErrors.storyName = 'completed with errors'

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
@@ -1,14 +1,12 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiChevronDown, mdiAlertCircle, mdiCloseCircleOutline, mdiPencil, mdiClose, mdiSync } from '@mdi/js'
-import { VisuallyHidden } from '@reach/visually-hidden'
+import { mdiChevronDown, mdiAlertCircle, mdiPencil, mdiClose, mdiSync, mdiCloseCircleOutline } from '@mdi/js'
 import { noop } from 'lodash'
 import { useHistory, useLocation } from 'react-router'
 
 import { useMutation } from '@sourcegraph/http-client'
 import {
     Button,
-    ButtonGroup,
     Icon,
     Link,
     Menu,
@@ -36,15 +34,35 @@ import { CancelExecutionModal } from './CancelExecutionModal'
 
 import styles from './ActionsMenu.module.scss'
 
-export const ActionsMenu: React.FunctionComponent = () => {
+export enum ActionsMenuMode {
+    Preview = 'PREVIEW',
+    Actions = 'ACTIONS',
+    ActionsOnlyClose = 'CLOSE',
+    ActionsWithPreview = 'ACTIONS_WITH_PREVIEW',
+}
+
+export interface ActionsMenuProps {
+    defaultMode?: ActionsMenuMode
+}
+
+export const ActionsMenu: React.FunctionComponent<React.PropsWithChildren<ActionsMenuProps>> = ({ defaultMode }) => {
     const { batchChange, batchSpec, setActionsError } = useBatchSpecContext<BatchSpecExecutionFields>()
 
-    return <MemoizedActionsMenu batchChange={batchChange} batchSpec={batchSpec} setActionsError={setActionsError} />
+    return (
+        <MemoizedActionsMenu
+            batchChange={batchChange}
+            batchSpec={batchSpec}
+            setActionsError={setActionsError}
+            defaultMode={defaultMode}
+        />
+    )
 }
 
 const MemoizedActionsMenu: React.FunctionComponent<
-    React.PropsWithChildren<Pick<BatchSpecContextState, 'batchChange' | 'batchSpec' | 'setActionsError'>>
-> = React.memo(function MemoizedActionsMenu({ batchChange, batchSpec, setActionsError }) {
+    React.PropsWithChildren<
+        Pick<BatchSpecContextState, 'batchChange' | 'batchSpec' | 'setActionsError'> & ActionsMenuProps
+    >
+> = React.memo(function MemoizedActionsMenu({ batchChange, batchSpec, setActionsError, defaultMode }) {
     const history = useHistory()
     const location = useLocation()
 
@@ -87,130 +105,125 @@ const MemoizedActionsMenu: React.FunctionComponent<
         setShowCancelModal(true)
     }, [])
 
-    const showPreviewButton = !location.pathname.endsWith('preview') && state === BatchSpecState.COMPLETED
-    const showPreviewMenuItem = !location.pathname.endsWith('preview') && state === BatchSpecState.FAILED
+    // We have to figure out exactly what menu to show. Our options are:
+    //
+    // Actions:            the default actions menu.
+    // ActionsOnlyClose:   a visually identical actions menu, but with _only_
+    //                     an option to close the batch change.
+    // ActionsWithPreview: the default actions menu, _plus_ an item to preview
+    //                     with errors.
+    // Preview:            a single Preview CTA primary button, with no dropdown
+    //                     menu.
+    //
+    // Most of the time, this component is used within the ExecuteBatchSpecPage,
+    // in which case we can parse location.pathname to figure out what page
+    // we're on, and combine that with the batch spec state to decide what to
+    // display. Here's that set of possible states:
+    //
+    // | Page           | State     | Mode               |
+    // |----------------|-----------|--------------------|
+    // | configuration  | pending   | ActionsOnlyClose   |
+    // | configuration  | any       | Actions            |
+    // | spec           | completed | Preview            |
+    // | spec           | failed    | ActionsWithPreview |
+    // | spec           | other     | Actions            |
+    // | execution      | completed | Preview            |
+    // | execution      | failed    | ActionsWithPreview |
+    // | execution      | other     | Actions            |
+    // | preview        | any       | Actions            |
+    //
+    // If none of these match, then the optional defaultMode property will be
+    // used. If that isn't provided, the we'll just fall back to Actions.
+    let mode = defaultMode ?? ActionsMenuMode.Actions
+    if (location.pathname.endsWith('configuration') && state === BatchSpecState.PENDING) {
+        mode = ActionsMenuMode.ActionsOnlyClose
+    } else if (location.pathname.endsWith('preview')) {
+        mode = ActionsMenuMode.Actions
+    } else if (state === BatchSpecState.COMPLETED) {
+        mode = ActionsMenuMode.Preview
+    } else if (state === BatchSpecState.FAILED) {
+        mode = ActionsMenuMode.ActionsWithPreview
+    }
 
-    // The Preview dropdown button is wider than the Actions menu,
-    // so to prevent layout shift, we apply the width of the Preview
-    // dropdown button to the Action button instead.
+    // The actions menu button is wider than the "Preview" button, so to prevent layout
+    // shift, we apply the width of the actions menu button to the "Preview" button
+    // instead.
     const [menuReference, { width: menuWidth }] = useMeasure()
 
     return (
         <div className="position-relative">
-            {showPreviewButton ? (
-                // eslint-disable-next-line react/forbid-dom-props
-                <div style={{ width: menuWidth }} className={styles.menuButton}>
-                    <Menu>
-                        <ButtonGroup>
-                            <Button to={`${batchSpec.executionURL}/preview`} variant="primary" as={Link}>
-                                Preview
-                            </Button>
-                            <MenuButton variant="primary" className={styles.dropdownButton}>
-                                <Icon aria-hidden={true} svgPath={mdiChevronDown} />
-                                <VisuallyHidden>Actions</VisuallyHidden>
-                            </MenuButton>
-                        </ButtonGroup>
-                        <MenuList position={Position.bottomEnd}>
-                            <MenuLink as={Link} to={`${batchChange.url}/close`}>
-                                <Icon
-                                    aria-hidden={true}
-                                    className={styles.cancelIcon}
-                                    svgPath={mdiCloseCircleOutline}
-                                />{' '}
-                                Close batch change
-                            </MenuLink>
-                        </MenuList>
-                    </Menu>
-                </div>
-            ) : (
-                <>
-                    <div className={styles.menuButton}>
-                        <Menu>
-                            <div className="d-inline-block" aria-hidden={showPreviewButton}>
-                                <MenuButton
-                                    variant="secondary"
-                                    style={{ width: menuWidth }}
-                                    className={styles.actionsButton}
-                                >
-                                    <div className={styles.actionLabel}>Actions</div>
-                                    <div className={styles.actionChevron}>
-                                        <Icon
-                                            aria-hidden={true}
-                                            className={styles.chevronIcon}
-                                            svgPath={mdiChevronDown}
-                                        />
-                                    </div>
-                                </MenuButton>
-                            </div>
-                            <MenuList position={Position.bottomEnd}>
-                                {showPreviewMenuItem && (
-                                    <MenuItem onSelect={() => history.push(`${batchSpec.executionURL}/preview`)}>
-                                        <Icon aria-hidden={true} svgPath={mdiAlertCircle} /> Preview with errors
-                                    </MenuItem>
-                                )}
-                                <MenuItem onSelect={onSelectEdit}>
-                                    <Icon aria-hidden={true} svgPath={mdiPencil} /> Edit spec{isExecuting ? '...' : ''}
-                                </MenuItem>
-                                {isExecuting && (
-                                    <MenuItem onSelect={onSelectCancel}>
-                                        <Icon aria-hidden={true} className={styles.cancelIcon} svgPath={mdiClose} />{' '}
-                                        Cancel execution...
-                                    </MenuItem>
-                                )}
-                                {batchSpec.viewerCanRetry && (
-                                    <MenuItem onSelect={retryBatchSpecExecution} disabled={isRetryLoading}>
-                                        <Icon aria-hidden={true} svgPath={mdiSync} /> Retry failed workspaces
-                                    </MenuItem>
-                                )}
-                                <MenuLink as={Link} to={`${batchChange.url}/close`}>
-                                    <Icon
-                                        aria-hidden={true}
-                                        className={styles.cancelIcon}
-                                        svgPath={mdiCloseCircleOutline}
-                                    />{' '}
-                                    Close batch change
-                                </MenuLink>
-                            </MenuList>
-                        </Menu>
-                    </div>
-                    <CancelExecutionModal
-                        isOpen={showCancelModal}
-                        onCancel={() => setShowCancelModal(false)}
-                        onConfirm={cancelModalType === 'cancel' ? cancelBatchSpecExecution : cancelAndEdit}
-                        modalHeader={
-                            cancelModalType === 'cancel' ? 'Cancel execution' : 'The execution is still running'
-                        }
-                        modalBody={
-                            <Text>
-                                {cancelModalType === 'cancel'
-                                    ? 'Are you sure you want to cancel the current execution?'
-                                    : 'You are unable to edit the spec when an execution is running.'}
-                            </Text>
-                        }
-                        isLoading={isCancelLoading}
-                    />
-                </>
+            {mode === ActionsMenuMode.Preview && (
+                <Button
+                    to={`${batchSpec.executionURL}/preview`}
+                    variant="primary"
+                    as={Link}
+                    className={styles.previewButton}
+                    style={{ width: menuWidth }}
+                >
+                    Preview
+                </Button>
             )}
-            {/* We need to render a Preview dropdown button, but make it invisible and non-actionable. */}
-            <div className={styles.menuButtonHidden} ref={menuReference}>
-                <Menu>
-                    <ButtonGroup>
-                        <Button to={`${batchSpec.executionURL}/preview`} variant="primary" as={Link}>
-                            Preview
-                        </Button>
-                        <MenuButton variant="primary" className={styles.dropdownButton}>
-                            <Icon aria-hidden={true} svgPath={mdiChevronDown} />
-                            <VisuallyHidden>Actions</VisuallyHidden>
-                        </MenuButton>
-                    </ButtonGroup>
-                    <MenuList position={Position.bottomEnd}>
-                        <MenuLink as={Link} to={`${batchChange.url}/close`}>
-                            <Icon aria-hidden={true} className={styles.cancelIcon} svgPath={mdiCloseCircleOutline} />{' '}
-                            Close batch change
-                        </MenuLink>
-                    </MenuList>
-                </Menu>
-            </div>
+            <Menu>
+                <div className="d-inline-block" ref={menuReference} aria-hidden={mode === ActionsMenuMode.Preview}>
+                    <MenuButton
+                        variant="secondary"
+                        className={mode === ActionsMenuMode.Preview ? styles.menuButtonHidden : undefined}
+                        // If an element with aria-hidden={true} contains a focusable
+                        // element, assistive technologies won't read the focusable
+                        // element, but keyboard users will still be able to navigate to
+                        // it, which can cause confusion. We pair this with negative tab
+                        // index to take the menu button out of the tab order when it is
+                        // hidden. See: https://web.dev/aria-hidden-focus/
+                        tabIndex={mode === ActionsMenuMode.Preview ? -1 : undefined}
+                    >
+                        Actions
+                        <Icon aria-hidden={true} className={styles.chevronIcon} svgPath={mdiChevronDown} />
+                    </MenuButton>
+                </div>
+                <MenuList position={Position.bottomEnd}>
+                    {mode !== ActionsMenuMode.ActionsOnlyClose && (
+                        <>
+                            {mode === ActionsMenuMode.ActionsWithPreview && (
+                                <MenuItem onSelect={() => history.push(`${batchSpec.executionURL}/preview`)}>
+                                    <Icon aria-hidden={true} svgPath={mdiAlertCircle} /> Preview with errors
+                                </MenuItem>
+                            )}
+                            <MenuItem onSelect={onSelectEdit}>
+                                <Icon aria-hidden={true} svgPath={mdiPencil} /> Edit spec{isExecuting ? '...' : ''}
+                            </MenuItem>
+                            {isExecuting && (
+                                <MenuItem onSelect={onSelectCancel}>
+                                    <Icon aria-hidden={true} className={styles.cancelIcon} svgPath={mdiClose} /> Cancel
+                                    execution...
+                                </MenuItem>
+                            )}
+                            {batchSpec.viewerCanRetry && (
+                                <MenuItem onSelect={retryBatchSpecExecution} disabled={isRetryLoading}>
+                                    <Icon aria-hidden={true} svgPath={mdiSync} /> Retry failed workspaces
+                                </MenuItem>
+                            )}
+                        </>
+                    )}
+                    <MenuLink as={Link} to={`${batchChange.url}/close`}>
+                        <Icon aria-hidden={true} className={styles.cancelIcon} svgPath={mdiCloseCircleOutline} /> Close
+                        batch change
+                    </MenuLink>
+                </MenuList>
+            </Menu>
+            <CancelExecutionModal
+                isOpen={showCancelModal}
+                onCancel={() => setShowCancelModal(false)}
+                onConfirm={cancelModalType === 'cancel' ? cancelBatchSpecExecution : cancelAndEdit}
+                modalHeader={cancelModalType === 'cancel' ? 'Cancel execution' : 'The execution is still running'}
+                modalBody={
+                    <Text>
+                        {cancelModalType === 'cancel'
+                            ? 'Are you sure you want to cancel the current execution?'
+                            : 'You are unable to edit the spec when an execution is running.'}
+                    </Text>
+                }
+                isLoading={isCancelLoading}
+            />
         </div>
     )
 })

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiChevronDown, mdiAlertCircle, mdiDelete, mdiPencil, mdiClose, mdiSync } from '@mdi/js'
+import { mdiChevronDown, mdiAlertCircle, mdiCloseCircleOutline, mdiPencil, mdiClose, mdiSync } from '@mdi/js'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import { noop } from 'lodash'
 import { useHistory, useLocation } from 'react-router'
 
 import { useMutation } from '@sourcegraph/http-client'
 import {
     Button,
+    ButtonGroup,
     Icon,
     Link,
     Menu,
@@ -71,8 +73,6 @@ const MemoizedActionsMenu: React.FunctionComponent<
         RetryBatchSpecExecutionVariables
     >(RETRY_BATCH_SPEC_EXECUTION, { variables: { id: batchSpec.id }, onError: setActionsError })
 
-    const onSelectDelete = useCallback(() => {}, [])
-
     const onSelectEdit = useCallback(() => {
         if (isExecuting) {
             setCancelModalType('edit')
@@ -90,81 +90,127 @@ const MemoizedActionsMenu: React.FunctionComponent<
     const showPreviewButton = !location.pathname.endsWith('preview') && state === BatchSpecState.COMPLETED
     const showPreviewMenuItem = !location.pathname.endsWith('preview') && state === BatchSpecState.FAILED
 
-    // The actions menu button is wider than the "Preview" button, so to prevent layout
-    // shift, we apply the width of the actions menu button to the "Preview" button
-    // instead.
+    // The Preview dropdown button is wider than the Actions menu,
+    // so to prevent layout shift, we apply the width of the Preview
+    // dropdown button to the Action button instead.
     const [menuReference, { width: menuWidth }] = useMeasure()
 
     return (
         <div className="position-relative">
-            {showPreviewButton && (
-                <Button
-                    to={`${batchSpec.executionURL}/preview`}
-                    variant="primary"
-                    as={Link}
-                    className={styles.previewButton}
-                    style={{ width: menuWidth }}
-                >
-                    Preview
-                </Button>
-            )}
-            <Menu>
-                <div className="d-inline-block" ref={menuReference} aria-hidden={showPreviewButton}>
-                    <MenuButton
-                        variant="secondary"
-                        className={showPreviewButton ? styles.menuButtonHidden : undefined}
-                        // If an element with aria-hidden={true} contains a focusable
-                        // element, assistive technologies won't read the focusable
-                        // element, but keyboard users will still be able to navigate to
-                        // it, which can cause confusion. We pair this with negative tab
-                        // index to take the menu button out of the tab order when it is
-                        // hidden. See: https://web.dev/aria-hidden-focus/
-                        tabIndex={showPreviewButton ? -1 : undefined}
-                    >
-                        Actions
-                        <Icon aria-hidden={true} className={styles.chevronIcon} svgPath={mdiChevronDown} />
-                    </MenuButton>
+            {showPreviewButton ? (
+                // eslint-disable-next-line react/forbid-dom-props
+                <div style={{ width: menuWidth }} className={styles.menuButton}>
+                    <Menu>
+                        <ButtonGroup>
+                            <Button to={`${batchSpec.executionURL}/preview`} variant="primary" as={Link}>
+                                Preview
+                            </Button>
+                            <MenuButton variant="primary" className={styles.dropdownButton}>
+                                <Icon aria-hidden={true} svgPath={mdiChevronDown} />
+                                <VisuallyHidden>Actions</VisuallyHidden>
+                            </MenuButton>
+                        </ButtonGroup>
+                        <MenuList position={Position.bottomEnd}>
+                            <MenuLink as={Link} to={`${batchChange.url}/close`}>
+                                <Icon
+                                    aria-hidden={true}
+                                    className={styles.cancelIcon}
+                                    svgPath={mdiCloseCircleOutline}
+                                />{' '}
+                                Close batch change
+                            </MenuLink>
+                        </MenuList>
+                    </Menu>
                 </div>
-                <MenuList position={Position.bottomEnd}>
-                    {showPreviewMenuItem && (
-                        <MenuItem onSelect={() => history.push(`${batchSpec.executionURL}/preview`)}>
-                            <Icon aria-hidden={true} svgPath={mdiAlertCircle} /> Preview with errors
-                        </MenuItem>
-                    )}
-                    <MenuItem onSelect={onSelectEdit}>
-                        <Icon aria-hidden={true} svgPath={mdiPencil} /> Edit spec{isExecuting ? '...' : ''}
-                    </MenuItem>
-                    {isExecuting && (
-                        <MenuItem onSelect={onSelectCancel}>
-                            <Icon aria-hidden={true} className={styles.cancelIcon} svgPath={mdiClose} /> Cancel
-                            execution...
-                        </MenuItem>
-                    )}
-                    {batchSpec.viewerCanRetry && (
-                        <MenuItem onSelect={retryBatchSpecExecution} disabled={isRetryLoading}>
-                            <Icon aria-hidden={true} svgPath={mdiSync} /> Retry failed workspaces
-                        </MenuItem>
-                    )}
-                    <MenuLink as={Link} to={`${batchChange.url}/close`}>
-                        <Icon aria-hidden={true} className={styles.cancelIcon} svgPath={mdiDelete} /> Delete batch
-                        change
-                    </MenuLink>
-                </MenuList>
-            </Menu>
-            <CancelExecutionModal
-                isOpen={showCancelModal}
-                onCancel={() => setShowCancelModal(false)}
-                onConfirm={cancelModalType === 'cancel' ? cancelBatchSpecExecution : cancelAndEdit}
-                modalHeader={cancelModalType === 'cancel' ? 'Cancel execution' : 'The execution is still running'}
-                modalBody={
-                    <Text>
-                        {cancelModalType === 'cancel'
-                            ? 'Are you sure you want to cancel the current execution?'
-                            : 'You are unable to edit the spec when an execution is running.'}
-                    </Text>
-                }
-                isLoading={isCancelLoading}
-            />
+            ) : (
+                <>
+                    <div className={styles.menuButton}>
+                        <Menu>
+                            <div className="d-inline-block" aria-hidden={showPreviewButton}>
+                                <MenuButton
+                                    variant="secondary"
+                                    style={{ width: menuWidth }}
+                                    className={styles.actionsButton}
+                                >
+                                    <div className={styles.actionLabel}>Actions</div>
+                                    <div className={styles.actionChevron}>
+                                        <Icon
+                                            aria-hidden={true}
+                                            className={styles.chevronIcon}
+                                            svgPath={mdiChevronDown}
+                                        />
+                                    </div>
+                                </MenuButton>
+                            </div>
+                            <MenuList position={Position.bottomEnd}>
+                                {showPreviewMenuItem && (
+                                    <MenuItem onSelect={() => history.push(`${batchSpec.executionURL}/preview`)}>
+                                        <Icon aria-hidden={true} svgPath={mdiAlertCircle} /> Preview with errors
+                                    </MenuItem>
+                                )}
+                                <MenuItem onSelect={onSelectEdit}>
+                                    <Icon aria-hidden={true} svgPath={mdiPencil} /> Edit spec{isExecuting ? '...' : ''}
+                                </MenuItem>
+                                {isExecuting && (
+                                    <MenuItem onSelect={onSelectCancel}>
+                                        <Icon aria-hidden={true} className={styles.cancelIcon} svgPath={mdiClose} />{' '}
+                                        Cancel execution...
+                                    </MenuItem>
+                                )}
+                                {batchSpec.viewerCanRetry && (
+                                    <MenuItem onSelect={retryBatchSpecExecution} disabled={isRetryLoading}>
+                                        <Icon aria-hidden={true} svgPath={mdiSync} /> Retry failed workspaces
+                                    </MenuItem>
+                                )}
+                                <MenuLink as={Link} to={`${batchChange.url}/close`}>
+                                    <Icon
+                                        aria-hidden={true}
+                                        className={styles.cancelIcon}
+                                        svgPath={mdiCloseCircleOutline}
+                                    />{' '}
+                                    Close batch change
+                                </MenuLink>
+                            </MenuList>
+                        </Menu>
+                    </div>
+                    <CancelExecutionModal
+                        isOpen={showCancelModal}
+                        onCancel={() => setShowCancelModal(false)}
+                        onConfirm={cancelModalType === 'cancel' ? cancelBatchSpecExecution : cancelAndEdit}
+                        modalHeader={
+                            cancelModalType === 'cancel' ? 'Cancel execution' : 'The execution is still running'
+                        }
+                        modalBody={
+                            <Text>
+                                {cancelModalType === 'cancel'
+                                    ? 'Are you sure you want to cancel the current execution?'
+                                    : 'You are unable to edit the spec when an execution is running.'}
+                            </Text>
+                        }
+                        isLoading={isCancelLoading}
+                    />
+                </>
+            )}
+            {/* We need to render a Preview dropdown button, but make it invisible and non-actionable. */}
+            <div className={styles.menuButtonHidden} ref={menuReference}>
+                <Menu>
+                    <ButtonGroup>
+                        <Button to={`${batchSpec.executionURL}/preview`} variant="primary" as={Link}>
+                            Preview
+                        </Button>
+                        <MenuButton variant="primary" className={styles.dropdownButton}>
+                            <Icon aria-hidden={true} svgPath={mdiChevronDown} />
+                            <VisuallyHidden>Actions</VisuallyHidden>
+                        </MenuButton>
+                    </ButtonGroup>
+                    <MenuList position={Position.bottomEnd}>
+                        <MenuLink as={Link} to={`${batchChange.url}/close`}>
+                            <Icon aria-hidden={true} className={styles.cancelIcon} svgPath={mdiCloseCircleOutline} />{' '}
+                            Close batch change
+                        </MenuLink>
+                    </MenuList>
+                </Menu>
+            </div>
         </div>
     )
 })

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiChevronDown, mdiAlertCircle, mdiPencil, mdiClose, mdiSync } from '@mdi/js'
+import { mdiChevronDown, mdiAlertCircle, mdiDelete, mdiPencil, mdiClose, mdiSync } from '@mdi/js'
 import { noop } from 'lodash'
 import { useHistory, useLocation } from 'react-router'
 
@@ -12,6 +12,7 @@ import {
     Menu,
     MenuButton,
     MenuItem,
+    MenuLink,
     MenuList,
     Position,
     Text,
@@ -69,6 +70,8 @@ const MemoizedActionsMenu: React.FunctionComponent<
         RetryBatchSpecExecutionResult,
         RetryBatchSpecExecutionVariables
     >(RETRY_BATCH_SPEC_EXECUTION, { variables: { id: batchSpec.id }, onError: setActionsError })
+
+    const onSelectDelete = useCallback(() => {}, [])
 
     const onSelectEdit = useCallback(() => {
         if (isExecuting) {
@@ -142,6 +145,10 @@ const MemoizedActionsMenu: React.FunctionComponent<
                             <Icon aria-hidden={true} svgPath={mdiSync} /> Retry failed workspaces
                         </MenuItem>
                     )}
+                    <MenuLink as={Link} to={`${batchChange.url}/close`}>
+                        <Icon aria-hidden={true} className={styles.cancelIcon} svgPath={mdiDelete} /> Delete batch
+                        change
+                    </MenuLink>
                 </MenuList>
             </Menu>
             <CancelExecutionModal

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsActionSection.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsActionSection.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiInformation, mdiDelete, mdiPencil } from '@mdi/js'
+import { mdiInformation, mdiClose, mdiDelete, mdiPencil } from '@mdi/js'
 import * as H from 'history'
 
 import { isErrorLike, asError } from '@sourcegraph/common'
@@ -85,7 +85,7 @@ export const BatchChangeDetailsActionSection: React.FunctionComponent<
                     outline={true}
                     as={Link}
                 >
-                    <Icon aria-hidden={true} svgPath={mdiDelete} /> Close
+                    <Icon aria-hidden={true} svgPath={mdiClose} /> Close
                 </Button>
             </Tooltip>
         </div>


### PR DESCRIPTION
This PR extends the _Actions_ menu that appears in several places in the execution UI (always on the Preview tab, and when an execution is incomplete or failed on the other tabs) to include a _Close batch change_ item. For batch changes that have been executed, this means that the user can now close a batch change more directly from the batch change list.

Additionally (see the previous version of this PR description and Kelli's comment below for context), the _Actions_ menu has been added to the _Configuration_ tab when creating a new batch spec, replacing the _Run batch spec_ CTA, thereby allowing a user who hasn't yet executed a batch spec (slightly) more immediate access to 

Compared to the original #39446, this descopes converting the preview CTA to a dropdown button in other places. Since that button takes you to the _Preview_ tab, which then has the full actions menu including the close batch change item, this felt unnecessary.

### A note on iconography

We already have a cross icon in the actions dropdown, so I've used a circled close to distinguish closing the batch change:

<img width="195" alt="image" src="https://user-images.githubusercontent.com/229984/181096575-3ca288bf-f92b-4b7f-ac09-4622eaa67173.png">

It also turns out that we used `mdiDelete` for the close button on a batch change, so I've updated that to `mdiClose` so it's at least closer.

Closes #39446.

## Test plan

I've run through the various permutations of this, including unexecuted batch specs, batch specs that are being executed, and batch specs that are complete.

Our automated storybook coverage here isn't zero, but it's also not complete, as far as I can tell. Manually using the storybook helps to validate this flow. I've restructured the `ActionsMenu` storybook to handle the new way it handles its various modes.

## App preview:

- [Web](https://sg-web-aharvey-ssbc-close.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bemvoenqfv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

