### PR TITLE
migration: Make definitions json serializable

### DIFF
--- a/internal/database/migration/definition/json.go
+++ b/internal/database/migration/definition/json.go
@@ -1,0 +1,70 @@
+package definition
+
+import (
+	"encoding/json"
+
+	"github.com/keegancsmith/sqlf"
+)
+
+func (ds *Definitions) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ds.All())
+}
+
+func (ds *Definitions) UnmarshalJSON(data []byte) error {
+	var definitions []Definition
+	if err := json.Unmarshal(data, &definitions); err != nil {
+		return err
+	}
+
+	newDefinitions, err := NewDefinitions(definitions)
+	if err != nil {
+		return err
+	}
+
+	*ds = *newDefinitions
+	return nil
+}
+
+type jsonDefinition struct {
+	ID                        int
+	Name                      string
+	UpQuery                   string
+	DownQuery                 string
+	Privileged                bool
+	NonIdempotent             bool
+	Parents                   []int
+	IsCreateIndexConcurrently bool
+	IndexMetadata             *IndexMetadata
+}
+
+func (d *Definition) MarshalJSON() ([]byte, error) {
+	return json.Marshal(jsonDefinition{
+		ID:                        d.ID,
+		Name:                      d.Name,
+		UpQuery:                   d.UpQuery.Query(sqlf.PostgresBindVar),
+		DownQuery:                 d.DownQuery.Query(sqlf.PostgresBindVar),
+		Privileged:                d.Privileged,
+		NonIdempotent:             d.NonIdempotent,
+		Parents:                   d.Parents,
+		IsCreateIndexConcurrently: d.IsCreateIndexConcurrently,
+		IndexMetadata:             d.IndexMetadata,
+	})
+}
+
+func (d *Definition) UnmarshalJSON(data []byte) error {
+	var jsonDefinition jsonDefinition
+	if err := json.Unmarshal(data, &jsonDefinition); err != nil {
+		return err
+	}
+
+	d.ID = jsonDefinition.ID
+	d.Name = jsonDefinition.Name
+	d.UpQuery = sqlf.Sprintf(jsonDefinition.UpQuery)
+	d.DownQuery = sqlf.Sprintf(jsonDefinition.DownQuery)
+	d.Privileged = jsonDefinition.Privileged
+	d.NonIdempotent = jsonDefinition.NonIdempotent
+	d.Parents = jsonDefinition.Parents
+	d.IsCreateIndexConcurrently = jsonDefinition.IsCreateIndexConcurrently
+	d.IndexMetadata = jsonDefinition.IndexMetadata
+	return nil
+}

--- a/internal/database/migration/definition/json.go
+++ b/internal/database/migration/definition/json.go
@@ -59,8 +59,8 @@ func (d *Definition) UnmarshalJSON(data []byte) error {
 
 	d.ID = jsonDefinition.ID
 	d.Name = jsonDefinition.Name
-	d.UpQuery = sqlf.Sprintf(jsonDefinition.UpQuery)
-	d.DownQuery = sqlf.Sprintf(jsonDefinition.DownQuery)
+	d.UpQuery = queryFromString(jsonDefinition.UpQuery)
+	d.DownQuery = queryFromString(jsonDefinition.DownQuery)
 	d.Privileged = jsonDefinition.Privileged
 	d.NonIdempotent = jsonDefinition.NonIdempotent
 	d.Parents = jsonDefinition.Parents

--- a/internal/database/migration/definition/read_test.go
+++ b/internal/database/migration/definition/read_test.go
@@ -140,7 +140,7 @@ parent: 12345
 -- +++
 `
 
-func TestCanonicalizeQuery(t *testing.T) {
+func TestQueryFromString(t *testing.T) {
 	for _, testCase := range []struct {
 		name     string
 		input    string
@@ -154,7 +154,7 @@ func TestCanonicalizeQuery(t *testing.T) {
 		{"kitchen sink", testFrontmatter + "\n\nBEGIN;\n\nMY QUERY;\n\nCOMMIT;\n", "MY QUERY;"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			if query := canonicalizeQuery(testCase.input); query != testCase.expected {
+			if query := queryFromString(testCase.input).Query(sqlf.PostgresBindVar); query != testCase.expected {
 				t.Errorf("unexpected canonical query. want=%q have=%q", testCase.expected, query)
 			}
 		})


### PR DESCRIPTION
This PR adds JSON encoders/decoders to definitions. These currently aren't exposed directly and ends up with empty JSON object literals for definition graphs.

## Test plan

N/A.
