### PR TITLE
docs: highlight subsection in sidebar even if on subpage of subsection

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -287,6 +287,12 @@ body > #sidebar .nav-section ul ul {
     font-size: 90%;
     padding-left: var(--spacing);
 }
+body > #sidebar .nav-section ul ul li.active-subsection {
+    font-weight: bold;
+}
+body > #sidebar .nav-section ul ul li.active-subsection a {
+    color: var(--text-color);
+}
 body > #sidebar .nav-section li.collapse ul {
     display: none;
 }

--- a/doc/_resources/assets/docsite.js
+++ b/doc/_resources/assets/docsite.js
@@ -40,11 +40,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const style = document.createElement('style')
   for (const link of document.querySelectorAll('body > #sidebar .nav-section.tree a')) {
     const current = link.pathname === pagePath
-    const expand = pagePath === link.pathname || pagePath.startsWith(link.pathname + '/')
+    const expand = current || pagePath.startsWith(link.pathname + '/')
+    const subsection = link.pathname.split('/').length >= 3
 
     const item = link.parentNode
     item.classList.toggle('current', current)
     item.classList.toggle('expand', expand)
+    item.classList.toggle('active-subsection', subsection && expand)
     item.classList.toggle('collapse', !expand)
   }
 })


### PR DESCRIPTION
Previously we wouldn't highlight the subsection in the sidebar if you were on a subpage of that subsection:
![screenshot_2022-07-29_17 34 31@2x](https://user-images.githubusercontent.com/1185253/181794132-e18a6bcd-8047-43f3-90af-3827fc10d418.png)

Now, with this change, we do:

![screenshot_2022-07-29_17 35 08@2x](https://user-images.githubusercontent.com/1185253/181794232-485614f2-d79d-47d3-866a-1f36c07e52f0.png)

This has been a huge pain for me in the past 😬 

## Test plan

- Tested locally