### PR TITLE
migration: Backfill old schema versions

### DIFF
--- a/internal/database/migration/cliutil/drift-schemas/README.md
+++ b/internal/database/migration/cliutil/drift-schemas/README.md
@@ -1,0 +1,5 @@
+# Historic drift schema generator
+
+This directory contains the script that generates squashed definitions from historic tagged commits.
+
+This data allows the drift utilities to work on instances prior to Sourcegraph 3.42, when the squashed definitions were stored reliably in the Git tree.

--- a/internal/database/migration/cliutil/drift-schemas/generate-all.sh
+++ b/internal/database/migration/cliutil/drift-schemas/generate-all.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+set -euo pipefail
+
+outdir="$(pwd)/data"
+rm -rf "${outdir}"
+mkdir "${outdir}"
+
+versions=(
+  v3.29.0 v3.29.1
+  v3.30.0 v3.30.1 v3.30.2 v3.30.3 v3.30.4
+  v3.31.0 v3.31.1 v3.31.2
+  v3.32.0 v3.32.1
+  v3.33.0 v3.33.1 v3.33.2
+  v3.34.0 v3.34.1 v3.34.2
+  v3.35.0 v3.35.1 v3.35.2
+  v3.36.0 v3.36.1 v3.36.2 v3.36.3
+  v3.37.0
+  v3.38.0 v3.38.1
+  v3.39.0 v3.39.1
+  v3.40.0 v3.40.1 v3.40.2
+  v3.41.0 v3.41.1
+)
+
+for version in "${versions[@]}"; do
+  ./generate.sh "${version}" "${outdir}"
+done

--- a/internal/database/migration/cliutil/drift-schemas/generate.sh
+++ b/internal/database/migration/cliutil/drift-schemas/generate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
+set -euo pipefail
+
+revision="${1:?no revision provided}"
+outdir="${2:?no output directory provided}"
+
+if [[ -f "${outdir}/${revision}-internal_database_schema.json" ]]; then
+  echo "exists!"
+  exit 0
+fi
+
+dropdbs() {
+  dropdb --if-exists sg-squasher-frontend 2>/dev/null
+  dropdb --if-exists sg-squasher-codeintel 2>/dev/null
+  dropdb --if-exists sg-squasher-codeinsights 2>/dev/null
+  docker stop squasher >/dev/null 2>&1 || true
+}
+
+cleanup() {
+  rm -rf temp-squash
+  git checkout -- migrations
+  git clean -qfd migrations
+  dropdbs
+}
+trap cleanup EXIT
+
+export PGDATASOURCE="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/sg-squasher-frontend"
+export CODEINTEL_PGDATASOURCE="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/sg-squasher-codeintel"
+export CODEINSIGHTS_PGDATASOURCE="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/sg-squasher-codeinsights"
+
+codeinsights_container_args=""
+if (("${revision:3:2}" < 37)); then
+  # If minor version < 37, launch and target TimescaleDB container
+  codeinsights_container_args="-in-timescaledb-container"
+  export CODEINSIGHTS_PGDATASOURCE="postgres://postgres:password@${PGHOST}:5433/codeinsights"
+fi
+
+go build ./dev/sg # Currently requires migration at compile time; doesn't read from disk
+echo "Rewriting migration definitions as they were at ${revision}..."
+./sg migration rewrite -db frontend -rev "${revision}" >/dev/null
+./sg migration rewrite -db codeintel -rev "${revision}" >/dev/null
+./sg migration rewrite -db codeinsights -rev "${revision}" >/dev/null
+
+go build ./dev/sg # Currently requires migration at compile time; doesn't read from disk
+echo "Squashing migration definitions as they were at ${revision}..."
+dropdbs
+./sg migration squash-all -skip-data -skip-teardown -db frontend -f temp-squash
+./sg migration squash-all -skip-data -skip-teardown -db codeintel -f temp-squash
+if [[ "${codeinsights_container_args}" == "" ]]; then
+  ./sg migration squash-all -skip-data -skip-teardown -db codeinsights -f temp-squash
+else
+  ./sg migration squash-all -skip-data -skip-teardown -db codeinsights -f temp-squash "${codeinsights_container_args}"
+fi
+
+echo "Describing migration definitions as they were at ${revision}..."
+./sg migration describe -db frontend --format=json -force -out "${outdir}/${revision}-internal_database_schema.json"
+./sg migration describe -db codeintel --format=json -force -out "${outdir}/${revision}-internal_database_schema.codeintel.json"
+./sg migration describe -db codeinsights --format=json -force -out "${outdir}/${revision}-internal_database_schema.codeinsights.json"

--- a/internal/database/migration/cliutil/drift_schema.go
+++ b/internal/database/migration/cliutil/drift_schema.go
@@ -18,6 +18,8 @@ type ExpectedSchemaFactory func(filename, version string) (descriptions.SchemaDe
 // a version of Sourcegraph that did not yet contain the squashed schema description file in-tree. These files
 // have been backfilled to this bucket by hand. A false-valued flag is returned if the schema does not exist
 // for this version.
+//
+// See the ./drift-schemas directory for more details on how this data was generated.
 func GCSExpectedSchemaFactory(filename, version string) (schemaDescription descriptions.SchemaDescription, _ bool, _ error) {
 	return fetchSchema(fmt.Sprintf("https://storage.googleapis.com/sourcegraph-assets/migrations/drift/%s-%s", version, strings.ReplaceAll(filename, "/", "_")))
 }


### PR DESCRIPTION
Fixes #39863. The artifacts generated by this scripts have already been uploaded.

## Test plan

N/A.