### PR TITLE
search: fix build for toggle integration test

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -325,7 +325,7 @@ describe('Search', () => {
                     await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal')
                 })
             })
         })


### PR DESCRIPTION
`main` is broken on the change in https://github.com/sourcegraph/sourcegraph/pull/39796. This fixes the test. Didn't catch it because didn't run the whole integration suite against the PR. I will put a follow up for the actual behavior we want.

## Test plan
Makes test pass again.

## App preview:

- [Web](https://sg-web-rvt-fix-ee-test.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mpsbzgehta.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

