### PR TITLE
search: clean up nits around description match ranges

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -292,9 +292,7 @@ func (s *repoStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (ma
 func (s *repoStore) GetRepoDescriptionsByIDs(ctx context.Context, ids ...api.RepoID) (_ map[api.RepoID]string, err error) {
 	tr, ctx := trace.New(ctx, "repos.GetRepoDescriptionsByIDs", "")
 	defer func() {
-		if err != nil {
-			tr.SetError(err)
-		}
+		tr.SetError(err)
 		tr.Finish()
 	}()
 

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -331,10 +331,6 @@ func TestRepos_GetByIDs_EmptyIDs(t *testing.T) {
 }
 
 func TestRepos_GetRepoDescriptionsByIDs(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
 	t.Parallel()
 	logger := logtest.Scoped(t)
 	db := NewDB(logger, dbtest.NewDB(logger, t))

--- a/internal/search/job/jobutil/repos_test.go
+++ b/internal/search/job/jobutil/repos_test.go
@@ -88,40 +88,6 @@ func Test_descriptionMatchRanges(t *testing.T) {
 			},
 		},
 		{
-			name:          "multiple description patterns that match",
-			inputPatterns: []string{"(?:this).*?(?:go)", "(?:input).*?(?:other).*?(?:things)"},
-			want: map[api.RepoID][]result.Range{
-				1: {
-					result.Range{
-						Start: result.Location{
-							Offset: 0,
-							Line:   0,
-							Column: 0,
-						},
-						End: result.Location{
-							Offset: 12,
-							Line:   0,
-							Column: 12,
-						},
-					},
-				},
-				2: {
-					result.Range{
-						Start: result.Location{
-							Offset: 37,
-							Line:   0,
-							Column: 37,
-						},
-						End: result.Location{
-							Offset: 62,
-							Line:   0,
-							Column: 62,
-						},
-					},
-				},
-			},
-		},
-		{
 			name:          "no matches",
 			inputPatterns: []string{"(?:this).*?(?:matches).*?(?:nothing)"},
 			want:          map[api.RepoID][]result.Range{},


### PR DESCRIPTION
Following up on comments in https://github.com/sourcegraph/sourcegraph/pull/39530

Removing an unneeded test and a couple unneeded `if` checks. Commit messages have explanations.

## Test plan
Tests pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
