### PR TITLE
Search backend: make `repohascommitafter` disable global search

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -756,6 +756,8 @@ func jobMode(b query.Basic, resultTypes result.Types, st query.SearchType, onSou
 				return n.Negated
 			case query.FieldRepoHasFile:
 				return false
+			case query.FieldRepoHasCommitAfter:
+				return false
 			default:
 				return true
 			}


### PR DESCRIPTION
Followup from https://sourcegraph.slack.com/archives/CHEKCRWKV/p1659366263303689?thread_ts=1659350560.077529&cid=CHEKCRWKV

## Test plan

Manual test. I'm actively in the process of factoring this out, so I'll add more tests then. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
