### PR TITLE
Bump src-cli to 3.42.2

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.42.0"
+const MinimumVersion = "3.42.2"


### PR DESCRIPTION
This prevents serving 3.42.0 by default, which is broken for the preview/apply workflows.



## Test plan

Const change.