### PR TITLE
httpcli: introduce mutable, wrapped transports

### DIFF
--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -612,7 +612,7 @@ func getTransportForMutation(cli *http.Client) (*http.Transport, error) {
 		*wrapped = tr
 
 	default:
-		return nil, errors.Errorf("http.Client.Transport cannot be cast as an *http.Transport: %T", cli.Transport)
+		return nil, errors.Errorf("http.Client.Transport cannot be cast as a *http.Transport: %T", cli.Transport)
 	}
 
 	return tr, nil

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -602,7 +602,7 @@ func getTransportForMutation(cli *http.Client) (*http.Transport, error) {
 		tr = v.Clone()
 		cli.Transport = tr
 
-	case UnwrappableTransport:
+	case WrappedTransport:
 		wrapped := unwrapAll(v)
 		t, ok := (*wrapped).(*http.Transport)
 		if !ok {

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -180,7 +180,7 @@ func TestNewCertPool(t *testing.T) {
 			name:  "fails if transport isn't an http.Transport",
 			cli:   &http.Client{Transport: bogusTransport{}},
 			certs: []string{cert},
-			err:   "httpcli.NewCertPoolOpt: http.Client.Transport is not an *http.Transport: httpcli.bogusTransport",
+			err:   "httpcli.NewCertPoolOpt: http.Client.Transport cannot be cast as a *http.Transport: httpcli.bogusTransport",
 		},
 		{
 			name:  "pool is set to what is given",
@@ -242,7 +242,7 @@ func TestNewIdleConnTimeoutOpt(t *testing.T) {
 		{
 			name: "fails if transport isn't an http.Transport",
 			cli:  &http.Client{Transport: bogusTransport{}},
-			err:  "httpcli.NewIdleConnTimeoutOpt: http.Client.Transport cannot be cast as an *http.Transport: httpcli.bogusTransport",
+			err:  "httpcli.NewIdleConnTimeoutOpt: http.Client.Transport cannot be cast as a *http.Transport: httpcli.bogusTransport",
 		},
 		{
 			name:    "IdleConnTimeout is set to what is given",

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/PuerkitoBio/rehttp"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -216,6 +218,11 @@ func TestNewCertPool(t *testing.T) {
 
 func TestNewIdleConnTimeoutOpt(t *testing.T) {
 	timeout := 33 * time.Second
+
+	// originalRoundtripper must only be used in one test, set at this scope for
+	// convenience.
+	originalRoundtripper := &http.Transport{}
+
 	for _, tc := range []struct {
 		name    string
 		cli     *http.Client
@@ -235,7 +242,7 @@ func TestNewIdleConnTimeoutOpt(t *testing.T) {
 		{
 			name: "fails if transport isn't an http.Transport",
 			cli:  &http.Client{Transport: bogusTransport{}},
-			err:  "httpcli.NewIdleConnTimeoutOpt: http.Client.Transport is not an *http.Transport: httpcli.bogusTransport",
+			err:  "httpcli.NewIdleConnTimeoutOpt: http.Client.Transport cannot be cast as an *http.Transport: httpcli.bogusTransport",
 		},
 		{
 			name:    "IdleConnTimeout is set to what is given",
@@ -246,6 +253,28 @@ func TestNewIdleConnTimeoutOpt(t *testing.T) {
 				if want := timeout; !reflect.DeepEqual(have, want) {
 					t.Fatal(cmp.Diff(have, want))
 				}
+			},
+		},
+		{
+			name: "IdleConnTimeout is set to what is given on a wrapped transport",
+			cli: func() *http.Client {
+				return &http.Client{Transport: &wrappedTransport{
+					RoundTripper: &actor.HTTPTransport{RoundTripper: originalRoundtripper},
+					Wrapped:      originalRoundtripper,
+				}}
+			}(),
+			timeout: timeout,
+			assert: func(t testing.TB, cli *http.Client) {
+				unwrapped := unwrapAll(cli.Transport.(UnwrappableTransport))
+				have := (*unwrapped).(*http.Transport).IdleConnTimeout
+
+				// Timeout is set on the underlying transport
+				if want := timeout; !reflect.DeepEqual(have, want) {
+					t.Fatal(cmp.Diff(have, want))
+				}
+
+				// Original roundtripper unchanged!
+				assert.Equal(t, time.Duration(0), originalRoundtripper.IdleConnTimeout)
 			},
 		},
 	} {

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -265,7 +265,7 @@ func TestNewIdleConnTimeoutOpt(t *testing.T) {
 			}(),
 			timeout: timeout,
 			assert: func(t testing.TB, cli *http.Client) {
-				unwrapped := unwrapAll(cli.Transport.(UnwrappableTransport))
+				unwrapped := unwrapAll(cli.Transport.(WrappedTransport))
 				have := (*unwrapped).(*http.Transport).IdleConnTimeout
 
 				// Timeout is set on the underlying transport

--- a/internal/httpcli/transport.go
+++ b/internal/httpcli/transport.go
@@ -1,0 +1,33 @@
+package httpcli
+
+import "net/http"
+
+// wrappedTransport is an http.RoundTripper that allows the underlying RoundTripper to be
+// exposed for modification.
+type wrappedTransport struct {
+	http.RoundTripper
+	Wrapped http.RoundTripper
+}
+
+var _ UnwrappableTransport = &wrappedTransport{}
+
+func (wt *wrappedTransport) Unwrap() *http.RoundTripper { return &wt.Wrapped }
+
+// UnwrappableTransport can be implemented to allow a wrapped transport to expose its
+// underlying transport for modification.
+type UnwrappableTransport interface {
+	http.RoundTripper
+
+	Unwrap() *http.RoundTripper
+}
+
+// unwrapAll performs a recursive unwrap on transport until we reach a transport that
+// cannot be unwrapped. The pointer to the pointer can be used to replace the underlying
+// transport.
+func unwrapAll(transport UnwrappableTransport) *http.RoundTripper {
+	wrapped := transport.Unwrap()
+	if unwrappable, ok := (*wrapped).(UnwrappableTransport); ok {
+		return unwrapAll(unwrappable)
+	}
+	return wrapped
+}

--- a/internal/repos/awscodecommit.go
+++ b/internal/repos/awscodecommit.go
@@ -206,6 +206,8 @@ type stubBadHTTPRedirectTransport struct {
 	tr http.RoundTripper
 }
 
+var _ httpcli.UnwrappableTransport = &stubBadHTTPRedirectTransport{}
+
 const stubBadHTTPRedirectLocation = `https://amazonaws.com/badhttpredirectlocation`
 
 func (t stubBadHTTPRedirectTransport) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -226,8 +228,4 @@ func (t stubBadHTTPRedirectTransport) RoundTrip(r *http.Request) (*http.Response
 	return resp, err
 }
 
-// UnwrappableTransport signals that this transport can't be wrapped. In
-// particular this means we won't respect global external
-// settings. https://github.com/sourcegraph/sourcegraph/issues/71 and
-// https://github.com/sourcegraph/sourcegraph/issues/7738
-func (stubBadHTTPRedirectTransport) UnwrappableTransport() {}
+func (t stubBadHTTPRedirectTransport) Unwrap() *http.RoundTripper { return &t.tr }

--- a/internal/repos/awscodecommit.go
+++ b/internal/repos/awscodecommit.go
@@ -206,7 +206,7 @@ type stubBadHTTPRedirectTransport struct {
 	tr http.RoundTripper
 }
 
-var _ httpcli.UnwrappableTransport = &stubBadHTTPRedirectTransport{}
+var _ httpcli.WrappedTransport = &stubBadHTTPRedirectTransport{}
 
 const stubBadHTTPRedirectLocation = `https://amazonaws.com/badhttpredirectlocation`
 

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -37,10 +37,7 @@ func NewGitoliteSource(svc *types.ExternalService, cf *httpcli.Factory) (*Gitoli
 
 	gitoliteDoer, err := cf.Doer(
 		httpcli.NewMaxIdleConnsPerHostOpt(500),
-		// The provided httpcli.Factory is one used for external services - however,
-		// GitoliteSource asks gitserver to communicate to gitolite instead, so we
-		// have to ensure that the actor transport used for internal clients is provided.
-		httpcli.ActorTransportOpt)
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -37,6 +37,10 @@ func NewGitoliteSource(svc *types.ExternalService, cf *httpcli.Factory) (*Gitoli
 
 	gitoliteDoer, err := cf.Doer(
 		httpcli.NewMaxIdleConnsPerHostOpt(500),
+		// The provided httpcli.Factory is one used for external services - however,
+		// GitoliteSource asks gitserver to communicate to gitolite instead, so we
+		// have to ensure that the actor transport used for internal clients is provided.
+		httpcli.ActorTransportOpt,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/repos/gitolite_test.go
+++ b/internal/repos/gitolite_test.go
@@ -10,30 +10,16 @@ import (
 )
 
 func TestGitoliteSource(t *testing.T) {
-	testCases := []struct {
-		name string
-	}{
-		{
-			name: "basic",
-		},
+	cf, save := newClientFactoryWithOpt(t, "basic", httpcli.ExternalTransportOpt)
+	defer save(t)
+
+	svc := &types.ExternalService{
+		Kind:   extsvc.KindGitolite,
+		Config: marshalJSON(t, &schema.GitoliteConnection{}),
 	}
 
-	for _, tc := range testCases {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			cf, save := newClientFactoryWithOpt(t, tc.name, httpcli.ExternalTransportOpt)
-			defer save(t)
-
-			svc := &types.ExternalService{
-				Kind:   extsvc.KindGitolite,
-				Config: marshalJSON(t, &schema.GitoliteConnection{}),
-			}
-
-			_, err := NewGitoliteSource(svc, cf)
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
+	_, err := NewGitoliteSource(svc, cf)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/repos/gitolite_test.go
+++ b/internal/repos/gitolite_test.go
@@ -1,0 +1,39 @@
+package repos
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestGitoliteSource(t *testing.T) {
+	testCases := []struct {
+		name string
+	}{
+		{
+			name: "basic",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			cf, save := newClientFactoryWithOpt(t, tc.name, httpcli.ExternalTransportOpt)
+			defer save(t)
+
+			svc := &types.ExternalService{
+				Kind:   extsvc.KindGitolite,
+				Config: marshalJSON(t, &schema.GitoliteConnection{}),
+			}
+
+			_, err := NewGitoliteSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Re-implements https://github.com/sourcegraph/sourcegraph/pull/39702 with an approach that makes our wrapped transports fully unwrappable, such that a pointer to the implementation can be retrieved _and replaced_, namely with a clone of the underlying `*http.Transport`. I think this fixes the issue described in https://github.com/sourcegraph/sourcegraph/pull/39702, and removes what seems to be an old workaround around some options not supporting wrapped transports.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Unit tests in `httpcli` to test the wrapping behaviour, and @mollylogue 's test of gitolite now passes.