### PR TITLE
Backend: add a flaky test exception

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v3.42.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.42.0.json
@@ -33,5 +33,10 @@
     "path": "enterprise/internal/batches/store",
     "prefix": "TestCancelQueuedBatchChangeChangesets",
     "reason": "New DB structure doesn't work with old test helper data."
+  },
+  {
+    "path": "lib/group",
+    "prefix": "ResultErrorGroup",
+    "reason": "A flaky test that was made unflaky after the release cut"
   }
 ]


### PR DESCRIPTION
This test was made un-flaky in https://github.com/sourcegraph/sourcegraph/pull/39340, but that was merged after the branch cut, so backcompat tests will continue to be flaky. This adds an exception for that test.

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
