### PR TITLE
move needs-design labeled issues to board

### DIFF
--- a/.github/workflows/move-labled-issues-to-project-beta.yml
+++ b/.github/workflows/move-labled-issues-to-project-beta.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           project-url: https://github.com/orgs/sourcegraph/projects/278
           github-token: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
-          labeled: design
+          labeled: design, needs-design
           label-operator: OR
           
 #       - name: Move team/CHANGEME issues


### PR DESCRIPTION
When anyone adds the label needs-design to an issue, it will appear on the design projects board. 

## Test plan

Manually test an issue with the label needs-design ends up on the correct board. 
