### PR TITLE
JetBrains: Add necessary dependency

### DIFF
--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -3,6 +3,8 @@
     <name>Sourcegraph</name>
     <vendor email="hi@sourcegraph.com" url="https://sourcegraph.com">Sourcegraph</vendor>
 
+    <depends>com.intellij.modules.platform</depends>
+
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="com.sourcegraph.config.SourcegraphProjectService"/>
         <projectService serviceImplementation="com.sourcegraph.config.SettingsChangeListener"/>


### PR DESCRIPTION
Got a failure when publishing 2.0:

```
> Task :verifyPlugin
[gradle-intellij-plugin :Sourcegraph:verifyPlugin] Plugin descriptor plugin.xml does not include any module dependency tags. The plugin is assumed to be a legacy plugin and is loaded only in IntelliJ IDEA. See https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html

> Task :publishPlugin FAILED
```

According to this section of the docs:
https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html#modules-available-in-all-products
the dependency I just added is needed.

## Test plan

Publishing succeeded right after adding this!

## App preview:

- [Web](https://sg-web-dv-jetbrains-add-missing.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hbfnjvwwhz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
