### PR TITLE
Make label-notify action edit body

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -8,9 +8,11 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-        - uses: jenschelkopf/issue-label-notification-action@f7d2363e5efa18b8aeea671ca8093e183ae8f218 # 1.3
+        - uses: felixfbecker/issue-label-notification-action@57b8a1f93c7951ce8af6cce8c6c90ae35a51c2e0
           with:
              token: "${{ secrets.LABELER_GITHUB_TOKEN }}"
+             edit_body: true
+             message: /cc {recipients}
              recipients: |
                   team/integrations=@muratsu @jjinnii @ryankscott
                   team/growth=@muratsu @a-bergevin

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -306,8 +306,8 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 	// Construct pipeline
 	pipeline := &bk.Pipeline{
-		Env: env,
-
+		Env:   env,
+		Steps: []any{},
 		AfterEveryStepOpts: []bk.StepOpt{
 			withDefaultTimeout,
 			withAgentQueueDefaults,


### PR DESCRIPTION
This changes something about label-notify that has been bothering me for a while:

label-notify will post a comment, meaning that in your email inbox you will get an email with that comment, but the email actually contains no information about the issue itself other than the title. You always have to open it in your browser. With many issues filed, that is super annoying.

This instead changes the behavior to edit the body of the issue, appending a `/cc @whoever` to it. That will equally trigger an email notification, but this time the entire issue body is part of the email, meaning it's quick to triage issues right in the inbox.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Only updates GitHub action, not production code touched.
Tested in external repo.