### PR TITLE
make repository mirror alert container scrollable

### DIFF
--- a/client/web/src/auth/Terminal/Terminal.tsx
+++ b/client/web/src/auth/Terminal/Terminal.tsx
@@ -1,8 +1,14 @@
 import React from 'react'
 
+import classNames from 'classnames'
+
 import { Code } from '@sourcegraph/wildcard'
 
 import terminalStyles from './Terminal.module.scss'
+
+interface TerminalLineProps extends React.HTMLAttributes<HTMLLIElement> {
+    className?: string
+}
 
 // 73 '=' characters are the 100% of the progress bar
 const CHARACTERS_LENGTH = 73
@@ -19,9 +25,10 @@ export const TerminalTitle: React.FunctionComponent<React.PropsWithChildren<unkn
     </header>
 )
 
-export const TerminalLine: React.FunctionComponent<React.PropsWithChildren<unknown>> = ({ children }) => (
-    <li className={terminalStyles.terminalLine}>{children}</li>
-)
+export const TerminalLine: React.FunctionComponent<React.PropsWithChildren<TerminalLineProps>> = ({
+    children,
+    className,
+}) => <li className={classNames(terminalStyles.terminalLine, className)}>{children}</li>
 
 export const TerminalDetails: React.FunctionComponent<React.PropsWithChildren<unknown>> = ({ children }) => (
     <div>

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
@@ -1,3 +1,9 @@
 .alert-wrapper {
     margin-top: 1rem;
+    overflow-y: auto;
+    max-height: 25rem;
+}
+
+.alert-content {
+    white-space: pre-wrap;
 }

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
@@ -1,6 +1,6 @@
 .alert-wrapper {
     margin-top: 1rem;
-    overflow-y: auto;
+    overflow-y: scroll;
     max-height: 25rem;
 }
 

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
@@ -5,5 +5,5 @@
 }
 
 .alert-content {
-    white-space: pre-wrap;
+    white-space: break-spaces;
 }

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useCallback } from 'react'
 
 import { mdiCloudDownload, mdiCog } from '@mdi/js'
-import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 
@@ -57,10 +56,12 @@ const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Repository
         </div>
 
         {node.mirrorInfo.lastError && (
-            <div className={classNames(styles.alertWrapper)}>
+            <div className={styles.alertWrapper}>
                 <Alert variant="warning">
-                    <TerminalLine>Error syncing repository:</TerminalLine>
-                    <TerminalLine>{node.mirrorInfo.lastError}</TerminalLine>
+                    <Text className="font-weight-bold">Error syncing repository:</Text>
+                    <TerminalLine>
+                        {node.mirrorInfo.lastError}
+                    </TerminalLine>
                 </Alert>
             </div>
         )}

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -59,7 +59,9 @@ const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Repository
             <div className={styles.alertWrapper}>
                 <Alert variant="warning">
                     <Text className="font-weight-bold">Error updating repo:</Text>
-                    <TerminalLine className={styles.alertContent}>{node.mirrorInfo.lastError}</TerminalLine>
+                    <TerminalLine className={styles.alertContent}>
+                        {node.mirrorInfo.lastError.replaceAll('\r', '\n')}
+                    </TerminalLine>
                 </Alert>
             </div>
         )}

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -58,7 +58,7 @@ const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Repository
         {node.mirrorInfo.lastError && (
             <div className={styles.alertWrapper}>
                 <Alert variant="warning">
-                    <Text className="font-weight-bold">Error updating repo:</Text>
+                    <Text className="font-weight-bold">Error syncing repository:</Text>
                     <TerminalLine className={styles.alertContent}>
                         {node.mirrorInfo.lastError.replaceAll('\r', '\n')}
                     </TerminalLine>

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -58,10 +58,8 @@ const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Repository
         {node.mirrorInfo.lastError && (
             <div className={styles.alertWrapper}>
                 <Alert variant="warning">
-                    <Text className="font-weight-bold">Error syncing repository:</Text>
-                    <TerminalLine>
-                        {node.mirrorInfo.lastError}
-                    </TerminalLine>
+                    <Text className="font-weight-bold">Error updating repo:</Text>
+                    <TerminalLine className={styles.alertContent}>{node.mirrorInfo.lastError}</TerminalLine>
                 </Alert>
             </div>
         )}


### PR DESCRIPTION
Before | After
:------:|:-------:
<img width="1179" alt="CleanShot 2022-07-26 at 14 41 08@2x" src="https://user-images.githubusercontent.com/25608335/181092924-4df01ba0-9cca-4ddc-90cd-186610ee1ba4.png"> | <img width="1192" alt="CleanShot 2022-08-01 at 08 17 27@2x" src="https://user-images.githubusercontent.com/25608335/182094060-0ee9d814-df90-46f9-a7ac-7c92659effad.png">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
When the error from a repository mirroring action is very large, we end up with a state in which the error is spilled over a large portion of the browser window.

This PR adds a `max-height` to the repository alert container and makes it scrollable when the error is large.

## App preview:

- [Web](https://sg-web-bo-add-max-height-repo-warnings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ugugyufuyx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
