### PR TITLE
Set text styles for better visibility in API console

### DIFF
--- a/client/web/src/api/graphiql-theme.scss
+++ b/client/web/src/api/graphiql-theme.scss
@@ -183,6 +183,16 @@
         }
     }
 
+    .variable-editor-title-text {
+        color: var(--text-muted);
+        font-weight: 400;
+
+        &.active {
+            color: var(--body-color);
+            font-weight: 600;
+        }
+    }
+
     .CodeMirror-hints {
         border-left: solid 1px var(--dropdown-border-color);
         border-right: solid 1px var(--dropdown-border-color);


### PR DESCRIPTION
Closes #19251.

## Test plan

CSS has been added so that our theme text colors are used for these titles, and will automatically update when the theme preference gets changed.

<img width="374" alt="image" src="https://user-images.githubusercontent.com/10523985/181627504-71d9adde-091d-4df2-87d4-47f09d9f33e7.png">
<img width="386" alt="image" src="https://user-images.githubusercontent.com/10523985/181627524-a341c09c-d016-42ce-a37f-a9168b602430.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lrh-fix-api-console-styles.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gldcubdebw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
