### PR TITLE
[dotcom] Small changes to support killing of private code on dotcom

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -112,7 +112,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                 iconLinkTo={props.context.sourcegraphDotComMode ? '/search' : undefined}
                 iconClassName="bg-transparent"
                 lessPadding={true}
-                title={props.context.sourcegraphDotComMode ? 'Sign in to Sourcegraph Cloud' : 'Sign in to Sourcegraph'}
+                title={'Sign in to Sourcegraph Cloud'}
                 body={body}
             />
         </div>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -112,7 +112,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                 iconLinkTo={props.context.sourcegraphDotComMode ? '/search' : undefined}
                 iconClassName="bg-transparent"
                 lessPadding={true}
-                title={'Sign in to Sourcegraph Cloud'}
+                title="Sign in to Sourcegraph"
                 body={body}
             />
         </div>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -112,11 +112,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                 iconLinkTo={props.context.sourcegraphDotComMode ? '/search' : undefined}
                 iconClassName="bg-transparent"
                 lessPadding={true}
-                title={
-                    props.context.sourcegraphDotComMode
-                        ? 'Sign in to Sourcegraph Cloud'
-                        : 'Sign in to Sourcegraph Server'
-                }
+                title={props.context.sourcegraphDotComMode ? 'Sign in to Sourcegraph Cloud' : 'Sign in to Sourcegraph'}
                 body={body}
             />
         </div>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
       <h1
         class="h1 title"
       >
-        Sign in to Sourcegraph Server
+        Sign in to Sourcegraph
       </h1>
       <div
         class="mb-4 pb-5 signinPageContainer"

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
       <h1
         class="h1 title"
       >
-        Sign in to Sourcegraph Cloud
+        Sign in to Sourcegraph
       </h1>
       <div
         class="mb-4 pb-5 signinPageContainer"

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -339,7 +339,11 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
         const links = isSiteAdmin ? roleLinks.admin : roleLinks.nonAdmin
 
         // no status messages
-        if (Array.isArray(noActivityOrStatus) && noActivityOrStatus.length === 0) {
+        if (
+            !window.context.sourcegraphDotComMode &&
+            Array.isArray(noActivityOrStatus) &&
+            noActivityOrStatus.length === 0
+        ) {
             return (
                 <StatusMessagesNavItemEntry
                     key="up-to-date"
@@ -353,7 +357,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
         }
 
         // no code hosts or no repos
-        if (isNoActivityReason(noActivityOrStatus)) {
+        if (!window.context.sourcegraphDotComMode && isNoActivityReason(noActivityOrStatus)) {
             if (noActivityOrStatus === ExternalServiceNoActivityReasons.NoRepos) {
                 return (
                     <StatusMessagesNavItemEntry

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -357,7 +357,10 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
         }
 
         // no code hosts or no repos
-        if (!window.context.sourcegraphDotComMode && isNoActivityReason(noActivityOrStatus)) {
+        if (isNoActivityReason(noActivityOrStatus)) {
+            if (window.context.sourcegraphDotComMode) {
+                return []
+            }
             if (noActivityOrStatus === ExternalServiceNoActivityReasons.NoRepos) {
                 return (
                     <StatusMessagesNavItemEntry


### PR DESCRIPTION
# Screenshot

<img width="358" alt="Screenshot 2022-08-02 at 14 45 25" src="https://user-images.githubusercontent.com/9974711/182392726-63e83851-9006-4911-b54e-3ca12b82ad63.png">
resolves: #39266

Another change, that was thrown into this PR:
https://sourcegraph.slack.com/archives/C03D4H7UBEV/p1658872943783169?thread_ts=1658524781.528869&cid=C03D4H7UBEV

## Test plan

Tested locally.

## App preview:

- [Web](https://sg-web-milan-dotcom-winddown.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pdfadlcfsb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
