### PR TITLE
Compute: use serializer in test

### DIFF
--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -53,7 +53,7 @@ func Test_matchOnly(t *testing.T) {
 	test := func(input string, serialize serializer) string {
 		r, _ := regexp.Compile(input)
 		result := matchOnly(data, r)
-		w := want{Input: input, Result: result}
+		w := want{Input: input, Result: serialize(result)}
 		v, _ := json.MarshalIndent(w, "", "  ")
 		return string(v)
 	}

--- a/enterprise/internal/compute/testdata/Test_matchOnly/match_only#01.golden
+++ b/enterprise/internal/compute/testdata/Test_matchOnly/match_only#01.golden
@@ -1,57 +1,7 @@
 {
   "Input": "(a)(?P\u003cThisIsNamed\u003eb)",
   "Result": {
-    "matches": [
-      {
-        "value": "ab",
-        "range": {
-          "start": {
-            "offset": 0,
-            "line": -1,
-            "column": -1
-          },
-          "end": {
-            "offset": 2,
-            "line": -1,
-            "column": -1
-          }
-        },
-        "environment": {
-          "1": {
-            "value": "a",
-            "range": {
-              "start": {
-                "offset": 0,
-                "line": -1,
-                "column": -1
-              },
-              "end": {
-                "offset": 1,
-                "line": -1,
-                "column": -1
-              }
-            }
-          },
-          "ThisIsNamed": {
-            "value": "b",
-            "range": {
-              "start": {
-                "offset": 1,
-                "line": -1,
-                "column": -1
-              },
-              "end": {
-                "offset": 2,
-                "line": -1,
-                "column": -1
-              }
-            }
-          }
-        }
-      }
-    ],
-    "path": "bedge",
-    "repositoryID": 5,
-    "repository": "codehost.com/myorg/myrepo"
+    "1": "a",
+    "ThisIsNamed": "b"
   }
 }

--- a/enterprise/internal/compute/testdata/Test_matchOnly/match_only#02.golden
+++ b/enterprise/internal/compute/testdata/Test_matchOnly/match_only#02.golden
@@ -1,26 +1,4 @@
 {
   "Input": "(lasvegans)|abcdefgh",
-  "Result": {
-    "matches": [
-      {
-        "value": "abcdefgh",
-        "range": {
-          "start": {
-            "offset": 0,
-            "line": -1,
-            "column": -1
-          },
-          "end": {
-            "offset": 8,
-            "line": -1,
-            "column": -1
-          }
-        },
-        "environment": {}
-      }
-    ],
-    "path": "bedge",
-    "repositoryID": 5,
-    "repository": "codehost.com/myorg/myrepo"
-  }
+  "Result": {}
 }


### PR DESCRIPTION
I was seeing linting complaints that `serialize` is unused. This seemed incorrect, so I updated the test with what I think the intent was. 

## Test plan

Just updated a test. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
