### PR TITLE
phabricator: Simplify repo create

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -137,7 +137,6 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	})
 
 	m.Get(apirouter.ExternalServiceConfigs).Handler(trace.Route(handler(serveExternalServiceConfigs(db))))
-	m.Get(apirouter.PhabricatorRepoCreate).Handler(trace.Route(handler(servePhabricatorRepoCreate(db))))
 
 	// zoekt-indexserver endpoints
 	indexer := &searchIndexerServer{

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -19,27 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func servePhabricatorRepoCreate(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
-	return func(w http.ResponseWriter, r *http.Request) error {
-		var repo api.PhabricatorRepoCreateRequest
-		err := json.NewDecoder(r.Body).Decode(&repo)
-		if err != nil {
-			return err
-		}
-		phabRepo, err := db.Phabricator().CreateOrUpdate(r.Context(), repo.Callsign, repo.RepoName, repo.URL)
-		if err != nil {
-			return err
-		}
-		data, err := json.Marshal(phabRepo)
-		if err != nil {
-			return err
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(data)
-		return nil
-	}
-}
-
 // serveExternalServiceConfigs serves a JSON response that is an array of all
 // external service configs that match the requested kind.
 func serveExternalServiceConfigs(db database.DB) func(w http.ResponseWriter, r *http.Request) error {

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -32,7 +32,6 @@ const (
 	SendEmail              = "internal.send-email"
 	GitInfoRefs            = "internal.git.info-refs"
 	GitUploadPack          = "internal.git.upload-pack"
-	PhabricatorRepoCreate  = "internal.phabricator.repo.create"
 	ReposIndex             = "internal.repos.index"
 	Configuration          = "internal.configuration"
 	SearchConfiguration    = "internal.search-configuration"
@@ -86,7 +85,6 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/send-email").Methods("POST").Name(SendEmail)
 	base.Path("/git/{RepoName:.*}/info/refs").Methods("GET").Name(GitInfoRefs)
 	base.Path("/git/{RepoName:.*}/git-upload-pack").Methods("GET", "POST").Name(GitUploadPack)
-	base.Path("/phabricator/repo-create").Methods("POST").Name(PhabricatorRepoCreate)
 	base.Path("/external-services/configs").Methods("POST").Name(ExternalServiceConfigs)
 	base.Path("/repos/index").Methods("POST").Name(ReposIndex)
 	base.Path("/configuration").Methods("POST").Name(Configuration)

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -194,7 +194,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		go syncer.RunSyncReposWithLastErrorsWorker(ctx, rateLimiter)
 	}
 
-	go repos.RunPhabricatorRepositorySyncWorker(ctx, log.Scoped("PhabricatorRepositorySyncWorker", ""), store)
+	go repos.RunPhabricatorRepositorySyncWorker(ctx, db, log.Scoped("PhabricatorRepositorySyncWorker", ""), store)
 
 	// git-server repos purging thread
 	var purgeTTL time.Duration

--- a/internal/api/httpapi_schema.go
+++ b/internal/api/httpapi_schema.go
@@ -33,12 +33,6 @@ type RepoCreateOrUpdateRequest struct {
 	Archived bool `json:"archived"`
 }
 
-type PhabricatorRepoCreateRequest struct {
-	RepoName `json:"repo"`
-	Callsign string `json:"callsign"`
-	URL      string `json:"url"`
-}
-
 type ExternalServiceConfigsRequest struct {
 	Kind    string `json:"kind"`
 	Limit   int    `json:"limit"`

--- a/internal/api/internalapi/client.go
+++ b/internal/api/internalapi/client.go
@@ -65,14 +65,6 @@ func (c *internalClient) Configuration(ctx context.Context) (conftypes.RawUnifie
 	return cfg, err
 }
 
-func (c *internalClient) PhabricatorRepoCreate(ctx context.Context, repo api.RepoName, callsign, url string) error {
-	return c.postInternal(ctx, "phabricator/repo-create", api.PhabricatorRepoCreateRequest{
-		RepoName: repo,
-		Callsign: callsign,
-		URL:      url,
-	}, nil)
-}
-
 var MockExternalServiceConfigs func(kind string, result any) error
 
 // ExternalServiceConfigs fetches external service configs of a single kind into the result parameter,


### PR DESCRIPTION
We no longer need to perform a remote call from repo-updater in order to
create a Phabricator repo, we can simply call the DB directly. This
removes the need for an internal handler in frontend to talk to the DB
as well as the client code to call this handler.

Part of https://github.com/sourcegraph/sourcegraph/issues/36290

## Test plan

All tests still pass