### PR TITLE
Enable deployment-notifier to post longer messages to Slack

### DIFF
--- a/enterprise/dev/deployment-notifier/main.go
+++ b/enterprise/dev/deployment-notifier/main.go
@@ -128,17 +128,18 @@ func main() {
 		}
 		fmt.Println(out)
 		fmt.Println("Slack\n---")
-		out, err = slackSummary(ctx, teammates, report, traceURL)
+		presenter, err := slackSummary(ctx, teammates, report, traceURL)
 		if err != nil {
 			logger.Fatal("can't render Slack post", log.Error(err))
 		}
-		fmt.Println(out)
+
+		fmt.Println(presenter.toString())
 	} else {
-		out, err := slackSummary(ctx, teammates, report, traceURL)
+		presenter, err := slackSummary(ctx, teammates, report, traceURL)
 		if err != nil {
 			logger.Fatal("can't render Slack post", log.Error(err))
 		}
-		err = postSlackUpdate(flags.SlackAnnounceWebhook, out)
+		err = postSlackUpdate(flags.SlackAnnounceWebhook, presenter)
 		if err != nil {
 			logger.Fatal("can't post Slack update", log.Error(err))
 		}

--- a/enterprise/dev/deployment-notifier/slack.go
+++ b/enterprise/dev/deployment-notifier/slack.go
@@ -16,7 +16,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var slackTemplate = `:arrow_left: *{{.Environment}} deployment (<{{.BuildURL}}|build>{{if .TraceURL}}, <{{.TraceURL}}|trace>{{end}})*
+var slackTemplate = `:arrow_left: *{{.Environment}} deployment*
+<{{.BuildURL}}|:hammer: Build>{{if .TraceURL}} <{{.TraceURL}}|:footprints: Trace>{{end}}
 
 *Updated services:*
 {{- range .Services }}


### PR DESCRIPTION
Due to less frequent deploys to dotcom, the amount of PRs included in a notification can lead to a message length that exceeds the max length of 3000 characters in a [text object](https://api.slack.com/reference/block-kit/composition-objects#text). Posting a message to the webhook that violates this constraint fails. As a workaround, PRs are broken up into multiple sections where necessary. This does introduce a line break between sections that's unavoidable 🤷‍♂️ 

Also does a little polishing of the message itself.
## Test plan
Tested with the Block Kit Builder by sending to myself:

![image](https://user-images.githubusercontent.com/2979513/181482540-a9a71e8b-7446-4aa5-b0aa-5b646071273f.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
