### PR TITLE
JetBrains: Make it compatible with 2022.2

### DIFF
--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.0.4
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       - name: Run Tests

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -30,12 +30,12 @@ jobs:
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.0.4
 
-      # Setup Java 17 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 11
           cache: gradle
 
       - name: Run Tests

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Sourcegraph Changelog
 
-## [Unreleased]
+## [2.0.0]
 
-- Added a new UI to search with Sourcegraph from inside your JetBrains product.
+- Added a new UI to search with Sourcegraph from inside the IDE. Open it with <kbd>Alt+S</kbd> (<kbd>⌥S</kbd> on Mac) by default.
+- Added a settings UI to conveniently configure the plugin
+- General revamp on the existing features
+- Source code is now at [https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains](https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains)
 
 ## [1.2.4]
 

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -6,7 +6,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
-    id("org.jetbrains.intellij") version "1.6.0"
+    id("org.jetbrains.intellij") version "1.7.0"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=2.0.0-alpha.5
+pluginVersion=2.0.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -13,12 +13,12 @@ pluginVersion=2.0.0-alpha.5
 pluginSinceBuild=211.0
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
-platformVersion=2022.1
+platformVersion=2022.2
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion=11
+javaVersion=17
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion=7.4.2
 # Opt-out flag for bundling Kotlin standard library.

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -18,7 +18,7 @@ platformVersion=2022.2
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion=17
+javaVersion=11
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion=7.4.2
 # Opt-out flag for bundling Kotlin standard library.

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
@@ -1,6 +1,7 @@
 package com.sourcegraph.config;
 
 import com.google.gson.JsonObject;
+import com.intellij.ide.ui.laf.LafManagerImpl;
 import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,7 +27,7 @@ public class ThemeUtil {
         for (Object key : keysList) {
             try {
                 Object value = UIManager.get(key);
-                if (value instanceof ColorUIResource) {
+                if (value instanceof ColorUIResource || value instanceof LafManagerImpl.IJColorUIResource) {
                     intelliJTheme.addProperty(key.toString(), getHexString(UIManager.getColor(key)));
                 }
             } catch (Exception e) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.config;
 
 import com.google.gson.JsonObject;
-import com.intellij.ide.ui.laf.LafManagerImpl;
 import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -9,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
-import javax.swing.plaf.ColorUIResource;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,7 +25,7 @@ public class ThemeUtil {
         for (Object key : keysList) {
             try {
                 Object value = UIManager.get(key);
-                if (value instanceof ColorUIResource || value instanceof LafManagerImpl.IJColorUIResource) {
+                if (value instanceof Color) {
                     intelliJTheme.addProperty(key.toString(), getHexString(UIManager.getColor(key)));
                 }
             } catch (Exception e) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/39571

- Updated platform+Java+IntelliJ versions
- Fixed the theme bug: apparently, JetBrains started using a new color class
- Bumped plugin version to 2.0.0, to go ahead with the release

## Test plan

Tested it, it looks nice again. When changing the theme, the “panda bug” reappears, but it's not directly related to this bug. I've created a separate issue for this, with priority:high, but in the Icebox: https://github.com/sourcegraph/sourcegraph/issues/39574

## App preview:

- [Web](https://sg-web-dv-jetbrains-2022-2-compatibility.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jwfngpyduk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
