### PR TITLE
Update base minio image

### DIFF
--- a/docker-images/minio/build.sh
+++ b/docker-images/minio/build.sh
@@ -4,6 +4,6 @@ set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Retag the 2022-05-08 MinIO release
-MINIO_RELEASE="RELEASE.2022-05-08T23-50-31Z"
+MINIO_RELEASE="RELEASE.2022-08-02T23-59-16Z"
 docker pull minio/minio:$MINIO_RELEASE
 docker tag minio/minio:$MINIO_RELEASE "$IMAGE"


### PR DESCRIPTION
This patches CVE-2022-1271 and closes https://github.com/sourcegraph/security-issues/issues/277.
Changelog: https://github.com/minio/minio/compare/RELEASE.2022-05-08T23-50-31Z...RELEASE.2022-08-02T23-59-16Z

## Test plan
CI checks
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
