### PR TITLE
search: fix quote parsing for standard queries

### DIFF
--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -762,4 +762,8 @@ func TestParseStandard(t *testing.T) {
 	t.Run("patterns are literal and slash-delimited patterns /.../ are regexp", func(t *testing.T) {
 		autogold.Equal(t, autogold.Raw(test("anjou /saumur/")))
 	})
+
+	t.Run("quoted patterns are still literal", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`"veneto"`)))
+	})
 }

--- a/internal/search/query/testdata/TestParseStandard/quoted_patterns_are_still_literal.golden
+++ b/internal/search/query/testdata/TestParseStandard/quoted_patterns_are_still_literal.golden
@@ -1,0 +1,19 @@
+[
+  {
+    "value": "\"veneto\"",
+    "negated": false,
+    "labels": [
+      "Literal"
+    ],
+    "range": {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 8
+      }
+    }
+  }
+]


### PR DESCRIPTION
There's a bug that causes `patterntype:standard` to parse quoted strings when it should continue to treat them literally (overlooked in https://github.com/sourcegraph/sourcegraph/pull/37656). The behavior is not live yet, but needs to be changed before merging https://github.com/sourcegraph/sourcegraph/pull/38141.

This PR just rewrites the existing logic to separate "parse `/.../`" and "parse `" "` or `' '`"  and then calls the right parser depending on Standard vs Regexp. This code is tested to heck and back, so don't worry too much about the rewriting.

## Test plan
Added test.