### PR TITLE
squash: Add `-skip-data` flag

### DIFF
--- a/dev/sg/internal/migration/squash.go
+++ b/dev/sg/internal/migration/squash.go
@@ -35,7 +35,7 @@ const (
 	squasherContainerPostgresName = "postgres"
 )
 
-func SquashAll(database db.Database, inContainer, skipTeardown bool, filepath string) error {
+func SquashAll(database db.Database, inContainer, skipTeardown, skipData bool, filepath string) error {
 	definitions, err := readDefinitions(database)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func SquashAll(database db.Database, inContainer, skipTeardown bool, filepath st
 		leafIDs = append(leafIDs, leaf.ID)
 	}
 
-	squashedUpMigration, _, err := generateSquashedMigrations(database, leafIDs, inContainer, skipTeardown)
+	squashedUpMigration, _, err := generateSquashedMigrations(database, leafIDs, inContainer, skipTeardown, skipData)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func SquashAll(database db.Database, inContainer, skipTeardown bool, filepath st
 	return os.WriteFile(filepath, []byte(squashedUpMigration), os.ModePerm)
 }
 
-func Squash(database db.Database, commit string, inContainer, skipTeardown bool) error {
+func Squash(database db.Database, commit string, inContainer, skipTeardown, skipData bool) error {
 	definitions, err := readDefinitions(database)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func Squash(database db.Database, commit string, inContainer, skipTeardown bool)
 	}
 
 	// Run migrations up to the new selected root and dump the database into a single migration file pair
-	squashedUpMigration, squashedDownMigration, err := generateSquashedMigrations(database, []int{newRoot.ID}, inContainer, skipTeardown)
+	squashedUpMigration, squashedDownMigration, err := generateSquashedMigrations(database, []int{newRoot.ID}, inContainer, skipTeardown, skipData)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func selectNewRootMigration(database db.Database, ds *definition.Definitions, co
 
 // generateSquashedMigrations generates the content of a migration file pair that contains the contents
 // of a database up to a given migration index.
-func generateSquashedMigrations(database db.Database, targetVersions []int, inContainer, skipTeardown bool) (up, down string, err error) {
+func generateSquashedMigrations(database db.Database, targetVersions []int, inContainer, skipTeardown, skipData bool) (up, down string, err error) {
 	postgresDSN, teardown, err := setupDatabaseForSquash(database, inContainer)
 	if err != nil {
 		return "", "", err
@@ -198,7 +198,7 @@ func generateSquashedMigrations(database db.Database, targetVersions []int, inCo
 		return "", "", err
 	}
 
-	upMigration, err := generateSquashedUpMigration(database, postgresDSN)
+	upMigration, err := generateSquashedUpMigration(database, postgresDSN, skipData)
 	if err != nil {
 		return "", "", err
 	}
@@ -379,7 +379,7 @@ func runPostgresContainer(databaseName string) (_ func(err error) error, err err
 
 // generateSquashedUpMigration returns the contents of an up migration file containing the
 // current contents of the given database.
-func generateSquashedUpMigration(database db.Database, postgresDSN string) (_ string, err error) {
+func generateSquashedUpMigration(database db.Database, postgresDSN string, skipData bool) (_ string, err error) {
 	pending := std.Out.Pending(output.Line("", output.StylePending, "Dumping current database..."))
 	defer func() {
 		if err == nil {
@@ -413,17 +413,19 @@ func generateSquashedUpMigration(database db.Database, postgresDSN string) (_ st
 		return "", err
 	}
 
-	for _, table := range database.DataTables {
-		dataOutput, err := pgDump("--data-only", "--inserts", "--table", table)
-		if err != nil {
-			return "", err
+	if !skipData {
+		for _, table := range database.DataTables {
+			dataOutput, err := pgDump("--data-only", "--inserts", "--table", table)
+			if err != nil {
+				return "", err
+			}
+
+			pgDumpOutput += dataOutput
 		}
 
-		pgDumpOutput += dataOutput
-	}
-
-	for _, table := range database.CountTables {
-		pgDumpOutput += fmt.Sprintf("INSERT INTO %s VALUES (0);\n", table)
+		for _, table := range database.CountTables {
+			pgDumpOutput += fmt.Sprintf("INSERT INTO %s VALUES (0);\n", table)
+		}
 	}
 
 	return sanitizePgDumpOutput(pgDumpOutput), nil

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -53,6 +53,14 @@ var (
 		Destination: &skipTeardown,
 	}
 
+	skipSquashData     bool
+	skipSquashDataFlag = &cli.BoolFlag{
+		Name:        "skip-data",
+		Usage:       "Skip writing data rows into the squashed migration",
+		Value:       false,
+		Destination: &skipSquashData,
+	}
+
 	outputFilepath     string
 	outputFilepathFlag = &cli.StringFlag{
 		Name:        "f",
@@ -117,7 +125,7 @@ var (
 		ArgsUsage:   "<current-release>",
 		Usage:       "Collapse migration files from historic releases together",
 		Description: cliutil.ConstructLongHelp(),
-		Flags:       []cli.Flag{migrateTargetDatabaseFlag, squashInContainerFlag, skipTeardownFlag},
+		Flags:       []cli.Flag{migrateTargetDatabaseFlag, squashInContainerFlag, skipTeardownFlag, skipSquashDataFlag},
 		Action:      squashExec,
 	}
 
@@ -126,7 +134,7 @@ var (
 		ArgsUsage:   "",
 		Usage:       "Collapse schema definitions into a single SQL file",
 		Description: cliutil.ConstructLongHelp(),
-		Flags:       []cli.Flag{migrateTargetDatabaseFlag, squashInContainerFlag, skipTeardownFlag, outputFilepathFlag},
+		Flags:       []cli.Flag{migrateTargetDatabaseFlag, squashInContainerFlag, skipTeardownFlag, skipSquashDataFlag, outputFilepathFlag},
 		Action:      squashAllExec,
 	}
 
@@ -341,7 +349,7 @@ func squashExec(ctx *cli.Context) (err error) {
 	}
 	std.Out.Writef("Squashing migration files defined up through %s", commit)
 
-	return migration.Squash(database, commit, squashInContainer, skipTeardown)
+	return migration.Squash(database, commit, squashInContainer, skipTeardown, skipSquashData)
 }
 
 func visualizeExec(ctx *cli.Context) (err error) {
@@ -407,7 +415,7 @@ func squashAllExec(ctx *cli.Context) (err error) {
 		return cli.NewExitError(fmt.Sprintf("database %q not found :(", databaseName), 1)
 	}
 
-	return migration.SquashAll(database, squashInContainer, skipTeardown, outputFilepath)
+	return migration.SquashAll(database, squashInContainer, skipTeardown, skipSquashData, outputFilepath)
 }
 
 func leavesExec(ctx *cli.Context) (err error) {

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -756,6 +756,7 @@ Flags:
 * `--db="<value>"`: The target database `schema` to modify (default: frontend)
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 * `--in-container`: Launch Postgres in a Docker container for squashing; do not use the host
+* `--skip-data`: Skip writing data rows into the squashed migration
 * `--skip-teardown`: Skip tearing down the database created to run all registered migrations
 
 ### sg migration squash-all
@@ -774,6 +775,7 @@ Flags:
 * `--db="<value>"`: The target database `schema` to modify (default: frontend)
 * `--feedback`: provide feedback about this command by opening up a Github discussion
 * `--in-container`: Launch Postgres in a Docker container for squashing; do not use the host
+* `--skip-data`: Skip writing data rows into the squashed migration
 * `--skip-teardown`: Skip tearing down the database created to run all registered migrations
 * `-f="<value>"`: The output filepath
 


### PR DESCRIPTION
Add the `-skip-data` toggle to the `sg migration squash` command that stops writing data or counts to tables. We don't need these in all circumstances and should be able to toggle them off.

## Test plan

Tested locally.