### PR TITLE
Fixup old lsif_indexes records that are in invalid errored state

### DIFF
--- a/migrations/frontend/1659368926_cleanup_lsif_indexes_errored/down.sql
+++ b/migrations/frontend/1659368926_cleanup_lsif_indexes_errored/down.sql
@@ -1,0 +1,1 @@
+-- Nothing to do here, to older instances both versions of this data are valid state.

--- a/migrations/frontend/1659368926_cleanup_lsif_indexes_errored/metadata.yaml
+++ b/migrations/frontend/1659368926_cleanup_lsif_indexes_errored/metadata.yaml
@@ -1,0 +1,2 @@
+name: cleanup_lsif_indexes_errored
+parents: [1658950366]

--- a/migrations/frontend/1659368926_cleanup_lsif_indexes_errored/up.sql
+++ b/migrations/frontend/1659368926_cleanup_lsif_indexes_errored/up.sql
@@ -1,0 +1,1 @@
+UPDATE lsif_indexes SET state = 'failed' WHERE state = 'errored' AND num_retries > 0;

--- a/migrations/frontend/1659368926_cleanup_lsif_indexes_errored/up.sql
+++ b/migrations/frontend/1659368926_cleanup_lsif_indexes_errored/up.sql
@@ -1,1 +1,1 @@
-UPDATE lsif_indexes SET state = 'failed' WHERE state = 'errored' AND num_retries > 0;
+UPDATE lsif_indexes SET state = 'failed' WHERE state = 'errored' AND num_failures > 0;


### PR DESCRIPTION
At some point we introduced the failed state and never migrated those, leading to incorrect stats because some records are still considered "retrying".



## Test plan

Shouldn't break anything, DB backcompat tests should prove that.