### PR TITLE
search: evaluate feature flag datatype early

### DIFF
--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -346,6 +346,7 @@ func BenchmarkSearchResults(b *testing.B) {
 			SearchInputs: &search.Inputs{
 				Plan:         plan,
 				Query:        plan.ToQ(),
+				Features:     &search.Features{},
 				UserSettings: &schema.Settings{},
 			},
 		}

--- a/enterprise/internal/codemonitors/search_test.go
+++ b/enterprise/internal/codemonitors/search_test.go
@@ -71,6 +71,7 @@ func TestAddCodeMonitorHook(t *testing.T) {
 				UserSettings:        &schema.Settings{},
 				PatternType:         query.SearchTypeLiteral,
 				Protocol:            search.Streaming,
+				Features:            &search.Features{},
 				OnSourcegraphDotCom: true,
 			}
 			j, err := jobutil.NewPlanJob(inputs, plan)

--- a/internal/search/alert/observer_test.go
+++ b/internal/search/alert/observer_test.go
@@ -77,6 +77,7 @@ func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 			OriginalQuery: searchQuery,
 			Query:         q,
 			UserSettings:  &schema.Settings{},
+			Features:      &search.Features{},
 		},
 	}
 

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/google/zoekt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -111,7 +113,7 @@ func (s *searchClient) Plan(
 		OriginalQuery:       searchQuery,
 		UserSettings:        settings,
 		OnSourcegraphDotCom: sourcegraphDotComMode,
-		Features:            featureflag.FromContext(ctx),
+		Features:            toFeatures(featureflag.FromContext(ctx), s.logger),
 		PatternType:         searchType,
 		Protocol:            protocol,
 	}
@@ -223,6 +225,25 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 	})
 	return searchType
 }
+
+func toFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Features {
+	if flagSet == nil {
+		flagSet = &featureflag.FlagSet{}
+		metricFeatureFlagUnavailable.Inc()
+		logger.Warn("search feature flags are not available")
+	}
+
+	return &search.Features{
+		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
+		HybridSearch:            flagSet.GetBoolOr("search-hybrid", false),
+		CodeOwnershipFilters:    flagSet.GetBoolOr("code-ownership", false),
+	}
+}
+
+var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "src_search_featureflag_unavailable",
+	Help: "temporary counter to check if we have feature flag available in practice.",
+})
 
 func getBoolPtr(b *bool, def bool) bool {
 	if b == nil {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -5,13 +5,9 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
-	"github.com/inconshreveable/log15"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	codeownershipjob "github.com/sourcegraph/sourcegraph/internal/search/codeownership"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
@@ -68,8 +64,6 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 		children = append(children, j)
 	}
 
-	features := toFeatures(inputs.Features)
-
 	// Modify the input query if the user specified `file:contains.content()`
 	fileContainsPatterns := b.FileContainsContent()
 	originalQuery := b
@@ -99,7 +93,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 			query:          b,
 			resultTypes:    resultTypes,
 			repoOptions:    repoOptions,
-			features:       &features,
+			features:       inputs.Features,
 			fileMatchLimit: fileMatchLimit,
 			selector:       selector,
 		}
@@ -189,7 +183,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 	}
 
 	{ // Apply code ownership post-search filter
-		if includeOwners, excludeOwners := b.FileHasOwner(); features.CodeOwnershipFilters == true && (len(includeOwners) > 0 || len(excludeOwners) > 0) {
+		if includeOwners, excludeOwners := b.FileHasOwner(); inputs.Features.CodeOwnershipFilters == true && (len(includeOwners) > 0 || len(excludeOwners) > 0) {
 			basicJob = codeownershipjob.New(basicJob, includeOwners, excludeOwners)
 		}
 	}
@@ -300,7 +294,6 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 	fileMatchLimit := int32(computeFileMatchLimit(f.ToBasic(), searchInputs.Protocol))
 	selector, _ := filter.SelectPathFromString(f.FindValue(query.FieldSelect)) // Invariant: select is validated
 
-	features := toFeatures(searchInputs.Features)
 	repoOptions := toRepoOptions(f.ToBasic(), searchInputs.UserSettings)
 
 	_, skipRepoSubsetSearch, _ := jobMode(f.ToBasic(), resultTypes, searchInputs.PatternType, searchInputs.OnSourcegraphDotCom)
@@ -325,7 +318,7 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 					PatternInfo:     patternInfo,
 					Indexed:         false,
 					UseFullDeadline: useFullDeadline,
-					Features:        features,
+					Features:        *searchInputs.Features,
 				}
 
 				addJob(&repoPagerJob{
@@ -355,7 +348,7 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 
 		if resultTypes.Has(result.TypeStructural) {
 			typ := search.TextRequest
-			zoektQuery, err := zoekt.QueryToZoektQuery(f.ToBasic(), resultTypes, &features, typ)
+			zoektQuery, err := zoekt.QueryToZoektQuery(f.ToBasic(), resultTypes, searchInputs.Features, typ)
 			if err != nil {
 				return nil, err
 			}
@@ -369,7 +362,7 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 			searcherArgs := &search.SearcherParameters{
 				PatternInfo:     patternInfo,
 				UseFullDeadline: useFullDeadline,
-				Features:        features,
+				Features:        *searchInputs.Features,
 			}
 
 			addJob(&structural.SearchJob{
@@ -467,11 +460,6 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 
 	return NewParallelJob(allJobs...), nil
 }
-
-var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{
-	Name: "src_search_featureflag_unavailable",
-	Help: "temporary counter to check if we have feature flag available in practice.",
-})
 
 func computeFileMatchLimit(b query.Basic, p search.Protocol) int {
 	if count := b.Count(); count != nil {
@@ -802,20 +790,6 @@ func jobMode(b query.Basic, resultTypes result.Types, st query.SearchType, onSou
 	runZoektOverRepos = !repoUniverseSearch || onSourcegraphDotCom
 
 	return repoUniverseSearch, skipRepoSubsetSearch, runZoektOverRepos
-}
-
-func toFeatures(flagSet *featureflag.FlagSet) search.Features {
-	if flagSet == nil {
-		flagSet = &featureflag.FlagSet{}
-		metricFeatureFlagUnavailable.Inc()
-		log15.Warn("search feature flags are not available")
-	}
-
-	return search.Features{
-		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
-		HybridSearch:            flagSet.GetBoolOr("search-hybrid", false),
-		CodeOwnershipFilters:    flagSet.GetBoolOr("code-ownership", false),
-	}
 }
 
 // toAndJob creates a new job from a basic query whose pattern is an And operator at the root.

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -599,6 +599,7 @@ func TestNewPlanJob(t *testing.T) {
 				UserSettings:        &schema.Settings{},
 				PatternType:         query.SearchTypeLiteral,
 				Protocol:            tc.protocol,
+				Features:            &search.Features{},
 				OnSourcegraphDotCom: true,
 			}
 

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -26,7 +27,7 @@ type Inputs struct {
 	PatternType         query.SearchType
 	UserSettings        *schema.Settings
 	OnSourcegraphDotCom bool
-	Features            *featureflag.FlagSet
+	Features            *Features
 	Protocol            Protocol
 }
 
@@ -315,17 +316,29 @@ type Features struct {
 	// ContentBasedLangFilters when true will use the language detected from
 	// the content of the file, rather than just file name patterns. This is
 	// currently just supported by Zoekt.
-	ContentBasedLangFilters bool
+	ContentBasedLangFilters bool `json:"search-content-based-lang-detection"`
 
 	// HybridSearch when true will consult the Zoekt index when running
 	// unindexed searches. Searcher (unindexed search) will the only search
 	// what has changed since the indexed commit.
-	HybridSearch bool
+	HybridSearch bool `json:"search-hybrd"`
 
 	// CodeOwnershipFilters when true will add the code ownership post-search
 	// filter and allow users to search by code owners using the has.owner
 	// predicate.
-	CodeOwnershipFilters bool
+	CodeOwnershipFilters bool `json:"code-ownership"`
+}
+
+func (f *Features) String() string {
+	jsonObject, err := json.Marshal(f)
+	if err != nil {
+		return "error encoding features as string"
+	}
+	flagMap := featureflag.EvaluatedFlagSet{}
+	if err := json.Unmarshal(jsonObject, &flagMap); err != nil {
+		return "error decoding features"
+	}
+	return flagMap.String()
 }
 
 type RepoOptions struct {


### PR DESCRIPTION
Job planner gets a flag set and then calls `toFeatures(flagSet *featureflag.FlagSet) search.Features` in multiple places to convert it to `search.Features`. We should do this conversion upfront, even before passing it to the Job planner, because it's only read.

Context: prep for adding feature flag for lucky search, and finding it ugly to have to do this `toFeatures(...)` thing.

## Test plan
Updates tests. Intended to be semantics-preserving. Running against `main-dry-run` in case we're not setting a non-nil value for this (now pointer) data type.
