### PR TITLE
batches: add limit to subquery for updating `batch_specs.batch_change_id`

### DIFF
--- a/migrations/frontend/1658122170_add_batch_change_id_to_batch_spec/up.sql
+++ b/migrations/frontend/1658122170_add_batch_change_id_to_batch_spec/up.sql
@@ -3,9 +3,9 @@ ALTER TABLE batch_specs
     ADD FOREIGN KEY (batch_change_id) REFERENCES batch_changes(id) ON DELETE SET NULL DEFERRABLE;
 
 UPDATE batch_specs SET batch_change_id = (
-    -- In the event that a batch change is manually mapped to different batch specs,
-    -- we want to use the oldest. This should never happen in production,
-    -- it's only added to minimize errors when running the migration on dev.
+    -- In the event, the database is in a not-so-optimal state (usually in dev environment)
+    -- we want the subquery to never return more than one row.
+    -- This will never happen in production.
     SELECT
         bc.id
     FROM batch_changes bc

--- a/migrations/frontend/1658122170_add_batch_change_id_to_batch_spec/up.sql
+++ b/migrations/frontend/1658122170_add_batch_change_id_to_batch_spec/up.sql
@@ -2,4 +2,13 @@ ALTER TABLE batch_specs
     ADD COLUMN IF NOT EXISTS batch_change_id bigint,
     ADD FOREIGN KEY (batch_change_id) REFERENCES batch_changes(id) ON DELETE SET NULL DEFERRABLE;
 
-UPDATE batch_specs SET batch_change_id = (SELECT bc.id FROM batch_changes bc WHERE bc.batch_spec_id = batch_specs.id);
+UPDATE batch_specs SET batch_change_id = (
+    -- In the event that a batch change is manually mapped to different batch specs,
+    -- we want to use the oldest. This should never happen in production,
+    -- it's only added to minimize errors when running the migration on dev.
+    SELECT
+        bc.id
+    FROM batch_changes bc
+    WHERE bc.batch_spec_id = batch_specs.id
+    LIMIT 1
+);


### PR DESCRIPTION
Thanks, @courier-new for reporting this.

It's possible (in your dev environment) for a `batch_spec` to be associated with more than one `batch_change`, this results in an error when running the migration added by #38921. 
Adding a limit to the subquery that fetches the `batch_change` associated with a `batch_spec` solves this and also gives the added advantage of having a faster execution time as we end the search once we find a match.

Before | After
:------:|:-------:
<img width="1064" alt="CleanShot 2022-08-01 at 05 08 37@2x" src="https://user-images.githubusercontent.com/25608335/182070462-5514cdca-c57d-4d8a-b824-2bc214786ccb.png"> | <img width="837" alt="CleanShot 2022-08-01 at 05 12 47@2x" src="https://user-images.githubusercontent.com/25608335/182070847-3b7b8358-aa85-4306-9125-ba6377b47e9b.png"> 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Manually verified migrations run locally.