### PR TITLE
Add pagination to commit fetching

### DIFF
--- a/enterprise/dev/deployment-lag-notifier/github.go
+++ b/enterprise/dev/deployment-lag-notifier/github.go
@@ -77,7 +77,7 @@ func getCommit(client *http.Client, sha string) (Commit, error) {
 	return commit, nil
 }
 
-// getCommitLog fetches the last 20 commits of sourcegraph/sourcegraph@main from the Github API
+// getCommitLog fetches the last numCommits commits of sourcegraph/sourcegraph@main from the Github API
 func getCommitLog(client *http.Client, numCommits int) ([]Commit, error) {
 	var commits []Commit
 
@@ -86,39 +86,57 @@ func getCommitLog(client *http.Client, numCommits int) ([]Commit, error) {
 
 	url := "https://api.github.com/repos/sourcegraph/sourcegraph/commits"
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return commits, err
-	}
-
-	q := req.URL.Query()
-	q.Add("branch", "main")
-	q.Add("per_page", fmt.Sprintf("%v", numCommits))
-	q.Add("page", "1")
-
-	req.URL.RawQuery = q.Encode()
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return commits, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return commits, errors.Newf("received non-200 status code %v", resp.StatusCode)
-	}
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return commits, err
-	}
-
 	var gh GithubResponse
-	err = json.Unmarshal(body, &gh)
-	if err != nil {
-		return commits, err
+
+	page := 1
+	for len(gh) < numCommits {
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return commits, err
+		}
+
+		commitsToGet := numCommits - (page-1)*100
+		if commitsToGet > 100 {
+			commitsToGet = 100
+		}
+
+		q := req.URL.Query()
+		q.Add("branch", "main")
+		q.Add("per_page", fmt.Sprintf("%v", commitsToGet))
+		q.Add("page", fmt.Sprintf("%v", page))
+
+		req.URL.RawQuery = q.Encode()
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return commits, err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return commits, errors.Newf("received non-200 status code %v", resp.StatusCode)
+		}
+
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return commits, err
+		}
+
+		var temp GithubResponse
+		err = json.Unmarshal(body, &temp)
+		if err != nil {
+			return commits, err
+		}
+		gh = append(gh, temp...)
+
+		// numCommits is greater than total amount of commits so stop querying
+		if len(temp) < 100 {
+			break
+		}
+		page += 1
 	}
+
 	if len(gh) != numCommits {
 		return commits, errors.Newf("did not receive the expected number of commits. got: %v", len(gh))
 	}


### PR DESCRIPTION
The deployment lag notifier is failing after [increasing the amount of commits](https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/17188) allowed to be behind, because the commit API is paginated and allows max 100 results per page. This PR adds pagination support.

## Test plan
Local dry run, first line shows fetched commits:
```shell
2022/07/28 15:19:00 numCommits: 150, fetched commits: 150

2022/07/28 15:19:00 Cloud is not current!
:warning: *cloud*'s version may be out of date.
Current version: `e397ff284928` was committed *14h32m16s hours ago*.

*Alerts*:

Check <https://github.com/sourcegraph/deploy-sourcegraph-cloud/pulls|deploy-sourcegraph-cloud> to see if a release is blocked.

cc <!subteam^S02J9TTQLBU|dev-experience-support>
2022/07/28 15:19:00 Now: 2022-07-28 15:19:00.825213 +0200 CEST m=+1.099375043
2022/07/28 15:19:00 cloud: 2022-07-27 22:46:44 +0000 UTC
2022/07/28 15:19:00 main: 2022-07-28 12:59:21 +0000 UTC

Process finished with the exit code 0

```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
