### PR TITLE
dev/ci: switch to sourcegraph/cache-buildkite-plugin

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/cache.go
+++ b/enterprise/dev/ci/internal/buildkite/cache.go
@@ -1,7 +1,7 @@
 package buildkite
 
 // Follow-up to INC-101, this fork of 'gencer/cache#v2.4.10' uses bsdtar instead of tar.
-const cachePluginName = "https://github.com/jhchabran/cache-buildkite-plugin.git#master"
+const cachePluginName = "https://github.com/sourcegraph/cache-buildkite-plugin.git#master"
 
 // CacheConfig represents the configuration data for https://github.com/gencer/cache-buildkite-plugin
 type CacheConfigPayload struct {


### PR DESCRIPTION
We've moved this fork to https://github.com/sourcegraph/cache-buildkite-plugin

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a