### PR TITLE
oneclickexport: add code host configs export functionality

### DIFF
--- a/cmd/frontend/oneclickexport/export.go
+++ b/cmd/frontend/oneclickexport/export.go
@@ -3,6 +3,7 @@ package oneclickexport
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,7 +14,7 @@ import (
 type Exporter interface {
 	// Export accepts an ExportRequest and returns bytes of a zip archive
 	// with requested data.
-	Export(request ExportRequest) ([]byte, error)
+	Export(ctx context.Context, request ExportRequest) ([]byte, error)
 }
 
 var _ Exporter = &DataExporter{}
@@ -24,7 +25,8 @@ type DataExporter struct {
 }
 
 type ExportRequest struct {
-	IncludeSiteConfig bool `json:"includeSiteConfig"`
+	IncludeSiteConfig     bool `json:"includeSiteConfig"`
+	IncludeCodeHostConfig bool `json:"includeCodeHostConfig"`
 }
 
 // Export generates and returns a ZIP archive with the data, specified in request.
@@ -33,7 +35,7 @@ type ExportRequest struct {
 // this directory is zipped in the end)
 // 2) ExportRequest is read and each corresponding processor is invoked
 // 3) Tmp directory is zipped after all the Processors finished their job
-func (e *DataExporter) Export(request ExportRequest) ([]byte, error) {
+func (e *DataExporter) Export(ctx context.Context, request ExportRequest) ([]byte, error) {
 	// 1) creating a tmp dir
 	dir, err := os.MkdirTemp(os.TempDir(), "export-*")
 	if err != nil {
@@ -43,7 +45,10 @@ func (e *DataExporter) Export(request ExportRequest) ([]byte, error) {
 
 	// 2) tmp dir is passed to every processor
 	if request.IncludeSiteConfig {
-		e.configProcessors["siteConfig"].Process(ConfigRequest{}, dir)
+		e.configProcessors["siteConfig"].Process(ctx, &ConfigRequest{}, dir)
+	}
+	if request.IncludeCodeHostConfig {
+		e.configProcessors["codeHostConfig"].Process(ctx, &ConfigRequest{}, dir)
 	}
 
 	// 3) after all request parts are processed, zip the tmp dir and return its bytes

--- a/cmd/frontend/oneclickexport/export.go
+++ b/cmd/frontend/oneclickexport/export.go
@@ -45,10 +45,10 @@ func (e *DataExporter) Export(ctx context.Context, request ExportRequest) ([]byt
 
 	// 2) tmp dir is passed to every processor
 	if request.IncludeSiteConfig {
-		e.configProcessors["siteConfig"].Process(ctx, &ConfigRequest{}, dir)
+		e.configProcessors["siteConfig"].Process(ctx, ConfigRequest{}, dir)
 	}
 	if request.IncludeCodeHostConfig {
-		e.configProcessors["codeHostConfig"].Process(ctx, &ConfigRequest{}, dir)
+		e.configProcessors["codeHostConfig"].Process(ctx, ConfigRequest{}, dir)
 	}
 
 	// 3) after all request parts are processed, zip the tmp dir and return its bytes

--- a/cmd/frontend/oneclickexport/export_test.go
+++ b/cmd/frontend/oneclickexport/export_test.go
@@ -264,9 +264,9 @@ func TestExport_CumulativeTest(t *testing.T) {
 	db := database.NewMockDB()
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
-	exporter := &OneClickExporter{
+	exporter := &DataExporter{
 		logger: logger,
-		cfgProcessors: map[string]Processor[ConfigRequest]{
+		configProcessors: map[string]Processor[ConfigRequest]{
 			"siteConfig": &SiteConfigProcessor{
 				logger: logger,
 				Type:   "siteConfig",
@@ -279,7 +279,7 @@ func TestExport_CumulativeTest(t *testing.T) {
 		},
 	}
 
-	archive, err := exporter.Export(ctx, &ExportRequest{IncludeSiteConfig: true, IncludeCodeHostConfig: true})
+	archive, err := exporter.Export(ctx, ExportRequest{IncludeSiteConfig: true, IncludeCodeHostConfig: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,8 +290,8 @@ func TestExport_CumulativeTest(t *testing.T) {
 	}
 
 	wantMap := map[string]string{
-		"site-config.txt":      wantSiteConfig,
-		"code-host-config.txt": wantCodeHostConfig,
+		"site-config.json":      wantSiteConfig,
+		"code-host-config.json": wantCodeHostConfig,
 	}
 
 	for _, f := range zr.File {
@@ -388,9 +388,9 @@ func TestExport_CodeHostConfigs(t *testing.T) {
 	db := database.NewMockDB()
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
-	exporter := &OneClickExporter{
+	exporter := &DataExporter{
 		logger: logger,
-		cfgProcessors: map[string]Processor[ConfigRequest]{
+		configProcessors: map[string]Processor[ConfigRequest]{
 			"codeHostConfig": &CodeHostConfigProcessor{
 				db:     db,
 				logger: logger,
@@ -399,7 +399,7 @@ func TestExport_CodeHostConfigs(t *testing.T) {
 		},
 	}
 
-	archive, err := exporter.Export(ctx, &ExportRequest{IncludeCodeHostConfig: true})
+	archive, err := exporter.Export(ctx, ExportRequest{IncludeCodeHostConfig: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +412,7 @@ func TestExport_CodeHostConfigs(t *testing.T) {
 	found := false
 
 	for _, f := range zr.File {
-		if f.Name != "code-host-config.txt" {
+		if f.Name != "code-host-config.json" {
 			continue
 		}
 		found = true

--- a/cmd/frontend/oneclickexport/export_test.go
+++ b/cmd/frontend/oneclickexport/export_test.go
@@ -3,19 +3,103 @@ package oneclickexport
 import (
 	"archive/zip"
 	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+const (
+	wantSiteConfig = `{
+  "auth.providers": [
+    {
+      "allowOrgs": [
+        "myorg"
+      ],
+      "clientID": "myclientid",
+      "clientSecret": "REDACTED",
+      "displayName": "GitHub",
+      "type": "github",
+      "url": "https://github.com"
+    }
+  ],
+  "experimentalFeatures": {
+    "search.index.query.contexts": true
+  },
+  "permissions.userMapping": {
+    "bindID": "username",
+    "enabled": true
+  }
+}`
+
+	wantCodeHostConfig = `[
+  {
+    "kind": "GITHUB",
+    "displayName": "Github - Test1",
+    "config": {
+      "url": "https://ghe.org/",
+      "token": "REDACTED",
+      "repos": [
+        "sgtest/test-repo1",
+        "sgtest/test-repo2",
+        "sgtest/test-repo3",
+        "sgtest/test-repo4",
+        "sgtest/test-repo5",
+        "sgtest/test-repo6",
+        "sgtest/test-repo7",
+        "sgtest/test-repo8"
+      ],
+      "repositoryPathPattern": "github.com/{nameWithOwner}"
+    }
+  },
+  {
+    "kind": "GITHUB",
+    "displayName": "Github - Test2",
+    "config": {
+      "url": "https://ghe.org/",
+      "token": "REDACTED",
+      "repos": [
+        "sgtest/test-repo1",
+        "sgtest/test-repo2",
+        "sgtest/test-repo3",
+        "sgtest/test-repo4",
+        "sgtest/test-repo5",
+        "sgtest/test-repo6",
+        "sgtest/test-repo7",
+        "sgtest/test-repo8"
+      ],
+      "repositoryPathPattern": "github.com/{nameWithOwner}"
+    }
+  },
+  {
+    "kind": "BITBUCKETCLOUD",
+    "displayName": "GitLab - Test1",
+    "config": {
+      "url": "https://bitbucket.org",
+      "token": "someToken",
+      "username": "user",
+      "repos": [
+        "SOURCEGRAPH/repo-0",
+        "SOURCEGRAPH/repo-1"
+      ],
+      "repositoryPathPattern": "bbs/{projectKey}/{repositorySlug}"
+    }
+  }
+]`
+)
+
 func TestExport(t *testing.T) {
 	logger := logtest.Scoped(t)
+	ctx := context.Background()
 
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{
@@ -50,7 +134,7 @@ func TestExport(t *testing.T) {
 		},
 	}
 
-	archive, err := exporter.Export(ExportRequest{IncludeSiteConfig: true})
+	archive, err := exporter.Export(ctx, ExportRequest{IncludeSiteConfig: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,28 +145,6 @@ func TestExport(t *testing.T) {
 	}
 
 	found := false
-
-	want := `{
-  "auth.providers": [
-    {
-      "allowOrgs": [
-        "myorg"
-      ],
-      "clientID": "myclientid",
-      "clientSecret": "REDACTED",
-      "displayName": "GitHub",
-      "type": "github",
-      "url": "https://github.com"
-    }
-  ],
-  "experimentalFeatures": {
-    "search.index.query.contexts": true
-  },
-  "permissions.userMapping": {
-    "bindID": "username",
-    "enabled": true
-  }
-}`
 
 	for _, f := range zr.File {
 		if f.Name != "site-config.json" {
@@ -101,7 +163,274 @@ func TestExport(t *testing.T) {
 
 		have := string(haveBytes)
 
+		if diff := cmp.Diff(wantSiteConfig, have); diff != "" {
+			t.Fatalf("Exported site config is different. (-want +got):\n%s", diff)
+		}
+	}
+
+	if !found {
+		t.Fatal(errors.New("site config file not found in exported zip archive"))
+	}
+}
+
+// TestExport_CumulativeTest is a test with a full export available at the
+// moment. This test should be updated with every new added piece of exported
+// data.
+func TestExport_CumulativeTest(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+
+	// Mocking site config
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			AuthProviders: []schema.AuthProviders{{
+				Github: &schema.GitHubAuthProvider{
+					ClientID:     "myclientid",
+					ClientSecret: "myclientsecret",
+					DisplayName:  "GitHub",
+					Type:         extsvc.TypeGitHub,
+					Url:          "https://github.com",
+					AllowOrgs:    []string{"myorg"},
+				},
+			}},
+			PermissionsUserMapping: &schema.PermissionsUserMapping{
+				BindID:  "username",
+				Enabled: true,
+			},
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				SearchIndexQueryContexts: true,
+			},
+		},
+	})
+	t.Cleanup(func() { conf.Mock(nil) })
+
+	// Mocking external services for code host configs export
+	externalServices := database.NewMockExternalServiceStore()
+	externalServices.ListFunc.SetDefaultReturn([]*types.ExternalService{
+		{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "Github - Test1",
+			Config: `{
+      "url": "https://ghe.org/",
+      "token": "someToken",
+      "repos": [
+        "sgtest/test-repo1",
+        "sgtest/test-repo2",
+        "sgtest/test-repo3",
+        "sgtest/test-repo4",
+        "sgtest/test-repo5",
+        "sgtest/test-repo6",
+        "sgtest/test-repo7",
+        "sgtest/test-repo8"
+      ],
+      "repositoryPathPattern": "github.com/{nameWithOwner}"
+    }`,
+		},
+		{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "Github - Test2",
+			Config: `{
+      "url": "https://ghe.org/",
+      "token": "someToken",
+      "repos": [
+        "sgtest/test-repo1",
+        "sgtest/test-repo2",
+        "sgtest/test-repo3",
+        "sgtest/test-repo4",
+        "sgtest/test-repo5",
+        "sgtest/test-repo6",
+        "sgtest/test-repo7",
+        "sgtest/test-repo8"
+      ],
+      "repositoryPathPattern": "github.com/{nameWithOwner}"
+    }`,
+		},
+		{
+			Kind:        extsvc.KindBitbucketCloud,
+			DisplayName: "GitLab - Test1",
+			Config: `{
+      "url": "https://bitbucket.org",
+      "token": "someToken",
+      "username": "user",
+      "repos": [
+        "SOURCEGRAPH/repo-0",
+        "SOURCEGRAPH/repo-1"
+      ],
+      "repositoryPathPattern": "bbs/{projectKey}/{repositorySlug}"
+    }`,
+		},
+	}, nil)
+
+	db := database.NewMockDB()
+	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
+
+	exporter := &OneClickExporter{
+		logger: logger,
+		cfgProcessors: map[string]Processor[ConfigRequest]{
+			"siteConfig": &SiteConfigProcessor{
+				logger: logger,
+				Type:   "siteConfig",
+			},
+			"codeHostConfig": &CodeHostConfigProcessor{
+				db:     db,
+				logger: logger,
+				Type:   "codeHostConfig",
+			},
+		},
+	}
+
+	archive, err := exporter.Export(ctx, &ExportRequest{IncludeSiteConfig: true, IncludeCodeHostConfig: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantMap := map[string]string{
+		"site-config.txt":      wantSiteConfig,
+		"code-host-config.txt": wantCodeHostConfig,
+	}
+
+	for _, f := range zr.File {
+		currentFileName := f.Name
+		want, ok := wantMap[currentFileName]
+		if !ok {
+			continue
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		haveBytes, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		delete(wantMap, currentFileName)
+
+		have := string(haveBytes)
+
 		if diff := cmp.Diff(want, have); diff != "" {
+			t.Errorf("%q has wrong content. (-want +got):\n%s", currentFileName, diff)
+		}
+	}
+
+	for file := range wantMap {
+		t.Errorf("Missing file from ZIP archive: %q", file)
+	}
+}
+
+func TestExport_CodeHostConfigs(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+
+	externalServices := database.NewMockExternalServiceStore()
+	externalServices.ListFunc.SetDefaultReturn([]*types.ExternalService{
+		{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "Github - Test1",
+			Config: `{
+      "url": "https://ghe.org/",
+      "token": "someToken",
+      "repos": [
+        "sgtest/test-repo1",
+        "sgtest/test-repo2",
+        "sgtest/test-repo3",
+        "sgtest/test-repo4",
+        "sgtest/test-repo5",
+        "sgtest/test-repo6",
+        "sgtest/test-repo7",
+        "sgtest/test-repo8"
+      ],
+      "repositoryPathPattern": "github.com/{nameWithOwner}"
+    }`,
+		},
+		{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "Github - Test2",
+			Config: `{
+      "url": "https://ghe.org/",
+      "token": "someToken",
+      "repos": [
+        "sgtest/test-repo1",
+        "sgtest/test-repo2",
+        "sgtest/test-repo3",
+        "sgtest/test-repo4",
+        "sgtest/test-repo5",
+        "sgtest/test-repo6",
+        "sgtest/test-repo7",
+        "sgtest/test-repo8"
+      ],
+      "repositoryPathPattern": "github.com/{nameWithOwner}"
+    }`,
+		},
+		{
+			Kind:        extsvc.KindBitbucketCloud,
+			DisplayName: "GitLab - Test1",
+			Config: `{
+      "url": "https://bitbucket.org",
+      "token": "someToken",
+      "username": "user",
+      "repos": [
+        "SOURCEGRAPH/repo-0",
+        "SOURCEGRAPH/repo-1"
+      ],
+      "repositoryPathPattern": "bbs/{projectKey}/{repositorySlug}"
+    }`,
+		},
+	}, nil)
+
+	db := database.NewMockDB()
+	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
+
+	exporter := &OneClickExporter{
+		logger: logger,
+		cfgProcessors: map[string]Processor[ConfigRequest]{
+			"codeHostConfig": &CodeHostConfigProcessor{
+				db:     db,
+				logger: logger,
+				Type:   "codeHostConfig",
+			},
+		},
+	}
+
+	archive, err := exporter.Export(ctx, &ExportRequest{IncludeCodeHostConfig: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+
+	for _, f := range zr.File {
+		if f.Name != "code-host-config.txt" {
+			continue
+		}
+		found = true
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		haveBytes, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have := string(haveBytes)
+
+		fmt.Println(have)
+
+		if diff := cmp.Diff(wantCodeHostConfig, have); diff != "" {
 			t.Fatalf("Exported site config is different. (-want +got):\n%s", diff)
 		}
 	}

--- a/cmd/frontend/oneclickexport/processor.go
+++ b/cmd/frontend/oneclickexport/processor.go
@@ -21,6 +21,7 @@ type Processor[T any] interface {
 }
 
 var _ Processor[ConfigRequest] = &SiteConfigProcessor{}
+var _ Processor[ConfigRequest] = &CodeHostConfigProcessor{}
 
 type ConfigRequest struct {
 }
@@ -59,10 +60,10 @@ type CodeHostConfigProcessor struct {
 
 // Process function of CodeHostConfigProcessor loads all code host configs
 // available and stores it in a provided tmp directory dir
-func (c CodeHostConfigProcessor) Process(ctx context.Context, _ *ConfigRequest, dir string) {
+func (c CodeHostConfigProcessor) Process(ctx context.Context, _ ConfigRequest, dir string) {
 	externalServices, err := c.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{})
 	if err != nil {
-		c.logger.Error("Error during getting external services", log.Error(err))
+		c.logger.Error("Error getting external services", log.Error(err))
 	}
 
 	if len(externalServices) == 0 {
@@ -85,10 +86,10 @@ func (c CodeHostConfigProcessor) Process(ctx context.Context, _ *ConfigRequest, 
 		c.logger.Error("Error during marshalling the code host config", log.Error(err))
 	}
 
-	err = ioutil.WriteFile(dir+"/code-host-config.txt", configBytes, 0644)
+	err = ioutil.WriteFile(dir+"/code-host-config.json", configBytes, 0644)
 
 	if err != nil {
-		c.logger.Error("Error during site config export", log.Error(err))
+		c.logger.Error("Error during code host config export", log.Error(err))
 	}
 }
 

--- a/cmd/frontend/oneclickexport/processor.go
+++ b/cmd/frontend/oneclickexport/processor.go
@@ -1,10 +1,14 @@
 package oneclickexport
 
 import (
+	"context"
+	"encoding/json"
 	"io/ioutil"
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // Processor is a generic interface for any data export processor.
@@ -12,26 +16,26 @@ import (
 // Processors are called from DataExporter and store exported data in provided
 // directory which is zipped after all the processors finished their job.
 type Processor[T any] interface {
-	Process(payload T, dir string)
+	Process(ctx context.Context, payload T, dir string)
 	ProcessorType() string
 }
 
 var _ Processor[ConfigRequest] = &SiteConfigProcessor{}
+
+type ConfigRequest struct {
+}
 
 type SiteConfigProcessor struct {
 	logger log.Logger
 	Type   string
 }
 
-type ConfigRequest struct {
-}
-
 // Process function of SiteConfigProcessor loads site config, redacts the secrets
-// and stores it in a provided tmp directory dir.
-func (g SiteConfigProcessor) Process(_ ConfigRequest, dir string) {
+// and stores it in a provided tmp directory dir
+func (s SiteConfigProcessor) Process(_ context.Context, _ ConfigRequest, dir string) {
 	siteConfig, err := conf.RedactSecrets(conf.Raw())
 	if err != nil {
-		g.logger.Error("Error during site config redacting", log.Error(err))
+		s.logger.Error("Error during site config redacting", log.Error(err))
 	}
 
 	configBytes := []byte(siteConfig.Site)
@@ -39,10 +43,73 @@ func (g SiteConfigProcessor) Process(_ ConfigRequest, dir string) {
 	err = ioutil.WriteFile(dir+"/site-config.json", configBytes, 0644)
 
 	if err != nil {
-		g.logger.Error("Error during site config export", log.Error(err))
+		s.logger.Error("Error during site config export", log.Error(err))
 	}
 }
 
-func (g SiteConfigProcessor) ProcessorType() string {
-	return g.Type
+func (s SiteConfigProcessor) ProcessorType() string {
+	return s.Type
+}
+
+type CodeHostConfigProcessor struct {
+	db     database.DB
+	logger log.Logger
+	Type   string
+}
+
+// Process function of CodeHostConfigProcessor loads all code host configs
+// available and stores it in a provided tmp directory dir
+func (c CodeHostConfigProcessor) Process(ctx context.Context, _ *ConfigRequest, dir string) {
+	externalServices, err := c.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{})
+	if err != nil {
+		c.logger.Error("Error during getting external services", log.Error(err))
+	}
+
+	if len(externalServices) == 0 {
+		return
+	}
+
+	summaries := make([]*ExternalServiceSummary, len(externalServices))
+	for idx, extSvc := range externalServices {
+		summary, err := convertToSummary(extSvc)
+		if err != nil {
+			// basically this is the only error that can occur
+			c.logger.Error("Error during redacting the code host config", log.Error(err))
+			return
+		}
+		summaries[idx] = summary
+	}
+
+	configBytes, err := json.MarshalIndent(summaries, "", "  ")
+	if err != nil {
+		c.logger.Error("Error during marshalling the code host config", log.Error(err))
+	}
+
+	err = ioutil.WriteFile(dir+"/code-host-config.txt", configBytes, 0644)
+
+	if err != nil {
+		c.logger.Error("Error during site config export", log.Error(err))
+	}
+}
+
+type ExternalServiceSummary struct {
+	Kind        string          `json:"kind"`
+	DisplayName string          `json:"displayName"`
+	Config      json.RawMessage `json:"config"`
+}
+
+func convertToSummary(extSvc *types.ExternalService) (*ExternalServiceSummary, error) {
+	config, err := extSvc.RedactedConfig()
+	if err != nil {
+		return nil, err
+	}
+	return &ExternalServiceSummary{
+		Kind:        extSvc.Kind,
+		DisplayName: extSvc.DisplayName,
+		Config:      json.RawMessage(config),
+	}, nil
+}
+
+func (c CodeHostConfigProcessor) ProcessorType() string {
+	return c.Type
 }


### PR DESCRIPTION
One thing: current design of how `ExportRequest` is composed and processed (very ugly and straightforward ATM) will be changed when new `Processor` types are added.

~~_I'll resolve merge conflicts after parent PR is merged._~~
✅Conflicts resolved✅

Depends on https://github.com/sourcegraph/sourcegraph/pull/39813

Closes https://github.com/sourcegraph/sourcegraph/issues/39618

## Test plan
Separate test case for code host config export is added. Cumulative test for complete export of everything currently supported is added.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
