### PR TITLE
gitserver: Consistently use ArchiveFormat constants

### DIFF
--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -116,10 +116,10 @@ func serveRaw(db database.DB) handlerFunc {
 		// Allow users to override the negotiated content type so that e.g. browser
 		// users can easily download tar/zip archives by adding ?format=zip etc. to
 		// the URL.
-		switch r.URL.Query().Get("format") {
-		case "zip":
+		switch gitserver.ArchiveFormat(r.URL.Query().Get("format")) {
+		case gitserver.ArchiveFormatZip:
 			contentType = applicationZip
-		case "tar":
+		case gitserver.ArchiveFormatTar:
 			contentType = applicationXTar
 		}
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1065,7 +1065,7 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	if format == "zip" {
+	if format == string(gitserver.ArchiveFormatZip) {
 		// Compression level of 0 (no compression) seems to perform the
 		// best overall on fast network links, but this has not been tuned
 		// thoroughly.

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -150,7 +150,7 @@ func run(logger log.Logger) error {
 			FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 				return git.Archive(ctx, repo, gitserver.ArchiveOptions{
 					Treeish: string(commit),
-					Format:  "tar",
+					Format:  gitserver.ArchiveFormatTar,
 				})
 			},
 			FetchTarPaths: func(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (io.ReadCloser, error) {
@@ -160,7 +160,7 @@ func run(logger log.Logger) error {
 				}
 				return git.Archive(ctx, repo, gitserver.ArchiveOptions{
 					Treeish:   string(commit),
-					Format:    "tar",
+					Format:    gitserver.ArchiveFormatTar,
 					Pathspecs: pathspecs,
 				})
 			},

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -61,7 +61,7 @@ func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commi
 
 	opts := gitserver.ArchiveOptions{
 		Treeish:   string(commit),
-		Format:    "tar",
+		Format:    gitserver.ArchiveFormatTar,
 		Pathspecs: pathSpecs,
 	}
 

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -355,7 +355,7 @@ func (s *Service) resolveFileContents(
 	}
 	opts := gitserver.ArchiveOptions{
 		Treeish:   invocationContext.commit,
-		Format:    "tar",
+		Format:    gitserver.ArchiveFormatTar,
 		Pathspecs: pathspecs,
 	}
 	rc, err := invocationContext.gitService.Archive(ctx, invocationContext.repo, opts)

--- a/internal/codeintel/dependencies/background/cratesyncer/init.go
+++ b/internal/codeintel/dependencies/background/cratesyncer/init.go
@@ -72,7 +72,7 @@ func (s *syncer) Handle(ctx context.Context) error {
 		repoName,
 		gitserver.ArchiveOptions{
 			Treeish:   "HEAD",
-			Format:    "tar",
+			Format:    gitserver.ArchiveFormatTar,
 			Pathspecs: []gitdomain.Pathspec{},
 		},
 	)

--- a/internal/codeintel/dependencies/internal/lockfiles/service.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/service.go
@@ -88,7 +88,7 @@ func (s *Service) StreamDependencies(ctx context.Context, repo api.RepoName, rev
 
 	opts := gitserver.ArchiveOptions{
 		Treeish:   rev,
-		Format:    "zip",
+		Format:    gitserver.ArchiveFormatZip,
 		Pathspecs: pathspecs,
 	}
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -480,7 +480,7 @@ func addrForKey(key string, addrs []string) string {
 // ArchiveOptions contains options for the Archive func.
 type ArchiveOptions struct {
 	Treeish   string               // the tree or commit to produce an archive for
-	Format    string               // format of the resulting archive (usually "tar" or "zip")
+	Format    ArchiveFormat        // format of the resulting archive (usually "tar" or "zip")
 	Pathspecs []gitdomain.Pathspec // if nonempty, only include these pathspecs.
 }
 
@@ -524,7 +524,7 @@ func (c *clientImplementor) archiveURL(ctx context.Context, repo api.RepoName, o
 	q := url.Values{
 		"repo":    {string(repo)},
 		"treeish": {opt.Treeish},
-		"format":  {opt.Format},
+		"format":  {string(opt.Format)},
 	}
 
 	for _, pathspec := range opt.Pathspecs {

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -262,7 +262,7 @@ func TestClient_Archive(t *testing.T) {
 				}
 			}
 
-			rc, err := cli.Archive(ctx, name, gitserver.ArchiveOptions{Treeish: "HEAD", Format: "zip"})
+			rc, err := cli.Archive(ctx, name, gitserver.ArchiveOptions{Treeish: "HEAD", Format: gitserver.ArchiveFormatZip})
 			if have, want := fmt.Sprint(err), fmt.Sprint(test.err); have != want {
 				t.Errorf("archive: have err %v, want %v", have, want)
 			}

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2417,12 +2417,14 @@ func (c *clientImplementor) CommitDate(ctx context.Context, repo api.RepoName, c
 	return parts[0], duration, true, nil
 }
 
+type ArchiveFormat string
+
 const (
 	// ArchiveFormatZip indicates a zip archive is desired.
-	ArchiveFormatZip = "zip"
+	ArchiveFormatZip ArchiveFormat = "zip"
 
 	// ArchiveFormatTar indicates a tar archive is desired.
-	ArchiveFormatTar = "tar"
+	ArchiveFormatTar ArchiveFormat = "tar"
 )
 
 // ArchiveReader streams back the file contents of an archived git repo.


### PR DESCRIPTION
Instead of sometimes falling back to raw strings

## Test plan

Tests all pass