### PR TITLE
notebook share dialog: use Dropdown instead of Menu

### DIFF
--- a/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
@@ -1,9 +1,11 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
-import { mdiLock, mdiChevronUp, mdiChevronDown, mdiDomain, mdiWeb } from '@mdi/js'
+import { mdiLock, mdiWeb, mdiDomain, mdiChevronUp, mdiChevronDown } from '@mdi/js'
+// eslint-disable-next-line no-restricted-imports
+import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Menu, MenuButton, MenuItem, MenuList, Icon } from '@sourcegraph/wildcard'
+import { Icon } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { OrgAvatar } from '../../org/OrgAvatar'
@@ -68,9 +70,11 @@ const ShareOptionComponent: React.FunctionComponent<
 export const NotebookShareOptionsDropdown: React.FunctionComponent<
     React.PropsWithChildren<NotebookShareOptionsDropdownProps>
 > = ({ isSourcegraphDotCom, telemetryService, authenticatedUser, selectedShareOption, onSelectShareOption }) => {
+    const [isOpen, setIsOpen] = useState(false)
     const handleToggle = useCallback(() => {
         telemetryService.log('NotebookVisibilitySettingsDropdownToggled')
-    }, [telemetryService])
+        setIsOpen(isOpen => !isOpen)
+    }, [telemetryService, setIsOpen])
 
     const shareOptions: ShareOption[] = useMemo(
         () => [
@@ -97,41 +101,36 @@ export const NotebookShareOptionsDropdown: React.FunctionComponent<
     )
 
     return (
-        <Menu>
-            {({ isOpen }) => (
-                <>
-                    <MenuButton
-                        onClick={handleToggle}
-                        className={styles.button}
-                        outline={true}
-                        variant="secondary"
-                        data-testid="share-notebook-options-dropdown-toggle"
+        <Dropdown isOpen={isOpen} toggle={handleToggle}>
+            <DropdownToggle
+                className={styles.button}
+                outline={true}
+                variant="secondary"
+                data-testid="share-notebook-options-dropdown-toggle"
+            >
+                <span className="d-flex align-items-center">
+                    <ShareOptionComponent {...selectedShareOption} isSourcegraphDotCom={isSourcegraphDotCom} />
+                </span>
+                <span className="ml-5">
+                    {isOpen ? (
+                        <Icon svgPath={mdiChevronUp} inline={false} aria-hidden={true} />
+                    ) : (
+                        <Icon svgPath={mdiChevronDown} inline={false} aria-hidden={true} />
+                    )}
+                </span>
+            </DropdownToggle>
+            <DropdownMenu>
+                {shareOptions.map(option => (
+                    <DropdownItem
+                        key={`${option.namespaceId}-${option.isPublic}`}
+                        className="d-flex align-items-center"
+                        onClick={() => onSelectShareOption(option)}
+                        data-testid={`share-notebook-option-${option.namespaceName}-${option.isPublic}`}
                     >
-                        <span className="d-flex align-items-center">
-                            <ShareOptionComponent {...selectedShareOption} isSourcegraphDotCom={isSourcegraphDotCom} />
-                        </span>
-                        <span className="ml-5">
-                            {isOpen ? (
-                                <Icon svgPath={mdiChevronUp} inline={false} aria-hidden={true} />
-                            ) : (
-                                <Icon svgPath={mdiChevronDown} inline={false} aria-hidden={true} />
-                            )}
-                        </span>
-                    </MenuButton>
-                    <MenuList>
-                        {shareOptions.map(option => (
-                            <MenuItem
-                                key={`${option.namespaceId}-${option.isPublic}`}
-                                className="d-flex align-items-center"
-                                onSelect={() => onSelectShareOption(option)}
-                                data-testid={`share-notebook-option-${option.namespaceName}-${option.isPublic}`}
-                            >
-                                <ShareOptionComponent {...option} isSourcegraphDotCom={isSourcegraphDotCom} />
-                            </MenuItem>
-                        ))}
-                    </MenuList>
-                </>
-            )}
-        </Menu>
+                        <ShareOptionComponent {...option} isSourcegraphDotCom={isSourcegraphDotCom} />
+                    </DropdownItem>
+                ))}
+            </DropdownMenu>
+        </Dropdown>
     )
 }


### PR DESCRIPTION
This was a really weird bug that only appeared in Safari. And even in Safari, it appeared under some weird circumstances. I was unable to find the root cause, so I switched from using Menu to the Dropdown menu, which seems to always work.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Open a notebook in Safari
* Open share dialog
* You should be able to switch between dropdown options

## App preview:

- [Web](https://sg-web-rn-fix-notebook-share-dropdown-in.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-doypqdhsqz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
