### PR TITLE
frontend: redact cookie for /-/debug/headers

### DIFF
--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -82,8 +82,12 @@ func NewHandler(db database.DB, githubAppCloudSetupHandler http.Handler) http.Ha
 	r.Get(router.Editor).Handler(trace.Route(errorutil.Handler(serveEditor(db))))
 
 	r.Get(router.DebugHeaders).Handler(trace.Route(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Header.Del("Cookie")
-		_ = r.Header.Write(w)
+		h := r.Header.Clone()
+		// We redact Cookie to prevent XSS attacks.
+		if len(h.Values("Cookie")) > 0 {
+			h.Set("Cookie", "REDACTED")
+		}
+		_ = h.Write(w)
 	})))
 	addDebugHandlers(r.Get(router.Debug).Subrouter(), db)
 

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -83,7 +83,7 @@ func NewHandler(db database.DB, githubAppCloudSetupHandler http.Handler) http.Ha
 
 	r.Get(router.DebugHeaders).Handler(trace.Route(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := r.Header.Clone()
-		// We redact Cookie to prevent XSS attacks.
+		// We redact Cookie to prevent XSS attacks from stealing sessions.
 		if len(h.Values("Cookie")) > 0 {
 			h.Set("Cookie", "REDACTED")
 		}


### PR DESCRIPTION
Instead of just removing the cookie, we instead redact it. This is to atleast tell users there is a cookie set.

Test Plan: visit /-/debug/headers

Part of https://github.com/sourcegraph/sourcegraph/issues/37873