### PR TITLE
worker: actually track error metrics on worker handle error

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -432,13 +432,13 @@ commands:
     cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-1" -pprof -rpc -listen "127.0.0.1:3071"
 
   codeintel-worker:
-    cmd: .bin/precise-code-intel-worker
+    cmd: .bin/codeintel-worker
     install: |
       if [ -n "$DELVE" ]; then
         export GCFLAGS='all=-N -l'
       fi
-      go build -gcflags="$GCFLAGS" -o .bin/precise-code-intel-worker github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker
-    checkBinary: .bin/precise-code-intel-worker
+      go build -gcflags="$GCFLAGS" -o .bin/codeintel-worker github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker
+    checkBinary: .bin/codeintel-worker
     watch:
       - lib
       - internal
@@ -573,7 +573,7 @@ commands:
     install: |
       mkdir -p "${GRAFANA_DISK}"
       mkdir -p "$(dirname ${GRAFANA_LOG_FILE})"
-
+      export CACHE=true
       docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
       ./docker-images/grafana/build.sh
     env:


### PR DESCRIPTION
Actually track workers' handle error in the error total metric `src_<banana>_processor_error_total`. Previously it wasnt doing that, because we were returning `nil` from handle if no error or only a handle error occurred. How did we not ever catch this lolmao

## Test plan

I tested this manually with these conditions:
1. handle errors dont bubble up beyond the call to `.handle()`
2. infra errors do bubble up
3. handle errors are counted in src_<banana>_processor_error_total
4. infra errors are also counted in the above
