### PR TITLE
e2e tests: disable flaky jump-to-definition test

### DIFF
--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -530,6 +530,7 @@ describe('Repository component', () => {
                 })
 
                 test.skip('does navigation (same repo, same file)', async () => {
+                    // See https://github.com/sourcegraph/sourcegraph/pull/39747
                     await driver.page.goto(
                         sourcegraphBaseUrl +
                             '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L25:10'

--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -529,7 +529,7 @@ describe('Repository component', () => {
                     )
                 })
 
-                test('does navigation (same repo, same file)', async () => {
+                test.skip('does navigation (same repo, same file)', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
                             '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L25:10'


### PR DESCRIPTION
I ran into this multiple times over the past few weeks.

Example failure: https://buildkite.com/sourcegraph/sourcegraph/builds/164530#01825985-d71b-4e4c-9bf7-bcb87ec6c596

Important part of error message:

    Expected: "http://localhost:7080/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6"
    Received: "http://localhost:7080/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L25:30#tab=def"

Line/col are different and the `tab=def` too. The "Received" contains
the current line/col but the expectation is that it's already navigated
away.

Maybe there needs to be a timeout to ensure that the client-side code in
`WebHoverOverlay` that turns the token into a link has been called?



## Test plan

- N/A

## App preview:

- [Web](https://sg-web-mrn-disable-flaky-e2e.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zuezqqjcwy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
