### PR TITLE
note insights *is* on cloud now

### DIFF
--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
@@ -143,7 +143,6 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<
                         <Card as={CardBody} className={styles.installLocallyRequirements}>
                             <H3>Code Insights requirements</H3>
                             <ul className={styles.installLocallyRequirementsList}>
-                                <li>On-prem installation</li>
                                 <li>Create up to 2 code insights for free</li>
                                 <li>Get unlimited insights with an Enterprise plan (or trial)</li>
                             </ul>


### PR DESCRIPTION

Need to remove the old cloud bullet point so prospects don't (incorrectly) think we are not – this information is outdated. 

## Test plan

Reviewed on deploy, small text change. 

## App preview:

- [Web](https://sg-web-fix-cloud-mention.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rjxxiawubk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
