### PR TITLE
drift: Fix missing conditional check

### DIFF
--- a/internal/database/migration/cliutil/drift_util.go
+++ b/internal/database/migration/cliutil/drift_util.go
@@ -499,7 +499,9 @@ func compareNamedLists[T schemas.Namer](
 		bv := bm[k]
 
 		if _, ok := am[k]; !ok {
-			primaryCallback(nil, bv)
+			if primaryCallback(nil, bv) {
+				outOfSync = true
+			}
 		}
 	}
 


### PR DESCRIPTION
Prior to this PR, we exit 0 with (only) missing items.

## Test plan

Tested locally.