### PR TITLE
Search backend: re-open #39501 against `main`

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1287,7 +1287,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:   `file contains content predicate type diff`,
 				query:  `type:diff repo:go-diff file:contains(after_success)`, // matches .travis.yml and its 10 commits
-				counts: counts{Commit: 10},
+				counts: counts{Commit: 1},
 			},
 			{
 				name:   `select repo on 'and' operation`,

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1285,8 +1285,9 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{File: 1},
 			},
 			{
-				name:   `file contains content predicate type diff`,
-				query:  `type:diff repo:go-diff file:contains(after_success)`, // matches .travis.yml and its 10 commits
+				name: `file contains content predicate type diff`,
+				// matches .travis.yml and in the last commit that added after_success, but not in previous commits
+				query:  `type:diff repo:go-diff file:contains(after_success)`,
 				counts: counts{Commit: 1},
 			},
 			{

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -220,6 +220,9 @@ func QueryToGitQuery(b query.Basic, diff bool) gitprotocol.Node {
 
 	// Convert parameters to nodes
 	for _, parameter := range b.Parameters {
+		if parameter.Annotation.Labels.IsSet(query.IsPredicate) {
+			continue
+		}
 		newPred := queryParameterToPredicate(parameter, caseSensitive, diff)
 		if newPred != nil {
 			res = append(res, newPred)

--- a/internal/search/job/jobutil/filter_file_contains.go
+++ b/internal/search/job/jobutil/filter_file_contains.go
@@ -1,0 +1,233 @@
+package jobutil
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	otlog "github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+func NewFileContainsFilterJob(includePatterns []string, originalPattern query.Node, caseSensitive bool, child job.Job) job.Job {
+	includeMatchers := make([]*regexp.Regexp, 0, len(includePatterns))
+	for _, pattern := range includePatterns {
+		if !caseSensitive {
+			pattern = "(?i:" + pattern + ")"
+		}
+		includeMatchers = append(includeMatchers, regexp.MustCompile(pattern))
+	}
+
+	return &fileContainsFilterJob{
+		includeMatchers:        includeMatchers,
+		originalPatternMatcher: newPatternTreeMatcher(originalPattern, caseSensitive),
+		child:                  child,
+	}
+}
+
+type fileContainsFilterJob struct {
+	includeMatchers        []*regexp.Regexp
+	originalPatternMatcher patternTreeMatcher
+	child                  job.Job
+}
+
+func (j *fileContainsFilterJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
+	_, ctx, stream, finish := job.StartSpan(ctx, stream, j)
+	defer func() { finish(alert, err) }()
+
+	filteredStream := streaming.StreamFunc(func(event streaming.SearchEvent) {
+		event = j.filterEvent(event)
+		stream.Send(event)
+	})
+
+	return j.child.Run(ctx, clients, filteredStream)
+}
+
+func (j *fileContainsFilterJob) filterEvent(event streaming.SearchEvent) streaming.SearchEvent {
+	// Don't filter out files with zero chunks because if the file contained
+	// the a result, we still want to return a match for the file even if it
+	// has no matched ranges left.
+	for i := range event.Results {
+		event.Results[i] = j.filterFileMatch(event.Results[i])
+	}
+	return event
+}
+
+func (j *fileContainsFilterJob) filterFileMatch(m result.Match) result.Match {
+	fm, ok := m.(*result.FileMatch)
+	if !ok {
+		return m
+	}
+
+	filteredChunks := fm.ChunkMatches[:0]
+	for _, chunk := range fm.ChunkMatches {
+		chunk = j.filterChunk(chunk)
+		if len(chunk.Ranges) == 0 {
+			continue
+		}
+		filteredChunks = append(filteredChunks, chunk)
+	}
+	fm.ChunkMatches = filteredChunks
+	return fm
+}
+
+func (j *fileContainsFilterJob) filterChunk(chunk result.ChunkMatch) result.ChunkMatch {
+	filteredRanges := chunk.Ranges[:0]
+	for i, val := range chunk.MatchedContent() {
+		if matchesAny(val, j.includeMatchers) && !j.originalPatternMatcher.Match(val) {
+			continue
+		}
+		filteredRanges = append(filteredRanges, chunk.Ranges[i])
+	}
+	chunk.Ranges = filteredRanges
+	return chunk
+}
+
+func matchesAny(val string, matchers []*regexp.Regexp) bool {
+	for _, re := range matchers {
+		if re.MatchString(val) {
+			return true
+		}
+	}
+	return false
+}
+
+func (j *fileContainsFilterJob) MapChildren(f job.MapFunc) job.Job {
+	cp := *j
+	cp.child = job.Map(j.child, f)
+	return &cp
+}
+
+func (j *fileContainsFilterJob) Children() []job.Describer {
+	return []job.Describer{j.child}
+}
+
+func (j *fileContainsFilterJob) Fields(v job.Verbosity) (res []otlog.Field) {
+	switch v {
+	case job.VerbosityMax:
+		fallthrough
+	case job.VerbosityBasic:
+		res = append(res, trace.Stringer("originalPattern", j.originalPatternMatcher))
+		filterStrings := make([]string, 0, len(j.includeMatchers))
+		for _, re := range j.includeMatchers {
+			filterStrings = append(filterStrings, re.String())
+		}
+		res = append(res, trace.Strings("filterPatterns", filterStrings))
+	}
+	return res
+}
+
+func (j *fileContainsFilterJob) Name() string {
+	return "FileContainsFilterJob"
+}
+
+func newPatternTreeMatcher(originalPattern query.Node, caseSensitive bool) patternTreeMatcher {
+	if originalPattern == nil {
+		return &constMatcher{false}
+	}
+	switch v := originalPattern.(type) {
+	case query.Operator:
+		children := make([]patternTreeMatcher, 0, len(v.Operands))
+		for _, operand := range v.Operands {
+			children = append(children, newPatternTreeMatcher(operand, caseSensitive))
+		}
+		switch v.Kind {
+		case query.And:
+			return &andMatcher{children: children}
+		case query.Or:
+			return &orMatcher{children: children}
+		default:
+			panic(fmt.Sprintf("cannot handle operator kind %d", v.Kind))
+		}
+	case query.Pattern:
+		value := v.Value
+		if caseSensitive {
+			value = "(?i:" + value + ")"
+
+		}
+		return &leafMatcher{
+			re: regexp.MustCompile(value), // already validated
+		}
+	default:
+		panic(fmt.Sprintf("unknown pattern node type %T", originalPattern))
+	}
+}
+
+type patternTreeMatcher interface {
+	Match(string) bool
+	String() string
+}
+
+type orMatcher struct {
+	children []patternTreeMatcher
+}
+
+func (m *orMatcher) Match(val string) bool {
+	for _, child := range m.children {
+		if child.Match(val) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *orMatcher) String() string {
+	childStrings := make([]string, 0, len(m.children))
+	for _, child := range m.children {
+		childStrings = append(childStrings, child.String())
+	}
+	return "(" + strings.Join(childStrings, " OR ") + ")"
+}
+
+type andMatcher struct {
+	children []patternTreeMatcher
+}
+
+func (m *andMatcher) Match(val string) bool {
+	for _, child := range m.children {
+		if !child.Match(val) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *andMatcher) String() string {
+	childStrings := make([]string, 0, len(m.children))
+	for _, child := range m.children {
+		childStrings = append(childStrings, child.String())
+	}
+	return "(" + strings.Join(childStrings, " AND ") + ")"
+}
+
+type leafMatcher struct {
+	re *regexp.Regexp
+}
+
+func (m *leafMatcher) Match(val string) bool {
+	return m.re.MatchString(val)
+}
+
+func (m *leafMatcher) String() string {
+	return fmt.Sprintf("%q", m.re.String())
+}
+
+type constMatcher struct {
+	value bool
+}
+
+func (m *constMatcher) Match(val string) bool {
+	return m.value
+}
+
+func (m *constMatcher) String() string {
+	return strconv.FormatBool(m.value)
+}

--- a/internal/search/job/jobutil/filter_file_contains.go
+++ b/internal/search/job/jobutil/filter_file_contains.go
@@ -27,6 +27,9 @@ func NewFileContainsFilterJob(includePatterns []string, originalPattern query.No
 	originalPatternStrings := patternsInTree(originalPattern)
 	originalPatternMatchers := make([]*regexp.Regexp, 0, len(originalPatternStrings))
 	for _, originalPatternString := range originalPatternStrings {
+		if !caseSensitive {
+			originalPatternString = "(?i:" + originalPatternString + ")"
+		}
 		originalPatternMatchers = append(originalPatternMatchers, regexp.MustCompile(originalPatternString))
 	}
 

--- a/internal/search/job/jobutil/filter_file_contains.go
+++ b/internal/search/job/jobutil/filter_file_contains.go
@@ -152,7 +152,7 @@ func matchesAny(val string, matchers []*regexp.Regexp) bool {
 }
 
 func (j *fileContainsFilterJob) filterCommitMatch(ctx context.Context, searcherURLs *endpoint.Map, cm *result.CommitMatch) result.Match {
-	// Skip any commit matches -- we can only handle diff matches
+	// Skip any commit matches -- we only handle diff matches
 	if cm.DiffPreview == nil {
 		return nil
 	}
@@ -254,7 +254,7 @@ func (j *fileContainsFilterJob) removeUnmatchedFileDiffs(cm *result.CommitMatch,
 			// If count != len(j.includeMatchers), that means that not all of our file:contains.content() patterns
 			// matched and this fileDiff should be dropped. Skip appending it, and add its length to the removed amount
 			// so we can adjust the matched ranges down.
-			removedAmount.Add(result.Location{Offset: len(diffStrings[i]), Line: strings.Count(diffStrings[i], "\n")})
+			removedAmount = removedAmount.Add(result.Location{Offset: len(diffStrings[i]), Line: strings.Count(diffStrings[i], "\n")})
 		}
 	}
 

--- a/internal/search/job/jobutil/filter_file_contains.go
+++ b/internal/search/job/jobutil/filter_file_contains.go
@@ -94,7 +94,7 @@ func (j *fileContainsFilterJob) Run(ctx context.Context, clients job.RuntimeClie
 
 func (j *fileContainsFilterJob) filterEvent(ctx context.Context, searcherURLs *endpoint.Map, event streaming.SearchEvent) streaming.SearchEvent {
 	// Don't filter out files with zero chunks because if the file contained
-	// the a result, we still want to return a match for the file even if it
+	// a result, we still want to return a match for the file even if it
 	// has no matched ranges left.
 	filtered := event.Results[:0]
 	for _, res := range event.Results {

--- a/internal/search/job/jobutil/filter_file_contains_test.go
+++ b/internal/search/job/jobutil/filter_file_contains_test.go
@@ -1,0 +1,192 @@
+package jobutil
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/job/mockjob"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+)
+
+func TestFileContainsFilterJob(t *testing.T) {
+	cm := func(matchedStrings ...string) result.ChunkMatch {
+		ranges := make([]result.Range, 0, len(matchedStrings))
+		currOffset := 0
+		for _, matchedString := range matchedStrings {
+			ranges = append(ranges, result.Range{
+				Start: result.Location{Offset: currOffset},
+				End:   result.Location{Offset: currOffset + len(matchedString)},
+			})
+			currOffset += len(matchedString)
+		}
+		return result.ChunkMatch{
+			Content: strings.Join(matchedStrings, ""),
+			Ranges:  ranges,
+		}
+	}
+	fm := func(cms ...result.ChunkMatch) *result.FileMatch {
+		if len(cms) == 0 {
+			cms = result.ChunkMatches{}
+		}
+		return &result.FileMatch{
+			ChunkMatches: cms,
+		}
+	}
+	r := func(fms ...*result.FileMatch) (res result.Matches) {
+		for _, fm := range fms {
+			res = append(res, fm)
+		}
+		return res
+	}
+	cases := []struct {
+		name            string
+		includePatterns []string
+		originalPattern query.Node
+		caseSensitive   bool
+		inputEvent      streaming.SearchEvent
+		outputEvent     streaming.SearchEvent
+	}{{
+		name:            "no matches in streamed event",
+		includePatterns: []string{"unused"},
+		originalPattern: nil,
+		caseSensitive:   false,
+		inputEvent: streaming.SearchEvent{
+			Stats: streaming.Stats{
+				IsLimitHit: true,
+			},
+		},
+		outputEvent: streaming.SearchEvent{
+			Stats: streaming.Stats{
+				IsLimitHit: true,
+			},
+		},
+	}, {
+		name:            "no original pattern",
+		includePatterns: []string{"needle"},
+		originalPattern: nil,
+		caseSensitive:   false,
+		inputEvent: streaming.SearchEvent{
+			Results: r(fm(cm("needle"))),
+		},
+		outputEvent: streaming.SearchEvent{
+			Results: r(fm()),
+		},
+	}, {
+		name:            "overlapping original pattern",
+		includePatterns: []string{"needle"},
+		originalPattern: query.Pattern{Value: "needle"},
+		caseSensitive:   false,
+		inputEvent: streaming.SearchEvent{
+			Results: r(fm(cm("needle"))),
+		},
+		outputEvent: streaming.SearchEvent{
+			Results: r(fm(cm("needle"))),
+		},
+	}, {
+		name:            "nonoverlapping original pattern",
+		includePatterns: []string{"needle"},
+		originalPattern: query.Pattern{Value: "pin"},
+		caseSensitive:   false,
+		inputEvent: streaming.SearchEvent{
+			Results: r(fm(cm("needle", "pin"))),
+		},
+		outputEvent: streaming.SearchEvent{
+			Results: r(fm(result.ChunkMatch{
+				Content: "needlepin",
+				Ranges: result.Ranges{{
+					Start: result.Location{Offset: len("needle")},
+					End:   result.Location{Offset: len("needlepin")},
+				}},
+			})),
+		},
+	}, {
+		name:            "multiple include patterns",
+		includePatterns: []string{"minimum", "viable", "product"},
+		originalPattern: query.Pattern{Value: "predicates"},
+		caseSensitive:   false,
+		inputEvent: streaming.SearchEvent{
+			Results: r(fm(cm("minimum", "viable"), cm("predicates", "product"))),
+		},
+		outputEvent: streaming.SearchEvent{
+			Results: r(fm(result.ChunkMatch{
+				Content: "predicatesproduct",
+				Ranges: result.Ranges{{
+					Start: result.Location{Offset: 0},
+					End:   result.Location{Offset: len("predicates")},
+				}},
+			})),
+		},
+	}, {
+		name:            "match that is not a file match",
+		includePatterns: []string{"minimum", "viable", "product"},
+		originalPattern: query.Pattern{Value: "predicates"},
+		caseSensitive:   false,
+		inputEvent: streaming.SearchEvent{
+			Results: result.Matches{&result.RepoMatch{Name: "test"}},
+		},
+		outputEvent: streaming.SearchEvent{
+			Results: result.Matches{&result.RepoMatch{Name: "test"}},
+		},
+	}, {
+		name:            "tree shaped pattern",
+		includePatterns: []string{"predicate"},
+		originalPattern: query.Operator{
+			Kind: query.Or,
+			Operands: []query.Node{
+				query.Pattern{Value: "outer"},
+				query.Operator{
+					Kind: query.And,
+					Operands: []query.Node{
+						query.Pattern{Value: "inner1"},
+						query.Pattern{Value: "inner2"},
+					},
+				},
+			},
+		},
+		caseSensitive: false,
+		inputEvent: streaming.SearchEvent{
+			Results: r(fm(cm("inner1", "inner2", "predicate", "outer"))),
+		},
+		outputEvent: streaming.SearchEvent{
+			Results: r(fm(result.ChunkMatch{
+				Content: "inner1inner2predicateouter",
+				Ranges: result.Ranges{{
+					Start: result.Location{Offset: 0},
+					End:   result.Location{Offset: len("inner1")},
+				}, {
+					Start: result.Location{Offset: len("inner1")},
+					End:   result.Location{Offset: len("inner1inner2")},
+				}, {
+					Start: result.Location{Offset: len("inner1inner2predicate")},
+					End:   result.Location{Offset: len("inner1inner2predicateouter")},
+				}},
+			})),
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			childJob := mockjob.NewMockJob()
+			childJob.RunFunc.SetDefaultHook(func(_ context.Context, _ job.RuntimeClients, s streaming.Sender) (*search.Alert, error) {
+				s.Send(tc.inputEvent)
+				return nil, nil
+			})
+			var result streaming.SearchEvent
+			streamCollector := streaming.StreamFunc(func(ev streaming.SearchEvent) {
+				result = ev
+			})
+			j := NewFileContainsFilterJob(tc.includePatterns, tc.originalPattern, tc.caseSensitive, childJob)
+			alert, err := j.Run(context.Background(), job.RuntimeClients{}, streamCollector)
+			require.Nil(t, alert)
+			require.NoError(t, err)
+			require.Equal(t, tc.outputEvent, result)
+		})
+	}
+}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -65,14 +65,14 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 
 	// Modify the input query if the user specified `file:contains.content()`
 	fileContainsPatterns := b.FileContainsContent()
-	fileContainsOriginalPattern := b.Pattern
+	originalQuery := b
 	if len(fileContainsPatterns) > 0 {
 		newNodes := make([]query.Node, 0, len(fileContainsPatterns)+1)
 		for _, pat := range fileContainsPatterns {
 			newNodes = append(newNodes, query.Pattern{Value: pat})
 		}
-		if fileContainsOriginalPattern != nil {
-			newNodes = append(newNodes, fileContainsOriginalPattern)
+		if b.Pattern != nil {
+			newNodes = append(newNodes, b.Pattern)
 		}
 		b.Pattern = query.Operator{Operands: newNodes, Kind: query.And}
 	}
@@ -148,7 +148,7 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 			repoOptionsCopy := repoOptions
 			repoOptionsCopy.OnlyCloned = true
 			addJob(&commit.SearchJob{
-				Query:                commit.QueryToGitQuery(b, diff),
+				Query:                commit.QueryToGitQuery(originalQuery, diff),
 				RepoOpts:             repoOptionsCopy,
 				Diff:                 diff,
 				Limit:                int(fileMatchLimit),
@@ -177,7 +177,7 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 
 	{ // Apply file:contains() post-filter
 		if len(fileContainsPatterns) > 0 {
-			basicJob = NewFileContainsFilterJob(fileContainsPatterns, fileContainsOriginalPattern, b.IsCaseSensitive(), basicJob)
+			basicJob = NewFileContainsFilterJob(fileContainsPatterns, originalQuery.Pattern, b.IsCaseSensitive(), basicJob)
 		}
 	}
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -63,6 +63,19 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 
 	features := toFeatures(inputs.Features)
 
+	fileContainsPatterns := b.FileContainsContent()
+	originalPattern := b.Pattern
+	if len(fileContainsPatterns) > 0 {
+		newNodes := make([]query.Node, 0, len(fileContainsPatterns)+1)
+		for _, pat := range fileContainsPatterns {
+			newNodes = append(newNodes, query.Pattern{Value: pat})
+		}
+		if originalPattern != nil {
+			newNodes = append(newNodes, originalPattern)
+		}
+		b.Pattern = query.Operator{Operands: newNodes, Kind: query.And}
+	}
+
 	{
 		// This block generates jobs that can be built directly from
 		// a basic query rather than first being expanded into
@@ -160,6 +173,12 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 	}
 
 	basicJob := NewParallelJob(children...)
+
+	{ // Apply file:contains() post-filter
+		if len(fileContainsPatterns) > 0 {
+			basicJob = NewFileContainsFilterJob(fileContainsPatterns, originalPattern, b.IsCaseSensitive(), basicJob)
+		}
+	}
 
 	{ // Apply code ownership post-search filter
 		if includeOwners, excludeOwners := b.FileHasOwner(); features.CodeOwnershipFilters == true && (len(includeOwners) > 0 || len(excludeOwners) > 0) {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -63,15 +63,16 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 
 	features := toFeatures(inputs.Features)
 
+	// Modify the input query if the user specified `file:contains.content()`
 	fileContainsPatterns := b.FileContainsContent()
-	originalPattern := b.Pattern
+	fileContainsOriginalPattern := b.Pattern
 	if len(fileContainsPatterns) > 0 {
 		newNodes := make([]query.Node, 0, len(fileContainsPatterns)+1)
 		for _, pat := range fileContainsPatterns {
 			newNodes = append(newNodes, query.Pattern{Value: pat})
 		}
-		if originalPattern != nil {
-			newNodes = append(newNodes, originalPattern)
+		if fileContainsOriginalPattern != nil {
+			newNodes = append(newNodes, fileContainsOriginalPattern)
 		}
 		b.Pattern = query.Operator{Operands: newNodes, Kind: query.And}
 	}
@@ -176,7 +177,7 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 
 	{ // Apply file:contains() post-filter
 		if len(fileContainsPatterns) > 0 {
-			basicJob = NewFileContainsFilterJob(fileContainsPatterns, originalPattern, b.IsCaseSensitive(), basicJob)
+			basicJob = NewFileContainsFilterJob(fileContainsPatterns, fileContainsOriginalPattern, b.IsCaseSensitive(), basicJob)
 		}
 	}
 

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -356,20 +356,7 @@ func (f FileContainsContentPredicate) Field() string { return FieldFile }
 func (f FileContainsContentPredicate) Name() string  { return "contains.content" }
 
 func (f *FileContainsContentPredicate) Plan(parent Basic) (Plan, error) {
-	nodes := make([]Node, 0, 3)
-	nodes = append(nodes, Parameter{
-		Field: FieldCount,
-		Value: "99999",
-	}, Parameter{
-		Field: FieldType,
-		Value: "file",
-	}, Pattern{
-		Value:      f.Pattern,
-		Annotation: Annotation{Labels: Regexp},
-	})
-
-	nodes = append(nodes, nonPredicateRepos(parent)...)
-	return BuildPlan(nodes), nil
+	return nil, nil
 }
 
 /* file:has.owner(pattern) */

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -326,6 +326,7 @@ func (p Parameters) IncludeExcludeValues(field string) (include, exclude []strin
 			// Skip predicates
 			return
 		}
+
 		if negated {
 			exclude = append(exclude, v)
 		} else {
@@ -379,6 +380,18 @@ func (p Parameters) RepoHasFileContent() (res []RepoHasFileContentArgs) {
 	})
 
 	return res
+}
+
+func (p Parameters) FileContainsContent() (include []string) {
+	nodes := toNodes(p)
+	VisitTypedPredicate(nodes, func(pred *FileContainsContentPredicate, negated bool) {
+		if negated {
+			// Negated is file contains predicates are not supported
+		} else {
+			include = append(include, pred.Pattern)
+		}
+	})
+	return include
 }
 
 func (p Parameters) RepoContainsCommitAfter() (value string) {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -383,11 +383,10 @@ func (p Parameters) RepoHasFileContent() (res []RepoHasFileContentArgs) {
 }
 
 func (p Parameters) FileContainsContent() (include []string) {
-	nodes := toNodes(p)
-	VisitTypedPredicate(nodes, func(pred *FileContainsContentPredicate, negated bool) {
-		if negated {
-			// Negated is file contains predicates are not supported
-		} else {
+	VisitPredicate(toNodes(p), func(field, name, value string) {
+		if field == FieldFile && (name == "contains" || name == "contains.content") {
+			var pred FileContainsContentPredicate
+			pred.ParseParams(value)
 			include = append(include, pred.Pattern)
 		}
 	})


### PR DESCRIPTION
Turns out, github really doesn't like when you have two PRs open from the same branch. Auto-rebasing on main failed dramatically, but the first PR still merged, just into the branch it was based off of. This is the same PR as https://github.com/sourcegraph/sourcegraph/pull/39501, nothing has changed. 

## Test plan

Covered in original PR.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
