### PR TITLE
insights: refactor just in time converter to account for correct series backfill starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fix issue during conversion of just in time code insights to start backfilling data from the current time instead of the date the insight was created. [#39923](https://github.com/sourcegraph/sourcegraph/pull/39923)
 - Fix issue during code insight creation where selecting `"Run your insight over all your repositories"` reset the currently selected distance between data points. [#39261](https://github.com/sourcegraph/sourcegraph/pull/39261)
 - Fix issue where symbols in the side panel did not have file level permission filtering applied correctly. [#39592](https://github.com/sourcegraph/sourcegraph/pull/39592)
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/segmentio/ksuid"
 
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
@@ -419,8 +420,8 @@ func (h *historicalEnqueuer) Handler(ctx context.Context) error {
 
 func (h *historicalEnqueuer) convertJustInTimeInsights(ctx context.Context) {
 
-	log15.Debug("fetching data series to convert from just in time and backfill")
-	foundSeries, err := h.dataSeriesStore.GetJustInTimeSearchSeriesToBackfill(ctx)
+	log15.Debug("fetching scoped search series that need a backfill")
+	foundSeries, err := h.dataSeriesStore.GetScopedSearchSeriesNeedBackfill(ctx)
 	if err != nil {
 		log15.Error("unable to find series to convert to backfilled", "error", err)
 		return
@@ -428,19 +429,36 @@ func (h *historicalEnqueuer) convertJustInTimeInsights(ctx context.Context) {
 
 	for _, series := range foundSeries {
 		log15.Info("loaded just in time data series for conversion to backfilled", "series_id", series.SeriesID)
-		incrementErr := h.dataSeriesStore.IncrementBackfillAttempts(ctx, series)
+
+		oldSeriesId := series.SeriesID
+		series.SeriesID = ksuid.New().String()
+		series.CreatedAt = time.Now()
+
+		// Update the backfill attempts and insert the new series_ID and sets just_in_time false
+		// so seriesID is available jobs run
+		incrementErr := h.dataSeriesStore.StartJustInTimeConversionAttempt(ctx, series)
 		if incrementErr != nil {
-			log15.Warn("unable to update backfill attempts", "seriesId", series.SeriesID, "error", err)
+			log15.Warn("unable to start jit conversion", "seriesId", oldSeriesId, "error", err)
+			continue
 		}
-		err := h.scopedBackfiller.ScopedBackfill(ctx, []itypes.InsightSeries{series})
+
+		err = h.scopedBackfiller.ScopedBackfill(ctx, []itypes.InsightSeries{series})
 		if err != nil {
+			// TODO: Determine if seriesID should be reset.
+			// If it was Just In Time it shouldn't matter it will still display just in time and continue to attempt to convert
+			// If it was scoped backfilled it will show `no data` and will retry to backfill next time enquerer runs
 			log15.Error("unable to backfill scoped series", "series_id", series.SeriesID, "error", err)
 			continue
 		}
 
-		err = h.dataSeriesStore.ConvertJustInTimeSearchSeriesToBackfill(ctx, series)
+		err = h.dataSeriesStore.CompleteJustInTimeConversionAttempt(ctx, series)
 		if err != nil {
-			log15.Error("unable to convert insight from jit to backfilled", "series_id", series.SeriesID, "error", err)
+			log15.Error("unable to complete insight from jit to backfilled", "series_id", series.SeriesID, "error", err)
+		}
+
+		err = queryrunner.PurgeJobsForSeries(ctx, h.scopedBackfiller.workerBaseStore, oldSeriesId)
+		if err != nil {
+			log15.Warn("unable to purge jobs for old seriesID", "seriesId", oldSeriesId, "error", err)
 		}
 
 	}

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -434,8 +434,7 @@ func (h *historicalEnqueuer) convertJustInTimeInsights(ctx context.Context) {
 		series.SeriesID = ksuid.New().String()
 		series.CreatedAt = time.Now()
 
-		// Update the backfill attempts and insert the new series_ID and sets just_in_time false
-		// so seriesID is available jobs run
+		// Update the backfill attempts adjusts created date and inserts the new series_ID
 		incrementErr := h.dataSeriesStore.StartJustInTimeConversionAttempt(ctx, series)
 		if incrementErr != nil {
 			log15.Warn("unable to start jit conversion", "seriesId", oldSeriesId, "error", err)

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -443,9 +443,6 @@ func (h *historicalEnqueuer) convertJustInTimeInsights(ctx context.Context) {
 
 		err = h.scopedBackfiller.ScopedBackfill(ctx, []itypes.InsightSeries{series})
 		if err != nil {
-			// TODO: Determine if seriesID should be reset.
-			// If it was Just In Time it shouldn't matter it will still display just in time and continue to attempt to convert
-			// If it was scoped backfilled it will show `no data` and will retry to backfill next time enquerer runs
 			log15.Error("unable to backfill scoped series", "series_id", series.SeriesID, "error", err)
 			continue
 		}

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -251,6 +251,25 @@ INSERT INTO insights_query_runner_jobs (
 RETURNING id
 `
 
+// PurgeJobsForSeries removes all jobs for a seriesID.
+func PurgeJobsForSeries(ctx context.Context, workerBaseStore *basestore.Store, seriesID string) (err error) {
+	tx, err := workerBaseStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	err = tx.Exec(ctx, sqlf.Sprintf(purgeJobsForSeriesFmtStr, seriesID))
+	return err
+
+}
+
+const purgeJobsForSeriesFmtStr = `
+-- source: enterprise/internal/insights/background/queryrunner/worker.go:purgeJobsForSeriesFmtStr
+DELETE FROM insights_query_runner_jobs
+WHERE series_id = %s
+`
+
 func dequeueJob(ctx context.Context, workerBaseStore *basestore.Store, recordID int) (_ *Job, err error) {
 	tx, err := workerBaseStore.Transact(ctx)
 	if err != nil {

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -385,24 +385,24 @@ func (s *InsightStore) GetDataSeries(ctx context.Context, args GetDataSeriesArgs
 	return scanDataSeries(s.Query(ctx, q))
 }
 
-// GetJustInTimeSearchSeriesToBackfill Is a special purpose func to get only just in time series that should
+// GetScopedSearchSeriesNeedBackfill Is a special purpose func to get only just in time series that should
 // be converted to scoped backfilled insights
-func (s *InsightStore) GetJustInTimeSearchSeriesToBackfill(ctx context.Context) ([]types.InsightSeries, error) {
+func (s *InsightStore) GetScopedSearchSeriesNeedBackfill(ctx context.Context) ([]types.InsightSeries, error) {
 	preds := make([]*sqlf.Query, 0, 1)
 
 	preds = append(preds, sqlf.Sprintf("deleted_at IS NULL"))
 	preds = append(preds, sqlf.Sprintf("CARDINALITY(repositories) > 0"))
-	preds = append(preds, sqlf.Sprintf("just_in_time = true"))
 	preds = append(preds, sqlf.Sprintf("backfill_attempts < 10"))
 	preds = append(preds, sqlf.Sprintf("generation_method !=  %s", "language-stats"))
+	preds = append(preds, sqlf.Sprintf("needs_migration = true"))
 
 	q := sqlf.Sprintf(getInsightDataSeriesSql, sqlf.Join(preds, "\n AND"))
 	return scanDataSeries(s.Query(ctx, q))
 }
 
-// GetJustInTimeSearchSeriesToBackfill Is a special purpose func to convert a Just In Time search insight
+// CompleteJustInTimeConversionAttempt Is a special purpose func to convert a Just In Time search insight
 // to a scoped backfilled serach insight
-func (s *InsightStore) ConvertJustInTimeSearchSeriesToBackfill(ctx context.Context, series types.InsightSeries) error {
+func (s *InsightStore) CompleteJustInTimeConversionAttempt(ctx context.Context, series types.InsightSeries) error {
 	interval := timeseries.TimeInterval{
 		Unit:  types.IntervalUnit(series.SampleIntervalUnit),
 		Value: series.SampleIntervalValue,
@@ -413,19 +413,20 @@ func (s *InsightStore) ConvertJustInTimeSearchSeriesToBackfill(ctx context.Conte
 	nextRecording := interval.StepForwards(s.Now())
 	nextSnapshot := NextSnapshot(s.Now())
 
-	return s.Exec(ctx, sqlf.Sprintf(convertJITSeriesToBackfillSql, nextRecording, nextSnapshot, series.SeriesID))
+	return s.Exec(ctx, sqlf.Sprintf(completeJustInTimeConversionAttemptSql, nextRecording, nextSnapshot, series.ID))
 
 }
 
-const convertJITSeriesToBackfillSql = `
--- source: enterprise/internal/insights/store/insight_store.go:ConvertJustInTimeSearchSeriesToBackfill
+const completeJustInTimeConversionAttemptSql = `
+-- source: enterprise/internal/insights/store/insight_store.go:CompleteJustInTimeConversionAttempt
 UPDATE insight_series
 SET just_in_time = false,
     next_recording_after = %s,
 	next_snapshot_after = %s,
-	backfill_queued_at = now()
+	backfill_queued_at = now(),
+	needs_migration = false
 WHERE
-	series_id = %s
+	id = %d
 	AND generation_method !='language-stats'
 	AND deleted_at is null;
 `
@@ -726,6 +727,16 @@ const incrementSeriesBackfillAttemptsSql = `
 update insight_series set backfill_attempts = backfill_attempts + 1 where series_id = %s;
 `
 
+// StartJustInTimeConversionAttempt increments backfill_attempts and updates the created date and seriesID.
+func (s *InsightStore) StartJustInTimeConversionAttempt(ctx context.Context, series types.InsightSeries) error {
+	return s.Exec(ctx, sqlf.Sprintf(startJustInTimeConversionAttemptSql, series.CreatedAt, series.SeriesID, series.ID))
+}
+
+const startJustInTimeConversionAttemptSql = `
+-- source: enterprise/internal/insights/store/insight_store.go:StartJITConversionAttempt
+update insight_series set backfill_attempts = backfill_attempts + 1, created_at=%s, series_id = %s where id = %d;
+`
+
 // CreateSeries will create a new insight data series. This series must be uniquely identified by the series ID.
 func (s *InsightStore) CreateSeries(ctx context.Context, series types.InsightSeries) (types.InsightSeries, error) {
 	if series.CreatedAt.IsZero() {
@@ -781,10 +792,11 @@ type DataSeriesStore interface {
 	StampRecording(ctx context.Context, series types.InsightSeries) (types.InsightSeries, error)
 	StampSnapshot(ctx context.Context, series types.InsightSeries) (types.InsightSeries, error)
 	StampBackfill(ctx context.Context, series types.InsightSeries) (types.InsightSeries, error)
-	IncrementBackfillAttempts(ctx context.Context, series types.InsightSeries) error
+	StartJustInTimeConversionAttempt(ctx context.Context, series types.InsightSeries) error
 	SetSeriesEnabled(ctx context.Context, seriesId string, enabled bool) error
-	GetJustInTimeSearchSeriesToBackfill(ctx context.Context) ([]types.InsightSeries, error)
-	ConvertJustInTimeSearchSeriesToBackfill(ctx context.Context, series types.InsightSeries) error
+	IncrementBackfillAttempts(ctx context.Context, series types.InsightSeries) error
+	GetScopedSearchSeriesNeedBackfill(ctx context.Context) ([]types.InsightSeries, error)
+	CompleteJustInTimeConversionAttempt(ctx context.Context, series types.InsightSeries) error
 }
 
 type InsightMetadataStore interface {

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -1018,8 +1018,8 @@ const createInsightSeriesSql = `
 INSERT INTO insight_series (series_id, query, created_at, oldest_historical_at, last_recorded_at,
                             next_recording_after, last_snapshot_at, next_snapshot_after, repositories,
 							sample_interval_unit, sample_interval_value, generated_from_capture_groups,
-							just_in_time, generation_method, group_by)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+							just_in_time, generation_method, group_by, needs_migration)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, false)
 RETURNING id;`
 
 const getInsightByViewSql = `

--- a/enterprise/internal/insights/store/mocks_temp.go
+++ b/enterprise/internal/insights/store/mocks_temp.go
@@ -18,17 +18,17 @@ import (
 // github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store)
 // used for unit testing.
 type MockDataSeriesStore struct {
-	// ConvertJustInTimeSearchSeriesToBackfillFunc is an instance of a mock
+	// CompleteJustInTimeConversionAttemptFunc is an instance of a mock
 	// function object controlling the behavior of the method
-	// ConvertJustInTimeSearchSeriesToBackfill.
-	ConvertJustInTimeSearchSeriesToBackfillFunc *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc
+	// CompleteJustInTimeConversionAttempt.
+	CompleteJustInTimeConversionAttemptFunc *DataSeriesStoreCompleteJustInTimeConversionAttemptFunc
 	// GetDataSeriesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDataSeries.
 	GetDataSeriesFunc *DataSeriesStoreGetDataSeriesFunc
-	// GetJustInTimeSearchSeriesToBackfillFunc is an instance of a mock
+	// GetScopedSearchSeriesNeedBackfillFunc is an instance of a mock
 	// function object controlling the behavior of the method
-	// GetJustInTimeSearchSeriesToBackfill.
-	GetJustInTimeSearchSeriesToBackfillFunc *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc
+	// GetScopedSearchSeriesNeedBackfill.
+	GetScopedSearchSeriesNeedBackfillFunc *DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc
 	// IncrementBackfillAttemptsFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// IncrementBackfillAttempts.
@@ -45,6 +45,10 @@ type MockDataSeriesStore struct {
 	// StampSnapshotFunc is an instance of a mock function object
 	// controlling the behavior of the method StampSnapshot.
 	StampSnapshotFunc *DataSeriesStoreStampSnapshotFunc
+	// StartJustInTimeConversionAttemptFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// StartJustInTimeConversionAttempt.
+	StartJustInTimeConversionAttemptFunc *DataSeriesStoreStartJustInTimeConversionAttemptFunc
 }
 
 // NewMockDataSeriesStore creates a new mock of the DataSeriesStore
@@ -52,7 +56,7 @@ type MockDataSeriesStore struct {
 // overwritten.
 func NewMockDataSeriesStore() *MockDataSeriesStore {
 	return &MockDataSeriesStore{
-		ConvertJustInTimeSearchSeriesToBackfillFunc: &DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc{
+		CompleteJustInTimeConversionAttemptFunc: &DataSeriesStoreCompleteJustInTimeConversionAttemptFunc{
 			defaultHook: func(context.Context, types.InsightSeries) (r0 error) {
 				return
 			},
@@ -62,7 +66,7 @@ func NewMockDataSeriesStore() *MockDataSeriesStore {
 				return
 			},
 		},
-		GetJustInTimeSearchSeriesToBackfillFunc: &DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc{
+		GetScopedSearchSeriesNeedBackfillFunc: &DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc{
 			defaultHook: func(context.Context) (r0 []types.InsightSeries, r1 error) {
 				return
 			},
@@ -92,6 +96,11 @@ func NewMockDataSeriesStore() *MockDataSeriesStore {
 				return
 			},
 		},
+		StartJustInTimeConversionAttemptFunc: &DataSeriesStoreStartJustInTimeConversionAttemptFunc{
+			defaultHook: func(context.Context, types.InsightSeries) (r0 error) {
+				return
+			},
+		},
 	}
 }
 
@@ -99,9 +108,9 @@ func NewMockDataSeriesStore() *MockDataSeriesStore {
 // interface. All methods panic on invocation, unless overwritten.
 func NewStrictMockDataSeriesStore() *MockDataSeriesStore {
 	return &MockDataSeriesStore{
-		ConvertJustInTimeSearchSeriesToBackfillFunc: &DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc{
+		CompleteJustInTimeConversionAttemptFunc: &DataSeriesStoreCompleteJustInTimeConversionAttemptFunc{
 			defaultHook: func(context.Context, types.InsightSeries) error {
-				panic("unexpected invocation of MockDataSeriesStore.ConvertJustInTimeSearchSeriesToBackfill")
+				panic("unexpected invocation of MockDataSeriesStore.CompleteJustInTimeConversionAttempt")
 			},
 		},
 		GetDataSeriesFunc: &DataSeriesStoreGetDataSeriesFunc{
@@ -109,9 +118,9 @@ func NewStrictMockDataSeriesStore() *MockDataSeriesStore {
 				panic("unexpected invocation of MockDataSeriesStore.GetDataSeries")
 			},
 		},
-		GetJustInTimeSearchSeriesToBackfillFunc: &DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc{
+		GetScopedSearchSeriesNeedBackfillFunc: &DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc{
 			defaultHook: func(context.Context) ([]types.InsightSeries, error) {
-				panic("unexpected invocation of MockDataSeriesStore.GetJustInTimeSearchSeriesToBackfill")
+				panic("unexpected invocation of MockDataSeriesStore.GetScopedSearchSeriesNeedBackfill")
 			},
 		},
 		IncrementBackfillAttemptsFunc: &DataSeriesStoreIncrementBackfillAttemptsFunc{
@@ -139,6 +148,11 @@ func NewStrictMockDataSeriesStore() *MockDataSeriesStore {
 				panic("unexpected invocation of MockDataSeriesStore.StampSnapshot")
 			},
 		},
+		StartJustInTimeConversionAttemptFunc: &DataSeriesStoreStartJustInTimeConversionAttemptFunc{
+			defaultHook: func(context.Context, types.InsightSeries) error {
+				panic("unexpected invocation of MockDataSeriesStore.StartJustInTimeConversionAttempt")
+			},
+		},
 	}
 }
 
@@ -147,14 +161,14 @@ func NewStrictMockDataSeriesStore() *MockDataSeriesStore {
 // overwritten.
 func NewMockDataSeriesStoreFrom(i DataSeriesStore) *MockDataSeriesStore {
 	return &MockDataSeriesStore{
-		ConvertJustInTimeSearchSeriesToBackfillFunc: &DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc{
-			defaultHook: i.ConvertJustInTimeSearchSeriesToBackfill,
+		CompleteJustInTimeConversionAttemptFunc: &DataSeriesStoreCompleteJustInTimeConversionAttemptFunc{
+			defaultHook: i.CompleteJustInTimeConversionAttempt,
 		},
 		GetDataSeriesFunc: &DataSeriesStoreGetDataSeriesFunc{
 			defaultHook: i.GetDataSeries,
 		},
-		GetJustInTimeSearchSeriesToBackfillFunc: &DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc{
-			defaultHook: i.GetJustInTimeSearchSeriesToBackfill,
+		GetScopedSearchSeriesNeedBackfillFunc: &DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc{
+			defaultHook: i.GetScopedSearchSeriesNeedBackfill,
 		},
 		IncrementBackfillAttemptsFunc: &DataSeriesStoreIncrementBackfillAttemptsFunc{
 			defaultHook: i.IncrementBackfillAttempts,
@@ -171,41 +185,44 @@ func NewMockDataSeriesStoreFrom(i DataSeriesStore) *MockDataSeriesStore {
 		StampSnapshotFunc: &DataSeriesStoreStampSnapshotFunc{
 			defaultHook: i.StampSnapshot,
 		},
+		StartJustInTimeConversionAttemptFunc: &DataSeriesStoreStartJustInTimeConversionAttemptFunc{
+			defaultHook: i.StartJustInTimeConversionAttempt,
+		},
 	}
 }
 
-// DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc describes the
-// behavior when the ConvertJustInTimeSearchSeriesToBackfill method of the
+// DataSeriesStoreCompleteJustInTimeConversionAttemptFunc describes the
+// behavior when the CompleteJustInTimeConversionAttempt method of the
 // parent MockDataSeriesStore instance is invoked.
-type DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc struct {
+type DataSeriesStoreCompleteJustInTimeConversionAttemptFunc struct {
 	defaultHook func(context.Context, types.InsightSeries) error
 	hooks       []func(context.Context, types.InsightSeries) error
-	history     []DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall
+	history     []DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall
 	mutex       sync.Mutex
 }
 
-// ConvertJustInTimeSearchSeriesToBackfill delegates to the next hook
-// function in the queue and stores the parameter and result values of this
+// CompleteJustInTimeConversionAttempt delegates to the next hook function
+// in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockDataSeriesStore) ConvertJustInTimeSearchSeriesToBackfill(v0 context.Context, v1 types.InsightSeries) error {
-	r0 := m.ConvertJustInTimeSearchSeriesToBackfillFunc.nextHook()(v0, v1)
-	m.ConvertJustInTimeSearchSeriesToBackfillFunc.appendCall(DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall{v0, v1, r0})
+func (m *MockDataSeriesStore) CompleteJustInTimeConversionAttempt(v0 context.Context, v1 types.InsightSeries) error {
+	r0 := m.CompleteJustInTimeConversionAttemptFunc.nextHook()(v0, v1)
+	m.CompleteJustInTimeConversionAttemptFunc.appendCall(DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall{v0, v1, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// ConvertJustInTimeSearchSeriesToBackfill method of the parent
+// CompleteJustInTimeConversionAttempt method of the parent
 // MockDataSeriesStore instance is invoked and the hook queue is empty.
-func (f *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc) SetDefaultHook(hook func(context.Context, types.InsightSeries) error) {
+func (f *DataSeriesStoreCompleteJustInTimeConversionAttemptFunc) SetDefaultHook(hook func(context.Context, types.InsightSeries) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// ConvertJustInTimeSearchSeriesToBackfill method of the parent
+// CompleteJustInTimeConversionAttempt method of the parent
 // MockDataSeriesStore instance invokes the hook at the front of the queue
 // and discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc) PushHook(hook func(context.Context, types.InsightSeries) error) {
+func (f *DataSeriesStoreCompleteJustInTimeConversionAttemptFunc) PushHook(hook func(context.Context, types.InsightSeries) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -213,20 +230,20 @@ func (f *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc) PushHook(ho
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc) SetDefaultReturn(r0 error) {
+func (f *DataSeriesStoreCompleteJustInTimeConversionAttemptFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, types.InsightSeries) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc) PushReturn(r0 error) {
+func (f *DataSeriesStoreCompleteJustInTimeConversionAttemptFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, types.InsightSeries) error {
 		return r0
 	})
 }
 
-func (f *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc) nextHook() func(context.Context, types.InsightSeries) error {
+func (f *DataSeriesStoreCompleteJustInTimeConversionAttemptFunc) nextHook() func(context.Context, types.InsightSeries) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -239,29 +256,29 @@ func (f *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc) nextHook() 
 	return hook
 }
 
-func (f *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc) appendCall(r0 DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall) {
+func (f *DataSeriesStoreCompleteJustInTimeConversionAttemptFunc) appendCall(r0 DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall objects
+// DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall objects
 // describing the invocations of this function.
-func (f *DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFunc) History() []DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall {
+func (f *DataSeriesStoreCompleteJustInTimeConversionAttemptFunc) History() []DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall {
 	f.mutex.Lock()
-	history := make([]DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall, len(f.history))
+	history := make([]DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall is an
-// object that describes an invocation of method
-// ConvertJustInTimeSearchSeriesToBackfill on an instance of
+// DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall is an object
+// that describes an invocation of method
+// CompleteJustInTimeConversionAttempt on an instance of
 // MockDataSeriesStore.
-type DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall struct {
+type DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -275,13 +292,13 @@ type DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall) Args() []interface{} {
+func (c DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DataSeriesStoreConvertJustInTimeSearchSeriesToBackfillFuncCall) Results() []interface{} {
+func (c DataSeriesStoreCompleteJustInTimeConversionAttemptFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -394,38 +411,37 @@ func (c DataSeriesStoreGetDataSeriesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc describes the
-// behavior when the GetJustInTimeSearchSeriesToBackfill method of the
-// parent MockDataSeriesStore instance is invoked.
-type DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc struct {
+// DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc describes the
+// behavior when the GetScopedSearchSeriesNeedBackfill method of the parent
+// MockDataSeriesStore instance is invoked.
+type DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc struct {
 	defaultHook func(context.Context) ([]types.InsightSeries, error)
 	hooks       []func(context.Context) ([]types.InsightSeries, error)
-	history     []DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall
+	history     []DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall
 	mutex       sync.Mutex
 }
 
-// GetJustInTimeSearchSeriesToBackfill delegates to the next hook function
-// in the queue and stores the parameter and result values of this
-// invocation.
-func (m *MockDataSeriesStore) GetJustInTimeSearchSeriesToBackfill(v0 context.Context) ([]types.InsightSeries, error) {
-	r0, r1 := m.GetJustInTimeSearchSeriesToBackfillFunc.nextHook()(v0)
-	m.GetJustInTimeSearchSeriesToBackfillFunc.appendCall(DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall{v0, r0, r1})
+// GetScopedSearchSeriesNeedBackfill delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockDataSeriesStore) GetScopedSearchSeriesNeedBackfill(v0 context.Context) ([]types.InsightSeries, error) {
+	r0, r1 := m.GetScopedSearchSeriesNeedBackfillFunc.nextHook()(v0)
+	m.GetScopedSearchSeriesNeedBackfillFunc.appendCall(DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetJustInTimeSearchSeriesToBackfill method of the parent
+// GetScopedSearchSeriesNeedBackfill method of the parent
 // MockDataSeriesStore instance is invoked and the hook queue is empty.
-func (f *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc) SetDefaultHook(hook func(context.Context) ([]types.InsightSeries, error)) {
+func (f *DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc) SetDefaultHook(hook func(context.Context) ([]types.InsightSeries, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetJustInTimeSearchSeriesToBackfill method of the parent
+// GetScopedSearchSeriesNeedBackfill method of the parent
 // MockDataSeriesStore instance invokes the hook at the front of the queue
 // and discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc) PushHook(hook func(context.Context) ([]types.InsightSeries, error)) {
+func (f *DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc) PushHook(hook func(context.Context) ([]types.InsightSeries, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -433,20 +449,20 @@ func (f *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc) PushHook(hook f
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc) SetDefaultReturn(r0 []types.InsightSeries, r1 error) {
+func (f *DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc) SetDefaultReturn(r0 []types.InsightSeries, r1 error) {
 	f.SetDefaultHook(func(context.Context) ([]types.InsightSeries, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc) PushReturn(r0 []types.InsightSeries, r1 error) {
+func (f *DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc) PushReturn(r0 []types.InsightSeries, r1 error) {
 	f.PushHook(func(context.Context) ([]types.InsightSeries, error) {
 		return r0, r1
 	})
 }
 
-func (f *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc) nextHook() func(context.Context) ([]types.InsightSeries, error) {
+func (f *DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc) nextHook() func(context.Context) ([]types.InsightSeries, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -459,29 +475,28 @@ func (f *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc) nextHook() func
 	return hook
 }
 
-func (f *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc) appendCall(r0 DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall) {
+func (f *DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc) appendCall(r0 DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall objects
+// DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall objects
 // describing the invocations of this function.
-func (f *DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFunc) History() []DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall {
+func (f *DataSeriesStoreGetScopedSearchSeriesNeedBackfillFunc) History() []DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall {
 	f.mutex.Lock()
-	history := make([]DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall, len(f.history))
+	history := make([]DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall is an object
-// that describes an invocation of method
-// GetJustInTimeSearchSeriesToBackfill on an instance of
-// MockDataSeriesStore.
-type DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall struct {
+// DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall is an object
+// that describes an invocation of method GetScopedSearchSeriesNeedBackfill
+// on an instance of MockDataSeriesStore.
+type DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -495,13 +510,13 @@ type DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall) Args() []interface{} {
+func (c DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DataSeriesStoreGetJustInTimeSearchSeriesToBackfillFuncCall) Results() []interface{} {
+func (c DataSeriesStoreGetScopedSearchSeriesNeedBackfillFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -1051,6 +1066,115 @@ func (c DataSeriesStoreStampSnapshotFuncCall) Args() []interface{} {
 // invocation.
 func (c DataSeriesStoreStampSnapshotFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// DataSeriesStoreStartJustInTimeConversionAttemptFunc describes the
+// behavior when the StartJustInTimeConversionAttempt method of the parent
+// MockDataSeriesStore instance is invoked.
+type DataSeriesStoreStartJustInTimeConversionAttemptFunc struct {
+	defaultHook func(context.Context, types.InsightSeries) error
+	hooks       []func(context.Context, types.InsightSeries) error
+	history     []DataSeriesStoreStartJustInTimeConversionAttemptFuncCall
+	mutex       sync.Mutex
+}
+
+// StartJustInTimeConversionAttempt delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockDataSeriesStore) StartJustInTimeConversionAttempt(v0 context.Context, v1 types.InsightSeries) error {
+	r0 := m.StartJustInTimeConversionAttemptFunc.nextHook()(v0, v1)
+	m.StartJustInTimeConversionAttemptFunc.appendCall(DataSeriesStoreStartJustInTimeConversionAttemptFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// StartJustInTimeConversionAttempt method of the parent MockDataSeriesStore
+// instance is invoked and the hook queue is empty.
+func (f *DataSeriesStoreStartJustInTimeConversionAttemptFunc) SetDefaultHook(hook func(context.Context, types.InsightSeries) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// StartJustInTimeConversionAttempt method of the parent MockDataSeriesStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *DataSeriesStoreStartJustInTimeConversionAttemptFunc) PushHook(hook func(context.Context, types.InsightSeries) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DataSeriesStoreStartJustInTimeConversionAttemptFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, types.InsightSeries) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DataSeriesStoreStartJustInTimeConversionAttemptFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, types.InsightSeries) error {
+		return r0
+	})
+}
+
+func (f *DataSeriesStoreStartJustInTimeConversionAttemptFunc) nextHook() func(context.Context, types.InsightSeries) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DataSeriesStoreStartJustInTimeConversionAttemptFunc) appendCall(r0 DataSeriesStoreStartJustInTimeConversionAttemptFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// DataSeriesStoreStartJustInTimeConversionAttemptFuncCall objects
+// describing the invocations of this function.
+func (f *DataSeriesStoreStartJustInTimeConversionAttemptFunc) History() []DataSeriesStoreStartJustInTimeConversionAttemptFuncCall {
+	f.mutex.Lock()
+	history := make([]DataSeriesStoreStartJustInTimeConversionAttemptFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DataSeriesStoreStartJustInTimeConversionAttemptFuncCall is an object that
+// describes an invocation of method StartJustInTimeConversionAttempt on an
+// instance of MockDataSeriesStore.
+type DataSeriesStoreStartJustInTimeConversionAttemptFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 types.InsightSeries
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DataSeriesStoreStartJustInTimeConversionAttemptFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DataSeriesStoreStartJustInTimeConversionAttemptFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // MockInsightMetadataStore is a mock implementation of the

--- a/internal/database/schema.codeinsights.json
+++ b/internal/database/schema.codeinsights.json
@@ -910,6 +910,19 @@
           "Comment": ""
         },
         {
+          "Name": "needs_migration",
+          "Index": 20,
+          "TypeName": "boolean",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "next_recording_after",
           "Index": 7,
           "TypeName": "timestamp without time zone",

--- a/internal/database/schema.codeinsights.md
+++ b/internal/database/schema.codeinsights.md
@@ -156,6 +156,7 @@ Stores queries that were unsuccessful or otherwise flagged as incomplete or inco
  just_in_time                  | boolean                     |           | not null | false
  group_by                      | text                        |           |          | 
  backfill_attempts             | integer                     |           | not null | 0
+ needs_migration               | boolean                     |           |          | 
 Indexes:
     "insight_series_pkey" PRIMARY KEY, btree (id)
     "insight_series_series_id_unique_idx" UNIQUE, btree (series_id)

--- a/migrations/codeinsights/1659572248_refresh_scoped_insights/down.sql
+++ b/migrations/codeinsights/1659572248_refresh_scoped_insights/down.sql
@@ -1,0 +1,2 @@
+-- take no action on down so that the next up will not trigger another refreshing of series data.
+

--- a/migrations/codeinsights/1659572248_refresh_scoped_insights/metadata.yaml
+++ b/migrations/codeinsights/1659572248_refresh_scoped_insights/metadata.yaml
@@ -1,0 +1,2 @@
+name: refresh_scoped_insights
+parents: [1656517037, 1656608833]

--- a/migrations/codeinsights/1659572248_refresh_scoped_insights/up.sql
+++ b/migrations/codeinsights/1659572248_refresh_scoped_insights/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE IF EXISTS insight_series
+    ADD COLUMN IF NOT EXISTS needs_migration bool;
+
+
+update insight_series
+set needs_migration = true
+where cardinality(repositories) > 0 AND generation_method in ('search', 'search-compute') AND needs_migration is NULL;

--- a/migrations/codeinsights/squashed.sql
+++ b/migrations/codeinsights/squashed.sql
@@ -169,7 +169,8 @@ CREATE TABLE insight_series (
     generation_method text NOT NULL,
     just_in_time boolean DEFAULT false NOT NULL,
     group_by text,
-    backfill_attempts integer DEFAULT 0 NOT NULL
+    backfill_attempts integer DEFAULT 0 NOT NULL,
+    needs_migration boolean
 );
 
 COMMENT ON TABLE insight_series IS 'Data series that comprise code insights.';


### PR DESCRIPTION
Adds a new field to the series to track if the series either needs to be converted from just in time or needs to be re-backfilled.

Adjusts the conversion logic to replace the seriesID so that re-backfilled series won't have extra conflicting points.


## Test plan
Manually tested the following 3 scenarios:

1. A db with a mix of all repo insights that haven't yet backfilled and just in time insights with a created date 4 months ago
2. A db with a mix of all repo insights and scoped insights with a created date 4 months ago that previously backfilled
3. A db with all repo insights and a mix of scoped insights that previously backfilled and just in time insights all of which have a created date of 4 months ago

In each scenario results passed as expected:
- The scoped insights properly moved in the processing state and the filled with data
- The most recent data point for the scoped insights corresponded to the current date as expected
- The db flag for migrating was properly updated and the scoped insights did not refresh again on future runs as expected
- Verified the count for a point on the series

In addition tested 2 additional paths:

1. Manually triggering multiple restarts during the conversion process 
2. Forcing 1 of the insights to fail the backfill step 
  - This resulted in all the other insights properly completing and the errored insight stopping after 10 attempts as expected. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
