### PR TITLE
Defining handler for webhook build worker

### DIFF
--- a/internal/repos/testdata/vcr/webhook-build-handler.yaml
+++ b/internal/repos/testdata/vcr/webhook-build-handler.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://ghe.sgdev.org/api/v3/repos/milton/test/hooks
     method: GET
   response:
-    body: '[{"type":"Repository","id":112,"name":"web","active":true,"events":["push"],"config":{"content_type":"json","insecure_ssl":"0","secret":"********","url":"https://example.com/github-webhooks"},"updated_at":"2022-07-26T13:52:51Z","created_at":"2022-07-26T13:52:51Z","url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/112","test_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/112/test","ping_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/112/pings","deliveries_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/112/deliveries","last_response":{"code":404,"status":"missing","message":"Invalid
+    body: '[{"type":"Repository","id":113,"name":"web","active":true,"events":["push"],"config":{"content_type":"json","insecure_ssl":"0","secret":"********","url":"https://example.com/github-webhooks"},"updated_at":"2022-08-04T10:58:33Z","created_at":"2022-08-04T10:58:33Z","url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113","test_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113/test","ping_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113/pings","deliveries_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113/deliveries","last_response":{"code":404,"status":"missing","message":"Invalid
       HTTP Response: 404"}}]'
     headers:
       Access-Control-Allow-Origin:
@@ -30,9 +30,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 02 Aug 2022 16:20:58 GMT
+      - Thu, 04 Aug 2022 11:00:51 GMT
       Etag:
-      - W/"dda4e239df7de2b18f9687a65d534b830b1a76575b684b58da99a01cee344f97"
+      - W/"8e1530ebe817e96a6dde15b958930e2194bfe0f98a7d968d5ce17f9e4269dd85"
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -51,9 +51,9 @@ interactions:
       - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
         format=json
       X-Github-Request-Id:
-      - 82363d0e-ac96-4d63-9264-b49371e60347
+      - 2bcc81c9-32a7-47b0-8970-d7ae99009fa6
       X-Runtime-Rack:
-      - "0.059898"
+      - "0.055444"
       X-Varied-Accept:
       - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
       X-Xss-Protection:

--- a/internal/repos/testdata/vcr/webhook-build-handler.yaml
+++ b/internal/repos/testdata/vcr/webhook-build-handler.yaml
@@ -1,0 +1,63 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://ghe.sgdev.org/api/v3/repos/milton/test/hooks
+    method: GET
+  response:
+    body: '[{"type":"Repository","id":112,"name":"web","active":true,"events":["push"],"config":{"content_type":"json","insecure_ssl":"0","secret":"********","url":"https://example.com/github-webhooks"},"updated_at":"2022-07-26T13:52:51Z","created_at":"2022-07-26T13:52:51Z","url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/112","test_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/112/test","ping_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/112/pings","deliveries_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/112/deliveries","last_response":{"code":404,"status":"missing","message":"Invalid
+      HTTP Response: 404"}}]'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 02 Aug 2022 16:20:58 GMT
+      Etag:
+      - W/"dda4e239df7de2b18f9687a65d534b830b1a76575b684b58da99a01cee344f97"
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Enterprise-Version:
+      - 3.3.0
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - 82363d0e-ac96-4d63-9264-b49371e60347
+      X-Runtime-Rack:
+      - "0.059898"
+      X-Varied-Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/repos/testdata/vcr/webhook-build-handler.yaml
+++ b/internal/repos/testdata/vcr/webhook-build-handler.yaml
@@ -13,7 +13,9 @@ interactions:
     url: https://ghe.sgdev.org/api/v3/repos/milton/test/hooks
     method: GET
   response:
-    body: '[{"type":"Repository","id":113,"name":"web","active":true,"events":["push"],"config":{"content_type":"json","insecure_ssl":"0","secret":"********","url":"https://example.com/github-webhooks"},"updated_at":"2022-08-04T10:58:33Z","created_at":"2022-08-04T10:58:33Z","url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113","test_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113/test","ping_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113/pings","deliveries_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113/deliveries","last_response":{"code":404,"status":"missing","message":"Invalid
+    body: '[{"type":"Repository","id":113,"name":"web","active":true,"events":["push"],"config":{"url":"https://example.com/github-webhooks","content_type":"json","secret":"********","insecure_ssl":"0"},"updated_at":"2022-08-04T10:58:33Z","created_at":"2022-08-04T10:58:33Z","url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113","test_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113/test","ping_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113/pings","deliveries_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/113/deliveries","last_response":{"code":404,"status":"missing","message":"Invalid
+      HTTP Response: 404"}},{"type":"Repository","id":114,"name":"web","active":true,"events":["push"],"config":{"url":"https://example.com/github-webhooks","content_type":"json","secret":"********","insecure_ssl":"0"},"updated_at":"2022-08-04T11:05:51Z","created_at":"2022-08-04T11:05:51Z","url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/114","test_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/114/test","ping_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/114/pings","deliveries_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/114/deliveries","last_response":{"code":404,"status":"missing","message":"Invalid
+      HTTP Response: 404"}},{"type":"Repository","id":115,"name":"web","active":true,"events":["push"],"config":{"url":"https://example.com/github-webhooks","content_type":"json","secret":"********","insecure_ssl":"0"},"updated_at":"2022-08-04T11:12:49Z","created_at":"2022-08-04T11:12:49Z","url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/115","test_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/115/test","ping_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/115/pings","deliveries_url":"https://ghe.sgdev.org/api/v3/repos/milton/test/hooks/115/deliveries","last_response":{"code":404,"status":"missing","message":"Invalid
       HTTP Response: 404"}}]'
     headers:
       Access-Control-Allow-Origin:
@@ -30,9 +32,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Aug 2022 11:00:51 GMT
+      - Thu, 04 Aug 2022 11:13:04 GMT
       Etag:
-      - W/"8e1530ebe817e96a6dde15b958930e2194bfe0f98a7d968d5ce17f9e4269dd85"
+      - W/"507295438187422b859340b4c8a022eae2c1eeadc81eb16ee18cd6d772fe03aa"
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -51,9 +53,9 @@ interactions:
       - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
         format=json
       X-Github-Request-Id:
-      - 2bcc81c9-32a7-47b0-8970-d7ae99009fa6
+      - 836967a3-0e52-4db4-8b6d-644e3db15ec5
       X-Runtime-Rack:
-      - "0.055444"
+      - "0.054841"
       X-Varied-Accept:
       - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
       X-Xss-Protection:

--- a/internal/repos/webhook_build_handler.go
+++ b/internal/repos/webhook_build_handler.go
@@ -87,7 +87,7 @@ func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.L
 
 	if !webhookExists(conn.Webhooks, job.Org) {
 		if err := addSecretToExtSvc(svc, conn, job.Org, secret); err != nil {
-			return errcode.MakeNonRetryable(errors.Wrap(err, "handleKindGitHub: Marshal failed"))
+			return errcode.MakeNonRetryable(errors.Wrap(err, "handleKindGitHub: addSecretToExtSvc failed"))
 		}
 	}
 

--- a/internal/repos/webhook_build_handler.go
+++ b/internal/repos/webhook_build_handler.go
@@ -69,7 +69,7 @@ func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.L
 
 	client := github.NewV3Client(logger, svc.URN(), baseURL, &auth.OAuthBearerToken{Token: conn.Token}, w.doer)
 	id, err := client.FindSyncWebhook(ctx, job.RepoName) // TODO: Don't make API calls every time
-	if err != nil {
+	if err != nil && err.Error() != "unable to find webhook" {
 		return errors.Wrap(err, "handleKindGitHub: FindSyncWebhook failed")
 	}
 
@@ -94,7 +94,7 @@ func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.L
 		return errcode.MakeNonRetryable(errors.Wrap(err, "handleKindGitHub: Marshal failed"))
 	}
 
-	id, err = client.CreateSyncWebhook(ctx, job.RepoName, globals.ExternalURL().Host, secret) // TODO: Add to DB
+	id, err = client.CreateSyncWebhook(ctx, job.RepoName, fmt.Sprintf("https://%s", globals.ExternalURL().Host), secret) // TODO: Add to DB
 	if err != nil {
 		return errors.Wrap(err, "handleKindGitHub: CreateSyncWebhook failed")
 	}

--- a/internal/repos/webhook_build_handler.go
+++ b/internal/repos/webhook_build_handler.go
@@ -2,21 +2,129 @@ package repos
 
 import (
 	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/url"
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	webhookworker "github.com/sourcegraph/sourcegraph/internal/repos/webhookworker"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type webhookBuildHandler struct {
 	store Store
+	doer  httpcli.Doer
 }
 
-func newWebhookBuildHandler(store Store) *webhookBuildHandler {
-	return &webhookBuildHandler{store: store}
+func newWebhookBuildHandler(store Store, doer httpcli.Doer) *webhookBuildHandler {
+	return &webhookBuildHandler{store: store, doer: doer}
 }
 
 func (w *webhookBuildHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) error {
-	return errors.New("TODO")
+	job, ok := record.(*webhookworker.Job)
+	if !ok {
+		return errors.Newf("expected Job, got %T", record)
+	}
+
+	switch job.ExtSvcKind {
+	case extsvc.KindGitHub:
+		return w.handleKindGitHub(ctx, logger, job)
+	}
+
+	return nil
+}
+
+func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.Logger, job *webhookworker.Job) error {
+	extsvc, err := w.store.ExternalServiceStore().GetByID(ctx, job.ExtSvcID)
+	if err != nil {
+		return errors.Wrap(err, "handleKindGitHub: get external service failed")
+	}
+
+	token, err := extractTokenFromConfig(extsvc)
+	if err != nil {
+		return errors.Wrap(err, "handleKindGitHub: extractTokenFromConfig failed")
+	}
+
+	baseURL, err := url.Parse("")
+	if err != nil {
+		return errors.Wrap(err, "handleKindGitHub: parse baseURL failed")
+	}
+
+	client := github.NewV3Client(logger, extsvc.URN(), baseURL, &auth.OAuthBearerToken{Token: token}, w.doer)
+	id, err := client.FindSyncWebhook(ctx, job.RepoName) // TODO: Don't make API calls every time
+	if err != nil {
+		return errors.Wrap(err, "handleKindGitHub: FindSyncWebhook failed")
+	}
+
+	// found the webhook
+	// don't build a new one
+	if id != 0 {
+		logger.Info(fmt.Sprintf("Webhook exists with ID: %d", id))
+		return nil
+	}
+
+	secret := randomHex(32)
+	if err := addSecretToExtSvc(extsvc, job.Org, secret); err != nil {
+		return errors.Wrap(err, "handleKindGitHub: add secret to external service failed")
+	}
+
+	id, err = client.CreateSyncWebhook(ctx, job.RepoName, globals.ExternalURL().Host, secret) // TODO: Add to DB
+	if err != nil {
+		return errors.Wrap(err, "handleKindGitHub: CreateSyncWebhook failed")
+	}
+
+	logger.Info(fmt.Sprintf("Created webhook with ID: %d", id))
+	return nil
+}
+
+func extractTokenFromConfig(extsvc *types.ExternalService) (string, error) {
+	var conn schema.GitHubConnection
+	if err := json.Unmarshal([]byte(extsvc.Config), &conn); err != nil {
+		return "", err
+	}
+
+	return conn.Token, nil
+}
+
+func randomHex(n int) string {
+	r := make([]byte, n/2)
+	_, err := rand.Read(r)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return hex.EncodeToString(r)
+}
+
+func addSecretToExtSvc(extsvc *types.ExternalService, org, secret string) error {
+	var config schema.GitHubConnection
+	err := json.Unmarshal([]byte(extsvc.Config), &config)
+	if err != nil {
+		return errors.Wrap(err, "addSecretToExtSvc: Unmarshal failed")
+	}
+
+	config.Webhooks = append(config.Webhooks, &schema.GitHubWebhook{
+		Org: org, Secret: secret,
+	})
+
+	newConfig, err := json.Marshal(config)
+	if err != nil {
+		return errors.Wrap(err, "addSecretToExtSvc: Marshal failed")
+	}
+
+	extsvc.Config = string(newConfig)
+
+	return nil
 }

--- a/internal/repos/webhook_build_handler_test.go
+++ b/internal/repos/webhook_build_handler_test.go
@@ -1,0 +1,93 @@
+package repos
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
+	"github.com/sourcegraph/sourcegraph/internal/repos/webhookworker"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestWebhookBuildHandle(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+
+	token := os.Getenv("ACCESS_TOKEN")
+
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := NewStore(logger, db)
+	esStore := store.ExternalServiceStore()
+	repoStore := store.RepoStore()
+
+	repo := &types.Repo{
+		ID:       1,
+		Name:     api.RepoName("ghe.sgdev.org/milton/test"),
+		Metadata: &github.Repository{},
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          "12345",
+			ServiceID:   "https://ghe.sgdev.org",
+			ServiceType: extsvc.TypeGitHub,
+		},
+	}
+	if err := repoStore.Create(ctx, repo); err != nil {
+		t.Fatal(err)
+	}
+
+	ghConn := &schema.GitHubConnection{
+		Url:      extsvc.KindGitHub,
+		Token:    token,
+		Repos:    []string{string(repo.Name)},
+		Webhooks: []*schema.GitHubWebhook{{Org: "ghe.sgdev.org", Secret: "secret"}},
+	}
+
+	configData, err := json.Marshal(ghConn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := string(configData)
+	svc := &types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "TestService",
+		Config:      config,
+	}
+	if err := esStore.Upsert(ctx, svc); err != nil {
+		t.Fatal(err)
+	}
+
+	job := &webhookworker.Job{
+		RepoID:     int32(repo.ID),
+		RepoName:   string(repo.Name),
+		Org:        strings.Split(string(repo.Name), "/")[0],
+		ExtSvcID:   svc.ID,
+		ExtSvcKind: svc.Kind,
+	}
+
+	testName := "webhook-build-handler"
+	cf, save := httptestutil.NewGitHubRecorderFactory(t, update(testName), testName)
+	defer save()
+
+	opts := []httpcli.Opt{}
+	doer, err := cf.Doer(opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := newWebhookBuildHandler(store, doer)
+	if err := handler.Handle(ctx, logger, job); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/repos/webhook_build_handler_test.go
+++ b/internal/repos/webhook_build_handler_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/joho/godotenv"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -26,9 +25,6 @@ func TestWebhookBuildHandle(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
-	if err := godotenv.Load("./.env"); err != nil {
-		t.Fatal(err)
-	}
 	token := os.Getenv("GITHUB_TOKEN")
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))

--- a/internal/repos/webhook_build_handler_test.go
+++ b/internal/repos/webhook_build_handler_test.go
@@ -25,7 +25,7 @@ func TestWebhookBuildHandle(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
-	token := os.Getenv("ACCESS_TOKEN")
+	token := os.Getenv("GITHUB_TOKEN")
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := NewStore(logger, db)

--- a/internal/repos/webhook_build_handler_test.go
+++ b/internal/repos/webhook_build_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/joho/godotenv"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -25,6 +26,9 @@ func TestWebhookBuildHandle(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
+	if err := godotenv.Load("./.env"); err != nil {
+		t.Fatal(err)
+	}
 	token := os.Getenv("GITHUB_TOKEN")
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))


### PR DESCRIPTION
This handler handles records for when a webhookBuildJob is dequeued. This PR contains:

- definition of the handler `webhook_build_handler.go`
- unit test for the handler `webhook_build_handler_test.go`
- vcr file for testing

This PR is built on top of the DB schema in this [PR](https://github.com/sourcegraph/sourcegraph/pull/39798) which also has a lot of comments resolved already, and the Job in this [PR](https://github.com/sourcegraph/sourcegraph/pull/39506).

## Test plan
go test-run TestWebhookBuildHandle