### PR TITLE
codeintel: fix java inferrence build tool flag, lsif->scip

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/lang_java_test.go
+++ b/internal/codeintel/autoindexing/internal/inference/lang_java_test.go
@@ -21,7 +21,7 @@ func TestJavaGenerator(t *testing.T) {
 					LocalSteps:  nil,
 					Root:        "",
 					Indexer:     "sourcegraph/scip-java",
-					IndexerArgs: []string{"scip-java", "index", "--build-tool=lsif"},
+					IndexerArgs: []string{"scip-java", "index", "--build-tool=scip"},
 					Outfile:     "index.scip",
 				},
 			},

--- a/internal/codeintel/autoindexing/internal/inference/lua/java.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/java.lua
@@ -32,7 +32,7 @@ return recognizers.path_recognizer {
           steps = {},
           root = "",
           indexer = indexer,
-          indexer_args = { "scip-java", "index", "--build-tool=lsif" },
+          indexer_args = { "scip-java", "index", "--build-tool=scip" },
           outfile = outfile,
         }
       end,


### PR DESCRIPTION
Fixes Java autoindexing inferrence to pass the correct `build-tool` flag to scip-java. Previously it was `lsif` but now its `scip` but wasn't updated here.

## Test plan

Tested manually, and covered by unit test