### PR TITLE
Code Insights: Connect sort and limit filters to the insight handler properly on the single insight page

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -151,7 +151,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                     variant="link"
                     className={classNames(styles.actionButton, styles.actionButtonWithCollapsed)}
                     onClick={() => onVisualModeChange(FilterSectionVisualMode.HorizontalSections)}
-                    aria-label="Switch to horizontal mode"
+                    aria-label="Open filters panel"
                 >
                     <Icon aria-hidden={true} svgPath={mdiArrowExpand} />
                 </Button>
@@ -183,7 +183,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         variant="link"
                         className={styles.actionButton}
                         onClick={() => onVisualModeChange(FilterSectionVisualMode.Preview)}
-                        aria-label="Switch to preview mode"
+                        aria-label="Close filters panel"
                     >
                         <Icon aria-hidden={true} svgPath={mdiArrowCollapse} />
                     </Button>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/index.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/index.ts
@@ -8,3 +8,5 @@ export { DrillDownInsightCreationForm } from './DrillDownInsightCreationForm'
 
 export type { DrillDownFiltersFormValues } from './drill-down-filters/DrillDownInsightFilters'
 export type { DrillDownInsightCreationFormValues } from './DrillDownInsightCreationForm'
+
+export { parseSeriesLimit } from './drill-down-filters/utils'

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/index.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/index.ts
@@ -4,6 +4,7 @@ export {
     DrillDownInsightFilters,
     FilterSectionVisualMode,
     DrillDownInsightCreationForm,
+    parseSeriesLimit,
 } from './drill-down-filters-panel'
 
 export { DrillDownFiltersPopover, DrillDownFiltersStep } from './drill-down-filters-popover/DrillDownFiltersPopover'

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
@@ -1,3 +1,5 @@
+import { ButtonHTMLAttributes, ChangeEventHandler, FC, FocusEventHandler, PropsWithChildren } from 'react'
+
 import classNames from 'classnames'
 
 import { Button, ButtonGroup, Input } from '@sourcegraph/wildcard'
@@ -20,12 +22,12 @@ interface SortFilterSeriesPanelProps {
 // or else it gets too cluttered to view
 const maxLimit = MAX_NUMBER_OF_SERIES
 
-export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPanelProps> = ({ value, onChange }) => {
+export const SortFilterSeriesPanel: FC<SortFilterSeriesPanelProps> = ({ value, onChange }) => {
     const handleToggle = (sortOptions: SeriesSortOptionsInput): void => {
         onChange({ ...value, sortOptions })
     }
 
-    const handleChange: React.ChangeEventHandler<HTMLInputElement> = event => {
+    const handleChange: ChangeEventHandler<HTMLInputElement> = event => {
         const inputValue = event.target.value
         let limit = inputValue
 
@@ -36,7 +38,7 @@ export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPane
         onChange({ ...value, limit })
     }
 
-    const handleBlur: React.FocusEventHandler<HTMLInputElement> = event => {
+    const handleBlur: FocusEventHandler<HTMLInputElement> = event => {
         const limit = event.target.value
         if (limit === '') {
             onChange({ ...value, limit: `${maxLimit}` })
@@ -50,16 +52,18 @@ export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPane
                     <small className={styles.label}>Sort by result count</small>
                     <ButtonGroup className={styles.toggleGroup}>
                         <ToggleButton
+                            aria-label="Sort by result count with descending order"
                             selected={value.sortOptions}
                             value={{ mode: SeriesSortMode.RESULT_COUNT, direction: SeriesSortDirection.DESC }}
-                            onClick={handleToggle}
+                            onToggle={handleToggle}
                         >
                             Highest
                         </ToggleButton>
                         <ToggleButton
+                            aria-label="Sort by result count with ascending order"
                             selected={value.sortOptions}
                             value={{ mode: SeriesSortMode.RESULT_COUNT, direction: SeriesSortDirection.ASC }}
-                            onClick={handleToggle}
+                            onToggle={handleToggle}
                         >
                             Lowest
                         </ToggleButton>
@@ -69,16 +73,18 @@ export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPane
                     <small className={styles.label}>Sort by name</small>
                     <ButtonGroup className={styles.toggleGroup}>
                         <ToggleButton
+                            aria-label="Sort by name with ascending order"
                             selected={value.sortOptions}
                             value={{ mode: SeriesSortMode.LEXICOGRAPHICAL, direction: SeriesSortDirection.ASC }}
-                            onClick={handleToggle}
+                            onToggle={handleToggle}
                         >
                             A-Z
                         </ToggleButton>
                         <ToggleButton
+                            aria-label="Sort by name with descending order"
                             selected={value.sortOptions}
                             value={{ mode: SeriesSortMode.LEXICOGRAPHICAL, direction: SeriesSortDirection.DESC }}
-                            onClick={handleToggle}
+                            onToggle={handleToggle}
                         >
                             Z-A
                         </ToggleButton>
@@ -88,16 +94,18 @@ export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPane
                     <small className={styles.label}>Sort by date added</small>
                     <ButtonGroup className={styles.toggleGroup}>
                         <ToggleButton
+                            aria-label="Sort by date with descending order"
                             selected={value.sortOptions}
                             value={{ mode: SeriesSortMode.DATE_ADDED, direction: SeriesSortDirection.DESC }}
-                            onClick={handleToggle}
+                            onToggle={handleToggle}
                         >
                             Newest
                         </ToggleButton>
                         <ToggleButton
+                            aria-label="Sort by date with ascending order"
                             selected={value.sortOptions}
                             value={{ mode: SeriesSortMode.DATE_ADDED, direction: SeriesSortDirection.ASC }}
-                            onClick={handleToggle}
+                            onToggle={handleToggle}
                         >
                             Oldest
                         </ToggleButton>
@@ -117,32 +125,35 @@ export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPane
                     onChange={handleChange}
                     onBlur={handleBlur}
                     variant="small"
+                    aria-label="Number of data series"
                 />
             </footer>
         </section>
     )
 }
 
-interface ToggleButtonProps {
+interface ToggleButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value'> {
     selected: SeriesSortOptionsInput
     value: SeriesSortOptionsInput
-    onClick: (value: SeriesSortOptionsInput) => void
+    onToggle: (value: SeriesSortOptionsInput) => void
 }
 
-const ToggleButton: React.FunctionComponent<React.PropsWithChildren<ToggleButtonProps>> = ({
+const ToggleButton: FC<PropsWithChildren<ToggleButtonProps>> = ({
     selected,
     value,
     children,
-    onClick,
+    onToggle,
+    ...attributes
 }) => {
     const isSelected = selected.mode === value.mode && selected.direction === value.direction
 
     return (
         <Button
+            {...attributes}
             variant="secondary"
             size="sm"
             className={classNames({ [styles.selected]: isSelected, [styles.unselected]: !isSelected })}
-            onClick={() => onClick(value)}
+            onClick={() => onToggle(value)}
         >
             {children}
         </Button>

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -33,8 +33,8 @@ import {
     BackendInsightErrorAlert,
     DrillDownFiltersFormValues,
     DrillDownInsightCreationFormValues,
+    parseSeriesLimit,
 } from '../../../../../components/insights-view-grid/components/backend-insight/components'
-import { parseSeriesLimit } from '../../../../../components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils'
 import {
     BackendInsightData,
     ALL_INSIGHTS_DASHBOARD,

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -34,6 +34,7 @@ import {
     DrillDownFiltersFormValues,
     DrillDownInsightCreationFormValues,
 } from '../../../../../components/insights-view-grid/components/backend-insight/components'
+import { parseSeriesLimit } from '../../../../../components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils'
 import {
     BackendInsightData,
     ALL_INSIGHTS_DASHBOARD,
@@ -83,15 +84,16 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         excludeRepoRegex: debouncedFilters.excludeRepoRegexp,
         searchContexts: [debouncedFilters.context],
     }
-    const displayInput: SeriesDisplayOptionsInput = {
-        limit: insight.seriesDisplayOptions?.limit,
-        sortOptions: insight.seriesDisplayOptions?.sortOptions,
+
+    const seriesDisplayOptions: SeriesDisplayOptionsInput = {
+        limit: parseSeriesLimit(debouncedFilters.seriesDisplayOptions.limit),
+        sortOptions: debouncedFilters.seriesDisplayOptions.sortOptions,
     }
 
     const { error, loading, stopPolling } = useQuery<GetInsightViewResult, GetInsightViewVariables>(
         GET_INSIGHT_VIEW_GQL,
         {
-            variables: { id: insight.id, filters: filterInput, seriesDisplayOptions: displayInput },
+            variables: { id: insight.id, filters: filterInput, seriesDisplayOptions },
             fetchPolicy: 'cache-and-network',
             pollInterval: pollingInterval,
             context: { concurrentRequests: { key: 'GET_INSIGHT_VIEW' } },
@@ -145,7 +147,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
             }).toPromise()
 
             setOriginalInsightFilters(filters)
-            history.push(`/insights/dashboard${ALL_INSIGHTS_DASHBOARD.id}`)
+            history.push(`/insights/dashboard/${ALL_INSIGHTS_DASHBOARD.id}`)
             telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
         } catch (error) {
             return { [FORM_ERROR]: asError(error) }

--- a/client/web/src/integration/insights/single-insight-page.test.ts
+++ b/client/web/src/integration/insights/single-insight-page.test.ts
@@ -1,0 +1,127 @@
+import assert from 'assert'
+
+import delay from 'delay'
+
+import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
+import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
+
+import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../context'
+import { percySnapshotWithVariants } from '../utils'
+
+import { MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE } from './fixtures/calculated-insights'
+import { createJITMigrationToGQLInsightMetadataFixture } from './fixtures/insights-metadata'
+import { overrideInsightsGraphQLApi } from './utils/override-insights-graphql-api'
+
+describe('Code insights single insight page', () => {
+    let driver: Driver
+    let testContext: WebIntegrationTestContext
+
+    before(async () => {
+        driver = await createDriverForTest()
+    })
+
+    beforeEach(async function () {
+        testContext = await createWebIntegrationTestContext({
+            driver,
+            currentTest: this.currentTest!,
+            directory: __dirname,
+            customContext: {
+                // Enforce using a new gql API for code insights pages
+                codeInsightsGqlApiEnabled: true,
+            },
+        })
+    })
+
+    after(() => driver?.close())
+    afterEach(() => testContext?.dispose())
+    afterEachSaveScreenshotIfFailed(() => driver.page)
+
+    async function takeChartSnapshot(name: string): Promise<void> {
+        await driver.page.waitForSelector('svg circle')
+        await delay(500)
+        await percySnapshotWithVariants(driver.page, name)
+    }
+
+    it('is styled correctly with common backend insights', async () => {
+        overrideInsightsGraphQLApi({
+            testContext,
+            overrides: {
+                // Mock insight config query
+                GetInsights: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [createJITMigrationToGQLInsightMetadataFixture({ id: '001', type: 'calculated' })],
+                    },
+                }),
+                GetInsightView: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE],
+                    },
+                }),
+            },
+        })
+
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/insight/001')
+
+        await takeChartSnapshot('Code insights single insight page with common backend insight')
+    })
+
+    it('is re-fetched correctly if any of sort and limit filters have been changed', async () => {
+        overrideInsightsGraphQLApi({
+            testContext,
+            overrides: {
+                // Mock insight config query
+                GetInsights: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [createJITMigrationToGQLInsightMetadataFixture({ id: '001', type: 'calculated' })],
+                    },
+                }),
+                GetInsightView: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE],
+                    },
+                }),
+
+                UpdateLineChartSearchInsight: () => ({
+                    __typename: 'Mutation',
+                    updateLineChartSearchInsight: {
+                        __typename: 'InsightViewPayload',
+                        view: createJITMigrationToGQLInsightMetadataFixture({ id: '001', type: 'calculated' }),
+                    },
+                }),
+            },
+        })
+
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/insight/001')
+        await driver.page.waitForSelector('[aria-label="Open filters panel"]')
+        await driver.page.click('[aria-label="Open filters panel"]')
+        await driver.page.waitForSelector('[aria-label="Sort by name with ascending order"]')
+
+        const variables = await testContext.waitForGraphQLRequest(async () => {
+            await driver.page.click('[aria-label="Sort by name with ascending order"]')
+            await driver.page.click('input[aria-label="Number of data series"]', { clickCount: 3 })
+            await driver.page.keyboard.type('2')
+        }, 'GetInsightView')
+
+        assert.deepStrictEqual(variables.filters, {
+            searchContexts: [''],
+            includeRepoRegex: '',
+            excludeRepoRegex: '',
+        })
+
+        assert.deepStrictEqual(variables.seriesDisplayOptions, {
+            limit: 2,
+            sortOptions: {
+                direction: 'ASC',
+                mode: 'LEXICOGRAPHICAL',
+            },
+        })
+    })
+})


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/39788
Fixes https://github.com/sourcegraph/sourcegraph/issues/39790

## Background 
In https://github.com/sourcegraph/sourcegraph/pull/36376 we broke our filtering on the signle insight page. More correct would be we didn't connect these series-like filters to the chart UI card. This PR fixes this. 
The part of the problem that we didn't catch this is lack of testing for the insight single page. This PR adds some happy path integrations test for this page.

## Test plan
- Try to filter insight on the single insight page. All filters (series sort and limit, search context, repo filters) should work properly and change data on the chart UI
- Try to create insight with filters you should be redirected to the all insights dashboard. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-single-insight-page-filters.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tiqlyyhkhi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
