### PR TITLE
JetBrains: Update docs

### DIFF
--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -2,11 +2,11 @@
 
 # Sourcegraph for JetBrains IDEs
 
-- **New:** Search with Sourcegraph directly from inside your JetBrains product.
-- Instantly search in all open source repos and your private code.
-- Peek into any remote repo in the IDE, without checking it out.
-- Create URLs to specific code blocks to share them with your teammates.
-- Open your files on Sourcegraph.
+- **New:** Search with Sourcegraph directly from inside the IDE
+- Instantly search in all open source repos and your private code
+- Peek into any remote repo in the IDE, without checking it out locally
+- Create URLs to specific code blocks to share them with your teammates
+- Open your files on Sourcegraph
 
 <!-- Plugin description end -->
 
@@ -31,16 +31,40 @@ The plugin works with all JetBrains IDEs, including:
 ## Installation
 
 - Open settings
+  - Windows: Go to `File | Settings` (or use <kbd>Ctrl+Alt+S</kbd>)
   - Mac: Go to `IntelliJ IDEA | Preferences` (or use <kbd>⌘,</kbd>)
-  - Windows: Go to `File | Settings` (or use <kb>Ctrl+Alt+S</kb>)
 - Click `Plugins` in the left-hand pane, then the `Marketplace` tab at the top
 - Search for `Sourcegraph`, then click the `Install` button
 - Restart your IDE if needed
-- To try the plugin, press <kbd>Alt+A</kbd> (<kbd>⌥A</kbd> on Mac) then select some code and choose `Sourcegraph` in the right-click context menu to see actions and keyboard shortcuts.
+- To search with Sourcegraph, press <kbd>Alt+S</kbd> (<kbd>⌥S</kbd> on Mac).
+- To share a link to your code or search through the website, right-click in the editor, and choose an action under the `Sourcegraph` context menu item.
+- To use your private Sourcegraph instance, open `Settings | Tools | Sourcegraph` and enter your URL and access token.
 
-## Configuring for use with a private Sourcegraph instance
+## Advanced settings
 
-The plugin is configurable _globally_ by creating a `.sourcegraph-jetbrains.properties` (or `sourcegraph-jetbrains.properties` pre-v1.2.2) in your home directory. For example, modify the following URL to match your on-premises Sourcegraph instance URL:
+You can configure the plugin at three levels:
+
+1. **Application level:** This is what you edit by default when you go to Settings and make changes in the UI. 
+    - Advanced tip: App-level settings are stored in a file called `sourcegraph.xml` together with the rest of the IDE settings. [This article](https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs) will help you find it if you should need it for anything.
+2. **Project level:** You can set up project-level settings in a less intuitive way:
+   1. Create a new file at `{project root}/.idea/sourcegraph.xml` if it doesn't exist, with this content:
+        ```xml
+        <?xml version="1.0" encoding="UTF-8"?>
+        <project version="4">
+          <component name="Config">
+            <option name="instanceType" value="DOTCOM" />
+            <option name="url" value="https://company.sourcegraph.com/" />
+            <option name="accessToken" value="" />
+            <option name="defaultBranch" value="main" />
+            <option name="remoteUrlReplacements" value="" />
+            <option name="isGlobbingEnabled" value="false" />
+          </component>
+        </project>
+        ```
+      If the file already exists, then just add the option lines next to the original ones.
+   2. Reopen your project to let the IDE catch up with the changes. Now you have custom settings enabled for this project. In the future, when you have this project open and you edit your settings in the Settings UI, they will be saved to the **project-level** file.
+   3. To remove the project-level settings, open the XML again and remove the lines you want to set on the app level.
+3. **User level:** This is something that's rarely used and is only kept for backwards compatibility. So, the plugin is also configurable by removing all creating a file called `.sourcegraph-jetbrains.properties` in your home directory. Both the app-level and project-level XMLs override this, plus it only supports three settings:
 
 ```
 url = https://sourcegraph.example.com
@@ -48,20 +72,7 @@ defaultBranch = example-branch
 remoteUrlReplacements = git.example.com, git-web.example.com
 ```
 
-You may also choose to configure it _per project_ using a `.idea/sourcegraph.xml` file in your project like so:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="com.sourcegraph.config.SourcegraphConfig">
-    <option name="url" value="https://sourcegraph.example.com"/>
-    <option name="defaultBranch" value="example-branch"/>
-    <option name="remoteUrlReplacements" value="git.example.com, git-web.example.com"/>
-  </component>
-</project>
-```
-
-By default, the plugin will use the git remote called `origin` to determine which repository on Sourcegraph corresponds to your local repository. If your `origin` remote doesn’t match Sourcegraph, you may instead configure a Git remote by the name of `sourcegraph`, and it will take priority.
+**+1 tip for git remotes:** By default, the plugin will use the git remote called `origin` to determine which repository on Sourcegraph corresponds to your local repository. If your `origin` remote doesn’t match Sourcegraph, you may instead configure a Git remote by the name of `sourcegraph`. It will take priority when creating Sourcegraph links.
 
 ## Questions & Feedback
 
@@ -70,14 +81,14 @@ If you have any questions, feedback, or bug report, we appreciate if you [open a
 ## Uninstallation
 
 - Open settings
+  - Windows: Go to `File | Settings` (or use <kbd>Ctrl+Alt+S</kbd>)
   - Mac: Go to `IntelliJ IDEA | Preferences` (or use <kbd>⌘,</kbd>)
-  - Windows: Go to `File | Settings` (or use <kb>Ctrl+Alt+S</kb>)
 - Click `Plugins` in the left-hand pane, then the `Installed` tab at the top
 - Find `Sourcegraph` → Right click → `Uninstall` (or uncheck to disable)
 
 ## Development
 
-- Clone `https://github.com/sourcegraph/sourcegraph`
+- Clone `https://github.com/sourcegraph/sourcegraph` (on Windows, you'll need to use WSL2)
 - Run `yarn install` in the root directory to get all dependencies
 - Run `yarn generate` in the root directory to generate graphql files
 - Go to `client/jetbrains/` and run `yarn build` to generate the JS files, or `yarn watch` to watch for changes and regenerate on the fly
@@ -93,9 +104,7 @@ The publishing process is based on the [intellij-platform-plugin-template](https
 ### Publishing from your local machine
 
 1. Update `pluginVersion` in `gradle.properties`
-
-- Pre-release builds with the same version as a previous one need to append a number. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
-
+    - To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
 2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md`
 3. Run `PUBLISH_TOKEN=<YOUR TOKEN HERE> ./scripts/release.sh` from inside the `client/jetbrains` directory (You can [generate tokens on the JetBrains marketplace](https://plugins.jetbrains.com/author/me/tokens)).
 
@@ -108,10 +117,10 @@ See [`CHANGELOG.md`](https://github.com/sourcegraph/sourcegraph/blob/main/client
 Parts of this extension rely on the [JCEF](https://plugins.jetbrains.com/docs/intellij/jcef.html) web view features built into the JetBrains platform. To enable debugging tools for this view, please follow these steps:
 
 1. [Enable JetBrains internal mode](https://plugins.jetbrains.com/docs/intellij/enabling-internal.html)
-2. Open Search Everywhere and the "Actions" tab: (On macOS via `cmd+shift+a`)
+2. Open Find Actions: (<kbd>Ctrl+Shift+A</kbd> / <kbd>⌘⇧A</kbd>)
 3. Search for "Registry..." and open it
-4. Search for an option called `ide.browser.jcef.debug.port`
-5. Change the default value to an open port (e.g. `9222`)
-6. After this, a restart of the IDE may be required
-7. Open the Sourcegraph search inside JetBrains `alt+a`
-8. Now, you can switch to a browser window, navigate to [`localhost:9222`](http://localhost:9222), and select the Sourcegraph window.
+4. Find option `ide.browser.jcef.debug.port`
+5. Change the default value to an open port (we use `9222`)
+6. Restart IDE
+7. Open the “Find with Sourcegraph” window (<kbd>Alt+A</kbd> / <kbd>⌥A</kbd>)
+8. Switch to a browser window, go to [`localhost:9222`](http://localhost:9222), and select the Sourcegraph window. Sometimes it needs some back and forth to focus the external browser with the JCEF component also focused—you may need to move the popup out of the way and click the external browser rather than using <kbd>Alt+Tab</kbd> / <kbd>⌘Tab</kbd>.

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -44,23 +44,23 @@ The plugin works with all JetBrains IDEs, including:
 
 You can configure the plugin at three levels:
 
-1. **Application level:** This is what you edit by default when you go to Settings and make changes in the UI. 
-    - Advanced tip: App-level settings are stored in a file called `sourcegraph.xml` together with the rest of the IDE settings. [This article](https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs) will help you find it if you should need it for anything.
+1. **Application level:** This is what you edit by default when you go to Settings and make changes in the UI.
+   - Advanced tip: App-level settings are stored in a file called `sourcegraph.xml` together with the rest of the IDE settings. [This article](https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs) will help you find it if you should need it for anything.
 2. **Project level:** You can set up project-level settings in a less intuitive way:
    1. Create a new file at `{project root}/.idea/sourcegraph.xml` if it doesn't exist, with this content:
-        ```xml
-        <?xml version="1.0" encoding="UTF-8"?>
-        <project version="4">
-          <component name="Config">
-            <option name="instanceType" value="DOTCOM" />
-            <option name="url" value="https://company.sourcegraph.com/" />
-            <option name="accessToken" value="" />
-            <option name="defaultBranch" value="main" />
-            <option name="remoteUrlReplacements" value="" />
-            <option name="isGlobbingEnabled" value="false" />
-          </component>
-        </project>
-        ```
+      ```xml
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project version="4">
+        <component name="Config">
+          <option name="instanceType" value="DOTCOM" />
+          <option name="url" value="https://company.sourcegraph.com/" />
+          <option name="accessToken" value="" />
+          <option name="defaultBranch" value="main" />
+          <option name="remoteUrlReplacements" value="" />
+          <option name="isGlobbingEnabled" value="false" />
+        </component>
+      </project>
+      ```
       If the file already exists, then just add the option lines next to the original ones.
    2. Reopen your project to let the IDE catch up with the changes. Now you have custom settings enabled for this project. In the future, when you have this project open and you edit your settings in the Settings UI, they will be saved to the **project-level** file.
    3. To remove the project-level settings, open the XML again and remove the lines you want to set on the app level.
@@ -104,7 +104,7 @@ The publishing process is based on the [intellij-platform-plugin-template](https
 ### Publishing from your local machine
 
 1. Update `pluginVersion` in `gradle.properties`
-    - To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
+   - To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
 2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md`
 3. Run `PUBLISH_TOKEN=<YOUR TOKEN HERE> ./scripts/release.sh` from inside the `client/jetbrains` directory (You can [generate tokens on the JetBrains marketplace](https://plugins.jetbrains.com/author/me/tokens)).
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Optional;
 
 /**
- * Jetbrains IDE action to open a selected revision in Sourcegraph.
+ * JetBrains IDE action to open a selected revision in Sourcegraph.
  */
 public class OpenRevisionAction extends DumbAwareAction {
     private final Logger logger = Logger.getInstance(this.getClass());

--- a/doc/admin/deployment_best_practices.md
+++ b/doc/admin/deployment_best_practices.md
@@ -66,8 +66,6 @@ _It is possible to migrate your data to a Docker-Compose or Kubernetes deploymen
 Only the latest versions of IDEs are generally supported, but most versions within a few months up-to-date generally work.
 
 - VS Code: [https://github.com/sourcegraph/sourcegraph/tree/main/client/vscode](https://github.com/sourcegraph/sourcegraph/tree/main/client/vscode); we don't yet support VSCodium
-- Atom: [https://github.com/sourcegraph/sourcegraph-atom](https://github.com/sourcegraph/sourcegraph-atom)
-- Sublime Text 3: [https://github.com/sourcegraph/sourcegraph-sublime](https://github.com/sourcegraph/sourcegraph-sublime); we don't yet support Sublime Text 2 or 4
 - JetBrains IDEs: [https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains](https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains) – we mainly test the plugin with IntelliJ IDEA, but it should work with no issues in all JetBrains IDEs, including:
   - IntelliJ IDEA
   - IntelliJ IDEA Community Edition
@@ -82,3 +80,5 @@ Only the latest versions of IDEs are generally supported, but most versions with
   - DataGrip
   - Rider
   - Android Studio
+- Sublime Text 3: [https://github.com/sourcegraph/sourcegraph-sublime](https://github.com/sourcegraph/sourcegraph-sublime); we don't yet support Sublime Text 2 or 4
+- Atom: [https://github.com/sourcegraph/sourcegraph-atom](https://github.com/sourcegraph/sourcegraph-atom)

--- a/doc/admin/deployment_best_practices.md
+++ b/doc/admin/deployment_best_practices.md
@@ -65,10 +65,10 @@ _It is possible to migrate your data to a Docker-Compose or Kubernetes deploymen
 
 Only the latest versions of IDEs are generally supported, but most versions within a few months up-to-date generally work.
 
-- VS code: [https://github.com/sourcegraph/sourcegraph-vscode](https://github.com/sourcegraph/sourcegraph-vscode); we don't yet support VSCodium
+- VS Code: [https://github.com/sourcegraph/sourcegraph/tree/main/client/vscode](https://github.com/sourcegraph/sourcegraph/tree/main/client/vscode); we don't yet support VSCodium
 - Atom: [https://github.com/sourcegraph/sourcegraph-atom](https://github.com/sourcegraph/sourcegraph-atom)
 - Sublime Text 3: [https://github.com/sourcegraph/sourcegraph-sublime](https://github.com/sourcegraph/sourcegraph-sublime); we don't yet support Sublime Text 2 or 4
-- Jetbrains IDEs: [https://github.com/sourcegraph/sourcegraph-jetbrains](https://github.com/sourcegraph/sourcegraph-jetbrains) - we only test with IntelliJ IDEA, but it should work with no issues in all Jetbrains IDEs:
+- JetBrains IDEs: [https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains](https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains) – we mainly test the plugin with IntelliJ IDEA, but it should work with no issues in all JetBrains IDEs, including:
   - IntelliJ IDEA
   - IntelliJ IDEA Community Edition
   - PhpStorm

--- a/doc/adopt/code_search_in_monorepos.md
+++ b/doc/adopt/code_search_in_monorepos.md
@@ -48,7 +48,7 @@ It might *seem* like staying in a single tool (your editor) means staying in flo
 - 😊 The code search tool can show much more helpful code context, such as [Git blame information after each line](https://sourcegraph.com/extensions/sourcegraph/git-extras), [code coverage overlays](https://sourcegraph.com/extensions/sourcegraph/codecov), runtime info from [Datadog](https://sourcegraph.com/extensions/sourcegraph/datadog-metrics)/[LightStep](https://sourcegraph.com/extensions/sourcegraph/lightstep)/[Sentry](https://sourcegraph.com/extensions/sourcegraph/sentry)/etc., static analysis and lint results from [SonarQube](https://sourcegraph.com/extensions/sourcegraph/sonarqube), and more. You could configure some of these things to display in your editor, but that's cumbersome and they're noisy for the majority of the time when you're writing code.
 - 😊 A code search tool does all the hard work (indexing and analysis) on the server beforehand, so your local machine remains fast and responsive.
 
-    > "The JetBrains IDEs have great search capabilities. However, indexing a large repo is slow and draining on even a powerful MacBook Pro, and that happens every time you switch to another branch."
+    > "The JetBrains IDEs have great search capabilities. However, indexing a large repo is slow and draining on even a powerful MacBook Pro, and some reindexing happens every time you switch to another branch."
 - 😊 If you identify a likely culprit (such as a problematic line of code) via code search, it's easy to get a permalink to that line to add to the bug report.
 
 

--- a/doc/dev/background-information/sourcegraph_extensions.md
+++ b/doc/dev/background-information/sourcegraph_extensions.md
@@ -9,10 +9,10 @@ Here are all repositories beyond sourcegraph/sourcegraph that relate to extensio
 - [bitbucket-server-plugin](https://github.com/sourcegraph/bitbucket-server-plugin)
 
 ### Editor extensions
-- [sourcegraph-vscode](https://github.com/sourcegraph/sourcegraph-vscode)
+- [sourcegraph-vscode](https://github.com/sourcegraph/sourcegraph/tree/main/client/vscode)
 - [sourcegraph-sublime](https://github.com/sourcegraph/sourcegraph-sublime)
 - [sourcegraph-atom](https://github.com/sourcegraph/sourcegraph-atom)
-- [sourcegraph-jetbrains](https://github.com/sourcegraph/sourcegraph-jetbrains)
+- [sourcegraph-jetbrains](https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains)
 
 ### Sourcegraph Extensions
 - [extension-api-classes](https://github.com/sourcegraph/extension-api-classes)


### PR DESCRIPTION
Updated a few docs pages, then the README for the JetBrains project, to be up-to-date with the latest changes, and have production-ready docs quality. I think it's good now.

Also fixed VS Code links once I was there.

Adding @philipp-spiess as a reviewer for the JetBrains part and @abeatrix for the tiny VS Code-related changes.

## Test plan

Only docs changes, so the code review should do it.

## App preview:

- [Web](https://sg-web-dv-jetbrains-update-docs.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pejwcojgxc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
