### PR TITLE
cm file view: Add max width to hovercard and fix(?) positioning problem

### DIFF
--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -1,5 +1,5 @@
 import { Extension } from '@codemirror/state'
-import { EditorView, hoverTooltip, Tooltip } from '@codemirror/view'
+import { EditorView, hoverTooltip, repositionTooltips, Tooltip } from '@codemirror/view'
 import { upperFirst } from 'lodash'
 import { createRoot } from 'react-dom/client'
 
@@ -11,6 +11,7 @@ import { HoverOverlayContent } from '@sourcegraph/shared/src/hover/HoverOverlayC
 import { Alert, Card, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import webHoverOverlayStyle from '../../../components/WebHoverOverlay/WebHoverOverlay.module.scss'
+import { useEffect } from 'react'
 
 const HOVER_TIMEOUT = 50
 
@@ -18,6 +19,7 @@ const hoverCardTheme = EditorView.theme({
     '.cm-code-intel-hovercard': {
         fontFamily: 'sans-serif',
         minWidth: '10rem',
+        maxWidth: '35rem',
     },
     '.cm-code-intel-contents': {
         maxHeight: '25rem',
@@ -47,8 +49,8 @@ export function hovercard(
         // hoverTooltip takes care of only calling the source (and processing
         // its return value) when necessary.
         hoverTooltip(
-            async (...args) => {
-                const result = await source(...args)
+            async (view, ...args) => {
+                const result = await source(view, ...args)
                 if (!result) {
                     return null
                 }
@@ -61,9 +63,19 @@ export function hovercard(
                         return {
                             dom: container,
                             overlap: true,
+
                             mount() {
                                 const root = createRoot(container)
-                                root.render(<Hovercard {...props} />)
+                                root.render(
+                                    <Hovercard
+                                        {...props}
+                                        onRender={() => {
+                                            // Trigger repositioning after component rendered to ensure that
+                                            // its position is account for its width and height
+                                            repositionTooltips(view)
+                                        }}
+                                    />
+                                )
                             },
                         }
                     },
@@ -81,7 +93,11 @@ export function hovercard(
  * A simple replication of the hovercard for the old blob view.
  * TODO: Reuse existing hovercard component for full feature parity
  */
-export const Hovercard: React.FunctionComponent<Pick<HoverOverlayBaseProps, 'hoverOrError'>> = ({ hoverOrError }) => {
+export const Hovercard: React.FunctionComponent<
+    Pick<HoverOverlayBaseProps, 'hoverOrError'> & { onRender: () => void }
+> = ({ hoverOrError, onRender }) => {
+    useEffect(onRender, [])
+
     if (isErrorLike(hoverOrError)) {
         return <Alert className={hoverOverlayStyle.hoverError}>{upperFirst(hoverOrError.message)}</Alert>
     }

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { Extension } from '@codemirror/state'
 import { EditorView, hoverTooltip, repositionTooltips, Tooltip } from '@codemirror/view'
 import { upperFirst } from 'lodash'
@@ -11,7 +13,6 @@ import { HoverOverlayContent } from '@sourcegraph/shared/src/hover/HoverOverlayC
 import { Alert, Card, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import webHoverOverlayStyle from '../../../components/WebHoverOverlay/WebHoverOverlay.module.scss'
-import { useEffect } from 'react'
 
 const HOVER_TIMEOUT = 50
 
@@ -96,7 +97,7 @@ export function hovercard(
 export const Hovercard: React.FunctionComponent<
     Pick<HoverOverlayBaseProps, 'hoverOrError'> & { onRender: () => void }
 > = ({ hoverOrError, onRender }) => {
-    useEffect(onRender, [])
+    useEffect(onRender, [onRender])
 
     if (isErrorLike(hoverOrError)) {
         return <Alert className={hoverOverlayStyle.hoverError}>{upperFirst(hoverOrError.message)}</Alert>


### PR DESCRIPTION
This commit adds a max width to the hovercard. Currently a hovercard
might use the full window width if necessary, which is bad on large
screens.

This also adds a callback function to the component to inform the parent
that it was rendered. I hope this fixes the positining issues mentioned
in https://github.com/sourcegraph/sourcegraph/pull/39482#pullrequestreview-1053177608
but I wasn't able to reliable reproduce the issue so I can't verify it.



## Test plan

- Enable CodeMirror file view with `"enableCodeMirrorFileView": true".
- Open a file.
- Hover over a token (e.g. Go's `time` shows a lot of text). The hovercard width should be constraint.
- Repeatedly hover over various tokens. As long as there is space the hovercard should always appear above the line.

## App preview:

- [Web](https://sg-web-fkling-cm-file-view-hovercard.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dphbxnwgyi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
