### PR TITLE
release: update the config for 3.43

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -11,15 +11,15 @@
 {
     // Captain information
     // To get your slack username, navigate to Profile -> More -> Account settings -> Username (at the bottom) -> Expand
-    "captainSlackUsername": "Idan",
-    "captainGitHubUsername": "varsanojidan",
+    "captainSlackUsername": "coury",
+    "captainGitHubUsername": "coury-clark   ",
     // Release versions
-    "previousRelease": "3.42.0",
-    "upcomingRelease": "3.42.1",
-    "oneWorkingWeekBeforeRelease": "21 July 2022 10:00 PST",
-    "threeWorkingDaysBeforeRelease": "25 July 2022 10:00 PST",
-    "releaseDate": "28 July 2022 10:00 PST",
-    "oneWorkingDayAfterRelease": "29 July 2022 10:00 PST",
+    "previousRelease": "3.42.1",
+    "upcomingRelease": "3.43.0",
+    "oneWorkingWeekBeforeRelease": "15 August 2022 10:00 PST",
+    "threeWorkingDaysBeforeRelease": "17 August 2022 10:00 PST",
+    "releaseDate": "22 August 2022 10:00 PST",
+    "oneWorkingDayAfterRelease": "23 August 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "eng-announce",
     // Email for preparing calendar events


### PR DESCRIPTION
I was just passing by, wanted to take a look at the next release date and found that the config should be updated.

## Test plan
cfg change, no tests needed
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
