### PR TITLE
oneclickexport: add external_service_repos table DB query processor

### DIFF
--- a/cmd/frontend/oneclickexport/db_processor.go
+++ b/cmd/frontend/oneclickexport/db_processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"path"
 	"time"
 
 	"github.com/sourcegraph/log"
@@ -13,21 +14,21 @@ import (
 
 const DefaultLimit = 1000
 
-var _ Processor[Limit] = &ExtSvcDBQueryProcessor{}
+var _ Processor[Limit] = &ExtSvcQueryProcessor{}
 
-type ExtSvcDBQueryProcessor struct {
+type ExtSvcQueryProcessor struct {
 	db     database.DB
 	logger log.Logger
 	Type   string
 }
 
-func (d ExtSvcDBQueryProcessor) Process(ctx context.Context, payload Limit, dir string) {
+func (d ExtSvcQueryProcessor) Process(ctx context.Context, payload Limit, dir string) {
 	externalServices, err := d.db.ExternalServices().List(
 		ctx,
 		database.ExternalServicesListOptions{LimitOffset: &database.LimitOffset{Limit: payload.getOrDefault(DefaultLimit)}},
 	)
 	if err != nil {
-		d.logger.Error("Error during fetching external services from the DB", log.Error(err))
+		d.logger.Error("error during fetching external services from the DB", log.Error(err))
 		return
 	}
 
@@ -36,7 +37,7 @@ func (d ExtSvcDBQueryProcessor) Process(ctx context.Context, payload Limit, dir 
 	for idx, extSvc := range externalServices {
 		redacted, err := convertExtSvcToRedacted(extSvc)
 		if err != nil {
-			d.logger.Error("Error during redacting external service code host config", log.Error(err))
+			d.logger.Error("error during redacting external service code host config", log.Error(err))
 			return
 		}
 		redactedExtSvc[idx] = redacted
@@ -44,18 +45,18 @@ func (d ExtSvcDBQueryProcessor) Process(ctx context.Context, payload Limit, dir 
 
 	bytes, err := json.MarshalIndent(redactedExtSvc, "", "  ")
 	if err != nil {
-		d.logger.Error("Error during marshalling the result", log.Error(err))
+		d.logger.Error("error during marshalling the result", log.Error(err))
 		return
 	}
 
-	err = ioutil.WriteFile(dir+"/db-external-services.txt", bytes, 0644)
-
+	outputFile := path.Join(dir, "db-external-services.txt")
+	err = ioutil.WriteFile(outputFile, bytes, 0644)
 	if err != nil {
-		d.logger.Error("Error during external_services export", log.Error(err))
+		d.logger.Error("error writing to file", log.Error(err), log.String("filePath", outputFile))
 	}
 }
 
-func (d ExtSvcDBQueryProcessor) ProcessorType() string {
+func (d ExtSvcQueryProcessor) ProcessorType() string {
 	return d.Type
 }
 
@@ -103,35 +104,37 @@ func convertExtSvcToRedacted(extSvc *types.ExternalService) (*RedactedExternalSe
 	}, nil
 }
 
-type ExtSvcReposDBQueryProcessor struct {
+// ExtSvcReposQueryProcessor is the query processor for the
+// external_service_repos table.
+type ExtSvcReposQueryProcessor struct {
 	db     database.DB
 	logger log.Logger
 	Type   string
 }
 
-func (e ExtSvcReposDBQueryProcessor) Process(ctx context.Context, payload Limit, dir string) {
+func (e ExtSvcReposQueryProcessor) Process(ctx context.Context, payload Limit, dir string) {
 	externalServiceRepos, err := e.db.ExternalServices().ListRepos(
 		ctx,
 		database.ExternalServiceReposListOptions{LimitOffset: &database.LimitOffset{Limit: payload.getOrDefault(DefaultLimit)}},
 	)
 	if err != nil {
-		e.logger.Error("Error during fetching external service repos from the DB", log.Error(err))
+		e.logger.Error("error during fetching external service repos from the DB", log.Error(err))
 		return
 	}
 
 	bytes, err := json.MarshalIndent(externalServiceRepos, "", "  ")
 	if err != nil {
-		e.logger.Error("Error during marshalling the result", log.Error(err))
+		e.logger.Error("error during marshalling the result", log.Error(err))
 		return
 	}
 
-	err = ioutil.WriteFile(dir+"/db-external-service-repos.txt", bytes, 0644)
-
+	outputFile := path.Join(dir, "db-external-service-repos.txt")
+	err = ioutil.WriteFile(outputFile, bytes, 0644)
 	if err != nil {
-		e.logger.Error("Error during external_service_repos export", log.Error(err))
+		e.logger.Error("error writing to file", log.Error(err), log.String("filePath", outputFile))
 	}
 }
 
-func (e ExtSvcReposDBQueryProcessor) ProcessorType() string {
+func (e ExtSvcReposQueryProcessor) ProcessorType() string {
 	return e.Type
 }

--- a/cmd/frontend/oneclickexport/export.go
+++ b/cmd/frontend/oneclickexport/export.go
@@ -58,7 +58,7 @@ func (e *DataExporter) Export(ctx context.Context, request ExportRequest) ([]byt
 	// 1) creating a tmp dir
 	dir, err := os.MkdirTemp(os.TempDir(), "export-*")
 	if err != nil {
-		e.logger.Fatal("Error during code tmp dir creation", log.Error(err))
+		e.logger.Fatal("error during code tmp dir creation", log.Error(err))
 	}
 	defer os.RemoveAll(dir)
 

--- a/cmd/frontend/oneclickexport/export.go
+++ b/cmd/frontend/oneclickexport/export.go
@@ -25,6 +25,23 @@ type DataExporter struct {
 	dbProcessors     map[string]Processor[Limit]
 }
 
+type ConfigRequest struct {
+}
+
+type DBQueryRequest struct {
+	TableName string `json:"tableName"`
+	Count     Limit  `json:"count"`
+}
+
+type Limit int
+
+func (l Limit) getOrDefault(defaultValue int) int {
+	if l == 0 {
+		return defaultValue
+	}
+	return int(l)
+}
+
 type ExportRequest struct {
 	IncludeSiteConfig     bool              `json:"includeSiteConfig"`
 	IncludeCodeHostConfig bool              `json:"includeCodeHostConfig"`

--- a/cmd/frontend/oneclickexport/export_test.go
+++ b/cmd/frontend/oneclickexport/export_test.go
@@ -502,7 +502,7 @@ func TestExport_DB_ExternalServices(t *testing.T) {
 	exporter := &DataExporter{
 		logger: logger,
 		dbProcessors: map[string]Processor[Limit]{
-			"externalServices": ExtSvcDBQueryProcessor{
+			"externalServices": ExtSvcQueryProcessor{
 				db:     db,
 				logger: logger,
 				Type:   "externalServices",
@@ -584,7 +584,7 @@ func TestExport_DB_ExternalServiceRepos(t *testing.T) {
 	exporter := &DataExporter{
 		logger: logger,
 		dbProcessors: map[string]Processor[Limit]{
-			"externalServiceRepos": ExtSvcReposDBQueryProcessor{
+			"externalServiceRepos": ExtSvcReposQueryProcessor{
 				db:     db,
 				logger: logger,
 				Type:   "externalServiceRepos",

--- a/cmd/frontend/oneclickexport/export_test.go
+++ b/cmd/frontend/oneclickexport/export_test.go
@@ -4,9 +4,9 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
@@ -183,6 +183,24 @@ const (
     "CloudDefault": false,
     "HasWebhooks": null,
     "TokenExpiresAt": null
+  }
+]`
+	wantExtSvcReposDBQueryResult = `[
+  {
+    "externalServiceID": 1,
+    "repoID": 1,
+    "cloneURL": "cloneUrl",
+    "userID": 1,
+    "orgID": 1,
+    "createdAt": "0001-01-01T00:00:00Z"
+  },
+  {
+    "externalServiceID": 1,
+    "repoID": 2,
+    "cloneURL": "cloneUrl",
+    "userID": 1,
+    "orgID": 1,
+    "createdAt": "0001-01-01T00:00:00Z"
   }
 ]`
 )
@@ -524,9 +542,89 @@ func TestExport_DB_ExternalServices(t *testing.T) {
 
 		have := string(haveBytes)
 
-		fmt.Println(have)
-
 		if diff := cmp.Diff(wantExtSvcDBQueryResult, have); diff != "" {
+			t.Fatalf("Exported external services are different. (-want +got):\n%s", diff)
+		}
+	}
+
+	if !found {
+		t.Fatal(errors.New("external services file not found in exported zip archive"))
+	}
+}
+
+func TestExport_DB_ExternalServiceRepos(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+
+	externalServices := database.NewMockExternalServiceStore()
+	externalServices.ListReposFunc.SetDefaultReturn([]*types.ExternalServiceRepo{
+		{
+			ExternalServiceID: 1,
+			RepoID:            1,
+			CloneURL:          "cloneUrl",
+			UserID:            1,
+			OrgID:             1,
+			CreatedAt:         time.Time{},
+		},
+		{
+			ExternalServiceID: 1,
+			RepoID:            2,
+			CloneURL:          "cloneUrl",
+			UserID:            1,
+			OrgID:             1,
+			CreatedAt:         time.Time{},
+		},
+	},
+		nil,
+	)
+
+	db := database.NewMockDB()
+	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
+
+	exporter := &DataExporter{
+		logger: logger,
+		dbProcessors: map[string]Processor[Limit]{
+			"externalServiceRepos": ExtSvcReposDBQueryProcessor{
+				db:     db,
+				logger: logger,
+				Type:   "externalServiceRepos",
+			},
+		},
+	}
+
+	archive, err := exporter.Export(ctx, ExportRequest{DBQueries: []*DBQueryRequest{{
+		TableName: "externalServiceRepos",
+		Count:     2,
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+
+	for _, f := range zr.File {
+		if f.Name != "db-external-service-repos.txt" {
+			continue
+		}
+		found = true
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		haveBytes, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		have := string(haveBytes)
+
+		if diff := cmp.Diff(wantExtSvcReposDBQueryResult, have); diff != "" {
 			t.Fatalf("Exported external services are different. (-want +got):\n%s", diff)
 		}
 	}

--- a/cmd/frontend/oneclickexport/processor.go
+++ b/cmd/frontend/oneclickexport/processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"path"
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -33,15 +34,15 @@ type SiteConfigProcessor struct {
 func (s SiteConfigProcessor) Process(_ context.Context, _ ConfigRequest, dir string) {
 	siteConfig, err := conf.RedactSecrets(conf.Raw())
 	if err != nil {
-		s.logger.Error("Error during site config redacting", log.Error(err))
+		s.logger.Error("error during site config redacting", log.Error(err))
 	}
 
 	configBytes := []byte(siteConfig.Site)
 
-	err = ioutil.WriteFile(dir+"/site-config.json", configBytes, 0644)
-
+	outputFile := path.Join(dir, "site-config.json")
+	err = ioutil.WriteFile(outputFile, configBytes, 0644)
 	if err != nil {
-		s.logger.Error("Error during site config export", log.Error(err))
+		s.logger.Error("error writing to file", log.Error(err), log.String("filePath", outputFile))
 	}
 }
 
@@ -62,7 +63,7 @@ type CodeHostConfigProcessor struct {
 func (c CodeHostConfigProcessor) Process(ctx context.Context, _ ConfigRequest, dir string) {
 	externalServices, err := c.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{})
 	if err != nil {
-		c.logger.Error("Error getting external services", log.Error(err))
+		c.logger.Error("error getting external services", log.Error(err))
 	}
 
 	if len(externalServices) == 0 {
@@ -74,7 +75,7 @@ func (c CodeHostConfigProcessor) Process(ctx context.Context, _ ConfigRequest, d
 		summary, err := convertToSummary(extSvc)
 		if err != nil {
 			// basically this is the only error that can occur
-			c.logger.Error("Error during redacting the code host config", log.Error(err))
+			c.logger.Error("error during redacting the code host config", log.Error(err))
 			return
 		}
 		summaries[idx] = summary
@@ -82,13 +83,13 @@ func (c CodeHostConfigProcessor) Process(ctx context.Context, _ ConfigRequest, d
 
 	configBytes, err := json.MarshalIndent(summaries, "", "  ")
 	if err != nil {
-		c.logger.Error("Error during marshalling the code host config", log.Error(err))
+		c.logger.Error("error during marshalling the code host config", log.Error(err))
 	}
 
-	err = ioutil.WriteFile(dir+"/code-host-config.json", configBytes, 0644)
-
+	outputFile := path.Join(dir, "code-host-config.json")
+	err = ioutil.WriteFile(outputFile, configBytes, 0644)
 	if err != nil {
-		c.logger.Error("Error during code host config export", log.Error(err))
+		c.logger.Error("error writing to file", log.Error(err), log.String("filePath", outputFile))
 	}
 }
 

--- a/cmd/frontend/oneclickexport/processor.go
+++ b/cmd/frontend/oneclickexport/processor.go
@@ -23,9 +23,6 @@ type Processor[T any] interface {
 var _ Processor[ConfigRequest] = &SiteConfigProcessor{}
 var _ Processor[ConfigRequest] = &CodeHostConfigProcessor{}
 
-type ConfigRequest struct {
-}
-
 type SiteConfigProcessor struct {
 	logger log.Logger
 	Type   string

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -12345,6 +12345,9 @@ type MockExternalServiceStore struct {
 	// ListFunc is an instance of a mock function object controlling the
 	// behavior of the method List.
 	ListFunc *ExternalServiceStoreListFunc
+	// ListReposFunc is an instance of a mock function object controlling
+	// the behavior of the method ListRepos.
+	ListReposFunc *ExternalServiceStoreListReposFunc
 	// RepoCountFunc is an instance of a mock function object controlling
 	// the behavior of the method RepoCount.
 	RepoCountFunc *ExternalServiceStoreRepoCountFunc
@@ -12435,6 +12438,11 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 		},
 		ListFunc: &ExternalServiceStoreListFunc{
 			defaultHook: func(context.Context, ExternalServicesListOptions) (r0 []*types.ExternalService, r1 error) {
+				return
+			},
+		},
+		ListReposFunc: &ExternalServiceStoreListReposFunc{
+			defaultHook: func(context.Context, ExternalServiceReposListOptions) (r0 []*types.ExternalServiceRepo, r1 error) {
 				return
 			},
 		},
@@ -12546,6 +12554,11 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 				panic("unexpected invocation of MockExternalServiceStore.List")
 			},
 		},
+		ListReposFunc: &ExternalServiceStoreListReposFunc{
+			defaultHook: func(context.Context, ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error) {
+				panic("unexpected invocation of MockExternalServiceStore.ListRepos")
+			},
+		},
 		RepoCountFunc: &ExternalServiceStoreRepoCountFunc{
 			defaultHook: func(context.Context, int64) (int32, error) {
 				panic("unexpected invocation of MockExternalServiceStore.RepoCount")
@@ -12627,6 +12640,9 @@ func NewMockExternalServiceStoreFrom(i ExternalServiceStore) *MockExternalServic
 		},
 		ListFunc: &ExternalServiceStoreListFunc{
 			defaultHook: i.List,
+		},
+		ListReposFunc: &ExternalServiceStoreListReposFunc{
+			defaultHook: i.ListRepos,
 		},
 		RepoCountFunc: &ExternalServiceStoreRepoCountFunc{
 			defaultHook: i.RepoCount,
@@ -14052,6 +14068,116 @@ func (c ExternalServiceStoreListFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ExternalServiceStoreListFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ExternalServiceStoreListReposFunc describes the behavior when the
+// ListRepos method of the parent MockExternalServiceStore instance is
+// invoked.
+type ExternalServiceStoreListReposFunc struct {
+	defaultHook func(context.Context, ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error)
+	hooks       []func(context.Context, ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error)
+	history     []ExternalServiceStoreListReposFuncCall
+	mutex       sync.Mutex
+}
+
+// ListRepos delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExternalServiceStore) ListRepos(v0 context.Context, v1 ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error) {
+	r0, r1 := m.ListReposFunc.nextHook()(v0, v1)
+	m.ListReposFunc.appendCall(ExternalServiceStoreListReposFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ListRepos method of
+// the parent MockExternalServiceStore instance is invoked and the hook
+// queue is empty.
+func (f *ExternalServiceStoreListReposFunc) SetDefaultHook(hook func(context.Context, ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListRepos method of the parent MockExternalServiceStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *ExternalServiceStoreListReposFunc) PushHook(hook func(context.Context, ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExternalServiceStoreListReposFunc) SetDefaultReturn(r0 []*types.ExternalServiceRepo, r1 error) {
+	f.SetDefaultHook(func(context.Context, ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExternalServiceStoreListReposFunc) PushReturn(r0 []*types.ExternalServiceRepo, r1 error) {
+	f.PushHook(func(context.Context, ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExternalServiceStoreListReposFunc) nextHook() func(context.Context, ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExternalServiceStoreListReposFunc) appendCall(r0 ExternalServiceStoreListReposFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExternalServiceStoreListReposFuncCall
+// objects describing the invocations of this function.
+func (f *ExternalServiceStoreListReposFunc) History() []ExternalServiceStoreListReposFuncCall {
+	f.mutex.Lock()
+	history := make([]ExternalServiceStoreListReposFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExternalServiceStoreListReposFuncCall is an object that describes an
+// invocation of method ListRepos on an instance of
+// MockExternalServiceStore.
+type ExternalServiceStoreListReposFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExternalServiceReposListOptions
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*types.ExternalServiceRepo
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExternalServiceStoreListReposFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExternalServiceStoreListReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -564,6 +564,15 @@ type ExternalService struct {
 	TokenExpiresAt  *time.Time // Whether the token in this external services expires, nil indicates never expires.
 }
 
+type ExternalServiceRepo struct {
+	ExternalServiceID int64      `json:"externalServiceID"`
+	RepoID            api.RepoID `json:"repoID"`
+	CloneURL          string     `json:"cloneURL"`
+	UserID            int32      `json:"userID"`
+	OrgID             int32      `json:"orgID"`
+	CreatedAt         time.Time  `json:"createdAt"`
+}
+
 // ExternalServiceSyncJob represents an sync job for an external service
 type ExternalServiceSyncJob struct {
 	ID                int64


### PR DESCRIPTION
This commit also adds a function to list external service repos to the store.

Closes https://github.com/sourcegraph/sourcegraph/issues/39947 and https://github.com/sourcegraph/sourcegraph/issues/39960

## Test plan
New tests added both for store and one-click export code.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
