### PR TITLE
search: increase number of match groups in core workflow

### DIFF
--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -115,9 +115,9 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
 
     const ranking = useMemo(() => {
         if (!isErrorLike(settings) && settings?.experimentalFeatures?.clientSearchResultRanking === BY_LINE_RANKING) {
-            return new LineRanking(coreWorkflowImprovementsEnabled ? 1 : 10)
+            return new LineRanking(coreWorkflowImprovementsEnabled ? 5 : 10)
         }
-        return new ZoektRanking(coreWorkflowImprovementsEnabled ? 1 : 5)
+        return new ZoektRanking(coreWorkflowImprovementsEnabled ? 3 : 5)
     }, [settings, coreWorkflowImprovementsEnabled])
 
     // The number of lines of context to show before and after each match.


### PR DESCRIPTION
Fixes #39388

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Do a search
* Number of match groups should be 3 instead of 1 for ZoektRanking
* Number of matches should be 5 instead of 1 for LineRanking

## App preview:

- [Web](https://sg-web-rn-increase-match-groups-shown.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-eisopzpdeq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
