### PR TITLE
oobmigration: Add version parser

### DIFF
--- a/internal/database/migration/stitch/rewriter.go
+++ b/internal/database/migration/stitch/rewriter.go
@@ -11,9 +11,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/mapfs"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
-
-var versionPattern = lazyregexp.New(`^v(\d+)\.(\d+)\.\d+$`)
 
 // readMigrations reads migrations from a locally available git revision for the given schema, and
 // rewrites old versions and explicit edge cases so that they can be more easily composed by the
@@ -51,23 +50,14 @@ func readMigrations(schemaName, root, rev string) (fs.FS, error) {
 		contents[filepath.Join(m.id, "metadata.yaml")] = m.metadata
 	}
 
-	if matches := versionPattern.FindStringSubmatch(rev); len(matches) > 0 {
-		majorVersion, err := strconv.Atoi(matches[1])
-		if err != nil {
-			return nil, err
-		}
-		minorVersion, err := strconv.Atoi(matches[2])
-		if err != nil {
-			return nil, err
-		}
-
+	if version, ok := oobmigration.NewVersionFromString(rev); ok {
 		migrationIDs, err := idsFromRawMigrations(migrations)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, rewrite := range rewriters {
-			rewrite(schemaName, majorVersion, minorVersion, migrationIDs, contents)
+			rewrite(schemaName, version, migrationIDs, contents)
 		}
 	}
 
@@ -109,7 +99,7 @@ func linkVirtualPrivilegedMigrations(definitionMap map[int]definition.Definition
 // beginning of the rewrite procedure will be represented in the provided slide of identifiers.
 // Additional files/migrations may be added to the contents map will not be reflected in this slice for
 // subsequent rewriters.
-var rewriters = []func(schemaName string, majorVersion, minorVersion int, migrationIDs []int, contents map[string]string){
+var rewriters = []func(schemaName string, version oobmigration.Version, migrationIDs []int, contents map[string]string){
 	rewriteInitialCodeinsightsMigration,
 	ensureParentMetadataExists,
 	extractPrivilegedQueriesFromSquashedMigrations,
@@ -122,7 +112,7 @@ var rewriters = []func(schemaName string, majorVersion, minorVersion int, migrat
 
 // rewriteInitialCodeinsightsMigration renames the initial codeinsights migration file to include the expected
 // title of "squashed migration".
-func rewriteInitialCodeinsightsMigration(schemaName string, _, _ int, _ []int, contents map[string]string) {
+func rewriteInitialCodeinsightsMigration(schemaName string, _ oobmigration.Version, _ []int, contents map[string]string) {
 	if schemaName != "codeinsights" {
 		return
 	}
@@ -134,9 +124,9 @@ func rewriteInitialCodeinsightsMigration(schemaName string, _, _ int, _ []int, c
 
 // ensureParentMetadataExists adds parent information to the metadata file of each migration, prior to 3.37,
 // in which metadata files did not exist and parentage was implied by linear migration identifiers.
-func ensureParentMetadataExists(_ string, majorVersion, minorVersion int, migrationIDs []int, contents map[string]string) {
+func ensureParentMetadataExists(_ string, version oobmigration.Version, migrationIDs []int, contents map[string]string) {
 	// 3.37 and above enforces this structure
-	if !(majorVersion == 3 && minorVersion < 37) || len(migrationIDs) == 0 {
+	if !(version.Major == 3 && version.Minor < 37) || len(migrationIDs) == 0 {
 		return
 	}
 
@@ -150,8 +140,8 @@ func ensureParentMetadataExists(_ string, majorVersion, minorVersion int, migrat
 // extractPrivilegedQueriesFromSquashedMigrations splits the squashed migration into a distinct set of
 // privileged and unprivileged queries. Prior to 3.38, privileged migrations were not distinct. The current
 // code that reads migration definitions require that privileged migrations are expilcitly marked.
-func extractPrivilegedQueriesFromSquashedMigrations(_ string, majorVersion, minorVersion int, migrationIDs []int, contents map[string]string) {
-	if !(majorVersion == 3 && minorVersion < 38) || len(migrationIDs) == 0 {
+func extractPrivilegedQueriesFromSquashedMigrations(_ string, version oobmigration.Version, migrationIDs []int, contents map[string]string) {
+	if !(version.Major == 3 && version.Minor < 38) || len(migrationIDs) == 0 {
 		// 3.38 and above enforces this structure
 		return
 	}
@@ -182,7 +172,7 @@ var unmarkedPrivilegedMigrationsMap = map[string][]int{
 
 // rewriteUnmarkedPrivilegedMigrations adds an explicit privileged marker to the metadata of migration
 // definitions that modify extensions (prior to the privileged/unprivileged split).
-func rewriteUnmarkedPrivilegedMigrations(schemaName string, _, _ int, _ []int, contents map[string]string) {
+func rewriteUnmarkedPrivilegedMigrations(schemaName string, _ oobmigration.Version, _ []int, contents map[string]string) {
 	for _, id := range unmarkedPrivilegedMigrationsMap[schemaName] {
 		mapContents(contents, migrationFilename(id, "metadata.yaml"), func(oldMetadata string) string {
 			return fmt.Sprintf("%s\nprivileged: true", oldMetadata)
@@ -198,7 +188,7 @@ var unmarkedConcurrentIndexCreationMigrationsMap = map[string][]int{
 
 // rewriteUnmarkedConcurrentIndexCreationMigrations adds an explicit marker to the metadata of migrations that
 // define a concurrent index (prior to the introduction of the migrator).
-func rewriteUnmarkedConcurrentIndexCreationMigrations(schemaName string, _, _ int, _ []int, contents map[string]string) {
+func rewriteUnmarkedConcurrentIndexCreationMigrations(schemaName string, _ oobmigration.Version, _ []int, contents map[string]string) {
 	for _, id := range unmarkedConcurrentIndexCreationMigrationsMap[schemaName] {
 		mapContents(contents, migrationFilename(id, "metadata.yaml"), func(oldMetadata string) string {
 			return fmt.Sprintf("%s\ncreateIndexConcurrently: true", oldMetadata)
@@ -213,7 +203,7 @@ var concurrentIndexCreationDownMigrationsMap = map[string][]int{
 }
 
 // rewriteConcurrentIndexCreationDownMigrations removes CONCURRENTLY from down migrations, which is now unsupported.
-func rewriteConcurrentIndexCreationDownMigrations(schemaName string, _, _ int, _ []int, contents map[string]string) {
+func rewriteConcurrentIndexCreationDownMigrations(schemaName string, _ oobmigration.Version, _ []int, contents map[string]string) {
 	for _, id := range concurrentIndexCreationDownMigrationsMap[schemaName] {
 		mapContents(contents, migrationFilename(id, "down.sql"), func(oldQuery string) string {
 			return strings.ReplaceAll(oldQuery, " CONCURRENTLY", "")
@@ -225,8 +215,8 @@ func rewriteConcurrentIndexCreationDownMigrations(schemaName string, _, _ int, _
 // these files exist and haven't yet been renamed, we do the renaming at this time to make it match later versions.
 //
 // See https://github.com/sourcegraph/sourcegraph/pull/29395.
-func reorderMigrations(schemaName string, majorVersion, minorVersion int, _ []int, contents map[string]string) {
-	if schemaName != "frontend" || !(majorVersion == 3 && minorVersion < 36) {
+func reorderMigrations(schemaName string, version oobmigration.Version, _ []int, contents map[string]string) {
+	if schemaName != "frontend" || !(version.Major == 3 && version.Minor < 36) {
 		// Rename occurred at v3.36
 		return
 	}

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -1,6 +1,11 @@
 package oobmigration
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+)
 
 type Version struct {
 	Major int
@@ -12,6 +17,19 @@ func NewVersion(major, minor int) Version {
 		Major: major,
 		Minor: minor,
 	}
+}
+
+var versionPattern = lazyregexp.New(`^v?(\d+)\.(\d+)(?:\.\d+)?$`)
+
+func NewVersionFromString(v string) (Version, bool) {
+	if matches := versionPattern.FindStringSubmatch(v); len(matches) >= 3 {
+		major, _ := strconv.Atoi(matches[1])
+		minor, _ := strconv.Atoi(matches[2])
+
+		return NewVersion(major, minor), true
+	}
+
+	return Version{}, false
 }
 
 func (v Version) String() string {


### PR DESCRIPTION
This PR is a small refactor that reuses the oobmigration `Version` type in the stitch package.

## Test plan

Existing tests.