### PR TITLE
Add enableLegacyExtensions

### DIFF
--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -34,6 +34,7 @@ export interface Settings {
         }
         enableExtensionsDecorationsColumnView?: boolean
         extensionsAsCoreFeatures?: boolean
+        enableLegacyExtensions?: boolean
     }
     [key: string]: any
 

--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -34,7 +34,7 @@ export interface Settings {
         }
         enableExtensionsDecorationsColumnView?: boolean
         extensionsAsCoreFeatures?: boolean
-        enableLegacyExtensions: boolean
+        enableLegacyExtensions?: boolean
     }
     [key: string]: any
 

--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -34,7 +34,7 @@ export interface Settings {
         }
         enableExtensionsDecorationsColumnView?: boolean
         extensionsAsCoreFeatures?: boolean
-        enableLegacyExtensions?: boolean
+        enableLegacyExtensions: boolean
     }
     [key: string]: any
 

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -48,4 +48,5 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     xhrHeaders: {},
     authProviders: [builtinAuthProvider],
     authMinPasswordLength: 12,
+    enableLegacyExtensions: true,
 })

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -163,6 +163,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** The publishable key for the billing service (Stripe). */
     billingPublishableKey?: string
 
+    /** Whether the extension registry and the use of extensions are enabled. (Doesn't affect code intel and git extras.) */
+    enableLegacyExtensions: boolean
+
     /** Prompt users with browsers that would crash to download a modern browser. */
     RedirectUnsupportedBrowser?: boolean
 }

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -180,7 +180,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 	var enableLegacyExtensions = true
 	if siteConfig.Extensions != nil {
-		enableLegacyExtensions = siteConfig.Extensions.EnableLegacyExtensions
+		enableLegacyExtensions = siteConfig.ExperimentalFeatures.EnableLegacyExtensions
 	}
 	// 🚨 SECURITY: This struct is sent to all users regardless of whether or
 	// not they are logged in, for example on an auth.public=false private

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -113,6 +113,8 @@ type JSContext struct {
 	ProductResearchPageEnabled bool `json:"productResearchPageEnabled"`
 
 	ExperimentalFeatures schema.ExperimentalFeatures `json:"experimentalFeatures"`
+
+	EnableLegacyExtensions bool `json:"enableLegacyExtensions"`
 }
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
@@ -176,6 +178,10 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		githubAppCloudClientID = siteConfig.Dotcom.GithubAppCloud.ClientID
 	}
 
+	var enableLegacyExtensions = true
+	if siteConfig.Extensions != nil {
+		enableLegacyExtensions = siteConfig.Extensions.EnableLegacyExtensions
+	}
 	// 🚨 SECURITY: This struct is sent to all users regardless of whether or
 	// not they are logged in, for example on an auth.public=false private
 	// server. Including secret fields here is OK if it is based on the user's
@@ -239,6 +245,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		ProductResearchPageEnabled: conf.ProductResearchPageEnabled(),
 
 		ExperimentalFeatures: conf.ExperimentalFeatures(),
+
+		EnableLegacyExtensions: enableLegacyExtensions,
 	}
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -607,6 +607,8 @@ type ExperimentalFeatures struct {
 	EnableGitServerCommandExecFilter bool `json:"enableGitServerCommandExecFilter,omitempty"`
 	// EnableGithubInternalRepoVisibility description: Enable support for visilibity of internal Github repositories
 	EnableGithubInternalRepoVisibility bool `json:"enableGithubInternalRepoVisibility,omitempty"`
+	// EnableLegacyExtensions description: Enable the extension registry and the use of extensions (doesn't affect code intel and git extras).
+	EnableLegacyExtensions bool `json:"enableLegacyExtensions,omitempty"`
 	// EnablePermissionsWebhooks description: Enables webhook consumers to sync permissions from external services faster than the defaults schedule
 	EnablePermissionsWebhooks bool `json:"enablePermissionsWebhooks,omitempty"`
 	// EnablePostSignupFlow description: Enables post sign-up user flow to add code hosts and sync code
@@ -671,8 +673,7 @@ type Extensions struct {
 	// Disabled description: Disable all usage of extensions.
 	Disabled *bool `json:"disabled,omitempty"`
 	// RemoteRegistry description: The remote extension registry URL, or `false` to not use a remote extension registry. If not set, the default remote extension registry URL is used.
-	RemoteRegistry         interface{} `json:"remoteRegistry,omitempty"`
-	EnableLegacyExtensions bool        `json:"enableLegacyExtensions,omitempty"`
+	RemoteRegistry interface{} `json:"remoteRegistry,omitempty"`
 }
 type ExternalIdentity struct {
 	// AuthProviderID description: The value of the `configID` field of the targeted authentication provider.
@@ -1764,8 +1765,6 @@ type SettingsExperimentalFeatures struct {
 	EnableSmartQuery *bool `json:"enableSmartQuery,omitempty"`
 	// ExtensionsAsCoreFeatures description: Use default extensions (Git extras, Open in editor, Search export) functionality as core features instead of extensions.
 	ExtensionsAsCoreFeatures *bool `json:"extensionsAsCoreFeatures,omitempty"`
-	// EnableLegacyExtensions description: Enable the extension registry and the use of extensions (doesn't affect code intel and git extras).
-	EnableLegacyExtensions *bool `json:"enableLegacyExtensions,omitempty"`
 	// FuzzyFinder description: Enables fuzzy finder with the keyboard shortcut `Cmd+K` on macOS and `Ctrl+K` on Linux/Windows.
 	FuzzyFinder *bool `json:"fuzzyFinder,omitempty"`
 	// FuzzyFinderCaseInsensitiveFileCountThreshold description: The maximum number of files a repo can have to use case-insensitive fuzzy finding

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -671,7 +671,8 @@ type Extensions struct {
 	// Disabled description: Disable all usage of extensions.
 	Disabled *bool `json:"disabled,omitempty"`
 	// RemoteRegistry description: The remote extension registry URL, or `false` to not use a remote extension registry. If not set, the default remote extension registry URL is used.
-	RemoteRegistry interface{} `json:"remoteRegistry,omitempty"`
+	RemoteRegistry         interface{} `json:"remoteRegistry,omitempty"`
+	EnableLegacyExtensions bool        `json:"enableLegacyExtensions,omitempty"`
 }
 type ExternalIdentity struct {
 	// AuthProviderID description: The value of the `configID` field of the targeted authentication provider.
@@ -1763,6 +1764,8 @@ type SettingsExperimentalFeatures struct {
 	EnableSmartQuery *bool `json:"enableSmartQuery,omitempty"`
 	// ExtensionsAsCoreFeatures description: Use default extensions (Git extras, Open in editor, Search export) functionality as core features instead of extensions.
 	ExtensionsAsCoreFeatures *bool `json:"extensionsAsCoreFeatures,omitempty"`
+	// EnableLegacyExtensions description: Enable the extension registry and the use of extensions (doesn't affect code intel and git extras).
+	EnableLegacyExtensions *bool `json:"enableLegacyExtensions,omitempty"`
 	// FuzzyFinder description: Enables fuzzy finder with the keyboard shortcut `Cmd+K` on macOS and `Ctrl+K` on Linux/Windows.
 	FuzzyFinder *bool `json:"fuzzyFinder,omitempty"`
 	// FuzzyFinderCaseInsensitiveFileCountThreshold description: The maximum number of files a repo can have to use case-insensitive fuzzy finding

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -495,6 +495,11 @@
               "github.com/foo/bar2": "gitserverHostname2"
             }
           ]
+        },
+        "enableLegacyExtensions": {
+          "description": "Enable the extension registry and the use of extensions (doesn't affect code intel and git extras).",
+          "type": "boolean",
+          "default": true
         }
       },
       "examples": [


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39429

Closely followed Taras's https://github.com/sourcegraph/sourcegraph/pull/39136
Also added a new React hook to make it easy to access the setting.

As for @philipp-spiess's comment “I think this should be an instance wide setting not a user specific one.” → good point, and in my best understanding, both Taras's and this new flag are instance-wide only, they can only be set in Global settings and not anywhere else.

![CleanShot 2022-07-27 at 21 39 32@2x](https://user-images.githubusercontent.com/2552265/181358041-f8fff5bd-4e1e-414e-ac9b-38b36e72a14c.png)

## Test plan

Nothing depends on this, so not much. See the screenshot that it _can_ be set. Autocomplete also lists it.