### PR TITLE
monitoring: limit error rate panel to value of 100%

### DIFF
--- a/monitoring/definitions/shared/standard.go
+++ b/monitoring/definitions/shared/standard.go
@@ -136,7 +136,7 @@ func (standardConstructor) ErrorRate(legend string) observableConstructor {
 				Description: fmt.Sprintf("%s%s error rate over 5m", options.MetricDescriptionRoot, legend),
 				Query: fmt.Sprintf(`sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m])) / (sum%[1]s(increase(src_%[2]s_total{%[3]s}[5m])) + sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m]))) * 100`,
 					by, options.MetricNameRoot, filters),
-				Panel: monitoring.Panel().LegendFormat(fmt.Sprintf("%s%s error rate", legendPrefix, legend)).With(monitoring.PanelOptions.ZeroIfNoData(options.By...)).Unit(monitoring.Percentage).Max(200),
+				Panel: monitoring.Panel().LegendFormat(fmt.Sprintf("%s%s error rate", legendPrefix, legend)).With(monitoring.PanelOptions.ZeroIfNoData(options.By...)).Unit(monitoring.Percentage).Max(100),
 				Owner: owner,
 			}
 		}


### PR DESCRIPTION
Updates RED metrics error rate panel generator to limit display to 100% instead of 200%

## Test plan

N/A, updating grafana queries
