### PR TITLE
search: toggling defaults to standard

### DIFF
--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -78,7 +78,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
             (settingsCascade.final &&
                 !isErrorLike(settingsCascade.final) &&
                 (settingsCascade.final['search.defaultPatternType'] as SearchPatternType)) ||
-            SearchPatternType.literal,
+            SearchPatternType.standard,
         [settingsCascade.final]
     )
 

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -325,7 +325,7 @@ describe('Search', () => {
                     await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard')
                 })
             })
         })


### PR DESCRIPTION
Currently toggling out of `regexp` or `structural` will default to `literal`. As of https://github.com/sourcegraph/sourcegraph/pull/38141 this should default to `standard`


## Test plan
Updated test.

## App preview:

- [Web](https://sg-web-rvt-toggle-default.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jknyxxcqxj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
