### PR TITLE
gitserver: Reduce to one ArchiveReader method

### DIFF
--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -148,7 +148,9 @@ func run(logger log.Logger) error {
 	service := &search.Service{
 		Store: &search.Store{
 			FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
-				return git.Archive(ctx, repo, gitserver.ArchiveOptions{
+				// We pass in a nil checker here since searcher needs access to all data in the
+				// archive
+				return git.ArchiveReader(ctx, nil, repo, gitserver.ArchiveOptions{
 					Treeish: string(commit),
 					Format:  gitserver.ArchiveFormatTar,
 				})
@@ -158,7 +160,9 @@ func run(logger log.Logger) error {
 				for i, p := range paths {
 					pathspecs[i] = gitdomain.PathspecLiteral(p)
 				}
-				return git.Archive(ctx, repo, gitserver.ArchiveOptions{
+				// We pass in a nil checker here since searcher needs access to all data in the
+				// archive
+				return git.ArchiveReader(ctx, nil, repo, gitserver.ArchiveOptions{
 					Treeish:   string(commit),
 					Format:    gitserver.ArchiveFormatTar,
 					Pathspecs: pathspecs,

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -148,8 +148,8 @@ func run(logger log.Logger) error {
 	service := &search.Service{
 		Store: &search.Store{
 			FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
-				// We pass in a nil checker here since searcher needs access to all data in the
-				// archive
+				// We pass in a nil sub-repo permissions checker here since searcher needs access
+				// to all data in the archive
 				return git.ArchiveReader(ctx, nil, repo, gitserver.ArchiveOptions{
 					Treeish: string(commit),
 					Format:  gitserver.ArchiveFormatTar,
@@ -160,8 +160,8 @@ func run(logger log.Logger) error {
 				for i, p := range paths {
 					pathspecs[i] = gitdomain.PathspecLiteral(p)
 				}
-				// We pass in a nil checker here since searcher needs access to all data in the
-				// archive
+				// We pass in a nil sub-repo permissions checker here since searcher needs access
+				// to all data in the archive
 				return git.ArchiveReader(ctx, nil, repo, gitserver.ArchiveOptions{
 					Treeish:   string(commit),
 					Format:    gitserver.ArchiveFormatTar,

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -164,9 +164,6 @@ type Client interface {
 	// AddrForRepo returns the gitserver address to use for the given repo name.
 	AddrForRepo(context.Context, api.RepoName) (string, error)
 
-	// Archive produces an archive from a Git repository.
-	Archive(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error)
-
 	// ArchiveReader streams back the file contents of an archived git repo.
 	ArchiveReader(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, options ArchiveOptions) (io.ReadCloser, error)
 
@@ -541,67 +538,6 @@ func (c *clientImplementor) archiveURL(ctx context.Context, repo api.RepoName, o
 		Path:     "/archive",
 		RawQuery: q.Encode(),
 	}, nil
-}
-
-func (c *clientImplementor) Archive(ctx context.Context, repo api.RepoName, opt ArchiveOptions) (_ io.ReadCloser, err error) {
-	if ClientMocks.Archive != nil {
-		return ClientMocks.Archive(ctx, repo, opt)
-	}
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Archive")
-	span.SetTag("Repo", repo)
-	span.SetTag("Treeish", opt.Treeish)
-	defer func() {
-		if err != nil {
-			ext.Error.Set(span, true)
-			span.LogFields(log.Error(err))
-		}
-		span.Finish()
-	}()
-
-	// Check that ctx is not expired.
-	if err := ctx.Err(); err != nil {
-		deadlineExceededCounter.Inc()
-		return nil, err
-	}
-
-	u, err := c.archiveURL(ctx, repo, opt)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.do(ctx, repo, "POST", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		return &archiveReader{
-			base: &cmdReader{
-				rc:      resp.Body,
-				trailer: resp.Trailer,
-			},
-			repo: repo,
-			spec: opt.Treeish,
-		}, nil
-	case http.StatusNotFound:
-		var payload protocol.NotFoundPayload
-		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-			resp.Body.Close()
-			return nil, err
-		}
-		resp.Body.Close()
-		return nil, &badRequestError{
-			error: &gitdomain.RepoNotExistError{
-				Repo:            repo,
-				CloneInProgress: payload.CloneInProgress,
-				CloneProgress:   payload.CloneProgress,
-			},
-		}
-	default:
-		resp.Body.Close()
-		return nil, errors.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
 }
 
 type badRequestError struct{ error }

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -208,7 +208,7 @@ func TestClient_Remove(t *testing.T) {
 	}
 }
 
-func TestClient_Archive(t *testing.T) {
+func TestClient_ArchiveReader(t *testing.T) {
 	root := gitserver.CreateRepoDir(t)
 
 	tests := map[api.RepoName]struct {
@@ -262,16 +262,19 @@ func TestClient_Archive(t *testing.T) {
 				}
 			}
 
-			rc, err := cli.Archive(ctx, name, gitserver.ArchiveOptions{Treeish: "HEAD", Format: gitserver.ArchiveFormatZip})
+			rc, err := cli.ArchiveReader(ctx, nil, name, gitserver.ArchiveOptions{Treeish: "HEAD", Format: gitserver.ArchiveFormatZip})
 			if have, want := fmt.Sprint(err), fmt.Sprint(test.err); have != want {
 				t.Errorf("archive: have err %v, want %v", have, want)
 			}
-
 			if rc == nil {
 				return
 			}
 
-			defer rc.Close()
+			t.Cleanup(func() {
+				if err := rc.Close(); err != nil {
+					t.Fatal(err)
+				}
+			})
 			data, err := io.ReadAll(rc)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"net/mail"
 	"os"
 	stdlibpath "path"
@@ -20,6 +22,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/golang/groupcache/lru"
 	"github.com/grafana/regexp"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -2412,7 +2415,7 @@ func (c *clientImplementor) ArchiveReader(
 	checker authz.SubRepoPermissionChecker,
 	repo api.RepoName,
 	options ArchiveOptions,
-) (io.ReadCloser, error) {
+) (_ io.ReadCloser, err error) {
 	if authz.SubRepoEnabled(checker) {
 		if enabled, err := authz.SubRepoEnabledForRepo(ctx, checker, repo); err != nil {
 			return nil, errors.Wrap(err, "sub-repo permissions check:")
@@ -2420,7 +2423,65 @@ func (c *clientImplementor) ArchiveReader(
 			return nil, errors.New("archiveReader invoked for a repo with sub-repo permissions")
 		}
 	}
-	return c.Archive(ctx, repo, options)
+
+	if ClientMocks.Archive != nil {
+		return ClientMocks.Archive(ctx, repo, options)
+	}
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: Archive")
+	span.SetTag("Repo", repo)
+	span.SetTag("Treeish", options.Treeish)
+	defer func() {
+		if err != nil {
+			ext.Error.Set(span, true)
+			span.LogFields(log.Error(err))
+		}
+		span.Finish()
+	}()
+
+	// Check that ctx is not expired.
+	if err := ctx.Err(); err != nil {
+		deadlineExceededCounter.Inc()
+		return nil, err
+	}
+
+	u, err := c.archiveURL(ctx, repo, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.do(ctx, repo, "POST", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return &archiveReader{
+			base: &cmdReader{
+				rc:      resp.Body,
+				trailer: resp.Trailer,
+			},
+			repo: repo,
+			spec: options.Treeish,
+		}, nil
+	case http.StatusNotFound:
+		var payload protocol.NotFoundPayload
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			resp.Body.Close()
+			return nil, err
+		}
+		resp.Body.Close()
+		return nil, &badRequestError{
+			error: &gitdomain.RepoNotExistError{
+				Repo:            repo,
+				CloneInProgress: payload.CloneInProgress,
+				CloneProgress:   payload.CloneProgress,
+			},
+		}
+	default:
+		resp.Body.Close()
+		return nil, errors.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
 }
 
 func addNameOnly(opt CommitsOptions, checker authz.SubRepoPermissionChecker) CommitsOptions {

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -32,9 +32,6 @@ type MockClient struct {
 	// AddrsFunc is an instance of a mock function object controlling the
 	// behavior of the method Addrs.
 	AddrsFunc *ClientAddrsFunc
-	// ArchiveFunc is an instance of a mock function object controlling the
-	// behavior of the method Archive.
-	ArchiveFunc *ClientArchiveFunc
 	// ArchiveReaderFunc is an instance of a mock function object
 	// controlling the behavior of the method ArchiveReader.
 	ArchiveReaderFunc *ClientArchiveReaderFunc
@@ -201,11 +198,6 @@ func NewMockClient() *MockClient {
 		},
 		AddrsFunc: &ClientAddrsFunc{
 			defaultHook: func() (r0 []string) {
-				return
-			},
-		},
-		ArchiveFunc: &ClientArchiveFunc{
-			defaultHook: func(context.Context, api.RepoName, ArchiveOptions) (r0 io.ReadCloser, r1 error) {
 				return
 			},
 		},
@@ -481,11 +473,6 @@ func NewStrictMockClient() *MockClient {
 				panic("unexpected invocation of MockClient.Addrs")
 			},
 		},
-		ArchiveFunc: &ClientArchiveFunc{
-			defaultHook: func(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error) {
-				panic("unexpected invocation of MockClient.Archive")
-			},
-		},
 		ArchiveReaderFunc: &ClientArchiveReaderFunc{
 			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ArchiveOptions) (io.ReadCloser, error) {
 				panic("unexpected invocation of MockClient.ArchiveReader")
@@ -753,9 +740,6 @@ func NewMockClientFrom(i Client) *MockClient {
 		},
 		AddrsFunc: &ClientAddrsFunc{
 			defaultHook: i.Addrs,
-		},
-		ArchiveFunc: &ClientArchiveFunc{
-			defaultHook: i.Archive,
 		},
 		ArchiveReaderFunc: &ClientArchiveReaderFunc{
 			defaultHook: i.ArchiveReader,
@@ -1116,116 +1100,6 @@ func (c ClientAddrsFuncCall) Args() []interface{} {
 // invocation.
 func (c ClientAddrsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// ClientArchiveFunc describes the behavior when the Archive method of the
-// parent MockClient instance is invoked.
-type ClientArchiveFunc struct {
-	defaultHook func(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error)
-	hooks       []func(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error)
-	history     []ClientArchiveFuncCall
-	mutex       sync.Mutex
-}
-
-// Archive delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockClient) Archive(v0 context.Context, v1 api.RepoName, v2 ArchiveOptions) (io.ReadCloser, error) {
-	r0, r1 := m.ArchiveFunc.nextHook()(v0, v1, v2)
-	m.ArchiveFunc.appendCall(ClientArchiveFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Archive method of
-// the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientArchiveFunc) SetDefaultHook(hook func(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Archive method of the parent MockClient instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *ClientArchiveFunc) PushHook(hook func(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ClientArchiveFunc) SetDefaultReturn(r0 io.ReadCloser, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientArchiveFunc) PushReturn(r0 io.ReadCloser, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error) {
-		return r0, r1
-	})
-}
-
-func (f *ClientArchiveFunc) nextHook() func(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ClientArchiveFunc) appendCall(r0 ClientArchiveFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ClientArchiveFuncCall objects describing
-// the invocations of this function.
-func (f *ClientArchiveFunc) History() []ClientArchiveFuncCall {
-	f.mutex.Lock()
-	history := make([]ClientArchiveFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ClientArchiveFuncCall is an object that describes an invocation of method
-// Archive on an instance of MockClient.
-type ClientArchiveFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.RepoName
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 ArchiveOptions
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 io.ReadCloser
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ClientArchiveFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ClientArchiveFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // ClientArchiveReaderFunc describes the behavior when the ArchiveReader


### PR DESCRIPTION
Before, we had client.Archive and ArchiveReader. The only difference was
that ArchiveReader took a sub-repo permissions checker but then called
Archive. Instead, we now just remove Archive and in the two places we
were still using it pass in a nil checker. This is safe as it replicates
the behavior from before.

## Test plan

All tests still pass