### PR TITLE
gitserver: update repo sizes only for repos that changed

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -565,12 +565,13 @@ func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]i
 	}
 
 	// updating repos
-	err = s.DB.GitserverRepos().UpdateRepoSizes(ctx, s.Hostname, reposToUpdate)
+	updatedRepos, err := s.DB.GitserverRepos().UpdateRepoSizes(ctx, s.Hostname, reposToUpdate)
 	if err != nil {
 		return err
 	}
-	logger.Info("repos had their sizes updated",
-		log.Int("reposToUpdate", len(reposToUpdate)))
+	if updatedRepos > 0 {
+		logger.Info("repos had their sizes updated", log.Int("updatedRepos", updatedRepos))
+	}
 
 	return nil
 }

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -86,7 +86,7 @@ update gitserver_repos set repo_size_bytes = 5 where repo_id = 3;
 			t.Fatal(err)
 		}
 		if repo.RepoSizeBytes == 0 {
-			t.Fatalf("repo_size_bytes is not updated: %d", repo.RepoSizeBytes)
+			t.Fatalf("repo %d - repo_size_bytes is not updated: %d", i, repo.RepoSizeBytes)
 		}
 	}
 

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -71,9 +71,9 @@ func TestCleanup_computeStats(t *testing.T) {
 	s.testSetup(t)
 
 	if _, err := s.DB.ExecContext(context.Background(), `
-insert into repo(id, name, fork) values (1, 'a', false), (2, 'b/d', false), (3, 'c', false);
-update gitserver_repos set shard_id = 1;
-update gitserver_repos set repo_size_bytes = 5 where repo_id = 3;
+INSERT INTO repo(id, name) VALUES (1, 'a'), (2, 'b/d'), (3, 'c');
+UPDATE gitserver_repos SET shard_id = 1;
+UPDATE gitserver_repos SET repo_size_bytes = 5 where repo_id = 3;
 `); err != nil {
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -73,7 +73,7 @@ func TestCleanup_computeStats(t *testing.T) {
 	if _, err := s.DB.ExecContext(context.Background(), `
 insert into repo(id, name, fork) values (1, 'a', false), (2, 'b/d', false), (3, 'c', false);
 update gitserver_repos set shard_id = 1;
-update gitserver_repos set repo_size_bytes = 228 where repo_id = 3;
+update gitserver_repos set repo_size_bytes = 5 where repo_id = 3;
 `); err != nil {
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}
@@ -81,12 +81,12 @@ update gitserver_repos set repo_size_bytes = 228 where repo_id = 3;
 	s.cleanupRepos([]string{"gitserver-0"})
 
 	for i := 1; i <= 3; i++ {
-		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), 1)
+		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), api.RepoID(i))
 		if err != nil {
 			t.Fatal(err)
 		}
 		if repo.RepoSizeBytes == 0 {
-			t.Fatal("repo_size_bytes is not updated")
+			t.Fatalf("repo_size_bytes is not updated: %d", repo.RepoSizeBytes)
 		}
 	}
 

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -604,8 +604,8 @@ WHERE gr.repo_size_bytes IS NULL
 
 // UpdateRepoSizes sets repo sizes according to input map. Key is repoID, value is repo_size_bytes.
 func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoID]int64) (updated int, err error) {
-	// NOTE: We have two args per row, so rows*2 should be less then maximum
-	// postgres allows
+	// NOTE: We have two args per row, so rows*2 should be less than maximum
+	// Postgres allows.
 	const batchSize = batch.MaxNumPostgresParameters / 2
 	return s.updateRepoSizesWithBatchSize(ctx, shardID, repos, batchSize)
 }
@@ -628,7 +628,7 @@ func (s *gitserverRepoStore) updateRepoSizesWithBatchSize(ctx context.Context, s
 		currentCount += 1
 
 		if currentCount == batchSize || currentCount == left {
-			// Important: we only take the elements of batch up to currentCount
+			// IMPORTANT: we only take the elements of batch up to currentCount
 			q := sqlf.Sprintf(updateRepoSizesQueryFmtstr, sqlf.Join(batch[:currentCount], ","))
 			res, err := tx.ExecResult(ctx, q)
 			if err != nil {

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -654,6 +654,7 @@ func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string
 }
 
 const updateRepoSizesQueryFmtstr = `
+-- source: internal/database/gitserver_repos.go:gitserverRepoStore.UpdateRepoSizes
 UPDATE gitserver_repos AS gr
 SET
     repo_size_bytes = tmp.repo_size_bytes

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -33,7 +33,7 @@ type GitserverRepoStore interface {
 	IteratePurgeableRepos(ctx context.Context, options IteratePurgableReposOptions, repoFn func(repo api.RepoName) error) error
 	TotalErroredCloudDefaultRepos(ctx context.Context) (int, error)
 	ListReposWithoutSize(ctx context.Context) (map[api.RepoName]api.RepoID, error)
-	UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoID]int64) error
+	UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoID]int64) (int, error)
 }
 
 var _ GitserverRepoStore = (*gitserverRepoStore)(nil)
@@ -603,37 +603,69 @@ WHERE gr.repo_size_bytes IS NULL
 `
 
 // UpdateRepoSizes sets repo sizes according to input map. Key is repoID, value is repo_size_bytes.
-func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoID]int64) (err error) {
-	inserter := func(inserter *batch.Inserter) error {
-		for repo, size := range repos {
-			if err := inserter.Insert(ctx, repo, shardID, size, "cloned", "now()"); err != nil {
-				return err
-			}
-		}
-		return nil
+func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoID]int64) (updated int, err error) {
+	type repoAndSize struct {
+		RepoID api.RepoID
+		Size   int64
+	}
+
+	toInsert := make([]repoAndSize, len(repos))
+	i := 0
+	for repo, size := range repos {
+		toInsert[i] = repoAndSize{RepoID: repo, Size: size}
+		i++
 	}
 
 	tx, err := s.Store.Transact(ctx)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer func() { err = tx.Done(err) }()
 
-	if err := batch.WithInserterWithReturn(
-		ctx,
-		tx.Handle(),
-		"gitserver_repos",
-		batch.MaxNumPostgresParameters,
-		[]string{"repo_id", "shard_id", "repo_size_bytes", "clone_status", "updated_at"},
-		"ON CONFLICT (repo_id) DO UPDATE SET (repo_size_bytes, shard_id, clone_status, updated_at) = (EXCLUDED.repo_size_bytes, gitserver_repos.shard_id, 'cloned', now())",
-		nil,
-		nil,
-		inserter,
-	); err != nil {
-		return err
+	// NOTE: We have two args per row, so rows*2 should be less then maximum
+	// postgres allows
+	const batchSize = batch.MaxNumPostgresParameters / 2
+	updatedRows := 0
+	for i := 0; i < len(toInsert); i += batchSize {
+		j := i + batchSize
+		if j > len(toInsert) {
+			j = len(toInsert)
+		}
+
+		batch := toInsert[i:j]
+
+		repoIdSizePairs := make([]*sqlf.Query, len(batch))
+		for i, b := range batch {
+			repoIdSizePairs[i] = sqlf.Sprintf("(%s::integer, %s::bigint)", b.RepoID, b.Size)
+		}
+		q := sqlf.Sprintf(updateRepoSizesQueryFmtstr, sqlf.Join(repoIdSizePairs, ","))
+
+		res, err := tx.ExecResult(ctx, q)
+		if err != nil {
+			return 0, err
+		}
+		rowsAffected, err := res.RowsAffected()
+		if err != nil {
+			return 0, err
+		}
+		updatedRows += int(rowsAffected)
 	}
-	return nil
+	return updatedRows, nil
 }
+
+const updateRepoSizesQueryFmtstr = `
+UPDATE gitserver_repos AS gr
+SET
+    repo_size_bytes = tmp.repo_size_bytes
+FROM (VALUES
+-- (<repo_id>, <repo_size_bytes>),
+    %s
+) AS tmp(repo_id, repo_size_bytes) 
+WHERE
+	tmp.repo_id = gr.repo_id
+AND
+	tmp.repo_size_bytes != gr.repo_size_bytes;
+`
 
 // sanitizeToUTF8 will remove any null character terminated string. The null character can be
 // represented in one of the following ways in Go:

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -661,7 +661,7 @@ FROM (VALUES
 WHERE
 	tmp.repo_id = gr.repo_id
 AND
-	tmp.repo_size_bytes != gr.repo_size_bytes;
+	(gr.repo_size_bytes IS NULL OR tmp.repo_size_bytes != gr.repo_size_bytes);
 `
 
 // sanitizeToUTF8 will remove any null character terminated string. The null character can be

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -661,7 +661,7 @@ FROM (VALUES
 WHERE
 	tmp.repo_id = gr.repo_id
 AND
-	(gr.repo_size_bytes IS NULL OR tmp.repo_size_bytes != gr.repo_size_bytes);
+	tmp.repo_size_bytes IS DISTINCT FROM gr.repo_size_bytes;
 `
 
 // sanitizeToUTF8 will remove any null character terminated string. The null character can be

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -1075,6 +1075,24 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	if have, want := numUpdated, 1; have != want {
 		t.Fatalf("wrong number of repos updated. have=%d, want=%d", have, want)
 	}
+
+	// update with different batch sizes
+	gitserverRepoStore := &gitserverRepoStore{Store: basestore.NewWithHandle(db.Handle())}
+	for _, batchSize := range []int64{1, 2, 3, 6} {
+		sizes = map[api.RepoID]int64{
+			repo1.ID: 123 + batchSize,
+			repo2.ID: 456 + batchSize,
+			repo3.ID: 789 + batchSize,
+		}
+
+		numUpdated, err = gitserverRepoStore.updateRepoSizesWithBatchSize(ctx, shardID, sizes, int(batchSize))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if have, want := numUpdated, 3; have != want {
+			t.Fatalf("wrong number of repos updated. have=%d, want=%d", have, want)
+		}
+	}
 }
 
 func createTestRepo(ctx context.Context, t *testing.T, db DB, payload *createTestRepoPayload) (*types.Repo, *types.GitserverRepo) {

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -990,24 +990,18 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	ctx := context.Background()
 
 	repo1, gitserverRepo1 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:         "github.com/sourcegraph/repo1",
-		URI:          "github.com/sourcegraph/repo1",
-		ExternalRepo: api.ExternalRepoSpec{},
-		ShardID:      shardID,
+		Name:    "github.com/sourcegraph/repo1",
+		ShardID: shardID,
 	})
 
 	repo2, gitserverRepo2 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:         "github.com/sourcegraph/repo2",
-		URI:          "github.com/sourcegraph/repo2",
-		ExternalRepo: api.ExternalRepoSpec{},
-		ShardID:      shardID,
+		Name:    "github.com/sourcegraph/repo2",
+		ShardID: shardID,
 	})
 
 	repo3, gitserverRepo3 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:         "github.com/sourcegraph/repo3",
-		URI:          "github.com/sourcegraph/repo3",
-		ExternalRepo: api.ExternalRepoSpec{},
-		ShardID:      shardID,
+		Name:    "github.com/sourcegraph/repo3",
+		ShardID: shardID,
 	})
 
 	// Setting repo sizes in DB

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -18021,7 +18021,7 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		UpdateRepoSizesFunc: &GitserverRepoStoreUpdateRepoSizesFunc{
-			defaultHook: func(context.Context, string, map[api.RepoID]int64) (r0 error) {
+			defaultHook: func(context.Context, string, map[api.RepoID]int64) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -18109,7 +18109,7 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		UpdateRepoSizesFunc: &GitserverRepoStoreUpdateRepoSizesFunc{
-			defaultHook: func(context.Context, string, map[api.RepoID]int64) error {
+			defaultHook: func(context.Context, string, map[api.RepoID]int64) (int, error) {
 				panic("unexpected invocation of MockGitserverRepoStore.UpdateRepoSizes")
 			},
 		},
@@ -19619,24 +19619,24 @@ func (c GitserverRepoStoreTotalErroredCloudDefaultReposFuncCall) Results() []int
 // UpdateRepoSizes method of the parent MockGitserverRepoStore instance is
 // invoked.
 type GitserverRepoStoreUpdateRepoSizesFunc struct {
-	defaultHook func(context.Context, string, map[api.RepoID]int64) error
-	hooks       []func(context.Context, string, map[api.RepoID]int64) error
+	defaultHook func(context.Context, string, map[api.RepoID]int64) (int, error)
+	hooks       []func(context.Context, string, map[api.RepoID]int64) (int, error)
 	history     []GitserverRepoStoreUpdateRepoSizesFuncCall
 	mutex       sync.Mutex
 }
 
 // UpdateRepoSizes delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) UpdateRepoSizes(v0 context.Context, v1 string, v2 map[api.RepoID]int64) error {
-	r0 := m.UpdateRepoSizesFunc.nextHook()(v0, v1, v2)
-	m.UpdateRepoSizesFunc.appendCall(GitserverRepoStoreUpdateRepoSizesFuncCall{v0, v1, v2, r0})
-	return r0
+func (m *MockGitserverRepoStore) UpdateRepoSizes(v0 context.Context, v1 string, v2 map[api.RepoID]int64) (int, error) {
+	r0, r1 := m.UpdateRepoSizesFunc.nextHook()(v0, v1, v2)
+	m.UpdateRepoSizesFunc.appendCall(GitserverRepoStoreUpdateRepoSizesFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the UpdateRepoSizes
 // method of the parent MockGitserverRepoStore instance is invoked and the
 // hook queue is empty.
-func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultHook(hook func(context.Context, string, map[api.RepoID]int64) error) {
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultHook(hook func(context.Context, string, map[api.RepoID]int64) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -19645,7 +19645,7 @@ func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushHook(hook func(context.Context, string, map[api.RepoID]int64) error) {
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushHook(hook func(context.Context, string, map[api.RepoID]int64) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -19653,20 +19653,20 @@ func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushHook(hook func(context.Conte
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, map[api.RepoID]int64) error {
-		return r0
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, map[api.RepoID]int64) (int, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, map[api.RepoID]int64) error {
-		return r0
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, string, map[api.RepoID]int64) (int, error) {
+		return r0, r1
 	})
 }
 
-func (f *GitserverRepoStoreUpdateRepoSizesFunc) nextHook() func(context.Context, string, map[api.RepoID]int64) error {
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) nextHook() func(context.Context, string, map[api.RepoID]int64) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -19711,7 +19711,10 @@ type GitserverRepoStoreUpdateRepoSizesFuncCall struct {
 	Arg2 map[api.RepoID]int64
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -19723,7 +19726,7 @@ func (c GitserverRepoStoreUpdateRepoSizesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverRepoStoreUpdateRepoSizesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // GitserverRepoStoreUpsertFunc describes the behavior when the Upsert


### PR DESCRIPTION
@eseliger and I noticed that we always do a full insert of possibly 10000 repositories when updating the repo size, even if that size didn't change, only updating it `on conflict`.

Since `repo` and `gitserver_repos` are consistent now, thanks to the database trigger, we can use normal `UPDATE` calls to update the size of the repos in `gitserver_repos`.

So what this does is it reduces the writes-to-disk that the database does and it fixes the reporting of "these repos have been updated" by only reporting when a repo _has_ in fact been updated in the database.

I think it's also clearer what the code does, vs. the previous use of `WithInserterWithReturner` where the `returner*` arguments where nil and the whole thing was only used because of the `ON CONFLICT`.

## Test plan

- Manual testing by checking log output locally, modifying database values, seeing how gitserver behaves, etc.
- Unit tests (old and new)