### PR TITLE
Fix docker for mac styles

### DIFF
--- a/client/web/src/site/DockerForMacAlert.module.scss
+++ b/client/web/src/site/DockerForMacAlert.module.scss
@@ -1,8 +1,0 @@
-.left {
-    flex: 3;
-}
-
-.right {
-    flex: 2;
-    margin-left: 4rem;
-}

--- a/client/web/src/site/DockerForMacAlert.tsx
+++ b/client/web/src/site/DockerForMacAlert.tsx
@@ -21,7 +21,6 @@ export const DockerForMacAlert: React.FunctionComponent<React.PropsWithChildren<
         <span>
             It looks like you're using Docker for Mac. Due to known issues related to Docker for Mac's file system
             access, search performance and cloning repositories on Sourcegraph will be much slower.&nbsp;
-
             <Link to="/help/admin">Run Sourcegraph on a different platform or deploy it to a server</Link> for much
             faster performance.
         </span>

--- a/client/web/src/site/DockerForMacAlert.tsx
+++ b/client/web/src/site/DockerForMacAlert.tsx
@@ -6,8 +6,6 @@ import { Link } from '@sourcegraph/wildcard'
 
 import { DismissibleAlert } from '../components/DismissibleAlert'
 
-import styles from './DockerForMacAlert.module.scss'
-
 /**
  * A global alert telling all users that due to Docker for Mac, site performance
  * will be degraded.
@@ -20,11 +18,10 @@ export const DockerForMacAlert: React.FunctionComponent<React.PropsWithChildren<
         variant="warning"
         className={classNames('docker-for-mac-alert d-flex align-items-center', className)}
     >
-        <span className={styles.left}>
+        <span>
             It looks like you're using Docker for Mac. Due to known issues related to Docker for Mac's file system
-            access, search performance and cloning repositories on Sourcegraph will be much slower.
-        </span>
-        <span className={styles.right}>
+            access, search performance and cloning repositories on Sourcegraph will be much slower.&nbsp;
+
             <Link to="/help/admin">Run Sourcegraph on a different platform or deploy it to a server</Link> for much
             faster performance.
         </span>


### PR DESCRIPTION
Current styles oddly float the sentences next to each other.

Before:
<img width="818" alt="Screen Shot 2022-08-04 at 8 44 42 PM" src="https://user-images.githubusercontent.com/754768/182983945-72dcb9f0-5365-455f-93d8-8b359a894010.png">

After:
<img width="1114" alt="Screen Shot 2022-08-04 at 8 47 11 PM" src="https://user-images.githubusercontent.com/754768/182984110-b3c08119-26ec-4976-a21d-9919d975f997.png">

## Test plan

Tested locally

## App preview:

- [Web](https://sg-web-ns-doc-mac-alert.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ripthqzuvm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
