### PR TITLE
migrator: Update concrete runner factory

### DIFF
--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -95,7 +95,7 @@ func newRunnerWithSchemas(ctx context.Context, schemaNames []string, schemas []*
 	storeFactory := func(db *sql.DB, migrationsTable string) connections.Store {
 		return connections.NewStoreShim(store.NewWithDB(db, migrationsTable, operations))
 	}
-	r, err := connections.RunnerFromDSNs(logger, dsns, appName, storeFactory)
+	r, err := connections.RunnerFromDSNsWithSchemas(logger, dsns, appName, storeFactory, schemas)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -14,6 +14,7 @@ import (
 
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/cliutil"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/store"
 	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -75,6 +76,15 @@ func mainErr(ctx context.Context, args []string) error {
 }
 
 func newRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, error) {
+	return newRunnerWithSchemas(ctx, schemas.FilterSchemasByName(schemas.Schemas, schemaNames))
+}
+
+func newRunnerWithSchemas(ctx context.Context, schemas []*schemas.Schema) (cliutil.Runner, error) {
+	schemaNames := make([]string, 0, len(schemas))
+	for _, schema := range schemas {
+		schemaNames = append(schemaNames, schema.Name)
+	}
+
 	logger := log.Scoped("runner", "")
 	observationContext := &observation.Context{
 		Logger:     logger,

--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -76,15 +76,10 @@ func mainErr(ctx context.Context, args []string) error {
 }
 
 func newRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, error) {
-	return newRunnerWithSchemas(ctx, schemas.FilterSchemasByName(schemas.Schemas, schemaNames))
+	return newRunnerWithSchemas(ctx, schemaNames, schemas.Schemas)
 }
 
-func newRunnerWithSchemas(ctx context.Context, schemas []*schemas.Schema) (cliutil.Runner, error) {
-	schemaNames := make([]string, 0, len(schemas))
-	for _, schema := range schemas {
-		schemaNames = append(schemaNames, schema.Name)
-	}
-
+func newRunnerWithSchemas(ctx context.Context, schemaNames []string, schemas []*schemas.Schema) (cliutil.Runner, error) {
 	logger := log.Scoped("runner", "")
 	observationContext := &observation.Context{
 		Logger:     logger,

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -172,15 +172,10 @@ func makeRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, erro
 		return nil, err
 	}
 
-	return makeRunnerWithSchemas(ctx, schemas.FilterSchemasByName(filesystemSchemas, schemaNames))
+	return makeRunnerWithSchemas(ctx, schemaNames, filesystemSchemas)
 }
 
-func makeRunnerWithSchemas(ctx context.Context, schemas []*schemas.Schema) (cliutil.Runner, error) {
-	schemaNames := make([]string, 0, len(schemas))
-	for _, schema := range schemas {
-		schemaNames = append(schemaNames, schema.Name)
-	}
-
+func makeRunnerWithSchemas(ctx context.Context, schemaNames []string, schemas []*schemas.Schema) (cliutil.Runner, error) {
 	// Try to read the `sg` configuration so we can read ENV vars from the
 	// configuration and use process env as fallback.
 	var getEnv func(string) string

--- a/internal/database/migration/cliutil/iface.go
+++ b/internal/database/migration/cliutil/iface.go
@@ -24,7 +24,7 @@ type Store interface {
 type OutputFactory func() *output.Output
 
 type RunnerFactory func(ctx context.Context, schemaNames []string) (Runner, error)
-type RunnerFactoryWithSchemas func(ctx context.Context, schemas []*schemas.Schema) (Runner, error)
+type RunnerFactoryWithSchemas func(ctx context.Context, schemaNames []string, schemas []*schemas.Schema) (Runner, error)
 
 type runnerShim struct {
 	*runner.Runner

--- a/internal/database/migration/cliutil/iface.go
+++ b/internal/database/migration/cliutil/iface.go
@@ -20,11 +20,11 @@ type Store interface {
 	Describe(ctx context.Context) (map[string]schemas.SchemaDescription, error)
 }
 
-// OutputFactory allows providing global output that might not be instantiated at compile
-// time.
+// OutputFactory allows providing global output that might not be instantiated at compile time.
 type OutputFactory func() *output.Output
 
 type RunnerFactory func(ctx context.Context, schemaNames []string) (Runner, error)
+type RunnerFactoryWithSchemas func(ctx context.Context, schemas []*schemas.Schema) (Runner, error)
 
 type runnerShim struct {
 	*runner.Runner


### PR DESCRIPTION
This introduced an (initially unused) type `RunnerFactoryWithSchemas` and rewrites the concrete runner factories in the sg migration and migrator commands in terms of this new constructor.

## Test plan

Existing tests.