### PR TITLE
Use enableLegacyExtensions over the other feature flag

### DIFF
--- a/client/web/src/Layout.test.tsx
+++ b/client/web/src/Layout.test.tsx
@@ -40,14 +40,19 @@ describe('Layout', () => {
         platformContext: { forceUpdateTooltip: () => {}, settings: NEVER },
     } as unknown) as LayoutProps
 
+    const origContext = window.context
     beforeEach(() => {
         const root = document.createElement('div')
         root.id = 'root'
         document.body.append(root)
+        window.context = {
+            enableLegacyExtensions: true,
+        } as any
     })
 
     afterEach(() => {
         document.querySelector('#root')?.remove()
+        window.context = origContext
     })
 
     it('should update patternType if different between URL and context', () => {

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -52,8 +52,15 @@ const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
 }
 
 describe('GlobalNavbar', () => {
+    const origContext = window.context
     beforeEach(() => {
         useExperimentalFeatures.setState({ codeMonitoring: false, showSearchContext: true })
+        window.context = {
+            enableLegacyExtensions: true,
+        } as any
+    })
+    afterEach(() => {
+        window.context = origContext
     })
 
     test('default', () => {

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -195,7 +195,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext)
     const enableCodeMonitoring = useExperimentalFeatures(features => features.codeMonitoring)
     const showSearchNotebook = useExperimentalFeatures(features => features.showSearchNotebook)
-    const extensionsAsCoreFeatures = useExperimentalFeatures(features => features.extensionsAsCoreFeatures)
 
     useEffect(() => {
         // On a non-search related page or non-repo page, we clear the query in
@@ -307,7 +306,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
                             </NavLink>
                         </NavItem>
                     )}
-                    {!extensionsAsCoreFeatures && (
+                    {window.context.enableLegacyExtensions && (
                         <NavItem icon={PuzzleOutlineIcon}>
                             <NavLink variant={navLinkVariant} to="/extensions">
                                 Extensions

--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -43,8 +43,6 @@ export interface Props extends ThemeProps {
      * Called when the user presses the key binding for "save" (Ctrl+S/Cmd+S).
      */
     onDidSave?: () => void
-
-    extensionsAsCoreFeatures?: boolean
 }
 
 interface State {}
@@ -81,7 +79,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
         this.subscriptions.add(
             componentUpdates.pipe(distinctUntilKeyChanged('jsonSchema')).subscribe(props => {
                 if (this.monaco) {
-                    setDiagnosticsOptions(this.monaco, props.jsonSchema, this.props.extensionsAsCoreFeatures || false)
+                    setDiagnosticsOptions(this.monaco, props.jsonSchema)
                 }
             })
         )
@@ -152,7 +150,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
 
         this.disposables.push(registerRedactedHover(monaco))
 
-        setDiagnosticsOptions(monaco, this.props.jsonSchema, this.props.extensionsAsCoreFeatures || false)
+        setDiagnosticsOptions(monaco, this.props.jsonSchema)
 
         // Only listen to 1 event each to avoid receiving events from other Monaco editors on the
         // same page (if there are multiple).
@@ -265,13 +263,9 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
     }
 }
 
-function setDiagnosticsOptions(
-    editor: typeof monaco,
-    jsonSchema: JSONSchema | undefined,
-    extensionsAsCoreFeatures: boolean
-): void {
+function setDiagnosticsOptions(editor: typeof monaco, jsonSchema: JSONSchema | undefined): void {
     const schema = { ...settingsSchema, properties: { ...settingsSchema.properties } }
-    if (extensionsAsCoreFeatures) {
+    if (!window.context.enableLegacyExtensions) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- we need to remove this key conditionally, but not from the schema
         // @ts-ignore
         delete schema.properties.extensions

--- a/client/web/src/settings/SettingsFile.tsx
+++ b/client/web/src/settings/SettingsFile.tsx
@@ -43,8 +43,6 @@ interface Props extends ThemeProps, TelemetryProps {
      * if any.
      */
     commitError?: Error
-
-    extensionsAsCoreFeatures: boolean
 }
 
 interface State {
@@ -201,7 +199,6 @@ export class SettingsFile extends React.PureComponent<Props, State> {
                         monacoRef={this.monacoRef}
                         isLightTheme={this.props.isLightTheme}
                         onDidSave={this.save}
-                        extensionsAsCoreFeatures={this.props.extensionsAsCoreFeatures}
                     />
                 </React.Suspense>
             </div>

--- a/client/web/src/settings/SettingsPage.tsx
+++ b/client/web/src/settings/SettingsPage.tsx
@@ -6,8 +6,6 @@ import { overwriteSettings } from '@sourcegraph/shared/src/settings/edit'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { extensionsAsCoreFeaturesEnabled } from '../util/settings'
-
 import { SettingsAreaPageProps } from './SettingsArea'
 import { SettingsFile } from './SettingsFile'
 
@@ -31,8 +29,6 @@ export class SettingsPage extends React.PureComponent<Props, State> {
     public state: State = {}
 
     public render(): JSX.Element | null {
-        const extensionsAsCoreFeatures = extensionsAsCoreFeaturesEnabled(this.props.settingsCascade)
-
         return (
             <SettingsFile
                 settings={this.props.data.subjects[this.props.data.subjects.length - 1].latestSettings}
@@ -43,7 +39,6 @@ export class SettingsPage extends React.PureComponent<Props, State> {
                 history={this.props.history}
                 isLightTheme={this.props.isLightTheme}
                 telemetryService={this.props.telemetryService}
-                extensionsAsCoreFeatures={extensionsAsCoreFeatures}
             />
         )
     }


### PR DESCRIPTION
This is a follow up to #39227

When we merged this PR, we did not have the newer feature flag yet. We want to seperate the option to deprecate the extension system from the option to enable the new integrations as core features. This just makes sure we use the right flag everywhere.

## Test plan

I reproduced @vdavid's testing plan from #39227 but did not make screenshots (they look like the one David was posting though 🙈 )

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-extension-deprecation-use.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dnseuulxcv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
