### PR TITLE
Fix 'Discard changes?' when updating external service

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -1,12 +1,15 @@
 import { DecoratorFn, Story, Meta } from '@storybook/react'
 import { of } from 'rxjs'
+import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
+import { getDocumentNode } from '@sourcegraph/http-client'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
-import { ExternalServiceKind } from '../../graphql-operations'
+import { ExternalServiceFields, ExternalServiceKind } from '../../graphql-operations'
 import { WebStory } from '../WebStory'
 
-import { fetchExternalService as _fetchExternalService } from './backend'
+import { FETCH_EXTERNAL_SERVICE, queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs } from './backend'
 import { ExternalServicePage } from './ExternalServicePage'
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
@@ -25,6 +28,7 @@ const config: Meta = {
 export default config
 
 const externalService = {
+    __typename: 'ExternalService' as const,
     id: 'service123',
     kind: ExternalServiceKind.GITHUB,
     warning: null,
@@ -45,22 +49,39 @@ const externalService = {
     },
 }
 
-const fetchExternalService: typeof _fetchExternalService = () => of(externalService)
+const queryExternalServiceSyncJobs: typeof _queryExternalServiceSyncJobs = () =>
+    of({
+        totalCount: 0,
+        pageInfo: { endCursor: null, hasNextPage: false },
+        nodes: [],
+    })
 
-const fetchExternalServiceWithInvalidConfigURL: typeof _fetchExternalService = () =>
-    of({ ...externalService, config: '{"url": "invalid-url"}' })
+function newFetchMock(node: { __typename: 'ExternalService' } & ExternalServiceFields): WildcardMockLink {
+    return new WildcardMockLink([
+        {
+            request: {
+                query: getDocumentNode(FETCH_EXTERNAL_SERVICE),
+                variables: MATCH_ANY_PARAMETERS,
+            },
+            result: { data: { node } },
+            nMatches: Number.POSITIVE_INFINITY,
+        },
+    ])
+}
 
 export const ViewConfig: Story = () => (
     <WebStory>
         {webProps => (
-            <ExternalServicePage
-                {...webProps}
-                afterUpdateRoute="/site-admin/after"
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-                externalServiceID="service123"
-                fetchExternalService={fetchExternalService}
-                autoFocusForm={false}
-            />
+            <MockedTestProvider link={newFetchMock(externalService)}>
+                <ExternalServicePage
+                    {...webProps}
+                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
+                    afterUpdateRoute="/site-admin/after"
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    externalServiceID="service123"
+                    autoFocusForm={false}
+                />
+            </MockedTestProvider>
         )}
     </WebStory>
 )
@@ -70,16 +91,39 @@ ViewConfig.storyName = 'View external service config'
 export const ConfigWithInvalidUrl: Story = () => (
     <WebStory>
         {webProps => (
-            <ExternalServicePage
-                {...webProps}
-                afterUpdateRoute="/site-admin/after"
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-                externalServiceID="service123"
-                fetchExternalService={fetchExternalServiceWithInvalidConfigURL}
-                autoFocusForm={false}
-            />
+            <MockedTestProvider link={newFetchMock({ ...externalService, config: '{"url": "invalid-url"}' })}>
+                <ExternalServicePage
+                    {...webProps}
+                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
+                    afterUpdateRoute="/site-admin/after"
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    externalServiceID="service123"
+                    autoFocusForm={false}
+                />
+            </MockedTestProvider>
         )}
     </WebStory>
 )
 
 ConfigWithInvalidUrl.storyName = 'External service config with invalid url'
+
+export const ConfigWithWarning: Story = () => (
+    <WebStory>
+        {webProps => (
+            <MockedTestProvider
+                link={newFetchMock({ ...externalService, warning: 'Invalid config we could not sync stuff' })}
+            >
+                <ExternalServicePage
+                    {...webProps}
+                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
+                    afterUpdateRoute="/site-admin/after"
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    externalServiceID="service123"
+                    autoFocusForm={false}
+                />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+ConfigWithWarning.storyName = 'External service config with warning after update'

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -2,12 +2,12 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react'
 
 import * as H from 'history'
 import { parse as parseJSONC } from 'jsonc-parser'
-import { useHistory } from 'react-router'
+import { Redirect, useHistory } from 'react-router'
 import { Observable, Subject } from 'rxjs'
-import { catchError } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { asError, ErrorLike, isErrorLike, hasProperty } from '@sourcegraph/common'
+import { hasProperty } from '@sourcegraph/common'
+import { useQuery } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, H2, H3, Badge, Container } from '@sourcegraph/wildcard'
@@ -18,6 +18,8 @@ import {
     AddExternalServiceInput,
     ExternalServiceSyncJobListFields,
     ExternalServiceSyncJobConnectionFields,
+    ExternalServiceResult,
+    ExternalServiceVariables,
 } from '../../graphql-operations'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../FilteredConnection'
 import { LoaderButton } from '../LoaderButton'
@@ -26,11 +28,10 @@ import { Duration } from '../time/Duration'
 import { Timestamp } from '../time/Timestamp'
 
 import {
-    isExternalService,
-    updateExternalService,
-    fetchExternalService as _fetchExternalService,
     useSyncExternalService,
-    queryExternalServiceSyncJobs,
+    queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs,
+    useUpdateExternalService,
+    FETCH_EXTERNAL_SERVICE,
 } from './backend'
 import { ExternalServiceCard } from './ExternalServiceCard'
 import { ExternalServiceForm } from './ExternalServiceForm'
@@ -44,7 +45,7 @@ interface Props extends TelemetryProps {
     afterUpdateRoute: string
 
     /** For testing only. */
-    fetchExternalService?: typeof _fetchExternalService
+    queryExternalServiceSyncJobs?: typeof _queryExternalServiceSyncJobs
     /** For testing only. */
     autoFocusForm?: boolean
 }
@@ -57,6 +58,8 @@ function isValidURL(url: string): boolean {
         return false
     }
 }
+const getExternalService = (queryResult?: ExternalServiceResult): ExternalServiceFields | null =>
+    queryResult?.node?.__typename === 'ExternalService' ? queryResult.node : null
 
 export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     externalServiceID,
@@ -64,74 +67,74 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
     isLightTheme,
     telemetryService,
     afterUpdateRoute,
-    fetchExternalService = _fetchExternalService,
+    queryExternalServiceSyncJobs = _queryExternalServiceSyncJobs,
     autoFocusForm,
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
     }, [telemetryService])
 
-    const [externalServiceOrError, setExternalServiceOrError] = useState<ExternalServiceFields | ErrorLike>()
+    const [externalService, setExternalService] = useState<ExternalServiceFields>()
 
-    useEffect(() => {
-        const subscription = fetchExternalService(externalServiceID)
-            .pipe(catchError(error => [asError(error)]))
-            .subscribe(result => {
-                setExternalServiceOrError(result)
-            })
-        return () => subscription.unsubscribe()
-    }, [externalServiceID, fetchExternalService])
-
-    const onChange = useCallback(
-        (input: AddExternalServiceInput) => {
-            if (isExternalService(externalServiceOrError)) {
-                setExternalServiceOrError({
-                    ...externalServiceOrError,
-                    ...input,
-                    namespace: externalServiceOrError.namespace,
-                })
-            }
-        },
-        [externalServiceOrError, setExternalServiceOrError]
-    )
-
-    const [isUpdating, setIsUpdating] = useState<boolean | Error>()
-    const onSubmit = useCallback(
-        async (event?: React.FormEvent<HTMLFormElement>): Promise<void> => {
-            if (event) {
-                event.preventDefault()
-            }
-            if (isExternalService(externalServiceOrError)) {
-                try {
-                    setIsUpdating(true)
-                    const updatedService = await updateExternalService({ input: externalServiceOrError })
-                    setIsUpdating(false)
-                    // If the update was successful, and did not surface a warning, redirect to the
-                    // repositories page, adding `?repositoriesUpdated` to the query string so that we display
-                    // a banner at the top of the page.
-                    if (updatedService.warning) {
-                        setExternalServiceOrError(updatedService)
-                    } else {
-                        history.push(afterUpdateRoute)
-                    }
-                } catch (error) {
-                    setIsUpdating(asError(error))
+    const { error: fetchError, loading: fetchLoading } = useQuery<ExternalServiceResult, ExternalServiceVariables>(
+        FETCH_EXTERNAL_SERVICE,
+        {
+            variables: { id: externalServiceID },
+            notifyOnNetworkStatusChange: false,
+            fetchPolicy: 'no-cache',
+            onCompleted: result => {
+                const data = getExternalService(result)
+                if (data) {
+                    setExternalService(data)
                 }
-            }
-        },
-        [afterUpdateRoute, externalServiceOrError, history]
+            },
+        }
     )
-    let error: ErrorLike | undefined
-    if (isErrorLike(isUpdating)) {
-        error = isUpdating
-    }
 
     const [
         syncExternalService,
         { error: syncExternalServiceError, loading: syncExternalServiceLoading },
     ] = useSyncExternalService()
 
-    const externalService = (!isErrorLike(externalServiceOrError) && externalServiceOrError) || undefined
+    const [updated, setUpdated] = useState(false)
+    const [
+        updateExternalService,
+        { error: updateExternalServiceError, loading: updateExternalServiceLoading },
+    ] = useUpdateExternalService(() => {
+        setUpdated(true)
+    })
+
+    const onSubmit = useCallback(
+        async (event?: React.FormEvent<HTMLFormElement>) => {
+            event?.preventDefault()
+
+            if (externalService !== undefined) {
+                await updateExternalService({
+                    variables: {
+                        input: {
+                            id: externalService.id,
+                            displayName: externalService.displayName,
+                            config: externalService.config,
+                        },
+                    },
+                })
+            }
+        },
+        [externalService, updateExternalService]
+    )
+
+    const onChange = useCallback(
+        (input: AddExternalServiceInput) => {
+            if (externalService !== undefined) {
+                setExternalService({
+                    ...externalService,
+                    ...input,
+                    namespace: externalService.namespace,
+                })
+            }
+        },
+        [externalService, setExternalService]
+    )
 
     const syncJobUpdates = useMemo(() => new Subject<void>(), [])
     const triggerSync = useCallback(
@@ -167,6 +170,13 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
         }
     }
 
+    const combinedError = fetchError || updateExternalServiceError
+    const combinedLoading = fetchLoading || updateExternalServiceLoading
+
+    if (updated && !combinedLoading && externalService?.warning === null) {
+        return <Redirect to={afterUpdateRoute} />
+    }
+
     return (
         <div>
             {externalService ? (
@@ -174,9 +184,9 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
             ) : (
                 <PageTitle title="External service" />
             )}
-            <H2>Update code host connection</H2>
-            {externalServiceOrError === undefined && <LoadingSpinner />}
-            {isErrorLike(externalServiceOrError) && <ErrorAlert className="mb-3" error={externalServiceOrError} />}
+            <H2>Update code host connection {combinedLoading}</H2>
+            {combinedLoading && <LoadingSpinner inline={true} />}
+            {combinedError !== undefined && !combinedLoading && <ErrorAlert className="mb-3" error={combinedError} />}
 
             {externalService && (
                 <Container className="mb-3">
@@ -190,10 +200,10 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
                             input={{ ...externalService, namespace: externalService.namespace?.id ?? null }}
                             editorActions={externalServiceCategory.editorActions}
                             jsonSchema={externalServiceCategory.jsonSchema}
-                            error={error}
+                            error={updateExternalServiceError}
                             warning={externalService.warning}
                             mode="edit"
-                            loading={isUpdating === true}
+                            loading={combinedLoading}
                             onSubmit={onSubmit}
                             onChange={onChange}
                             history={history}
@@ -212,7 +222,11 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
                     />
                     {syncExternalServiceError && <ErrorAlert error={syncExternalServiceError} />}
                     <ExternalServiceWebhook externalService={externalService} className="mt-3" />
-                    <ExternalServiceSyncJobsList externalServiceID={externalService.id} updates={syncJobUpdates} />
+                    <ExternalServiceSyncJobsList
+                        queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
+                        externalServiceID={externalService.id}
+                        updates={syncJobUpdates}
+                    />
                 </Container>
             )}
         </div>
@@ -222,11 +236,15 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
 interface ExternalServiceSyncJobsListProps {
     externalServiceID: Scalars['ID']
     updates: Observable<void>
+
+    /** For testing only. */
+    queryExternalServiceSyncJobs?: typeof _queryExternalServiceSyncJobs
 }
 
 const ExternalServiceSyncJobsList: React.FunctionComponent<ExternalServiceSyncJobsListProps> = ({
     externalServiceID,
     updates,
+    queryExternalServiceSyncJobs = _queryExternalServiceSyncJobs,
 }) => {
     const queryConnection = useCallback(
         (args: FilteredConnectionQueryArguments) =>
@@ -234,7 +252,7 @@ const ExternalServiceSyncJobsList: React.FunctionComponent<ExternalServiceSyncJo
                 first: args.first ?? null,
                 externalService: externalServiceID,
             }),
-        [externalServiceID]
+        [externalServiceID, queryExternalServiceSyncJobs]
     )
 
     const history = useHistory()

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -100,7 +100,8 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
     const [
         updateExternalService,
         { error: updateExternalServiceError, loading: updateExternalServiceLoading },
-    ] = useUpdateExternalService(() => {
+    ] = useUpdateExternalService(result => {
+        setExternalService(result.updateExternalService)
         setUpdated(true)
     })
 
@@ -184,8 +185,7 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
             ) : (
                 <PageTitle title="External service" />
             )}
-            <H2>Update code host connection {combinedLoading}</H2>
-            {combinedLoading && <LoadingSpinner inline={true} />}
+            <H2>Update code host connection {combinedLoading && <LoadingSpinner inline={true} />}</H2>
             {combinedError !== undefined && !combinedLoading && <ErrorAlert className="mb-3" error={combinedError} />}
 
             {externalService && (

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -2,7 +2,7 @@ import { MutationTuple } from '@apollo/client'
 import { Observable } from 'rxjs'
 import { map, mapTo } from 'rxjs/operators'
 
-import { createAggregateError, isErrorLike, ErrorLike } from '@sourcegraph/common'
+import { createAggregateError } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors, useMutation } from '@sourcegraph/http-client'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -14,8 +14,6 @@ import {
     AddExternalServiceVariables,
     AddExternalServiceResult,
     ExternalServiceFields,
-    ExternalServiceVariables,
-    ExternalServiceResult,
     DeleteExternalServiceVariables,
     DeleteExternalServiceResult,
     ExternalServicesVariables,
@@ -83,24 +81,25 @@ export async function addExternalService(
         .toPromise()
 }
 
-export function isExternalService(
-    externalServiceOrError?: ExternalServiceFields | ErrorLike
-): externalServiceOrError is ExternalServiceFields {
-    return !!externalServiceOrError && !isErrorLike(externalServiceOrError)
-}
+export const UPDATE_EXTERNAL_SERVICE = gql`
+    mutation UpdateExternalService($input: UpdateExternalServiceInput!) {
+        updateExternalService(input: $input) {
+            ...ExternalServiceFields
+        }
+    }
+    ${externalServiceFragment}
+`
+
+export const useUpdateExternalService = (
+    onCompleted: () => void
+): MutationTuple<UpdateExternalServiceResult, UpdateExternalServiceVariables> =>
+    useMutation(UPDATE_EXTERNAL_SERVICE, { onCompleted })
 
 export function updateExternalService(
     variables: UpdateExternalServiceVariables
 ): Promise<UpdateExternalServiceResult['updateExternalService']> {
     return requestGraphQL<UpdateExternalServiceResult, UpdateExternalServiceVariables>(
-        gql`
-            mutation UpdateExternalService($input: UpdateExternalServiceInput!) {
-                updateExternalService(input: $input) {
-                    ...ExternalServiceFields
-                }
-            }
-            ${externalServiceFragment}
-        `,
+        UPDATE_EXTERNAL_SERVICE,
         variables
     )
         .pipe(
@@ -125,31 +124,15 @@ export function setExternalServiceRepos(variables: SetExternalServiceReposVariab
         .toPromise()
 }
 
-export function fetchExternalService(id: Scalars['ID']): Observable<ExternalServiceFields> {
-    return requestGraphQL<ExternalServiceResult, ExternalServiceVariables>(
-        gql`
-            query ExternalService($id: ID!) {
-                node(id: $id) {
-                    __typename
-                    ...ExternalServiceFields
-                }
-            }
-            ${externalServiceFragment}
-        `,
-        { id }
-    ).pipe(
-        map(dataOrThrowErrors),
-        map(({ node }) => {
-            if (!node) {
-                throw new Error('External service not found')
-            }
-            if (node.__typename !== 'ExternalService') {
-                throw new Error(`Node is a ${node.__typename}, not a ExternalService`)
-            }
-            return node
-        })
-    )
-}
+export const FETCH_EXTERNAL_SERVICE = gql`
+    query ExternalService($id: ID!) {
+        node(id: $id) {
+            __typename
+            ...ExternalServiceFields
+        }
+    }
+    ${externalServiceFragment}
+`
 
 export function listAffiliatedRepositories(
     args: AffiliatedRepositoriesVariables
@@ -314,7 +297,7 @@ export function queryExternalServicesScope(
     )
 }
 
-const SYNC_EXTERNAL_SERVICE = gql`
+export const SYNC_EXTERNAL_SERVICE = gql`
     mutation SyncExternalService($id: ID!) {
         syncExternalService(id: $id) {
             alwaysNil

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -91,7 +91,7 @@ export const UPDATE_EXTERNAL_SERVICE = gql`
 `
 
 export const useUpdateExternalService = (
-    onCompleted: () => void
+    onCompleted: (result: UpdateExternalServiceResult) => void
 ): MutationTuple<UpdateExternalServiceResult, UpdateExternalServiceVariables> =>
     useMutation(UPDATE_EXTERNAL_SERVICE, { onCompleted })
 

--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -85,6 +85,9 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
                     if (action === 'REPLACE') {
                         return undefined
                     }
+                    console.log('action', action)
+                    console.log('loading', this.props.loading)
+                    console.log('isDirty', this.isDirty)
                     if (this.props.loading || this.isDirty) {
                         return 'Discard changes?'
                     }
@@ -165,6 +168,7 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
     private onSave = async (): Promise<void> => {
         const value = this.effectiveValue
         if (this.props.onSave) {
+            console.log('on Save')
             const newConfig = await this.props.onSave(value)
             if (newConfig) {
                 this.setState({ value: newConfig })

--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -85,9 +85,6 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
                     if (action === 'REPLACE') {
                         return undefined
                     }
-                    console.log('action', action)
-                    console.log('loading', this.props.loading)
-                    console.log('isDirty', this.isDirty)
                     if (this.props.loading || this.isDirty) {
                         return 'Discard changes?'
                     }


### PR DESCRIPTION
This fixes the 'Discard changes?' confirmation dialog that pops up when the user
saves the external service config.

It also refactors the code to use `useQuery` and `useMutation` hooks (which are recommended by frontend-platform team), which makes the logic a bit simpler and more consistent with rest of codebase.

## Test plan

- Storybook
- Manual testing (with modified graphql backend to check for warnings)

## App preview:

- [Web](https://sg-web-mrn-fix-discard-changes.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lxmviewego.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

