### PR TITLE
conf: small fixes to (Un)redacting the site config

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -73,14 +73,6 @@ func NewSiteProblem(msg string) *Problem {
 	}
 }
 
-// NewExternalServiceProblem creates a new external service config problem with given message.
-func NewExternalServiceProblem(msg string) *Problem {
-	return &Problem{
-		kind:        problemExternalService,
-		description: msg,
-	}
-}
-
 // IsSite returns true if the problem is about site config.
 func (p Problem) IsSite() bool {
 	return p.kind == problemSite
@@ -276,7 +268,13 @@ func UnredactSecrets(input string, raw conftypes.RawUnified) (string, error) {
 			return input, errors.Wrapf(err, `unredact %q`, strings.Join(secret.editPaths, " > "))
 		}
 	}
-	return unredactedSite, err
+
+	formattedSite, err := jsonc.Format(unredactedSite, &jsonc.DefaultFormatOptions)
+	if err != nil {
+		return input, errors.Wrapf(err, "JSON formatting")
+	}
+
+	return formattedSite, err
 }
 
 // RedactSecrets redacts defined list of secrets from the given configuration. It
@@ -301,9 +299,12 @@ func RedactSecrets(raw conftypes.RawUnified) (empty conftypes.RawUnified, err er
 			ap.Gitlab.ClientSecret = redactedSecret
 		}
 	}
-	redactedSite, err := jsonc.Edit(raw.Site, cfg.AuthProviders, "auth.providers")
-	if err != nil {
-		return empty, errors.Wrap(err, `redact "auth.providers"`)
+	redactedSite := raw.Site
+	if len(cfg.AuthProviders) > 0 {
+		redactedSite, err = jsonc.Edit(raw.Site, cfg.AuthProviders, "auth.providers")
+		if err != nil {
+			return empty, errors.Wrap(err, `redact "auth.providers"`)
+		}
 	}
 
 	for _, secret := range siteConfigSecrets {
@@ -318,8 +319,13 @@ func RedactSecrets(raw conftypes.RawUnified) (empty conftypes.RawUnified, err er
 		}
 	}
 
+	formattedSite, err := jsonc.Format(redactedSite, &jsonc.DefaultFormatOptions)
+	if err != nil {
+		return empty, errors.Wrapf(err, "JSON formatting")
+	}
+
 	return conftypes.RawUnified{
-		Site: redactedSite,
+		Site: formattedSite,
 	}, err
 }
 

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -162,6 +162,21 @@ func TestRedactSecrets(t *testing.T) {
 	assert.Equal(t, want, redacted.Site)
 }
 
+func TestRedactSecrets_AuthProvidersSectionNotAdded(t *testing.T) {
+	const cfgWithoutAuthProviders = `{
+  "executors.accessToken": "%s"
+}`
+	redacted, err := RedactSecrets(
+		conftypes.RawUnified{
+			Site: fmt.Sprintf(cfgWithoutAuthProviders, executorsAccessToken),
+		},
+	)
+	require.NoError(t, err)
+
+	want := fmt.Sprintf(cfgWithoutAuthProviders, "REDACTED")
+	assert.Equal(t, want, redacted.Site)
+}
+
 func TestUnredactSecrets(t *testing.T) {
 	previousSite := getTestSiteWithSecrets(
 		executorsAccessToken,
@@ -260,8 +275,7 @@ func getTestSiteWithSecrets(
 	if len(optionalEdit) > 0 {
 		email = optionalEdit[0]
 	}
-	return fmt.Sprintf(`
-{
+	return fmt.Sprintf(`{
   "disablePublicRepoRedirects": true,
   "repoListUpdateInterval": 1,
   "email.address": "%s",
@@ -295,7 +309,7 @@ func getTestSiteWithSecrets(
     }
   ],
   "observability.tracing": {
-    "sampling":"selective"
+    "sampling": "selective"
   },
   "externalService.userMode": "all",
   "email.smtp": {
@@ -312,8 +326,7 @@ func getTestSiteWithSecrets(
     }
   },
   "auth.unlockAccountLinkSigningKey": "%s",
-}
-`,
+}`,
 		email,
 		executorsAccessToken,
 		authOpenIDClientSecret, authGitHubClientSecret, authGitLabClientSecret,


### PR DESCRIPTION
_During my work on 1-click export I noticed that these slight changes can be made to site config redacting code._

This commit fixes an issue of adding an entry of `"auth.providers": null` to site config after redacting it in case of initial "auth.provider" absence.

This commit also adds formatting of a site config after (un)redacting it. Previously, if site config being (un)redacted was not pretty-printed before that, it ended up being partially formatted: only the parts of config being edited were formatted because of `jsonc.Edit` function specific, while the "untouched" parts of config were not formatted.

## Test plan
Unit tests changed, new test added.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
