### PR TITLE
migrator: Run out-of-band migrations

### DIFF
--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	logger := log.Scoped("migrator", "migrator oss edition")
 
-	if err := shared.Start(logger); err != nil {
+	if err := shared.Start(logger, nil); err != nil {
 		logger.Fatal(err.Error())
 	}
 }

--- a/cmd/migrator/shared/conf.go
+++ b/cmd/migrator/shared/conf.go
@@ -1,0 +1,79 @@
+package shared
+
+import (
+	"context"
+	"errors"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type staticConf struct {
+	serviceConnections conftypes.ServiceConnections
+	siteConfig         schema.SiteConfiguration
+}
+
+func newStaticConf(ctx context.Context, db database.DB) (*staticConf, error) {
+	serviceConnections, err := serviceConnections()
+	if err != nil {
+		return nil, err
+	}
+
+	siteConfig, err := siteConfig(ctx, basestore.NewWithHandle(db.Handle()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &staticConf{
+		serviceConnections: serviceConnections,
+		siteConfig:         siteConfig,
+	}, nil
+}
+
+func (c staticConf) ServiceConnections() conftypes.ServiceConnections { return c.serviceConnections }
+func (c staticConf) SiteConfig() schema.SiteConfiguration             { return c.siteConfig }
+
+func serviceConnections() (conftypes.ServiceConnections, error) {
+	dsns, err := postgresdsn.DSNsBySchema(schemas.SchemaNames)
+	if err != nil {
+		return conftypes.ServiceConnections{}, err
+	}
+
+	return conftypes.ServiceConnections{
+		PostgresDSN:          dsns["frontend"],
+		CodeIntelPostgresDSN: dsns["codeintel"],
+		CodeInsightsDSN:      dsns["codeinsights"],
+	}, nil
+}
+
+func siteConfig(ctx context.Context, store *basestore.Store) (siteConfig schema.SiteConfiguration, _ error) {
+	raw, ok, err := basestore.ScanFirstString(store.Query(ctx, sqlf.Sprintf(siteConfigQuery)))
+	if err != nil {
+		return siteConfig, err
+	}
+	if !ok {
+		return siteConfig, errors.New("instance is new")
+	}
+
+	if err := jsonc.Unmarshal(raw, &siteConfig); err != nil {
+		return siteConfig, err
+	}
+
+	return siteConfig, nil
+}
+
+const siteConfigQuery = `
+-- source: cmd/migrator/shared/conf.go:siteConfig
+SELECT c.contents
+FROM critical_and_site_config c
+WHERE c.type = 'site'
+ORDER BY c.id DESC
+LIMIT 1
+`

--- a/cmd/migrator/shared/registration.go
+++ b/cmd/migrator/shared/registration.go
@@ -1,0 +1,36 @@
+package shared
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+)
+
+type registerMigratorsFromConfFunc func(
+	ctx context.Context,
+	db database.DB,
+	runner *oobmigration.Runner,
+	conf conftypes.UnifiedQuerier,
+) error
+
+func composeRegisterMigratorsFuncs(fnsFromConfig ...registerMigratorsFromConfFunc) oobmigration.RegisterMigratorsFunc {
+	return func(ctx context.Context, db database.DB, runner *oobmigration.Runner) error {
+		conf, err := newStaticConf(ctx, db)
+		if err != nil {
+			return err
+		}
+
+		fns := make([]oobmigration.RegisterMigratorsFunc, 0, len(fnsFromConfig))
+		for _, f := range fnsFromConfig {
+			f := f // avoid loop capture
+
+			fns = append(fns, func(ctx context.Context, db database.DB, runner *oobmigration.Runner) error {
+				return f(ctx, db, runner, conf)
+			})
+		}
+
+		return oobmigration.ComposeRegisterMigratorsFuncs(fns...)(ctx, db, runner)
+	}
+}

--- a/enterprise/cmd/migrator/main.go
+++ b/enterprise/cmd/migrator/main.go
@@ -4,9 +4,15 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/migrator/shared"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/oobmigration/migrations"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
+
+func init() {
+	oobmigration.ReturnEnterpriseMigrations = true
+}
 
 func main() {
 	liblog := log.Init(log.Resource{
@@ -17,7 +23,7 @@ func main() {
 
 	logger := log.Scoped("migrator", "migrator enterprise edition")
 
-	if err := shared.Start(logger); err != nil {
+	if err := shared.Start(logger, migrations.RegisterEnterpriseMigrationsFromConfig); err != nil {
 		logger.Fatal(err.Error())
 	}
 }

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -71,16 +71,19 @@ func RegisterEnterpriseMigrationsFromConfig(ctx context.Context, db database.DB,
 		insightsStore = basestore.NewWithHandle(basestore.NewHandleWithDB(codeInsightsDB, sql.TxOptions{}))
 	}
 
-	keyring, err := keyring.NewRing(ctx, conf.SiteConfig().EncryptionKeys)
+	keys, err := keyring.NewRing(ctx, conf.SiteConfig().EncryptionKeys)
 	if err != nil {
 		return err
+	}
+	if keys == nil {
+		keys = &keyring.Ring{}
 	}
 
 	return registerEnterpriseMigrations(runner, dependencies{
 		store:          basestore.NewWithHandle(db.Handle()),
 		codeIntelStore: basestore.NewWithHandle(basestore.NewHandleWithDB(codeIntelDB, sql.TxOptions{})),
 		insightsStore:  insightsStore,
-		keyring:        keyring,
+		keyring:        keys,
 	})
 }
 

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -1,0 +1,107 @@
+package cliutil
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/sourcegraph/log"
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+func RunOutOfBandMigrations(
+	logger log.Logger,
+	commandName string,
+	runnerFactory RunnerFactory,
+	outFactory OutputFactory,
+	register oobmigration.RegisterMigratorsFunc,
+) *cli.Command {
+	idFlag := &cli.IntFlag{
+		Name:     "id",
+		Usage:    "The target migration to run. If not supplied, all migrations are run.",
+		Required: false,
+	}
+	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
+		r, err := runnerFactory(ctx, schemas.SchemaNames)
+		if err != nil {
+			return err
+		}
+		db, err := extractDatabase(ctx, r)
+		if err != nil {
+			return err
+		}
+
+		store := oobmigration.NewStoreWithDB(db)
+		runner := outOfBandMigrationRunnerWithStore(store)
+		if err := runner.SynchronizeMetadata(ctx); err != nil {
+			return err
+		}
+		if err := register(ctx, db, runner); err != nil {
+			return err
+		}
+
+		getMigrations := func() ([]oobmigration.Migration, error) {
+			id := idFlag.Get(cmd)
+			if id == 0 {
+				migrations, err := store.List(ctx)
+				if err != nil {
+					return nil, err
+				}
+
+				return migrations, nil
+			}
+
+			migration, ok, err := store.GetByID(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, errors.Newf("unknown migration id %d", id)
+			}
+			return []oobmigration.Migration{migration}, nil
+		}
+
+		go runner.Start()
+		defer runner.Stop()
+
+		for range time.NewTicker(time.Second).C {
+			migrations, err := getMigrations()
+			if err != nil {
+				return err
+			}
+
+			sort.Slice(migrations, func(i, j int) bool { return migrations[i].ID < migrations[j].ID })
+
+			incomplete := migrations[:0]
+			for _, m := range migrations {
+				if !m.Complete() {
+					incomplete = append(incomplete, m)
+				}
+			}
+			if len(incomplete) == 0 {
+				break
+			}
+			for _, m := range incomplete {
+				out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleReset, "Migration #%d is at %.2f%%", m.ID, m.Progress*100))
+			}
+		}
+
+		out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Migrations complete"))
+		return nil
+	})
+
+	return &cli.Command{
+		Name:        "run-out-of-band-migrations",
+		Usage:       "Run incomplete out of band migrations (experimental).",
+		Description: "",
+		Action:      action,
+		Flags: []cli.Flag{
+			idFlag,
+		},
+	}
+}

--- a/internal/database/migration/cliutil/util.go
+++ b/internal/database/migration/cliutil/util.go
@@ -139,3 +139,7 @@ var migratorObservationContext = &observation.TestContext
 func outOfBandMigrationRunner(db database.DB) *oobmigration.Runner {
 	return oobmigration.NewRunnerWithDB(db, time.Second, migratorObservationContext)
 }
+
+func outOfBandMigrationRunnerWithStore(store *oobmigration.Store) *oobmigration.Runner {
+	return oobmigration.NewRunner(store, time.Second, migratorObservationContext)
+}

--- a/internal/oobmigration/migrations/register.go
+++ b/internal/oobmigration/migrations/register.go
@@ -22,14 +22,17 @@ func RegisterOSSMigrations(ctx context.Context, db database.DB, runner *oobmigra
 }
 
 func RegisterOSSMigrationsFromConfig(ctx context.Context, db database.DB, runner *oobmigration.Runner, conf conftypes.UnifiedQuerier) error {
-	keyring, err := keyring.NewRing(ctx, conf.SiteConfig().EncryptionKeys)
+	keys, err := keyring.NewRing(ctx, conf.SiteConfig().EncryptionKeys)
 	if err != nil {
 		return err
+	}
+	if keys == nil {
+		keys = &keyring.Ring{}
 	}
 
 	return registerOSSMigrations(runner, migratorDependencies{
 		store:   basestore.NewWithHandle(db.Handle()),
-		keyring: keyring,
+		keyring: keys,
 	})
 }
 

--- a/internal/oobmigration/runner.go
+++ b/internal/oobmigration/runner.go
@@ -40,7 +40,11 @@ type migratorAndOption struct {
 var _ goroutine.BackgroundRoutine = &Runner{}
 
 func NewRunnerWithDB(db database.DB, refreshInterval time.Duration, observationContext *observation.Context) *Runner {
-	return newRunner(NewStoreWithDB(db), glock.NewRealTicker(refreshInterval), observationContext)
+	return NewRunner(NewStoreWithDB(db), refreshInterval, observationContext)
+}
+
+func NewRunner(store *Store, refreshInterval time.Duration, observationContext *observation.Context) *Runner {
+	return newRunner(store, glock.NewRealTicker(refreshInterval), observationContext)
 }
 
 func newRunner(store storeIface, refreshTicker glock.Ticker, observationContext *observation.Context) *Runner {


### PR DESCRIPTION
This PR adds a `run-out-of-band-migrations` command to the `migrator` service which runs all incomplete out of band migrations to completion.

Fixes #38047. Follow-up PRs will improve UX, as this implementation works but is very bare-bones.

## Test plan

Tested on a local instance.