### PR TITLE
search: highlight repo:has.description match ranges

### DIFF
--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -126,11 +126,15 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
             const visibleDescription = containerElement.current.querySelector('small em')
             if (visibleDescription) {
                 for (const range of result.descriptionMatches) {
-                    highlightNode(visibleDescription as HTMLElement, range.start.offset, range.end.offset - range.start.offset)
+                    highlightNode(
+                        visibleDescription as HTMLElement,
+                        range.start.column,
+                        range.end.column - range.start.column
+                    )
                 }
             }
         }
-    }, [result.description, result.descriptionMatches])
+    }, [result.description, result.descriptionMatches, containerElement])
 
     return (
         <ResultContainer

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 
 import { mdiSourceFork, mdiArchive, mdiLock } from '@mdi/js'
 import classNames from 'classnames'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
+import { highlightNode } from '@sourcegraph/common'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
@@ -32,6 +33,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     index,
 }) => {
     const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+    const containerElement = useRef<HTMLDivElement>(null)
 
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
@@ -104,7 +106,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                 {result.description && (
                     <>
                         <div className={styles.dividerVertical} />
-                        <div>
+                        <div ref={containerElement}>
                             <small>
                                 <em>
                                     {result.description.length > REPO_DESCRIPTION_CHAR_LIMIT
@@ -118,6 +120,17 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
             </div>
         </div>
     )
+
+    useEffect((): void => {
+        if (containerElement.current && result.descriptionMatches) {
+            const visibleDescription = containerElement.current.querySelector('small em')
+            if (visibleDescription) {
+                for (const range of result.descriptionMatches) {
+                    highlightNode(visibleDescription as HTMLElement, range.start.offset, range.end.offset - range.start.offset)
+                }
+            }
+        }
+    }, [result.description, result.descriptionMatches])
 
     return (
         <ResultContainer

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -136,6 +136,7 @@ export interface RepositoryMatch {
     archived?: boolean
     private?: boolean
     branches?: string[]
+    descriptionMatches?: Range[]
 }
 
 /**

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -459,6 +459,17 @@ func fromRepository(rm *result.RepoMatch, repoCache map[api.RepoID]*types.Search
 		Branches:     branches,
 	}
 
+	if len(rm.DescriptionMatches) > 0 {
+		dms := make([]streamhttp.Range, 0, len(rm.DescriptionMatches))
+		for _, matchRange := range rm.DescriptionMatches {
+			dms = append(dms, streamhttp.Range{
+				Start: fromLocation(matchRange.Start),
+				End:   fromLocation(matchRange.End),
+			})
+		}
+		repoEvent.DescriptionMatches = dms
+	}
+
 	if r, ok := repoCache[rm.ID]; ok {
 		repoEvent.RepoStars = r.Stars
 		repoEvent.RepoLastFetched = r.LastFetched

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -457,8 +457,14 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 
 			if valid() {
 				if repoOptions, ok := addPatternAsRepoFilter(f.ToBasic().PatternString(), repoOptions); ok {
+					descriptionPatterns := make([]*regexp.Regexp, 0, len(repoOptions.DescriptionPatterns))
+					for _, pat := range repoOptions.DescriptionPatterns {
+						descriptionPatterns = append(descriptionPatterns, regexp.MustCompile(`(?is)`+pat))
+					}
+
 					addJob(&RepoSearchJob{
-						RepoOpts: repoOptions,
+						RepoOpts:            repoOptions,
+						DescriptionPatterns: descriptionPatterns,
 					})
 				}
 			}

--- a/internal/search/job/jobutil/repos.go
+++ b/internal/search/job/jobutil/repos.go
@@ -30,8 +30,17 @@ func (s *RepoSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 	err = repos.Paginate(ctx, s.RepoOpts, func(page *searchrepos.Resolved) error {
 		tr.LogFields(log.Int("resolved.len", len(page.RepoRevs)))
 
+		descriptionMatches := make(map[api.RepoID][]result.Range)
+		if len(s.DescriptionPatterns) > 0 {
+			repoDescriptionsSet, err := s.repoDescriptions(ctx, clients.DB, page.RepoRevs)
+			if err != nil {
+				return err
+			}
+			descriptionMatches = s.descriptionMatchRanges(repoDescriptionsSet)
+		}
+
 		stream.Send(streaming.SearchEvent{
-			Results: repoRevsToRepoMatches(page.RepoRevs),
+			Results: repoRevsToRepoMatches(page.RepoRevs, descriptionMatches),
 		})
 
 		return nil
@@ -107,15 +116,19 @@ func (s *RepoSearchJob) Fields(v job.Verbosity) (res []log.Field) {
 func (s *RepoSearchJob) Children() []job.Describer       { return nil }
 func (s *RepoSearchJob) MapChildren(job.MapFunc) job.Job { return s }
 
-func repoRevsToRepoMatches(repos []*search.RepositoryRevisions) []result.Match {
+func repoRevsToRepoMatches(repos []*search.RepositoryRevisions, descriptionMatches map[api.RepoID][]result.Range) []result.Match {
 	matches := make([]result.Match, 0, len(repos))
 	for _, r := range repos {
 		for _, rev := range r.Revs {
-			matches = append(matches, &result.RepoMatch{
+			rm := result.RepoMatch{
 				Name: r.Repo.Name,
 				ID:   r.Repo.ID,
 				Rev:  rev,
-			})
+			}
+			if ranges, ok := descriptionMatches[r.Repo.ID]; ok {
+				rm.DescriptionMatches = ranges
+			}
+			matches = append(matches, &rm)
 		}
 	}
 	return matches

--- a/internal/search/job/jobutil/repos.go
+++ b/internal/search/job/jobutil/repos.go
@@ -2,6 +2,7 @@ package jobutil
 
 import (
 	"context"
+	"unicode/utf8"
 
 	"github.com/grafana/regexp"
 	"github.com/opentracing/opentracing-go/log"
@@ -82,12 +83,12 @@ func (s *RepoSearchJob) descriptionMatchRanges(repoDescriptions map[api.RepoID]s
 					Start: result.Location{
 						Offset: sm[0],
 						Line:   0,
-						Column: sm[0],
+						Column: utf8.RuneCount([]byte(repoDescription[:sm[0]])),
 					},
 					End: result.Location{
 						Offset: sm[1],
 						Line:   0,
-						Column: sm[1],
+						Column: utf8.RuneCount([]byte(repoDescription[:sm[1]])),
 					},
 				})
 			}

--- a/internal/search/job/jobutil/repos_test.go
+++ b/internal/search/job/jobutil/repos_test.go
@@ -16,6 +16,7 @@ func Test_descriptionMatchRanges(t *testing.T) {
 		2: "description for tests and validating input, among other things",
 		3: "description containing go but also\na newline",
 		4: "---zb bz zb bz---",
+		5: "this description has unicode 🙈 characters",
 	}
 
 	// NOTE: Any pattern passed into repo:has.description() is converted to the format `(?:*).*?(?:*)` when the predicate
@@ -118,6 +119,26 @@ func Test_descriptionMatchRanges(t *testing.T) {
 							Offset: 11,
 							Line:   0,
 							Column: 11,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "counts unicode characters correctly",
+			inputPatterns: []*regexp.Regexp{regexp.MustCompile(`(?is)(?:unicode).*?(?:🙈).*?(?:char)`)},
+			want: map[api.RepoID][]result.Range{
+				5: {
+					result.Range{
+						Start: result.Location{
+							Offset: 21,
+							Line:   0,
+							Column: 21,
+						},
+						End: result.Location{
+							Offset: 38,
+							Line:   0,
+							Column: 35,
 						},
 					},
 				},

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -14,6 +14,8 @@ type RepoMatch struct {
 
 	// rev optionally specifies a revision to go to for search results.
 	Rev string
+
+	DescriptionMatches []Range
 }
 
 func (r RepoMatch) RepoName() types.MinimalRepo {

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -93,15 +93,16 @@ type EventRepoMatch struct {
 	// Type is always RepoMatchType. Included here for marshalling.
 	Type MatchType `json:"type"`
 
-	RepositoryID    int32      `json:"repositoryID"`
-	Repository      string     `json:"repository"`
-	Branches        []string   `json:"branches,omitempty"`
-	RepoStars       int        `json:"repoStars,omitempty"`
-	RepoLastFetched *time.Time `json:"repoLastFetched,omitempty"`
-	Description     string     `json:"description,omitempty"`
-	Fork            bool       `json:"fork,omitempty"`
-	Archived        bool       `json:"archived,omitempty"`
-	Private         bool       `json:"private,omitempty"`
+	RepositoryID       int32      `json:"repositoryID"`
+	Repository         string     `json:"repository"`
+	Branches           []string   `json:"branches,omitempty"`
+	RepoStars          int        `json:"repoStars,omitempty"`
+	RepoLastFetched    *time.Time `json:"repoLastFetched,omitempty"`
+	Description        string     `json:"description,omitempty"`
+	DescriptionMatches []Range    `json:"descriptionMatches,omitempty"`
+	Fork               bool       `json:"fork,omitempty"`
+	Archived           bool       `json:"archived,omitempty"`
+	Private            bool       `json:"private,omitempty"`
 }
 
 func (e *EventRepoMatch) eventMatch() {}


### PR DESCRIPTION
This PR adds highlighting for ranges in the visible portion of repo descriptions that are matched by `repo:has.description`.

- During `RepoSearchJob` construction, compile any `repo:has.description` patterns into regexes that match case-insensitively and across newline characters
- During `RepoSearchJob` execution, get resolved repositories' descriptions from the database, match them against the list of compiled regexes, and return the matched ranges as the field `DescriptionMatches` on `result.RepoMatch`
- Add field `DescriptionMatches` to `EventRepoMatch` and populate it with the values from `result.RepoMatch` in `frontend`
- Add field `descriptionMatches` to `RepositoryMatch` interface in the client
- Use `highlightNode` to highlight matched ranges in the `RepoSearchResult` component

## Test plan
Unit tests, manual testing. `highlightNode` [is well-tested](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/common/src/util/highlightNode.test.ts?subtree=true)

![Screen Shot 2022-08-03 at 8 58 58 AM](https://user-images.githubusercontent.com/70350613/182626983-deefebf1-e4b2-4165-adc3-05a5ad801053.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
