### PR TITLE
Search backend: remove unneeded fields on searchResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -58,7 +58,6 @@ func NewBatchSearchImplementer(ctx context.Context, logger log.Logger, db databa
 		client:       cli,
 		db:           db,
 		SearchInputs: inputs,
-		searcherURLs: search.SearcherURLs(),
 	}, nil
 }
 
@@ -71,8 +70,6 @@ type searchResolver struct {
 	client       client.SearchClient
 	SearchInputs *run.SearchInputs
 	db           database.DB
-
-	searcherURLs *endpoint.Map
 }
 
 var MockDecodedViewerFinalSettings *schema.Settings

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -58,7 +58,6 @@ func NewBatchSearchImplementer(ctx context.Context, logger log.Logger, db databa
 		client:       cli,
 		db:           db,
 		SearchInputs: inputs,
-		zoekt:        search.Indexed(),
 		searcherURLs: search.SearcherURLs(),
 	}, nil
 }
@@ -73,7 +72,6 @@ type searchResolver struct {
 	SearchInputs *run.SearchInputs
 	db           database.DB
 
-	zoekt        zoekt.Streamer
 	searcherURLs *endpoint.Map
 }
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -60,7 +60,6 @@ func NewBatchSearchImplementer(ctx context.Context, logger log.Logger, db databa
 		SearchInputs: inputs,
 		zoekt:        search.Indexed(),
 		searcherURLs: search.SearcherURLs(),
-		logger:       logger,
 	}, nil
 }
 
@@ -73,7 +72,6 @@ type searchResolver struct {
 	client       client.SearchClient
 	SearchInputs *run.SearchInputs
 	db           database.DB
-	logger       log.Logger
 
 	zoekt        zoekt.Streamer
 	searcherURLs *endpoint.Map

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -3,12 +3,10 @@ package graphqlbackend
 import (
 	"context"
 
-	"github.com/google/zoekt"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -340,7 +340,6 @@ func TestSearchResultsHydration(t *testing.T) {
 	resolver := &searchResolver{
 		client:       cli,
 		db:           db,
-		logger:       logtest.Scoped(t),
 		SearchInputs: searchInputs,
 		zoekt:        z,
 	}
@@ -579,7 +578,6 @@ func TestEvaluateAnd(t *testing.T) {
 			resolver := &searchResolver{
 				client:       cli,
 				db:           db,
-				logger:       logtest.Scoped(t),
 				SearchInputs: searchInputs,
 				zoekt:        z,
 			}
@@ -687,7 +685,6 @@ func TestSubRepoFiltering(t *testing.T) {
 				SearchInputs: searchInputs,
 				zoekt:        mockZoekt,
 				db:           db,
-				logger:       logtest.Scoped(t),
 			}
 
 			ctx := context.Background()

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -341,7 +341,6 @@ func TestSearchResultsHydration(t *testing.T) {
 		client:       cli,
 		db:           db,
 		SearchInputs: searchInputs,
-		zoekt:        z,
 	}
 	results, err := resolver.Results(ctx)
 	if err != nil {
@@ -579,7 +578,6 @@ func TestEvaluateAnd(t *testing.T) {
 				client:       cli,
 				db:           db,
 				SearchInputs: searchInputs,
-				zoekt:        z,
 			}
 			results, err := resolver.Results(ctx)
 			if err != nil {
@@ -683,7 +681,6 @@ func TestSubRepoFiltering(t *testing.T) {
 			resolver := searchResolver{
 				client:       cli,
 				SearchInputs: searchInputs,
-				zoekt:        mockZoekt,
 				db:           db,
 			}
 

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -343,7 +343,6 @@ func BenchmarkSearchResults(b *testing.B) {
 		resolver := &searchResolver{
 			client: client.NewSearchClient(logtest.Scoped(b), db, z, nil),
 			db:     db,
-			logger: logtest.Scoped(b),
 			SearchInputs: &run.SearchInputs{
 				Plan:         plan,
 				Query:        plan.ToQ(),

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -348,7 +348,6 @@ func BenchmarkSearchResults(b *testing.B) {
 				Query:        plan.ToQ(),
 				UserSettings: &schema.Settings{},
 			},
-			zoekt: z,
 		}
 		results, err := resolver.Results(ctx)
 		if err != nil {


### PR DESCRIPTION
With the introduction of `SearchClient` in https://github.com/sourcegraph/sourcegraph/pull/39528, these fields are no longer necessary.

Stacked on #39528

## Test plan

Semantics-preserving. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
