### PR TITLE
release: add latest tag/build to status message

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -34,6 +34,7 @@ import {
     changelogURL,
     ensureReleaseBranchUpToDate,
     ensureSrcCliUpToDate,
+    getLatestTag,
 } from './util'
 
 const sed = process.platform === 'linux' ? 'sed' : 'gsed'
@@ -335,7 +336,9 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
             if (!trackingIssue) {
                 throw new Error(`Tracking issue for version ${release.version} not found - has it been created yet?`)
             }
-
+            const latestTag = (await getLatestTag('sourcegraph','sourcegraph')).toString()
+            const latestBuildURL = `https://buildkite.com/sourcegraph/sourcegraph/builds?branch=${latestTag}`
+            const latestBuildMessage = `Latest release build: ${latestTag}. See the build status [here](${latestBuildURL}) `
             const blockingQuery = 'is:open org:sourcegraph label:release-blocker'
             const blockingIssues = await listIssues(githubClient, blockingQuery)
             const blockingIssuesURL = `https://github.com/issues?q=${encodeURIComponent(blockingQuery)}`
@@ -351,7 +354,8 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
             const message = `:mega: *${release.version} Release Status Update*
 
 * Tracking issue: ${trackingIssue.url}
-* ${blockingMessage}: ${blockingIssuesURL}`
+* ${blockingMessage}: ${blockingIssuesURL}
+* ${latestBuildMessage}`
             if (!config.dryRun.slack) {
                 await postMessage(message, config.slackAnnounceChannel)
             }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -336,7 +336,7 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
             if (!trackingIssue) {
                 throw new Error(`Tracking issue for version ${release.version} not found - has it been created yet?`)
             }
-            const latestTag = (await getLatestTag('sourcegraph','sourcegraph')).toString()
+            const latestTag = (await getLatestTag('sourcegraph', 'sourcegraph')).toString()
             const latestBuildURL = `https://buildkite.com/sourcegraph/sourcegraph/builds?branch=${latestTag}`
             const latestBuildMessage = `Latest release build: ${latestTag}. See the build status [here](${latestBuildURL}) `
             const blockingQuery = 'is:open org:sourcegraph label:release-blocker'

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -162,6 +162,18 @@ export async function ensureSrcCliUpToDate(): Promise<void> {
     }
 }
 
+export async function getLatestTag(owner: string, repo: string): Promise<string> {
+    const latestTag = await fetch(`https://api.github.com/repos/${owner}/${repo}/tags`, {
+        method: 'GET',
+        headers: {
+            Accept: 'application/json',
+        },
+    })
+        .then(response => response.json())
+        .then(json => json[0].name)
+    return latestTag
+}
+
 interface ContainerRegistryCredential {
     username: string
     password: string


### PR DESCRIPTION
Adds a note to the status message with the latest build number, as well as a link to the build.

Fixes https://github.com/sourcegraph/sourcegraph/issues/31742

## Test plan

new function works with a local test as a separate function, as well as CI passing. 

```
➜  release git:(main) ✗ yarn run release util:latest-tag
yarn run v1.22.17
$ ts-node --transpile-only ./src/main.ts util:latest-tag
{
  name: 'v3.42.0',
  zipball_url: 'https://api.github.com/repos/sourcegraph/sourcegraph/zipball/refs/tags/v3.42.0',
  tarball_url: 'https://api.github.com/repos/sourcegraph/sourcegraph/tarball/refs/tags/v3.42.0',
  commit: {
    sha: '8cf5aa13c21715e357423932aaff8f2803840a30',
    url: 'https://api.github.com/repos/sourcegraph/sourcegraph/commits/8cf5aa13c21715e357423932aaff8f2803840a30'
  },
  node_id: 'MDM6UmVmNDEyODg3MDg6cmVmcy90YWdzL3YzLjQyLjA='
}
✨  Done in 2.81s.
➜  release git:(main) ✗ yarn run release util:latest-tag
yarn run v1.22.17
$ ts-node --transpile-only ./src/main.ts util:latest-tag
v3.42.0
```