### PR TITLE
Search backend: remove unnecessary channel argument

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -315,7 +315,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender 
 		p.Branch = "HEAD"
 	}
 	branchRepos := []zoektquery.BranchRepos{{Branch: p.Branch, Repos: roaring.BitmapOf(uint32(p.RepoID))}}
-	err = zoektSearch(ctx, patternInfo, branchRepos, time.Since, p.IndexerEndpoints, nil, p.Repo, sender)
+	err = zoektSearch(ctx, patternInfo, branchRepos, time.Since, p.IndexerEndpoints, p.Repo, sender)
 	if err != nil {
 		return err
 	}

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -85,29 +85,13 @@ func buildQuery(args *search.TextPatternInfo, branchRepos []zoektquery.BranchRep
 	), nil
 }
 
-type zoektSearchStreamEvent struct {
-	fm       []zoekt.FileMatch
-	limitHit bool
-	partial  map[api.RepoID]struct{}
-	err      error
-}
-
-const defaultMaxSearchResults = 30
-
 // zoektSearch searches repositories using zoekt, returning file contents for
 // files that match the given pattern.
 //
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, endpoints []string, c chan<- zoektSearchStreamEvent, repo api.RepoName, sender matchSender) (err error) {
-	defer func() {
-		if c != nil {
-			c <- zoektSearchStreamEvent{
-				err: err,
-			}
-		}
-	}()
+func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, endpoints []string, repo api.RepoName, sender matchSender) (err error) {
 	if len(branchRepos) == 0 {
 		return nil
 	}


### PR DESCRIPTION
This channel is always nil, so we can just get rid of it. Unrelated, but this also deletes the  unused `defaultMaxSearchResults`. 

## Test plan

Just deleting unused code. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
