### PR TITLE
gitserver_repos: update updated_at when updating repo size

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -654,7 +654,7 @@ const updateRepoSizesQueryFmtstr = `
 UPDATE gitserver_repos AS gr
 SET
     repo_size_bytes = tmp.repo_size_bytes,
-	updated_at = now()
+	updated_at = NOW()
 FROM (VALUES
 -- (<repo_id>, <repo_size_bytes>),
     %s

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -653,7 +653,8 @@ const updateRepoSizesQueryFmtstr = `
 -- source: internal/database/gitserver_repos.go:gitserverRepoStore.UpdateRepoSizes
 UPDATE gitserver_repos AS gr
 SET
-    repo_size_bytes = tmp.repo_size_bytes
+    repo_size_bytes = tmp.repo_size_bytes,
+	updated_at = now()
 FROM (VALUES
 -- (<repo_id>, <repo_size_bytes>),
     %s


### PR DESCRIPTION
I missed this in my last PR. We probably want to update the `updated_at`
column when we update the size.

## Test plan

- Existing and new unit tests