### PR TITLE
compute: support date subfields in output

### DIFF
--- a/enterprise/internal/compute/template.go
+++ b/enterprise/internal/compute/template.go
@@ -2,8 +2,11 @@ package compute
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
 	"strings"
 	"text/template"
+	"time"
 	"unicode/utf8"
 
 	"github.com/go-enry/go-enry/v2"
@@ -48,7 +51,7 @@ func (v Variable) String() string {
 }
 func (c Constant) String() string { return string(c) }
 
-const varAllowed = "abcdefghijklmnopqrstuvwxyzABCEDEFGHIJKLMNOPQRSTUVWXYZ1234567890_"
+const varAllowed = "abcdefghijklmnopqrstuvwxyzABCEDEFGHIJKLMNOPQRSTUVWXYZ1234567890_."
 
 // scanTemplate scans an input string to produce a Template. Recognized
 // metavariable syntax is `$(varAllowed+)`.
@@ -188,7 +191,7 @@ type MetaEnvironment struct {
 	Content string
 	Commit  string
 	Author  string
-	Date    string
+	Date    time.Time
 	Email   string
 	Lang    string
 }
@@ -196,17 +199,21 @@ type MetaEnvironment struct {
 var empty = struct{}{}
 
 var builtinVariables = map[string]struct{}{
-	"repo":    empty,
-	"path":    empty,
-	"content": empty,
-	"commit":  empty,
-	"author":  empty,
-	"date":    empty,
-	"email":   empty,
-	"lang":    empty,
+	"repo":            empty,
+	"path":            empty,
+	"content":         empty,
+	"commit":          empty,
+	"author":          empty,
+	"date":            empty,
+	"date.day":        empty,
+	"date.month":      empty,
+	"date.month.name": empty,
+	"date.year":       empty,
+	"email":           empty,
+	"lang":            empty,
 }
 
-func templatize(pattern string) string {
+func templatize(pattern string, env *MetaEnvironment) string {
 	t := scanTemplate([]byte(pattern))
 	var templatized []string
 	for _, atom := range *t {
@@ -215,8 +222,26 @@ func templatize(pattern string) string {
 			templatized = append(templatized, string(a))
 		case Variable:
 			if _, ok := builtinVariables[a.Name[1:]]; ok {
-				templateVar := strings.Title(a.Name[1:])
-				templatized = append(templatized, `{{.`+templateVar+`}}`)
+				name := a.Name[1:]
+				if name == "date.year" {
+					constant := strconv.Itoa(env.Date.Year())
+					templatized = append(templatized, constant)
+				} else if name == "date.month.name" {
+					constant := env.Date.Month().String()
+					templatized = append(templatized, constant)
+				} else if name == "date.month" {
+					constant := fmt.Sprintf("%02d", int(env.Date.Month()))
+					templatized = append(templatized, constant)
+				} else if name == "date.day" {
+					constant := strconv.Itoa(env.Date.Day())
+					templatized = append(templatized, constant)
+				} else if name == "date" {
+					constant := env.Date.Format("2006-01-02")
+					templatized = append(templatized, constant)
+				} else {
+					templateVar := strings.Title(name)
+					templatized = append(templatized, `{{.`+templateVar+`}}`)
+				}
 				continue
 			}
 			// Leave alone other variables that don't correspond to
@@ -228,7 +253,7 @@ func templatize(pattern string) string {
 }
 
 func substituteMetaVariables(pattern string, env *MetaEnvironment) (string, error) {
-	templated := templatize(pattern)
+	templated := templatize(pattern, env)
 	t, err := template.New("").Parse(templated)
 	if err != nil {
 		return "", err
@@ -263,7 +288,7 @@ func NewMetaEnvironment(r result.Match, content string) *MetaEnvironment {
 			Repo:    string(m.Repo.Name),
 			Commit:  string(m.Commit.ID),
 			Author:  m.Commit.Author.Name,
-			Date:    m.Commit.Committer.Date.Format("2006-01-02"),
+			Date:    m.Commit.Committer.Date,
 			Email:   m.Commit.Author.Email,
 			Content: content,
 		}
@@ -274,7 +299,7 @@ func NewMetaEnvironment(r result.Match, content string) *MetaEnvironment {
 			Repo:    string(m.Repo.Name),
 			Commit:  string(m.Commit.ID),
 			Author:  m.Commit.Author.Name,
-			Date:    m.Commit.Committer.Date.Format("2006-01-02"),
+			Date:    m.Commit.Committer.Date,
 			Email:   m.Commit.Author.Email,
 			Path:    path,
 			Lang:    lang,

--- a/enterprise/internal/compute/template_test.go
+++ b/enterprise/internal/compute/template_test.go
@@ -63,12 +63,12 @@ func Test_templatize(t *testing.T) {
 	autogold.Want(
 		"basic templatize",
 		"artifcats: {{.Repo}}").
-		Equal(t, templatize("artifcats: $repo"))
+		Equal(t, templatize("artifcats: $repo", &MetaEnvironment{}))
 
 	autogold.Want(
 		"exclude regex var in templatize",
 		"artifcats: {{.Repo}} $1").
-		Equal(t, templatize("artifcats: $repo $1"))
+		Equal(t, templatize("artifcats: $repo $1", &MetaEnvironment{}))
 }
 
 func Test_substituteMetaVariables(t *testing.T) {


### PR DESCRIPTION
Let's you substitute for `date.month`, `$date.year`, `$date.day`. This allows group-by behavior in simple clients (like the one in our Notebook) without having to implement explicit group-by operations.

![Screen Shot 2022-08-01 at 8 08 12 PM](https://user-images.githubusercontent.com/888624/182283460-d4af28ec-cc80-47c1-98ba-2f1acffc7a79.png)


In draft so I can make it cleaner, will revisit tomorrow.

## Test plan
Adds test.