### PR TITLE
Update docs for #39963

### DIFF
--- a/doc/admin/deploy/docker-single-container/index.md
+++ b/doc/admin/deploy/docker-single-container/index.md
@@ -198,7 +198,7 @@ If you run Docker on an OS such as RHEL, Fedora, or CentOS with SELinux enabled,
 
 To fix this, run:
 
-`mkdir -p ~/.sourcegraph/config ~/.sourcegraph/data && chown -R -t svirt_sandbox_file_t ~/.sourcegraph/config ~/.sourcegraph/data`
+`mkdir -p ~/.sourcegraph/config ~/.sourcegraph/data && chcon -R -t svirt_sandbox_file_t ~/.sourcegraph/config ~/.sourcegraph/data`
 
 ## Reference
 


### PR DESCRIPTION
via @ben-alkov #39963

Describe the issue
The command in "[special-instructions-for-rhel-fedora-centos-and-others](https://docs.sourcegraph.com/admin/deploy/docker-single-container#special-instructions-for-rhel-fedora-centos-and-others)" is incorrect

Where is the issue located?
https://docs.sourcegraph.com/admin/deploy/docker-single-container#special-instructions-for-rhel-fedora-centos-and-others

## Test plan

* Check with Ben to verify the command is correct

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
