### PR TITLE
dev/sg: account for overrides in gomod guard

### DIFF
--- a/dev/sg/linters/gomod_test.go
+++ b/dev/sg/linters/gomod_test.go
@@ -1,0 +1,44 @@
+package linters
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+)
+
+func TestGoModGuards(t *testing.T) {
+	lint := goModGuards()
+	discard := std.NewFixedOutput(io.Discard, false)
+
+	t.Run("unacceptable version", func(t *testing.T) {
+		err := lint.Check(context.Background(), discard, repo.NewMockState(repo.Diff{
+			"go.mod": []repo.DiffHunk{
+				{
+					AddedLines: []string{
+						`	github.com/prometheus/common v0.37.0`,
+					},
+				},
+			},
+		}))
+		assert.NotNil(t, err)
+	})
+
+	t.Run("unacceptable version gets override", func(t *testing.T) {
+		err := lint.Check(context.Background(), discard, repo.NewMockState(repo.Diff{
+			"go.mod": []repo.DiffHunk{
+				{
+					AddedLines: []string{
+						`	github.com/prometheus/common v0.37.0`,
+						`	github.com/prometheus/common => github.com/prometheus/common v0.32.1`,
+					},
+				},
+			},
+		}))
+		assert.Nil(t, err)
+	})
+}


### PR DESCRIPTION
Lets the version guard linter account for overrides.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Unit tests, tested in https://github.com/sourcegraph/sourcegraph/pull/39453