### PR TITLE
codeintel: Ensure queue size count and queue size candidates match

### DIFF
--- a/internal/codeintel/stores/dbstore/commits.go
+++ b/internal/codeintel/stores/dbstore/commits.go
@@ -179,6 +179,7 @@ SELECT EXTRACT(EPOCH FROM NOW() - ldr.set_dirty_at)::integer AS age
     INNER JOIN repo ON repo.id = ldr.repository_id
   WHERE ldr.dirty_token > ldr.update_token
     AND repo.deleted_at IS NULL
+    AND repo.blocked IS NULL
   ORDER BY age DESC
   LIMIT 1
 `

--- a/internal/codeintel/uploads/internal/store/store_repositories.go
+++ b/internal/codeintel/uploads/internal/store/store_repositories.go
@@ -134,6 +134,7 @@ SELECT EXTRACT(EPOCH FROM NOW() - ldr.set_dirty_at)::integer AS age
     INNER JOIN repo ON repo.id = ldr.repository_id
   WHERE ldr.dirty_token > ldr.update_token
     AND repo.deleted_at IS NULL
+	AND repo.blocked IS NULL
   ORDER BY age DESC
   LIMIT 1
 `

--- a/internal/codeintel/uploads/internal/store/store_repositories.go
+++ b/internal/codeintel/uploads/internal/store/store_repositories.go
@@ -134,7 +134,7 @@ SELECT EXTRACT(EPOCH FROM NOW() - ldr.set_dirty_at)::integer AS age
     INNER JOIN repo ON repo.id = ldr.repository_id
   WHERE ldr.dirty_token > ldr.update_token
     AND repo.deleted_at IS NULL
-	AND repo.blocked IS NULL
+    AND repo.blocked IS NULL
   ORDER BY age DESC
   LIMIT 1
 `


### PR DESCRIPTION
This should prune additional candidates from the alert count that aren't being selected by the background task.

## Test plan

Existing unit tests.