### PR TITLE
Clarifying note for common mistake amongst users

### DIFF
--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -196,6 +196,7 @@ In your [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-
    ```
    - '/LOCAL/KEY/PATH.key:/sourcegraph.key'
    ```
+**NOTE**: When adding your certs to your instance, make sure they are in the `deploy-sourcegraph-docker` folder, not outside of it. They will not be recognized otherwise.
 
 ## Other Sourcegraph clusters (e.g. pure-Docker)
 


### PR DESCRIPTION
Users often place their certs in the home folder of their VM. Adds a note to clarify that self-signed certs must be in the `deploy-sourcegraph-docker` folder.



## Test plan

Manually tested certs inside and outside of the `deploy-sourcegraph-docker` folder.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
