### PR TITLE
Fix parsing revisions with @ sign

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -601,7 +601,7 @@ export interface ParsedRepoRevision {
 export function parseRepoRevision(repoRevision: string): ParsedRepoRevision {
     const firstAtSign = repoRevision.indexOf('@')
     if (firstAtSign === -1) {
-        return { repoName: repoRevision }
+        return { repoName: decodeURIComponent(repoRevision) }
     }
 
     const repository = repoRevision.slice(0, firstAtSign)

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -599,7 +599,13 @@ export interface ParsedRepoRevision {
  * Parses a repo-revision string like "my/repo@my/revision" to the repo and revision components.
  */
 export function parseRepoRevision(repoRevision: string): ParsedRepoRevision {
-    const [repository, revision] = repoRevision.split('@', 2) as [string, string | undefined]
+    const firstAtSign = repoRevision.indexOf('@')
+    if (firstAtSign === -1) {
+        return { repoName: repoRevision }
+    }
+
+    const repository = repoRevision.slice(0, firstAtSign)
+    const revision = repoRevision.slice(firstAtSign + 1)
     return {
         repoName: decodeURIComponent(repository),
         revision: revision && decodeURIComponent(revision),

--- a/client/web/src/util/url.test.ts
+++ b/client/web/src/util/url.test.ts
@@ -183,4 +183,13 @@ describe('parseBrowserRepoURL', () => {
             },
         })
     })
+
+    test('should parse repo with revisions containing @', () => {
+        const parsed = parseBrowserRepoURL('https://sourcegraph.com/github.com/emotion-js/emotion@@emotion/core@11.0.0')
+        assertDeepStrictEqual(parsed, {
+            repoName: 'github.com/emotion-js/emotion',
+            revision: '@emotion/core@11.0.0',
+            rawRevision: '@emotion/core@11.0.0',
+        })
+    })
 })


### PR DESCRIPTION
Fixes #31692

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Navigate to `/github.com/emotion-js/emotion@@emotion/core@11.0.0/-/blob/README.md`
* The file should open up

## App preview:

- [Web](https://sg-web-rn-fix-parsing-revisions-with-at.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gvfwfcpyjt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
