### PR TITLE
sg: stop grafana watching ./monitoring

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -587,8 +587,6 @@ commands:
       DOCKER_USER: ''
       ADD_HOST_FLAG: ''
       CACHE: false
-    watch:
-      - monitoring
 
   prometheus:
     cmd: |


### PR DESCRIPTION
monitoring-generator updates Grafana if there are changes, having Grafana watch ./monitoring to adds extra unnecessary time to the feedback loop

## Test plan

N/A, dev-env changes
