### PR TITLE
Show count of not_cloned/cloned/cloning/failed in admin UI

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
@@ -7,8 +7,3 @@
 .alert-content {
     white-space: break-spaces;
 }
-
-.repo-stats-number {
-    font-weight: heavy;
-    font-size: 2rem;
-}

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
@@ -7,3 +7,8 @@
 .alert-content {
     white-space: break-spaces;
 }
+
+.repo-stats-number {
+    font-weight: heavy;
+    font-size: 2rem;
+}

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1113,3 +1113,16 @@ export function fetchFeatureFlags(): Observable<FeatureFlagFields[]> {
         map(data => data.featureFlags)
     )
 }
+
+export const REPOSITORY_STATS = gql`
+    query RepositoryStats {
+        repositoryStats {
+            __typename
+            total
+            notCloned
+            cloned
+            cloning
+            failedFetch
+        }
+    }
+`

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -471,6 +471,8 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
     )
 }
 
+export const REPO_PAGE_POLL_INTERVAL = 5000
+
 export function fetchAllRepositoriesAndPollIfEmptyOrAnyCloning(
     args: Partial<RepositoriesVariables>
 ): Observable<RepositoriesResult['repositories']> {
@@ -481,7 +483,7 @@ export function fetchAllRepositoriesAndPollIfEmptyOrAnyCloning(
                 result.nodes &&
                 result.nodes.length > 0 &&
                 result.nodes.every(nodes => !nodes.mirrorInfo.cloneInProgress && nodes.mirrorInfo.cloned),
-            { delay: 5000 }
+            { delay: REPO_PAGE_POLL_INTERVAL }
         )
     )
 }

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -10,6 +10,12 @@ import (
 type repositoryStatsResolver struct {
 	gitDirBytes       uint64
 	indexedLinesCount uint64
+
+	total       int
+	cloned      int
+	cloning     int
+	notCloned   int
+	failedFetch int
 }
 
 func (r *repositoryStatsResolver) GitDirBytes() BigInt {
@@ -19,6 +25,12 @@ func (r *repositoryStatsResolver) GitDirBytes() BigInt {
 func (r *repositoryStatsResolver) IndexedLinesCount() BigInt {
 	return BigInt{Int: int64(r.indexedLinesCount)}
 }
+
+func (r *repositoryStatsResolver) Total() int32       { return int32(r.total) }
+func (r *repositoryStatsResolver) Cloned() int32      { return int32(r.cloned) }
+func (r *repositoryStatsResolver) Cloning() int32     { return int32(r.cloning) }
+func (r *repositoryStatsResolver) NotCloned() int32   { return int32(r.notCloned) }
+func (r *repositoryStatsResolver) FailedFetch() int32 { return int32(r.failedFetch) }
 
 func (r *schemaResolver) RepositoryStats(ctx context.Context) (*repositoryStatsResolver, error) {
 	// 🚨 SECURITY: Only site admins may query repository statistics for the site.
@@ -32,8 +44,18 @@ func (r *schemaResolver) RepositoryStats(ctx context.Context) (*repositoryStatsR
 		return nil, err
 	}
 
+	statisticsCounts, err := r.db.Repos().StatisticsCounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return &repositoryStatsResolver{
 		gitDirBytes:       stats.GitDirBytes,
 		indexedLinesCount: stats.DefaultBranchNewLinesCount + stats.OtherBranchesNewLinesCount,
+		total:             statisticsCounts.Total,
+		cloned:            statisticsCounts.Cloned,
+		cloning:           statisticsCounts.Cloning,
+		notCloned:         statisticsCounts.NotCloned,
+		failedFetch:       statisticsCounts.FailedFetch,
 	}, nil
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1263,6 +1263,7 @@ type Query {
         """
         descending: Boolean = false
     ): RepositoryConnection!
+
     """
     Looks up a Phabricator repository by name.
     """
@@ -7172,6 +7173,29 @@ type RepositoryStats {
     The number of lines indexed
     """
     indexedLinesCount: BigInt!
+
+    """
+    The number of all repositories in the instance, without soft-deleted or blocked repositories.
+    """
+    total: Int!
+    """
+    The number of cloned repositories in the instance. This number might be
+    higher than 'total', if soft-deleted repositories haven't been cleaned up
+    yet.
+    """
+    cloned: Int!
+    """
+    The number of repositories in the instance that are currently being cloned.
+    """
+    cloning: Int!
+    """
+    The number of repositories in the instance that not cloned yet.
+    """
+    notCloned: Int!
+    """
+    The number of repositories where initial cloning or subsequent fetching resulted in an error.
+    """
+    failedFetch: Int!
 }
 
 """

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -27459,6 +27459,9 @@ type MockRepoStore struct {
 	// QueryFunc is an instance of a mock function object controlling the
 	// behavior of the method Query.
 	QueryFunc *RepoStoreQueryFunc
+	// StatisticsCountsFunc is an instance of a mock function object
+	// controlling the behavior of the method StatisticsCounts.
+	StatisticsCountsFunc *RepoStoreStatisticsCountsFunc
 	// StreamMinimalReposFunc is an instance of a mock function object
 	// controlling the behavior of the method StreamMinimalRepos.
 	StreamMinimalReposFunc *RepoStoreStreamMinimalReposFunc
@@ -27556,6 +27559,11 @@ func NewMockRepoStore() *MockRepoStore {
 		},
 		QueryFunc: &RepoStoreQueryFunc{
 			defaultHook: func(context.Context, *sqlf.Query) (r0 *sql.Rows, r1 error) {
+				return
+			},
+		},
+		StatisticsCountsFunc: &RepoStoreStatisticsCountsFunc{
+			defaultHook: func(context.Context) (r0 StatisticsCounts, r1 error) {
 				return
 			},
 		},
@@ -27666,6 +27674,11 @@ func NewStrictMockRepoStore() *MockRepoStore {
 				panic("unexpected invocation of MockRepoStore.Query")
 			},
 		},
+		StatisticsCountsFunc: &RepoStoreStatisticsCountsFunc{
+			defaultHook: func(context.Context) (StatisticsCounts, error) {
+				panic("unexpected invocation of MockRepoStore.StatisticsCounts")
+			},
+		},
 		StreamMinimalReposFunc: &RepoStoreStreamMinimalReposFunc{
 			defaultHook: func(context.Context, ReposListOptions, func(*types.MinimalRepo)) error {
 				panic("unexpected invocation of MockRepoStore.StreamMinimalRepos")
@@ -27738,6 +27751,9 @@ func NewMockRepoStoreFrom(i RepoStore) *MockRepoStore {
 		},
 		QueryFunc: &RepoStoreQueryFunc{
 			defaultHook: i.Query,
+		},
+		StatisticsCountsFunc: &RepoStoreStatisticsCountsFunc{
+			defaultHook: i.StatisticsCounts,
 		},
 		StreamMinimalReposFunc: &RepoStoreStreamMinimalReposFunc{
 			defaultHook: i.StreamMinimalRepos,
@@ -29601,6 +29617,111 @@ func (c RepoStoreQueryFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RepoStoreQueryFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// RepoStoreStatisticsCountsFunc describes the behavior when the
+// StatisticsCounts method of the parent MockRepoStore instance is invoked.
+type RepoStoreStatisticsCountsFunc struct {
+	defaultHook func(context.Context) (StatisticsCounts, error)
+	hooks       []func(context.Context) (StatisticsCounts, error)
+	history     []RepoStoreStatisticsCountsFuncCall
+	mutex       sync.Mutex
+}
+
+// StatisticsCounts delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockRepoStore) StatisticsCounts(v0 context.Context) (StatisticsCounts, error) {
+	r0, r1 := m.StatisticsCountsFunc.nextHook()(v0)
+	m.StatisticsCountsFunc.appendCall(RepoStoreStatisticsCountsFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the StatisticsCounts
+// method of the parent MockRepoStore instance is invoked and the hook queue
+// is empty.
+func (f *RepoStoreStatisticsCountsFunc) SetDefaultHook(hook func(context.Context) (StatisticsCounts, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// StatisticsCounts method of the parent MockRepoStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *RepoStoreStatisticsCountsFunc) PushHook(hook func(context.Context) (StatisticsCounts, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RepoStoreStatisticsCountsFunc) SetDefaultReturn(r0 StatisticsCounts, r1 error) {
+	f.SetDefaultHook(func(context.Context) (StatisticsCounts, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RepoStoreStatisticsCountsFunc) PushReturn(r0 StatisticsCounts, r1 error) {
+	f.PushHook(func(context.Context) (StatisticsCounts, error) {
+		return r0, r1
+	})
+}
+
+func (f *RepoStoreStatisticsCountsFunc) nextHook() func(context.Context) (StatisticsCounts, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RepoStoreStatisticsCountsFunc) appendCall(r0 RepoStoreStatisticsCountsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of RepoStoreStatisticsCountsFuncCall objects
+// describing the invocations of this function.
+func (f *RepoStoreStatisticsCountsFunc) History() []RepoStoreStatisticsCountsFuncCall {
+	f.mutex.Lock()
+	history := make([]RepoStoreStatisticsCountsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RepoStoreStatisticsCountsFuncCall is an object that describes an
+// invocation of method StatisticsCounts on an instance of MockRepoStore.
+type RepoStoreStatisticsCountsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 StatisticsCounts
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RepoStoreStatisticsCountsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RepoStoreStatisticsCountsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -86,6 +86,7 @@ type RepoStore interface {
 	ListMinimalRepos(context.Context, ReposListOptions) ([]types.MinimalRepo, error)
 	Metadata(context.Context, ...api.RepoID) ([]*types.SearchedRepo, error)
 	StreamMinimalRepos(context.Context, ReposListOptions, func(*types.MinimalRepo)) error
+	StatisticsCounts(context.Context) (StatisticsCounts, error)
 }
 
 var _ RepoStore = (*repoStore)(nil)
@@ -338,6 +339,54 @@ func (s *repoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, er
 
 	return ct, err
 }
+
+type StatisticsCounts struct {
+	Total       int
+	NotCloned   int
+	Cloning     int
+	Cloned      int
+	FailedFetch int
+}
+
+func (s *repoStore) StatisticsCounts(ctx context.Context) (counts StatisticsCounts, err error) {
+	tr, ctx := trace.New(ctx, "repos.StatisticsCounts", "")
+	defer func() {
+		if err != nil {
+			tr.SetError(err)
+		}
+		tr.Finish()
+	}()
+
+	row := s.QueryRow(ctx, sqlf.Sprintf(statisticsCountsQueryFmtstr))
+
+	if err := row.Scan(
+		&counts.Total,
+		&counts.NotCloned,
+		&counts.Cloning,
+		&counts.Cloned,
+		&counts.FailedFetch,
+	); err != nil {
+		return counts, err
+	}
+
+	return counts, nil
+}
+
+const statisticsCountsQueryFmtstr = `
+-- source: internal/database/repos.go:statisticsCounts
+SELECT
+	COUNT(*) AS total,
+	COUNT(*) FILTER(WHERE gr.clone_status = 'not_cloned') AS not_cloned,
+	COUNT(*) FILTER(WHERE gr.clone_status = 'cloning') AS cloning,
+	COUNT(*) FILTER(WHERE gr.clone_status = 'cloned') AS cloned,
+	COUNT(*) FILTER(WHERE gr.last_error IS NOT NULL) AS failed_fetch
+FROM repo r
+JOIN gitserver_repos gr ON gr.repo_id = r.id
+WHERE
+	r.deleted_at is NULL
+AND
+	r.blocked IS NULL
+`
 
 // Metadata returns repo metadata used to decorate search results. The returned slice may be smaller than the
 // number of IDs given if a repo with the given ID does not exist.


### PR DESCRIPTION
This adds repository counts to the site-admin repositories page.

Under the hood, the SQL query used to count the repositories is not as efficient as it can be, because the first attempt in https://github.com/sourcegraph/sourcegraph/pull/39660 was a deadend. But I have an idea for a better solution.

Until I have that efficient solution done, though, I don't think it's harmful to ship this version, which does a single `SELECT` when viewing the page.

This also uses the new UI components that @erzhtor and @thenamankumar added for the analytics pages (cc @rob) to display the counts.

## Demo video


https://user-images.githubusercontent.com/1185253/185087781-4b223777-49ed-4b1b-aa51-cff459ac8d6f.mp4



## Test plan

- Unit tests
- Manual testing