### PR TITLE
Tree: Reduce prop drilling to File

### DIFF
--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -13,7 +13,7 @@ import { SingleChildTreeLayer } from './SingleChildTreeLayer'
 import { TreeRootContext } from './TreeContext'
 import { TreeLayer } from './TreeLayer'
 import { TreeRootProps } from './TreeRoot'
-import { hasSingleChild, SingleChildGitTree, TreeEntryInfo } from './util'
+import { hasSingleChild, NOOP, SingleChildGitTree, TreeEntryInfo } from './util'
 
 interface ChildTreeLayerProps extends Pick<TreeRootProps, Exclude<keyof TreeRootProps, 'sizeKey'>> {
     fileDecorationsByPath: FileDecorationsByPath
@@ -76,13 +76,11 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                                     submodule: null,
                                                 }}
                                                 location={props.location}
-                                                repoID={props.repoID}
-                                                revision={props.revision}
                                                 depth={sharedProps.depth}
                                                 index={0}
                                                 isLightTheme={sharedProps.isLightTheme}
-                                                handleTreeClick={() => undefined}
-                                                noopRowClick={() => undefined}
+                                                handleTreeClick={NOOP}
+                                                noopRowClick={NOOP}
                                                 linkRowClick={() => props.telemetryService.log('FileTreeClick')}
                                                 isActive={false}
                                                 isSelected={false}

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -15,7 +15,7 @@ import { SymbolTag } from '@sourcegraph/shared/src/symbols/SymbolTag'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Icon, LoadingSpinner } from '@sourcegraph/wildcard'
 
-import { InlineSymbolsResult, Scalars } from '../graphql-operations'
+import { InlineSymbolsResult } from '../graphql-operations'
 import { parseBrowserRepoURL } from '../util/url'
 
 import {
@@ -30,6 +30,7 @@ import {
 } from './components'
 import { MAX_TREE_ENTRIES } from './constants'
 import { FileDecorator } from './FileDecorator'
+import { useTreeRootContext } from './TreeContext'
 import { TreeLayerProps } from './TreeLayer'
 import { TreeEntryInfo, getTreeItemOffset } from './util'
 
@@ -50,8 +51,6 @@ interface FileProps extends ThemeProps {
     customIconPath?: string
 
     // For core workflow inline symbols redesign
-    repoID: Scalars['ID']
-    revision: string
     location: H.Location
 }
 
@@ -146,13 +145,7 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
                 </TreeLayerCell>
             </TreeRow>
             {coreWorkflowImprovementsEnabled && props.isActive && (
-                <Symbols
-                    repoID={props.repoID}
-                    revision={props.revision}
-                    activePath={props.entryInfo.path}
-                    location={props.location}
-                    style={offsetStyle}
-                />
+                <Symbols activePath={props.entryInfo.path} location={props.location} style={offsetStyle} />
             )}
         </>
     )
@@ -205,10 +198,11 @@ export const SYMBOLS_QUERY = gql`
 `
 
 interface SymbolsProps
-    extends Pick<TreeLayerProps, 'repoID' | 'revision' | 'activePath' | 'location'>,
+    extends Pick<TreeLayerProps, 'activePath' | 'location'>,
         Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> {}
 
-const Symbols: React.FunctionComponent<SymbolsProps> = ({ repoID, revision, activePath, location, style }) => {
+const Symbols: React.FunctionComponent<SymbolsProps> = ({ activePath, location, style }) => {
+    const { repoID, revision } = useTreeRootContext()
     const { data, loading, error } = useQuery<InlineSymbolsResult>(SYMBOLS_QUERY, {
         variables: {
             repo: repoID,

--- a/client/web/src/tree/TreeContext.tsx
+++ b/client/web/src/tree/TreeContext.tsx
@@ -1,9 +1,19 @@
-import React from 'react'
+import React, { useContext } from 'react'
 
-export interface TreeRootContext {
+import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { AbsoluteRepo } from '@sourcegraph/shared/src/util/url'
+
+export interface TreeRootContext extends AbsoluteRepo {
     rootTreeUrl: string
+    repoID: Scalars['ID']
 }
 
 export const TreeRootContext = React.createContext<TreeRootContext>({
     rootTreeUrl: '',
+    repoID: '',
+    repoName: '',
+    revision: '',
+    commitID: '',
 })
+
+export const useTreeRootContext = (): TreeRootContext => useContext(TreeRootContext)

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -328,8 +328,6 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                 linkRowClick={this.linkRowClick}
                                 isActive={isActive}
                                 isSelected={isSelected}
-                                repoID={this.props.repoID}
-                                revision={this.props.revision}
                                 location={this.props.location}
                             />
                         )}

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -214,6 +214,10 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                                             <TreeRootContext.Provider
                                                 value={{
                                                     rootTreeUrl: treeOrError.url,
+                                                    repoID: this.props.repoID,
+                                                    repoName: this.props.repoName,
+                                                    revision: this.props.revision,
+                                                    commitID: this.props.commitID,
                                                 }}
                                             >
                                                 <ChildTreeLayer

--- a/client/web/src/tree/util.tsx
+++ b/client/web/src/tree/util.tsx
@@ -104,3 +104,5 @@ export function compareTreeProps(a: ComparisonTreeRootProps, b: ComparisonTreeRo
         a.location === b.location
     )
 }
+
+export const NOOP = (): void => undefined


### PR DESCRIPTION
## Description
When I saw one of the recent changes with [adding symbols](https://github.com/sourcegraph/sourcegraph/pull/39295), I realised it only adds to the existing prop drilling issue we've got in the Tree-related components.

Although originally I intended to put almost everything used down the component tree into the `TreeRootContext`, unfortunately, it doesn't necessarily make code better as there's `ChildTreeLayer` and `TreeLayer` that can render each other and use this context in lifecycle methods, which is not as easily changed as in functional components. And without changing these two cornerstone components, the _bigger_ refactoring I imagined doesn't really change things much.

So this PR only removes prop drilling to the FIle and Symbols components, as they're able to pluck them from the context.

**The conclusion is:** once we want any massive changes to the Tree, we would need to refactor it massively. 

## Test plan
1. Pull the branch
2. Run the app locally
3. Make sure you opted in for using "Simple UI" 
4. Navigate a few example repos and see that things work as previously:
    - https://sourcegraph.test:3443/github.com/sourcegraph/code-intel-extensions/-/blob/template/src/language-specs/cpp.test.ts
    - https://sourcegraph.test:3443/github.com/sgtest/java-pom-with-deps-javaconfig/-/tree/src/main
    - https://sourcegraph.test:3443/github.com/sgtest/head-branch/-/blob/foo

## App preview:

- [Web](https://sg-web-og-tree-refactoring.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ohyxquzgyp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
