### PR TITLE
gqltest: split tests so that every test case is run against the clean database

### DIFF
--- a/dev/gqltest/bitbucket_projects_perms_sync_test.go
+++ b/dev/gqltest/bitbucket_projects_perms_sync_test.go
@@ -13,13 +13,236 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func TestBitbucketProjectsPermsSync(t *testing.T) {
+const (
+	projectKey     = "SOURCEGRAPH"
+	clonedRepoName = "bbs/SOURCEGRAPH/jsonrpc2"
+)
+
+func TestBitbucketProjectsPermsSync_SetUnrestrictedPermissions(t *testing.T) {
 	if len(*bbsURL) == 0 || len(*bbsToken) == 0 || len(*bbsUsername) == 0 {
 		t.Skip("Environment variable BITBUCKET_SERVER_URL, BITBUCKET_SERVER_TOKEN, or BITBUCKET_SERVER_USERNAME is not set")
 	}
 
-	// Set up external service
-	esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
+	// External service setup
+	esID, err := setUpExternalService(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err := client.DeleteExternalService(esID, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Triggering the sync job
+	unrestricted := true
+	err = client.SetRepositoryPermissionsForBitbucketProject(gqltestutil.BitbucketProjectPermsSyncArgs{
+		ProjectKey:      projectKey,
+		CodeHost:        esID,
+		UserPermissions: make([]types.UserPermission, 0),
+		Unrestricted:    &unrestricted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait up to 30 seconds for worker to finish the permissions sync.
+	err = waitForSyncJobToFinish()
+	if err != nil {
+		t.Fatal("Waiting for repository permissions to be synced:", err)
+	}
+
+	// Perform the checks
+	permissionsInfo, err := client.RepositoryPermissionsInfo(clonedRepoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if permissionsInfo.Permissions[0] != "READ" {
+		t.Fatal("READ permission hasn't been set", err)
+	}
+
+	if !permissionsInfo.Unrestricted {
+		t.Fatal("unrestricted permission hasn't been set", err)
+	}
+}
+
+func TestBitbucketProjectsPermsSync_SetPendingPermissions_NonExistentUsersOnly(t *testing.T) {
+	if len(*bbsURL) == 0 || len(*bbsToken) == 0 || len(*bbsUsername) == 0 {
+		t.Skip("Environment variable BITBUCKET_SERVER_URL, BITBUCKET_SERVER_TOKEN, or BITBUCKET_SERVER_USERNAME is not set")
+	}
+
+	// External service setup
+	esID, err := setUpExternalService(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err := client.DeleteExternalService(esID, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Triggering the sync job
+	unrestricted := false
+	err = client.SetRepositoryPermissionsForBitbucketProject(gqltestutil.BitbucketProjectPermsSyncArgs{
+		ProjectKey: projectKey,
+		CodeHost:   esID,
+		UserPermissions: []types.UserPermission{
+			{
+				BindID:     "some-user-1@domain.com",
+				Permission: "READ",
+			},
+			{
+				BindID:     "some-user-2@domain.com",
+				Permission: "READ",
+			},
+			{
+				BindID:     "some-user-3@domain.com",
+				Permission: "READ",
+			},
+		},
+		Unrestricted: &unrestricted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait up to 30 seconds for worker to finish the permissions sync.
+	err = waitForSyncJobToFinish()
+	if err != nil {
+		t.Fatal("Waiting for repository permissions to be synced:", err)
+	}
+
+	// Perform the checks
+	pendingPerms, err := client.UsersWithPendingPermissions()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pendingPerms) != 3 {
+		t.Fatalf("Expected 3 pending permissions entries, got: %d", len(pendingPerms))
+	}
+
+	want := []string{
+		"some-user-1@domain.com",
+		"some-user-2@domain.com",
+		"some-user-3@domain.com",
+	}
+
+	if diff := cmp.Diff(want, pendingPerms); diff != "" {
+		t.Fatalf("Pending permissions mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBitbucketProjectsPermsSync_SetPendingPermissions_ExistentAndNonExistentUsers(t *testing.T) {
+	if len(*bbsURL) == 0 || len(*bbsToken) == 0 || len(*bbsUsername) == 0 {
+		t.Skip("Environment variable BITBUCKET_SERVER_URL, BITBUCKET_SERVER_TOKEN, or BITBUCKET_SERVER_USERNAME is not set")
+	}
+
+	// External service setup
+	esID, err := setUpExternalService(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err := client.DeleteExternalService(esID, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Triggering the sync job
+	unrestricted := false
+	err = client.SetRepositoryPermissionsForBitbucketProject(gqltestutil.BitbucketProjectPermsSyncArgs{
+		ProjectKey: projectKey,
+		CodeHost:   esID,
+		UserPermissions: []types.UserPermission{
+			{
+				BindID:     "gqltest@sourcegraph.com", // existing user
+				Permission: "READ",
+			},
+			{
+				BindID:     "some-user-2@domain.com",
+				Permission: "READ",
+			},
+			{
+				BindID:     "some-user-3@domain.com",
+				Permission: "READ",
+			},
+		},
+		Unrestricted: &unrestricted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait up to 30 seconds for worker to finish the permissions sync.
+	err = waitForSyncJobToFinish()
+	if err != nil {
+		t.Fatal("Waiting for repository permissions to be synced:", err)
+	}
+
+	// Perform the checks
+	// First we check pending permissions
+	pendingPerms, err := client.UsersWithPendingPermissions()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"some-user-2@domain.com",
+		"some-user-3@domain.com",
+	}
+
+	if diff := cmp.Diff(want, pendingPerms); diff != "" {
+		t.Fatalf("Pending permissions mismatch (-want +got):\n%s", diff)
+	}
+
+	// Then we check existing user permissions
+	permissionsInfo, err := client.UserPermissions(*username)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(permissionsInfo) == 0 {
+		t.Fatalf("User '%s' has no expected permissions", *username)
+	}
+
+	if permissionsInfo[0] != "READ" {
+		t.Fatalf("READ permission hasn't been set for user '%s'", *username)
+	}
+}
+
+func waitForSyncJobToFinish() error {
+	return gqltestutil.Retry(30*time.Second, func() error {
+		status, failureMessage, err := client.GetLastBitbucketProjectPermissionJob(projectKey)
+		if err != nil || status == "" {
+			return errors.New("Error during getting the status of a Bitbucket Permissions job")
+		}
+
+		if status == "errored" || status == "failed" {
+			return errors.Newf("Bitbucket Permissions job failed with status: '%s' and failure message: '%s'", status, failureMessage)
+		}
+
+		if status == "completed" {
+			return nil
+		}
+		return gqltestutil.ErrContinueRetry
+	})
+}
+
+func setUpExternalService(t *testing.T) (esID string, err error) {
+	t.Helper()
+	// Set up external service.
+	// It is configured to clone only "SOURCEGRAPH/jsonrpc2" repo, but this project
+	// also has another repo "empty-repo-1"
+	esID, err = client.AddExternalService(gqltestutil.AddExternalServiceInput{
 		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "gqltest-bitbucket-server",
 		Config: mustMarshalJSONString(struct {
@@ -40,185 +263,12 @@ func TestBitbucketProjectsPermsSync(t *testing.T) {
 	// The repo-updater might not be up yet, but it will eventually catch up for the
 	// external service we just added, thus it is OK to ignore this transient error.
 	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
-		t.Fatal(err)
+		return "", err
 	}
-	defer func() {
-		err := client.DeleteExternalService(esID, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
 
-	const repoName = "bbs/SOURCEGRAPH/jsonrpc2"
-	err = client.WaitForReposToBeCloned(repoName)
+	err = client.WaitForReposToBeCloned(clonedRepoName)
 	if err != nil {
-		t.Fatal(err)
+		return "", err
 	}
-
-	const projectKey = "SOURCEGRAPH"
-
-	tests := []struct {
-		name         string
-		projectKey   string
-		codeHost     string
-		userPerms    []types.UserPermission
-		unrestricted bool
-		checkFunc    func() error
-	}{
-		{
-			name:         "Setting unrestricted permissions",
-			projectKey:   projectKey,
-			codeHost:     esID,
-			userPerms:    make([]types.UserPermission, 0),
-			unrestricted: true,
-			checkFunc: func() error {
-				permissionsInfo, err := client.RepositoryPermissionsInfo(repoName)
-				if err != nil {
-					return err
-				}
-
-				if permissionsInfo.Permissions[0] != "READ" {
-					return errors.Wrap(err, "READ permission hasn't been set")
-				}
-
-				if !permissionsInfo.Unrestricted {
-					return errors.Wrap(err, "unrestricted permission hasn't been set:")
-				}
-				return nil
-			},
-		},
-		{
-			name:       "Setting pending permissions for non-existing users",
-			projectKey: projectKey,
-			codeHost:   esID,
-			userPerms: []types.UserPermission{
-				{
-					BindID:     "some-user-1@domain.com",
-					Permission: "READ",
-				},
-				{
-					BindID:     "some-user-2@domain.com",
-					Permission: "READ",
-				},
-				{
-					BindID:     "some-user-3@domain.com",
-					Permission: "READ",
-				},
-			},
-			unrestricted: false,
-			checkFunc: func() error {
-				pendingPerms, err := client.UsersWithPendingPermissions()
-				if err != nil {
-					return err
-				}
-
-				if len(pendingPerms) != 3 {
-					return errors.Newf("Expected 3 pending permissions entries, got: %d", len(pendingPerms))
-				}
-
-				want := []string{
-					"some-user-1@domain.com",
-					"some-user-2@domain.com",
-					"some-user-3@domain.com",
-				}
-
-				if diff := cmp.Diff(want, pendingPerms); diff != "" {
-					return errors.Newf("Pending permissions mismatch (-want +got):\n%s", diff)
-				}
-
-				return nil
-			},
-		},
-		{
-			name:       "Setting permissions for both existing and non-existing users",
-			projectKey: projectKey,
-			codeHost:   esID,
-			userPerms: []types.UserPermission{
-				{
-					BindID:     "gqltest@sourcegraph.com", // existing user
-					Permission: "READ",
-				},
-				{
-					BindID:     "some-user-2@domain.com",
-					Permission: "READ",
-				},
-				{
-					BindID:     "some-user-3@domain.com",
-					Permission: "READ",
-				},
-			},
-			unrestricted: false,
-			checkFunc: func() error {
-				// First we check pending permissions
-				pendingPerms, err := client.UsersWithPendingPermissions()
-				if err != nil {
-					return err
-				}
-
-				want := []string{
-					"some-user-2@domain.com",
-					"some-user-3@domain.com",
-				}
-
-				if diff := cmp.Diff(want, pendingPerms); diff != "" {
-					return errors.Newf("Pending permissions mismatch (-want +got):\n%s", diff)
-				}
-
-				// Then we check existing user permissions
-				permissionsInfo, err := client.UserPermissions(*username)
-				if err != nil {
-					return err
-				}
-
-				if len(permissionsInfo) == 0 {
-					return errors.Newf("User '%s' has no expected permissions", *username)
-				}
-
-				if permissionsInfo[0] != "READ" {
-					return errors.Wrapf(err, "READ permission hasn't been set for user '%s'", *username)
-				}
-
-				return nil
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err = client.SetRepositoryPermissionsForBitbucketProject(gqltestutil.BitbucketProjectPermsSyncArgs{
-				ProjectKey:      test.projectKey,
-				CodeHost:        test.codeHost,
-				UserPermissions: test.userPerms,
-				Unrestricted:    &test.unrestricted,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Wait up to 30 seconds for worker to finish the permissions sync.
-			err = gqltestutil.Retry(30*time.Second, func() error {
-				status, failureMessage, err := client.GetLastBitbucketProjectPermissionJob(projectKey)
-				if err != nil || status == "" {
-					t.Fatal("Error during getting the status of a Bitbucket Permissions job")
-				}
-
-				if status == "errored" || status == "failed" {
-					t.Fatalf("Bitbucket Permissions job failed with status: '%s' and failure message: '%s'", status, failureMessage)
-				}
-
-				if status == "completed" {
-					return nil
-				}
-				return gqltestutil.ErrContinueRetry
-			})
-			if err != nil {
-				t.Fatal("Waiting for repository permissions to be synced:", err)
-			}
-
-			// Perform checks described in the test case
-			if err = test.checkFunc(); err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
+	return
 }

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	repoName   = "perforce/test-perms"
-	aliceEmail = "alice@perforce.sgdev.org"
+	perforceRepoName = "perforce/test-perms"
+	aliceEmail       = "alice@perforce.sgdev.org"
 )
 
 func TestSubRepoPermissionsPerforce(t *testing.T) {
@@ -82,7 +82,7 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 	createPerforceExternalService(t)
 	userClient, _ := createTestUserAndWaitForRepo(t)
 
-	err := client.WaitForReposToBeIndexed(repoName)
+	err := client.WaitForReposToBeIndexed(perforceRepoName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,7 +232,7 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 
 	for _, test := range commitAccessTests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := userClient.GitGetCommitMessage(repoName, test.revision)
+			_, err := userClient.GitGetCommitMessage(perforceRepoName, test.revision)
 			if err != nil {
 				if test.hasAccess {
 					t.Fatal(err)
@@ -246,7 +246,7 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 	}
 
 	t.Run("archive repo", func(t *testing.T) {
-		url := fmt.Sprintf("%s/%s/-/raw/", *baseURL, repoName)
+		url := fmt.Sprintf("%s/%s/-/raw/", *baseURL, perforceRepoName)
 		response, err := userClient.GetWithHeaders(url, map[string][]string{"Accept": {"application/zip"}})
 		if err != nil {
 			t.Fatal(err)
@@ -295,11 +295,11 @@ func createTestUserAndWaitForRepo(t *testing.T) (*gqltestutil.Client, string) {
 		t.Fatal(err)
 	}
 
-	err = userClient.WaitForReposToBeCloned(repoName)
+	err = userClient.WaitForReposToBeCloned(perforceRepoName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return userClient, repoName
+	return userClient, perforceRepoName
 }
 
 func enableSubRepoPermissions(t *testing.T) {


### PR DESCRIPTION
Previously every test case was run in the same test function which led to every consequent test case use the database with some state changed from every previous test case. As all the test cases deal with similar tables in the database, this can lead to unexpected behaviour or false positives, which possibility is now eliminated as every test runs against the clean database.

## Test plan
Existing tests should pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
