### PR TITLE
migrator: Pass down root logger instance

### DIFF
--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	logger := log.Scoped("migrator", "migrator oss edition")
 
-	if err := shared.Start(); err != nil {
+	if err := shared.Start(logger); err != nil {
 		logger.Fatal(err.Error())
 	}
 }

--- a/enterprise/cmd/migrator/main.go
+++ b/enterprise/cmd/migrator/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	logger := log.Scoped("migrator", "migrator enterprise edition")
 
-	if err := shared.Start(); err != nil {
+	if err := shared.Start(logger); err != nil {
 		logger.Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
Do not create ad-hoc loggers; pass the root logger instance down here possible.

## Test plan

Ran binary locally.