### PR TITLE
otel-collector: enable http receiver for dev purposes

### DIFF
--- a/docker-images/opentelemetry-collector/configs/honeycomb.yaml
+++ b/docker-images/opentelemetry-collector/configs/honeycomb.yaml
@@ -11,6 +11,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+      http:
 
 exporters:
   otlp:

--- a/docker-images/opentelemetry-collector/configs/jaeger.yaml
+++ b/docker-images/opentelemetry-collector/configs/jaeger.yaml
@@ -8,6 +8,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+      http:
 
 exporters:
   jaeger:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -684,7 +684,7 @@ commands:
 
       docker container rm otel-collector
       docker run --rm --name=otel-collector $DOCKER_NET $DOCKER_ARGS \
-        -p 4317:4317 -p 55679:55679 \
+        -p 4317:4317 -p 4318:4318 -p 55679:55679 \
         -e JAEGER_HOST=$JAEGER_HOST \
         -e HONEYCOMB_API_KEY=$HONEYCOMB_API_KEY \
         -e HONEYCOMB_DATASET=$HONEYCOMB_DATASET \


### PR DESCRIPTION
Spun out from investigations re: https://github.com/sourcegraph/sourcegraph/pull/39453

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg run otel`