### PR TITLE
FilterControl: fix warning by using value on <Select>

### DIFF
--- a/client/web/src/components/FilteredConnection/FilterControl.tsx
+++ b/client/web/src/components/FilteredConnection/FilterControl.tsx
@@ -93,15 +93,11 @@ export const FilterControl: React.FunctionComponent<React.PropsWithChildren<Filt
                                     id=""
                                     name={filter.id}
                                     onChange={event => onChange(filter, event.currentTarget.value)}
+                                    value={values.get(filter.id)?.value}
                                     className="mb-0"
                                 >
                                     {filter.values.map(value => (
-                                        <option
-                                            key={value.value}
-                                            value={value.value}
-                                            label={value.label}
-                                            selected={values.get(filter.id)?.value === value.value}
-                                        />
+                                        <option key={value.value} value={value.value} label={value.label} />
                                     ))}
                                 </Select>
                             </div>


### PR DESCRIPTION
Previous solution created a warning in console saying that `selected` on
`<option />` is discouraged and one should use `value` directly.

Works.

## Test plan

- Manual testing and existing tests

## App preview:

- [Web](https://sg-web-mrn-select-fix-warning.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hmafnjacqk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
