### PR TITLE
Docs: remove broken link

### DIFF
--- a/client/web/src/search/home/SelfHostInstructions.tsx
+++ b/client/web/src/search/home/SelfHostInstructions.tsx
@@ -55,9 +55,6 @@ export const SelfHostInstructions: React.FunctionComponent<React.PropsWithChildr
                     <li>Your code never leaves your server</li>
                     <li>Free 30 day trial of enterprise-only features</li>
                 </ul>
-                <Link to="/help/cloud/cloud_ent_on-prem_comparison" target="_blank" rel="noopener noreferrer">
-                    Learn more about self-hosted vs. cloud features <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
-                </Link>
             </div>
 
             <div className={styles.column}>


### PR DESCRIPTION
The page being linked to here was deleted, which is causing a lint error and build failures on `main`. This just deletes the link, but we may want to repoint it to a page comparing self-hosted with managed instances (I'm not sure if that exists). For now, this just deletes it to unblock `main`. 

## Test plan

Lints should pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-fix-main.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-manvbchfhm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
