### PR TITLE
bext: fix command palette styles

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
+- Fix command palette style regression on GitHub: [issues/39495](https://github.com/sourcegraph/sourcegraph/issues/39495), [pull/39580](https://github.com/sourcegraph/sourcegraph/pull/39580)
+
 ## Chrome & Firefox v22.7.11.926
 
 - Fix Sourcegraph buttons styles on Bitbucket cloud: [issues/32598](https://github.com/sourcegraph/sourcegraph/issues/32598), [pull/33787](https://github.com/sourcegraph/sourcegraph/pull/33787)

--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
-- Fix command palette style regression on GitHub: [issues/39495](https://github.com/sourcegraph/sourcegraph/issues/39495), [pull/39580](https://github.com/sourcegraph/sourcegraph/pull/39580)
+- Fix command palette style regression on GitHub: [issues/39495](https://github.com/sourcegraph/sourcegraph/issues/39495), [issues/33433](https://github.com/sourcegraph/sourcegraph/issues/33433) [pull/39580](https://github.com/sourcegraph/sourcegraph/pull/39580)
 
 ## Chrome & Firefox v22.7.11.926
 

--- a/client/browser/src/shared/code-hosts/github/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/github/codeHost.module.scss
@@ -23,9 +23,19 @@
     --mark-bg: var(--mark-bg-dark);
 }
 
+.command-palette-popover {
+    border: 1px solid var(--color-border-default);
+    border-radius: 6px;
+    overflow: hidden;
+}
+
 .command-palette-action-item {
     /* Reset GitHub's 44px min-height */
     min-height: initial;
+
+    /* Reset default user agent button styles */
+    border: none;
+    background-color: transparent;
 }
 
 .action-item {

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -719,9 +719,9 @@ export const githubCodeHost: GithubCodeHost = {
     notificationClassNames,
     commandPaletteClassProps: {
         buttonClassName: 'Header-link d-flex flex-items-baseline',
-        popoverClassName: 'Box',
+        popoverClassName: classNames('Box', styles.commandPalettePopover),
         formClassName: 'p-1',
-        inputClassName: 'form-control input-sm header-search-input jump-to-field',
+        inputClassName: 'form-control input-sm header-search-input jump-to-field-active',
         listClassName: 'p-0 m-0 js-navigation-container jump-to-suggestions-results-container',
         selectedListItemClassName: 'navigation-focus',
         listItemClassName:


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39495
Closes https://github.com/sourcegraph/sourcegraph/issues/33433

| Before | After |
| - | - |
|<img width="880" alt="Screenshot 2022-07-28 at 16 32 03" src="https://user-images.githubusercontent.com/25318659/181518024-4fa214cd-cab5-44f8-a53f-91eab1e76564.png"><img width="880" alt="Screenshot 2022-07-28 at 16 32 28" src="https://user-images.githubusercontent.com/25318659/181518005-5956648d-441f-45a3-910d-a6e73298234d.png">  |<img width="880" alt="Screenshot 2022-07-28 at 16 31 34" src="https://user-images.githubusercontent.com/25318659/181518072-43a5a719-c151-4f62-a86b-5f0378f9a8dc.png"><img width="880" alt="Screenshot 2022-07-28 at 16 31 19" src="https://user-images.githubusercontent.com/25318659/181518078-9392c11c-e862-4280-9540-8f8f96cfacc4.png">|

## Test plan
- `sg run bext`
- open any repo on GitHub and open command palette 
- ensure its styles are consistent with the rest of GitHub UI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-bext-fix-command.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ypjkyxhkmo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

