### PR TITLE
gitserver: Restore repo pinning functionality

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/fileutil"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -163,7 +164,7 @@ const reposStatsName = "repos-stats.json"
 // 10. Perform sg-maintenance
 // 11. Git prune
 // 12. Only during first run: Set sizes of repos which don't have it in a database.
-func (s *Server) cleanupRepos(gitServerAddrs []string) {
+func (s *Server) cleanupRepos(gitServerAddrs gitserver.GitServerAddresses) {
 	janitorRunning.Set(1)
 	janitorStart := time.Now()
 	defer func() {
@@ -173,14 +174,14 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 	cleanupLogger := s.Logger.Scoped("cleanup", "cleanup operation")
 
 	knownGitServerShard := false
-	for _, addr := range gitServerAddrs {
+	for _, addr := range gitServerAddrs.Addresses {
 		if s.hostnameMatch(addr) {
 			knownGitServerShard = true
 			break
 		}
 	}
 	if !knownGitServerShard {
-		s.Logger.Warn("current shard is not included in the list of known gitserver shards, will not delete repos", log.String("current-hostname", s.Hostname), log.Strings("all-shards", gitServerAddrs))
+		s.Logger.Warn("current shard is not included in the list of known gitserver shards, will not delete repos", log.String("current-hostname", s.Hostname), log.Strings("all-shards", gitServerAddrs.Addresses))
 	}
 
 	bCtx, bCancel := s.serverContext()
@@ -215,7 +216,7 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 
 		// Record the number and disk usage used of repos that should
 		// not belong on this instance and remove up to SRC_WRONG_SHARD_DELETE_LIMIT in a single Janitor run.
-		addr := addrForKey(name, gitServerAddrs)
+		addr, err := s.addrForRepo(bCtx, name, gitServerAddrs)
 		if !s.hostnameMatch(addr) {
 			wrongShardRepoCount++
 			wrongShardRepoSize += size

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -80,7 +81,7 @@ UPDATE gitserver_repos SET repo_size_bytes = 5 where repo_id = 3;
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}
 
-	s.cleanupRepos([]string{"gitserver-0"})
+	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	for i := 1; i <= 3; i++ {
 		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), api.RepoID(i))
@@ -136,7 +137,7 @@ func TestCleanupInactive(t *testing.T) {
 		DB:     database.NewMockDB(),
 	}
 	s.testSetup(t)
-	s.cleanupRepos([]string{"gitserver-0"})
+	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	if _, err := os.Stat(repoA); os.IsNotExist(err) {
 		t.Error("expected repoA not to be removed")
@@ -169,7 +170,7 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		s.Hostname = "does-not-exist"
-		s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
+		s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
 
 		if _, err := os.Stat(repoA); err != nil {
 			t.Error("expected repoA not to be removed")
@@ -200,7 +201,7 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		s.Hostname = "gitserver-0"
-		s.cleanupRepos([]string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"})
+		s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"}})
 
 		if _, err := os.Stat(repoA); err != nil {
 			t.Error("expected repoA not to be removed")
@@ -231,7 +232,7 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		wrongShardReposDeleteLimit = -1
-		s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
+		s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
 
 		if _, err := os.Stat(repoA); os.IsNotExist(err) {
 			t.Error("expected repoA not to be removed")
@@ -297,7 +298,7 @@ func TestGitGCAuto(t *testing.T) {
 		DB:     database.NewMockDB(),
 	}
 	s.testSetup(t)
-	s.cleanupRepos([]string{"gitserver-0"})
+	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	// Verify that there are no more GC-able objects in the repository.
 	if !strings.Contains(countObjects(), "count: 0") {
@@ -418,7 +419,7 @@ func TestCleanupExpired(t *testing.T) {
 		DB: database.NewMockDB(),
 	}
 	s.testSetup(t)
-	s.cleanupRepos([]string{"gitserver-0"})
+	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	// repos that shouldn't be re-cloned
 	if repoNewTime.Before(modTime(repoNew)) {
@@ -599,7 +600,7 @@ func TestCleanupOldLocks(t *testing.T) {
 
 	s := &Server{ReposDir: root, Logger: logtest.Scoped(t), DB: database.NewMockDB()}
 	s.testSetup(t)
-	s.cleanupRepos([]string{"gitserver-0"})
+	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	isRemoved := func(path string) bool {
 		_, err := os.Stat(path)
@@ -1455,7 +1456,7 @@ update gitserver_repos set repo_size_bytes = 228 where repo_id = 1;
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}
 
-	s.cleanupRepos([]string{"gitserver-0"})
+	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	for i := 1; i <= 3; i++ {
 		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), 1)


### PR DESCRIPTION
When we [switched to this helper method](https://github.com/sourcegraph/sourcegraph/pull/34362/files), we lost repo pinning as this method doesn't take it into consideration. Since we have it in the settings, I'd rather restore it or completely remove it, but not keep it broken. Who knows who relies on it. Currently, pinned repos would most likely just be unreachable.
Current behavior: The gitserver.Client uses the pinning map, and directs traffic to the defined gitserver, but the gitserver would not recognize that repo as "owned by itself" hence it would never clone it / unclone it.

## Test plan

Test suite gotta tell us if this breaks gitserver.