### PR TITLE
Search backend: do not error on empty repo

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -461,8 +461,11 @@ func (r *Resolver) filterHasCommitAfter(
 			rev := rev
 			g.Go(func(ctx context.Context) error {
 				if hasCommitAfter, err := r.gitserver.HasCommitAfter(ctx, repoRev.Repo.Name, op.CommitAfter, rev, authz.DefaultSubRepoPermsChecker); err != nil {
-					if !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) && !gitdomain.IsRepoNotExist(err) {
-						return err
+					if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) || gitdomain.IsRepoNotExist(err) {
+						// If the revision does not exist or the repo does not exist,
+						// it certainly does not have any commits after some time.
+						// Ignore the error, but filter this repo out.
+						return nil
 					}
 					return err
 				} else if !hasCommitAfter {


### PR DESCRIPTION
The recent changes to how `repo:has.commit.after()` executes made it so we no longer ignore errors. However, in the case of `repo:has.commit.after()`, we will receive an error for empty repos which should be interpreted as "repo does not have commit after."

This updates the logic to do so.

Related Slack thread [here](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1659630314821299)

## Test plan

Added unit tests and manually tested that `repo:has.commit.after()` does not bomb out on empty repos now.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
