### PR TITLE
gitserver: Remove newClientImplementor

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -71,15 +71,10 @@ func ResetClientMocks() {
 
 var _ Client = &clientImplementor{}
 
-// NewClient returns a new gitserver.Client instantiated with default arguments
-// and httpcli.Doer.
+// NewClient returns a new gitserver.Client.
 func NewClient(db database.DB) Client {
-	return newClientImplementor(db)
-}
-
-func newClientImplementor(db database.DB) *clientImplementor {
 	return &clientImplementor{
-		logger: sglog.Scoped("NewClient", "returns a new gitserver.Client instantiated with default arguments and httpcli.Doer."),
+		logger: sglog.Scoped("NewClient", "returns a new gitserver.Client"),
 		addrs: func() []string {
 			return conf.Get().ServiceConnections().GitServers
 		},
@@ -101,6 +96,8 @@ func newClientImplementor(db database.DB) *clientImplementor {
 	}
 }
 
+// NewTestClient returns a test client that will use the given hard coded list of
+// addresses instead of reading them from config.
 func NewTestClient(cli httpcli.Doer, db database.DB, addrs []string) Client {
 	return &clientImplementor{
 		logger: sglog.Scoped("NewTestClient", "Test New client"),

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -994,7 +994,7 @@ func TestClientImplementor_ExecSafe(t *testing.T) {
 
 	repo := MakeGitRepository(t, "GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z")
 
-	client := newClientImplementor(database.NewMockDB())
+	client := NewClient(database.NewMockDB()).(*clientImplementor)
 	for _, test := range tests {
 		t.Run(fmt.Sprint(test.args), func(t *testing.T) {
 			stdout, stderr, exitCode, err := client.execSafe(context.Background(), repo, test.args)
@@ -2247,7 +2247,7 @@ func TestFilterRefDescriptions(t *testing.T) { // KEEP
 	}
 
 	checker := getTestSubRepoPermsChecker("file3")
-	client := newClientImplementor(database.NewMockDB())
+	client := NewClient(database.NewMockDB()).(*clientImplementor)
 	filtered := client.filterRefDescriptions(ctx, repo, refDescriptions, checker)
 	expectedRefDescriptions := map[string][]gitdomain.RefDescription{
 		"d38233a79e037d2ab8170b0d0bc0aa438473e6da": {},
@@ -2395,7 +2395,7 @@ func TestCommitDate(t *testing.T) {
 func testCommits(ctx context.Context, label string, repo api.RepoName, opt CommitsOptions, checker authz.SubRepoPermissionChecker, wantTotal uint, wantCommits []*gitdomain.Commit, t *testing.T) {
 	t.Helper()
 	db := database.NewMockDB()
-	client := newClientImplementor(db)
+	client := NewClient(db).(*clientImplementor)
 	commits, err := client.Commits(ctx, repo, opt, checker)
 	if err != nil {
 		t.Errorf("%s: Commits(): %s", label, err)


### PR DESCRIPTION
No need, we can extract the implementation we need in tests

## Test plan

All tests still pass
