### PR TITLE
Remove code host rate limit critical alerts

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -3803,7 +3803,6 @@ with your code hosts connections or networking issues affecting communication wi
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: less than 250 remaining calls to GitHub graphql API before hitting the rate limit
-- <span class="badge badge-critical">critical</span> repo-updater: less than 250 remaining calls to GitHub graphql API before hitting the rate limit for 50m0s
 
 **Next steps**
 
@@ -3813,8 +3812,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 ```json
 "observability.silenceAlerts": [
-  "warning_repo-updater_github_graphql_rate_limit_remaining",
-  "critical_repo-updater_github_graphql_rate_limit_remaining"
+  "warning_repo-updater_github_graphql_rate_limit_remaining"
 ]
 ```
 
@@ -3829,7 +3827,6 @@ with your code hosts connections or networking issues affecting communication wi
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: less than 250 remaining calls to GitHub rest API before hitting the rate limit
-- <span class="badge badge-critical">critical</span> repo-updater: less than 250 remaining calls to GitHub rest API before hitting the rate limit for 50m0s
 
 **Next steps**
 
@@ -3839,8 +3836,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 ```json
 "observability.silenceAlerts": [
-  "warning_repo-updater_github_rest_rate_limit_remaining",
-  "critical_repo-updater_github_rest_rate_limit_remaining"
+  "warning_repo-updater_github_rest_rate_limit_remaining"
 ]
 ```
 
@@ -3855,7 +3851,6 @@ with your code hosts connections or networking issues affecting communication wi
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: less than 5 remaining calls to GitHub search API before hitting the rate limit
-- <span class="badge badge-critical">critical</span> repo-updater: less than 5 remaining calls to GitHub search API before hitting the rate limit for 50m0s
 
 **Next steps**
 
@@ -3865,8 +3860,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 ```json
 "observability.silenceAlerts": [
-  "warning_repo-updater_github_search_rate_limit_remaining",
-  "critical_repo-updater_github_search_rate_limit_remaining"
+  "warning_repo-updater_github_search_rate_limit_remaining"
 ]
 ```
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12047,7 +12047,7 @@ Query: `max(src_repoupdater_errored_sync_jobs_percentage)`
 
 <p class="subtitle">Remaining calls to GitHub graphql API before hitting the rate limit</p>
 
-Refer to the [alerts reference](./alerts.md#repo-updater-github-graphql-rate-limit-remaining) for 2 alerts related to this panel.
+Refer to the [alerts reference](./alerts.md#repo-updater-github-graphql-rate-limit-remaining) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100220` on your Sourcegraph instance.
 
@@ -12066,7 +12066,7 @@ Query: `max by (name) (src_github_rate_limit_remaining_v2{resource="graphql"})`
 
 <p class="subtitle">Remaining calls to GitHub rest API before hitting the rate limit</p>
 
-Refer to the [alerts reference](./alerts.md#repo-updater-github-rest-rate-limit-remaining) for 2 alerts related to this panel.
+Refer to the [alerts reference](./alerts.md#repo-updater-github-rest-rate-limit-remaining) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100221` on your Sourcegraph instance.
 
@@ -12085,7 +12085,7 @@ Query: `max by (name) (src_github_rate_limit_remaining_v2{resource="rest"})`
 
 <p class="subtitle">Remaining calls to GitHub search API before hitting the rate limit</p>
 
-Refer to the [alerts reference](./alerts.md#repo-updater-github-search-rate-limit-remaining) for 2 alerts related to this panel.
+Refer to the [alerts reference](./alerts.md#repo-updater-github-search-rate-limit-remaining) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100222` on your Sourcegraph instance.
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -393,11 +393,8 @@ func RepoUpdater() *monitoring.Dashboard {
 							Query:       `max by (name) (src_github_rate_limit_remaining_v2{resource="graphql"})`,
 							// 5% of initial limit of 5000
 							Warning: monitoring.Alert().LessOrEqual(250),
-							// Critical if most of a 60-minute reset window is spent below
-							// the threshold.
-							Critical: monitoring.Alert().LessOrEqual(250).For(50 * time.Minute),
-							Panel:    monitoring.Panel().LegendFormat("{{name}}"),
-							Owner:    monitoring.ObservableOwnerRepoManagement,
+							Panel:   monitoring.Panel().LegendFormat("{{name}}"),
+							Owner:   monitoring.ObservableOwnerRepoManagement,
 							NextSteps: `
 								- Consider creating a new token for the indicated resource (the 'name' label for series below the threshold in the dashboard) under a dedicated machine user to reduce rate limit pressure.
 							`,
@@ -408,11 +405,8 @@ func RepoUpdater() *monitoring.Dashboard {
 							Query:       `max by (name) (src_github_rate_limit_remaining_v2{resource="rest"})`,
 							// 5% of initial limit of 5000
 							Warning: monitoring.Alert().LessOrEqual(250),
-							// Critical if most of a 60-minute reset window is spent below
-							// the threshold.
-							Critical: monitoring.Alert().LessOrEqual(250).For(50 * time.Minute),
-							Panel:    monitoring.Panel().LegendFormat("{{name}}"),
-							Owner:    monitoring.ObservableOwnerRepoManagement,
+							Panel:   monitoring.Panel().LegendFormat("{{name}}"),
+							Owner:   monitoring.ObservableOwnerRepoManagement,
 							NextSteps: `
 								- Consider creating a new token for the indicated resource (the 'name' label for series below the threshold in the dashboard) under a dedicated machine user to reduce rate limit pressure.
 							`,
@@ -422,11 +416,8 @@ func RepoUpdater() *monitoring.Dashboard {
 							Description: "remaining calls to GitHub search API before hitting the rate limit",
 							Query:       `max by (name) (src_github_rate_limit_remaining_v2{resource="search"})`,
 							Warning:     monitoring.Alert().LessOrEqual(5),
-							// Critical if most of a 60-minute reset window is spent below
-							// the threshold.
-							Critical: monitoring.Alert().LessOrEqual(5).For(50 * time.Minute),
-							Panel:    monitoring.Panel().LegendFormat("{{name}}"),
-							Owner:    monitoring.ObservableOwnerRepoManagement,
+							Panel:       monitoring.Panel().LegendFormat("{{name}}"),
+							Owner:       monitoring.ObservableOwnerRepoManagement,
 							NextSteps: `
 								- Consider creating a new token for the indicated resource (the 'name' label for series below the threshold in the dashboard) under a dedicated machine user to reduce rate limit pressure.
 							`,


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/36434 to clean up critical alerts that are not worth waking a site admin up at night.

This alert get trigger quite frequently on managed instances, especially when customers are running large batch changes https://sourcegraph.slack.com/archives/C017SLJGA2Z/p1659432203371909

If we're running into rate limiting issue, we should instead show a warning notification from the admin UI.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI