### PR TITLE
admin-analytics: add tooltips and descriptions to events

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
@@ -74,11 +74,14 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
                 value: changesetsCreated.summary.totalCount,
                 description: 'Changesets created',
                 color: 'var(--orange)',
+                tooltip:
+                    'The number of changesets created on a code host during the timeframe. This does not include changesets that are unpublished.',
             },
             {
                 value: changesetsMerged.summary.totalCount,
                 description: 'Changesets merged',
                 color: 'var(--cyan)',
+                tooltip: 'The number of changesets merged on the code host during the timeframe.',
             },
         ]
 

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -106,6 +106,8 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                 description: 'Cross repo events',
                 position: 'right',
                 color: 'var(--body-color)',
+                tooltip:
+                    'Cross repository code intel identifies symbols in code throughout your Sourcegraph instance, in a single click, without locating and downloading a repository.',
             },
         ]
 

--- a/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
@@ -79,13 +79,19 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
                 value: creations.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: eventAggregation === 'count' ? 'Notebooks created' : 'Users created notebooks',
                 color: 'var(--cyan)',
-                tooltip: 'The number of notebooks created in the timeframe.',
+                tooltip:
+                    eventAggregation === 'count'
+                        ? 'The number of notebooks created in the timeframe.'
+                        : 'The number of users who created notebooks in the timeframe.',
             },
             {
                 value: views.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: eventAggregation === 'count' ? 'Notebook views' : 'Users viewed notebooks',
                 color: 'var(--orange)',
-                tooltip: 'The number of views of all notebooks in the timeframe.',
+                tooltip:
+                    eventAggregation === 'count'
+                        ? 'The number of views of all notebooks in the timeframe.'
+                        : 'The number of users who viewed notebooks in the timeframe.',
             },
             {
                 value: blockRuns.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
@@ -93,7 +99,9 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
                 color: 'var(--body-color)',
                 position: 'right',
                 tooltip:
-                    'The number of of blocks within each notebook that are run. Some blocks such as the search results block must be run for the user to see code.',
+                    eventAggregation === 'count'
+                        ? 'The number of of blocks within each notebook that are run. Some blocks such as the search results block must be run for the user to see code.'
+                        : 'The number of users who ran blocks within each notebook in the timeframe.',
             },
         ]
 

--- a/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
@@ -79,17 +79,21 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
                 value: creations.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: eventAggregation === 'count' ? 'Notebooks created' : 'Users created notebooks',
                 color: 'var(--cyan)',
+                tooltip: 'The number of notebooks created in the timeframe.',
             },
             {
                 value: views.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: eventAggregation === 'count' ? 'Notebook views' : 'Users viewed notebooks',
                 color: 'var(--orange)',
+                tooltip: 'The number of views of all notebooks in the timeframe.',
             },
             {
                 value: blockRuns.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: eventAggregation === 'count' ? 'Block runs' : 'Users ran blocks',
                 color: 'var(--body-color)',
                 position: 'right',
+                tooltip:
+                    'The number of of blocks within each notebook that are run. Some blocks such as the search results block must be run for the user to see code.',
             },
         ]
 

--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
@@ -87,22 +87,27 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
                 value: searches.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: eventAggregation === 'count' ? 'Searches' : 'Users searched',
                 color: 'var(--cyan)',
+                tooltip: 'Any search conducted via the UI, API, or browser or IDE extensions.',
             },
             {
                 value: resultClicks.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: eventAggregation === 'count' ? 'Result clicks' : 'Users clicked results',
                 color: 'var(--purple)',
+                tooltip:
+                    'This event is triggered when a user clicks a result, which may be a file, repository, diff, or commit. Note that at times, a user is able to find the answer to their query directly in search results, therefore fewer interactions may actually speak to higher relevancy and usefulness of search results.',
             },
             {
                 value: fileViews.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: eventAggregation === 'count' ? 'File views' : 'Users viewed files',
                 color: 'var(--orange)',
+                tooltip: 'File views can be generated from a search result, or be linked to directly.',
             },
             {
                 value: fileOpens.summary[eventAggregation === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: eventAggregation === 'count' ? 'File opens' : 'Users opened files',
                 color: 'var(--body-color)',
                 position: 'right',
+                tooltip: 'File views can be generated from a search result, or be linked to directly.',
             },
         ]
         return [stats, legends]

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -42,18 +42,21 @@ export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>
                 value: users.activity.summary.totalUniqueUsers,
                 description: 'Active users',
                 color: 'var(--purple)',
+                tooltip: 'Users using the application in the selected timeframe.',
             },
             {
                 value: data.users.totalCount,
                 description: 'Registered Users',
                 color: 'var(--body-color)',
                 position: 'right',
+                tooltip: 'The number of users who have created an account.',
             },
             {
                 value: data.site.productSubscription.license?.userCount ?? 0,
                 description: 'User licenses',
                 color: 'var(--body-color)',
                 position: 'right',
+                tooltip: 'The number of user licenses your current account is provisioned for.',
             },
         ]
 

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { Text } from '@sourcegraph/wildcard'
+import { Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { formatNumber } from '../utils'
 
@@ -13,16 +13,20 @@ interface ValueLegendItemProps {
     color: string
     description: string
     value: number
+    tooltip?: string
 }
 
-const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({ value, color, description }) => (
+const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({ value, color, description, tooltip }) => (
     <div className="d-flex flex-column align-items-center mr-4 justify-content-center">
         <span style={{ color }} className={styles.count}>
             {formatNumber(value)}
         </span>
-        <Text as="span" alignment="center" className={styles.textWrap}>
-            {description}
-        </Text>
+        <Tooltip content={tooltip}>
+            <Text as="span" alignment="center" className={classNames(styles.textWrap, tooltip && 'cursor-pointer')}>
+                {description}
+                {tooltip && <span className={styles.linkColor}>*</span>}
+            </Text>
+        </Tooltip>
     </div>
 )
 

--- a/client/web/src/site-admin/analytics/components/index.module.scss
+++ b/client/web/src/site-admin/analytics/components/index.module.scss
@@ -39,3 +39,7 @@
 .count-box-value {
     padding: 0.6rem;
 }
+
+.link-color {
+    color: var(--link-color);
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39311.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/6717049/182160265-d293ed1f-2301-4d15-8752-76b9ae0488d9.gif)

## Test plan
- `sg start`
- Open http://localhost:3080/site-admin/analytics/search and check event have (right) tooltips.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->



## App preview:

- [Web](https://sg-web-erzhtor-add-tooltips-to-admin.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qpyodelxze.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
