### PR TITLE
web: Remove thread-loader from Webpack

### DIFF
--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -212,7 +212,6 @@ const config = {
         include: hotLoadablePaths,
         exclude: extensionHostWorker,
         use: [
-          ...(IS_PRODUCTION ? ['thread-loader'] : []),
           {
             loader: 'babel-loader',
             options: {
@@ -225,7 +224,7 @@ const config = {
       {
         test: /\.[jt]sx?$/,
         exclude: [...hotLoadablePaths, extensionHostWorker],
-        use: [...(IS_PRODUCTION ? ['thread-loader'] : []), getBabelLoader()],
+        use: [getBabelLoader()],
       },
       {
         test: /\.(sass|scss)$/,

--- a/package.json
+++ b/package.json
@@ -340,7 +340,6 @@
     "svgo": "^2.7.0",
     "term-size": "^2.2.0",
     "terser-webpack-plugin": "^5.1.4",
-    "thread-loader": "^3.0.4",
     "ts-loader": "^9.3.0",
     "ts-node": "^10.7.0",
     "typed-scss-modules": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17182,7 +17182,7 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-loader-runner@^4.1.0, loader-runner@^4.2.0:
+loader-runner@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
@@ -23533,17 +23533,6 @@ third-party-web@^0.12.2:
   version "0.12.5"
   resolved "https://registry.npmjs.org/third-party-web/-/third-party-web-0.12.5.tgz#df336053ddcbce68aa2da3787641233739ad5a64"
   integrity sha512-A8YS1bpOzm9os0w7wH/BbN5WZgzyf0zbrrWHckX57v+EkCaM7jZPoRpzgqrakh2e7IWP1KwAnMtlcGTATYZw8A==
-
-thread-loader@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/thread-loader/-/thread-loader-3.0.4.tgz#c392e4c0241fbc80430eb680e4886819b504a31b"
-  integrity sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==
-  dependencies:
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^4.1.0"
-    loader-utils "^2.0.0"
-    neo-async "^2.6.2"
-    schema-utils "^3.0.0"
 
 thread-stream@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Should be merged before https://github.com/sourcegraph/sourcegraph/pull/39381.

---

The `SentryWebpackPlugin` does not work with `thread-loader`, since `thread-loader` doesn't have access to webpack options, thus it cannot access `query` params of the loader. See https://github.com/getsentry/sentry-webpack-plugin/issues/272#issuecomment-942381393.

Secondly, thread-loader itself has not shown any substantial performance or build-time improvements.

<table>
<tr>
	<td><strong>With <code>thread-loader</code></strong></td>
	<td><img width="384" alt="Google Chrome 2022-07-28 at 15 22 15 000232@2x" src="https://user-images.githubusercontent.com/31861755/181477312-bce7818b-0651-48d0-8abb-80a583d50bd4.png"></td>
<tr>
	<td><strong>Without <code>thread-loader</code></strong></td>
	<td><img width="374" alt="Google Chrome 2022-07-28 at 15 25 03 000234@2x" src="https://user-images.githubusercontent.com/31861755/181477749-5e4d38e8-011d-45da-a600-b8780b3190ed.png"></td>
</table>

## Test plan

Builds are passing with green checks without `thread-loader`.

## App preview:

- [Web](https://sg-web-mihir-remove-thread-loader.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nrmgxznwdb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

