### PR TITLE
frontend: Apply sub-repo filtering in symbols side panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fix issue during code insight creation where selecting `"Run your insight over all your repositories"` reset the currently selected distance between data points. [#39261](https://github.com/sourcegraph/sourcegraph/pull/39261)
+- Fix issue where symbols in the side panel did not have file level permission filtering applied correctly. [#39592](https://github.com/sourcegraph/sourcegraph/pull/39592)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
@@ -18,7 +19,7 @@ type symbolsArgs struct {
 }
 
 func (r *GitTreeEntryResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
-	symbols, err := symbol.Compute(ctx, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.commit.inputRev, args.Query, args.First, args.IncludePatterns)
+	symbols, err := symbol.Compute(ctx, authz.DefaultSubRepoPermsChecker, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.commit.inputRev, args.Query, args.First, args.IncludePatterns)
 	if err != nil && len(symbols) == 0 {
 		return nil, err
 	}
@@ -32,7 +33,7 @@ func (r *GitTreeEntryResolver) Symbol(ctx context.Context, args *struct {
 	Line      int32
 	Character int32
 }) (*symbolResolver, error) {
-	symbol, err := symbol.GetMatchAtLineCharacter(ctx, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.Path(), int(args.Line), int(args.Character))
+	symbol, err := symbol.GetMatchAtLineCharacter(ctx, authz.DefaultSubRepoPermsChecker, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.Path(), int(args.Line), int(args.Character))
 	if err != nil || symbol == nil {
 		return nil, err
 	}
@@ -40,7 +41,7 @@ func (r *GitTreeEntryResolver) Symbol(ctx context.Context, args *struct {
 }
 
 func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
-	symbols, err := symbol.Compute(ctx, r.repoResolver.RepoMatch.RepoName(), api.CommitID(r.oid), r.inputRev, args.Query, args.First, args.IncludePatterns)
+	symbols, err := symbol.Compute(ctx, authz.DefaultSubRepoPermsChecker, r.repoResolver.RepoMatch.RepoName(), api.CommitID(r.oid), r.inputRev, args.Query, args.First, args.IncludePatterns)
 	if err != nil && len(symbols) == 0 {
 		return nil, err
 	}

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -251,6 +251,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 
 			if symbolMatch, _ := symbol.GetMatchAtLineCharacter(
 				ctx,
+				authz.DefaultSubRepoPermsChecker,
 				types.MinimalRepo{ID: common.Repo.ID, Name: common.Repo.Name},
 				common.CommitID,
 				strings.TrimLeft(blobPath, "/"),

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -55,7 +55,23 @@ func indexedSymbolsBranch(ctx context.Context, repo *types.MinimalRepo, commit s
 	return ""
 }
 
-func searchZoekt(ctx context.Context, checker authz.SubRepoPermissionChecker, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, branch string, queryString *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
+func filterZoektResults(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, results []*result.SymbolMatch) ([]*result.SymbolMatch, error) {
+	// Filter out results from files we don't have access to:
+	act := actor.FromContext(ctx)
+	filtered := results[:0]
+	for i, r := range results {
+		ok, err := authz.FilterActorPath(ctx, checker, act, repo, r.File.Path)
+		if err != nil {
+			return nil, errors.Wrap(err, "checking permissions")
+		}
+		if ok {
+			filtered = append(filtered, results[i])
+		}
+	}
+	return filtered, nil
+}
+
+func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, branch string, queryString *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
 	raw := *queryString
 	if raw == "" {
 		raw = ".*"
@@ -111,20 +127,7 @@ func searchZoekt(ctx context.Context, checker authz.SubRepoPermissionChecker, re
 		return nil, err
 	}
 
-	// Filter out results from files we don't have access to:
-	act := actor.FromContext(ctx)
-	filtered := resp.Files[:0]
-	for i, f := range resp.Files {
-		ok, err := authz.FilterActorPath(ctx, checker, act, repoName.Name, f.FileName)
-		if err != nil {
-			return nil, errors.Wrap(err, "checking permissions")
-		}
-		if ok {
-			filtered = append(filtered, resp.Files[i])
-		}
-	}
-
-	for _, file := range filtered {
+	for _, file := range resp.Files {
 		newFile := &result.File{
 			Repo:     repoName,
 			CommitID: commitID,
@@ -190,7 +193,15 @@ func Compute(ctx context.Context, checker authz.SubRepoPermissionChecker, repoNa
 	// TODO(keegancsmith) we should be able to use indexedSearchRequest here
 	// and remove indexedSymbolsBranch.
 	if branch := indexedSymbolsBranch(ctx, &repoName, string(commitID)); branch != "" {
-		return searchZoekt(ctx, checker, repoName, commitID, inputRev, branch, query, first, includePatterns)
+		results, err := searchZoekt(ctx, repoName, commitID, inputRev, branch, query, first, includePatterns)
+		if err != nil {
+			return nil, errors.Wrap(err, "zoekt symbol search")
+		}
+		results, err = filterZoektResults(ctx, checker, repoName.Name, results)
+		if err != nil {
+			return nil, errors.Wrap(err, "checking permissions")
+		}
+		return results, nil
 	}
 	serverTimeout := 5 * time.Second
 	clientTimeout := 2 * serverTimeout

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -11,7 +11,9 @@ import (
 	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -53,7 +55,7 @@ func indexedSymbolsBranch(ctx context.Context, repo *types.MinimalRepo, commit s
 	return ""
 }
 
-func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, branch string, queryString *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
+func searchZoekt(ctx context.Context, checker authz.SubRepoPermissionChecker, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, branch string, queryString *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
 	raw := *queryString
 	if raw == "" {
 		raw = ".*"
@@ -109,7 +111,20 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 		return nil, err
 	}
 
-	for _, file := range resp.Files {
+	// Filter out results from files we don't have access to:
+	act := actor.FromContext(ctx)
+	filtered := resp.Files[:0]
+	for i, f := range resp.Files {
+		ok, err := authz.FilterActorPath(ctx, checker, act, repoName.Name, f.FileName)
+		if err != nil {
+			return nil, errors.Wrap(err, "checking permissions")
+		}
+		if ok {
+			filtered = append(filtered, resp.Files[i])
+		}
+	}
+
+	for _, file := range filtered {
 		newFile := &result.File{
 			Repo:     repoName,
 			CommitID: commitID,
@@ -171,13 +186,12 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 	return
 }
 
-func Compute(ctx context.Context, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, query *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
+func Compute(ctx context.Context, checker authz.SubRepoPermissionChecker, repoName types.MinimalRepo, commitID api.CommitID, inputRev *string, query *string, first *int32, includePatterns *[]string) (res []*result.SymbolMatch, err error) {
 	// TODO(keegancsmith) we should be able to use indexedSearchRequest here
 	// and remove indexedSymbolsBranch.
 	if branch := indexedSymbolsBranch(ctx, &repoName, string(commitID)); branch != "" {
-		return searchZoekt(ctx, repoName, commitID, inputRev, branch, query, first, includePatterns)
+		return searchZoekt(ctx, checker, repoName, commitID, inputRev, branch, query, first, includePatterns)
 	}
-
 	serverTimeout := 5 * time.Second
 	clientTimeout := 2 * serverTimeout
 
@@ -230,12 +244,12 @@ func Compute(ctx context.Context, repoName types.MinimalRepo, commitID api.Commi
 
 // GetMatchAtLineCharacter retrieves the shortest matching symbol (if exists) defined
 // at a specific line number and character offset in the provided file.
-func GetMatchAtLineCharacter(ctx context.Context, repo types.MinimalRepo, commitID api.CommitID, filePath string, line int, character int) (*result.SymbolMatch, error) {
+func GetMatchAtLineCharacter(ctx context.Context, checker authz.SubRepoPermissionChecker, repo types.MinimalRepo, commitID api.CommitID, filePath string, line int, character int) (*result.SymbolMatch, error) {
 	// Should be large enough to include all symbols from a single file
 	first := int32(999999)
 	emptyString := ""
 	includePatterns := []string{regexp.QuoteMeta(filePath)}
-	symbolMatches, err := Compute(ctx, repo, commitID, &emptyString, &emptyString, &first, &includePatterns)
+	symbolMatches, err := Compute(ctx, checker, repo, commitID, &emptyString, &emptyString, &first, &includePatterns)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -56,6 +56,9 @@ func indexedSymbolsBranch(ctx context.Context, repo *types.MinimalRepo, commit s
 }
 
 func filterZoektResults(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, results []*result.SymbolMatch) ([]*result.SymbolMatch, error) {
+	if !authz.SubRepoEnabled(checker) {
+		return results, nil
+	}
 	// Filter out results from files we don't have access to:
 	act := actor.FromContext(ctx)
 	filtered := results[:0]

--- a/internal/search/symbol/symbol_test.go
+++ b/internal/search/symbol/symbol_test.go
@@ -1,0 +1,59 @@
+package symbol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestFilterZoektResults(t *testing.T) {
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				SubRepoPermissions: &schema.SubRepoPermissions{
+					Enabled: true,
+				},
+			},
+		},
+	})
+	t.Cleanup(func() { conf.Mock(nil) })
+
+	repoName := api.RepoName("foo")
+	ctx := context.Background()
+	ctx = actor.WithActor(ctx, &actor.Actor{
+		UID: 1,
+	})
+	checker, err := authz.NewSimpleChecker(repoName, []string{"**"}, []string{"*_test.go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := []*result.SymbolMatch{
+		{
+			Symbol: result.Symbol{},
+			File: &result.File{
+				Path: "foo.go",
+			},
+		},
+		{
+			Symbol: result.Symbol{},
+			File: &result.File{
+				Path: "foo_test.go",
+			},
+		},
+	}
+	filtered, err := filterZoektResults(ctx, checker, repoName, results)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, filtered, 1)
+	r := filtered[0]
+	assert.Equal(t, r.File.Path, "foo.go")
+}


### PR DESCRIPTION
Apply sub-repo filtering to symbols side panel for indexed branches.

This fixes an issue where symbols on an indexed branch were fetched directly from 
Zoekt without passing through sub-repo filtering. 

On a non-indexed branch we fall back to using the symbols client which already had
sub-repo filtering enabled.

## Test plan

Confirmed manually and added a unit test

- [x] CHANGELOG