### PR TITLE
Refactor symbols gitserver client and make sure we always use the DB connection

### DIFF
--- a/cmd/symbols/fetcher/mocks_test.go
+++ b/cmd/symbols/fetcher/mocks_test.go
@@ -13,6 +13,8 @@ import (
 
 	gitserver "github.com/sourcegraph/sourcegraph/cmd/symbols/gitserver"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
+	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	types "github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // MockGitserverClient is a mock implementation of the GitserverClient
@@ -29,6 +31,15 @@ type MockGitserverClient struct {
 	// GitDiffFunc is an instance of a mock function object controlling the
 	// behavior of the method GitDiff.
 	GitDiffFunc *GitserverClientGitDiffFunc
+	// LogReverseEachFunc is an instance of a mock function object
+	// controlling the behavior of the method LogReverseEach.
+	LogReverseEachFunc *GitserverClientLogReverseEachFunc
+	// ReadFileFunc is an instance of a mock function object controlling the
+	// behavior of the method ReadFile.
+	ReadFileFunc *GitserverClientReadFileFunc
+	// RevListFunc is an instance of a mock function object controlling the
+	// behavior of the method RevList.
+	RevListFunc *GitserverClientRevListFunc
 }
 
 // NewMockGitserverClient creates a new mock of the GitserverClient
@@ -48,6 +59,21 @@ func NewMockGitserverClient() *MockGitserverClient {
 		},
 		GitDiffFunc: &GitserverClientGitDiffFunc{
 			defaultHook: func(context.Context, api.RepoName, api.CommitID, api.CommitID) (r0 gitserver.Changes, r1 error) {
+				return
+			},
+		},
+		LogReverseEachFunc: &GitserverClientLogReverseEachFunc{
+			defaultHook: func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) (r0 error) {
+				return
+			},
+		},
+		ReadFileFunc: &GitserverClientReadFileFunc{
+			defaultHook: func(context.Context, types.RepoCommitPath) (r0 []byte, r1 error) {
+				return
+			},
+		},
+		RevListFunc: &GitserverClientRevListFunc{
+			defaultHook: func(context.Context, string, string, func(commit string) (bool, error)) (r0 error) {
 				return
 			},
 		},
@@ -73,6 +99,21 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 				panic("unexpected invocation of MockGitserverClient.GitDiff")
 			},
 		},
+		LogReverseEachFunc: &GitserverClientLogReverseEachFunc{
+			defaultHook: func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
+				panic("unexpected invocation of MockGitserverClient.LogReverseEach")
+			},
+		},
+		ReadFileFunc: &GitserverClientReadFileFunc{
+			defaultHook: func(context.Context, types.RepoCommitPath) ([]byte, error) {
+				panic("unexpected invocation of MockGitserverClient.ReadFile")
+			},
+		},
+		RevListFunc: &GitserverClientRevListFunc{
+			defaultHook: func(context.Context, string, string, func(commit string) (bool, error)) error {
+				panic("unexpected invocation of MockGitserverClient.RevList")
+			},
+		},
 	}
 }
 
@@ -89,6 +130,15 @@ func NewMockGitserverClientFrom(i gitserver.GitserverClient) *MockGitserverClien
 		},
 		GitDiffFunc: &GitserverClientGitDiffFunc{
 			defaultHook: i.GitDiff,
+		},
+		LogReverseEachFunc: &GitserverClientLogReverseEachFunc{
+			defaultHook: i.LogReverseEach,
+		},
+		ReadFileFunc: &GitserverClientReadFileFunc{
+			defaultHook: i.ReadFile,
+		},
+		RevListFunc: &GitserverClientRevListFunc{
+			defaultHook: i.RevList,
 		},
 	}
 }
@@ -427,4 +477,339 @@ func (c GitserverClientGitDiffFuncCall) Args() []interface{} {
 // invocation.
 func (c GitserverClientGitDiffFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverClientLogReverseEachFunc describes the behavior when the
+// LogReverseEach method of the parent MockGitserverClient instance is
+// invoked.
+type GitserverClientLogReverseEachFunc struct {
+	defaultHook func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error
+	hooks       []func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error
+	history     []GitserverClientLogReverseEachFuncCall
+	mutex       sync.Mutex
+}
+
+// LogReverseEach delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockGitserverClient) LogReverseEach(v0 context.Context, v1 string, v2 string, v3 int, v4 func(entry gitdomain.LogEntry) error) error {
+	r0 := m.LogReverseEachFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.LogReverseEachFunc.appendCall(GitserverClientLogReverseEachFuncCall{v0, v1, v2, v3, v4, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the LogReverseEach
+// method of the parent MockGitserverClient instance is invoked and the hook
+// queue is empty.
+func (f *GitserverClientLogReverseEachFunc) SetDefaultHook(hook func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// LogReverseEach method of the parent MockGitserverClient instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GitserverClientLogReverseEachFunc) PushHook(hook func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverClientLogReverseEachFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverClientLogReverseEachFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
+		return r0
+	})
+}
+
+func (f *GitserverClientLogReverseEachFunc) nextHook() func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientLogReverseEachFunc) appendCall(r0 GitserverClientLogReverseEachFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientLogReverseEachFuncCall
+// objects describing the invocations of this function.
+func (f *GitserverClientLogReverseEachFunc) History() []GitserverClientLogReverseEachFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientLogReverseEachFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientLogReverseEachFuncCall is an object that describes an
+// invocation of method LogReverseEach on an instance of
+// MockGitserverClient.
+type GitserverClientLogReverseEachFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 int
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 func(entry gitdomain.LogEntry) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientLogReverseEachFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientLogReverseEachFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// GitserverClientReadFileFunc describes the behavior when the ReadFile
+// method of the parent MockGitserverClient instance is invoked.
+type GitserverClientReadFileFunc struct {
+	defaultHook func(context.Context, types.RepoCommitPath) ([]byte, error)
+	hooks       []func(context.Context, types.RepoCommitPath) ([]byte, error)
+	history     []GitserverClientReadFileFuncCall
+	mutex       sync.Mutex
+}
+
+// ReadFile delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockGitserverClient) ReadFile(v0 context.Context, v1 types.RepoCommitPath) ([]byte, error) {
+	r0, r1 := m.ReadFileFunc.nextHook()(v0, v1)
+	m.ReadFileFunc.appendCall(GitserverClientReadFileFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ReadFile method of
+// the parent MockGitserverClient instance is invoked and the hook queue is
+// empty.
+func (f *GitserverClientReadFileFunc) SetDefaultHook(hook func(context.Context, types.RepoCommitPath) ([]byte, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ReadFile method of the parent MockGitserverClient instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *GitserverClientReadFileFunc) PushHook(hook func(context.Context, types.RepoCommitPath) ([]byte, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverClientReadFileFunc) SetDefaultReturn(r0 []byte, r1 error) {
+	f.SetDefaultHook(func(context.Context, types.RepoCommitPath) ([]byte, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverClientReadFileFunc) PushReturn(r0 []byte, r1 error) {
+	f.PushHook(func(context.Context, types.RepoCommitPath) ([]byte, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverClientReadFileFunc) nextHook() func(context.Context, types.RepoCommitPath) ([]byte, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientReadFileFunc) appendCall(r0 GitserverClientReadFileFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientReadFileFuncCall objects
+// describing the invocations of this function.
+func (f *GitserverClientReadFileFunc) History() []GitserverClientReadFileFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientReadFileFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientReadFileFuncCall is an object that describes an invocation
+// of method ReadFile on an instance of MockGitserverClient.
+type GitserverClientReadFileFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 types.RepoCommitPath
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []byte
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientReadFileFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientReadFileFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverClientRevListFunc describes the behavior when the RevList method
+// of the parent MockGitserverClient instance is invoked.
+type GitserverClientRevListFunc struct {
+	defaultHook func(context.Context, string, string, func(commit string) (bool, error)) error
+	hooks       []func(context.Context, string, string, func(commit string) (bool, error)) error
+	history     []GitserverClientRevListFuncCall
+	mutex       sync.Mutex
+}
+
+// RevList delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockGitserverClient) RevList(v0 context.Context, v1 string, v2 string, v3 func(commit string) (bool, error)) error {
+	r0 := m.RevListFunc.nextHook()(v0, v1, v2, v3)
+	m.RevListFunc.appendCall(GitserverClientRevListFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RevList method of
+// the parent MockGitserverClient instance is invoked and the hook queue is
+// empty.
+func (f *GitserverClientRevListFunc) SetDefaultHook(hook func(context.Context, string, string, func(commit string) (bool, error)) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RevList method of the parent MockGitserverClient instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *GitserverClientRevListFunc) PushHook(hook func(context.Context, string, string, func(commit string) (bool, error)) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverClientRevListFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, string, func(commit string) (bool, error)) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverClientRevListFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, string, func(commit string) (bool, error)) error {
+		return r0
+	})
+}
+
+func (f *GitserverClientRevListFunc) nextHook() func(context.Context, string, string, func(commit string) (bool, error)) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientRevListFunc) appendCall(r0 GitserverClientRevListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientRevListFuncCall objects
+// describing the invocations of this function.
+func (f *GitserverClientRevListFunc) History() []GitserverClientRevListFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientRevListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientRevListFuncCall is an object that describes an invocation
+// of method RevList on an instance of MockGitserverClient.
+type GitserverClientRevListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 func(commit string) (bool, error)
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientRevListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientRevListFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }

--- a/cmd/symbols/fetcher/repository_fetcher.go
+++ b/cmd/symbols/fetcher/repository_fetcher.go
@@ -14,7 +14,7 @@ import (
 )
 
 type RepositoryFetcher interface {
-	FetchRepositoryArchive(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) <-chan parseRequestOrError
+	FetchRepositoryArchive(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) <-chan ParseRequestOrError
 }
 
 type repositoryFetcher struct {
@@ -29,7 +29,7 @@ type ParseRequest struct {
 	Data []byte
 }
 
-type parseRequestOrError struct {
+type ParseRequestOrError struct {
 	ParseRequest ParseRequest
 	Err          error
 }
@@ -43,16 +43,16 @@ func NewRepositoryFetcher(gitserverClient gitserver.GitserverClient, maxTotalPat
 	}
 }
 
-func (f *repositoryFetcher) FetchRepositoryArchive(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) <-chan parseRequestOrError {
-	requestCh := make(chan parseRequestOrError)
+func (f *repositoryFetcher) FetchRepositoryArchive(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) <-chan ParseRequestOrError {
+	requestCh := make(chan ParseRequestOrError)
 
 	go func() {
 		defer close(requestCh)
 
 		if err := f.fetchRepositoryArchive(ctx, repo, commit, paths, func(request ParseRequest) {
-			requestCh <- parseRequestOrError{ParseRequest: request}
+			requestCh <- ParseRequestOrError{ParseRequest: request}
 		}); err != nil {
-			requestCh <- parseRequestOrError{Err: err}
+			requestCh <- ParseRequestOrError{Err: err}
 		}
 	}()
 

--- a/cmd/symbols/fetcher/repository_fetcher_test.go
+++ b/cmd/symbols/fetcher/repository_fetcher_test.go
@@ -62,7 +62,7 @@ func TestRepositoryFetcher(t *testing.T) {
 	})
 }
 
-func consumeParseRequests(t *testing.T, ch <-chan parseRequestOrError) map[string]string {
+func consumeParseRequests(t *testing.T, ch <-chan ParseRequestOrError) map[string]string {
 	parseRequests := map[string]string{}
 	for v := range ch {
 		if v.Err != nil {

--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -17,6 +17,7 @@ import (
 
 func NewHandler(
 	searchFunc types.SearchFunc,
+	readFileFunc squirrel.ReadFileFunc,
 	handleStatus func(http.ResponseWriter, *http.Request),
 	ctagsBinary string,
 ) http.Handler {
@@ -24,9 +25,9 @@ func NewHandler(
 	mux.HandleFunc("/search", handleSearchWith(searchFunc))
 	mux.HandleFunc("/healthz", handleHealthCheck)
 	mux.HandleFunc("/list-languages", handleListLanguages(ctagsBinary))
-	mux.HandleFunc("/localCodeIntel", squirrel.LocalCodeIntelHandler)
+	mux.HandleFunc("/localCodeIntel", squirrel.LocalCodeIntelHandler(readFileFunc))
 	mux.HandleFunc("/debugLocalCodeIntel", squirrel.DebugLocalCodeIntelHandler)
-	mux.HandleFunc("/symbolInfo", squirrel.NewSymbolInfoHandler(searchFunc))
+	mux.HandleFunc("/symbolInfo", squirrel.NewSymbolInfoHandler(searchFunc, readFileFunc))
 	if handleStatus != nil {
 		mux.HandleFunc("/status", handleStatus)
 	}

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -65,7 +65,7 @@ func TestHandler(t *testing.T) {
 	parser := parser.NewParser(parserPool, fetcher.NewRepositoryFetcher(gitserverClient, 1000, 1_000_000, &observation.TestContext), 0, 10, &observation.TestContext)
 	databaseWriter := writer.NewDatabaseWriter(tmpDir, gitserverClient, parser, semaphore.NewWeighted(1))
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
-	handler := NewHandler(MakeSqliteSearchFunc(sharedobservability.NewOperations(&observation.TestContext), cachedDatabaseWriter, gitserverClient), nil, "")
+	handler := NewHandler(MakeSqliteSearchFunc(sharedobservability.NewOperations(&observation.TestContext), cachedDatabaseWriter, gitserverClient), gitserverClient.ReadFile, nil, "")
 
 	server := httptest.NewServer(handler)
 	defer server.Close()

--- a/cmd/symbols/internal/api/mocks_test.go
+++ b/cmd/symbols/internal/api/mocks_test.go
@@ -13,6 +13,8 @@ import (
 
 	gitserver "github.com/sourcegraph/sourcegraph/cmd/symbols/gitserver"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
+	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	types "github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // MockGitserverClient is a mock implementation of the GitserverClient
@@ -29,6 +31,15 @@ type MockGitserverClient struct {
 	// GitDiffFunc is an instance of a mock function object controlling the
 	// behavior of the method GitDiff.
 	GitDiffFunc *GitserverClientGitDiffFunc
+	// LogReverseEachFunc is an instance of a mock function object
+	// controlling the behavior of the method LogReverseEach.
+	LogReverseEachFunc *GitserverClientLogReverseEachFunc
+	// ReadFileFunc is an instance of a mock function object controlling the
+	// behavior of the method ReadFile.
+	ReadFileFunc *GitserverClientReadFileFunc
+	// RevListFunc is an instance of a mock function object controlling the
+	// behavior of the method RevList.
+	RevListFunc *GitserverClientRevListFunc
 }
 
 // NewMockGitserverClient creates a new mock of the GitserverClient
@@ -48,6 +59,21 @@ func NewMockGitserverClient() *MockGitserverClient {
 		},
 		GitDiffFunc: &GitserverClientGitDiffFunc{
 			defaultHook: func(context.Context, api.RepoName, api.CommitID, api.CommitID) (r0 gitserver.Changes, r1 error) {
+				return
+			},
+		},
+		LogReverseEachFunc: &GitserverClientLogReverseEachFunc{
+			defaultHook: func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) (r0 error) {
+				return
+			},
+		},
+		ReadFileFunc: &GitserverClientReadFileFunc{
+			defaultHook: func(context.Context, types.RepoCommitPath) (r0 []byte, r1 error) {
+				return
+			},
+		},
+		RevListFunc: &GitserverClientRevListFunc{
+			defaultHook: func(context.Context, string, string, func(commit string) (bool, error)) (r0 error) {
 				return
 			},
 		},
@@ -73,6 +99,21 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 				panic("unexpected invocation of MockGitserverClient.GitDiff")
 			},
 		},
+		LogReverseEachFunc: &GitserverClientLogReverseEachFunc{
+			defaultHook: func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
+				panic("unexpected invocation of MockGitserverClient.LogReverseEach")
+			},
+		},
+		ReadFileFunc: &GitserverClientReadFileFunc{
+			defaultHook: func(context.Context, types.RepoCommitPath) ([]byte, error) {
+				panic("unexpected invocation of MockGitserverClient.ReadFile")
+			},
+		},
+		RevListFunc: &GitserverClientRevListFunc{
+			defaultHook: func(context.Context, string, string, func(commit string) (bool, error)) error {
+				panic("unexpected invocation of MockGitserverClient.RevList")
+			},
+		},
 	}
 }
 
@@ -89,6 +130,15 @@ func NewMockGitserverClientFrom(i gitserver.GitserverClient) *MockGitserverClien
 		},
 		GitDiffFunc: &GitserverClientGitDiffFunc{
 			defaultHook: i.GitDiff,
+		},
+		LogReverseEachFunc: &GitserverClientLogReverseEachFunc{
+			defaultHook: i.LogReverseEach,
+		},
+		ReadFileFunc: &GitserverClientReadFileFunc{
+			defaultHook: i.ReadFile,
+		},
+		RevListFunc: &GitserverClientRevListFunc{
+			defaultHook: i.RevList,
 		},
 	}
 }
@@ -427,4 +477,339 @@ func (c GitserverClientGitDiffFuncCall) Args() []interface{} {
 // invocation.
 func (c GitserverClientGitDiffFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverClientLogReverseEachFunc describes the behavior when the
+// LogReverseEach method of the parent MockGitserverClient instance is
+// invoked.
+type GitserverClientLogReverseEachFunc struct {
+	defaultHook func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error
+	hooks       []func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error
+	history     []GitserverClientLogReverseEachFuncCall
+	mutex       sync.Mutex
+}
+
+// LogReverseEach delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockGitserverClient) LogReverseEach(v0 context.Context, v1 string, v2 string, v3 int, v4 func(entry gitdomain.LogEntry) error) error {
+	r0 := m.LogReverseEachFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.LogReverseEachFunc.appendCall(GitserverClientLogReverseEachFuncCall{v0, v1, v2, v3, v4, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the LogReverseEach
+// method of the parent MockGitserverClient instance is invoked and the hook
+// queue is empty.
+func (f *GitserverClientLogReverseEachFunc) SetDefaultHook(hook func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// LogReverseEach method of the parent MockGitserverClient instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GitserverClientLogReverseEachFunc) PushHook(hook func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverClientLogReverseEachFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverClientLogReverseEachFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
+		return r0
+	})
+}
+
+func (f *GitserverClientLogReverseEachFunc) nextHook() func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientLogReverseEachFunc) appendCall(r0 GitserverClientLogReverseEachFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientLogReverseEachFuncCall
+// objects describing the invocations of this function.
+func (f *GitserverClientLogReverseEachFunc) History() []GitserverClientLogReverseEachFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientLogReverseEachFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientLogReverseEachFuncCall is an object that describes an
+// invocation of method LogReverseEach on an instance of
+// MockGitserverClient.
+type GitserverClientLogReverseEachFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 int
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 func(entry gitdomain.LogEntry) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientLogReverseEachFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientLogReverseEachFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// GitserverClientReadFileFunc describes the behavior when the ReadFile
+// method of the parent MockGitserverClient instance is invoked.
+type GitserverClientReadFileFunc struct {
+	defaultHook func(context.Context, types.RepoCommitPath) ([]byte, error)
+	hooks       []func(context.Context, types.RepoCommitPath) ([]byte, error)
+	history     []GitserverClientReadFileFuncCall
+	mutex       sync.Mutex
+}
+
+// ReadFile delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockGitserverClient) ReadFile(v0 context.Context, v1 types.RepoCommitPath) ([]byte, error) {
+	r0, r1 := m.ReadFileFunc.nextHook()(v0, v1)
+	m.ReadFileFunc.appendCall(GitserverClientReadFileFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ReadFile method of
+// the parent MockGitserverClient instance is invoked and the hook queue is
+// empty.
+func (f *GitserverClientReadFileFunc) SetDefaultHook(hook func(context.Context, types.RepoCommitPath) ([]byte, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ReadFile method of the parent MockGitserverClient instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *GitserverClientReadFileFunc) PushHook(hook func(context.Context, types.RepoCommitPath) ([]byte, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverClientReadFileFunc) SetDefaultReturn(r0 []byte, r1 error) {
+	f.SetDefaultHook(func(context.Context, types.RepoCommitPath) ([]byte, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverClientReadFileFunc) PushReturn(r0 []byte, r1 error) {
+	f.PushHook(func(context.Context, types.RepoCommitPath) ([]byte, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverClientReadFileFunc) nextHook() func(context.Context, types.RepoCommitPath) ([]byte, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientReadFileFunc) appendCall(r0 GitserverClientReadFileFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientReadFileFuncCall objects
+// describing the invocations of this function.
+func (f *GitserverClientReadFileFunc) History() []GitserverClientReadFileFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientReadFileFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientReadFileFuncCall is an object that describes an invocation
+// of method ReadFile on an instance of MockGitserverClient.
+type GitserverClientReadFileFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 types.RepoCommitPath
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []byte
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientReadFileFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientReadFileFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverClientRevListFunc describes the behavior when the RevList method
+// of the parent MockGitserverClient instance is invoked.
+type GitserverClientRevListFunc struct {
+	defaultHook func(context.Context, string, string, func(commit string) (bool, error)) error
+	hooks       []func(context.Context, string, string, func(commit string) (bool, error)) error
+	history     []GitserverClientRevListFuncCall
+	mutex       sync.Mutex
+}
+
+// RevList delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockGitserverClient) RevList(v0 context.Context, v1 string, v2 string, v3 func(commit string) (bool, error)) error {
+	r0 := m.RevListFunc.nextHook()(v0, v1, v2, v3)
+	m.RevListFunc.appendCall(GitserverClientRevListFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RevList method of
+// the parent MockGitserverClient instance is invoked and the hook queue is
+// empty.
+func (f *GitserverClientRevListFunc) SetDefaultHook(hook func(context.Context, string, string, func(commit string) (bool, error)) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RevList method of the parent MockGitserverClient instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *GitserverClientRevListFunc) PushHook(hook func(context.Context, string, string, func(commit string) (bool, error)) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverClientRevListFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, string, func(commit string) (bool, error)) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverClientRevListFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, string, func(commit string) (bool, error)) error {
+		return r0
+	})
+}
+
+func (f *GitserverClientRevListFunc) nextHook() func(context.Context, string, string, func(commit string) (bool, error)) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientRevListFunc) appendCall(r0 GitserverClientRevListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientRevListFuncCall objects
+// describing the invocations of this function.
+func (f *GitserverClientRevListFunc) History() []GitserverClientRevListFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientRevListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientRevListFuncCall is an object that describes an invocation
+// of method RevList on an instance of MockGitserverClient.
+type GitserverClientRevListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 func(commit string) (bool, error)
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientRevListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientRevListFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }

--- a/cmd/symbols/squirrel/service.go
+++ b/cmd/symbols/squirrel/service.go
@@ -10,8 +10,6 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 
 	symbolsTypes "github.com/sourcegraph/sourcegraph/cmd/symbols/types"
-	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -122,15 +120,6 @@ func (squirrel *SquirrelService) symbolInfo(ctx context.Context, point types.Rep
 		Definition: *def,
 		Hover:      hover,
 	}, nil
-}
-
-// How to read a file from gitserver.
-func readFileFromGitserver(ctx context.Context, repoCommitPath types.RepoCommitPath) ([]byte, error) {
-	data, err := gitserver.NewClient(nil).ReadFile(ctx, api.RepoName(repoCommitPath.Repo), api.CommitID(repoCommitPath.Commit), repoCommitPath.Path, nil)
-	if err != nil {
-		return nil, errors.Newf("failed to get file contents: %s", err)
-	}
-	return data, nil
 }
 
 // DirOrNode is a union type that can either be a directory or a node. It's returned by getDef().

--- a/enterprise/internal/rockskip/git.go
+++ b/enterprise/internal/rockskip/git.go
@@ -1,12 +1,43 @@
 package rockskip
 
 import (
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/symbols/fetcher"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type Git interface {
-	LogReverseEach(repo string, db database.DB, commit string, n int, onLogEntry func(logEntry gitdomain.LogEntry) error) error
-	RevListEach(repo string, db database.DB, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error
-	ArchiveEach(repo string, commit string, paths []string, onFile func(path string, contents []byte) error) error
+type GitserverClient interface {
+	LogReverseEach(ctx context.Context, repo string, commit string, n int, onLogEntry func(logEntry gitdomain.LogEntry) error) error
+	RevList(ctx context.Context, repo string, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error
+}
+
+func archiveEach(ctx context.Context, fetcher fetcher.RepositoryFetcher, repo string, commit string, paths []string, onFile func(path string, contents []byte) error) error {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	args := search.SymbolsParameters{Repo: api.RepoName(repo), CommitID: api.CommitID(commit)}
+	parseRequestOrErrors := fetcher.FetchRepositoryArchive(ctx, args.Repo, args.CommitID, paths)
+	defer func() {
+		// Ensure the channel is drained
+		for range parseRequestOrErrors {
+		}
+	}()
+
+	for parseRequestOrError := range parseRequestOrErrors {
+		if parseRequestOrError.Err != nil {
+			return errors.Wrap(parseRequestOrError.Err, "FetchRepositoryArchive")
+		}
+
+		err := onFile(parseRequestOrError.ParseRequest.Path, parseRequestOrError.ParseRequest.Data)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/enterprise/internal/rockskip/search.go
+++ b/enterprise/internal/rockskip/search.go
@@ -250,7 +250,7 @@ func (s *Service) querySymbols(ctx context.Context, args search.SymbolsParameter
 	defer parser.Close()
 
 	threadStatus.Tasklog.Start("ArchiveEach")
-	err = s.git.ArchiveEach(string(args.Repo), string(args.CommitID), paths.Items(), func(path string, contents []byte) error {
+	err = archiveEach(ctx, s.fetcher, string(args.Repo), string(args.CommitID), paths.Items(), func(path string, contents []byte) error {
 		defer threadStatus.Tasklog.Continue("ArchiveEach")
 
 		threadStatus.Tasklog.Start("parse")

--- a/enterprise/internal/rockskip/server.go
+++ b/enterprise/internal/rockskip/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/go-ctags"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/cmd/symbols/fetcher"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -26,7 +26,8 @@ const NULL CommitId = 0
 type Service struct {
 	logger               log.Logger
 	db                   *sql.DB
-	git                  Git
+	git                  GitserverClient
+	fetcher              fetcher.RepositoryFetcher
 	createParser         func() (ctags.Parser, error)
 	status               *ServiceStatus
 	repoUpdates          chan struct{}
@@ -41,7 +42,8 @@ type Service struct {
 
 func NewService(
 	db *sql.DB,
-	git Git,
+	git GitserverClient,
+	fetcher fetcher.RepositoryFetcher,
 	createParser func() (ctags.Parser, error),
 	maxConcurrentlyIndexing int,
 	maxRepos int,
@@ -61,6 +63,7 @@ func NewService(
 		logger:               logger,
 		db:                   db,
 		git:                  git,
+		fetcher:              fetcher,
 		createParser:         createParser,
 		status:               NewStatus(),
 		repoUpdates:          make(chan struct{}, 1),
@@ -76,15 +79,15 @@ func NewService(
 	go service.startCleanupLoop()
 
 	for i := 0; i < maxConcurrentlyIndexing; i++ {
-		go service.startIndexingLoop(database.NewDB(logger, service.db), service.indexRequestQueues[i])
+		go service.startIndexingLoop(service.indexRequestQueues[i])
 	}
 
 	return service, nil
 }
 
-func (s *Service) startIndexingLoop(db database.DB, indexRequestQueue chan indexRequest) {
+func (s *Service) startIndexingLoop(indexRequestQueue chan indexRequest) {
 	for indexRequest := range indexRequestQueue {
-		err := s.Index(context.Background(), db, indexRequest.repo, indexRequest.commit)
+		err := s.Index(context.Background(), indexRequest.repo, indexRequest.commit)
 		close(indexRequest.done)
 		if err != nil {
 			log15.Error("indexing error", "repo", indexRequest.repo, "commit", indexRequest.commit, "err", err)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -392,12 +392,12 @@ type Client interface {
 	// TODO: Rename to something like PersonCount?
 	ShortLog(ctx context.Context, repo api.RepoName, opt ShortLogOptions) ([]*gitdomain.PersonCount, error)
 
-	LogReverseEach(repo string, commit string, n int, onLogEntry func(entry gitdomain.LogEntry) error) error
+	// LogReverseEach runs git log in reverse order and calls the given callback for each entry.
+	LogReverseEach(ctx context.Context, repo string, commit string, n int, onLogEntry func(entry gitdomain.LogEntry) error) error
 
-	// RevList makes a git rev-list call and iterates through the resulting commits, calling the provided onCommit function for each.
-	RevList(repo string, commit string, onCommit func(commit string) (bool, error)) error
-
-	RevListEach(stdout io.Reader, onCommit func(commit string) (shouldContinue bool, err error)) error
+	// RevList makes a git rev-list call and iterates through the resulting commits, calling the provided
+	// onCommit function for each.
+	RevList(ctx context.Context, repo string, commit string, onCommit func(commit string) (bool, error)) error
 
 	Addrs() []string
 }

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1,7 +1,6 @@
 package gitserver
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/hex"
@@ -652,8 +651,8 @@ func decodeOID(sha string) (gitdomain.OID, error) {
 	return oid, nil
 }
 
-func (c *clientImplementor) LogReverseEach(repo string, commit string, n int, onLogEntry func(entry gitdomain.LogEntry) error) error {
-	ctx, cancel := context.WithCancel(context.Background())
+func (c *clientImplementor) LogReverseEach(ctx context.Context, repo string, commit string, n int, onLogEntry func(entry gitdomain.LogEntry) error) error {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	command := c.gitCommand(api.RepoName(repo), gitdomain.LogReverseArgs(n, commit)...)
@@ -1264,8 +1263,8 @@ func (c *clientImplementor) MergeBase(ctx context.Context, repo api.RepoName, a,
 }
 
 // RevList makes a git rev-list call and iterates through the resulting commits, calling the provided onCommit function for each.
-func (c *clientImplementor) RevList(repo string, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error {
-	ctx, cancel := context.WithCancel(context.Background())
+func (c *clientImplementor) RevList(ctx context.Context, repo string, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	command := c.gitCommand(api.RepoName(repo), RevListArgs(commit)...)
@@ -1276,31 +1275,11 @@ func (c *clientImplementor) RevList(repo string, commit string, onCommit func(co
 	}
 	defer stdout.Close()
 
-	return c.RevListEach(stdout, onCommit)
+	return gitdomain.RevListEach(stdout, onCommit)
 }
 
 func RevListArgs(givenCommit string) []string {
 	return []string{"rev-list", "--first-parent", givenCommit}
-}
-
-func (c *clientImplementor) RevListEach(stdout io.Reader, onCommit func(commit string) (shouldContinue bool, err error)) error {
-	reader := bufio.NewReader(stdout)
-
-	for {
-		commit, err := reader.ReadString('\n')
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return err
-		}
-		commit = commit[:len(commit)-1] // Drop the trailing newline
-		shouldContinue, err := onCommit(commit)
-		if !shouldContinue {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // GetBehindAhead returns the behind/ahead commit counts information for right vs. left (both Git

--- a/internal/gitserver/gitdomain/log.go
+++ b/internal/gitserver/gitdomain/log.go
@@ -44,6 +44,26 @@ func LogReverseArgs(n int, givenCommit string) []string {
 	}
 }
 
+func RevListEach(stdout io.Reader, onCommit func(commit string) (shouldContinue bool, err error)) error {
+	reader := bufio.NewReader(stdout)
+
+	for {
+		commit, err := reader.ReadString('\n')
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		commit = commit[:len(commit)-1] // Drop the trailing newline
+		shouldContinue, err := onCommit(commit)
+		if !shouldContinue {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func ParseLogReverseEach(stdout io.Reader, onLogEntry func(entry LogEntry) error) error {
 	reader := bufio.NewReader(stdout)
 

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -179,9 +179,6 @@ type MockClient struct {
 	// RevListFunc is an instance of a mock function object controlling the
 	// behavior of the method RevList.
 	RevListFunc *ClientRevListFunc
-	// RevListEachFunc is an instance of a mock function object controlling
-	// the behavior of the method RevListEach.
-	RevListEachFunc *ClientRevListEachFunc
 	// SearchFunc is an instance of a mock function object controlling the
 	// behavior of the method Search.
 	SearchFunc *ClientSearchFunc
@@ -358,7 +355,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		LogReverseEachFunc: &ClientLogReverseEachFunc{
-			defaultHook: func(string, string, int, func(entry gitdomain.LogEntry) error) (r0 error) {
+			defaultHook: func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) (r0 error) {
 				return
 			},
 		},
@@ -448,12 +445,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		RevListFunc: &ClientRevListFunc{
-			defaultHook: func(string, string, func(commit string) (bool, error)) (r0 error) {
-				return
-			},
-		},
-		RevListEachFunc: &ClientRevListEachFunc{
-			defaultHook: func(io.Reader, func(commit string) (bool, error)) (r0 error) {
+			defaultHook: func(context.Context, string, string, func(commit string) (bool, error)) (r0 error) {
 				return
 			},
 		},
@@ -640,7 +632,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		LogReverseEachFunc: &ClientLogReverseEachFunc{
-			defaultHook: func(string, string, int, func(entry gitdomain.LogEntry) error) error {
+			defaultHook: func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
 				panic("unexpected invocation of MockClient.LogReverseEach")
 			},
 		},
@@ -730,13 +722,8 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		RevListFunc: &ClientRevListFunc{
-			defaultHook: func(string, string, func(commit string) (bool, error)) error {
+			defaultHook: func(context.Context, string, string, func(commit string) (bool, error)) error {
 				panic("unexpected invocation of MockClient.RevList")
-			},
-		},
-		RevListEachFunc: &ClientRevListEachFunc{
-			defaultHook: func(io.Reader, func(commit string) (bool, error)) error {
-				panic("unexpected invocation of MockClient.RevListEach")
 			},
 		},
 		SearchFunc: &ClientSearchFunc{
@@ -913,9 +900,6 @@ func NewMockClientFrom(i Client) *MockClient {
 		},
 		RevListFunc: &ClientRevListFunc{
 			defaultHook: i.RevList,
-		},
-		RevListEachFunc: &ClientRevListEachFunc{
-			defaultHook: i.RevListEach,
 		},
 		SearchFunc: &ClientSearchFunc{
 			defaultHook: i.Search,
@@ -4524,24 +4508,24 @@ func (c ClientListTagsFuncCall) Results() []interface{} {
 // ClientLogReverseEachFunc describes the behavior when the LogReverseEach
 // method of the parent MockClient instance is invoked.
 type ClientLogReverseEachFunc struct {
-	defaultHook func(string, string, int, func(entry gitdomain.LogEntry) error) error
-	hooks       []func(string, string, int, func(entry gitdomain.LogEntry) error) error
+	defaultHook func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error
+	hooks       []func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error
 	history     []ClientLogReverseEachFuncCall
 	mutex       sync.Mutex
 }
 
 // LogReverseEach delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockClient) LogReverseEach(v0 string, v1 string, v2 int, v3 func(entry gitdomain.LogEntry) error) error {
-	r0 := m.LogReverseEachFunc.nextHook()(v0, v1, v2, v3)
-	m.LogReverseEachFunc.appendCall(ClientLogReverseEachFuncCall{v0, v1, v2, v3, r0})
+func (m *MockClient) LogReverseEach(v0 context.Context, v1 string, v2 string, v3 int, v4 func(entry gitdomain.LogEntry) error) error {
+	r0 := m.LogReverseEachFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.LogReverseEachFunc.appendCall(ClientLogReverseEachFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the LogReverseEach
 // method of the parent MockClient instance is invoked and the hook queue is
 // empty.
-func (f *ClientLogReverseEachFunc) SetDefaultHook(hook func(string, string, int, func(entry gitdomain.LogEntry) error) error) {
+func (f *ClientLogReverseEachFunc) SetDefaultHook(hook func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error) {
 	f.defaultHook = hook
 }
 
@@ -4549,7 +4533,7 @@ func (f *ClientLogReverseEachFunc) SetDefaultHook(hook func(string, string, int,
 // LogReverseEach method of the parent MockClient instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientLogReverseEachFunc) PushHook(hook func(string, string, int, func(entry gitdomain.LogEntry) error) error) {
+func (f *ClientLogReverseEachFunc) PushHook(hook func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4558,19 +4542,19 @@ func (f *ClientLogReverseEachFunc) PushHook(hook func(string, string, int, func(
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientLogReverseEachFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(string, string, int, func(entry gitdomain.LogEntry) error) error {
+	f.SetDefaultHook(func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientLogReverseEachFunc) PushReturn(r0 error) {
-	f.PushHook(func(string, string, int, func(entry gitdomain.LogEntry) error) error {
+	f.PushHook(func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
 		return r0
 	})
 }
 
-func (f *ClientLogReverseEachFunc) nextHook() func(string, string, int, func(entry gitdomain.LogEntry) error) error {
+func (f *ClientLogReverseEachFunc) nextHook() func(context.Context, string, string, int, func(entry gitdomain.LogEntry) error) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4605,16 +4589,19 @@ func (f *ClientLogReverseEachFunc) History() []ClientLogReverseEachFuncCall {
 type ClientLogReverseEachFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 string
+	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 int
+	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 func(entry gitdomain.LogEntry) error
+	Arg3 int
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 func(entry gitdomain.LogEntry) error
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -4623,7 +4610,7 @@ type ClientLogReverseEachFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ClientLogReverseEachFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
@@ -6566,23 +6553,23 @@ func (c ClientResolveRevisionsFuncCall) Results() []interface{} {
 // ClientRevListFunc describes the behavior when the RevList method of the
 // parent MockClient instance is invoked.
 type ClientRevListFunc struct {
-	defaultHook func(string, string, func(commit string) (bool, error)) error
-	hooks       []func(string, string, func(commit string) (bool, error)) error
+	defaultHook func(context.Context, string, string, func(commit string) (bool, error)) error
+	hooks       []func(context.Context, string, string, func(commit string) (bool, error)) error
 	history     []ClientRevListFuncCall
 	mutex       sync.Mutex
 }
 
 // RevList delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) RevList(v0 string, v1 string, v2 func(commit string) (bool, error)) error {
-	r0 := m.RevListFunc.nextHook()(v0, v1, v2)
-	m.RevListFunc.appendCall(ClientRevListFuncCall{v0, v1, v2, r0})
+func (m *MockClient) RevList(v0 context.Context, v1 string, v2 string, v3 func(commit string) (bool, error)) error {
+	r0 := m.RevListFunc.nextHook()(v0, v1, v2, v3)
+	m.RevListFunc.appendCall(ClientRevListFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the RevList method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientRevListFunc) SetDefaultHook(hook func(string, string, func(commit string) (bool, error)) error) {
+func (f *ClientRevListFunc) SetDefaultHook(hook func(context.Context, string, string, func(commit string) (bool, error)) error) {
 	f.defaultHook = hook
 }
 
@@ -6590,7 +6577,7 @@ func (f *ClientRevListFunc) SetDefaultHook(hook func(string, string, func(commit
 // RevList method of the parent MockClient instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *ClientRevListFunc) PushHook(hook func(string, string, func(commit string) (bool, error)) error) {
+func (f *ClientRevListFunc) PushHook(hook func(context.Context, string, string, func(commit string) (bool, error)) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -6599,19 +6586,19 @@ func (f *ClientRevListFunc) PushHook(hook func(string, string, func(commit strin
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientRevListFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(string, string, func(commit string) (bool, error)) error {
+	f.SetDefaultHook(func(context.Context, string, string, func(commit string) (bool, error)) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientRevListFunc) PushReturn(r0 error) {
-	f.PushHook(func(string, string, func(commit string) (bool, error)) error {
+	f.PushHook(func(context.Context, string, string, func(commit string) (bool, error)) error {
 		return r0
 	})
 }
 
-func (f *ClientRevListFunc) nextHook() func(string, string, func(commit string) (bool, error)) error {
+func (f *ClientRevListFunc) nextHook() func(context.Context, string, string, func(commit string) (bool, error)) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -6646,13 +6633,16 @@ func (f *ClientRevListFunc) History() []ClientRevListFuncCall {
 type ClientRevListFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 string
+	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 func(commit string) (bool, error)
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 func(commit string) (bool, error)
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -6661,116 +6651,12 @@ type ClientRevListFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ClientRevListFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ClientRevListFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// ClientRevListEachFunc describes the behavior when the RevListEach method
-// of the parent MockClient instance is invoked.
-type ClientRevListEachFunc struct {
-	defaultHook func(io.Reader, func(commit string) (bool, error)) error
-	hooks       []func(io.Reader, func(commit string) (bool, error)) error
-	history     []ClientRevListEachFuncCall
-	mutex       sync.Mutex
-}
-
-// RevListEach delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockClient) RevListEach(v0 io.Reader, v1 func(commit string) (bool, error)) error {
-	r0 := m.RevListEachFunc.nextHook()(v0, v1)
-	m.RevListEachFunc.appendCall(ClientRevListEachFuncCall{v0, v1, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the RevListEach method
-// of the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientRevListEachFunc) SetDefaultHook(hook func(io.Reader, func(commit string) (bool, error)) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// RevListEach method of the parent MockClient instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *ClientRevListEachFunc) PushHook(hook func(io.Reader, func(commit string) (bool, error)) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ClientRevListEachFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(io.Reader, func(commit string) (bool, error)) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientRevListEachFunc) PushReturn(r0 error) {
-	f.PushHook(func(io.Reader, func(commit string) (bool, error)) error {
-		return r0
-	})
-}
-
-func (f *ClientRevListEachFunc) nextHook() func(io.Reader, func(commit string) (bool, error)) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ClientRevListEachFunc) appendCall(r0 ClientRevListEachFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ClientRevListEachFuncCall objects
-// describing the invocations of this function.
-func (f *ClientRevListEachFunc) History() []ClientRevListEachFuncCall {
-	f.mutex.Lock()
-	history := make([]ClientRevListEachFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ClientRevListEachFuncCall is an object that describes an invocation of
-// method RevListEach on an instance of MockClient.
-type ClientRevListEachFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 io.Reader
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 func(commit string) (bool, error)
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ClientRevListEachFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ClientRevListEachFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 


### PR DESCRIPTION
Stacked on top of https://github.com/sourcegraph/sourcegraph/pull/39503.
This also addresses a comment from Ryan here: https://github.com/sourcegraph/sourcegraph/pull/38635#issuecomment-1184105336. Review without whitespace changes.

## Test plan

Test suite and main dry run.