### PR TITLE
trace: allow configurable trace URL template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added experimental support for exporting traces to an OpenTelemetry collector with `"observability.tracing": { "type": "opentelemetry" }` [#37984](https://github.com/sourcegraph/sourcegraph/pull/37984)
 - Code Insights over some repos now get 12 historic data points in addition to a current daily value and future points that align with the defined interval. [#37756](https://github.com/sourcegraph/sourcegraph/pull/37756)
 - Added `ROCKSKIP_MIN_REPO_SIZE_MB` to automatically use [Rockskip](https://docs.sourcegraph.com/code_intelligence/explanations/rockskip) for repositories over a certain size. [#38192](https://github.com/sourcegraph/sourcegraph/pull/38192)
+- `"observability.tracing": { "urlTemplate": "..." }` can now be set to configure generated trace URLs (for example those generated via `&trace=1`). [#39765](https://github.com/sourcegraph/sourcegraph/pull/39765)
 
 ### Changed
 

--- a/cmd/frontend/internal/app/errorutil/handlers.go
+++ b/cmd/frontend/internal/app/errorutil/handlers.go
@@ -28,7 +28,7 @@ func Handler(h func(http.ResponseWriter, *http.Request) error) http.Handler {
 					ext.Error.Set(span, true)
 					span.SetTag("err", err)
 					traceID = trace.ID(req.Context())
-					traceURL = trace.URL(traceID, conf.ExternalURL(), conf.Tracer())
+					traceURL = trace.URL(traceID, conf.DefaultClient())
 				}
 				log15.Error(
 					"App HTTP handler error response",

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -474,7 +474,7 @@ func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, db database.DB, e
 		ext.Error.Set(span, true)
 		span.SetTag("err", err)
 		span.SetTag("error-id", errorID)
-		traceURL = trace.URL(trace.ID(r.Context()), conf.ExternalURL(), conf.Tracer())
+		traceURL = trace.URL(trace.ID(r.Context()), conf.DefaultClient())
 	}
 	log15.Error("ui HTTP handler error response", "method", r.Method, "request_uri", r.URL.RequestURI(), "status_code", statusCode, "error", err, "error_id", errorID, "trace", traceURL)
 

--- a/cmd/frontend/internal/handlerutil/error_reporting.go
+++ b/cmd/frontend/internal/handlerutil/error_reporting.go
@@ -78,7 +78,7 @@ func reportError(r *http.Request, status int, err error, panicked bool) {
 
 	// Add appdash span ID.
 	if traceID := trace.ID(r.Context()); traceID != "" {
-		pkt.Extra["trace"] = trace.URL(traceID, conf.ExternalURL(), conf.Tracer())
+		pkt.Extra["trace"] = trace.URL(traceID, conf.DefaultClient())
 		pkt.Extra["traceID"] = traceID
 	}
 

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -223,7 +223,7 @@ func (h *errorHandler) Handle(w http.ResponseWriter, r *http.Request, status int
 	}
 	http.Error(w, displayErrBody, status)
 	traceID := trace.ID(r.Context())
-	traceURL := trace.URL(traceID, conf.ExternalURL(), conf.Tracer())
+	traceURL := trace.URL(traceID, conf.DefaultClient())
 
 	if status < 200 || status >= 500 {
 		log15.Error("API HTTP handler error response", "method", r.Method, "request_uri", r.URL.RequestURI(), "status_code", status, "error", err, "trace", traceURL, "traceID", traceID)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -126,7 +126,7 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 	progress := &streamclient.ProgressAggregator{
 		Start:        start,
 		Limit:        limit,
-		Trace:        trace.URL(trace.ID(ctx), conf.ExternalURL(), conf.Tracer()),
+		Trace:        trace.URL(trace.ID(ctx), conf.DefaultClient()),
 		DisplayLimit: displayLimit,
 		RepoNamer:    streamclient.RepoNamer(ctx, h.db),
 	}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1146,7 +1146,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		}
 		if traceID := trace.ID(ctx); traceID != "" {
 			ev.AddField("traceID", traceID)
-			ev.AddField("trace", trace.URL(traceID, conf.ExternalURL(), conf.Tracer()))
+			ev.AddField("trace", trace.URL(traceID, conf.DefaultClient()))
 		}
 		if honey.Enabled() {
 			_ = ev.Send()
@@ -1577,7 +1577,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 				if traceID := trace.ID(ctx); traceID != "" {
 					ev.AddField("traceID", traceID)
-					ev.AddField("trace", trace.URL(traceID, conf.ExternalURL(), conf.Tracer()))
+					ev.AddField("trace", trace.URL(traceID, conf.DefaultClient()))
 				}
 
 				if honey.Enabled() {
@@ -1822,7 +1822,7 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 
 				if traceID := trace.ID(ctx); traceID != "" {
 					ev.AddField("traceID", traceID)
-					ev.AddField("trace", trace.URL(traceID, conf.ExternalURL(), conf.Tracer()))
+					ev.AddField("trace", trace.URL(traceID, conf.DefaultClient()))
 				}
 
 				_ = ev.Send()

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -66,7 +66,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	progress := &streamclient.ProgressAggregator{
 		Start:     start,
 		RepoNamer: streamclient.RepoNamer(ctx, h.db),
-		Trace:     trace.URL(trace.ID(ctx), conf.ExternalURL(), conf.Tracer()),
+		Trace:     trace.URL(trace.ID(ctx), conf.DefaultClient()),
 	}
 
 	sendProgress := func() {

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -161,14 +161,7 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 		trace := Context(ctx)
 		var traceURL string
 		if trace != nil && trace.TraceID != "" {
-			var traceType string
-			if ob := siteConfig.SiteConfig().ObservabilityTracing; ob == nil {
-				traceType = ""
-			} else {
-				traceType = ob.Type
-			}
-
-			traceURL = URL(trace.TraceID, siteConfig.SiteConfig().ExternalURL, traceType)
+			traceURL = URL(trace.TraceID, siteConfig)
 			rw.Header().Set("X-Trace", traceURL)
 			logger = logger.WithTrace(*trace)
 		}

--- a/internal/trace/url.go
+++ b/internal/trace/url.go
@@ -5,14 +5,39 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"text/template"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
 // URL returns a trace URL for the given trace ID at the given external URL.
-func URL(traceID, externalURL, traceProvider string) string {
+func URL(traceID string, querier conftypes.SiteConfigQuerier) string {
 	if traceID == "" {
 		return ""
 	}
+	c := querier.SiteConfig()
+	tracing := c.ObservabilityTracing
+	if tracing == nil || tracing.UrlTemplate == "" {
+		return legacyTraceURL(traceID, c.ExternalURL)
+	}
 
+	tpl, err := template.New("traceURL").Parse(tracing.UrlTemplate)
+	if err != nil {
+		// We contribute a validator on tracer package init, so safe to no-op here
+		return ""
+	}
+
+	var sb strings.Builder
+	_ = tpl.Execute(&sb, map[string]string{
+		"TraceID":     traceID,
+		"ExternalURL": c.ExternalURL,
+	})
+	return sb.String()
+}
+
+// legacyTraceURL preserves the old trace URL generation behaviour if no template is
+// provided.
+func legacyTraceURL(traceID, externalURL string) string {
 	if os.Getenv("ENABLE_GRAFANA_CLOUD_TRACE_URL") != "true" {
 		// We proxy jaeger so we can construct URLs to traces.
 		return strings.TrimSuffix(externalURL, "/") + "/-/debug/jaeger/trace/" + traceID

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1296,6 +1296,8 @@ type ObservabilityTracing struct {
 	Sampling string `json:"sampling,omitempty"`
 	// Type description: Determines what tracing provider to enable. For "opentracing", the required backend is a Jaeger instance. For "opentelemetry" (EXPERIMENTAL), the required backend is a OpenTelemetry collector instance. "datadog" support has been removed, and the configuration option will be removed in a future release.
 	Type string `json:"type,omitempty"`
+	// UrlTemplate description: Template for linking to trace URLs - '{{ .TraceID }}' is replaced with the trace ID, and {{ .ExternalURL }} is replaced with the value of 'externalURL'.
+	UrlTemplate string `json:"urlTemplate,omitempty"`
 }
 
 // OnQuery description: A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the batch change will be run on.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1222,9 +1222,7 @@
           "description": "Template for linking to trace URLs - '{{ .TraceID }}' is replaced with the trace ID, and {{ .ExternalURL }} is replaced with the value of 'externalURL'.",
           "type": "string",
           "default": "{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}",
-          "examples": [
-            "https://ui.honeycomb.io/$ORG/environments/$DATASET/trace?trace_id={{ .TraceID }}"
-          ]
+          "examples": ["https://ui.honeycomb.io/$ORG/environments/$DATASET/trace?trace_id={{ .TraceID }}"]
         }
       }
     },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1217,6 +1217,14 @@
           "description": "Turns on debug logging of tracing client requests. This can be useful for debugging connectivity issues between the tracing client and tracing backend, the performance overhead of tracing, and other issues related to the use of distributed tracing. May have performance implications in production.",
           "type": "boolean",
           "default": false
+        },
+        "urlTemplate": {
+          "description": "Template for linking to trace URLs - '{{ .TraceID }}' is replaced with the trace ID, and {{ .ExternalURL }} is replaced with the value of 'externalURL'.",
+          "type": "string",
+          "default": "{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}",
+          "examples": [
+            "https://ui.honeycomb.io/$ORG/environments/$DATASET/trace?trace_id={{ .TraceID }}"
+          ]
         }
       }
     },


### PR DESCRIPTION
Adds `"observability.tracing": { "urlTemplate": "..." }` for configuring where generated trace links point to. Preserves back-compat with existing behaviour if configured. Part of DevX work to migrate to OpenTelemetry with more flexible backend options.

## Test plan

Invalid config:

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="634" alt="image" src="https://user-images.githubusercontent.com/23356519/182197824-f44dbd83-2c10-4edb-b7b7-1a5a7fafa847.png">

Pointing to honeycomb:

![image](https://user-images.githubusercontent.com/23356519/182197812-d29be37f-cb54-4d85-a523-3756c6359fea.png)

<img width="1468" alt="image" src="https://user-images.githubusercontent.com/23356519/182197785-44e7000c-ed15-4187-860c-e8ee9ed104e9.png">
