### PR TITLE
Harden ignite networking

### DIFF
--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -244,7 +244,7 @@ EOF
 ## vector and talking to link-local services like the google metadata server.
 function setup_iptables() {
   # Make sure the below install doesn't block.
-  apt-get install -y dialog apt-utils
+  echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
   # Ensure iptables-persistent is installed.
   apt-get install -y iptables-persistent
 

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -215,7 +215,7 @@ function configure_cni() {
       "bridge": "ignite0",
       "isGateway": true,
       "isDefaultGateway": true,
-      "promiscMode": true,
+      "promiscMode": false,
       "ipMasq": true,
       "ipam": {
         "type": "host-local",

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -243,6 +243,8 @@ EOF
 ## traffic except the traffic to nameservers. This is to prevent any internal attack
 ## vector and talking to link-local services like the google metadata server.
 function setup_iptables() {
+  # Make sure the below install doesn't block.
+  apt-get install -y dialog apt-utils
   # Ensure iptables-persistent is installed.
   apt-get install -y iptables-persistent
 

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -243,6 +243,9 @@ EOF
 ## traffic except the traffic to nameservers. This is to prevent any internal attack
 ## vector and talking to link-local services like the google metadata server.
 function setup_iptables() {
+  # Ensure iptables-persistent is installed.
+  apt-get install -y iptables-persistent
+
   # Ensure the chain exists.
   iptables --list | grep CNI-ADMIN 1>/dev/null || iptables -N CNI-ADMIN
 

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -78,8 +78,11 @@ function install_ignite() {
   mv ignite /usr/local/bin
 }
 
+## Install the CNI plus plugins, used by ignite.
 function install_cni() {
   mkdir -p /opt/cni/bin
+  curl -sSL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz | tar -xz -C /opt/cni/bin
+  # Also install the isolation plugin.
   curl -sSL https://github.com/AkihiroSuda/cni-isolation/releases/download/v0.0.4/cni-isolation-amd64.tgz | tar -xz -C /opt/cni/bin
 }
 

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -247,18 +247,13 @@ function setup_iptables() {
   # to prevent leaking any network details).
   iptables -A CNI-ADMIN -p udp --dport 53 -j ACCEPT
 
-  # Allow access to the gateway on the bridge network. TODO: Accept or return?
-  # TODO: This doesn't seem to be required. Why does it work though? Because
-  # it is a gateway and not the _destination_? Does that mean you can hit other
-  # internals too?
-  # iptables -A CNI-ADMIN -d 10.61.0.1 -j RETURN
-
   # Disallow any host-VM network traffic from the guests, except connections made
   # FROM the host (to ssh into the guest).
   iptables -A INPUT -d 10.61.0.0/16 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
   iptables -A INPUT -s 10.61.0.0/16 -j DROP
 
   # Disallow any inter-VM traffic.
+  # But allow to reach the gateway for internet access.
   iptables -A CNI-ADMIN -s 10.61.0.1/32 -d 10.61.0.0/16 -j ACCEPT
   iptables -A CNI-ADMIN -d 10.61.0.0/16 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
   iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 10.61.0.0/16 -j DROP

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -248,7 +248,14 @@ function setup_iptables() {
   # Allow access to the gateway on the bridge network.
   iptables -A CNI-ADMIN -d 10.61.0.1 -j RETURN
   # Disallow any host-VM network traffic
-  iptables -A CNI-ADMIN -d 10.0.1.0/24 -j DROP
+  iptables -A INPUT -d 10.61.0.0/16 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+  iptables -A INPUT -s 10.61.0.0/16 -p tcp -j DROP
+  iptables -A INPUT -s 10.61.0.0/16 -p udp -j DROP
+  iptables -A INPUT -s 10.61.0.0/16 -p icmp --icmp-type echo-request -j DROP
+  iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 10.61.0.0/16 -j ACCEPT
+  iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 10.0.0.0/8 -p tcp -j DROP
+  iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 192.168.0.0/16 -p tcp -j DROP
+  iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 172.16.0.0/16 -p tcp -j DROP
   # Disallow any inter-VM traffic.
   # TODO: This rule doesn't do what we want yet.
   iptables -A CNI-ADMIN -s 10.61.0.1 -j RETURN

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -256,18 +256,14 @@ function setup_iptables() {
   # Disallow any host-VM network traffic from the guests, except connections made
   # FROM the host (to ssh into the guest).
   iptables -A INPUT -d 10.61.0.0/16 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-  # TODO: Can those be combined?
-  iptables -A INPUT -s 10.61.0.0/16 -p tcp -j DROP
-  iptables -A INPUT -s 10.61.0.0/16 -p udp -j DROP
-  iptables -A INPUT -s 10.61.0.0/16 -p icmp --icmp-type echo-request -j DROP
+  iptables -A INPUT -s 10.61.0.0/16 -j DROP
 
   # Disallow any inter-VM traffic.
-  # TODO: This rule doesn't do what we want yet.
-  # iptables -A CNI-ADMIN -s 10.61.0.1 -j RETURN
-  # iptables -A CNI-ADMIN -d 10.61.0.0/16 -j DROP
+  iptables -A CNI-ADMIN -s 10.61.0.1/32 -d 10.61.0.0/16 -j ACCEPT
+  iptables -A CNI-ADMIN -d 10.61.0.0/16 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+  iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 10.61.0.0/16 -j DROP
 
   # Disallow local networks access.
-  iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 10.61.0.0/16 -j ACCEPT
   iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 10.0.0.0/8 -p tcp -j DROP
   iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 192.168.0.0/16 -p tcp -j DROP
   iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 172.16.0.0/12 -p tcp -j DROP

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -255,7 +255,7 @@ function setup_iptables() {
   iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 10.61.0.0/16 -j ACCEPT
   iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 10.0.0.0/8 -p tcp -j DROP
   iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 192.168.0.0/16 -p tcp -j DROP
-  iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 172.16.0.0/16 -p tcp -j DROP
+  iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 172.16.0.0/12 -p tcp -j DROP
   # Disallow any inter-VM traffic.
   # TODO: This rule doesn't do what we want yet.
   iptables -A CNI-ADMIN -s 10.61.0.1 -j RETURN

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -244,7 +244,7 @@ function setup_iptables() {
   # Ensure the chain exists.
   iptables -N CNI-ADMIN
   # Explicitly allow UDP link local traffic (required for google cloud).
-  iptables -A CNI-ADMIN -m udp --dport 53 -d 169.254.0.0/16 -j ACCEPT
+  iptables -A CNI-ADMIN -p udp --dport 53 -d 169.254.0.0/16 -j ACCEPT
   # Allow access to the gateway on the bridge network.
   iptables -A CNI-ADMIN -d 10.61.0.1 -j RETURN
   # Disallow any host-VM network traffic

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -247,6 +247,8 @@ function setup_iptables() {
   iptables -A CNI-ADMIN -m udp --dport 53 -d 169.254.0.0/16 -j ACCEPT
   # Allow access to the gateway on the bridge network.
   iptables -A CNI-ADMIN -d 10.61.0.1 -j RETURN
+  # Disallow any host-VM network traffic
+  iptables -A CNI-ADMIN -d 10.0.1.0/24 -j DROP
   # Disallow any inter-VM traffic.
   # TODO: This rule doesn't do what we want yet.
   iptables -A CNI-ADMIN -s 10.61.0.1 -j RETURN

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -271,6 +271,7 @@ function setup_iptables() {
   iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 169.254.0.0/16 -j DROP
 
   # Store the iptables config.
+  mkdir -p /etc/iptables
   iptables-save >/etc/iptables/rules.v4
 }
 

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -271,13 +271,7 @@ function setup_iptables() {
   iptables -A CNI-ADMIN -s 10.61.0.0/16 -d 169.254.0.0/16 -j DROP
 
   # Store the iptables config.
-  iptables-save >/etc/iptables-store.conf
-  # And make sure it gets loaded on boot.
-  cat <<EOF >/etc/network/if-up.d/iptables
-#!/bin/sh
-iptables-restore < /etc/iptables-store.conf
-EOF
-  chmod +x /etc/network/if-up.d/iptables
+  iptables-save >/etc/iptables/rules.v4
 }
 
 function cleanup() {

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -204,6 +204,7 @@ function preheat_kernel_image() {
 ## This is to prevent cross-network communication (which currently doesn't happen
 ## as we only have 1 bridge).
 function configure_cni() {
+  mkdir -p /etc/cni/net.d
   cat <<EOF >/etc/cni/net.d/10-ignite.conflist
 {
   "cniVersion": "0.4.0",


### PR DESCRIPTION
This PR improves the isolation of our executor VMs further by making them all fully isolated on the network.

```
# Test points:

- SSH into ignite VM
- curl -fv http://169.254.169.254/latest/meta-data/
- ssh 10.61.0.1
- curl -fv google.com
- curl -fvL http://10.0.1.4:5000 FAIL (will fix in tf module)
- ping 10.61.0.1
- ping 10.61.0.3 (other VM) 
- ssh <host_internal_ip>
- ssh <host_external_ip>
```

Addresses https://github.com/sourcegraph/security-issues/issues/295

## Test plan

See test points above, both tested on GCP and AWS.