### PR TITLE
dev/sg/check: deduplicate checks by setting Enabled() to error

### DIFF
--- a/dev/sg/internal/check/category.go
+++ b/dev/sg/internal/check/category.go
@@ -8,7 +8,8 @@ import (
 
 // Check can be defined for Runner to execute as part of a Category.
 type Check[Args any] struct {
-	// Name is used to identify this Check.
+	// Name is used to identify this Check. It must be unique across categories when used
+	// with Runner, otherwise duplicate Checks are set to be skipped.
 	Name string
 	// Description can be used to provide additional context and manual fix instructions.
 	Description string


### PR DESCRIPTION
If multiple Checks, even across categories, have the same name, we override Enabled() to always return an error so that they are skipped.

## Test plan

Unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
