### PR TITLE
ci: remove Sentry uploads step

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -142,7 +142,6 @@ Base pipeline (more steps might be included based on branch changes):
 - **CI script tests**: test-trace-command.sh
 - **Integration tests**: Backend integration tests, Code Intel QA
 - **End-to-end tests**: Sourcegraph E2E, Sourcegraph QA, Sourcegraph Cluster (deploy-sourcegraph) QA, Sourcegraph Upgrade
-- Build and upload sourcemaps to Sentry
 - **Publish images**: alpine-3.14, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, jaeger-agent, jaeger-all-in-one, minio, postgres-12-alpine, postgres_exporter, precise-code-intel-worker, prometheus, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, symbols, syntax-highlighter, worker, migrator, executor, server, sg, Publish executor image, Publish docker registry mirror image
 - Upload build trace
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -216,25 +216,6 @@ func addWebApp(pipeline *bk.Pipeline) {
 		bk.Cmd("dev/ci/codecov.sh -c -F typescript -F unit"))
 }
 
-// Adds steps for building webapp with the Sentry Webpack plugin enabled to upload sourcemaps
-// Only builds webapp without ENTERPRISE=1, no tests are performed. Should only run on release branches.
-func buildWebAppWithSentrySourcemaps(version string) operations.Operation {
-	return func(pipeline *bk.Pipeline) {
-		// Webapp build with Sentry's webpack plugin enabled
-		pipeline.AddStep(":webpack::globe_with_meridians: Build and upload sourcemaps to Sentry",
-			withYarnCache(),
-			bk.SoftFail(),
-			bk.Cmd("dev/ci/yarn-build.sh client/web"),
-			bk.Env("NODE_ENV", "production"),
-			bk.Env("ENTERPRISE", ""),
-			bk.Env("SENTRY_UPLOAD_SOURCE_MAPS", "1"),
-			bk.Env("SENTRY_ORGANIZATION", "sourcegraph"),
-			bk.Env("SENTRY_PROJECT", "sourcegraph-dot-com"),
-			bk.Env("RELEASE_CANDIDATE_VERSION", version),
-		)
-	}
-}
-
 var browsers = []string{"chrome"}
 
 func getParallelTestCount(webParallelTestCount int) int {

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -290,9 +290,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			if c.RunType.Is(runtype.ReleaseBranch) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
 				publishOps.Append(publishExecutorDockerMirror(c.Version))
 			}
-			if c.RunType.Is(runtype.ReleaseBranch) {
-				ops.Append(buildWebAppWithSentrySourcemaps(c.Version))
-			}
 		}
 		ops.Merge(publishOps)
 	}


### PR DESCRIPTION
## Context 

Removing the failing step to unblock the release. It will be removed anyway in https://github.com/sourcegraph/sourcegraph/pull/39381.

## Test plan

n/a
