### PR TITLE
remove google tag manager on docs site, add cloudflare analytics

### DIFF
--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -13,28 +13,12 @@
             <script src="{{asset "docsite.js"}}"></script>
             <script src="{{asset "railroad.js"}}"></script>
 			<meta name="viewport" content="width=device-width, initial-scale=1" />
-      {{block "seo" . }}{{end}}
-
-            <!-- Google Tag Manager -->
-            <script>(function (w, d, s, l, i) {
-                    w[l] = w[l] || []; w[l].push({
-                        'gtm.start':
-                            new Date().getTime(), event: 'gtm.js'
-                    }); var f = d.getElementsByTagName(s)[0],
-                        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-                            'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-                })(window, document, 'script', 'dataLayer', 'GTM-TB4NLS7');</script>
-            <!-- End Google Tag Manager -->
-
+			{{block "seo" . }}{{end}}
 			{{block "head" .}}{{end}}
 		</head>
 
         <!-- Default to light theme if no JavaScript -->
 		<body class="theme-light">
-            <!-- Google Tag Manager (noscript) -->
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TB4NLS7" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-            <!-- End Google Tag Manager (noscript) -->
-
 			<aside id="sidebar">
                 <header>
 				    <h1 id="logo"><a href="/">

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -15,6 +15,7 @@
 			<meta name="viewport" content="width=device-width, initial-scale=1" />
 			{{block "seo" . }}{{end}}
 			{{block "head" .}}{{end}}
+            <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "a3a591d105ce4bdc807d6cecfb925cad"}'></script><!-- End Cloudflare Web Analytics -->
 		</head>
 
         <!-- Default to light theme if no JavaScript -->


### PR DESCRIPTION
The old GTM ID was wrong.




## Test plan

None (docs only).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->