### PR TITLE
update broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ All open issues are not yet solved. If the task is interesting to you, take it a
 
 ### Getting applications up and running
 
-- [Getting Started Guide](https://docs.sourcegraph.com/dev/getting-started)
-- [Troubleshooting section](https://docs.sourcegraph.com/dev/how-to/troubleshooting_local_development)
+- [Getting Started Guide](https://docs.sourcegraph.com/getting-started)
+- [Troubleshooting section](https://docs.sourcegraph.com/dev/setup/troubleshooting)
 
 ### How to write tests
 
@@ -51,7 +51,7 @@ All open issues are not yet solved. If the task is interesting to you, take it a
 ### Pull Requests
 
 - [How to structure](https://docs.sourcegraph.com/dev/background-information/pull_request_reviews#what-makes-an-effective-pull-request-pr)
-- [Size guidelines](https://handbook.sourcegraph.com/engineering/enablement#prefer-small-prs-400-lines)
+- [PR guidelines](https://handbook.sourcegraph.com/departments/engineering/dev/onboarding/pr-checklist/)
 - Git branch name convention: `[developer-initials]/short-feature-description`
 - [Examples on Github](https://github.com/sourcegraph/sourcegraph/pulls?q=is%3Apr+label%3Ateam%2Ffrontend-platform)
 - (For Sourcegraph team) [How to accept contributions](https://docs.sourcegraph.com/dev/contributing/accepting_contribution)


### PR DESCRIPTION
replaced broken links for Getting Started Guide and Troubleshooting section
I wasn't able to find the size guidelines page but PR checklist feels like a good replacement



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
n/a. Docs change only