### PR TITLE
insights: during just in time migration make series look like it was created now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fix issue during conversion of a just in time code insight to one that is persisted where the incorrect start date was used to calculate the series. [#39867](https://github.com/sourcegraph/sourcegraph/pull/39867)
 - Fix issue during code insight creation where selecting `"Run your insight over all your repositories"` reset the currently selected distance between data points. [#39261](https://github.com/sourcegraph/sourcegraph/pull/39261)
 - Fix issue where symbols in the side panel did not have file level permission filtering applied correctly. [#39592](https://github.com/sourcegraph/sourcegraph/pull/39592)
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -432,6 +432,8 @@ func (h *historicalEnqueuer) convertJustInTimeInsights(ctx context.Context) {
 		if incrementErr != nil {
 			log15.Warn("unable to update backfill attempts", "seriesId", series.SeriesID, "error", err)
 		}
+		// Series should backfill as if it were just created now
+		series.CreatedAt = time.Now()
 		err := h.scopedBackfiller.ScopedBackfill(ctx, []itypes.InsightSeries{series})
 		if err != nil {
 			log15.Error("unable to backfill scoped series", "series_id", series.SeriesID, "error", err)


### PR DESCRIPTION
When migrating just in time the backfill start date is based on the series created at time .  This is incorrect the backfill should start from the current time.  This change preserves the created at date but sends the current time to the scoped backfiller so that it backfills the 12 most recent points.

closes https://github.com/sourcegraph/sourcegraph/issues/39866
## Test plan

- Set the `code_insights_deprecate_jit` feature flag to `false`

- Create Just in time Track Changes insight and a Detect & track insight scoped to a repo then manually backdate the created at<img width="937" alt="Screen Shot 2022-08-03 at 8 38 13 AM" src="https://user-images.githubusercontent.com/6098507/182611453-84104169-8625-4d69-a0f6-3f45ea438562.png">
- Verify insights display 7 historical points from now <img width="972" alt="Screen Shot 2022-08-03 at 8 38 45 AM" src="https://user-images.githubusercontent.com/6098507/182612121-644ba6d5-948e-4613-9c0f-c7c41e36b9ea.png">
- Set the `code_insights_deprecate_jit` feature flag to `true`
- Restart the worker so the code to convert Just in time insights runs
- Verify 12 data points with the most recent being start of current day UTC <img width="1009" alt="Screen Shot 2022-08-03 at 8 41 07 AM" src="https://user-images.githubusercontent.com/6098507/182612172-178c18e1-2ad4-43e6-8a09-8819e229d187.png">
- Verify next recording date is 1 interval from now and next snapshot is start of next day <img width="1245" alt="Screen Shot 2022-08-03 at 8 41 45 AM" src="https://user-images.githubusercontent.com/6098507/182612375-ac18eadb-8578-462a-8f72-65c2928e964f.png">




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
