### PR TITLE
dev/ci: migrate prettier to fixable sg lint

### DIFF
--- a/dev/sg/internal/check/category.go
+++ b/dev/sg/internal/check/category.go
@@ -8,7 +8,8 @@ import (
 
 // Check can be defined for Runner to execute as part of a Category.
 type Check[Args any] struct {
-	// Name is used to identify this Check.
+	// Name is used to identify this Check. It must be unique across categories when used
+	// with Runner, otherwise duplicate Checks are set to be skipped.
 	Name string
 	// Description can be used to provide additional context and manual fix instructions.
 	Description string

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -2,7 +2,9 @@
 package linters
 
 import (
+	"bytes"
 	"context"
+	"io"
 
 	"github.com/sourcegraph/run"
 
@@ -48,6 +50,7 @@ var Targets = []Target{
 		Description: "Documentation checks",
 		Checks: []*linter{
 			runScript("Docsite lint", "dev/docsite.sh check"),
+			prettier,
 		},
 	},
 	{
@@ -66,6 +69,7 @@ var Targets = []Target{
 			inlineTemplates,
 			runScript("Yarn duplicate", "dev/check/yarn-deduplicate.sh"),
 			checkUnversionedDocsLinks(),
+			prettier,
 		},
 	},
 	{
@@ -101,5 +105,28 @@ func runCheck(name string, check check.CheckAction[*repo.State]) *linter {
 	return &linter{
 		Name:  name,
 		Check: check,
+	}
+}
+
+// yarnInstallFilter is a LineMap that filters out all the warning junk that yarn install
+// emits that seem inconsequential, for example:
+//
+// 	warning "@storybook/addon-storyshots > react-test-renderer@16.14.0" has incorrect peer dependency "react@^16.14.0".
+// 	warning "@storybook/addon-storyshots > @storybook/core > @storybook/core-server > @storybook/builder-webpack4 > webpack-filter-warnings-plugin@1.2.1" has incorrect peer dependency "webpack@^2.0.0 || ^3.0.0 || ^4.0.0".
+// 	warning " > @storybook/react@6.5.9" has unmet peer dependency "require-from-string@^2.0.2".
+// 	warning "@storybook/react > react-element-to-jsx-string@14.3.4" has incorrect peer dependency "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
+// 	warning " > @testing-library/react-hooks@8.0.0" has incorrect peer dependency "react@^16.9.0 || ^17.0.0".
+// 	warning "storybook-addon-designs > @figspec/react@1.0.0" has incorrect peer dependency "react@^16.14.0 || ^17.0.0".
+// 	warning Workspaces can only be enabled in private projects.
+// 	warning Workspaces can only be enabled in private projects.
+//
+func yarnInstallFilter() run.LineMap {
+	return func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+		// We can't seem to do a simple prefix check, so let's just do something lazy for
+		// now and figure it out later if it's an issue.
+		if bytes.Contains(line, []byte("warning")) {
+			return 0, nil
+		}
+		return dst.Write(line)
 	}
 }

--- a/dev/sg/linters/prettier.go
+++ b/dev/sg/linters/prettier.go
@@ -1,0 +1,27 @@
+package linters
+
+import (
+	"context"
+
+	"github.com/sourcegraph/run"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/check"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+)
+
+var prettier = &linter{
+	Name: "Prettier",
+	// TODO unfortunate that we have to use 'dev/ci/yarn-run.sh'
+	Check: func(ctx context.Context, out *std.Output, args *repo.State) error {
+		return root.Run(run.Cmd(ctx, "dev/ci/yarn-run.sh format:check")).
+			Map(yarnInstallFilter()).
+			StreamLines(out.Write)
+	},
+	Fix: func(ctx context.Context, cio check.IO, args *repo.State) error {
+		return root.Run(run.Cmd(ctx, "dev/ci/yarn-run.sh format")).
+			Map(yarnInstallFilter()).
+			StreamLines(cio.Write)
+	},
+}

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -17,6 +17,12 @@ var generateAnnotations = &cli.BoolFlag{
 	Usage: "Write helpful output to ./annotations directory",
 }
 
+var lintFixFlag = &cli.BoolFlag{
+	Name:    "fix",
+	Aliases: []string{"f"},
+	Usage:   "Try to fix any lint issues",
+}
+
 var lintCommand = &cli.Command{
 	Name:        "lint",
 	ArgsUsage:   "[targets...]",
@@ -41,11 +47,7 @@ sg lint --help
 	Category: CategoryDev,
 	Flags: []cli.Flag{
 		generateAnnotations,
-		&cli.BoolFlag{
-			Name:    "fix",
-			Aliases: []string{"f"},
-			Usage:   "Try to fix any lint issues",
-		},
+		lintFixFlag,
 	},
 	Before: func(cmd *cli.Context) error {
 		// If more than 1 target is requested, hijack subcommands by setting it to nil
@@ -86,11 +88,12 @@ sg lint --help
 			return errors.Wrap(err, "repo.GetState")
 		}
 
-		std.Out.WriteNoticef("Running checks from targets: %s", strings.Join(targets, ", "))
 		runner := linters.NewRunner(std.Out, generateAnnotations.Get(cmd), lintTargets...)
 		if cmd.Bool("fix") {
+			std.Out.WriteNoticef("Fixing checks from targets: %s", strings.Join(targets, ", "))
 			return runner.Fix(cmd.Context, repoState)
 		}
+		std.Out.WriteNoticef("Running checks from targets: %s", strings.Join(targets, ", "))
 		return runner.Check(cmd.Context, repoState)
 	},
 	Subcommands: lintTargets(linters.Targets).Commands(),
@@ -116,9 +119,13 @@ func (lt lintTargets) Commands() (cmds []*cli.Command) {
 					return errors.Wrap(err, "repo.GetState")
 				}
 
+				runner := linters.NewRunner(std.Out, generateAnnotations.Get(cmd), target)
+				if lintFixFlag.Get(cmd) {
+					std.Out.WriteNoticef("Fixing checks from target: %s", target.Name)
+					return runner.Fix(cmd.Context, repoState)
+				}
 				std.Out.WriteNoticef("Running checks from target: %s", target.Name)
-				return linters.NewRunner(std.Out, generateAnnotations.Get(cmd), target).
-					Check(cmd.Context, repoState)
+				return runner.Check(cmd.Context, repoState)
 			},
 			// Completions to chain multiple commands
 			BashComplete: completeOptions(func() (options []string) {

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -15,59 +15,59 @@ For a higher-level overview, please refer to the [continuous integration docs](h
 The default run type.
 
 - Pipeline for `Go` changes:
-  - **Linters and static analysis**: Prettier, Run sg lint
+  - **Linters and static analysis**: Run sg lint
   - **Go checks**: Test (all), Test (internal/codeintel/stores/dbstore), Test (internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
   - Upload build trace
 
 - Pipeline for `Client` changes:
-  - **Linters and static analysis**: Prettier, Run sg lint
+  - **Linters and static analysis**: Run sg lint
   - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Test (client/jetbrains), Build TS, ESLint (all), Stylelint (all)
   - **Pipeline setup**: Trigger async
   - Client PR preview
   - Upload build trace
 
 - Pipeline for `GraphQL` changes:
-  - **Linters and static analysis**: Prettier, GraphQL lint
+  - **Linters and static analysis**: GraphQL lint
   - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Test (client/jetbrains), Build TS, ESLint (all), Stylelint (all)
   - **Go checks**: Test (all), Test (internal/codeintel/stores/dbstore), Test (internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
   - Upload build trace
 
 - Pipeline for `DatabaseSchema` changes:
-  - **Linters and static analysis**: Prettier
+  - **Linters and static analysis**: 
   - **DB backcompat tests**: Backcompat test (all), Backcompat test (internal/codeintel/stores/dbstore), Backcompat test (internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
   - Upload build trace
 
 - Pipeline for `Docs` changes:
-  - **Linters and static analysis**: Prettier, Run sg lint
+  - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `Dockerfiles` changes:
-  - **Linters and static analysis**: Prettier, Run sg lint
+  - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `ExecutorDockerRegistryMirror` changes:
-  - **Linters and static analysis**: Prettier
+  - **Linters and static analysis**: 
   - Upload build trace
 
 - Pipeline for `CIScripts` changes:
-  - **Linters and static analysis**: Prettier
+  - **Linters and static analysis**: 
   - **CI script tests**: test-trace-command.sh
   - Upload build trace
 
 - Pipeline for `Terraform` changes:
-  - **Linters and static analysis**: Prettier
+  - **Linters and static analysis**: 
   - Upload build trace
 
 - Pipeline for `SVG` changes:
-  - **Linters and static analysis**: Prettier, Run sg lint
+  - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `Shell` changes:
-  - **Linters and static analysis**: Prettier, Run sg lint
+  - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `DockerImages` changes:
-  - **Linters and static analysis**: Prettier
+  - **Linters and static analysis**: 
   - **Test builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build opentelemetry-collector, Build server, Build sg
   - **Scan test builds**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan opentelemetry-collector, Scan server, Scan sg
   - Upload build trace
@@ -116,7 +116,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build opentelemetry-collector, Build server, Build sg
 - **Image security scans**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan opentelemetry-collector, Scan server, Scan sg
-- **Linters and static analysis**: Prettier, GraphQL lint, Run sg lint
+- **Linters and static analysis**: GraphQL lint, Run sg lint
 - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Test (client/jetbrains), Build TS, ESLint (all), Stylelint (all)
 - **Go checks**: Test (all), Test (internal/codeintel/stores/dbstore), Test (internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (internal/codeintel/stores/dbstore), Backcompat test (internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
@@ -135,7 +135,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build opentelemetry-collector, Build server, Build sg, Build executor image, Build docker registry mirror image
 - **Image security scans**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan opentelemetry-collector, Scan server, Scan sg
-- **Linters and static analysis**: Prettier, GraphQL lint, Run sg lint
+- **Linters and static analysis**: GraphQL lint, Run sg lint
 - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Test (client/jetbrains), Build TS, ESLint (all), Stylelint (all)
 - **Go checks**: Test (all), Test (internal/codeintel/stores/dbstore), Test (internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (internal/codeintel/stores/dbstore), Backcompat test (internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
@@ -184,7 +184,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build opentelemetry-collector, Build server, Build sg, Build executor image
 - **Image security scans**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan opentelemetry-collector, Scan server, Scan sg
-- **Linters and static analysis**: Prettier, GraphQL lint, Run sg lint
+- **Linters and static analysis**: GraphQL lint, Run sg lint
 - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Test (client/jetbrains), Build TS, ESLint (all), Stylelint (all)
 - **Go checks**: Test (all), Test (internal/codeintel/stores/dbstore), Test (internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (internal/codeintel/stores/dbstore), Backcompat test (internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
@@ -208,7 +208,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build opentelemetry-collector, Build server, Build sg, Build executor image
 - **Image security scans**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan opentelemetry-collector, Scan server, Scan sg
-- **Linters and static analysis**: Prettier, GraphQL lint, Run sg lint
+- **Linters and static analysis**: GraphQL lint, Run sg lint
 - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Test (client/jetbrains), Build TS, ESLint (all), Stylelint (all)
 - **Go checks**: Test (all), Test (internal/codeintel/stores/dbstore), Test (internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (internal/codeintel/stores/dbstore), Backcompat test (internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
@@ -309,7 +309,7 @@ Base pipeline (more steps might be included based on branch changes):
 
 - Build server
 - Backend integration tests
-- **Linters and static analysis**: Prettier, Run sg lint
+- **Linters and static analysis**: Run sg lint
 - **Go checks**: Test (all), Test (internal/codeintel/stores/dbstore), Test (internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (internal/codeintel/stores/dbstore), Backcompat test (internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
 - Upload build trace

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -43,10 +43,7 @@ func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *oper
 	ops := operations.NewSet()
 
 	// Simple, fast-ish linter checks
-	linterOps := operations.NewNamedSet("Linters and static analysis",
-		// lightweight check that works over a lot of stuff - we are okay with running
-		// these on all PRs
-		addPrettier)
+	linterOps := operations.NewNamedSet("Linters and static analysis")
 	if diff.Has(changed.GraphQL) {
 		linterOps.Append(addGraphQLLint)
 	}


### PR DESCRIPTION
Today the prettier check just returns a vague "have you run prettier yet" with no indication as to how we are supposed to run prettier. This migrates it to sg lint so that we can recommend a fix, and also remove a CI job.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/23356519/182432247-040bc8ba-2053-4be6-a3f8-6522cfdc0558.png">

<img width="714" alt="image" src="https://user-images.githubusercontent.com/23356519/182432758-b13f3f40-f10c-4a3c-98f3-46625128bc4d.png">

<img width="770" alt="image" src="https://user-images.githubusercontent.com/23356519/182434128-0ff50969-b912-478d-a827-962bf0e2b3f2.png">
