### PR TITLE
oobmigration: Add additional behavior around versions

### DIFF
--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type Version struct {
@@ -57,6 +58,21 @@ func (v Version) Next() Version {
 
 	// Bump minor version
 	return NewVersion(v.Major, v.Minor+1)
+}
+
+// UpgradeRange returns all minor versions in the closed interval [from, to].
+// An error is returned if the interval would be empty.
+func UpgradeRange(from, to Version) ([]Version, error) {
+	if compareVersions(from, to) != VersionOrderBefore {
+		return nil, errors.Newf("invalid range (from=%s > to=%s)", from, to)
+	}
+
+	var versions []Version
+	for v := from; compareVersions(v, to) != VersionOrderAfter; v = v.Next() {
+		versions = append(versions, v)
+	}
+
+	return versions, nil
 }
 
 type VersionOrder int

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -21,6 +21,8 @@ func NewVersion(major, minor int) Version {
 
 var versionPattern = lazyregexp.New(`^v?(\d+)\.(\d+)(?:\.\d+)?$`)
 
+// NewVersionFromString parses the major and minor version from the given string. If
+// the string does not look like a parseable version, a false-valued flag is returned.
 func NewVersionFromString(v string) (Version, bool) {
 	if matches := versionPattern.FindStringSubmatch(v); len(matches) >= 3 {
 		major, _ := strconv.Atoi(matches[1])

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -42,6 +42,23 @@ func (v Version) GitTag() string {
 	return fmt.Sprintf("v%d.%d.0", v.Major, v.Minor)
 }
 
+// Next returns the next minor version immediately following the receiver.
+func (v Version) Next() Version {
+	lastMinorVersionInMajorRelease := map[int]int{
+		// TODO: Determine last minor version in Sourcegraph v3; e.g., `3: 47, // 3.47.0 -> 4.0.0`
+	}
+
+	if minor, ok := lastMinorVersionInMajorRelease[v.Major]; ok && minor == v.Minor {
+		// We're at terminal minor version for some major release
+		// :tada:
+		// Bump the major version and reset the minor version
+		return NewVersion(v.Major+1, 0)
+	}
+
+	// Bump minor version
+	return NewVersion(v.Major, v.Minor+1)
+}
+
 type VersionOrder int
 
 const (

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -38,6 +38,10 @@ func (v Version) String() string {
 	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 }
 
+func (v Version) GitTag() string {
+	return fmt.Sprintf("v%d.%d.0", v.Major, v.Minor)
+}
+
 type VersionOrder int
 
 const (

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -46,7 +46,7 @@ func (v Version) GitTag() string {
 // Next returns the next minor version immediately following the receiver.
 func (v Version) Next() Version {
 	lastMinorVersionInMajorRelease := map[int]int{
-		3: 47, // 3.47.0 -> 4.0.0
+		3: 43, // 3.43.0 -> 4.0.0
 	}
 
 	if minor, ok := lastMinorVersionInMajorRelease[v.Major]; ok && minor == v.Minor {

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -46,7 +46,7 @@ func (v Version) GitTag() string {
 // Next returns the next minor version immediately following the receiver.
 func (v Version) Next() Version {
 	lastMinorVersionInMajorRelease := map[int]int{
-		// TODO: Determine last minor version in Sourcegraph v3; e.g., `3: 47, // 3.47.0 -> 4.0.0`
+		3: 47, // 3.47.0 -> 4.0.0
 	}
 
 	if minor, ok := lastMinorVersionInMajorRelease[v.Major]; ok && minor == v.Minor {

--- a/internal/oobmigration/version_test.go
+++ b/internal/oobmigration/version_test.go
@@ -1,13 +1,16 @@
 package oobmigration
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestCompareVersions(t *testing.T) {
 	testCases := []struct {
 		left     Version
 		right    Version
 		expected VersionOrder
-		err      bool
 	}{
 		{left: NewVersion(3, 12), right: NewVersion(3, 12), expected: VersionOrderEqual},
 		{left: NewVersion(3, 11), right: NewVersion(3, 12), expected: VersionOrderBefore},

--- a/internal/oobmigration/version_test.go
+++ b/internal/oobmigration/version_test.go
@@ -23,3 +23,36 @@ func TestCompareVersions(t *testing.T) {
 		}
 	}
 }
+
+func TestUpgradeRange(t *testing.T) {
+	testCases := []struct {
+		from     Version
+		to       Version
+		expected []Version
+		err      bool
+	}{
+		{from: Version{3, 12}, to: Version{3, 10}, err: true},
+		{from: Version{3, 12}, to: Version{3, 12}, err: true},
+		{from: Version{3, 12}, to: Version{3, 13}, expected: []Version{{3, 12}, {3, 13}}},
+		{from: Version{3, 12}, to: Version{3, 16}, expected: []Version{{3, 12}, {3, 13}, {3, 14}, {3, 15}, {3, 16}}},
+		{from: Version{3, 45}, to: Version{4, 2}, expected: []Version{{3, 45}, {3, 46}, {3, 47}, {4, 0}, {4, 1}, {4, 2}}},
+	}
+
+	for _, testCase := range testCases {
+		versions, err := UpgradeRange(testCase.from, testCase.to)
+		if err != nil {
+			if testCase.err {
+				continue
+			}
+
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if testCase.err {
+			t.Errorf("expected error")
+		} else {
+			if diff := cmp.Diff(testCase.expected, versions); diff != "" {
+				t.Errorf("unexpected versions (-want +got):\n%s", diff)
+			}
+		}
+	}
+}

--- a/internal/oobmigration/version_test.go
+++ b/internal/oobmigration/version_test.go
@@ -38,7 +38,7 @@ func TestUpgradeRange(t *testing.T) {
 		{from: Version{3, 12}, to: Version{3, 12}, err: true},
 		{from: Version{3, 12}, to: Version{3, 13}, expected: []Version{{3, 12}, {3, 13}}},
 		{from: Version{3, 12}, to: Version{3, 16}, expected: []Version{{3, 12}, {3, 13}, {3, 14}, {3, 15}, {3, 16}}},
-		{from: Version{3, 45}, to: Version{4, 2}, expected: []Version{{3, 45}, {3, 46}, {3, 47}, {4, 0}, {4, 1}, {4, 2}}},
+		{from: Version{3, 42}, to: Version{4, 2}, expected: []Version{{3, 42}, {3, 43}, {4, 0}, {4, 1}, {4, 2}}},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This PR adds a new functions to the oobmigration package to help with version operations.

## Test plan

New unit tests.