### PR TITLE
Remove unused field from code-intel issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/code-intel.md
+++ b/.github/ISSUE_TEMPLATE/code-intel.md
@@ -3,7 +3,6 @@ name: 'Code Intel ፨'
 about: 'Anything related to code navigation, language tools, or language platform (executors, auto-indexing)'
 title: ''
 labels: 'team/code-intelligence'
-projects: 'sourcegraph/211'
 assignees: ''
 
 ---


### PR DESCRIPTION
One of the issue templates has the `projects` key in its header but this key is invalid and it does nothing. Valid keys are: about, title, labels, assignees. That's why I am removing it.
See: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates

## Test plan

No review required