### PR TITLE
migration: Export CanonicalizeQuery functionality

### DIFF
--- a/internal/database/migration/definition/read_test.go
+++ b/internal/database/migration/definition/read_test.go
@@ -140,7 +140,7 @@ parent: 12345
 -- +++
 `
 
-func TestQueryFromString(t *testing.T) {
+func TestCanonicalizeQuery(t *testing.T) {
 	for _, testCase := range []struct {
 		name     string
 		input    string
@@ -154,7 +154,7 @@ func TestQueryFromString(t *testing.T) {
 		{"kitchen sink", testFrontmatter + "\n\nBEGIN;\n\nMY QUERY;\n\nCOMMIT;\n", "MY QUERY;"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			if query := queryFromString(testCase.input).Query(sqlf.PostgresBindVar); query != testCase.expected {
+			if query := CanonicalizeQuery(testCase.input); query != testCase.expected {
 				t.Errorf("unexpected canonical query. want=%q have=%q", testCase.expected, query)
 			}
 		})


### PR DESCRIPTION
Partial fix to #39863. Export cruft-shedding functionality from an unexported method. I need to use this in a bit.

## Test plan

Existing unit tests.