### PR TITLE
FilteredConnection: set <select> option as selected if value is in URL

### DIFF
--- a/client/web/src/components/FilteredConnection/FilterControl.tsx
+++ b/client/web/src/components/FilteredConnection/FilterControl.tsx
@@ -96,7 +96,12 @@ export const FilterControl: React.FunctionComponent<React.PropsWithChildren<Filt
                                     className="mb-0"
                                 >
                                     {filter.values.map(value => (
-                                        <option key={value.value} value={value.value} label={value.label} />
+                                        <option
+                                            key={value.value}
+                                            value={value.value}
+                                            label={value.label}
+                                            selected={values.get(filter.id)?.value === value.value}
+                                        />
                                     ))}
                                 </Select>
                             </div>


### PR DESCRIPTION
This fixes `<Select />` by displaying the selected option when `?filter=<option>` is given in the URL.

It worked for `radio` before, which does the same thing as I do in the `selected={}` here.

Before:
<img width="480" alt="screenshot_2022-08-02_14 18 17@2x" src="https://user-images.githubusercontent.com/1185253/182372707-3c553a94-011a-4135-b005-8aa2eb7480cf.png">

After:

<img width="388" alt="screenshot_2022-08-02_14 17 39@2x" src="https://user-images.githubusercontent.com/1185253/182372661-570a3488-39fe-4b9c-8d54-3a6a8d77f3df.png">


## Test plan

- Manual testing

## App preview:

- [Web](https://sg-web-mrn-fix-filt-conn-select.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mjivmhfgnw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
