### PR TITLE
admin-analytics: follow-up tooltip updates

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -114,7 +114,7 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                 position: 'right',
                 color: 'var(--body-color)',
                 tooltip:
-                    'Cross repository code intel identifies symbols in code throughout your Sourcegraph instance, in a single click, without locating and downloading a repository.',
+                    'Cross repository code navigation identifies symbols in code throughout your Sourcegraph instance, in a single click, without locating and downloading a repository.',
             },
         ]
 

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -94,11 +94,19 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                 value: referenceClicks.summary[aggregation.selected === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: aggregation.selected === 'count' ? 'References' : 'Users using references',
                 color: 'var(--cyan)',
+                tooltip:
+                    aggregation.selected === 'count'
+                        ? "The number of times users clicked 'References' in code navigation hovers to view usages of an item."
+                        : "The number of users who clicked 'References'. in code navigation hovers to view usages of an item.",
             },
             {
                 value: definitionClicks.summary[aggregation.selected === 'count' ? 'totalCount' : 'totalUniqueUsers'],
                 description: aggregation.selected === 'count' ? 'Definitions' : 'Users using definitions',
                 color: 'var(--orange)',
+                tooltip:
+                    aggregation.selected === 'count'
+                        ? "The number of times users clicked 'Definitions' in code navigation hovers to view the definition of an item."
+                        : "The number of users who clicked 'Definitions' in code navigation hovers to view the definition of an item.",
             },
             {
                 value: Math.floor((crossRepoEvents.summary.totalCount * totalEvents) / totalHoverEvents || 0),

--- a/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
@@ -97,8 +97,8 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
                 position: 'right',
                 tooltip:
                     aggregation.selected === 'count'
-                        ? 'The number of of blocks within each notebook that are run. Some blocks such as the search results block must be run for the user to see code.'
-                        : 'The number of users who ran blocks within each notebook in the timeframe.',
+                        ? 'The number of blocks within each notebook that have been run. Some blocks such as the search results block must be run for the user to see code.'
+                        : 'The number of users who ran notebook blocks in the timeframe.',
             },
         ]
 

--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
@@ -108,7 +108,10 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
                 description: aggregation.selected === 'count' ? 'File opens' : 'Users opened files',
                 color: 'var(--body-color)',
                 position: 'right',
-                tooltip: 'File views can be generated from a search result, or be linked to directly.',
+                tooltip:
+                    aggregation.selected === 'count'
+                        ? 'The number of times a file is opened in the code host or IDE.'
+                        : 'The number users who opened file in the code host or IDE.',
             },
         ]
         return [stats, legends]


### PR DESCRIPTION
Follow-up https://github.com/sourcegraph/sourcegraph/issues/39311.

> ON search, for file opens, the copy I supplied was wrong, sorry! Should be: "The number of times a file is opened in the code host or IDE."

> On notebooks, for Block Runs, there is an extra of and the tense needs to be changed. Offending of is struck through below: 
The number of ~~of~~ blocks within each notebook that `have been` run. Some blocks such as the search results block must be run for the user to see code."

> On code intel:
References s/b: "The number of times users clicked 'References' in code navigation hovers to view usages of an item."
Definitions s/b: "The number of times users clicked 'Definitions' in code navigation hovers to view the "
Cross repo events should replace the reference to code intel with "code navigation". Navigation team will replace other references.


## Test plan
- See the diff changes
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-admin-analytics-tooltip.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ojghawjltn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
