### PR TITLE
admin-analytics: add user administration backend API endpoints

### DIFF
--- a/cmd/frontend/external/session/session.go
+++ b/cmd/frontend/external/session/session.go
@@ -5,9 +5,10 @@ package session
 import "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session"
 
 var (
-	ResetMockSessionStore  = session.ResetMockSessionStore
-	SetActor               = session.SetActor
-	SetData                = session.SetData
-	GetData                = session.GetData
-	InvalidateSessionsByID = session.InvalidateSessionsByID
+	ResetMockSessionStore   = session.ResetMockSessionStore
+	SetActor                = session.SetActor
+	SetData                 = session.SetData
+	GetData                 = session.GetData
+	InvalidateSessionsByID  = session.InvalidateSessionsByID
+	InvalidateSessionsByIDs = session.InvalidateSessionsByIDs
 )

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -536,6 +536,10 @@ type Mutation {
     """
     invalidateSessionsByID(userID: ID!): EmptyResponse
     """
+    Bulk "invalidateSessionsByID" action.
+    """
+    invalidateSessionsByIDs(userIDs: [ID!]!): EmptyResponse
+    """
     Reloads the site by restarting the server. This is not supported for all deployment
     types. This may cause downtime.
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5688,6 +5688,28 @@ type Site implements SettingsSubject {
     analytics: Analytics!
 
     """
+    List all users.
+    """
+    users(
+        """
+        Return users whose usernames or display names match the query.
+        """
+        query: String
+        """
+        Returns users who have been active in a given period of time.
+        """
+        siteAdmin: Boolean
+        """
+        Returns users that contain filter in the username field.
+        """
+        username: String
+        """
+        Returns users that contain filter in the email field.
+        """
+        email: String
+    ): SiteUsers!
+
+    """
     Monitoring overview for this site.
     Note: This is primarily used for displaying recently-fired alerts in the web app. If your intent
     is to monitor Sourcegraph, it is better to configure alerting or query Prometheus directly in
@@ -6272,6 +6294,78 @@ type Analytics {
     Batch changes statistics
     """
     batchChanges(dateRange: AnalyticsDateRange, grouping: AnalyticsGrouping): AnalyticsBatchChangesResult!
+}
+
+type SiteUser {
+    """
+    The unique ID for the user.
+    """
+    id: ID!
+    """
+    User's username.
+    """
+    username: String!
+    """
+    User's primary email.
+    """
+    email: String
+    """
+    The datetime when user was created in the system.
+    """
+    createdAt: String!
+    """
+    The datetime when user was last active.
+    """
+    lastActiveAt: String
+    """
+    The datetime when user was deleted.
+    """
+    deletedAt: String
+    """
+    Whether user is site admin or not.
+    """
+    siteAdmin: Boolean!
+    """
+    Total number of user's event_logs.
+    """
+    eventsCount: Float!
+}
+
+enum SiteUserOrderBy {
+    USERNAME
+    EMAIL
+    EVENTS_COUNT
+    LAST_ACTIVE_AT
+    CREATED_AT
+    DELETED_AT
+    SITE_ADMIN
+}
+
+"""
+Site users.
+"""
+type SiteUsers {
+    """
+    User total count.
+    """
+    totalCount: Float!
+    """
+    List of users.
+    """
+    nodes(
+        """
+        Returns the first n users from the list.
+        """
+        first: Int
+        """
+        Returns users ordered by a given column.
+        """
+        orderBy: SiteUserOrderBy
+        """
+        Returns ordered users in descending order provided by orderBy field.
+        """
+        descending: Boolean
+    ): [SiteUser!]!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6304,6 +6304,9 @@ type Analytics {
     batchChanges(dateRange: AnalyticsDateRange, grouping: AnalyticsGrouping): AnalyticsBatchChangesResult!
 }
 
+"""
+Site user.
+"""
 type SiteUser {
     """
     The unique ID for the user.
@@ -6339,13 +6342,34 @@ type SiteUser {
     eventsCount: Float!
 }
 
+"""
+SiteUserOrderBy enumerates the ways a users list can be ordered.
+"""
 enum SiteUserOrderBy {
     USERNAME
+    """
+    User's primary email.
+    """
     EMAIL
+    """
+    The total number of user's event_logs.
+    """
     EVENTS_COUNT
+    """
+    The last event_log datetime.
+    """
     LAST_ACTIVE_AT
+    """
+    The datetime when user was added to the system.
+    """
     CREATED_AT
+    """
+    The datetime when user was soft deleted.
+    """
     DELETED_AT
+    """
+    Whether the user is site admin or not.
+    """
     SITE_ADMIN
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -214,6 +214,10 @@ type Mutation {
     """
     deleteUser(user: ID!, hard: Boolean): EmptyResponse
     """
+    Bulk "deleteUser" action.
+    """
+    deleteUsers(users: [ID!]!, hard: Boolean): EmptyResponse
+    """
     Updates the current user's password. The oldPassword arg must match the user's current password.
     """
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -22,67 +22,97 @@ func (r *schemaResolver) DeleteUser(ctx context.Context, args *struct {
 	User graphql.ID
 	Hard *bool
 }) (*EmptyResponse, error) {
+	return r.DeleteUsers(ctx, &struct {
+		Users []graphql.ID
+		Hard  *bool
+	}{
+		Users: []graphql.ID{args.User},
+		Hard:  args.Hard,
+	})
+}
+
+func (r *schemaResolver) DeleteUsers(ctx context.Context, args *struct {
+	Users []graphql.ID
+	Hard  *bool
+}) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins can delete users.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
-	userID, err := UnmarshalUserID(args.User)
-	if err != nil {
-		return nil, err
-	}
-
 	// a must be authenticated at this point, CheckCurrentUserIsSiteAdmin enforces it.
 	a := actor.FromContext(ctx)
-	if a.UID == userID {
-		return nil, errors.New("unable to delete current user")
+
+	ids := make([]int32, len(args.Users))
+	for index, user := range args.Users {
+		id, err := UnmarshalUserID(user)
+		if err != nil {
+			return nil, err
+		}
+		if a.UID == id {
+			return nil, errors.New("unable to delete current user")
+		}
+		ids[index] = id
 	}
 
 	// Collect username, verified email addresses, and external accounts to be used
 	// for revoking user permissions later, otherwise they will be removed from database
 	// if it's a hard delete.
-	user, err := r.db.Users().GetByID(ctx, userID)
+	users, err := r.db.Users().List(ctx, &database.UsersListOptions{
+		UserIDs: ids,
+	})
 	if err != nil {
-		return nil, errors.Wrap(err, "get user by ID")
+		return nil, errors.Wrap(err, "list users by IDs")
 	}
 
-	var accounts []*extsvc.Accounts
+	var accountsList [][]*extsvc.Accounts
+	var revokeUserPermissionsArgsList []*database.RevokeUserPermissionsArgs
+	for _, user := range users {
+		var accounts []*extsvc.Accounts
 
-	extAccounts, err := r.db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{UserID: userID})
-	if err != nil {
-		return nil, errors.Wrap(err, "list external accounts")
-	}
-	for _, acct := range extAccounts {
+		extAccounts, err := r.db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{UserID: user.ID})
+		if err != nil {
+			return nil, errors.Wrap(err, "list external accounts")
+		}
+		for _, acct := range extAccounts {
+			accounts = append(accounts, &extsvc.Accounts{
+				ServiceType: acct.ServiceType,
+				ServiceID:   acct.ServiceID,
+				AccountIDs:  []string{acct.AccountID},
+			})
+		}
+
+		verifiedEmails, err := r.db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{
+			UserID:       user.ID,
+			OnlyVerified: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		emailStrs := make([]string, len(verifiedEmails))
+		for i := range verifiedEmails {
+			emailStrs[i] = verifiedEmails[i].Email
+		}
 		accounts = append(accounts, &extsvc.Accounts{
-			ServiceType: acct.ServiceType,
-			ServiceID:   acct.ServiceID,
-			AccountIDs:  []string{acct.AccountID},
+			ServiceType: authz.SourcegraphServiceType,
+			ServiceID:   authz.SourcegraphServiceID,
+			AccountIDs:  append(emailStrs, user.Username),
+		})
+
+		accountsList = append(accountsList, accounts)
+
+		revokeUserPermissionsArgsList = append(revokeUserPermissionsArgsList, &database.RevokeUserPermissionsArgs{
+			UserID:   user.ID,
+			Accounts: accounts,
 		})
 	}
 
-	verifiedEmails, err := r.db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{
-		UserID:       user.ID,
-		OnlyVerified: true,
-	})
-	if err != nil {
-		return nil, err
-	}
-	emailStrs := make([]string, len(verifiedEmails))
-	for i := range verifiedEmails {
-		emailStrs[i] = verifiedEmails[i].Email
-	}
-	accounts = append(accounts, &extsvc.Accounts{
-		ServiceType: authz.SourcegraphServiceType,
-		ServiceID:   authz.SourcegraphServiceID,
-		AccountIDs:  append(emailStrs, user.Username),
-	})
-
 	if args.Hard != nil && *args.Hard {
-		if err := r.db.Users().HardDelete(ctx, user.ID); err != nil {
+		if err := r.db.Users().HardDeleteList(ctx, ids); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := r.db.Users().Delete(ctx, user.ID); err != nil {
+		if err := r.db.Users().DeleteList(ctx, ids); err != nil {
 			return nil, err
 		}
 	}
@@ -90,10 +120,7 @@ func (r *schemaResolver) DeleteUser(ctx context.Context, args *struct {
 	// NOTE: Practically, we don't reuse the ID for any new users, and the situation of left-over pending permissions
 	// is possible but highly unlikely. Therefore, there is no need to roll back user deletion even if this step failed.
 	// This call is purely for the purpose of cleanup.
-	if err := r.db.Authz().RevokeUserPermissions(ctx, &database.RevokeUserPermissionsArgs{
-		UserID:   user.ID,
-		Accounts: accounts,
-	}); err != nil {
+	if err := r.db.Authz().RevokeUserPermissionsList(ctx, revokeUserPermissionsArgsList); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -33,10 +33,10 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 		conds = append(conds, sqlf.Sprintf("site_admin = %s", *args.SiteAdmin))
 	}
 	if args.Username != nil {
-		conds = append(conds, sqlf.Sprintf("username ILIKE %s", "%" + *args.Username + "%"))
+		conds = append(conds, sqlf.Sprintf("username ILIKE %s", "%"+*args.Username+"%"))
 	}
 	if args.Email != nil {
-		conds = append(conds, sqlf.Sprintf("email ILIKE %s", "%" + *args.Email + "%"))
+		conds = append(conds, sqlf.Sprintf("email ILIKE %s", "%"+*args.Email+"%"))
 	}
 	return &SiteUsersResolver{s.db, conds}, nil
 }

--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -1,0 +1,201 @@
+package graphqlbackend
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func (s *siteResolver) Users(ctx context.Context, args *struct {
+	Query     *string
+	SiteAdmin *bool
+	Username  *string
+	Email     *string
+}) (*SiteUsersResolver, error) {
+	// 🚨 SECURITY: Only site admins can see users.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, s.db); err != nil {
+		return nil, err
+	}
+
+	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
+	if args.Query != nil && *args.Query != "" {
+		query := "%" + *args.Query + "%"
+		conds = append(conds, sqlf.Sprintf("(username ILIKE %s OR display_name ILIKE %s)", query, query))
+	}
+	if args.SiteAdmin != nil {
+		conds = append(conds, sqlf.Sprintf("site_admin = %s", *args.SiteAdmin))
+	}
+	if args.Username != nil {
+		conds = append(conds, sqlf.Sprintf("username ILIKE %s", "%" + *args.Username + "%"))
+	}
+	if args.Email != nil {
+		conds = append(conds, sqlf.Sprintf("email ILIKE %s", "%" + *args.Email + "%"))
+	}
+	return &SiteUsersResolver{s.db, conds}, nil
+}
+
+type SiteUsersResolver struct {
+	db    database.DB
+	conds []*sqlf.Query
+}
+
+func (s *SiteUsersResolver) TotalCount(ctx context.Context) (float64, error) {
+	var totalCount float64
+
+	query := sqlf.Sprintf(`
+	SELECT
+		COUNT(*)
+	FROM
+		users
+		LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true
+	WHERE %s`, sqlf.Join(s.conds, "AND"))
+
+	if err := s.db.QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...).Scan(&totalCount); err != nil {
+		return 0, err
+	}
+
+	return totalCount, nil
+}
+
+func (s *SiteUsersResolver) Nodes(ctx context.Context, args *struct {
+	OrderBy    *string
+	Descending *bool
+	First      *int32
+}) ([]*SiteUserResolver, error) {
+	// ORDER BY
+	orderDirection := "ASC"
+	if args.Descending != nil && *args.Descending {
+		orderDirection = "DESC"
+	}
+	orderBy := sqlf.Sprintf("id " + orderDirection)
+	if args.OrderBy != nil {
+		newOrderBy, err := toUsersField(*args.OrderBy)
+		orderBy = sqlf.Sprintf(newOrderBy + " " + orderDirection)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// LIMIT
+	limit := int32(100)
+	if args.First != nil {
+		limit = *args.First
+	}
+
+	query := sqlf.Sprintf(`
+	SELECT
+		users.id,
+		users.username,
+		emails.email,
+		users.created_at,
+		MAX(events.timestamp) AS last_active_at,
+		users.deleted_at,
+		users.site_admin,
+		COUNT(events.*) AS events_count
+	FROM
+		users
+		LEFT JOIN event_logs events ON events.user_id = users.id
+		LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true
+	WHERE %s
+	GROUP BY
+		users.id,
+		users.username,
+		emails.email,
+		users.created_at,
+		users.deleted_at,
+		users.site_admin
+	ORDER BY %s
+	LIMIT %s`, sqlf.Join(s.conds, "AND"), orderBy, limit)
+	fmt.Println(query.Query(sqlf.PostgresBindVar))
+	fmt.Println(query.Args())
+
+	rows, err := s.db.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	nodes := make([]*SiteUserResolver, 0)
+	for rows.Next() {
+		var node SiteUserResolver
+
+		if err := rows.Scan(&node.id, &node.username, &node.email, &node.createdAt, &node.lastActiveAt, &node.deletedAt, &node.siteAdmin, &node.eventsCount); err != nil {
+			return nil, err
+		}
+
+		nodes = append(nodes, &node)
+	}
+
+	return nodes, nil
+}
+
+func toUsersField(orderBy string) (string, error) {
+	switch orderBy {
+	case "USERNAME":
+		return "username", nil
+	case "EMAIL":
+		return "emails.email", nil
+	case "CREATED_AT":
+		return "users.created_at", nil
+	case "LAST_ACTIVE_AT":
+		return "last_active_at", nil
+	case "DELETED_AT":
+		return "users.deleted_at", nil
+	case "EVENTS_COUNT":
+		return "events_count", nil
+	case "SITE_ADMIN":
+		return "site_admin", nil
+	default:
+		return "", errors.New("invalid orderBy")
+	}
+}
+
+type SiteUserResolver struct {
+	id           int32
+	username     string
+	email        *string
+	createdAt    time.Time
+	lastActiveAt *time.Time
+	deletedAt    *time.Time
+	siteAdmin    bool
+	eventsCount  float64
+}
+
+func (s *SiteUserResolver) ID(ctx context.Context) graphql.ID { return MarshalUserID(s.id) }
+
+func (s *SiteUserResolver) Username(ctx context.Context) string { return s.username }
+
+func (s *SiteUserResolver) Email(ctx context.Context) *string { return s.email }
+
+func (s *SiteUserResolver) CreatedAt(ctx context.Context) string {
+	return s.createdAt.Format(time.RFC3339)
+}
+
+func (s *SiteUserResolver) LastActiveAt(ctx context.Context) *string {
+	if s.lastActiveAt != nil {
+		result := s.lastActiveAt.Format(time.RFC3339)
+		return &result
+	}
+	return nil
+}
+
+func (s *SiteUserResolver) DeletedAt(ctx context.Context) *string {
+	if s.deletedAt != nil {
+		result := s.deletedAt.Format(time.RFC3339)
+		return &result
+	}
+	return nil
+}
+
+func (s *SiteUserResolver) SiteAdmin(ctx context.Context) bool { return s.siteAdmin }
+
+func (s *SiteUserResolver) EventsCount(ctx context.Context) float64 { return s.eventsCount }

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -284,8 +284,13 @@ func InvalidateSessionCurrentUser(w http.ResponseWriter, r *http.Request, db dat
 // InvalidateSessionsByID invalidates all sessions for a user
 // If an error occurs, it returns the error
 func InvalidateSessionsByID(ctx context.Context, db database.DB, id int32) error {
-	// Get the user from the request context
-	return db.Users().InvalidateSessionsByID(ctx, id)
+	return InvalidateSessionsByIDs(ctx, db, []int32{id})
+}
+
+// InvalidateSessionsByIDs invalidates all sessions for users
+// If an error occurs, it returns the error
+func InvalidateSessionsByIDs(ctx context.Context, db database.DB, ids []int32) error {
+	return db.Users().InvalidateSessionsByIDs(ctx, ids)
 }
 
 // CookieMiddleware is an http.Handler middleware that authenticates

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -287,8 +287,7 @@ func InvalidateSessionsByID(ctx context.Context, db database.DB, id int32) error
 	return InvalidateSessionsByIDs(ctx, db, []int32{id})
 }
 
-// InvalidateSessionsByIDs invalidates all sessions for users
-// If an error occurs, it returns the error
+// Bulk "InvalidateSessionsByID" action.
 func InvalidateSessionsByIDs(ctx context.Context, db database.DB, ids []int32) error {
 	return db.Users().InvalidateSessionsByIDs(ctx, ids)
 }

--- a/doc/cli/references/code-intel.md
+++ b/doc/cli/references/code-intel.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-'src code-intel' manages code graph data on a Sourcegraph instance.
+'src code-intel' manages code intelligence data on a Sourcegraph instance.
 
 Usage:
 

--- a/internal/database/authz.go
+++ b/internal/database/authz.go
@@ -54,6 +54,8 @@ type AuthzStore interface {
 	// RevokeUserPermissions deletes both effective and pending permissions that could be related to a user.
 	// It is a no-op in the OSS version.
 	RevokeUserPermissions(ctx context.Context, args *RevokeUserPermissionsArgs) error
+	// Bulk "RevokeUserPermissions" action.
+	RevokeUserPermissionsList(ctx context.Context, argsList []*RevokeUserPermissionsArgs) error
 }
 
 // AuthzWith instantiates and returns a new AuthzStore using the other store
@@ -73,5 +75,8 @@ func (*authzStore) AuthorizedRepos(_ context.Context, _ *AuthorizedReposArgs) ([
 	return []*types.Repo{}, nil
 }
 func (*authzStore) RevokeUserPermissions(_ context.Context, _ *RevokeUserPermissionsArgs) error {
+	return nil
+}
+func (*authzStore) RevokeUserPermissionsList(_ context.Context, _ []*RevokeUserPermissionsArgs) error {
 	return nil
 }

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -1687,6 +1687,10 @@ type MockAuthzStore struct {
 	// RevokeUserPermissionsFunc is an instance of a mock function object
 	// controlling the behavior of the method RevokeUserPermissions.
 	RevokeUserPermissionsFunc *AuthzStoreRevokeUserPermissionsFunc
+	// RevokeUserPermissionsListFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// RevokeUserPermissionsList.
+	RevokeUserPermissionsListFunc *AuthzStoreRevokeUserPermissionsListFunc
 }
 
 // NewMockAuthzStore creates a new mock of the AuthzStore interface. All
@@ -1705,6 +1709,11 @@ func NewMockAuthzStore() *MockAuthzStore {
 		},
 		RevokeUserPermissionsFunc: &AuthzStoreRevokeUserPermissionsFunc{
 			defaultHook: func(context.Context, *RevokeUserPermissionsArgs) (r0 error) {
+				return
+			},
+		},
+		RevokeUserPermissionsListFunc: &AuthzStoreRevokeUserPermissionsListFunc{
+			defaultHook: func(context.Context, []*RevokeUserPermissionsArgs) (r0 error) {
 				return
 			},
 		},
@@ -1730,6 +1739,11 @@ func NewStrictMockAuthzStore() *MockAuthzStore {
 				panic("unexpected invocation of MockAuthzStore.RevokeUserPermissions")
 			},
 		},
+		RevokeUserPermissionsListFunc: &AuthzStoreRevokeUserPermissionsListFunc{
+			defaultHook: func(context.Context, []*RevokeUserPermissionsArgs) error {
+				panic("unexpected invocation of MockAuthzStore.RevokeUserPermissionsList")
+			},
+		},
 	}
 }
 
@@ -1745,6 +1759,9 @@ func NewMockAuthzStoreFrom(i AuthzStore) *MockAuthzStore {
 		},
 		RevokeUserPermissionsFunc: &AuthzStoreRevokeUserPermissionsFunc{
 			defaultHook: i.RevokeUserPermissions,
+		},
+		RevokeUserPermissionsListFunc: &AuthzStoreRevokeUserPermissionsListFunc{
+			defaultHook: i.RevokeUserPermissionsList,
 		},
 	}
 }
@@ -2070,6 +2087,114 @@ func (c AuthzStoreRevokeUserPermissionsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c AuthzStoreRevokeUserPermissionsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// AuthzStoreRevokeUserPermissionsListFunc describes the behavior when the
+// RevokeUserPermissionsList method of the parent MockAuthzStore instance is
+// invoked.
+type AuthzStoreRevokeUserPermissionsListFunc struct {
+	defaultHook func(context.Context, []*RevokeUserPermissionsArgs) error
+	hooks       []func(context.Context, []*RevokeUserPermissionsArgs) error
+	history     []AuthzStoreRevokeUserPermissionsListFuncCall
+	mutex       sync.Mutex
+}
+
+// RevokeUserPermissionsList delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockAuthzStore) RevokeUserPermissionsList(v0 context.Context, v1 []*RevokeUserPermissionsArgs) error {
+	r0 := m.RevokeUserPermissionsListFunc.nextHook()(v0, v1)
+	m.RevokeUserPermissionsListFunc.appendCall(AuthzStoreRevokeUserPermissionsListFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// RevokeUserPermissionsList method of the parent MockAuthzStore instance is
+// invoked and the hook queue is empty.
+func (f *AuthzStoreRevokeUserPermissionsListFunc) SetDefaultHook(hook func(context.Context, []*RevokeUserPermissionsArgs) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RevokeUserPermissionsList method of the parent MockAuthzStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *AuthzStoreRevokeUserPermissionsListFunc) PushHook(hook func(context.Context, []*RevokeUserPermissionsArgs) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *AuthzStoreRevokeUserPermissionsListFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, []*RevokeUserPermissionsArgs) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *AuthzStoreRevokeUserPermissionsListFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, []*RevokeUserPermissionsArgs) error {
+		return r0
+	})
+}
+
+func (f *AuthzStoreRevokeUserPermissionsListFunc) nextHook() func(context.Context, []*RevokeUserPermissionsArgs) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *AuthzStoreRevokeUserPermissionsListFunc) appendCall(r0 AuthzStoreRevokeUserPermissionsListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of AuthzStoreRevokeUserPermissionsListFuncCall
+// objects describing the invocations of this function.
+func (f *AuthzStoreRevokeUserPermissionsListFunc) History() []AuthzStoreRevokeUserPermissionsListFuncCall {
+	f.mutex.Lock()
+	history := make([]AuthzStoreRevokeUserPermissionsListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// AuthzStoreRevokeUserPermissionsListFuncCall is an object that describes
+// an invocation of method RevokeUserPermissionsList on an instance of
+// MockAuthzStore.
+type AuthzStoreRevokeUserPermissionsListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []*RevokeUserPermissionsArgs
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c AuthzStoreRevokeUserPermissionsListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c AuthzStoreRevokeUserPermissionsListFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -32741,9 +32866,15 @@ type MockSecurityEventLogsStore struct {
 	// InsertFunc is an instance of a mock function object controlling the
 	// behavior of the method Insert.
 	InsertFunc *SecurityEventLogsStoreInsertFunc
+	// InsertListFunc is an instance of a mock function object controlling
+	// the behavior of the method InsertList.
+	InsertListFunc *SecurityEventLogsStoreInsertListFunc
 	// LogEventFunc is an instance of a mock function object controlling the
 	// behavior of the method LogEvent.
 	LogEventFunc *SecurityEventLogsStoreLogEventFunc
+	// LogEventListFunc is an instance of a mock function object controlling
+	// the behavior of the method LogEventList.
+	LogEventListFunc *SecurityEventLogsStoreLogEventListFunc
 }
 
 // NewMockSecurityEventLogsStore creates a new mock of the
@@ -32761,8 +32892,18 @@ func NewMockSecurityEventLogsStore() *MockSecurityEventLogsStore {
 				return
 			},
 		},
+		InsertListFunc: &SecurityEventLogsStoreInsertListFunc{
+			defaultHook: func(context.Context, []*SecurityEvent) (r0 error) {
+				return
+			},
+		},
 		LogEventFunc: &SecurityEventLogsStoreLogEventFunc{
 			defaultHook: func(context.Context, *SecurityEvent) {
+				return
+			},
+		},
+		LogEventListFunc: &SecurityEventLogsStoreLogEventListFunc{
+			defaultHook: func(context.Context, []*SecurityEvent) {
 				return
 			},
 		},
@@ -32784,9 +32925,19 @@ func NewStrictMockSecurityEventLogsStore() *MockSecurityEventLogsStore {
 				panic("unexpected invocation of MockSecurityEventLogsStore.Insert")
 			},
 		},
+		InsertListFunc: &SecurityEventLogsStoreInsertListFunc{
+			defaultHook: func(context.Context, []*SecurityEvent) error {
+				panic("unexpected invocation of MockSecurityEventLogsStore.InsertList")
+			},
+		},
 		LogEventFunc: &SecurityEventLogsStoreLogEventFunc{
 			defaultHook: func(context.Context, *SecurityEvent) {
 				panic("unexpected invocation of MockSecurityEventLogsStore.LogEvent")
+			},
+		},
+		LogEventListFunc: &SecurityEventLogsStoreLogEventListFunc{
+			defaultHook: func(context.Context, []*SecurityEvent) {
+				panic("unexpected invocation of MockSecurityEventLogsStore.LogEventList")
 			},
 		},
 	}
@@ -32803,8 +32954,14 @@ func NewMockSecurityEventLogsStoreFrom(i SecurityEventLogsStore) *MockSecurityEv
 		InsertFunc: &SecurityEventLogsStoreInsertFunc{
 			defaultHook: i.Insert,
 		},
+		InsertListFunc: &SecurityEventLogsStoreInsertListFunc{
+			defaultHook: i.InsertList,
+		},
 		LogEventFunc: &SecurityEventLogsStoreLogEventFunc{
 			defaultHook: i.LogEvent,
+		},
+		LogEventListFunc: &SecurityEventLogsStoreLogEventListFunc{
+			defaultHook: i.LogEventList,
 		},
 	}
 }
@@ -33013,6 +33170,114 @@ func (c SecurityEventLogsStoreInsertFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
+// SecurityEventLogsStoreInsertListFunc describes the behavior when the
+// InsertList method of the parent MockSecurityEventLogsStore instance is
+// invoked.
+type SecurityEventLogsStoreInsertListFunc struct {
+	defaultHook func(context.Context, []*SecurityEvent) error
+	hooks       []func(context.Context, []*SecurityEvent) error
+	history     []SecurityEventLogsStoreInsertListFuncCall
+	mutex       sync.Mutex
+}
+
+// InsertList delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockSecurityEventLogsStore) InsertList(v0 context.Context, v1 []*SecurityEvent) error {
+	r0 := m.InsertListFunc.nextHook()(v0, v1)
+	m.InsertListFunc.appendCall(SecurityEventLogsStoreInsertListFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the InsertList method of
+// the parent MockSecurityEventLogsStore instance is invoked and the hook
+// queue is empty.
+func (f *SecurityEventLogsStoreInsertListFunc) SetDefaultHook(hook func(context.Context, []*SecurityEvent) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InsertList method of the parent MockSecurityEventLogsStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *SecurityEventLogsStoreInsertListFunc) PushHook(hook func(context.Context, []*SecurityEvent) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *SecurityEventLogsStoreInsertListFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, []*SecurityEvent) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *SecurityEventLogsStoreInsertListFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, []*SecurityEvent) error {
+		return r0
+	})
+}
+
+func (f *SecurityEventLogsStoreInsertListFunc) nextHook() func(context.Context, []*SecurityEvent) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SecurityEventLogsStoreInsertListFunc) appendCall(r0 SecurityEventLogsStoreInsertListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of SecurityEventLogsStoreInsertListFuncCall
+// objects describing the invocations of this function.
+func (f *SecurityEventLogsStoreInsertListFunc) History() []SecurityEventLogsStoreInsertListFuncCall {
+	f.mutex.Lock()
+	history := make([]SecurityEventLogsStoreInsertListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SecurityEventLogsStoreInsertListFuncCall is an object that describes an
+// invocation of method InsertList on an instance of
+// MockSecurityEventLogsStore.
+type SecurityEventLogsStoreInsertListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []*SecurityEvent
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SecurityEventLogsStoreInsertListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SecurityEventLogsStoreInsertListFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
 // SecurityEventLogsStoreLogEventFunc describes the behavior when the
 // LogEvent method of the parent MockSecurityEventLogsStore instance is
 // invoked.
@@ -33114,6 +33379,111 @@ func (c SecurityEventLogsStoreLogEventFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c SecurityEventLogsStoreLogEventFuncCall) Results() []interface{} {
+	return []interface{}{}
+}
+
+// SecurityEventLogsStoreLogEventListFunc describes the behavior when the
+// LogEventList method of the parent MockSecurityEventLogsStore instance is
+// invoked.
+type SecurityEventLogsStoreLogEventListFunc struct {
+	defaultHook func(context.Context, []*SecurityEvent)
+	hooks       []func(context.Context, []*SecurityEvent)
+	history     []SecurityEventLogsStoreLogEventListFuncCall
+	mutex       sync.Mutex
+}
+
+// LogEventList delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockSecurityEventLogsStore) LogEventList(v0 context.Context, v1 []*SecurityEvent) {
+	m.LogEventListFunc.nextHook()(v0, v1)
+	m.LogEventListFunc.appendCall(SecurityEventLogsStoreLogEventListFuncCall{v0, v1})
+	return
+}
+
+// SetDefaultHook sets function that is called when the LogEventList method
+// of the parent MockSecurityEventLogsStore instance is invoked and the hook
+// queue is empty.
+func (f *SecurityEventLogsStoreLogEventListFunc) SetDefaultHook(hook func(context.Context, []*SecurityEvent)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// LogEventList method of the parent MockSecurityEventLogsStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *SecurityEventLogsStoreLogEventListFunc) PushHook(hook func(context.Context, []*SecurityEvent)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *SecurityEventLogsStoreLogEventListFunc) SetDefaultReturn() {
+	f.SetDefaultHook(func(context.Context, []*SecurityEvent) {
+		return
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *SecurityEventLogsStoreLogEventListFunc) PushReturn() {
+	f.PushHook(func(context.Context, []*SecurityEvent) {
+		return
+	})
+}
+
+func (f *SecurityEventLogsStoreLogEventListFunc) nextHook() func(context.Context, []*SecurityEvent) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SecurityEventLogsStoreLogEventListFunc) appendCall(r0 SecurityEventLogsStoreLogEventListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of SecurityEventLogsStoreLogEventListFuncCall
+// objects describing the invocations of this function.
+func (f *SecurityEventLogsStoreLogEventListFunc) History() []SecurityEventLogsStoreLogEventListFuncCall {
+	f.mutex.Lock()
+	history := make([]SecurityEventLogsStoreLogEventListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SecurityEventLogsStoreLogEventListFuncCall is an object that describes an
+// invocation of method LogEventList on an instance of
+// MockSecurityEventLogsStore.
+type SecurityEventLogsStoreLogEventListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []*SecurityEvent
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SecurityEventLogsStoreLogEventListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SecurityEventLogsStoreLogEventListFuncCall) Results() []interface{} {
 	return []interface{}{}
 }
 
@@ -41945,6 +42315,9 @@ type MockUserStore struct {
 	// DeleteFunc is an instance of a mock function object controlling the
 	// behavior of the method Delete.
 	DeleteFunc *UserStoreDeleteFunc
+	// DeleteListFunc is an instance of a mock function object controlling
+	// the behavior of the method DeleteList.
+	DeleteListFunc *UserStoreDeleteListFunc
 	// DeletePasswordResetCodeFunc is an instance of a mock function object
 	// controlling the behavior of the method DeletePasswordResetCode.
 	DeletePasswordResetCodeFunc *UserStoreDeletePasswordResetCodeFunc
@@ -41975,12 +42348,18 @@ type MockUserStore struct {
 	// HardDeleteFunc is an instance of a mock function object controlling
 	// the behavior of the method HardDelete.
 	HardDeleteFunc *UserStoreHardDeleteFunc
+	// HardDeleteListFunc is an instance of a mock function object
+	// controlling the behavior of the method HardDeleteList.
+	HardDeleteListFunc *UserStoreHardDeleteListFunc
 	// HasTagFunc is an instance of a mock function object controlling the
 	// behavior of the method HasTag.
 	HasTagFunc *UserStoreHasTagFunc
 	// InvalidateSessionsByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method InvalidateSessionsByID.
 	InvalidateSessionsByIDFunc *UserStoreInvalidateSessionsByIDFunc
+	// InvalidateSessionsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method InvalidateSessionsByIDs.
+	InvalidateSessionsByIDsFunc *UserStoreInvalidateSessionsByIDsFunc
 	// IsPasswordFunc is an instance of a mock function object controlling
 	// the behavior of the method IsPassword.
 	IsPasswordFunc *UserStoreIsPasswordFunc
@@ -42066,6 +42445,11 @@ func NewMockUserStore() *MockUserStore {
 				return
 			},
 		},
+		DeleteListFunc: &UserStoreDeleteListFunc{
+			defaultHook: func(context.Context, []int32) (r0 error) {
+				return
+			},
+		},
 		DeletePasswordResetCodeFunc: &UserStoreDeletePasswordResetCodeFunc{
 			defaultHook: func(context.Context, int32) (r0 error) {
 				return
@@ -42116,6 +42500,11 @@ func NewMockUserStore() *MockUserStore {
 				return
 			},
 		},
+		HardDeleteListFunc: &UserStoreHardDeleteListFunc{
+			defaultHook: func(context.Context, []int32) (r0 error) {
+				return
+			},
+		},
 		HasTagFunc: &UserStoreHasTagFunc{
 			defaultHook: func(context.Context, int32, string) (r0 bool, r1 error) {
 				return
@@ -42123,6 +42512,11 @@ func NewMockUserStore() *MockUserStore {
 		},
 		InvalidateSessionsByIDFunc: &UserStoreInvalidateSessionsByIDFunc{
 			defaultHook: func(context.Context, int32) (r0 error) {
+				return
+			},
+		},
+		InvalidateSessionsByIDsFunc: &UserStoreInvalidateSessionsByIDsFunc{
+			defaultHook: func(context.Context, []int32) (r0 error) {
 				return
 			},
 		},
@@ -42238,6 +42632,11 @@ func NewStrictMockUserStore() *MockUserStore {
 				panic("unexpected invocation of MockUserStore.Delete")
 			},
 		},
+		DeleteListFunc: &UserStoreDeleteListFunc{
+			defaultHook: func(context.Context, []int32) error {
+				panic("unexpected invocation of MockUserStore.DeleteList")
+			},
+		},
 		DeletePasswordResetCodeFunc: &UserStoreDeletePasswordResetCodeFunc{
 			defaultHook: func(context.Context, int32) error {
 				panic("unexpected invocation of MockUserStore.DeletePasswordResetCode")
@@ -42288,6 +42687,11 @@ func NewStrictMockUserStore() *MockUserStore {
 				panic("unexpected invocation of MockUserStore.HardDelete")
 			},
 		},
+		HardDeleteListFunc: &UserStoreHardDeleteListFunc{
+			defaultHook: func(context.Context, []int32) error {
+				panic("unexpected invocation of MockUserStore.HardDeleteList")
+			},
+		},
 		HasTagFunc: &UserStoreHasTagFunc{
 			defaultHook: func(context.Context, int32, string) (bool, error) {
 				panic("unexpected invocation of MockUserStore.HasTag")
@@ -42296,6 +42700,11 @@ func NewStrictMockUserStore() *MockUserStore {
 		InvalidateSessionsByIDFunc: &UserStoreInvalidateSessionsByIDFunc{
 			defaultHook: func(context.Context, int32) error {
 				panic("unexpected invocation of MockUserStore.InvalidateSessionsByID")
+			},
+		},
+		InvalidateSessionsByIDsFunc: &UserStoreInvalidateSessionsByIDsFunc{
+			defaultHook: func(context.Context, []int32) error {
+				panic("unexpected invocation of MockUserStore.InvalidateSessionsByIDs")
 			},
 		},
 		IsPasswordFunc: &UserStoreIsPasswordFunc{
@@ -42396,6 +42805,9 @@ func NewMockUserStoreFrom(i UserStore) *MockUserStore {
 		DeleteFunc: &UserStoreDeleteFunc{
 			defaultHook: i.Delete,
 		},
+		DeleteListFunc: &UserStoreDeleteListFunc{
+			defaultHook: i.DeleteList,
+		},
 		DeletePasswordResetCodeFunc: &UserStoreDeletePasswordResetCodeFunc{
 			defaultHook: i.DeletePasswordResetCode,
 		},
@@ -42426,11 +42838,17 @@ func NewMockUserStoreFrom(i UserStore) *MockUserStore {
 		HardDeleteFunc: &UserStoreHardDeleteFunc{
 			defaultHook: i.HardDelete,
 		},
+		HardDeleteListFunc: &UserStoreHardDeleteListFunc{
+			defaultHook: i.HardDeleteList,
+		},
 		HasTagFunc: &UserStoreHasTagFunc{
 			defaultHook: i.HasTag,
 		},
 		InvalidateSessionsByIDFunc: &UserStoreInvalidateSessionsByIDFunc{
 			defaultHook: i.InvalidateSessionsByID,
+		},
+		InvalidateSessionsByIDsFunc: &UserStoreInvalidateSessionsByIDsFunc{
+			defaultHook: i.InvalidateSessionsByIDs,
 		},
 		IsPasswordFunc: &UserStoreIsPasswordFunc{
 			defaultHook: i.IsPassword,
@@ -43230,6 +43648,110 @@ func (c UserStoreDeleteFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserStoreDeleteFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// UserStoreDeleteListFunc describes the behavior when the DeleteList method
+// of the parent MockUserStore instance is invoked.
+type UserStoreDeleteListFunc struct {
+	defaultHook func(context.Context, []int32) error
+	hooks       []func(context.Context, []int32) error
+	history     []UserStoreDeleteListFuncCall
+	mutex       sync.Mutex
+}
+
+// DeleteList delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockUserStore) DeleteList(v0 context.Context, v1 []int32) error {
+	r0 := m.DeleteListFunc.nextHook()(v0, v1)
+	m.DeleteListFunc.appendCall(UserStoreDeleteListFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the DeleteList method of
+// the parent MockUserStore instance is invoked and the hook queue is empty.
+func (f *UserStoreDeleteListFunc) SetDefaultHook(hook func(context.Context, []int32) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DeleteList method of the parent MockUserStore instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *UserStoreDeleteListFunc) PushHook(hook func(context.Context, []int32) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserStoreDeleteListFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, []int32) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserStoreDeleteListFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, []int32) error {
+		return r0
+	})
+}
+
+func (f *UserStoreDeleteListFunc) nextHook() func(context.Context, []int32) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserStoreDeleteListFunc) appendCall(r0 UserStoreDeleteListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UserStoreDeleteListFuncCall objects
+// describing the invocations of this function.
+func (f *UserStoreDeleteListFunc) History() []UserStoreDeleteListFuncCall {
+	f.mutex.Lock()
+	history := make([]UserStoreDeleteListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserStoreDeleteListFuncCall is an object that describes an invocation of
+// method DeleteList on an instance of MockUserStore.
+type UserStoreDeleteListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserStoreDeleteListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserStoreDeleteListFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -44303,6 +44825,111 @@ func (c UserStoreHardDeleteFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
+// UserStoreHardDeleteListFunc describes the behavior when the
+// HardDeleteList method of the parent MockUserStore instance is invoked.
+type UserStoreHardDeleteListFunc struct {
+	defaultHook func(context.Context, []int32) error
+	hooks       []func(context.Context, []int32) error
+	history     []UserStoreHardDeleteListFuncCall
+	mutex       sync.Mutex
+}
+
+// HardDeleteList delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockUserStore) HardDeleteList(v0 context.Context, v1 []int32) error {
+	r0 := m.HardDeleteListFunc.nextHook()(v0, v1)
+	m.HardDeleteListFunc.appendCall(UserStoreHardDeleteListFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the HardDeleteList
+// method of the parent MockUserStore instance is invoked and the hook queue
+// is empty.
+func (f *UserStoreHardDeleteListFunc) SetDefaultHook(hook func(context.Context, []int32) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// HardDeleteList method of the parent MockUserStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *UserStoreHardDeleteListFunc) PushHook(hook func(context.Context, []int32) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserStoreHardDeleteListFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, []int32) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserStoreHardDeleteListFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, []int32) error {
+		return r0
+	})
+}
+
+func (f *UserStoreHardDeleteListFunc) nextHook() func(context.Context, []int32) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserStoreHardDeleteListFunc) appendCall(r0 UserStoreHardDeleteListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UserStoreHardDeleteListFuncCall objects
+// describing the invocations of this function.
+func (f *UserStoreHardDeleteListFunc) History() []UserStoreHardDeleteListFuncCall {
+	f.mutex.Lock()
+	history := make([]UserStoreHardDeleteListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserStoreHardDeleteListFuncCall is an object that describes an invocation
+// of method HardDeleteList on an instance of MockUserStore.
+type UserStoreHardDeleteListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserStoreHardDeleteListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserStoreHardDeleteListFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
 // UserStoreHasTagFunc describes the behavior when the HasTag method of the
 // parent MockUserStore instance is invoked.
 type UserStoreHasTagFunc struct {
@@ -44518,6 +45145,114 @@ func (c UserStoreInvalidateSessionsByIDFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserStoreInvalidateSessionsByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// UserStoreInvalidateSessionsByIDsFunc describes the behavior when the
+// InvalidateSessionsByIDs method of the parent MockUserStore instance is
+// invoked.
+type UserStoreInvalidateSessionsByIDsFunc struct {
+	defaultHook func(context.Context, []int32) error
+	hooks       []func(context.Context, []int32) error
+	history     []UserStoreInvalidateSessionsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// InvalidateSessionsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockUserStore) InvalidateSessionsByIDs(v0 context.Context, v1 []int32) error {
+	r0 := m.InvalidateSessionsByIDsFunc.nextHook()(v0, v1)
+	m.InvalidateSessionsByIDsFunc.appendCall(UserStoreInvalidateSessionsByIDsFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// InvalidateSessionsByIDs method of the parent MockUserStore instance is
+// invoked and the hook queue is empty.
+func (f *UserStoreInvalidateSessionsByIDsFunc) SetDefaultHook(hook func(context.Context, []int32) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InvalidateSessionsByIDs method of the parent MockUserStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UserStoreInvalidateSessionsByIDsFunc) PushHook(hook func(context.Context, []int32) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserStoreInvalidateSessionsByIDsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, []int32) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserStoreInvalidateSessionsByIDsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, []int32) error {
+		return r0
+	})
+}
+
+func (f *UserStoreInvalidateSessionsByIDsFunc) nextHook() func(context.Context, []int32) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserStoreInvalidateSessionsByIDsFunc) appendCall(r0 UserStoreInvalidateSessionsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UserStoreInvalidateSessionsByIDsFuncCall
+// objects describing the invocations of this function.
+func (f *UserStoreInvalidateSessionsByIDsFunc) History() []UserStoreInvalidateSessionsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]UserStoreInvalidateSessionsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserStoreInvalidateSessionsByIDsFuncCall is an object that describes an
+// invocation of method InvalidateSessionsByIDs on an instance of
+// MockUserStore.
+type UserStoreInvalidateSessionsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserStoreInvalidateSessionsByIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserStoreInvalidateSessionsByIDsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -3,8 +3,10 @@ package database
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -58,10 +60,14 @@ type SecurityEventLogsStore interface {
 
 	// Insert adds a new security event to the store.
 	Insert(ctx context.Context, e *SecurityEvent) error
+	// Bulk "Insert" action.
+	InsertList(ctx context.Context, events []*SecurityEvent) error
 	// LogEvent logs the given security events.
 	//
 	// It logs errors directly instead of returning to callers.
 	LogEvent(ctx context.Context, e *SecurityEvent)
+	// Bulk "LogEvent" action.
+	LogEventList(ctx context.Context, events []*SecurityEvent)
 }
 
 type securityEventLogsStore struct {
@@ -76,25 +82,34 @@ func SecurityEventLogsWith(other basestore.ShareableStore) SecurityEventLogsStor
 	return &securityEventLogsStore{logger: logger, Store: basestore.NewWithHandle(other.Handle())}
 }
 
-func (s *securityEventLogsStore) Insert(ctx context.Context, e *SecurityEvent) error {
-	argument := e.Argument
-	if argument == nil {
-		argument = []byte(`{}`)
-	}
+func (s *securityEventLogsStore) Insert(ctx context.Context, event *SecurityEvent) error {
+	return s.InsertList(ctx, []*SecurityEvent{event})
+}
 
-	_, err := s.Handle().ExecContext(
-		ctx,
-		"INSERT INTO security_event_logs(name, url, user_id, anonymous_user_id, source, argument, version, timestamp) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-		e.Name,
-		e.URL,
-		e.UserID,
-		e.AnonymousUserID,
-		e.Source,
-		argument,
-		version.Version(),
-		e.Timestamp.UTC(),
-	)
-	if err != nil {
+func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*SecurityEvent) error {
+	vals := make([]*sqlf.Query, len(events))
+	for _, event := range events {
+		argument := event.Argument
+		if argument == nil {
+			argument = []byte(`{}`)
+		}
+		vals = append(
+			vals,
+			sqlf.Sprintf(`(%s, %s, %s, %s, %s, %s, %s, %s)`,
+				event.Name,
+				event.URL,
+				event.UserID,
+				event.AnonymousUserID,
+				event.Source,
+				argument,
+				version.Version(),
+				event.Timestamp.UTC(),
+			),
+		)
+	}
+	query := sqlf.Sprintf("INSERT INTO security_event_logs(name, url, user_id, anonymous_user_id, source, argument, version, timestamp) VALUES %s", sqlf.Join(vals, ","))
+
+	if _, err := s.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		return errors.Wrap(err, "INSERT")
 	}
 	return nil
@@ -107,8 +122,25 @@ func (s *securityEventLogsStore) LogEvent(ctx context.Context, e *SecurityEvent)
 		return
 	}
 
-	if err := s.Insert(ctx, e); err != nil {
+	if err := s.InsertList(ctx, []*SecurityEvent{e}); err != nil {
 		j, _ := json.Marshal(e)
 		trace.Logger(ctx, s.logger).Error(string(e.Name), log.String("event", string(j)), log.Error(err))
+	}
+}
+
+func (s *securityEventLogsStore) LogEventList(ctx context.Context, events []*SecurityEvent) {
+	// We don't want to begin logging authentication or authorization events in
+	// on-premises installations yet.
+	if !envvar.SourcegraphDotComMode() {
+		return
+	}
+
+	if err := s.InsertList(ctx, events); err != nil {
+		names := make([]string, len(events))
+		for i, e := range events {
+			names[i] = string(e.Name)
+		}
+		j, _ := json.Marshal(events)
+		trace.Logger(ctx, s.logger).Error(strings.Join(names, ","), log.String("events", string(j)), log.Error(err))
 	}
 }

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -59,6 +59,7 @@ type UserStore interface {
 	CreatePassword(ctx context.Context, id int32, password string) error
 	CurrentUserAllowedExternalServices(context.Context) (conf.ExternalServiceMode, error)
 	Delete(context.Context, int32) error
+	DeleteList(context.Context, []int32) error
 	DeletePasswordResetCode(context.Context, int32) error
 	Done(error) error
 	Exec(ctx context.Context, query *sqlf.Query) error
@@ -69,6 +70,7 @@ type UserStore interface {
 	GetByUsernames(context.Context, ...string) ([]*types.User, error)
 	GetByVerifiedEmail(context.Context, string) (*types.User, error)
 	HardDelete(context.Context, int32) error
+	HardDeleteList(context.Context, []int32) error
 	HasTag(ctx context.Context, userID int32, tag string) (bool, error)
 	InvalidateSessionsByID(context.Context, int32) (err error)
 	InvalidateSessionsByIDs(context.Context, []int32) (err error)
@@ -504,13 +506,25 @@ func (u *userStore) Update(ctx context.Context, id int32, update UserUpdate) (er
 
 // Delete performs a soft-delete of the user and all resources associated with this user.
 func (u *userStore) Delete(ctx context.Context, id int32) (err error) {
+	return u.DeleteList(ctx, []int32{id})
+}
+
+// Bulk "Delete" action.
+func (u *userStore) DeleteList(ctx context.Context, ids []int32) (err error) {
 	tx, err := u.Transact(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { err = tx.Done(err) }()
 
-	res, err := tx.ExecResult(ctx, sqlf.Sprintf("UPDATE users SET deleted_at=now() WHERE id=%s AND deleted_at IS NULL", id))
+	userIDs := make([]*sqlf.Query, len(ids))
+	for i := range ids {
+		userIDs[i] = sqlf.Sprintf("%d", ids[i])
+	}
+
+	idsCond := sqlf.Join(userIDs, ",")
+
+	res, err := tx.ExecResult(ctx, sqlf.Sprintf("UPDATE users SET deleted_at=now() WHERE id IN (%s) AND deleted_at IS NULL", idsCond))
 	if err != nil {
 		return err
 	}
@@ -518,37 +532,42 @@ func (u *userStore) Delete(ctx context.Context, id int32) (err error) {
 	if err != nil {
 		return err
 	}
-	if rows == 0 {
-		return userNotFoundErr{args: []any{id}}
+	if rows == int64(len(ids)) {
+		return errors.New("some users were not deleted")
 	}
 
 	// Release the username so it can be used by another user or org.
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM names WHERE user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM names WHERE user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE access_tokens SET deleted_at=now() WHERE subject_user_id=%s OR creator_user_id=%s", id, id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE access_tokens SET deleted_at=now() WHERE subject_user_id IN (%s) OR creator_user_id IN (%s)", idsCond, idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM user_emails WHERE user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM user_emails WHERE user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE user_external_accounts SET deleted_at=now() WHERE user_id=%s AND deleted_at IS NULL", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE user_external_accounts SET deleted_at=now() WHERE user_id IN (%s) AND deleted_at IS NULL", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE org_invitations SET deleted_at=now() WHERE deleted_at IS NULL AND (sender_user_id=%s OR recipient_user_id=%s)", id, id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE org_invitations SET deleted_at=now() WHERE deleted_at IS NULL AND (sender_user_id IN (%s) OR recipient_user_id IN (%s))", idsCond, idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE registry_extensions SET deleted_at=now() WHERE deleted_at IS NULL AND publisher_user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE registry_extensions SET deleted_at=now() WHERE deleted_at IS NULL AND publisher_user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
 
-	logUserDeletionEvent(ctx, NewDBWith(u.logger, u), id, SecurityEventNameAccountDeleted)
+	logUserDeletionEvents(ctx, NewDBWith(u.logger, u), ids, SecurityEventNameAccountDeleted)
 
 	return nil
 }
 
 // HardDelete removes the user and all resources associated with this user.
 func (u *userStore) HardDelete(ctx context.Context, id int32) (err error) {
+	return u.HardDeleteList(ctx, []int32{id})
+}
+
+// Bulk "HardDelete" action.
+func (u *userStore) HardDeleteList(ctx context.Context, ids []int32) (err error) {
 	// Wrap in transaction because we delete from multiple tables.
 	tx, err := u.Transact(ctx)
 	if err != nil {
@@ -556,51 +575,58 @@ func (u *userStore) HardDelete(ctx context.Context, id int32) (err error) {
 	}
 	defer func() { err = tx.Done(err) }()
 
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM names WHERE user_id=%s", id)); err != nil {
+	userIDs := make([]*sqlf.Query, len(ids))
+	for i := range ids {
+		userIDs[i] = sqlf.Sprintf("%d", ids[i])
+	}
+
+	idsCond := sqlf.Join(userIDs, ",")
+
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM names WHERE user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM access_tokens WHERE subject_user_id=%s OR creator_user_id=%s", id, id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM access_tokens WHERE subject_user_id IN (%s) OR creator_user_id IN (%s)", idsCond, idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM user_emails WHERE user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM user_emails WHERE user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM user_external_accounts WHERE user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM user_external_accounts WHERE user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM survey_responses WHERE user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM survey_responses WHERE user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM registry_extension_releases WHERE registry_extension_id IN (SELECT id FROM registry_extensions WHERE publisher_user_id=%s)", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM registry_extension_releases WHERE registry_extension_id IN (SELECT id FROM registry_extensions WHERE publisher_user_id IN (%s))", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM registry_extensions WHERE publisher_user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM registry_extensions WHERE publisher_user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM org_invitations WHERE sender_user_id=%s OR recipient_user_id=%s", id, id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM org_invitations WHERE sender_user_id IN (%s) OR recipient_user_id IN (%s)", idsCond, idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM org_members WHERE user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM org_members WHERE user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM settings WHERE user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM settings WHERE user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
-	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM saved_searches WHERE user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM saved_searches WHERE user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
 	// Anonymize all entries for the deleted user
-	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE event_logs SET user_id=0, anonymous_user_id=%s WHERE user_id = %s", uuid.New().String(), id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE event_logs SET user_id=0, anonymous_user_id=%s WHERE user_id IN (%s)", uuid.New().String(), idsCond)); err != nil {
 		return err
 	}
 	// Settings that were merely authored by this user should not be deleted. They may be global or
 	// org settings that apply to other users, too. There is currently no way to hard-delete
 	// settings for an org or globally, but we can handle those rare cases manually.
-	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE settings SET author_user_id=NULL WHERE author_user_id=%s", id)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf("UPDATE settings SET author_user_id=NULL WHERE author_user_id IN (%s)", idsCond)); err != nil {
 		return err
 	}
 
-	res, err := tx.ExecResult(ctx, sqlf.Sprintf("DELETE FROM users WHERE id=%s", id))
+	res, err := tx.ExecResult(ctx, sqlf.Sprintf("DELETE FROM users WHERE id IN (%s)", idsCond))
 	if err != nil {
 		return err
 	}
@@ -608,16 +634,16 @@ func (u *userStore) HardDelete(ctx context.Context, id int32) (err error) {
 	if err != nil {
 		return err
 	}
-	if rows == 0 {
-		return userNotFoundErr{args: []any{id}}
+	if rows != int64(len(ids)) {
+		return errors.New("some users were not hard deleted")
 	}
 
-	logUserDeletionEvent(ctx, NewDBWith(u.logger, u), id, SecurityEventNameAccountNuked)
+	logUserDeletionEvents(ctx, NewDBWith(u.logger, u), ids, SecurityEventNameAccountNuked)
 
 	return nil
 }
 
-func logUserDeletionEvent(ctx context.Context, db DB, id int32, name SecurityEventName) {
+func logUserDeletionEvents(ctx context.Context, db DB, ids []int32, name SecurityEventName) {
 	// The actor deleting the user could be a different user, for example a site
 	// admin
 	a := actor.FromContext(ctx)
@@ -627,17 +653,20 @@ func logUserDeletionEvent(ctx context.Context, db DB, id int32, name SecurityEve
 		Deleter: a.UID,
 	})
 
-	event := &SecurityEvent{
-		Name:            name,
-		URL:             "",
-		UserID:          uint32(id),
-		AnonymousUserID: "",
-		Argument:        arg,
-		Source:          "BACKEND",
-		Timestamp:       time.Now(),
+	now := time.Now()
+	events := make([]*SecurityEvent, len(ids))
+	for _, id := range ids {
+		events = append(events, &SecurityEvent{
+			Name:            name,
+			URL:             "",
+			UserID:          uint32(id),
+			AnonymousUserID: "",
+			Argument:        arg,
+			Source:          "BACKEND",
+			Timestamp:       now,
+		})
 	}
-
-	db.SecurityEventLogs().LogEvent(ctx, event)
+	db.SecurityEventLogs().LogEventList(ctx, events)
 }
 
 // SetIsSiteAdmin sets the user with the given ID to be or not to be the site admin.


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39820.

- Add `query site.users(...` GraphQL API query endpoint
- Add `mutation invalidateSessionsByUserIDs(...` GraphQL API bulk mutation endpoint
- Add `mutation deleteUsers(...` GraphQL API bulk mutation endpoint
  - It handles both hard and soft deletion of users, similar to the existing `mutation deleteUsers` API endpoint

## Test plan
> NOTE: the frontend part is still under development (in parallel).

- `sg start`
- Test "site.users" API:
```graphql
{
  site {
    users(query: "some-username-or-email-or-displayname", siteAdmin: true, username: "user's username", email: "user's email") {
      totalCount
      nodes(first: 100, orderBy: EVENTS_COUNT, descending: true) {
        id
        username
        email
        createdAt
        lastActiveAt
        deletedAt
        siteAdmin
        eventsCount
      }
    }
  }
}
```
- Test "invalidateSessionsByUserIDs" GraphQL API bulk mutation endpoint
```graphql
mutation {
  invalidateSessionsByIDs(userIDs: ["userID1", "userID2"]) {
    alwaysNil
  }
}
```
- Test "deleteUsers" GraphQL API bulk mutation endpoint
```graphql
mutation {
  # soft delete
  softDeleteUsers: deleteUsers(users: ["userID1", "userID2"]) {
    alwaysNil
  }
  # permanently delete from system
  hardDeleteUsers: deleteUsers(users: ["userID1", "userID2"], hard: true) {
    alwaysNil
  }
}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
