### PR TITLE
ci: integrate client bundlesize observability script

### DIFF
--- a/client/observability/src/webBundleSize/index.ts
+++ b/client/observability/src/webBundleSize/index.ts
@@ -29,7 +29,7 @@ const environment = cleanEnv(process.env, {
 
 const bundleSizeStats = getBundleSizeStats(path.join(WORKSPACES_PATH, 'web/bundlesize.config'))
 const commit = execSync('git rev-parse HEAD').toString().trim()
-const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
+const branch = process.env.BUILDKITE_BRANCH || execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
 
 /**
  * Log every file size as a separate event to Honeycomb.

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -31,7 +31,7 @@ body,
 
 // Selection highlight is the background color for matched/highlighted tokens,
 // e.g. for search results, for identifying the token currently being hovered over,
-// or identifying the token the references panel is toggled for
+// or identifying the token the references panel is toggled for.
 .selection-highlight,
 .selection-highlight-sticky {
     background-color: var(--mark-bg);

--- a/dev/ci/yarn-build.sh
+++ b/dev/ci/yarn-build.sh
@@ -20,5 +20,6 @@ yarn -s run build --color
 if [ "$CHECK_BUNDLESIZE" ] && jq -e '.scripts.bundlesize' package.json >/dev/null; then
   echo "--- bundlesize"
   yarn -s run bundlesize --enable-github-checks
+  echo "--- bundlesize:web:upload"
   HONEYCOMB_API_KEY="$CI_HONEYCOMB_CLIENT_ENV_API_KEY" yarn workspace @sourcegraph/observability run bundlesize:web:upload
 fi

--- a/dev/ci/yarn-build.sh
+++ b/dev/ci/yarn-build.sh
@@ -20,4 +20,5 @@ yarn -s run build --color
 if [ "$CHECK_BUNDLESIZE" ] && jq -e '.scripts.bundlesize' package.json >/dev/null; then
   echo "--- bundlesize"
   yarn -s run bundlesize --enable-github-checks
+  HONEYCOMB_API_KEY="$CI_HONEYCOMB_CLIENT_ENV_API_KEY" yarn workspace @sourcegraph/observability run bundlesize:web:upload
 fi


### PR DESCRIPTION
## Context

Integrate the bundlesize upload script into the CI pipeline to enable continuous bundlesize monitoring.

The Honeycomb client env API key secret was added here https://github.com/sourcegraph/infrastructure/pull/3740.
Closes https://github.com/sourcegraph/sourcegraph/issues/39737.

## Test plan

Check if bundlesize stats are uploaded to Honeycomb during the `Web Enterprise build` step.
See dashboard [here](https://ui.honeycomb.io/sourcegraph/environments/client/board/8RjpcGkEvSq/Client).

## App preview:

- [Web](https://sg-web-vb-bundlesize-observability.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jljjhwneum.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
