### PR TITLE
usage-data: restrict scraped events to an allowlist

### DIFF
--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -295,7 +295,8 @@ func (l *eventLogStore) ListAll(ctx context.Context, opt EventLogsListOptions) (
 }
 
 func (l *eventLogStore) ListExportableEvents(ctx context.Context, after, limit int) ([]*types.Event, error) {
-	return l.getBySQL(ctx, sqlf.Sprintf("WHERE id > %d ORDER BY id LIMIT %d", after, limit))
+	suffix := "WHERE event_logs.id > %d AND name IN (SELECT event_name FROM event_logs_export_allowlist) ORDER BY event_logs.id LIMIT %d"
+	return l.getBySQL(ctx, sqlf.Sprintf(suffix, after, limit))
 }
 
 func (l *eventLogStore) LatestPing(ctx context.Context) (*types.Event, error) {

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7294,7 +7294,7 @@
     },
     {
       "Name": "event_logs_export_allowlist",
-      "Comment": "An allowlist of events that are approved for export if the scraping job is nabled",
+      "Comment": "An allowlist of events that are approved for export if the scraping job is enabled",
       "Columns": [
         {
           "Name": "event_name",
@@ -7325,6 +7325,16 @@
       ],
       "Indexes": [
         {
+          "Name": "event_logs_export_allowlist_event_name_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist USING btree (event_name)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "event_logs_export_allowlist_pkey",
           "IsPrimaryKey": true,
           "IsUnique": true,
@@ -7333,16 +7343,6 @@
           "IndexDefinition": "CREATE UNIQUE INDEX event_logs_export_allowlist_pkey ON event_logs_export_allowlist USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
-        },
-        {
-          "Name": "event_logs_export_allowlist_event_name_idx",
-          "IsPrimaryKey": false,
-          "IsUnique": false,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist USING btree (event_name)",
-          "ConstraintType": "",
-          "ConstraintDefinition": ""
         }
       ],
       "Constraints": null,

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -423,6 +423,15 @@
       "CycleOption": "NO"
     },
     {
+      "Name": "event_logs_export_allowlist_id_seq",
+      "TypeName": "integer",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 2147483647,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
       "Name": "event_logs_id_seq",
       "TypeName": "bigint",
       "StartValue": 1,
@@ -7281,6 +7290,62 @@
           "ConstraintDefinition": "CHECK (version \u003c\u003e ''::text)"
         }
       ],
+      "Triggers": []
+    },
+    {
+      "Name": "event_logs_export_allowlist",
+      "Comment": "An allowlist of events that are approved for export if the scraping job is nabled",
+      "Columns": [
+        {
+          "Name": "event_name",
+          "Index": 2,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Name of the event that corresponds to event_logs.name"
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "nextval('event_logs_export_allowlist_id_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "event_logs_export_allowlist_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX event_logs_export_allowlist_pkey ON event_logs_export_allowlist USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "event_logs_export_allowlist_event_name_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist USING btree (event_name)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        }
+      ],
+      "Constraints": null,
       "Triggers": []
     },
     {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -947,6 +947,22 @@ Check constraints:
 
 ```
 
+# Table "public.event_logs_export_allowlist"
+```
+   Column   |  Type   | Collation | Nullable |                         Default                         
+------------+---------+-----------+----------+---------------------------------------------------------
+ id         | integer |           | not null | nextval('event_logs_export_allowlist_id_seq'::regclass)
+ event_name | text    |           | not null | 
+Indexes:
+    "event_logs_export_allowlist_pkey" PRIMARY KEY, btree (id)
+    "event_logs_export_allowlist_event_name_idx" btree (event_name)
+
+```
+
+An allowlist of events that are approved for export if the scraping job is nabled
+
+**event_name**: Name of the event that corresponds to event_logs.name
+
 # Table "public.event_logs_scrape_state"
 ```
    Column    |  Type   | Collation | Nullable |                       Default                       

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -955,11 +955,11 @@ Check constraints:
  event_name | text    |           | not null | 
 Indexes:
     "event_logs_export_allowlist_pkey" PRIMARY KEY, btree (id)
-    "event_logs_export_allowlist_event_name_idx" btree (event_name)
+    "event_logs_export_allowlist_event_name_idx" UNIQUE, btree (event_name)
 
 ```
 
-An allowlist of events that are approved for export if the scraping job is nabled
+An allowlist of events that are approved for export if the scraping job is enabled
 
 **event_name**: Name of the event that corresponds to event_logs.name
 

--- a/migrations/frontend/1658950366_event_log_scrape_allow_list/down.sql
+++ b/migrations/frontend/1658950366_event_log_scrape_allow_list/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS event_logs_export_allowlist;

--- a/migrations/frontend/1658950366_event_log_scrape_allow_list/metadata.yaml
+++ b/migrations/frontend/1658950366_event_log_scrape_allow_list/metadata.yaml
@@ -1,0 +1,2 @@
+name: event_log_scrape_allow_list
+parents: [1658122170, 1658484997, 1658856572]

--- a/migrations/frontend/1658950366_event_log_scrape_allow_list/up.sql
+++ b/migrations/frontend/1658950366_event_log_scrape_allow_list/up.sql
@@ -6,5 +6,5 @@ CREATE TABLE IF NOT EXISTS event_logs_export_allowlist
 
 CREATE INDEX IF NOT EXISTS event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist (event_name);
 
-COMMENT ON TABLE event_logs_export_allowlist IS 'An allowlist of events that are approved for export if the scraping job is nabled';
+COMMENT ON TABLE event_logs_export_allowlist IS 'An allowlist of events that are approved for export if the scraping job is enabled';
 COMMENT ON COLUMN event_logs_export_allowlist.event_name IS 'Name of the event that corresponds to event_logs.name';

--- a/migrations/frontend/1658950366_event_log_scrape_allow_list/up.sql
+++ b/migrations/frontend/1658950366_event_log_scrape_allow_list/up.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS event_logs_export_allowlist
     event_name TEXT NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist (event_name);
+CREATE UNIQUE INDEX IF NOT EXISTS event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist (event_name);
 
 COMMENT ON TABLE event_logs_export_allowlist IS 'An allowlist of events that are approved for export if the scraping job is enabled';
 COMMENT ON COLUMN event_logs_export_allowlist.event_name IS 'Name of the event that corresponds to event_logs.name';

--- a/migrations/frontend/1658950366_event_log_scrape_allow_list/up.sql
+++ b/migrations/frontend/1658950366_event_log_scrape_allow_list/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS event_logs_export_allowlist
+(
+    id         SERIAL PRIMARY KEY,
+    event_name TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist (event_name);
+
+COMMENT ON TABLE event_logs_export_allowlist IS 'An allowlist of events that are approved for export if the scraping job is nabled';
+COMMENT ON COLUMN event_logs_export_allowlist.event_name IS 'Name of the event that corresponds to event_logs.name';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1429,7 +1429,7 @@ CREATE TABLE event_logs_export_allowlist (
     event_name text NOT NULL
 );
 
-COMMENT ON TABLE event_logs_export_allowlist IS 'An allowlist of events that are approved for export if the scraping job is nabled';
+COMMENT ON TABLE event_logs_export_allowlist IS 'An allowlist of events that are approved for export if the scraping job is enabled';
 
 COMMENT ON COLUMN event_logs_export_allowlist.event_name IS 'Name of the event that corresponds to event_logs.name';
 

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1424,6 +1424,25 @@ CREATE TABLE event_logs (
     CONSTRAINT event_logs_check_version_not_empty CHECK ((version <> ''::text))
 );
 
+CREATE TABLE event_logs_export_allowlist (
+    id integer NOT NULL,
+    event_name text NOT NULL
+);
+
+COMMENT ON TABLE event_logs_export_allowlist IS 'An allowlist of events that are approved for export if the scraping job is nabled';
+
+COMMENT ON COLUMN event_logs_export_allowlist.event_name IS 'Name of the event that corresponds to event_logs.name';
+
+CREATE SEQUENCE event_logs_export_allowlist_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE event_logs_export_allowlist_id_seq OWNED BY event_logs_export_allowlist.id;
+
 CREATE SEQUENCE event_logs_id_seq
     START WITH 1
     INCREMENT BY 1
@@ -3212,6 +3231,8 @@ ALTER TABLE ONLY discussion_threads_target_repo ALTER COLUMN id SET DEFAULT next
 
 ALTER TABLE ONLY event_logs ALTER COLUMN id SET DEFAULT nextval('event_logs_id_seq'::regclass);
 
+ALTER TABLE ONLY event_logs_export_allowlist ALTER COLUMN id SET DEFAULT nextval('event_logs_export_allowlist_id_seq'::regclass);
+
 ALTER TABLE ONLY event_logs_scrape_state ALTER COLUMN id SET DEFAULT nextval('event_logs_scrape_state_id_seq'::regclass);
 
 ALTER TABLE ONLY executor_heartbeats ALTER COLUMN id SET DEFAULT nextval('executor_heartbeats_id_seq'::regclass);
@@ -3393,6 +3414,9 @@ ALTER TABLE ONLY discussion_threads
 
 ALTER TABLE ONLY discussion_threads_target_repo
     ADD CONSTRAINT discussion_threads_target_repo_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY event_logs_export_allowlist
+    ADD CONSTRAINT event_logs_export_allowlist_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY event_logs
     ADD CONSTRAINT event_logs_pkey PRIMARY KEY (id);
@@ -3718,6 +3742,8 @@ CREATE INDEX discussion_threads_author_user_id_idx ON discussion_threads USING b
 CREATE INDEX discussion_threads_target_repo_repo_id_path_idx ON discussion_threads_target_repo USING btree (repo_id, path);
 
 CREATE INDEX event_logs_anonymous_user_id ON event_logs USING btree (anonymous_user_id);
+
+CREATE INDEX event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist USING btree (event_name);
 
 CREATE INDEX event_logs_name ON event_logs USING btree (name);
 

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3743,7 +3743,7 @@ CREATE INDEX discussion_threads_target_repo_repo_id_path_idx ON discussion_threa
 
 CREATE INDEX event_logs_anonymous_user_id ON event_logs USING btree (anonymous_user_id);
 
-CREATE INDEX event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist USING btree (event_name);
+CREATE UNIQUE INDEX event_logs_export_allowlist_event_name_idx ON event_logs_export_allowlist USING btree (event_name);
 
 CREATE INDEX event_logs_name ON event_logs USING btree (name);
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39094 

Implements an allowlist for events that are keyed by name. Currently this is stored in a database table. See linked issue for some thoughts on how this could be improved.

## Test plan

To test locally:

Set up gcp credentials 
```
gcloud auth application-default login
```
Start `sg` 
```
GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json" sg start ...
```

Add configuration to the site config
```
    "exportUsageTelemetry": {
      "enabled": true,
      "topicProjectName": "sourcegraph-dogfood",
      "topicName": "usage-data-testing"
    },
```

Adding `InsightHover` to the allowlist and resetting the scraper state:

```
[         worker] INFO worker.export-usage-telemetry telemetry/telemetry_job.go:127 fetching events from bookmark {"bookmark_id": 0}
[         worker] INFO worker.export-usage-telemetry telemetry/telemetry_job.go:138 telemetryHandler executed {"event count": 448, "maxId": 20578}
```

```
select count(*) from event_logs where name = 'InsightHover';
```

| count |
| :--- |
| 448 |

