### PR TITLE
opentelemetry-collector: bundle lokiexporter, fluentforwardreceiver

### DIFF
--- a/docker-images/opentelemetry-collector/builder.template.yaml
+++ b/docker-images/opentelemetry-collector/builder.template.yaml
@@ -14,11 +14,15 @@ exporters:
   # Contrib exporters - https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v$OTEL_COLLECTOR_VERSION"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v$OTEL_COLLECTOR_VERSION"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v$OTEL_COLLECTOR_VERSION"
 
 receivers:
   # OpenTelemetry receivers - https://go.opentelemetry.io/collector/receiver
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
     gomod: go.opentelemetry.io/collector v$OTEL_COLLECTOR_VERSION
+
+  # Contrib receivers - https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v$OTEL_COLLECTOR_VERSION"
 
 extensions:
   # OpenTelemetry extensions - https://go.opentelemetry.io/collector/extension


### PR DESCRIPTION
Fluent is a logging driver that Docker ships with (https://docs.docker.com/config/containers/logging/fluentd/), and Loki is something we've used for logging before and might want to in the future - this bundles relevant extensions for these services in the collector to enable easier experimentation. Inspired by https://grafana.com/blog/2022/06/23/how-to-send-logs-to-grafana-loki-with-the-opentelemetry-collector-using-fluent-forward-and-filelog-receivers/

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start otel`