### PR TITLE
oobmigrations: Consolidate out of band migration runners into a single package

### DIFF
--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -15,8 +15,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/migrations"
-	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/migrations/migrators"
+	workermigrations "github.com/sourcegraph/sourcegraph/cmd/worker/internal/migrations"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/webhooks"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -28,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration/migrations"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -38,11 +38,11 @@ const addr = ":3189"
 
 // Start runs the worker.
 func Start(logger log.Logger, additionalJobs map[string]job.Job, registerEnterpriseMigrations func(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) error) error {
-	registerMigrations := composeRegisterMigrations(migrators.RegisterOSSMigrations, registerEnterpriseMigrations)
+	registerMigrations := composeRegisterMigrations(migrations.RegisterOSSMigrations, registerEnterpriseMigrations)
 
 	builtins := map[string]job.Job{
 		"webhook-log-janitor":                   webhooks.NewJanitor(),
-		"out-of-band-migrations":                migrations.NewMigrator(registerMigrations),
+		"out-of-band-migrations":                workermigrations.NewMigrator(registerMigrations),
 		"codeintel-documents-indexer":           codeintel.NewDocumentsIndexerJob(),
 		"codeintel-policies-repository-matcher": codeintel.NewPoliciesRepositoryMatcherJob(),
 		"gitserver-metrics":                     gitserver.NewMetricsJob(),

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/telemetry"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/productsubscription"
 
 	"github.com/sourcegraph/log"
 
@@ -14,16 +13,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/batches"
-	batchesmigrations "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/batches/migrations"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel"
 	freshcodeintel "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel/fresh"
-	codeintelmigrations "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel/migrations"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/executors"
 	workerinsights "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/insights"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/permissions"
 	eiauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/oobmigration/migrations"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -69,7 +66,7 @@ func main() {
 		"codeintel-auto-indexing": codeintel.NewIndexingJob(),
 	}
 
-	if err := shared.Start(logger, additionalJobs, registerEnterpriseMigrations); err != nil {
+	if err := shared.Start(logger, additionalJobs, migrations.RegisterEnterpriseMigrations); err != nil {
 		logger.Fatal(err.Error())
 	}
 }
@@ -99,24 +96,4 @@ func setAuthzProviders(logger log.Logger) {
 		allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.ExternalServices(), db)
 		authz.SetProviders(allowAccessByDefault, authzProviders)
 	}
-}
-
-func registerEnterpriseMigrations(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) error {
-	if err := batchesmigrations.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
-		return err
-	}
-
-	if err := codeintelmigrations.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
-		return err
-	}
-
-	if err := insights.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
-		return err
-	}
-
-	if err := productsubscription.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/enterprise/internal/oobmigration/migrations/batches/migrations.go
+++ b/enterprise/internal/oobmigration/migrations/batches/migrations.go
@@ -1,4 +1,4 @@
-package migrations
+package batches
 
 import (
 	"os"

--- a/enterprise/internal/oobmigration/migrations/batches/site_credential_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/site_credential_migrator.go
@@ -1,4 +1,4 @@
-package migrations
+package batches
 
 import (
 	"context"

--- a/enterprise/internal/oobmigration/migrations/batches/site_credential_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/site_credential_migrator_test.go
@@ -1,4 +1,4 @@
-package migrations
+package batches
 
 import (
 	"context"

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -1,4 +1,4 @@
-package migrations
+package batches
 
 import (
 	"context"

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
@@ -1,4 +1,4 @@
-package migrations
+package batches
 
 import (
 	"context"

--- a/enterprise/internal/oobmigration/migrations/batches/user_credential_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/user_credential_migrator.go
@@ -1,4 +1,4 @@
-package migrations
+package batches
 
 import (
 	"context"

--- a/enterprise/internal/oobmigration/migrations/batches/user_credential_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/user_credential_migrator_test.go
@@ -1,4 +1,4 @@
-package migrations
+package batches
 
 import (
 	"context"

--- a/enterprise/internal/oobmigration/migrations/codeintel/config.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/config.go
@@ -1,4 +1,4 @@
-package migrations
+package codeintel
 
 import (
 	"time"

--- a/enterprise/internal/oobmigration/migrations/codeintel/register.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/register.go
@@ -1,4 +1,4 @@
-package migrations
+package codeintel
 
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/codeintel"

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
+	batchesmigrations "github.com/sourcegraph/sourcegraph/enterprise/internal/oobmigration/migrations/batches"
+	codeintelmigrations "github.com/sourcegraph/sourcegraph/enterprise/internal/oobmigration/migrations/codeintel"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/productsubscription"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+)
+
+func RegisterEnterpriseMigrations(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) error {
+	if err := batchesmigrations.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
+		return err
+	}
+
+	if err := codeintelmigrations.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
+		return err
+	}
+
+	if err := insights.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
+		return err
+	}
+
+	if err := productsubscription.RegisterMigrations(db, outOfBandMigrationRunner); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/oobmigration/migrations/external_accounts_migrator.go
+++ b/internal/oobmigration/migrations/external_accounts_migrator.go
@@ -1,4 +1,4 @@
-package migrators
+package migrations
 
 import (
 	"context"

--- a/internal/oobmigration/migrations/external_accounts_migrator_test.go
+++ b/internal/oobmigration/migrations/external_accounts_migrator_test.go
@@ -1,4 +1,4 @@
-package migrators
+package migrations
 
 import (
 	"context"

--- a/internal/oobmigration/migrations/extsvc_config_migrator.go
+++ b/internal/oobmigration/migrations/extsvc_config_migrator.go
@@ -1,4 +1,4 @@
-package migrators
+package migrations
 
 import (
 	"context"

--- a/internal/oobmigration/migrations/extsvc_migrator_test.go
+++ b/internal/oobmigration/migrations/extsvc_migrator_test.go
@@ -1,4 +1,4 @@
-package migrators
+package migrations
 
 import (
 	"context"

--- a/internal/oobmigration/migrations/extsvc_webhook_migrator.go
+++ b/internal/oobmigration/migrations/extsvc_webhook_migrator.go
@@ -1,4 +1,4 @@
-package migrators
+package migrations
 
 import (
 	"context"

--- a/internal/oobmigration/migrations/extsvc_webhook_migrator_test.go
+++ b/internal/oobmigration/migrations/extsvc_webhook_migrator_test.go
@@ -1,4 +1,4 @@
-package migrators
+package migrations
 
 import (
 	"context"

--- a/internal/oobmigration/migrations/helpers_test.go
+++ b/internal/oobmigration/migrations/helpers_test.go
@@ -1,4 +1,4 @@
-package migrators
+package migrations
 
 import (
 	"context"

--- a/internal/oobmigration/migrations/register.go
+++ b/internal/oobmigration/migrations/register.go
@@ -1,4 +1,4 @@
-package migrators
+package migrations
 
 import (
 	"os"


### PR DESCRIPTION
This PR enables us to run the out of band migration runners in the `migrator` binary (or, at least moves the code to something importable). At this point, we are able to run the migrators _as long as there's a running instance_. Since this doesn't work for upgrade scenarios, we still have to *isolate* the runners so that they can run without access to frontend configuration, gitserver, etc. This will be done in future PRs over time.

## Test plan

Tested by hand that migrators are still registered in the worker.