### PR TITLE
[SG-39484] When hovering on UserNavBar, blue color flashes

### DIFF
--- a/client/web/src/nav/UserNavItem.module.scss
+++ b/client/web/src/nav/UserNavItem.module.scss
@@ -46,13 +46,6 @@
     min-width: 12rem;
 }
 
-.dropdown-item {
-    &:hover {
-        background-color: var(--link-color);
-        color: var(--light-text);
-    }
-}
-
 .dropdown-header {
     font-size: 0.75rem;
 }

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -133,27 +133,18 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
                                 Signed in as <strong>@{props.authenticatedUser.username}</strong>
                             </MenuHeader>
                             <MenuDivider className={styles.dropdownDivider} />
-                            <MenuLink
-                                className={styles.dropdownItem}
-                                as={Link}
-                                to={props.authenticatedUser.settingsURL!}
-                            >
+                            <MenuLink as={Link} to={props.authenticatedUser.settingsURL!}>
                                 Settings
                             </MenuLink>
                             {props.showRepositorySection && (
                                 <MenuLink
-                                    className={styles.dropdownItem}
                                     as={Link}
                                     to={`/users/${props.authenticatedUser.username}/settings/repositories`}
                                 >
                                     Your repositories
                                 </MenuLink>
                             )}
-                            <MenuLink
-                                className={styles.dropdownItem}
-                                as={Link}
-                                to={`/users/${props.authenticatedUser.username}/searches`}
-                            >
+                            <MenuLink as={Link} to={`/users/${props.authenticatedUser.username}/searches`}>
                                 Saved searches
                             </MenuLink>
                             {isOpenBetaEnabled && (
@@ -213,12 +204,7 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
                                     <MenuDivider className={styles.dropdownDivider} />
                                     <MenuHeader className={styles.dropdownHeader}>Your organizations</MenuHeader>
                                     {props.authenticatedUser.organizations.nodes.map(org => (
-                                        <MenuLink
-                                            className={styles.dropdownItem}
-                                            as={Link}
-                                            key={org.id}
-                                            to={org.settingsURL || org.url}
-                                        >
+                                        <MenuLink as={Link} key={org.id} to={org.settingsURL || org.url}>
                                             {org.displayName || org.name}
                                         </MenuLink>
                                     ))}
@@ -226,30 +212,23 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
                             )}
                             <MenuDivider className={styles.dropdownDivider} />
                             {props.authenticatedUser.siteAdmin && (
-                                <MenuLink className={styles.dropdownItem} as={Link} to="/site-admin">
+                                <MenuLink as={Link} to="/site-admin">
                                     Site admin
                                 </MenuLink>
                             )}
-                            <MenuLink
-                                className={styles.dropdownItem}
-                                as={Link}
-                                to="/help"
-                                target="_blank"
-                                rel="noopener"
-                            >
+                            <MenuLink as={Link} to="/help" target="_blank" rel="noopener">
                                 Help <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
                             </MenuLink>
                             <MenuItem onSelect={showKeyboardShortcutsHelp}>Keyboard shortcuts</MenuItem>
 
                             {props.authenticatedUser.session?.canSignOut && (
-                                <MenuLink className={styles.dropdownItem} as={AnchorLink} to="/-/sign-out">
+                                <MenuLink as={AnchorLink} to="/-/sign-out">
                                     Sign out
                                 </MenuLink>
                             )}
                             <MenuDivider className={styles.dropdownDivider} />
                             {props.showDotComMarketing && (
                                 <MenuLink
-                                    className={styles.dropdownItem}
                                     as={AnchorLink}
                                     to="https://about.sourcegraph.com"
                                     target="_blank"
@@ -260,7 +239,6 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
                             )}
                             {codeHostIntegrationMessaging === 'browser-extension' && (
                                 <MenuLink
-                                    className={styles.dropdownItem}
                                     as={AnchorLink}
                                     to="/help/integration/browser_extension"
                                     target="_blank"


### PR DESCRIPTION
## Description
UserNavBar flashing is fixed

## Problem statement
On hovering the UserNavItem, blue color flashes
https://www.loom.com/share/f3359ea119bd49babbbb2318515baba0
<!-- Describe the problem and why it is important to solve it, point to external resources. -->

## Success criteria
Above mentioned bug is fixed

## Refs 
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/39484)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-39484)

## Test Plan
Open sourcegraph webapp
Click on user icon at the top right side
On hovering over the dropdown it doesn't flashes

## App preview:

- [Web](https://sg-web-contractors-sg-39484.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xqfltytayk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
