### PR TITLE
Sunsetting extensions: Deeper copy settings schema

### DIFF
--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -270,7 +270,7 @@ function setDiagnosticsOptions(
     jsonSchema: JSONSchema | undefined,
     extensionsAsCoreFeatures: boolean
 ): void {
-    const schema = settingsSchema
+    const schema = { ...settingsSchema, properties: { ...settingsSchema.properties } }
     if (extensionsAsCoreFeatures) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- we need to remove this key conditionally, but not from the schema
         // @ts-ignore


### PR DESCRIPTION
Fixes the mistake I made [here](https://github.com/sourcegraph/sourcegraph/pull/39227#discussion_r931634246)

## Test plan

If the CI tests pass, it should be fine.
Behavior shouldn't change.

## App preview:

- [Web](https://sg-web-dv-deeper-copy-settings-schema.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kmwwsyvahq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
