### PR TITLE
JetBrains: Add compatibility note for M1 and old IDE versions

### DIFF
--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -28,6 +28,8 @@ The plugin works with all JetBrains IDEs, including:
 - Rider
 - Android Studio
 
+**Exception:** Due to a Java bug, search doesn't work with IDE versions **2021.1** and **2021.2** for users with **Apple Silicone** CPUs.
+
 ## Installation
 
 - Open settings


### PR DESCRIPTION
Also added it under "Getting started", here: https://plugins.jetbrains.com/plugin/9682-sourcegraph

## Test plan

(only docs change)
