### PR TITLE
codemirror blob view: (almost) full hovercard support

### DIFF
--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -157,7 +157,6 @@ export const WithSmallTextAlert: Story = () => (
             alerts: [FIXTURE_SMALL_TEXT_MARKDOWN_ALERT],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -178,7 +177,6 @@ export const WithOneLineAlert: Story = () => (
             ],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -200,7 +198,6 @@ export const WithAlertWithWarningIcon: Story = () => (
             ],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -224,7 +221,6 @@ export const WithDismissibleAlertWithIcon: Story = () => (
             ],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -239,7 +235,6 @@ export const WithLongMarkdownTextAndDismissibleAlertWithIcon: Story = () => (
             aggregatedBadges: [FIXTURE_PARTIAL_BADGE, FIXTURE_SEMANTIC_BADGE],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -255,7 +250,6 @@ export const MultipleMarkupContentsWithBadgesAndAlerts: Story = () => (
                 alerts: [FIXTURE_SMALL_TEXT_MARKDOWN_ALERT, FIXTURE_WARNING_MARKDOWN_ALERT],
             }}
             actionsOrError={FIXTURE_ACTIONS}
-            onAlertDismissed={action('onAlertDismissed')}
         />
     </div>
 )
@@ -271,7 +265,6 @@ export const WithCloseButton: Story = () => (
             alerts: [FIXTURE_SMALL_TEXT_MARKDOWN_ALERT, FIXTURE_WARNING_MARKDOWN_ALERT],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        onAlertDismissed={action('onAlertDismissed')}
         pinOptions={{ showCloseButton: true }}
     />
 )

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -157,6 +157,7 @@ export const WithSmallTextAlert: Story = () => (
             alerts: [FIXTURE_SMALL_TEXT_MARKDOWN_ALERT],
         }}
         actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -177,6 +178,7 @@ export const WithOneLineAlert: Story = () => (
             ],
         }}
         actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -198,6 +200,7 @@ export const WithAlertWithWarningIcon: Story = () => (
             ],
         }}
         actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -221,6 +224,7 @@ export const WithDismissibleAlertWithIcon: Story = () => (
             ],
         }}
         actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -235,6 +239,7 @@ export const WithLongMarkdownTextAndDismissibleAlertWithIcon: Story = () => (
             aggregatedBadges: [FIXTURE_PARTIAL_BADGE, FIXTURE_SEMANTIC_BADGE],
         }}
         actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
     />
 )
 
@@ -250,6 +255,7 @@ export const MultipleMarkupContentsWithBadgesAndAlerts: Story = () => (
                 alerts: [FIXTURE_SMALL_TEXT_MARKDOWN_ALERT, FIXTURE_WARNING_MARKDOWN_ALERT],
             }}
             actionsOrError={FIXTURE_ACTIONS}
+            onAlertDismissed={action('onAlertDismissed')}
         />
     </div>
 )
@@ -265,6 +271,7 @@ export const WithCloseButton: Story = () => (
             alerts: [FIXTURE_SMALL_TEXT_MARKDOWN_ALERT, FIXTURE_WARNING_MARKDOWN_ALERT],
         }}
         actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
         pinOptions={{ showCloseButton: true }}
     />
 )

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -35,15 +35,16 @@ export interface WebHoverOverlayProps
 }
 
 export const WebHoverOverlay: React.FunctionComponent<React.PropsWithChildren<WebHoverOverlayProps>> = props => {
+    const { onAlertDismissed: outerOnAlertDismissed } = props
     const [dismissedAlerts, setDismissedAlerts] = useLocalStorage<string[]>('WebHoverOverlay.dismissedAlerts', [])
     const onAlertDismissed = useCallback(
         (alertType: string) => {
             if (!dismissedAlerts.includes(alertType)) {
                 setDismissedAlerts([...dismissedAlerts, alertType])
-                props.onAlertDismissed?.(alertType)
+                outerOnAlertDismissed?.(alertType)
             }
         },
-        [dismissedAlerts, setDismissedAlerts]
+        [dismissedAlerts, setDismissedAlerts, outerOnAlertDismissed]
     )
 
     let propsToUse = props

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -26,12 +26,7 @@ const getAlertVariant: HoverOverlayProps['getAlertVariant'] = iconKind => iconKi
 export interface WebHoverOverlayProps
     extends Omit<
             HoverOverlayProps,
-            | 'className'
-            | 'closeButtonClassName'
-            | 'actionItemClassName'
-            | 'onAlertDismissed'
-            | 'getAlertVariant'
-            | 'actionItemStyleProps'
+            'className' | 'closeButtonClassName' | 'actionItemClassName' | 'getAlertVariant' | 'actionItemStyleProps'
         >,
         HoverThresholdProps,
         SettingsCascadeProps {
@@ -45,6 +40,7 @@ export const WebHoverOverlay: React.FunctionComponent<React.PropsWithChildren<We
         (alertType: string) => {
             if (!dismissedAlerts.includes(alertType)) {
                 setDismissedAlerts([...dismissedAlerts, alertType])
+                props.onAlertDismissed?.(alertType)
             }
         },
         [dismissedAlerts, setDismissedAlerts]

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -23,12 +23,23 @@ const iconKindToAlertVariant: Record<number, AlertProps['variant']> = {
 
 const getAlertVariant: HoverOverlayProps['getAlertVariant'] = iconKind => iconKindToAlertVariant[iconKind]
 
-interface Props extends HoverOverlayProps, HoverThresholdProps, SettingsCascadeProps {
+export interface WebHoverOverlayProps
+    extends Omit<
+            HoverOverlayProps,
+            | 'className'
+            | 'closeButtonClassName'
+            | 'actionItemClassName'
+            | 'onAlertDismissed'
+            | 'getAlertVariant'
+            | 'actionItemStyleProps'
+        >,
+        HoverThresholdProps,
+        SettingsCascadeProps {
     hoveredTokenElement?: HTMLElement
     nav?: (url: string) => void
 }
 
-export const WebHoverOverlay: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
+export const WebHoverOverlay: React.FunctionComponent<React.PropsWithChildren<WebHoverOverlayProps>> = props => {
     const [dismissedAlerts, setDismissedAlerts] = useLocalStorage<string[]>('WebHoverOverlay.dismissedAlerts', [])
     const onAlertDismissed = useCallback(
         (alertType: string) => {

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -218,8 +218,6 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         if (editor && !blobIsLoading) {
             selectLines(editor, position.line ? position : null)
         }
-        // editor is not provided because this should only be triggered after the
-        // editor was created (i.e. not on first render)
     }, [editor, position, blobIsLoading])
 
     // Update pinned hovercard range
@@ -235,13 +233,17 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     return <div ref={setContainer} aria-label={ariaLabel} role={role} className={`${className} overflow-hidden`} />
 }
 
+/**
+ * Returns true when the URL indicates that the hovercard at the URL position
+ * should be shown on load (the hovercard is "pinned").
+ */
 function urlIsPinned(search: string): boolean {
     return new URLSearchParams(search).get('popover') === 'pinned'
 }
 
 /**
  * Because the location changes before new blob info is available we often apply
- * updates to the old document, which can be problematic or thorw errors. This
+ * updates to the old document, which can be problematic or throw errors. This
  * helper hook keeps track of which path is set when the blob info updates
  * and compares it against the current path.
  */

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -5,17 +5,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { search, searchKeymap } from '@codemirror/search'
-import { EditorState, Extension } from '@codemirror/state'
+import { Compartment, EditorState, Extension } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
 
-import { addLineRangeQueryParameter, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
-import {
-    createUpdateableField,
-    editorHeight,
-    useCodeMirror,
-    useCompartment,
-} from '@sourcegraph/shared/src/components/CodeMirrorEditor'
-import { parseQueryAndHash, toURIWithPath } from '@sourcegraph/shared/src/util/url'
+import { addLineRangeQueryParameter, LineOrPositionOrRange, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
+import { createUpdateableField, editorHeight, useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import { parseQueryAndHash, UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { enableExtensionsDecorationsColumnViewFromSettings } from '../../util/settings'
 
@@ -25,10 +20,11 @@ import {
     showTextDocumentDecorations,
 } from './codemirror/decorations'
 import { syntaxHighlight } from './codemirror/highlight'
+import { hovercardRanges } from './codemirror/hovercard'
 import { selectLines, selectableLineNumbers, SelectedLineRange } from './codemirror/linenumbers'
 import { sourcegraphExtensions } from './codemirror/sourcegraph-extensions'
-import { blobPropsFacet, hovercardRangeFromPin } from './codemirror'
-import { hovercardRanges } from './codemirror/hovercard'
+import { blobPropsFacet } from './codemirror'
+import { offsetToUIPosition, uiPositionToOffset } from './codemirror/utils'
 
 const staticExtensions: Extension = [
     // Using EditorState.readOnly instead of EditorView.editable allows us to
@@ -55,6 +51,16 @@ const staticExtensions: Extension = [
     keymap.of(searchKeymap),
 ]
 
+// Compartments are used to reconfigure some parts of the editor withoug
+// affecting others.
+
+// Compartment to update various smaller settings
+const settingsCompartment = new Compartment()
+// Compartment to update blame information
+const blameDecorationsCompartment = new Compartment()
+// Compartment for propagating component props
+const blobPropsCompartment = new Compartment()
+
 export const Blob: React.FunctionComponent<BlobProps> = props => {
     const {
         className,
@@ -67,7 +73,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         settingsCascade,
         location,
         history,
-        blameDecorations,
+        blameDecorations: blameTextDocumentDecorations,
 
         // These props don't have to be supported yet because the CodeMirror blob
         // view is only used on the blob page where these are always true
@@ -78,32 +84,32 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     const [container, setContainer] = useState<HTMLDivElement | null>(null)
     const position = useMemo(() => parseQueryAndHash(location.search, location.hash), [location.search, location.hash])
     const blobIsLoading = useBlobIsLoading(blobInfo, location.pathname)
+    const hasPin = useMemo(() => urlIsPinned(location.search), [location.search])
+
+    const blobProps = useMemo(() => blobPropsFacet.of(props), [props])
 
     const enableExtensionsDecorationsColumnView = enableExtensionsDecorationsColumnViewFromSettings(settingsCascade)
-
     const settings = useMemo(
         () => [
             wrapCode ? EditorView.lineWrapping : [],
             EditorView.darkTheme.of(isLightTheme === false),
-            blameDecorations
+            enableColumnView.of(enableExtensionsDecorationsColumnView),
+        ],
+        [wrapCode, isLightTheme, location, enableExtensionsDecorationsColumnView]
+    )
+
+    const blameDecorations = useMemo(
+        () =>
+            blameTextDocumentDecorations
                 ? [
                       // Force column view if blameDecorations is set
                       enableColumnView.of(true),
-                      showTextDocumentDecorations.of([[blameDecorationType, blameDecorations]]),
+                      showTextDocumentDecorations.of([[blameDecorationType, blameTextDocumentDecorations]]),
                   ]
                 : [],
-            enableColumnView.of(enableExtensionsDecorationsColumnView),
-        ],
-        [wrapCode, isLightTheme, location, enableExtensionsDecorationsColumnView, blameDecorations]
-    )
-    const [settingsCompartment, updateSettingsCompartment] = useCompartment(settings)
 
-    // Used to render pinned hovercards
-    const [pinnedRangeField, updatePinnedRangeField] = useMemo(() => {
-        return createUpdateableField(urlIsPinned(location.search) ? position : null, field =>
-            hovercardRangeFromPin(field)
-        )
-    }, [blobInfo])
+        [blameTextDocumentDecorations]
+    )
 
     // Keep history and location in a ref so that we can use the latest value in
     // the onSelection callback without having to recreate it and having to
@@ -135,23 +141,18 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         )
     }, [])
 
-    const [propsField, updatePropsField] = useMemo(
-        () => createUpdateableField(props, field => blobPropsFacet.from(field)),
-        // Should only be executed on first render
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        []
-    )
     const extensions = useMemo(
         () => [
-            selectableLineNumbers({ onSelection }),
             staticExtensions,
-            settingsCompartment,
+            selectableLineNumbers({ onSelection }),
             syntaxHighlight.of(blobInfo),
+            pinnedRangeField.init(() => (hasPin ? position : null)),
             sourcegraphExtensions({ blobInfo, extensionsController }),
-            propsField,
-            pinnedRangeField,
+            blobPropsCompartment.of(blobProps),
+            blameDecorationsCompartment.of(blameDecorations),
+            settingsCompartment.of(settings),
         ],
-        [propsField, settingsCompartment, onSelection, blobInfo, extensionsController]
+        [onSelection, blobInfo, extensionsController]
     )
 
     const editor = useCodeMirror(container, blobInfo.content, extensions, {
@@ -159,24 +160,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         updateOnExtensionChange: false,
     })
 
-    useEffect(() => {
-        if (editor) {
-            updatePropsField(editor, props)
-        }
-        // editor is not provided because this should only be triggered after the
-        // editor was created (i.e. not on first render)
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props])
-
-    useEffect(() => {
-        if (editor) {
-            updateSettingsCompartment(editor, settings)
-        }
-        // editor is not provided because this should only be triggered after the
-        // editor was created (i.e. not on first render)
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [updateSettingsCompartment, settings])
-
+    // Reconfigure editor when blobInfo or core extensions changed
     useEffect(() => {
         if (editor) {
             // We use setState here instead of dispatching a transaction because
@@ -194,6 +178,36 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [blobInfo, extensions])
 
+    // Propagate props changes to extensions
+    useEffect(() => {
+        if (editor) {
+            editor.dispatch({ effects: blobPropsCompartment.reconfigure(blobProps) })
+        }
+        // editor is not provided because this should only be triggered after the
+        // editor was created (i.e. not on first render)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [blobProps])
+
+    // Update blame information
+    useEffect(() => {
+        if (editor) {
+            editor.dispatch({ effects: blameDecorationsCompartment.reconfigure(blameDecorations) })
+        }
+        // editor is not provided because this should only be triggered after the
+        // editor was created (i.e. not on first render)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [blameDecorations])
+
+    // Update settings
+    useEffect(() => {
+        if (editor) {
+            editor.dispatch({ effects: settingsCompartment.reconfigure(settings) })
+        }
+        // editor is not provided because this should only be triggered after the
+        // editor was created (i.e. not on first render)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [settings])
+
     // Update selected lines when URL changes
     useEffect(() => {
         if (editor && !blobIsLoading) {
@@ -204,7 +218,6 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     }, [editor, position, blobIsLoading])
 
     // Update pinned hovercard range
-    const hasPin = useMemo(() => urlIsPinned(location.search), [location.search])
     useEffect(() => {
         if (editor && !blobIsLoading) {
             updatePinnedRangeField(editor, hasPin ? position : null)
@@ -229,3 +242,60 @@ function urlIsPinned(search: string): boolean {
 function useBlobIsLoading(blobInfo: BlobInfo, pathname: string): boolean {
     return pathname !== useMemo(() => pathname, [blobInfo])
 }
+
+/**
+ * Field used by the CodeMirror blob view to provide hovercard range information
+ * for pinned cards. Since we have to use the editor's current state to compute
+ * the final position we are using a field instead of a compartment to provide
+ * this information.
+ */
+const [pinnedRangeField, updatePinnedRangeField] = createUpdateableField<LineOrPositionOrRange | null>(null, field =>
+    hovercardRanges.computeN([field], state => {
+        const position = state.field(field)
+        if (!position) {
+            return []
+        }
+
+        if (!position.line || !position.character) {
+            return []
+        }
+        const startLine = state.doc.line(position.line)
+
+        const startPosition = {
+            line: position.line,
+            character: position.character,
+        }
+        const from = uiPositionToOffset(state.doc, startPosition, startLine)
+
+        let endPosition: UIPositionSpec['position']
+        let to: number
+
+        if (position.endLine && position.endCharacter) {
+            endPosition = {
+                line: position.endLine,
+                character: position.endCharacter,
+            }
+            to = uiPositionToOffset(state.doc, endPosition)
+        } else {
+            // To determine the end position we have to find the word at the
+            // start position
+            const word = state.wordAt(from)
+            if (!word) {
+                return []
+            }
+            to = word.to
+            endPosition = offsetToUIPosition(state.doc, word.to)
+        }
+
+        return [
+            {
+                to,
+                from,
+                range: {
+                    start: startPosition,
+                    end: endPosition,
+                },
+            },
+        ]
+    })
+)

--- a/client/web/src/repo/blob/codemirror/document-highlights.ts
+++ b/client/web/src/repo/blob/codemirror/document-highlights.ts
@@ -15,9 +15,9 @@ import { switchMap, filter, mergeAll, map, tap } from 'rxjs/operators'
 import { DocumentHighlight } from '@sourcegraph/codeintellify'
 import { Position } from '@sourcegraph/extension-api-types'
 import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import { UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { offsetToUIPosition, positionToOffset, distinctWordAtCoords, sortRangeValuesByStart } from './utils'
-import { UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 
 type DocumentHighlightsSource = (position: Position) => Observable<DocumentHighlight[]>
 

--- a/client/web/src/repo/blob/codemirror/document-highlights.ts
+++ b/client/web/src/repo/blob/codemirror/document-highlights.ts
@@ -9,23 +9,18 @@
  */
 import { Extension, Facet, RangeSetBuilder, StateEffectType, StateField } from '@codemirror/state'
 import { Decoration, DecorationSet, EditorView, ViewPlugin } from '@codemirror/view'
-import { from, Observable, Subject, Subscription } from 'rxjs'
-import { switchMap, throttleTime, filter, mergeAll, map } from 'rxjs/operators'
+import { from, fromEvent, Observable, Subscription } from 'rxjs'
+import { switchMap, filter, mergeAll, map, tap } from 'rxjs/operators'
 
 import { DocumentHighlight } from '@sourcegraph/codeintellify'
 import { Position } from '@sourcegraph/extension-api-types'
 import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 
-import { positionToOffset, sortRangeValuesByStart } from './utils'
-
-interface HoverPosition {
-    position: Position
-    offset: number
-}
+import { offsetToUIPosition, positionToOffset, distinctWordAtCoords, sortRangeValuesByStart } from './utils'
+import { UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 
 type DocumentHighlightsSource = (position: Position) => Observable<DocumentHighlight[]>
 
-const HOVER_TIMEOUT = 50
 const highlightDecoration = Decoration.mark({ class: 'sourcegraph-document-highlight' })
 
 /**
@@ -95,28 +90,7 @@ function documentHighlights(sources: Facet<DocumentHighlightsSource>, sink: Face
     return [
         documentHighlightsField,
         ViewPlugin.define(
-            view => new DocumentHighlightsManager(view, sources, documentHighlightsField, setDocumentHighlights),
-            {
-                eventHandlers: {
-                    mousemove(event, view) {
-                        const offset = view.posAtCoords(event)
-                        let position: HoverPosition | null = null
-
-                        if (offset !== null) {
-                            const line = view.state.doc.lineAt(offset)
-                            position = {
-                                position: {
-                                    line: line.number,
-                                    character: Math.max(offset - line.from, 1),
-                                },
-                                offset,
-                            }
-                        }
-
-                        this.setHoverPosition(position)
-                    },
-                },
-            }
+            view => new DocumentHighlightsManager(view, sources, documentHighlightsField, setDocumentHighlights)
         ),
     ]
 }
@@ -127,7 +101,6 @@ function documentHighlights(sources: Facet<DocumentHighlightsSource>, sink: Face
  * {@link showDocumentHighlights} facet with their responses.
  */
 class DocumentHighlightsManager {
-    private nextPosition: Subject<Position | null> = new Subject()
     private querySubscription: Subscription
 
     constructor(
@@ -136,9 +109,17 @@ class DocumentHighlightsManager {
         private readonly documentHighlightsField: StateField<DocumentHighlight[]>,
         private readonly setDocumentHighlights: StateEffectType<DocumentHighlight[]>
     ) {
-        this.querySubscription = this.nextPosition
+        this.querySubscription = fromEvent<MouseEvent>(this.view.contentDOM, 'mousemove')
             .pipe(
-                throttleTime(HOVER_TIMEOUT),
+                distinctWordAtCoords(this.view),
+                tap(word => {
+                    if (!word) {
+                        this.clearHighlights()
+                    }
+                }),
+                // Convert from offsets to UIPosition. We only need the start
+                // position
+                map(word => (word ? offsetToUIPosition(this.view.state.doc, word.from) : null)),
                 // Ignore position changes if we already have a document highlight
                 // within that range
                 filter(
@@ -170,18 +151,7 @@ class DocumentHighlightsManager {
         this.querySubscription.unsubscribe()
     }
 
-    public setHoverPosition(position: HoverPosition | null): void {
-        if (position === null || !this.view.state.wordAt(position.offset)) {
-            // User is hovering over something that is not a word. Cancel
-            // current query and clear highlights.
-            this.nextPosition.next(null)
-            this.clearHighlights()
-        } else {
-            this.nextPosition.next(position.position)
-        }
-    }
-
-    public clearHighlights(): void {
+    private clearHighlights(): void {
         if (this.view.state.field(this.documentHighlightsField).length > 0) {
             this.view.dispatch({ effects: this.setDocumentHighlights.of([]) })
         }
@@ -192,15 +162,18 @@ class DocumentHighlightsManager {
  * Helper function for determining whether the given position is with any of the
  * document highlight ranges.
  */
-function hasDocumentHighlightAtPosition(highlights: DocumentHighlight[], position: Position): boolean {
+function hasDocumentHighlightAtPosition(
+    highlights: DocumentHighlight[],
+    position: UIPositionSpec['position']
+): boolean {
     for (const {
         range: { start, end },
     } of highlights) {
         if (
             position.line >= start.line + 1 &&
             position.line <= end.line + 1 &&
-            position.character >= start.character &&
-            position.character <= end.character
+            position.character >= start.character + 1 &&
+            position.character <= end.character + 1
         ) {
             return true
         }

--- a/client/web/src/repo/blob/codemirror/hovercard.dot
+++ b/client/web/src/repo/blob/codemirror/hovercard.dot
@@ -1,0 +1,28 @@
+digraph {
+    extension [label="Extensions integration" style=dashed];
+    pin [label="Hovercard pin" style=dashed];
+
+    hs [label="hovercardSource (facet)" style=bold];
+    hp [label="HoverPlugin (view plugin)"];
+    hr [label="hovercardRanges (facet)" style=bold];
+    ht [label="hovercardTheme (theme)"];
+    hm [label="HovercardManager (view plugin)"];
+    hir [label="highlightRanges (field)"];
+    t [label="showTooltips (facet)", style=bold];
+    hc [label="Hovercard (tooltip view)"]
+    d [label="decoration (facet)" style=bold]
+
+    pin -> hr [label=provides];
+    extension -> hs [label=provides];
+    hs -> hp [label=enables];
+    hp -> hr [label=provides];
+    hr -> ht [label=enables];
+    hr -> hm [label=enables];
+    hr -> hir [label=enables];
+    hm -> t [label="provides"];
+    hm -> hc [label="creates"];
+    hc -> hs [label="uses"];
+    hir -> d [label="provides"];
+    hc -> hir [label="updates"];
+    hm -> hr [label="reads"];
+}

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -470,6 +470,7 @@ class Hovercard implements TooltipView {
                         overlayPosition={dummyOverlayPosition}
                         hoveredToken={hoveredToken}
                         hoveredTokenElement={dummyHoveredElement}
+                        onAlertDismissed={() => repositionTooltips(this.view)}
                         pinOptions={{
                             showCloseButton: true,
                             onCloseButtonClick: () => {

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -362,7 +362,8 @@ class Hovercard implements TooltipView {
             this.view.state.facet(hovercardSource)(view, range.range.start),
             this.nextProps.pipe(startWith(view.state.facet(blobPropsFacet))),
         ]).subscribe(([container, hovercardData, props]) => {
-            if (hovercardData.hoverOrError) {
+            // undefined means the data is still loading
+            if (hovercardData.hoverOrError !== undefined) {
                 if (!this.root) {
                     // Defer creating a React container until absolutely
                     // necessary
@@ -410,11 +411,21 @@ class Hovercard implements TooltipView {
     }
 
     private render(root: Root, { hoverOrError, actionsOrError }: HovercardData, props: BlobProps): void {
-        if (!hoverOrError) {
+        // Only render if we either have something for hover or actions. Adapted
+        // from shouldRenderOverlay in codeintellify/src/hoverifier.ts
+        if (
+            !(
+                (hoverOrError && hoverOrError !== 'loading') ||
+                (actionsOrError &&
+                    actionsOrError !== 'loading' &&
+                    (isErrorLike(actionsOrError) || actionsOrError.length > 0))
+            )
+        ) {
             this.removeRange()
             root.render([])
             return
         }
+
         this.addRange()
 
         const hoverContext = {

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -1,26 +1,49 @@
-import { Extension, Facet } from '@codemirror/state'
-import { EditorView, hoverTooltip, repositionTooltips, ViewUpdate } from '@codemirror/view'
+import { Extension, Facet, RangeSet, StateEffect, StateEffectType, StateField } from '@codemirror/state'
+import {
+    Decoration,
+    EditorView,
+    PluginValue,
+    repositionTooltips,
+    showTooltip,
+    Tooltip,
+    TooltipView,
+    ViewPlugin,
+    ViewUpdate,
+} from '@codemirror/view'
 import { createRoot, Root } from 'react-dom/client'
 
 import { addLineRangeQueryParameter, isErrorLike, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
-import { HoverOverlayBaseProps } from '@sourcegraph/shared/src/hover/HoverOverlay.types'
 
-import { Position } from '@sourcegraph/extension-api-types'
 import { WebHoverOverlay, WebHoverOverlayProps } from '../../../components/WebHoverOverlay'
 import { blobPropsFacet } from '.'
-import { combineLatest, Observable, Subject } from 'rxjs'
-import { startWith } from 'rxjs/operators'
+import { combineLatest, Observable, Subject, Subscription } from 'rxjs'
+import { startWith, scan, distinctUntilChanged } from 'rxjs/operators'
 import { BlobProps, updateBrowserHistoryIfChanged } from '../Blob'
 import { Container } from './react-interop'
 import webOverlayStyles from '../../../components/WebHoverOverlay/WebHoverOverlay.module.scss'
+import { UIPositionSpec, UIRangeSpec } from '@sourcegraph/shared/src/util/url'
+import { offsetToPosition } from './utils'
+import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 
-type HovercardSource = (
-    view: EditorView,
-    position: Position
-) => Observable<Pick<HoverOverlayBaseProps, 'hoverOrError' | 'actionsOrError'>>
+type HovercardData = Pick<WebHoverOverlayProps, 'hoverOrError' | 'actionsOrError'>
+type HovercardRange = {
+    // Line/column position
+    range: UIRangeSpec['range']
 
-const HOVER_TIMEOUT = 50
+    // CodeMirror document offsets
+    from: number
+    to: number
+}
 
+/**
+ * A HovercardSource is a function that is passed a position and returns an
+ * observable that provides hover information.
+ */
+export type HovercardSource = (view: EditorView, position: UIPositionSpec['position']) => Observable<HovercardData>
+
+/**
+ * Some style overrides to replicate the existing hovercard style.
+ */
 const hoverCardTheme = EditorView.theme({
     '.cm-code-intel-hovercard': {
         // Without this all text in the hovercard is monospace
@@ -39,6 +62,250 @@ const hoverCardTheme = EditorView.theme({
     },
 })
 
+/**
+ * This field (and effects) are necessary for highlighting the hovered token
+ * properly. Unfortunately we cannot create decorations directly from
+ * hovercardRanges because we don't know whether any of these ranges have
+ * information associated with them. So it's on the Hovercard instances to
+ * inform this field about the ranges that have information.
+ * This field also monitors hovercardRanges to remove any stray highlights.
+ */
+const addRange = StateEffect.define<HovercardRange>()
+const removeRange = StateEffect.define<HovercardRange>()
+const selectionHighlightDecoration = Decoration.mark({ class: 'selection-highlight' })
+
+const validTokenRanges = StateField.define<HovercardRange[]>({
+    create() {
+        return []
+    },
+
+    update(value, transaction) {
+        const availableRanges = transaction.state.facet(hovercardRanges)
+
+        const newValues = [...value]
+        let changed = false
+
+        // Remove any values not in the current set of ranges. availableRanges and
+        // value will be small, so processing them this way should be fine.
+        for (const range of value) {
+            if (!availableRanges.includes(range)) {
+                newValues.splice(newValues.indexOf(range), 1)
+                changed = true
+            }
+        }
+
+        for (const effect of transaction.effects) {
+            if (effect.is(addRange)) {
+                if (availableRanges.includes(effect.value) && !newValues.includes(effect.value)) {
+                    newValues.push(effect.value)
+                    changed = true
+                }
+            }
+            if (effect.is(removeRange)) {
+                const index = newValues.indexOf(effect.value)
+                if (index > -1) {
+                    newValues.splice(index, 1)
+                    changed = true
+                }
+            }
+        }
+
+        return changed ? newValues : value
+    },
+
+    provide(field) {
+        return EditorView.decorations.from(field, ranges =>
+            RangeSet.of(
+                ranges.map(range => selectionHighlightDecoration.range(range.from, range.to)),
+                true
+            )
+        )
+    },
+})
+
+/**
+ * This class is used to prevent flickering when a hovercard is pinned or when a
+ * pinned and a hovered hovercard are rendered.
+ * This class keeps track of for which ranges a tooltip exists and will
+ * add/remove tooltips as necessary. Flickering is prevented by reusing existing
+ * tooltip instances for existing ranges.
+ */
+class HovercardManager implements PluginValue {
+    private tooltips: Map<string, Tooltip> = new Map()
+    private hovercardRanges: readonly HovercardRange[] = []
+
+    constructor(readonly view: EditorView, readonly setTooltips: StateEffectType<Tooltip[]>) {}
+
+    public update(update: ViewUpdate) {
+        const ranges = update.state.facet(hovercardRanges)
+        if (this.hovercardRanges !== ranges) {
+            this.hovercardRanges = ranges
+            this.updateTooltips()
+        }
+    }
+
+    private updateTooltips() {
+        // Remove removed tooltips
+        for (const [key, tooltip] of this.tooltips) {
+            if (!this.hovercardRanges.some(range => range.from === tooltip.pos && range.to === tooltip.end)) {
+                this.tooltips.delete(key)
+            }
+        }
+
+        // Add new ranges
+        for (const range of this.hovercardRanges) {
+            const key = this.toKey(range)
+            if (!this.tooltips.has(key)) {
+                this.tooltips.set(key, {
+                    pos: range.from,
+                    end: range.to,
+                    above: true,
+                    create: view => Hovercard.create(view, range),
+                })
+            }
+        }
+
+        // We cannot directly dispatch a transaction within an update cycle
+        window.requestAnimationFrame(() =>
+            this.view.dispatch({ effects: this.setTooltips.of(Array.from(this.tooltips.values())) })
+        )
+    }
+
+    private toKey(range: HovercardRange): string {
+        return `${range.from}:${range.to}`
+    }
+}
+
+function hovercardManager(): Extension {
+    const [tooltips, , setTooltips] = createUpdateableField<Tooltip[]>([], field =>
+        showTooltip.computeN([field], state => {
+            return state.field(field)
+        })
+    )
+
+    return [tooltips, ViewPlugin.define(view => new HovercardManager(view, setTooltips))]
+}
+
+/**
+ * Facet to which an extension can add a value to show a hovercard.
+ */
+export const hovercardRanges = Facet.define<HovercardRange>({
+    enables: [
+        hoverCardTheme,
+        // Compute CodeMirror tooltips from hovercard ranges
+        hovercardManager(),
+        // Highlight hovered token(s)
+        validTokenRanges,
+    ],
+})
+
+/**
+ * Facet with which an extension can provide a hovercard source. For simplicity
+ * only one source can be provided, others are ignored (in practice there is
+ * only one source at the moment anyway).
+ */
+export const hovercardSource = Facet.define<HovercardSource, HovercardSource>({
+    combine: sources => sources[0],
+    enables: hovercard(),
+})
+
+/**
+ * Converts mousemove events to hovercard ranges.
+ */
+class HoverPlugin implements PluginValue {
+    position: { from: number; to: number } | null = null
+    subscription: Subscription = new Subscription()
+
+    constructor(
+        readonly view: EditorView,
+        readonly setHovercardPosition: StateEffectType<HovercardRange | null>,
+        nextOffset: Subject<number | null>
+    ) {
+        this.subscription.add(
+            nextOffset
+                .pipe(
+                    scan((position: { from: number; to: number } | null, offset) => {
+                        if (offset === null) {
+                            return null
+                        }
+                        if (position && position.from <= offset && position.to >= offset) {
+                            // Nothing to do, return same value
+                            return position
+                        }
+
+                        {
+                            const word = this.view.state.wordAt(offset)
+                            if (word) {
+                                return { from: word.from, to: word.to }
+                            }
+                        }
+
+                        return null
+                    }, null),
+                    distinctUntilChanged()
+                )
+                .subscribe(position => {
+                    this.view.dispatch({
+                        effects: setHovercardPosition.of(
+                            position
+                                ? {
+                                      ...position,
+                                      range: offsetToPosition(this.view.state.doc, position.from, position.to),
+                                  }
+                                : null
+                        ),
+                    })
+                })
+        )
+    }
+
+    destroy() {
+        this.subscription.unsubscribe()
+    }
+}
+
+function hovercard(): Extension {
+    const [hovercardRange, , setHovercardRange] = createUpdateableField<HovercardRange | null>(null, field =>
+        hovercardRanges.computeN([field], state => {
+            const range = state.field(field)
+            return range ? [range] : []
+        })
+    )
+    const nextOffset = new Subject<number | null>()
+
+    return [
+        hovercardRange,
+        ViewPlugin.define(view => new HoverPlugin(view, setHovercardRange, nextOffset), {
+            eventHandlers: {
+                mousemove(event: MouseEvent, view) {
+                    let pos = view.posAtCoords(event)
+
+                    if (pos) {
+                        // It seems CodeMirror returns the document position _closest_ to mouse position.
+                        // This has the unfortunate effect that hovering over empty parts a line will find
+                        // the closest word next to it, which is not something we want. To ensure that we
+                        // only consider positions of actual words/characters we perform the inverse
+                        // conversion and compare the results. This is also done by CodeMirror's own hover
+                        // tooltip plugin.
+                        const posCoords = view.coordsAtPos(pos)
+                        if (
+                            posCoords == null ||
+                            event.y < posCoords.top ||
+                            event.y > posCoords.bottom ||
+                            event.x < posCoords.left - this.view.defaultCharacterWidth ||
+                            event.x > posCoords.right + this.view.defaultCharacterWidth
+                        ) {
+                            pos = null
+                        }
+                    }
+
+                    nextOffset.next(pos)
+                },
+            },
+        }),
+    ]
+}
+
 // WebHoverOverlay requires to be passed an element representing the currently
 // hovered token.  Since we don't have/want that for CodeMirror we are passing a
 // dummy element.
@@ -48,159 +315,152 @@ const dummyHoveredElement = document.createElement('span')
 const dummyOverlayPosition = { left: 0, bottom: 0 }
 
 /**
- * Facet with which an extension can provide a hovercard source. For simplicity
- * only one source can be provided, others are ignored (in practice there is
- * only one source at the moment anyway).
+ * This class is responsible for rendering a WebHoverOverlay component as a
+ * CodeMirror tooltip. When constructed the instance subscribes to the hovercard
+ * data source and the component props, and updates the component as it receives
+ * changes.
  */
-export const hovercardSource = Facet.define<HovercardSource, HovercardSource>({
-    combine: sources => sources[0],
-    enables: facet => hovercard(facet),
-})
+class Hovercard implements TooltipView {
+    public dom: HTMLElement
+    private root: Root | null = null
+    private nextRoot = new Subject<Root>()
+    private nextProps = new Subject<BlobProps>()
+    private props: BlobProps | null = null
+    public overlap = true
+    private subscription: Subscription
 
-/**
- * Registers an extension to show a hovercard
- */
-export function hovercard(facet: Facet<HovercardSource, HovercardSource>): Extension {
-    return [
-        // hoverTooltip takes care of only calling the source (and processing
-        // its return value) when necessary.
-        hoverTooltip(
-            async (view, offset) => {
-                const line = view.state.doc.lineAt(offset)
+    static create(view: EditorView, range: HovercardRange): Hovercard {
+        return new Hovercard(view, range)
+    }
 
-                // Find enclosing word/token. This is necessary otherwise
-                // the extension host cannot determine whether we are the
-                // definition or not.
-                let start = offset
-                let end = offset
+    constructor(readonly view: EditorView, readonly range: HovercardRange) {
+        this.dom = document.createElement('div')
 
-                {
-                    const word = view.state.wordAt(offset)
-                    if (word) {
-                        start = word.from
-                        end = word.to
-                    }
-                }
+        this.subscription = combineLatest([
+            this.nextRoot,
+            this.view.state.facet(hovercardSource)(view, range.range.start),
+            this.nextProps.pipe(startWith(view.state.facet(blobPropsFacet))),
+        ]).subscribe(([root, hovercardData, props]) => {
+            this.render(root, hovercardData, props)
+        })
+    }
 
-                const character = Math.max(start - line.from + 1, 1)
-                const position = { character, line: line.number }
-                const nextRoot = new Subject<Root>()
-                const nextProps = new Subject<BlobProps>()
+    public mount() {
+        this.root = createRoot(this.dom)
+        this.nextRoot.next(this.root)
+    }
 
-                combineLatest([
-                    nextRoot,
-                    view.state.facet(facet)(view, position),
-                    nextProps.pipe(startWith(view.state.facet(blobPropsFacet))),
-                ]).subscribe(([root, { hoverOrError, actionsOrError }, props]) => {
-                    let hoverContext = {
-                        commitID: props.blobInfo.commitID,
-                        filePath: props.blobInfo.filePath,
-                        repoName: props.blobInfo.repoName,
-                        revision: props.blobInfo.revision,
-                    }
+    public update(update: ViewUpdate) {
+        // Umount React components when tooltip range does exist anymore
+        if (
+            !update.state
+                .facet(hovercardRanges)
+                .some(range => range.from === this.range.from && range.to === this.range.to)
+        ) {
+            this.root?.unmount()
+            this.subscription.unsubscribe()
+            return
+        }
 
-                    let hoveredToken: WebHoverOverlayProps['hoveredToken'] = {
-                        ...hoverContext,
-                        ...position,
-                    }
+        // Update component when props change
+        const props = update.state.facet(blobPropsFacet)
+        if (this.props !== props) {
+            this.props = props
+            this.nextProps.next(props)
+        }
+    }
 
-                    if (
-                        hoverOrError &&
-                        hoverOrError !== 'loading' &&
-                        !isErrorLike(hoverOrError) &&
-                        hoverOrError.range
-                    ) {
-                        hoveredToken = {
-                            ...hoveredToken,
-                            line: hoverOrError.range.start.line + 1,
-                            character: hoverOrError.range.start.character + 1,
-                        }
-                    }
+    private addRange() {
+        window.requestAnimationFrame(() => {
+            this.view.dispatch({ effects: addRange.of(this.range) })
+        })
+    }
 
-                    if (hoverOrError) {
-                        root.render(
-                            <Container onRender={() => repositionTooltips(view)} history={props.history}>
-                                <div className="cm-code-intel-hovercard">
-                                    <WebHoverOverlay
-                                        // Blob props
-                                        location={props.location}
-                                        onHoverShown={props.onHoverShown}
-                                        isLightTheme={props.isLightTheme}
-                                        platformContext={props.platformContext}
-                                        settingsCascade={props.settingsCascade}
-                                        telemetryService={props.telemetryService}
-                                        extensionsController={props.extensionsController}
-                                        nav={props.nav ?? (url => props.history.push(url))}
-                                        // Hover props
-                                        actionsOrError={actionsOrError}
-                                        hoverOrError={hoverOrError}
-                                        // CodeMirror handles the positioning but a
-                                        // non-nullable value must be passed for the
-                                        // hovercard to render
-                                        overlayPosition={dummyOverlayPosition}
-                                        hoveredToken={hoveredToken}
-                                        hoveredTokenElement={dummyHoveredElement}
-                                        pinOptions={{
-                                            showCloseButton: true,
-                                            onCloseButtonClick: () => {
-                                                const parameters = new URLSearchParams(props.location.search)
-                                                parameters.delete('popover')
+    private removeRange() {
+        window.requestAnimationFrame(() => {
+            this.view.dispatch({ effects: removeRange.of(this.range) })
+        })
+    }
 
-                                                updateBrowserHistoryIfChanged(props.history, props.location, parameters)
-                                            },
-                                            onCopyLinkButtonClick: async () => {
-                                                const range = { start: position, end: position }
-                                                const context = { position, range }
-                                                const search = new URLSearchParams(location.search)
-                                                search.set('popover', 'pinned')
-                                                updateBrowserHistoryIfChanged(
-                                                    props.history,
-                                                    props.location,
-                                                    addLineRangeQueryParameter(
-                                                        search,
-                                                        toPositionOrRangeQueryParameter(context)
-                                                    )
-                                                )
-                                                await navigator.clipboard.writeText(window.location.href)
-                                            },
-                                        }}
-                                    />
-                                </div>
-                            </Container>
-                        )
-                    } else {
-                        root.render([])
-                    }
-                })
+    private render(root: Root, { hoverOrError, actionsOrError }: HovercardData, props: BlobProps) {
+        let hoverContext = {
+            commitID: props.blobInfo.commitID,
+            filePath: props.blobInfo.filePath,
+            repoName: props.blobInfo.repoName,
+            revision: props.blobInfo.revision,
+        }
 
-                return {
-                    pos: start,
-                    end,
-                    above: true,
-                    create() {
-                        const container = document.createElement('div')
-                        return {
-                            dom: container,
-                            overlap: true,
-                            mount() {
-                                nextRoot.next(createRoot(container))
-                            },
-                            update(viewUpdate: ViewUpdate) {
-                                if (
-                                    viewUpdate.startState.facet(blobPropsFacet) !==
-                                    viewUpdate.state.facet(blobPropsFacet)
-                                ) {
-                                    nextProps.next(viewUpdate.state.facet(blobPropsFacet))
-                                }
-                            },
-                        }
-                    },
-                }
-            },
-            {
-                hoverTime: HOVER_TIMEOUT,
+        let hoveredToken: WebHoverOverlayProps['hoveredToken'] = {
+            ...hoverContext,
+            ...this.range.range.start,
+        }
+
+        if (hoverOrError && hoverOrError !== 'loading' && !isErrorLike(hoverOrError) && hoverOrError.range) {
+            hoveredToken = {
+                ...hoveredToken,
+                line: hoverOrError.range.start.line + 1,
+                character: hoverOrError.range.start.character + 1,
             }
-        ),
-        hoverCardTheme,
-    ]
+        }
+
+        if (hoverOrError) {
+            this.addRange()
+
+            root.render(
+                <Container onRender={() => repositionTooltips(this.view)} history={props.history}>
+                    <div className="cm-code-intel-hovercard">
+                        <WebHoverOverlay
+                            // Blob props
+                            location={props.location}
+                            onHoverShown={props.onHoverShown}
+                            isLightTheme={props.isLightTheme}
+                            platformContext={props.platformContext}
+                            settingsCascade={props.settingsCascade}
+                            telemetryService={props.telemetryService}
+                            extensionsController={props.extensionsController}
+                            nav={props.nav ?? (url => props.history.push(url))}
+                            // Hover props
+                            actionsOrError={actionsOrError}
+                            hoverOrError={hoverOrError}
+                            // CodeMirror handles the positioning but a
+                            // non-nullable value must be passed for the
+                            // hovercard to render
+                            overlayPosition={dummyOverlayPosition}
+                            hoveredToken={hoveredToken}
+                            hoveredTokenElement={dummyHoveredElement}
+                            pinOptions={{
+                                showCloseButton: true,
+                                onCloseButtonClick: () => {
+                                    const parameters = new URLSearchParams(props.location.search)
+                                    parameters.delete('popover')
+
+                                    updateBrowserHistoryIfChanged(props.history, props.location, parameters)
+                                },
+                                onCopyLinkButtonClick: async () => {
+                                    const context = {
+                                        position: this.range.range.start,
+                                        range: {
+                                            start: this.range.range.start,
+                                            end: this.range.range.start,
+                                        },
+                                    }
+                                    const search = new URLSearchParams(location.search)
+                                    search.set('popover', 'pinned')
+                                    updateBrowserHistoryIfChanged(
+                                        props.history,
+                                        props.location,
+                                        addLineRangeQueryParameter(search, toPositionOrRangeQueryParameter(context))
+                                    )
+                                    await navigator.clipboard.writeText(window.location.href)
+                                },
+                            }}
+                        />
+                    </div>
+                </Container>
+            )
+        } else {
+            this.removeRange()
+            root.render([])
+        }
+    }
 }

--- a/client/web/src/repo/blob/codemirror/index.ts
+++ b/client/web/src/repo/blob/codemirror/index.ts
@@ -1,5 +1,9 @@
-import { Facet } from '@codemirror/state'
+import { Extension, Facet, StateField } from '@codemirror/state'
+import { LineOrPositionOrRange } from '@sourcegraph/common'
+import { UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 import { BlobProps } from '../Blob'
+import { hovercardRanges } from './hovercard'
+import { offsetToPosition, uiPositionToOffset } from './utils'
 
 /**
  * This facet is a necessary evil to allow access to props passed to the blob
@@ -8,3 +12,54 @@ import { BlobProps } from '../Blob'
 export const blobPropsFacet = Facet.define<BlobProps, BlobProps>({
     combine: props => props[0],
 })
+
+export function hovercardRangeFromPin(field: StateField<LineOrPositionOrRange | null>): Extension {
+    return hovercardRanges.computeN([field], state => {
+        const position = state.field(field)
+        if (!position) {
+            return []
+        }
+
+        if (!position.line || !position.character) {
+            return []
+        }
+        const startLine = state.doc.line(position.line)
+
+        const startPosition = {
+            line: position.line,
+            character: position.character,
+        }
+        const from = uiPositionToOffset(state.doc, startPosition, startLine)
+
+        let endPosition: UIPositionSpec['position']
+        let to: number
+
+        if (position.endLine && position.endCharacter) {
+            endPosition = {
+                line: position.endLine,
+                character: position.endCharacter,
+            }
+            to = uiPositionToOffset(state.doc, endPosition)
+        } else {
+            // To determine the end position we have to find the word at the
+            // start position
+            const word = state.wordAt(from)
+            if (!word) {
+                return []
+            }
+            to = word.to
+            endPosition = offsetToPosition(state.doc, word.to)
+        }
+
+        return [
+            {
+                to,
+                from,
+                range: {
+                    start: startPosition,
+                    end: endPosition,
+                },
+            },
+        ]
+    })
+}

--- a/client/web/src/repo/blob/codemirror/index.ts
+++ b/client/web/src/repo/blob/codemirror/index.ts
@@ -1,5 +1,10 @@
-import * as H from 'history'
+import { Facet } from '@codemirror/state'
+import { BlobProps } from '../Blob'
 
-import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
-
-export const [locationField, updateLocation] = createUpdateableField<H.Location | null>(null)
+/**
+ * This facet is a necessary evil to allow access to props passed to the blob
+ * component from React components rendered by extensions.
+ */
+export const blobPropsFacet = Facet.define<BlobProps, BlobProps>({
+    combine: props => props[0],
+})

--- a/client/web/src/repo/blob/codemirror/index.ts
+++ b/client/web/src/repo/blob/codemirror/index.ts
@@ -1,65 +1,17 @@
 import { Extension, Facet, StateField } from '@codemirror/state'
 import { LineOrPositionOrRange } from '@sourcegraph/common'
+import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 import { BlobProps } from '../Blob'
 import { hovercardRanges } from './hovercard'
-import { offsetToPosition, uiPositionToOffset } from './utils'
+import { offsetToUIPosition, uiPositionToOffset } from './utils'
 
 /**
  * This facet is a necessary evil to allow access to props passed to the blob
  * component from React components rendered by extensions.
  */
 export const blobPropsFacet = Facet.define<BlobProps, BlobProps>({
-    combine: props => props[0],
+    combine: props => {
+        return props[0]
+    },
 })
-
-export function hovercardRangeFromPin(field: StateField<LineOrPositionOrRange | null>): Extension {
-    return hovercardRanges.computeN([field], state => {
-        const position = state.field(field)
-        if (!position) {
-            return []
-        }
-
-        if (!position.line || !position.character) {
-            return []
-        }
-        const startLine = state.doc.line(position.line)
-
-        const startPosition = {
-            line: position.line,
-            character: position.character,
-        }
-        const from = uiPositionToOffset(state.doc, startPosition, startLine)
-
-        let endPosition: UIPositionSpec['position']
-        let to: number
-
-        if (position.endLine && position.endCharacter) {
-            endPosition = {
-                line: position.endLine,
-                character: position.endCharacter,
-            }
-            to = uiPositionToOffset(state.doc, endPosition)
-        } else {
-            // To determine the end position we have to find the word at the
-            // start position
-            const word = state.wordAt(from)
-            if (!word) {
-                return []
-            }
-            to = word.to
-            endPosition = offsetToPosition(state.doc, word.to)
-        }
-
-        return [
-            {
-                to,
-                from,
-                range: {
-                    start: startPosition,
-                    end: endPosition,
-                },
-            },
-        ]
-    })
-}

--- a/client/web/src/repo/blob/codemirror/index.ts
+++ b/client/web/src/repo/blob/codemirror/index.ts
@@ -1,17 +1,11 @@
-import { Extension, Facet, StateField } from '@codemirror/state'
-import { LineOrPositionOrRange } from '@sourcegraph/common'
-import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
-import { UIPositionSpec } from '@sourcegraph/shared/src/util/url'
+import { Facet } from '@codemirror/state'
+
 import { BlobProps } from '../Blob'
-import { hovercardRanges } from './hovercard'
-import { offsetToUIPosition, uiPositionToOffset } from './utils'
 
 /**
  * This facet is a necessary evil to allow access to props passed to the blob
  * component from React components rendered by extensions.
  */
 export const blobPropsFacet = Facet.define<BlobProps, BlobProps>({
-    combine: props => {
-        return props[0]
-    },
+    combine: props => props[0],
 })

--- a/client/web/src/repo/blob/codemirror/react-interop.tsx
+++ b/client/web/src/repo/blob/codemirror/react-interop.tsx
@@ -1,8 +1,10 @@
-import { WildcardThemeContext } from '@sourcegraph/wildcard'
 import React, { useEffect } from 'react'
+
+import { History } from 'history'
 import { Router } from 'react-router'
 import { CompatRouter } from 'react-router-dom-v5-compat'
-import { History } from 'history'
+
+import { WildcardThemeContext } from '@sourcegraph/wildcard'
 
 /**
  * Creates the necessary context for React components to be rendered inside

--- a/client/web/src/repo/blob/codemirror/react-interop.tsx
+++ b/client/web/src/repo/blob/codemirror/react-interop.tsx
@@ -1,0 +1,23 @@
+import { WildcardThemeContext } from '@sourcegraph/wildcard'
+import React, { useEffect } from 'react'
+import { Router } from 'react-router'
+import { CompatRouter } from 'react-router-dom-v5-compat'
+import { History } from 'history'
+
+/**
+ * Creates the necessary context for React components to be rendered inside
+ * CodeMirror.
+ */
+export const Container: React.FunctionComponent<
+    React.PropsWithChildren<{ history: History; onRender?: () => void }>
+> = ({ history, onRender, children }) => {
+    useEffect(() => onRender?.())
+
+    return (
+        <WildcardThemeContext.Provider value={{ isBranded: true }}>
+            <Router history={history}>
+                <CompatRouter>{children}</CompatRouter>
+            </Router>
+        </WildcardThemeContext.Provider>
+    )
+}

--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -12,7 +12,7 @@ import { EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view'
 import { Remote } from 'comlink'
 import { createRoot, Root } from 'react-dom/client'
 import { combineLatest, Observable, of, ReplaySubject, Subject, Subscription } from 'rxjs'
-import { filter, map, skipWhile, switchMap, distinctUntilChanged, startWith, tap } from 'rxjs/operators'
+import { filter, map, skipWhile, switchMap, distinctUntilChanged, startWith } from 'rxjs/operators'
 import { TextDocumentDecorationType } from 'sourcegraph'
 
 import { DocumentHighlight, LineOrPositionOrRange } from '@sourcegraph/codeintellify'

--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -11,8 +11,8 @@ import { Extension, Facet, StateEffect, StateEffectType, StateField } from '@cod
 import { EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view'
 import { Remote } from 'comlink'
 import { createRoot, Root } from 'react-dom/client'
-import { BehaviorSubject, combineLatest, Observable, of, ReplaySubject, Subject, Subscription } from 'rxjs'
-import { filter, map, switchMap, first } from 'rxjs/operators'
+import { combineLatest, Observable, of, ReplaySubject, Subject, Subscription } from 'rxjs'
+import { filter, map, skipWhile, switchMap, distinctUntilChanged, startWith } from 'rxjs/operators'
 import { TextDocumentDecorationType } from 'sourcegraph'
 
 import { DocumentHighlight, LineOrPositionOrRange } from '@sourcegraph/codeintellify'
@@ -25,19 +25,22 @@ import { ViewerId } from '@sourcegraph/shared/src/api/viewerTypes'
 import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { toURIWithPath } from '@sourcegraph/shared/src/util/url'
-import { WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import { StatusBar } from '../../../extensions/components/StatusBar'
-import { BlobInfo } from '../Blob'
+import { BlobInfo, BlobProps } from '../Blob'
 
 import { showTextDocumentDecorations } from './decorations'
 import { documentHighlightsSource } from './document-highlights'
 
-import { locationField } from '.'
+import { blobPropsFacet } from '.'
 
 import blobStyles from '../Blob.module.scss'
 import { HoverOverlayBaseProps } from '@sourcegraph/shared/src/hover/HoverOverlay.types'
 import { hovercardSource } from './hovercard'
+import { getHover } from '../../../backend/features'
+import { getHoverActions } from '@sourcegraph/shared/src/hover/actions'
+import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/features'
+import { Container } from './react-interop'
 
 /**
  * Context holds all the information needed for CodeMirror extensions to
@@ -129,6 +132,7 @@ export function sourcegraphExtensions({
         updateSelection(),
         hovercardDataSource(),
         statusBar,
+        warmupReferences,
     ]
 }
 
@@ -336,27 +340,40 @@ function updateSelection(): Extension {
 function hovercardDataSource() {
     const nextContext: Subject<Context | null> = new ReplaySubject(1)
 
-    const createObservable = (position: Position): Promise<Pick<HoverOverlayBaseProps, 'hoverOrError'> | null> =>
-        nextContext
-            .pipe(
-                switchMap(context =>
-                    context
-                        ? wrapRemoteObservable(
-                              context.extensionHostAPI.getHover({
-                                  textDocument: {
-                                      uri: toURIWithPath(context.blobInfo),
-                                  },
-                                  position,
-                              })
-                          ).pipe(
-                              filter(({ isLoading }) => !isLoading),
-                              map(({ result }) => ({ hoverOrError: result }))
-                          )
-                        : of(null)
-                ),
-                first()
-            )
-            .toPromise()
+    const createObservable = (
+        view: EditorView,
+        position: Position
+    ): Observable<Pick<HoverOverlayBaseProps, 'hoverOrError' | 'actionsOrError'>> =>
+        nextContext.pipe(
+            filter((context): context is Context => context != null),
+            switchMap(context => {
+                const hoverContext = {
+                    commitID: context.blobInfo.commitID,
+                    revision: context.blobInfo.revision,
+                    filePath: context.blobInfo.filePath,
+                    repoName: context.blobInfo.repoName,
+                }
+                const { extensionsController, platformContext } = view.state.facet(blobPropsFacet)
+
+                return combineLatest([
+                    getHover({ ...hoverContext, position }, { extensionsController }).pipe(
+                        skipWhile(({ isLoading }) => isLoading === true)
+                    ),
+                    getHoverActions(
+                        { extensionsController, platformContext },
+                        {
+                            ...hoverContext,
+                            ...position,
+                        }
+                    ),
+                ])
+            }),
+            map(([hoverResult, actionsResult]) => ({
+                hoverOrError: hoverResult.result,
+                actionsOrError: actionsResult,
+            }))
+            //tap(console.log),
+        )
 
     return [updateOnContextChange.of(context => nextContext.next(context)), hovercardSource.of(createObservable)]
 }
@@ -370,40 +387,47 @@ function hovercardDataSource() {
  * capabilities of CodeMirror. It only attaches a container DOM element to the
  * editor's DOM and renders itself it that container.
  */
-class StatusBarPlugin {
-    private container: HTMLDivElement
-    private reactRoot: Root
-    private subscription: Subscription
-    private triggerRender = new BehaviorSubject<void>(undefined)
+const statusBar = ViewPlugin.fromClass(
+    class {
+        private container: HTMLDivElement
+        private reactRoot: Root
+        private subscription: Subscription
+        private nextProps = new Subject<BlobProps>()
 
-    constructor(private readonly view: EditorView) {
-        this.container = document.createElement('div')
-        this.reactRoot = createRoot(this.container)
-        const contextUpdates = this.view.state.field(sgExtensionsContextField).contextObservable
+        constructor(private readonly view: EditorView) {
+            this.container = document.createElement('div')
+            this.reactRoot = createRoot(this.container)
+            const contextUpdates = this.view.state.field(sgExtensionsContextField).contextObservable
 
-        const getStatusBarItems = (): Observable<'loading' | StatusBarItemWithKey[]> =>
-            contextUpdates.pipe(
-                switchMap(context => {
-                    if (!context) {
-                        return of('loading' as const)
-                    }
+            const getStatusBarItems = (): Observable<'loading' | StatusBarItemWithKey[]> =>
+                contextUpdates.pipe(
+                    switchMap(context => {
+                        if (!context) {
+                            return of('loading' as const)
+                        }
 
-                    return wrapRemoteObservable(context.extensionHostAPI.getStatusBarItems(context.viewerId))
-                })
-            )
+                        return wrapRemoteObservable(context.extensionHostAPI.getStatusBarItems(context.viewerId))
+                    })
+                )
 
-        this.subscription = combineLatest([contextUpdates, this.triggerRender]).subscribe(([context]) => {
-            const location = view.state.field(locationField)
-            if (location) {
+            this.subscription = combineLatest([
+                contextUpdates,
+                this.nextProps.pipe(
+                    distinctUntilChanged(
+                        (previous, next) => previous.location === next.location && previous.history === next.history
+                    ),
+                    startWith(view.state.facet(blobPropsFacet))
+                ),
+            ]).subscribe(([context, props]) => {
                 this.reactRoot.render(
                     React.createElement(
-                        WildcardThemeContext.Provider,
-                        { value: { isBranded: true } },
+                        Container,
+                        { history: props.history },
                         React.createElement(StatusBar, {
                             getStatusBarItems,
                             extensionsController: context.extensionsController,
                             uri: toURIWithPath(context.blobInfo),
-                            location,
+                            location: props.location,
                             className: blobStyles.blobStatusBarBody,
                             statusBarRef: () => {},
                             hideWhileInitializing: true,
@@ -411,26 +435,48 @@ class StatusBarPlugin {
                         })
                     )
                 )
-            }
-        })
+            })
 
-        this.view.dom.append(this.container)
-    }
+            this.view.dom.append(this.container)
+        }
 
-    public update(update: ViewUpdate): void {
-        if (update.startState.field(locationField) !== update.state.field(locationField)) {
-            this.triggerRender.next()
+        public update(update: ViewUpdate): void {
+            this.nextProps.next(update.state.facet(blobPropsFacet))
+        }
+
+        public destroy(): void {
+            this.subscription.unsubscribe()
+            this.container.remove()
+
+            // setTimeout seems necessary to prevent React from complaining that the
+            // root is synchronously unmounted while rendering is in progress
+            setTimeout(() => this.reactRoot.unmount(), 0)
         }
     }
+)
 
-    public destroy(): void {
-        this.subscription.unsubscribe()
-        this.container.remove()
+const warmupReferences = ViewPlugin.fromClass(
+    class {
+        nextContext: Subject<Context> = new Subject()
+        subscription: Subscription = new Subscription()
 
-        // setTimeout seems necessary to prevent React from complaining that the
-        // root is synchronously unmounted while rendering is in progress
-        setTimeout(() => this.reactRoot.unmount(), 0)
+        constructor() {
+            this.subscription.add(
+                this.nextContext
+                    .pipe(switchMap(context => haveInitialExtensionsLoaded(context.extensionsController.extHostAPI)))
+                    .subscribe()
+            )
+        }
+
+        setContext(context: Context) {
+            this.nextContext.next(context)
+        }
+
+        destroy() {
+            this.subscription.unsubscribe()
+        }
+    },
+    {
+        provide: plugin => updateOnContextChange.of(plugin),
     }
-}
-
-const statusBar = ViewPlugin.fromClass(StatusBarPlugin)
+)

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -1,7 +1,18 @@
 import { Text } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
 
 import { Position, Range } from '@sourcegraph/extension-api-types'
 import { UIPositionSpec, UIRangeSpec } from '@sourcegraph/shared/src/util/url'
+import { OperatorFunction, pipe } from 'rxjs'
+import { scan, distinctUntilChanged } from 'rxjs/operators'
+
+/**
+ * Returns true of any of the document offset ranges contains the provided
+ * point.
+ */
+export function rangesContain(ranges: readonly { from: number; to: number }[], point: number): boolean {
+    return ranges.some(range => range.from <= point && range.to >= point)
+}
 
 /**
  * Converts 0-based line/character positions to document offsets.
@@ -25,9 +36,9 @@ export function uiPositionToOffset(
 /**
  * Converts document offsets 1-based line/character positions.
  */
-export function offsetToPosition(textDocument: Text, from: number): UIPositionSpec['position']
-export function offsetToPosition(textDocument: Text, from: number, to: number): UIRangeSpec['range']
-export function offsetToPosition(
+export function offsetToUIPosition(textDocument: Text, from: number): UIPositionSpec['position']
+export function offsetToUIPosition(textDocument: Text, from: number, to: number): UIRangeSpec['range']
+export function offsetToUIPosition(
     textDocument: Text,
     from: number,
     to?: number
@@ -68,5 +79,70 @@ export function sortRangeValuesByStart<T extends { range: Range }>(values: T[]):
         rangeA.start.line === rangeB.start.line
             ? rangeA.start.character - rangeB.start.character
             : rangeA.start.line - rangeB.start.line
+    )
+}
+
+/**
+ * Returns the document offset at the provided coordindates or null if there is
+ * no text underneath these coordinates.
+ *
+ * It seems when using `posAtCoords` CodeMirror returns the document position
+ * _closest_ to the coordinates. This has the unfortunate effect that hovering
+ * over empty parts a line will find the position of the closest character next
+ * to it, which we do not want.
+ * To ensure that we only consider positions of actual words/characters we
+ * perform the inverse conversion and compare the results.
+ * This is also done by CodeMirror's own hover tooltip plugin.
+ */
+export function preciseOffsetAtCoords(view: EditorView, coords: { x: number; y: number }): number | null {
+    const offset = view.posAtCoords(coords)
+    if (offset === null) {
+        return null
+    }
+    const offsetCords = view.coordsAtPos(offset)
+    if (
+        offsetCords == null ||
+        coords.y < offsetCords.top ||
+        coords.y > offsetCords.bottom ||
+        coords.x < offsetCords.left - view.defaultCharacterWidth ||
+        coords.x > offsetCords.right + view.defaultCharacterWidth
+    ) {
+        return null
+    }
+    return offset
+}
+
+/**
+ * Helper operator to find the distinct position of words at coordinates. Used
+ * together with mousemove events.
+ */
+export function distinctWordAtCoords(
+    view: EditorView
+): OperatorFunction<{ x: number; y: number }, { from: number; to: number } | null> {
+    return pipe(
+        scan((position: { from: number; to: number } | null, coords) => {
+            const offset = preciseOffsetAtCoords(view, coords)
+
+            if (offset === null) {
+                return null
+            }
+
+            // Still hovering over the same word
+            if (position && position.from <= offset && position.to >= offset) {
+                return position
+            }
+
+            {
+                const word = view.state.wordAt(offset)
+                // Update position if we are hovering over a
+                // different word
+                if (word) {
+                    return { from: word.from, to: word.to }
+                }
+            }
+
+            return null
+        }, null),
+        distinctUntilChanged()
     )
 }

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -1,13 +1,59 @@
 import { Text } from '@codemirror/state'
 
 import { Position, Range } from '@sourcegraph/extension-api-types'
+import { UIPositionSpec, UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 
 /**
- * Converts line/character positions to document offsets.
+ * Converts 0-based line/character positions to document offsets.
  */
 export function positionToOffset(textDocument: Text, position: Position): number {
     // Position is 0-based
     return textDocument.line(position.line + 1).from + position.character
+}
+
+/*
+ * Converts 1-based line/character positions to document offsets.
+ */
+export function uiPositionToOffset(
+    textDocument: Text,
+    position: UIPositionSpec['position'],
+    line = textDocument.line(position.line)
+): number {
+    return line.from + position.character - 1
+}
+
+/**
+ * Converts document offsets 1-based line/character positions.
+ */
+export function offsetToPosition(textDocument: Text, from: number): UIPositionSpec['position']
+export function offsetToPosition(textDocument: Text, from: number, to: number): UIRangeSpec['range']
+export function offsetToPosition(
+    textDocument: Text,
+    from: number,
+    to?: number
+): UIRangeSpec['range'] | UIPositionSpec['position'] {
+    const startLine = textDocument.lineAt(from)
+    const startCharacter = Math.max(0, from - startLine.from) + 1
+
+    const startPosition: Position = {
+        line: startLine.number,
+        character: startCharacter,
+    }
+
+    if (to !== undefined) {
+        const endLine = to <= startLine.to ? startLine : textDocument.lineAt(to)
+        const endCharacter = Math.max(0, to - endLine.to) + 1
+
+        return {
+            start: startPosition,
+            end: {
+                line: endLine.number,
+                character: endCharacter,
+            },
+        }
+    }
+
+    return startPosition
 }
 
 export function viewPortChanged(

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -1,10 +1,10 @@
 import { Text } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
+import { OperatorFunction, pipe } from 'rxjs'
+import { scan, distinctUntilChanged } from 'rxjs/operators'
 
 import { Position, Range } from '@sourcegraph/extension-api-types'
 import { UIPositionSpec, UIRangeSpec } from '@sourcegraph/shared/src/util/url'
-import { OperatorFunction, pipe } from 'rxjs'
-import { scan, distinctUntilChanged } from 'rxjs/operators'
 
 /**
  * Returns true of any of the document offset ranges contains the provided
@@ -101,7 +101,7 @@ export function preciseOffsetAtCoords(view: EditorView, coords: { x: number; y: 
     }
     const offsetCords = view.coordsAtPos(offset)
     if (
-        offsetCords == null ||
+        offsetCords === null ||
         coords.y < offsetCords.top ||
         coords.y > offsetCords.bottom ||
         coords.x < offsetCords.left - view.defaultCharacterWidth ||


### PR DESCRIPTION
> **Note**
> I don't necessarily expect a thorough review but please ask if things are unclear. I'll add better comments or make the code clearer.

This PR refactors the replaces the minimal hovercard implementation with the (almost) complete one. Instead of building a custom version of the hovercard UI we are not reusing `WebHoverOverlay`. 

To make this work properly I had to do a couple of things:
- Added a way to pass current component props to extensions. This is done via the `blobProps` facet.
- Do not use CodeMirror's own _hover_ tooltip extension but implement custom mouseover handling and use CodeMirro's more generic tooltip extension. Without this it's not possible to render pinned hovercards.

There are a couple of facets and plugins at work here so I added a diagram and a short explanation of how everything works together. I hope it's useful.

While working on this I also refactored other parts to reuse helper functions that I created for the hovercards (e.g. `distinctWordAtCoords` is also used for document highilights).

I also tried to provide more uniformity into how facets/fields are used to pass information from the component to the extensions.

**Notable differences:**

- Pinned hovercards now work properly when navigating back and forth
- More than one hovercard can be shown. If there is a pinned hovercard, hovering over other tokens will still show their hovercards (if available).

**What doesn't work yet**
Click to jump to definition.


Demo: 

https://user-images.githubusercontent.com/179026/182654084-d8528f6f-9191-4218-97c5-ec795351c51d.mp4



## Test plan

Enable CodeMirror file view and hover over tokens.

## App preview:

- [Web](https://sg-web-fkling-cm-file-hovercards.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rljpnbfzzm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
