### PR TITLE
Revert "Update git to 2.35.2 in docker images (#37712)"

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -7,9 +7,9 @@
 FROM sourcegraph/alpine-3.14:159028_2022-07-07_1f3b17ce1db8@sha256:25d682b5fd069c716c2b29dcf757c0dc0ce29810a07f91e1347901920272b4a7 AS p4cli
 
 # hadolint ignore=DL3003
-RUN wget http://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/p4
-RUN mv p4 /usr/local/bin/p4
-RUN chmod +x /usr/local/bin/p4
+RUN wget http://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/p4 && \
+    mv p4 /usr/local/bin/p4 && \
+    chmod +x /usr/local/bin/p4
 
 FROM sourcegraph/alpine-3.14:159028_2022-07-07_1f3b17ce1db8@sha256:25d682b5fd069c716c2b29dcf757c0dc0ce29810a07f91e1347901920272b4a7 AS p4-fusion
 
@@ -38,12 +38,9 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 RUN apk add --no-cache \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    # We require git 2.35.2 to fix this vulnerability:
-    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    'git>=2.35.2' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main \
-    git-p4
-
-RUN apk add --no-cache  \
+    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    git-p4 \
+    && apk add --no-cache  \
     openssh-client \
     # We require libstdc++ for p4-fusion
     libstdc++ \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -2,9 +2,9 @@
 FROM sourcegraph/alpine-3.14:159028_2022-07-07_1f3b17ce1db8@sha256:25d682b5fd069c716c2b29dcf757c0dc0ce29810a07f91e1347901920272b4a7 AS p4cli
 
 # hadolint ignore=DL3003
-RUN wget http://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/p4
-RUN mv p4 /usr/local/bin/p4
-RUN chmod +x /usr/local/bin/p4
+RUN wget http://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/p4 && \
+    mv p4 /usr/local/bin/p4 && \
+    chmod +x /usr/local/bin/p4
 
 # Install p4-fusion (keep this up to date with cmd/gitserver/Dockerfile)
 FROM sourcegraph/alpine-3.14:159028_2022-07-07_1f3b17ce1db8@sha256:25d682b5fd069c716c2b29dcf757c0dc0ce29810a07f91e1347901920272b4a7 AS p4-fusion
@@ -42,24 +42,20 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    # We require git 2.35.2 to fix this vulnerability:
-    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    'git>=2.35.2' \
+    'git>=2.34.1' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main
-
-RUN apk add --no-cache --verbose \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     # You can't just bump the major version since that requires pgupgrade
     # between Sourcegraph releases.
+    && apk add --no-cache --verbose \
     postgresql=~12 \
     postgresql-contrib=~12 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main
-
-RUN apk add --no-cache --verbose \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main  \
+    && apk add --no-cache --verbose \
     'bash>=5.0.17' \
     'redis>=5.0' \
     python2 \


### PR DESCRIPTION
This reverts commit 04c98ab493e0889394e2e60fb85e1a53225e5a35.

There is a bug in the current release of git that causes sgm to corrupt repos with a commit-graph malformed error. 
Reverting this git version upgrade to avoid these corruptions while we find a more up to date version of git that doesn't have this bug. 

See additional details here: https://github.com/sourcegraph/sourcegraph/pull/37906

## Test plan
Existing tests pass