### PR TITLE
insights: `seriesCount` field does not fail whole gql query

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
@@ -76,6 +76,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
                     // Prevent unnecessary network request after mutation over dashboard or insights within
                     // current dashboard
                     nextFetchPolicy: 'cache-first',
+                    errorPolicy: 'all',
                 })
             ).pipe(
                 map(({ data }) => data.insightViews.nodes.map(createInsightView)),
@@ -90,6 +91,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
                 // Prevent unnecessary network request after mutation over dashboard or insights within
                 // current dashboard
                 nextFetchPolicy: 'cache-first',
+                errorPolicy: 'all',
                 variables: { id: dashboardId },
             })
         ).pipe(
@@ -104,6 +106,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
             this.apolloClient.watchQuery<GetInsightsResult>({
                 query: GET_INSIGHTS_GQL,
                 variables: { id },
+                errorPolicy: 'all',
             })
         ).pipe(
             map(({ data }) => {

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -199,7 +199,7 @@ type InsightViewResolver interface {
 	DefaultSeriesDisplayOptions(ctx context.Context) (InsightViewSeriesDisplayOptionsResolver, error)
 	AppliedSeriesDisplayOptions(ctx context.Context) (InsightViewSeriesDisplayOptionsResolver, error)
 	Dashboards(ctx context.Context, args *InsightsDashboardsArgs) InsightsDashboardConnectionResolver
-	SeriesCount(ctx context.Context) (int32, error)
+	SeriesCount(ctx context.Context) (*int32, error)
 }
 
 type InsightDataSeriesDefinition interface {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -976,7 +976,7 @@ type InsightView implements Node {
     """
     The total number of series on this insight.
     """
-    seriesCount: Int!
+    seriesCount: Int
 }
 
 """

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -357,9 +357,6 @@ func (i *insightViewResolver) IsFrozen(ctx context.Context) (bool, error) {
 func (i *insightViewResolver) SeriesCount(ctx context.Context) (*int32, error) {
 	_, err := i.computeDataSeries(ctx)
 	total := int32(i.totalSeries)
-	if total == 2 {
-		return nil, errors.New("2-series error")
-	}
 	return &total, err
 }
 

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -354,9 +354,13 @@ func (i *insightViewResolver) IsFrozen(ctx context.Context) (bool, error) {
 	return i.view.IsFrozen, nil
 }
 
-func (i *insightViewResolver) SeriesCount(ctx context.Context) (int32, error) {
+func (i *insightViewResolver) SeriesCount(ctx context.Context) (*int32, error) {
 	_, err := i.computeDataSeries(ctx)
-	return int32(i.totalSeries), err
+	total := int32(i.totalSeries)
+	if total == 2 {
+		return nil, errors.New("2-series error")
+	}
+	return &total, err
 }
 
 type searchInsightDataSeriesDefinitionResolver struct {


### PR DESCRIPTION
tackles part of #38951

* `SeriesCount` return value is made nullable
* use `errorPolicy: ’all'` on `insightViews` queries in the webapp

nb. this isn't a catch-all fix, but this creates a blueprint if we are to add more fields to query in the future. I believe that right now `SeriesCount` is the only query that can fail in this way

#### some background:
graphql allows to return both data and errors in its response. however:
* in graphql, if there is an error on a non-nullable field then its whole parent is errored ([spec](https://spec.graphql.org/October2021/#sec-Handling-Field-Errors))

so if we make a field nullable we'll be able to get both data and errors. however that must still be handled correctly by the client.
* the apollo client allows to set an error policy we can use ([docs](https://www.apollographql.com/docs/react/data/queries/#errorpolicy))

## Test plan
The following test plan was ran on both `main` and commit c8524fee4662257ab218a7c08873c77dd613754a (parent of [this PR](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/b18b87a73b592b15fb1f86a3effc6cef14ecfb11) which removed `seriesCount` and the issue)

1. Test ’All insights’ page works, even when an individual insight errors
2. Test a specific dashboard page works, even when an individual insight errors
3. Test single-insight page works, even when the insight errors.

Screenshots:

### before:

| all insights | dashboard | single insight |
| ----- | ----- | ---- |
| <img width="1840" alt="Screenshot 2022-07-27 at 12 32 05" src="https://user-images.githubusercontent.com/29406849/181238945-8f729a29-14dd-4fc5-9499-79073559fde0.png"> | <img width="1840" alt="Screenshot 2022-07-27 at 12 32 01" src="https://user-images.githubusercontent.com/29406849/181238954-9c55718e-a809-4279-96d0-83af887eb9ac.png"> | <img width="1840" alt="Screenshot 2022-07-27 at 12 24 07" src="https://user-images.githubusercontent.com/29406849/181238958-6c25ba47-8925-4109-8252-f905bcd4b68c.png"> |

### after:

| all insights | dashboard | single insight |
| ----- | ----- | ---- |
| <img width="1840" alt="Screenshot 2022-07-27 at 12 29 04" src="https://user-images.githubusercontent.com/29406849/181239010-338d3a18-c2a3-4ae6-8f6e-481aa77a3203.png"> | <img width="1840" alt="Screenshot 2022-07-27 at 12 29 09" src="https://user-images.githubusercontent.com/29406849/181239006-6e6c30e1-66d8-4e2e-b29d-8bed95749ecb.png"> | <img width="1840" alt="Screenshot 2022-07-27 at 12 28 53" src="https://user-images.githubusercontent.com/29406849/181239017-6e1a1a1f-7621-40fb-814d-c719c8e29f60.png"> |

