### PR TITLE
gitserver: Unexport RemoveFrom from client

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -211,9 +211,6 @@ type Client interface {
 	// Remove removes the repository clone from gitserver.
 	Remove(context.Context, api.RepoName) error
 
-	// RemoveFrom removes the repository clone from the given gitserver.
-	RemoveFrom(ctx context.Context, repo api.RepoName, from string) error
-
 	// RendezvousAddrForRepo returns the gitserver address to use for the given
 	// repo name using the Rendezvous hashing scheme.
 	RendezvousAddrForRepo(api.RepoName) string
@@ -1079,10 +1076,10 @@ func (c *clientImplementor) Remove(ctx context.Context, repo api.RepoName) error
 	if err != nil {
 		return err
 	}
-	return c.RemoveFrom(ctx, repo, addr)
+	return c.removeFrom(ctx, repo, addr)
 }
 
-func (c *clientImplementor) RemoveFrom(ctx context.Context, repo api.RepoName, from string) error {
+func (c *clientImplementor) removeFrom(ctx context.Context, repo api.RepoName, from string) error {
 	b, err := json.Marshal(&protocol.RepoDeleteRequest{
 		Repo: repo,
 	})

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -143,9 +143,6 @@ type MockClient struct {
 	// RemoveFunc is an instance of a mock function object controlling the
 	// behavior of the method Remove.
 	RemoveFunc *ClientRemoveFunc
-	// RemoveFromFunc is an instance of a mock function object controlling
-	// the behavior of the method RemoveFrom.
-	RemoveFromFunc *ClientRemoveFromFunc
 	// RendezvousAddrForRepoFunc is an instance of a mock function object
 	// controlling the behavior of the method RendezvousAddrForRepo.
 	RendezvousAddrForRepoFunc *ClientRendezvousAddrForRepoFunc
@@ -377,11 +374,6 @@ func NewMockClient() *MockClient {
 		},
 		RemoveFunc: &ClientRemoveFunc{
 			defaultHook: func(context.Context, api.RepoName) (r0 error) {
-				return
-			},
-		},
-		RemoveFromFunc: &ClientRemoveFromFunc{
-			defaultHook: func(context.Context, api.RepoName, string) (r0 error) {
 				return
 			},
 		},
@@ -642,11 +634,6 @@ func NewStrictMockClient() *MockClient {
 				panic("unexpected invocation of MockClient.Remove")
 			},
 		},
-		RemoveFromFunc: &ClientRemoveFromFunc{
-			defaultHook: func(context.Context, api.RepoName, string) error {
-				panic("unexpected invocation of MockClient.RemoveFrom")
-			},
-		},
 		RendezvousAddrForRepoFunc: &ClientRendezvousAddrForRepoFunc{
 			defaultHook: func(api.RepoName) string {
 				panic("unexpected invocation of MockClient.RendezvousAddrForRepo")
@@ -825,9 +812,6 @@ func NewMockClientFrom(i Client) *MockClient {
 		},
 		RemoveFunc: &ClientRemoveFunc{
 			defaultHook: i.Remove,
-		},
-		RemoveFromFunc: &ClientRemoveFromFunc{
-			defaultHook: i.RemoveFrom,
 		},
 		RendezvousAddrForRepoFunc: &ClientRendezvousAddrForRepoFunc{
 			defaultHook: i.RendezvousAddrForRepo,
@@ -5287,113 +5271,6 @@ func (c ClientRemoveFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ClientRemoveFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// ClientRemoveFromFunc describes the behavior when the RemoveFrom method of
-// the parent MockClient instance is invoked.
-type ClientRemoveFromFunc struct {
-	defaultHook func(context.Context, api.RepoName, string) error
-	hooks       []func(context.Context, api.RepoName, string) error
-	history     []ClientRemoveFromFuncCall
-	mutex       sync.Mutex
-}
-
-// RemoveFrom delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockClient) RemoveFrom(v0 context.Context, v1 api.RepoName, v2 string) error {
-	r0 := m.RemoveFromFunc.nextHook()(v0, v1, v2)
-	m.RemoveFromFunc.appendCall(ClientRemoveFromFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the RemoveFrom method of
-// the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientRemoveFromFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// RemoveFrom method of the parent MockClient instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *ClientRemoveFromFunc) PushHook(hook func(context.Context, api.RepoName, string) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ClientRemoveFromFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, string) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientRemoveFromFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, api.RepoName, string) error {
-		return r0
-	})
-}
-
-func (f *ClientRemoveFromFunc) nextHook() func(context.Context, api.RepoName, string) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ClientRemoveFromFunc) appendCall(r0 ClientRemoveFromFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ClientRemoveFromFuncCall objects describing
-// the invocations of this function.
-func (f *ClientRemoveFromFunc) History() []ClientRemoveFromFuncCall {
-	f.mutex.Lock()
-	history := make([]ClientRemoveFromFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ClientRemoveFromFuncCall is an object that describes an invocation of
-// method RemoveFrom on an instance of MockClient.
-type ClientRemoveFromFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.RepoName
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ClientRemoveFromFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ClientRemoveFromFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 


### PR DESCRIPTION
Not used outside the implementor, so let's keep the interface lean.



## Test plan

Static compile checks will find out if this is ok.