### PR TITLE
bk: SoftFail() means any exit code is ok

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -13,9 +13,9 @@
     # Turn the string of exit codes "1 2 3 4" into an array of strings
     IFS=' ' read -ra codes <<<"$SOFT_FAIL_EXIT_CODES 0" # append exit code 0 for the test below.
     for code in "${codes[@]}"; do
-        if [ "$code" == "$exit_code" ]; then
+        if [ "$code" == "*" ] || [ "$code" == "$exit_code" ]; then
             # If the Buildkite exit code is a soft fail, do nothing either.
-            exit "$code"
+            exit "$exit_code"
         fi
     done
 

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -21,7 +21,7 @@ if [ "$BUILDKITE_BRANCH" == "main" ]; then
   # Turn the string of exit codes "1 2 3 4" into an array of strings
   IFS=' ' read -ra codes <<<"$SOFT_FAIL_EXIT_CODES"
   for code in "${codes[@]}"; do
-    if [ "$code" == "$BUILDKITE_COMMAND_EXIT_STATUS" ]; then
+    if [ "$code" == "*" ] || [ "$code" == "$BUILDKITE_COMMAND_EXIT_STATUS" ]; then
       # If the Buildkite exit code is a soft fail, do nothing either.
       exit 0
     fi

--- a/enterprise/dev/ci/internal/buildkite/buildkite_test.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite_test.go
@@ -10,18 +10,34 @@ import (
 )
 
 func TestStepSoftFail(t *testing.T) {
-	pipeline := buildkite.Pipeline{}
-	stepOpt := buildkite.SoftFail(1, 2, 3, 4)
-	pipeline.AddStep("foo", stepOpt)
-	step, ok := pipeline.Steps[0].(*buildkite.Step)
-	if !ok {
-		t.Fatal("Pipeline step is not a buildkite.Step")
-	}
-	want := "1 2 3 4"
-	got := step.Env["SOFT_FAIL_EXIT_CODES"]
-	if got != want {
-		t.Fatalf("want %q, got %q", want, got)
-	}
+	t.Run("Explicit exit codes", func(t *testing.T) {
+		pipeline := buildkite.Pipeline{}
+		stepOpt := buildkite.SoftFail(1, 2, 3, 4)
+		pipeline.AddStep("foo", stepOpt)
+		step, ok := pipeline.Steps[0].(*buildkite.Step)
+		if !ok {
+			t.Fatal("Pipeline step is not a buildkite.Step")
+		}
+		want := "1 2 3 4"
+		got := step.Env["SOFT_FAIL_EXIT_CODES"]
+		if got != want {
+			t.Fatalf("want %q, got %q", want, got)
+		}
+	})
+	t.Run("Any exit code", func(t *testing.T) {
+		pipeline := buildkite.Pipeline{}
+		stepOpt := buildkite.SoftFail()
+		pipeline.AddStep("foo", stepOpt)
+		step, ok := pipeline.Steps[0].(*buildkite.Step)
+		if !ok {
+			t.Fatal("Pipeline step is not a buildkite.Step")
+		}
+		want := "*"
+		got := step.Env["SOFT_FAIL_EXIT_CODES"]
+		if got != want {
+			t.Fatalf("want %q, got %q", want, got)
+		}
+	})
 }
 
 func TestOutputSanitization(t *testing.T) {

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -93,39 +93,45 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	// PERF: Try to order steps such that slower steps are first.
 	switch c.RunType {
 	case runtype.PullRequest:
-		// First, we set up core test operations that apply both to PRs and to other run
-		// types such as main.
-		ops.Merge(CoreTestOperations(c.Diff, CoreTestOperationsOptions{
-			MinimumUpgradeableVersion: minimumUpgradeableVersion,
-			ForceReadyForReview:       c.MessageFlags.ForceReadyForReview,
-			// TODO: (@umpox, @valerybugakov) Figure out if we can reliably enable this in PRs.
-			ClientLintOnlyChangedFiles: false,
-		}))
-
-		// Now we set up conditional operations that only apply to pull requests.
-		if c.Diff.Has(changed.Client) {
-			// triggers a slow pipeline, currently only affects web. It's optional so we
-			// set it up separately from CoreTestOperations
-			ops.Merge(operations.NewNamedSet(operations.PipelineSetupSetName,
-				triggerAsync(buildOptions)))
-
-			// Do not create client PR preview if Go or GraphQL is changed to avoid confusing
-			// preview behavior, because only Client code is used to deploy application preview.
-			if !c.Diff.Has(changed.Go) && !c.Diff.Has(changed.GraphQL) {
-				ops.Append(prPreview())
-			}
-		}
-		if c.Diff.Has(changed.DockerImages) {
-			// Build and scan docker images
-			testBuilds := operations.NewNamedSet("Test builds")
-			scanBuilds := operations.NewNamedSet("Scan test builds")
-			for _, image := range images.SourcegraphDockerImages {
-				testBuilds.Append(buildCandidateDockerImage(image, c.Version, c.candidateImageTag()))
-				scanBuilds.Append(trivyScanCandidateImage(image, c.candidateImageTag()))
-			}
-			ops.Merge(testBuilds)
-			ops.Merge(scanBuilds)
-		}
+		ops.Append(func(p *bk.Pipeline) {
+			p.AddStep("testing stuff",
+				bk.Cmd("exit 33"),
+				bk.SoftFail(),
+			)
+		})
+		// // First, we set up core test operations that apply both to PRs and to other run
+		// // types such as main.
+		// ops.Merge(CoreTestOperations(c.Diff, CoreTestOperationsOptions{
+		// 	MinimumUpgradeableVersion: minimumUpgradeableVersion,
+		// 	ForceReadyForReview:       c.MessageFlags.ForceReadyForReview,
+		// 	// TODO: (@umpox, @valerybugakov) Figure out if we can reliably enable this in PRs.
+		// 	ClientLintOnlyChangedFiles: false,
+		// }))
+		//
+		// // Now we set up conditional operations that only apply to pull requests.
+		// if c.Diff.Has(changed.Client) {
+		// 	// triggers a slow pipeline, currently only affects web. It's optional so we
+		// 	// set it up separately from CoreTestOperations
+		// 	ops.Merge(operations.NewNamedSet(operations.PipelineSetupSetName,
+		// 		triggerAsync(buildOptions)))
+		//
+		// 	// Do not create client PR preview if Go or GraphQL is changed to avoid confusing
+		// 	// preview behavior, because only Client code is used to deploy application preview.
+		// 	if !c.Diff.Has(changed.Go) && !c.Diff.Has(changed.GraphQL) {
+		// 		ops.Append(prPreview())
+		// 	}
+		// }
+		// if c.Diff.Has(changed.DockerImages) {
+		// 	// Build and scan docker images
+		// 	testBuilds := operations.NewNamedSet("Test builds")
+		// 	scanBuilds := operations.NewNamedSet("Scan test builds")
+		// 	for _, image := range images.SourcegraphDockerImages {
+		// 		testBuilds.Append(buildCandidateDockerImage(image, c.Version, c.candidateImageTag()))
+		// 		scanBuilds.Append(trivyScanCandidateImage(image, c.candidateImageTag()))
+		// 	}
+		// 	ops.Merge(testBuilds)
+		// 	ops.Merge(scanBuilds)
+		// }
 
 	case runtype.ReleaseNightly:
 		ops.Append(triggerReleaseBranchHealthchecks(minimumUpgradeableVersion))


### PR DESCRIPTION
Prior to this pr, the `buildkite.SoftFail(int...)` helper did not support using the `*` form of the soft fail attribute. Now, it's possible to do so, by simply using the zero arguments form of the `buildkite.SoftFail()` function. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested here: https://buildkite.com/sourcegraph/sourcegraph/builds/164165#01824927-af32-4411-87ed-f513a6727334