### PR TITLE
sg: Add `migration rewrite` command

### DIFF
--- a/dev/sg/internal/migration/rewrite.go
+++ b/dev/sg/internal/migration/rewrite.go
@@ -1,0 +1,70 @@
+package migration
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/db"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/stitch"
+)
+
+func Rewrite(database db.Database, rev string) error {
+	repoRoot, err := root.RepositoryRoot()
+	if err != nil {
+		return err
+	}
+	migrationsDir := filepath.Join(repoRoot, "migrations", database.Name)
+
+	fs, err := stitch.ReadMigrations(database.Name, repoRoot, rev)
+	if err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(migrationsDir); err != nil {
+		return err
+	}
+
+	root, err := http.FS(fs).Open("/")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+
+	migrations, err := root.Readdir(0)
+	if err != nil {
+		return err
+	}
+
+	for _, migration := range migrations {
+		if err := os.MkdirAll(filepath.Join(migrationsDir, migration.Name()), os.ModePerm); err != nil {
+			return err
+		}
+
+		for _, basename := range []string{"up.sql", "down.sql", "metadata.yaml"} {
+			f, err := fs.Open(filepath.Join(migration.Name(), basename))
+			if err != nil {
+				return err
+			}
+			defer func() { _ = f.Close() }()
+
+			contents, err := io.ReadAll(f)
+			if err != nil {
+				return err
+			}
+
+			if err := os.WriteFile(
+				filepath.Join(migrationsDir, migration.Name(), basename),
+				[]byte(definition.CanonicalizeQuery(string(contents))),
+				os.ModePerm,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -794,6 +794,23 @@ Flags:
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 * `-f="<value>"`: The output filepath
 
+### sg migration rewrite
+
+Rewrite schemas definitions as they were at a particular version.
+
+Available schemas:
+
+* frontend
+* codeintel
+* codeinsights
+
+
+Flags:
+
+* `--db="<value>"`: The target database `schema` to modify (default: frontend)
+* `--feedback`: provide feedback about this command by opening up a Github discussion
+* `--rev="<value>"`: The target revision
+
 ## sg insights
 
 Tools to interact with Code Insights data.

--- a/internal/database/migration/stitch/rewriter.go
+++ b/internal/database/migration/stitch/rewriter.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-// readMigrations reads migrations from a locally available git revision for the given schema, and
+// ReadMigrations reads migrations from a locally available git revision for the given schema, and
 // rewrites old versions and explicit edge cases so that they can be more easily composed by the
 // migration stitch utilities.
 //
@@ -31,7 +31,7 @@ import (
 // stitch these relations back together, as it can't be done easily pre-composition across versions.
 //
 // See the method `linkVirtualPrivilegedMigrations`.
-func readMigrations(schemaName, root, rev string) (fs.FS, error) {
+func ReadMigrations(schemaName, root, rev string) (fs.FS, error) {
 	migrations, err := readRawMigrations(schemaName, root, rev)
 	if err != nil {
 		return nil, err

--- a/internal/database/migration/stitch/stitch.go
+++ b/internal/database/migration/stitch/stitch.go
@@ -83,7 +83,7 @@ const squashedMigrationPrefix = "squashed migrations"
 // differ in a significant way (e.g., definitions, parents) and there is not an explicit exception to deal
 // with it in this code.
 func overlayDefinition(schemaName, root, rev string, definitionMap map[int]definition.Definition) (shared.MigrationBounds, error) {
-	fs, err := readMigrations(schemaName, root, rev)
+	fs, err := ReadMigrations(schemaName, root, rev)
 	if err != nil {
 		return shared.MigrationBounds{}, err
 	}


### PR DESCRIPTION
Partial fix to https://github.com/sourcegraph/sourcegraph/issues/39863. This PR adds an `sg migration rewrite` command that resets the migrations on-disk of your clone to the canonical version at the given git revision.

## Test plan

Tested by hand locally.