### PR TITLE
batches: Fix Filter Row hiding when no matching items

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react'
 
-import { mdiMagnify, mdiAlert } from '@mdi/js'
+import { mdiAlert, mdiMagnify } from '@mdi/js'
 import classNames from 'classnames'
 import { animated, useSpring } from 'react-spring'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { CodeSnippet } from '@sourcegraph/branded/src/components/CodeSnippet'
-import { Button, useAccordion, useStopwatch, Icon, H4, Tooltip } from '@sourcegraph/wildcard'
+import { Button, H4, Icon, Tooltip, useAccordion, useStopwatch } from '@sourcegraph/wildcard'
 
 import { Connection } from '../../../../../components/FilteredConnection'
 import {
@@ -259,7 +259,7 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<
                     {ctaButton}
                 </div>
             )}
-            {shouldShowConnection && (
+            {(hasPreviewed || isReadOnly) && (
                 <WorkspacePreviewFilterRow onFiltersChange={setFilters} disabled={isWorkspacesPreviewInProgress} />
             )}
             {shouldShowConnection && (

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -89,7 +89,7 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<
     const connection = workspacesConnection.connection
 
     // Before we've ever previewed workspaces for this batch change, there's no reason to
-    // show the list or filters for the connection.
+    // show the list.
     const shouldShowConnection = hasPreviewed || !!connection?.nodes.length
 
     // We "cache" the last results of the workspaces preview so that we can continue to


### PR DESCRIPTION
Closes #39414.

The variable `shouldShowConnection` becomes false when there are no connection nodes. Thus hiding the filter row. Changed to show the filter row when the preview action has occurred or the page is in read only mode.

## Test plan

Manual testing

### Video

#### Before

https://user-images.githubusercontent.com/38407415/181089818-4cb68932-2658-4150-8f6b-01a00abf411c.mov

#### After

https://user-images.githubusercontent.com/38407415/181089767-5c001df9-0b7d-4fd2-88a1-94b2cbe382b6.mov



## App preview:

- [Web](https://sg-web-rc-workspace-preview.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ahzfsxlayj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
