### PR TITLE
gitserver: remove outdated comment

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -514,8 +514,6 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 		cleanupLogger.Error("failed to write periodic stats", log.Error(err))
 	}
 
-	// Repo sizes are set only once during the first janitor run.
-	// There is no need for a second run because all repo sizes will be set until this moment
 	err = s.setRepoSizes(context.Background(), repoToSize)
 	if err != nil {
 		cleanupLogger.Error("setting repo sizes", log.Error(err))


### PR DESCRIPTION
This was a headscratcher. Turns out the comment became invalid with #38307.

## Test plan

- N/A