### PR TITLE
search: remove unneeded url.ts changes for standard queries

### DIFF
--- a/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsLanguages.test.tsx.snap
+++ b/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsLanguages.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`SearchStatsLanguages renders 1`] = `
               <td>
                 <a
                   class=""
-                  href="/search?q=abc+lang:a&patternType=standard"
+                  href="/search?q=abc+lang:a&patternType=literal"
                 >
                   A
                 </a>
@@ -69,7 +69,7 @@ exports[`SearchStatsLanguages renders 1`] = `
               <td>
                 <a
                   class=""
-                  href="/search?q=abc+lang:b&patternType=standard"
+                  href="/search?q=abc+lang:b&patternType=literal"
                 >
                   B
                 </a>
@@ -85,7 +85,7 @@ exports[`SearchStatsLanguages renders 1`] = `
               <td>
                 <a
                   class=""
-                  href="/search?q=abc+lang:c&patternType=standard"
+                  href="/search?q=abc+lang:c&patternType=literal"
                 >
                   C
                 </a>
@@ -101,7 +101,7 @@ exports[`SearchStatsLanguages renders 1`] = `
               <td>
                 <a
                   class=""
-                  href="/search?q=abc+lang:d&patternType=standard"
+                  href="/search?q=abc+lang:d&patternType=literal"
                 >
                   D
                 </a>

--- a/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
+++ b/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
@@ -186,7 +186,7 @@ exports[`SearchStatsPage renders 1`] = `
                 <td>
                   <a
                     class=""
-                    href="/search?q=abc+lang:a&patternType=standard"
+                    href="/search?q=abc+lang:a&patternType=literal"
                   >
                     A
                   </a>
@@ -202,7 +202,7 @@ exports[`SearchStatsPage renders 1`] = `
                 <td>
                   <a
                     class=""
-                    href="/search?q=abc+lang:b&patternType=standard"
+                    href="/search?q=abc+lang:b&patternType=literal"
                   >
                     B
                   </a>
@@ -218,7 +218,7 @@ exports[`SearchStatsPage renders 1`] = `
                 <td>
                   <a
                     class=""
-                    href="/search?q=abc+lang:c&patternType=standard"
+                    href="/search?q=abc+lang:c&patternType=literal"
                   >
                     C
                   </a>
@@ -234,7 +234,7 @@ exports[`SearchStatsPage renders 1`] = `
                 <td>
                   <a
                     class=""
-                    href="/search?q=abc+lang:d&patternType=standard"
+                    href="/search?q=abc+lang:d&patternType=literal"
                   >
                     D
                   </a>


### PR DESCRIPTION
Accidentally did not unstage changes to `url.ts` in https://github.com/sourcegraph/sourcegraph/pull/38141. These changes are not needed, and just restores/reverts `url.ts` to its previous state before #38141 

## Test plan
Undos unintended changes.

## App preview:

- [Web](https://sg-web-rvt-remove-unneeded.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ztjyrydmgd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
