### PR TITLE
Fix gitolite ext svc connection

### DIFF
--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -37,10 +37,7 @@ func NewGitoliteSource(svc *types.ExternalService, cf *httpcli.Factory) (*Gitoli
 
 	gitoliteDoer, err := cf.Doer(
 		httpcli.NewMaxIdleConnsPerHostOpt(500),
-		// The provided httpcli.Factory is one used for external services - however,
-		// GitoliteSource asks gitserver to communicate to gitolite instead, so we
-		// have to ensure that the actor transport used for internal clients is provided.
-		httpcli.ActorTransportOpt)
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/gitolite_test.go
+++ b/internal/repos/gitolite_test.go
@@ -1,0 +1,39 @@
+package repos
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestGitoliteSource(t *testing.T) {
+	testCases := []struct {
+		name string
+	}{
+		{
+			name: "basic",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			cf, save := newClientFactoryWithOpt(t, tc.name, httpcli.ExternalTransportOpt)
+			defer save(t)
+
+			svc := &types.ExternalService{
+				Kind:   extsvc.KindGitolite,
+				Config: marshalJSON(t, &schema.GitoliteConnection{}),
+			}
+
+			_, err := NewGitoliteSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add test to demonstrate failure scenario when using `httpcli.ActorTransportOpt` with `httpcli.ExternalTransportOpt`. Remove the use of `httpcli.ActorTransportOpt` for now. 

The root of the problem is that we can't wrap the `http.Transport` multiple times, which is what we're trying to do here. 

Looking into a way to add the actor transport back in without breaking things (may need @bobheadxi help), but this is the quickest fix to get the connection working for now. 

It's worth noting that adding this `httpcli.ExternalTransportOpt` to other unit tests causes a similar breakage. It seems that if it goes before other `httpcli.Opt` functions, then it works fine, but if it comes after, then we see the error that looks like `httpcli.ExternalTransportOpt: http.Client.Transport is not an *http.Transport: *recorder.Recorder` which comes from [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/httpcli/client.go?L613) when we try to modify the transport, but this assumes it's a `*http.Transport` and it isn't.

## Test plan
added unit tests. also verifying gitolite connection in local sg deployment.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
