### PR TITLE
sg: Silence runner logs when running squash commands

### DIFF
--- a/dev/sg/internal/migration/squash.go
+++ b/dev/sg/internal/migration/squash.go
@@ -264,7 +264,8 @@ func runTargetedUpMigrations(database db.Database, targetVersions []int, postgre
 
 		return connections.NewStoreShim(store.NewWithDB(db, migrationsTable, store.NewOperations(&observation.TestContext)))
 	}
-	r, err := connections.RunnerFromDSNs(logger, dsns, "sg", storeFactory)
+
+	r, err := connections.RunnerFromDSNs(logger.IncreaseLevel("runner", "", log.LevelNone), dsns, "sg", storeFactory)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This logger should be 🤫 

## Test plan

Tested by hand.