### PR TITLE
🧹 cmd/gitserver: Remove method setLastError as it's only used once

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1883,8 +1883,7 @@ func (s *Server) setLastFetched(ctx context.Context, name api.RepoName) error {
 	})
 }
 
-// setLastErrorNonFatal will set the last_error column for the repo in the gitserver table and log
-// the error.
+// setLastErrorNonFatal will set the last_error column for the repo in the gitserver table.
 func (s *Server) setLastErrorNonFatal(ctx context.Context, name api.RepoName, err error) {
 	var errString string
 	if err != nil {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1863,10 +1863,6 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 	w.Header().Set("X-Exec-Stderr", stderr)
 }
 
-func (s *Server) setLastError(ctx context.Context, name api.RepoName, error string) (err error) {
-	return s.DB.GitserverRepos().SetLastError(ctx, name, error, s.Hostname)
-}
-
 func (s *Server) setLastFetched(ctx context.Context, name api.RepoName) error {
 	dir := s.dir(name)
 
@@ -1887,13 +1883,15 @@ func (s *Server) setLastFetched(ctx context.Context, name api.RepoName) error {
 	})
 }
 
-// setLastErrorNonFatal is the same as setLastError but only logs errors
+// setLastErrorNonFatal will set the last_error column for the repo in the gitserver table and log
+// the error.
 func (s *Server) setLastErrorNonFatal(ctx context.Context, name api.RepoName, err error) {
 	var errString string
 	if err != nil {
 		errString = err.Error()
 	}
-	if err := s.setLastError(ctx, name, errString); err != nil {
+
+	if err := s.DB.GitserverRepos().SetLastError(ctx, name, errString, s.Hostname); err != nil {
 		s.Logger.Warn("Setting last error in DB", log.Error(err))
 	}
 }


### PR DESCRIPTION
Started working on #38616 when I noticed this.

Also, update misleading comment about logging error (see [commit message](https://github.com/sourcegraph/sourcegraph/pull/39895/commits/26b17a2ed748edc5fce08a058552eaa1d2835892)).
 
👉 [Sourcegraph search query](https://sourcegraph.sourcegraph.com/search?q=context:global+repo:^github\.com/sourcegraph/sourcegraph%24%401b5cf3b90b625eaa47aa367215ced050a433744d+setLastError&patternType=standard&case=yes) at this commit showing that `setLastError` is not referenced anywhere else.

## Test plan

Existing build should pass as there's no change in functionality.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
