### PR TITLE
compute streaming api close channel on query parsing errors

### DIFF
--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -10,6 +10,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	streamclient "github.com/sourcegraph/sourcegraph/internal/search/streaming/client"
@@ -63,6 +64,18 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	computeQuery, err := compute.Parse(args.Query)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	searchQuery, err := computeQuery.ToSearchQuery()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	progress := &streamclient.ProgressAggregator{
 		Start:     start,
 		RepoNamer: streamclient.RepoNamer(ctx, h.db),
@@ -80,7 +93,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Log events to trace
 	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
 
-	events, getResults := NewComputeStream(ctx, h.logger, h.db, args.Query)
+	events, getResults := NewComputeStream(ctx, h.logger, h.db, searchQuery, computeQuery.Command)
 	events = batchEvents(events, 50*time.Millisecond)
 
 	// Store marshalled matches and flush periodically or when we go over


### PR DESCRIPTION
In the streaming endpoint when the parsing of the query errored a nil channel was returned which was blocking and caused the endpoint to hang. 

closes https://github.com/sourcegraph/sourcegraph/issues/39835
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Without a pattern
```
GET 'https://sourcegraph.test:3443/.api/compute/stream?q=select:file count:all patternType:literal repo:^github.com/sourcegraph/sourcegraph$' 
```

```
HTTP/2 500
compute endpoint expects nonempty pattern
```

With a pattern
```
GET 'https://sourcegraph.test:3443/.api/compute/stream' --data-urlencode 'q=select:file count:all patternType:literal repo:^github.com/sourcegraph/sourcegraph$ hasapattern' 
```

```
event: progress
data: {"done":true,"matchCount":0,"durationMs":9,"skipped":[]}

event: done
data: {}
```