### PR TITLE
repo-updater: Remove unused method

### DIFF
--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -385,17 +385,6 @@ func configuredRepoFromRepo(r *types.Repo) configuredRepo {
 	return repo
 }
 
-// UpdateOnce causes a single update of the given repository.
-// It neither adds nor removes the repo from the schedule.
-func (s *UpdateScheduler) UpdateOnce(id api.RepoID, name api.RepoName) {
-	repo := configuredRepo{
-		ID:   id,
-		Name: name,
-	}
-	schedManualFetch.Inc()
-	s.updateQueue.enqueue(repo, priorityHigh)
-}
-
 // DebugDump returns the state of the update scheduler for debugging.
 func (s *UpdateScheduler) DebugDump(ctx context.Context) any {
 	data := struct {


### PR DESCRIPTION
Found while browsing, makes it easier to understand what could call what if no unused callsites exist, so removing it here.

## Test plan

Go static compile checks should validate this change is ok.