### PR TITLE
Remove feature flag for executors on MI

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -10,7 +10,6 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Button, Icon, LoadingSpinner, H3, H4, Alert } from '@sourcegraph/wildcard'
 
 import { HeroPage } from '../../../../components/HeroPage'
-import { useFeatureFlag } from '../../../../featureFlags/useFeatureFlag'
 import {
     CheckExecutorsAccessTokenResult,
     CheckExecutorsAccessTokenVariables,
@@ -18,7 +17,6 @@ import {
     GetBatchChangeToEditVariables,
     Scalars,
 } from '../../../../graphql-operations'
-// import { BatchSpecDownloadLink } from '../../BatchSpec'
 import { BatchSpecDownloadLink } from '../../BatchSpec'
 import { EXECUTORS, GET_BATCH_CHANGE_TO_EDIT } from '../../create/backend'
 import { ConfigurationForm } from '../../create/ConfigurationForm'
@@ -165,12 +163,6 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
         false
     )
 
-    /**
-     * For managed instances we want to hide the `run server side` button by default. To do this we make use of a
-     * feature flag to ensure Managed Instances.
-     */
-    const [isRunBatchSpecButtonHidden] = useFeatureFlag('hide-run-batch-spec-for-mi', false)
-
     const activeExecutorsActionButtons = (
         <>
             <RunBatchSpecButton
@@ -214,15 +206,9 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                 </Button>
             )}
 
-            {!isRunBatchSpecButtonHidden && (
-                <Button
-                    className={styles.downloadLink}
-                    variant="link"
-                    onClick={() => setIsRunServerSideModalOpen(true)}
-                >
-                    or run server-side
-                </Button>
-            )}
+            <Button className={styles.downloadLink} variant="link" onClick={() => setIsRunServerSideModalOpen(true)}>
+                or run server-side
+            </Button>
         </>
     )
 

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -11,7 +11,6 @@ export type FeatureFlagName =
     | 'insight-polling-enabled'
     | 'ab-visitor-tour-with-notebooks'
     | 'ab-email-verification-alert'
-    | 'hide-run-batch-spec-for-mi'
     | 'contrast-compliant-syntax-highlighting'
     | 'admin-analytics-disabled'
     | 'admin-analytics-cache-disabled'


### PR DESCRIPTION
This doesn't exist for any MIs anymore, so we can remove it 🎊 

## Test plan

Verified that everything still looks correct.

## App preview:

- [Web](https://sg-web-es-executors-for-the-world.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bvtbpplsem.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

