### PR TITLE
Revert "insights: during just in time insight conversion start backfi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Fix issue during conversion of a just in time code insight to one that is persisted where the incorrect start date was used to calculate the series. [#39867](https://github.com/sourcegraph/sourcegraph/pull/39867)
 - Fix issue during code insight creation where selecting `"Run your insight over all your repositories"` reset the currently selected distance between data points. [#39261](https://github.com/sourcegraph/sourcegraph/pull/39261)
 - Fix issue where symbols in the side panel did not have file level permission filtering applied correctly. [#39592](https://github.com/sourcegraph/sourcegraph/pull/39592)
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -432,8 +432,6 @@ func (h *historicalEnqueuer) convertJustInTimeInsights(ctx context.Context) {
 		if incrementErr != nil {
 			log15.Warn("unable to update backfill attempts", "seriesId", series.SeriesID, "error", err)
 		}
-		// Series should backfill as if it were just created now
-		series.CreatedAt = time.Now()
 		err := h.scopedBackfiller.ScopedBackfill(ctx, []itypes.InsightSeries{series})
 		if err != nil {
 			log15.Error("unable to backfill scoped series", "series_id", series.SeriesID, "error", err)


### PR DESCRIPTION
Reverts update to just in time conversion logic.

This reverts commit 4ae071b5fb8668487f83ec56f4b9fc9c63371a90.



## Test plan
revert
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
