### PR TITLE
search: add a/b feature flag for lucky search

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -237,6 +237,7 @@ func toFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
 		HybridSearch:            flagSet.GetBoolOr("search-hybrid", false),
 		CodeOwnershipFilters:    flagSet.GetBoolOr("code-ownership", false),
+		AbLuckySearch:           flagSet.GetBoolOr("ab-lucky-search", false),
 	}
 }
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -42,7 +42,7 @@ func NewPlanJob(inputs *search.Inputs, plan query.Plan) (job.Job, error) {
 	newJob := func(b query.Basic) (job.Job, error) {
 		return NewBasicJob(inputs, b)
 	}
-	if inputs.PatternType == query.SearchTypeLucky {
+	if inputs.PatternType == query.SearchTypeLucky || inputs.Features.AbLuckySearch {
 		jobTree = lucky.NewFeelingLuckySearchJob(jobTree, newJob, plan)
 	} else if inputs.PatternType == query.SearchTypeKeyword && len(plan) == 1 {
 		newJobTree, err := keyword.NewKeywordSearchJob(plan[0], newJob)

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -327,6 +327,10 @@ type Features struct {
 	// filter and allow users to search by code owners using the has.owner
 	// predicate.
 	CodeOwnershipFilters bool `json:"code-ownership"`
+
+	// When true lucky search runs by default. Adding for A/B testing in
+	// 08/2022. To be removed at latest by 12/2022.
+	AbLuckySearch bool `json:"ab-lucky-search"`
 }
 
 func (f *Features) String() string {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/39920.

Only need a A/B testing flag in the backend--the client behavior and event logging is entirely dependent on backend result response. A/B users will just "get" lucky search in the currently default `standard` query mode (no separate lucky search toggles or such, it would be as if they turned on `defaultPatternType == lucky` but without actually setting that value).

I will document the Q/A and duration for A/B test in a short doc separately, before rolling out the change.

## Test plan
No test needed, just a feature flag addition.
