### PR TITLE
Accessibility: Fix annotated search example accessibility

### DIFF
--- a/client/search-ui/src/results/AnnotatedSearchExample.tsx
+++ b/client/search-ui/src/results/AnnotatedSearchExample.tsx
@@ -68,8 +68,6 @@ export const AnnotatedSearchInput: React.FunctionComponent<
         // the viewBox is adjusted to "crop" the image to its content
         // Original width and height of the image was 800x270
         <svg
-            role="img"
-            aria-hidden={true}
             className={styles.annotatedSearchInput}
             width={width}
             height={height}

--- a/client/search-ui/src/results/AnnotatedSearchExample.tsx
+++ b/client/search-ui/src/results/AnnotatedSearchExample.tsx
@@ -99,9 +99,9 @@ export const AnnotatedSearchInput: React.FunctionComponent<
                     <tspan className={styles.metaRegexpRangeQuantifier}>*</tspan>
                     <tspan> function auth(){'{'} </tspan>
                 </text>
-                <Icon aria-hidden={true} x="590" y="115" svgPath={mdiFormatLetterCase} />
-                <Icon aria-hidden={true} x="620" y="115" svgPath={mdiRegex} />
-                <Icon aria-hidden={true} x="650" y="115" svgPath={mdiCodeBrackets} />
+                <Icon aria-label="Case sensitivity toggle" x="590" y="115" svgPath={mdiFormatLetterCase} />
+                <Icon aria-label="Regular expression toggle" x="620" y="115" svgPath={mdiRegex} />
+                <Icon aria-label="Structural search toggle" x="650" y="115" svgPath={mdiCodeBrackets} />
                 <path
                     d="M688 110H731C732.105 110 733 110.895 733 112V142C733 143.105 732.105 144 731 144H688V110Z"
                     fill="#1475CF"

--- a/client/search-ui/src/results/AnnotatedSearchExample.tsx
+++ b/client/search-ui/src/results/AnnotatedSearchExample.tsx
@@ -106,7 +106,7 @@ export const AnnotatedSearchInput: React.FunctionComponent<
                     d="M688 110H731C732.105 110 733 110.895 733 112V142C733 143.105 732.105 144 731 144H688V110Z"
                     fill="#1475CF"
                 />
-                <Icon aria-hidden={true} className={styles.searchIcon} x="698" y="115" svgPath={mdiMagnify} />
+                <Icon aria-label="Search" className={styles.searchIcon} x="698" y="115" svgPath={mdiMagnify} />
 
                 {arrow(188, 30, 'above')}
                 <text transform={`translate(${filterTextStart}, 44)`}>


### PR DESCRIPTION
## Description

This should never have had `role="img"` and `aria-hidden` at the top level as we need screen readers to properly treat this as a vector graphic and thus read any `<text>` within.

Screen readers now, read all `<text>` in the graphic.

Note: I think the icons in the search bar are still OK to be hidden, the main useful text here is `Search can be case-sensitive one of three modes: literal (default), regexp or structural.`. Curious if anyone thinks we should label the icons too.

<img width="635" alt="image" src="https://user-images.githubusercontent.com/9516420/181715213-c53dfe98-fef5-43c6-95bb-41c13efdd9ce.png">

## Test plan

Tested locally with a screen reader

## App preview:

- [Web](https://sg-web-tr-fix-annotated-a11y.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wbghtsnvdk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

