### PR TITLE
ci: only ignore scripts with yarn in the deduplicate script

### DIFF
--- a/dev/check/yarn-deduplicate.sh
+++ b/dev/check/yarn-deduplicate.sh
@@ -5,7 +5,7 @@ echo "--- check yarn.lock for duplicates"
 
 # Prevent duplicates in yarn.lock/node_modules that lead to errors and bloated bundle sizes
 
-./dev/ci/yarn-install-with-retry.sh
+./dev/ci/yarn-install-with-retry.sh --ignore-scripts
 
 echo "Checking for duplicate dependencies in yarn.lock"
 yarn run -s yarn-deduplicate --fail --list --strategy fewer ./yarn.lock || {

--- a/dev/ci/yarn-install-with-retry.sh
+++ b/dev/ci/yarn-install-with-retry.sh
@@ -10,7 +10,7 @@ while : ; do
     echo "--- ✂️ timeout reached, aborting".
     exit 1
   fi
-  if yarn --mutex network --frozen-lockfile --ignore-scripts --network-timeout 30000 --silent "$@" 2> >(tee "$tmp_log">&2); then
+  if yarn --mutex network --frozen-lockfile --network-timeout 30000 --silent "$@" 2> >(tee "$tmp_log">&2); then
     break
   fi
 


### PR DESCRIPTION
This fixes the `sourcegraph-async` breakage introduced in #39454: most invocations of `yarn` that were replaced by `yarn-install-with-retry.sh` did not disable lifecycle scripts, but the new unified `yarn-install-with-retry.sh` script did globally. This moves the `--ignore-scripts` flag back into the only script that actually used it, which is `yarn-deduplicate.sh`.

## Test plan

CI only; will be verified by a green `sourcegraph-async` run.