### PR TITLE
gitserver: only load MinimalRepo when updating size

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -578,7 +578,7 @@ func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]i
 }
 
 // fetchRepos returns up to count random repos found by names (i.e. keys) in repoToSize map
-func (s *Server) fetchRepos(ctx context.Context, repoToSize map[api.RepoName]int64, count int) ([]*types.Repo, error) {
+func (s *Server) fetchRepos(ctx context.Context, repoToSize map[api.RepoName]int64, count int) ([]types.MinimalRepo, error) {
 	reposToUpdateNames := make([]string, count)
 	idx := 0
 	// random nature of map traversal yields a different subset of repos every time this function is called
@@ -590,7 +590,7 @@ func (s *Server) fetchRepos(ctx context.Context, repoToSize map[api.RepoName]int
 		idx++
 	}
 
-	foundRepos, err := s.DB.Repos().List(ctx, database.ReposListOptions{
+	foundRepos, err := s.DB.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
 		Names:          reposToUpdateNames,
 		LimitOffset:    &database.LimitOffset{Limit: count},
 		IncludeBlocked: true,


### PR DESCRIPTION
We don't need the full repo object and our database will be thankful for
this (and our memory usage).


## Test plan

- Existing tests
- Manual testing and watching of update routine