### PR TITLE
migration: Extract type to prevent cyclic import

### DIFF
--- a/internal/database/migration/shared/types.go
+++ b/internal/database/migration/shared/types.go
@@ -1,5 +1,19 @@
 package shared
 
+import "github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
+
+// StitchedMigration represents a "virtual" migration graph constructed over time.
+type StitchedMigration struct {
+	// Definitions is a graph formed by concatenating and canonicalizing schema migration graphs over
+	// several releases. This should contain all migrations defined in the associated version range.
+	Definitions *definition.Definitions
+
+	// LeafIDsByRev is a map from schema name to the set of identifiers of leaf migration for that
+	// schema. This is used to determine the points in the graph that are associated with a particular
+	// minor release.
+	LeafIDsByRev map[string][]int
+}
+
 // IndexStatus describes the state of an index. Is{Valid,Ready,Live} is taken
 // from the `pg_index` system table. If the index is currently being created,
 // then the remaining reference fields will be populated describing the index

--- a/internal/database/migration/shared/upgradedata/cmd/generator/main.go
+++ b/internal/database/migration/shared/upgradedata/cmd/generator/main.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/stitch"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -38,7 +39,7 @@ func mainErr() error {
 		versionTags = append(versionTags, version.GitTag())
 	}
 
-	stitchedMigrationBySchemaName := map[string]stitch.StitchedMigration{}
+	stitchedMigrationBySchemaName := map[string]shared.StitchedMigration{}
 	for _, schemaName := range schemas.SchemaNames {
 		stitched, err := stitch.StitchDefinitions(schemaName, repoRoot, versionTags)
 		if err != nil {

--- a/internal/database/migration/shared/upgradedata/embed.go
+++ b/internal/database/migration/shared/upgradedata/embed.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/migration/stitch"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/shared"
 )
 
 //go:generate go run ./cmd/generator
@@ -16,7 +16,7 @@ var upgradeDataPayloadContents string
 
 // stitchedMigationsBySchemaName is a map from schema name to migration upgrade metadata.
 // The data backing the map is updated by `go generating` this package.
-var stitchedMigationsBySchemaName = map[string]stitch.StitchedMigration{}
+var stitchedMigationsBySchemaName = map[string]shared.StitchedMigration{}
 
 func init() {
 	if err := json.Unmarshal([]byte(upgradeDataPayloadContents), &stitchedMigationsBySchemaName); err != nil {

--- a/internal/database/migration/stitch/stitch.go
+++ b/internal/database/migration/stitch/stitch.go
@@ -7,13 +7,9 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/shared"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-type StitchedMigration struct {
-	Definitions  *definition.Definitions
-	LeafIDsByRev map[string][]int
-}
 
 // StitchDefinitions constructs a migration graph over time in two values. First, the migration graph
 // itself is formed by merging migration definitions as they were defined over time in Git. Second, the set
@@ -27,10 +23,10 @@ type StitchedMigration struct {
 //
 // NOTE: This should only be used at development or build time - the root parameter should point to a
 // valid git clone root directory. Resulting errors are apparent.
-func StitchDefinitions(schemaName, root string, revs []string) (StitchedMigration, error) {
+func StitchDefinitions(schemaName, root string, revs []string) (shared.StitchedMigration, error) {
 	definitionMap, leafIDsByRev, err := overlayDefinitions(schemaName, root, revs)
 	if err != nil {
-		return StitchedMigration{}, err
+		return shared.StitchedMigration{}, err
 	}
 
 	migrationDefinitions := make([]definition.Definition, 0, len(definitionMap))
@@ -40,10 +36,10 @@ func StitchDefinitions(schemaName, root string, revs []string) (StitchedMigratio
 
 	definitions, err := definition.NewDefinitions(migrationDefinitions)
 	if err != nil {
-		return StitchedMigration{}, err
+		return shared.StitchedMigration{}, err
 	}
 
-	return StitchedMigration{definitions, leafIDsByRev}, nil
+	return shared.StitchedMigration{definitions, leafIDsByRev}, nil
 }
 
 // overlayDefinitions combines the definitions defined at all of the given git revisions for the given schema,


### PR DESCRIPTION
Extract `StitchedMigration` into a shared directory to prevent a future cyclic import.

## Test plan

Existing CI.