### PR TITLE
Fix bare repos for other(src-cli) code host type

### DIFF
--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -190,7 +190,12 @@ func (s OtherSource) srcExpose(ctx context.Context) ([]*types.Repo, error) {
 			ServiceType: extsvc.TypeOther,
 			ServiceID:   s.conn.Url,
 		}
-		cloneURL := clonePrefix + strings.TrimPrefix(r.URI, "/") + "/.git"
+
+		cloneURL := clonePrefix + strings.TrimPrefix(r.URI, "/")
+		// If the repo is not a bare repo, add a .git
+		if !strings.HasSuffix(r.URI, ".git") {
+			cloneURL += "/.git"
+		}
 		r.Sources = map[string]*types.SourceInfo{
 			urn: {
 				ID:       urn,
@@ -201,9 +206,13 @@ func (s OtherSource) srcExpose(ctx context.Context) ([]*types.Repo, error) {
 			RelativePath: strings.TrimPrefix(cloneURL, s.conn.Url),
 		}
 		// The only required field left is Name
-		if r.Name == "" {
-			r.Name = api.RepoName(r.URI)
+		name := string(r.Name)
+		if name == "" {
+			name = r.URI
 		}
+		// Remove any trailing .git in the name if exists (bare repos)
+		r.Name = api.RepoName(strings.TrimSuffix(name, ".git"))
+
 	}
 
 	return data.Items, nil

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -193,7 +193,7 @@ func (s OtherSource) srcExpose(ctx context.Context) ([]*types.Repo, error) {
 
 		cloneURL := clonePrefix + strings.TrimPrefix(r.URI, "/")
 		// If the repo is not a bare repo, add a .git
-		if !strings.HasSuffix(r.URI, ".git") {
+		if !strings.HasSuffix(cloneURL, ".git") {
 			cloneURL += "/.git"
 		}
 		r.Sources = map[string]*types.SourceInfo{

--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -99,6 +99,25 @@ func TestSrcExpose(t *testing.T) {
 			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/repos/foo/.git"},
 		}},
 	}, {
+		name: "bare",
+		body: `{"Items":[{"uri": "/repos/bare.git", "name": "bare.git"}]}`,
+		want: []*types.Repo{{
+			URI:  "/repos/bare.git",
+			Name: "bare",
+			ExternalRepo: api.ExternalRepoSpec{
+				ServiceID:   s.URL,
+				ServiceType: extsvc.TypeOther,
+				ID:          "/repos/bare.git",
+			},
+			Sources: map[string]*types.SourceInfo{
+				"extsvc:other:1": {
+					ID:       "extsvc:other:1",
+					CloneURL: s.URL + "/repos/bare.git",
+				},
+			},
+			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/repos/bare.git"},
+		}},
+	}, {
 		name: "immutable",
 		body: `{"Items":[{"uri": "foo", "enabled": false, "externalrepo": {"serviceid": "x", "servicetype": "y", "id": "z"}, "sources": {"x":{"id":"x", "cloneurl":"y"}}}]}`,
 		want: []*types.Repo{{


### PR DESCRIPTION
When serving repos using src-cli, if the repo was of bare-repo type, sg couldn't clone it do to an invalid clone URL (had an extra .git at the end of the URL and name), this PR fixes that.

Fixes https://github.com/sourcegraph/customer/issues/1210

## Test plan
Tested locally with both bare and non-bare repos being served up by src-cli, my local sg was able to clone both
Added a unit test to cover bare repos