### PR TITLE
Bump base cadvisor image

### DIFF
--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/cadvisor/cadvisor@sha256:8938726fe00fd7a3889f7c4fb50a54b728f1d02fb5f6cbdbea604824ad11ff3f
-LABEL com.sourcegraph.cadvisor.version=v0.44.0
+FROM gcr.io/cadvisor/cadvisor@sha256:9360d7421c5e9b646ea13e5ced3f8e6da80017b0144733a04b7401dd8c01a5cb
+LABEL com.sourcegraph.cadvisor.version=v0.45.0
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"


### PR DESCRIPTION
This patches CVE-2022-23648 and CVE-2022-29162, closing https://github.com/sourcegraph/security-issues/issues/278 and https://github.com/sourcegraph/security-issues/issues/271.
## Test plan
CI checks. I validated that the image is x86_64 as requested:
```
docker run -it --entrypoint /bin/sh gcr.io/cadvisor/cadvisor@sha256:9360d7421c5e9b646ea13e5ced3f8e6da80017b0144733a04b7401dd8c01a5cb
Unable to find image 'gcr.io/cadvisor/cadvisor@sha256:9360d7421c5e9b646ea13e5ced3f8e6da80017b0144733a04b7401dd8c01a5cb' locally
gcr.io/cadvisor/cadvisor@sha256:9360d7421c5e9b646ea13e5ced3f8e6da80017b0144733a04b7401dd8c01a5cb: Pulling from cadvisor/cadvisor
530afca65e2e: Pull complete
e8c0c1e3704d: Pull complete
95f354d92493: Pull complete
320efad5b270: Pull complete
eab003b8c4a6: Pull complete
Digest: sha256:9360d7421c5e9b646ea13e5ced3f8e6da80017b0144733a04b7401dd8c01a5cb
Status: Downloaded newer image for gcr.io/cadvisor/cadvisor@sha256:9360d7421c5e9b646ea13e5ced3f8e6da80017b0144733a04b7401dd8c01a5cb
/ # uname -a
Linux d9dc68550712 5.10.104-linuxkit #1 SMP Thu Mar 17 17:08:06 UTC 2022 x86_64 Linux
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
