### PR TITLE
Query examples homepage

### DIFF
--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import { mdiSourceRepositoryMultiple, mdiGithub, mdiGitlab, mdiBitbucket } from '@mdi/js'
 import classNames from 'classnames'
@@ -6,7 +6,7 @@ import * as H from 'history'
 import { catchError, startWith } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
-import { SearchContextInputProps, SearchContextProps } from '@sourcegraph/search'
+import { QueryState, SearchContextInputProps, SearchContextProps } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
@@ -56,6 +56,10 @@ export const CommunitySearchContextPage: React.FunctionComponent<
     React.PropsWithChildren<CommunitySearchContextPageProps>
 > = (props: CommunitySearchContextPageProps) => {
     const LOADING = 'loading' as const
+
+    const [queryState, setQueryState] = useState<QueryState>({
+        query: '',
+    })
 
     useEffect(
         () =>
@@ -113,12 +117,16 @@ export const CommunitySearchContextPage: React.FunctionComponent<
                 {props.communitySearchContextMetadata.lowProfile ? (
                     <SearchPageInput
                         {...props}
+                        queryState={queryState}
+                        setQueryState={setQueryState}
                         selectedSearchContextSpec={props.communitySearchContextMetadata.spec}
                         source="communitySearchContextPage"
                     />
                 ) : (
                     <SearchPageInput
                         {...props}
+                        queryState={queryState}
+                        setQueryState={setQueryState}
                         selectedSearchContextSpec={props.communitySearchContextMetadata.spec}
                         source="communitySearchContextPage"
                     />

--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -1,0 +1,65 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
+.query-example-chip {
+    background-color: var(--code-bg);
+    box-shadow: var(--search-input-shadow);
+    border-radius: var(--border-radius);
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+
+    &:hover {
+        border: 1px solid var(--border-color);
+    }
+
+    &:active {
+        border: 1px solid var(--border-color);
+        box-shadow: none;
+    }
+
+    &:focus {
+        border: 1px solid transparent;
+        box-shadow: 0px 0px 0px 2px var(--primary-2);
+        outline: none;
+    }
+}
+
+.query-examples-section-title {
+    margin-bottom: 0.75rem;
+    color: var(--text-muted);
+}
+
+.query-examples-sections-columns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6rem;
+
+    @media (--sm-breakpoint-down) {
+        gap: 1rem;
+    }
+}
+
+.query-examples-section {
+    margin-bottom: 1.5rem;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+.tip {
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    min-height: 2rem;
+    margin-bottom: 2.25rem;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.25s;
+
+    &--visible {
+        visibility: visible;
+        opacity: 1;
+    }
+}

--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -18,7 +18,7 @@
 
     &:focus {
         border: 1px solid transparent;
-        box-shadow: 0px 0px 0px 2px var(--primary-2);
+        box-shadow: 0 0 0 0.125rem var(--primary-2);
         outline: none;
     }
 }

--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -4,7 +4,7 @@
     background-color: var(--code-bg);
     box-shadow: var(--search-input-shadow);
     border-radius: var(--border-radius);
-    padding: 0.25rem 0.5rem;
+    padding: 0.125rem 0.375rem;
     font-size: 0.75rem;
 
     &:hover {
@@ -12,6 +12,8 @@
     }
 
     &:active {
+        position: relative;
+        top: 1px;
         border: 1px solid var(--border-color);
         box-shadow: none;
     }
@@ -20,6 +22,11 @@
         border: 1px solid transparent;
         box-shadow: 0 0 0 0.125rem var(--primary-2);
         outline: none;
+    }
+
+    &:active:focus {
+        border: 1px solid var(--border-color);
+        box-shadow: none;
     }
 }
 
@@ -43,6 +50,16 @@
 
     &:last-child {
         margin-bottom: 0;
+    }
+}
+
+.query-examples-items {
+    > * {
+        margin-bottom: 0.25rem;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
     }
 }
 

--- a/client/web/src/search/home/QueryExamplesHomepage.tsx
+++ b/client/web/src/search/home/QueryExamplesHomepage.tsx
@@ -56,7 +56,7 @@ const queryExampleSectionsColumns = [
             title: 'Get advanced',
             queryExamples: [{ id: 'contains-commit-after', query: 'repo:contains.commit.after(yesterday)' }],
             footer: (
-                <small className="d-block mt-2">
+                <small className="d-block mt-3">
                     <Link target="blank" to="/help/code_search/reference/queries">
                         Complete query reference{' '}
                         <Icon role="img" aria-label="Open in a new tab" svgPath={mdiOpenInNew} />
@@ -189,7 +189,7 @@ export const QueryExamplesSection: React.FunctionComponent<QueryExamplesSection>
 }) => (
     <div className={styles.queryExamplesSection}>
         <div className={styles.queryExamplesSectionTitle}>{title}</div>
-        <div>
+        <div className={styles.queryExamplesItems}>
             {queryExamples.map(({ id, query, helperText }) => (
                 <QueryExampleChip
                     id={id}
@@ -222,7 +222,7 @@ export const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = 
     className,
     onClick,
 }) => (
-    <span className={classNames('d-flex align-items-center mb-1', className)}>
+    <span className={classNames('d-flex align-items-center', className)}>
         <Button type="button" className={styles.queryExampleChip} onClick={() => onClick(id, query)}>
             <SyntaxHighlightedSearchQuery query={query} />
         </Button>

--- a/client/web/src/search/home/QueryExamplesHomepage.tsx
+++ b/client/web/src/search/home/QueryExamplesHomepage.tsx
@@ -1,0 +1,223 @@
+import React, { useCallback, useState } from 'react'
+
+import { mdiOpenInNew } from '@mdi/js'
+import classNames from 'classnames'
+
+import { EditorHint, QueryState } from '@sourcegraph/search'
+import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
+import { Button, Icon, Link } from '@sourcegraph/wildcard'
+
+import styles from './QueryExamplesHomepage.module.scss'
+
+export interface QueryExamplesHomepageProps {
+    queryState: QueryState
+    setQueryState: (newState: QueryState) => void
+}
+
+const queryExampleSectionsColumns = [
+    [
+        {
+            title: 'Scope search to specific repos',
+            queryExamples: [
+                { id: 'single-repo', query: 'repo:awesomecorp/big-repo' },
+                { id: 'org-repos', query: 'repo:awesomecorp/*' },
+            ],
+        },
+        {
+            title: 'Jump into code navigation',
+            queryExamples: [
+                { id: 'file-filter', query: 'file:examplefile.go' },
+                { id: 'type-symbol', query: 'type:symbol Handler' },
+            ],
+        },
+        {
+            title: 'Get specific',
+            queryExamples: [
+                { id: 'author', query: 'author:logansmith' },
+                { id: 'before-after-filters', query: 'before:today after:earlydate' },
+            ],
+        },
+    ],
+    [
+        {
+            title: 'Find exact matches',
+            queryExamples: [{ id: 'exact-matches', query: 'some error message', helperText: 'No quotes needed' }],
+        },
+        {
+            title: 'Operators',
+            queryExamples: [
+                { id: 'or-operator', query: 'lang:javascript OR lang:typescript' },
+                { id: 'and-operator', query: 'example AND secondexample' },
+                { id: 'not-operator', query: 'lang:go NOT file:main.go' },
+            ],
+        },
+        {
+            title: 'Get advanced',
+            queryExamples: [{ id: 'contains-commit-after', query: 'repo:contains.commit.after(yesterday)' }],
+            footer: (
+                <small className="d-block mt-2">
+                    <Link target="blank" to="https://docs.sourcegraph.com/code_search/reference/queries">
+                        Complete query reference{' '}
+                        <Icon role="img" aria-label="Open in a new tab" svgPath={mdiOpenInNew} />
+                    </Link>
+                </small>
+            ),
+        },
+    ],
+]
+
+type Tip = 'rev' | 'lang' | 'type-commit-diff'
+
+export const queryToTip = (id: string | undefined): Tip | null => {
+    switch (id) {
+        case 'single-repo':
+        case 'org-repos':
+            return 'rev'
+        case 'file-filter':
+        case 'type-symbol':
+        case 'exact-matches':
+            return 'lang'
+        case 'author':
+            return 'type-commit-diff'
+    }
+    return null
+}
+
+export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepageProps> = ({
+    queryState,
+    setQueryState,
+}) => {
+    const [selectedTip, setSelectedTip] = useState<Tip | null>(null)
+    const [selectTipTimeout, setSelectTipTimeout] = useState<NodeJS.Timeout>()
+
+    const onQueryExampleClick = useCallback(
+        (id: string | undefined, query: string) => {
+            setQueryState({ query: `${queryState.query} ${query}`.trimStart(), hint: EditorHint.Focus })
+
+            // Clear any previously set timeout.
+            if (selectTipTimeout) {
+                clearTimeout(selectTipTimeout)
+            }
+
+            const newSelectedTip = queryToTip(id)
+            if (newSelectedTip) {
+                // If the user selected a query with a different tip, reset the currently selected tip, so that we
+                // can apply the fade-in transition.
+                if (newSelectedTip !== selectedTip) {
+                    setSelectedTip(null)
+                }
+
+                const timeoutId = setTimeout(() => setSelectedTip(newSelectedTip), 1000)
+                setSelectTipTimeout(timeoutId)
+            } else {
+                // Immediately reset the selected tip if the query does not have an associated tip.
+                setSelectedTip(null)
+            }
+        },
+        [queryState.query, setQueryState, selectedTip, setSelectedTip, selectTipTimeout, setSelectTipTimeout]
+    )
+
+    return (
+        <div>
+            <div className={classNames(styles.tip, selectedTip && styles.tipVisible)}>
+                <strong>Tip</strong>
+                <span className="mx-1">–</span>
+                {selectedTip === 'rev' && (
+                    <>
+                        Add <QueryExampleChip query="rev:branchname" onClick={onQueryExampleClick} className="mx-1" />{' '}
+                        to query accross a specific branch or commit
+                    </>
+                )}
+                {selectedTip === 'lang' && (
+                    <>
+                        Use <QueryExampleChip query="lang:" onClick={onQueryExampleClick} className="mx-1" /> to query
+                        for matches only in a given language
+                    </>
+                )}
+                {selectedTip === 'type-commit-diff' && (
+                    <>
+                        Use <QueryExampleChip query="type:commit" onClick={onQueryExampleClick} className="mx-1" /> or{' '}
+                        <QueryExampleChip query="type:diff" onClick={onQueryExampleClick} className="mx-1" /> to specify
+                        where the author appears
+                    </>
+                )}
+            </div>
+            <div className={styles.queryExamplesSectionsColumns}>
+                {queryExampleSectionsColumns.map((column, index) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <div key={`column-${index}`}>
+                        {column.map(({ title, queryExamples, footer }) => (
+                            <QueryExamplesSection
+                                key={title}
+                                title={title}
+                                queryExamples={queryExamples}
+                                footer={footer}
+                                onQueryExampleClick={onQueryExampleClick}
+                            />
+                        ))}
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+interface QueryExamplesSection {
+    title: string
+    queryExamples: QueryExample[]
+    footer?: React.ReactElement
+    onQueryExampleClick: (id: string | undefined, query: string) => void
+}
+
+export const QueryExamplesSection: React.FunctionComponent<QueryExamplesSection> = ({
+    title,
+    queryExamples,
+    footer,
+    onQueryExampleClick,
+}) => (
+    <div className={styles.queryExamplesSection}>
+        <div className={styles.queryExamplesSectionTitle}>{title}</div>
+        <div>
+            {queryExamples.map(({ id, query, helperText }) => (
+                <QueryExampleChip
+                    id={id}
+                    key={query}
+                    query={query}
+                    helperText={helperText}
+                    onClick={onQueryExampleClick}
+                />
+            ))}
+        </div>
+        {footer}
+    </div>
+)
+
+interface QueryExample {
+    id?: string
+    query: string
+    helperText?: string
+}
+
+interface QueryExampleChipProps extends QueryExample {
+    className?: string
+    onClick: (id: string | undefined, query: string) => void
+}
+
+export const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
+    id,
+    query,
+    helperText,
+    className,
+    onClick,
+}) => (
+    <span className={classNames('d-flex align-items-center mb-1', className)}>
+        <Button type="button" className={styles.queryExampleChip} onClick={() => onClick(id, query)}>
+            <SyntaxHighlightedSearchQuery query={query} />
+        </Button>
+        {helperText && (
+            <span className="text-muted ml-2">
+                <small>{helperText}</small>
+            </span>
+        )}
+    </span>
+)

--- a/client/web/src/search/home/QueryExamplesHomepage.tsx
+++ b/client/web/src/search/home/QueryExamplesHomepage.tsx
@@ -5,11 +5,12 @@ import classNames from 'classnames'
 
 import { EditorHint, QueryState } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, Link } from '@sourcegraph/wildcard'
 
 import styles from './QueryExamplesHomepage.module.scss'
 
-export interface QueryExamplesHomepageProps {
+export interface QueryExamplesHomepageProps extends TelemetryProps {
     queryState: QueryState
     setQueryState: (newState: QueryState) => void
 }
@@ -56,7 +57,7 @@ const queryExampleSectionsColumns = [
             queryExamples: [{ id: 'contains-commit-after', query: 'repo:contains.commit.after(yesterday)' }],
             footer: (
                 <small className="d-block mt-2">
-                    <Link target="blank" to="https://docs.sourcegraph.com/code_search/reference/queries">
+                    <Link target="blank" to="/help/code_search/reference/queries">
                         Complete query reference{' '}
                         <Icon role="img" aria-label="Open in a new tab" svgPath={mdiOpenInNew} />
                     </Link>
@@ -84,6 +85,7 @@ export const queryToTip = (id: string | undefined): Tip | null => {
 }
 
 export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepageProps> = ({
+    telemetryService,
     queryState,
     setQueryState,
 }) => {
@@ -93,6 +95,8 @@ export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepag
     const onQueryExampleClick = useCallback(
         (id: string | undefined, query: string) => {
             setQueryState({ query: `${queryState.query} ${query}`.trimStart(), hint: EditorHint.Focus })
+
+            telemetryService.log('QueryExampleClicked', { queryExample: query }, { queryExample: query })
 
             // Clear any previously set timeout.
             if (selectTipTimeout) {
@@ -114,7 +118,15 @@ export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepag
                 setSelectedTip(null)
             }
         },
-        [queryState.query, setQueryState, selectedTip, setSelectedTip, selectTipTimeout, setSelectTipTimeout]
+        [
+            telemetryService,
+            queryState.query,
+            setQueryState,
+            selectedTip,
+            setSelectedTip,
+            selectTipTimeout,
+            setSelectTipTimeout,
+        ]
     )
 
     return (

--- a/client/web/src/search/home/SearchPage.module.scss
+++ b/client/web/src/search/home/SearchPage.module.scss
@@ -32,6 +32,10 @@
     &--with-content-below {
         flex-grow: 0;
         margin-bottom: 5rem;
+
+        :global(.core-workflow-improvements-enabled) & {
+            margin-bottom: 2.25rem;
+        }
     }
 }
 

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -91,7 +91,11 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 )}
 
                 {coreWorkflowImprovementsEnabled && !showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
-                    <QueryExamplesHomepage queryState={queryState} setQueryState={setQueryState} />
+                    <QueryExamplesHomepage
+                        telemetryService={props.telemetryService}
+                        queryState={queryState}
+                        setQueryState={setQueryState}
+                    />
                 )}
             </div>
 

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -1,14 +1,15 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import classNames from 'classnames'
 import * as H from 'history'
 
-import { SearchContextInputProps } from '@sourcegraph/search'
+import { QueryState, SearchContextInputProps } from '@sourcegraph/search'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
@@ -21,6 +22,7 @@ import { ThemePreferenceProps } from '../../theme'
 import { HomePanels } from '../panels/HomePanels'
 
 import { LoggedOutHomepage } from './LoggedOutHomepage'
+import { QueryExamplesHomepage } from './QueryExamplesHomepage'
 import { SearchPageFooter } from './SearchPageFooter'
 import { SearchPageInput } from './SearchPageInput'
 
@@ -54,6 +56,12 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
     const showEnterpriseHomePanels = useExperimentalFeatures(features => features.showEnterpriseHomePanels ?? false)
     const homepageUserInvitation = useExperimentalFeatures(features => features.homepageUserInvitation) ?? false
     const showCollaborators = window.context.allowSignup && homepageUserInvitation && props.isSourcegraphDotCom
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+
+    /** The value entered by the user in the query input */
+    const [queryState, setQueryState] = useState<QueryState>({
+        query: '',
+    })
 
     useEffect(() => props.telemetryService.logViewEvent('Home'), [props.telemetryService])
 
@@ -65,10 +73,11 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
             )}
             <div
                 className={classNames(styles.searchContainer, {
-                    [styles.searchContainerWithContentBelow]: props.isSourcegraphDotCom || showEnterpriseHomePanels,
+                    [styles.searchContainerWithContentBelow]:
+                        props.isSourcegraphDotCom || showEnterpriseHomePanels || coreWorkflowImprovementsEnabled,
                 })}
             >
-                <SearchPageInput {...props} source="home" />
+                <SearchPageInput {...props} queryState={queryState} setQueryState={setQueryState} source="home" />
             </div>
             <div
                 className={classNames(styles.panelsContainer, {
@@ -79,6 +88,10 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
 
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />
+                )}
+
+                {coreWorkflowImprovementsEnabled && !showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
+                    <QueryExamplesHomepage queryState={queryState} setQueryState={setQueryState} />
                 )}
             </div>
 

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useCallback } from 'react'
 
 import * as H from 'history'
 import { NavbarQueryState } from 'src/stores/navbarSearchQueryState'
@@ -11,6 +11,7 @@ import {
     SearchPatternTypeProps,
     SubmitSearchParameters,
     canSubmitSearch,
+    QueryState,
 } from '@sourcegraph/search'
 import { SearchBox } from '@sourcegraph/search-ui'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
@@ -49,11 +50,9 @@ interface Props
     isSourcegraphDotCom: boolean
     /** Whether globbing is enabled for filters. */
     globbing: boolean
-    /** A query fragment to appear at the beginning of the input. */
-    queryPrefix?: string
-    /** A query fragment to be prepended to queries. This will not appear in the input until a search is submitted. */
-    hiddenQueryPrefix?: string
     autoFocus?: boolean
+    queryState: QueryState
+    setQueryState: (newState: QueryState) => void
 }
 
 const queryStateSelector = (
@@ -64,10 +63,6 @@ const queryStateSelector = (
 })
 
 export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Props>> = (props: Props) => {
-    /** The value entered by the user in the query input */
-    const [userQueryState, setUserQueryState] = useState({
-        query: props.queryPrefix ? props.queryPrefix : '',
-    })
     const { caseSensitive, patternType } = useNavbarQueryState(queryStateSelector, shallow)
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext ?? false)
     const showSearchContextManagement = useExperimentalFeatures(
@@ -75,18 +70,12 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
     )
     const editorComponent = useExperimentalFeatures(features => features.editor ?? 'codemirror6')
 
-    useEffect(() => {
-        setUserQueryState({ query: props.queryPrefix || '' })
-    }, [props.queryPrefix])
-
     const quickLinks =
         (isSettingsValid<Settings>(props.settingsCascade) && props.settingsCascade.final.quicklinks) || []
 
     const submitSearchOnChange = useCallback(
         (parameters: Partial<SubmitSearchParameters> = {}) => {
-            const query = props.hiddenQueryPrefix
-                ? `${props.hiddenQueryPrefix} ${userQueryState.query}`
-                : userQueryState.query
+            const query = props.queryState.query
 
             if (canSubmitSearch(query, props.selectedSearchContextSpec)) {
                 submitSearch({
@@ -102,13 +91,12 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
             }
         },
         [
+            props.queryState.query,
+            props.selectedSearchContextSpec,
             props.history,
+            props.activation,
             patternType,
             caseSensitive,
-            props.activation,
-            props.selectedSearchContextSpec,
-            props.hiddenQueryPrefix,
-            userQueryState.query,
         ]
     )
 
@@ -141,8 +129,8 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         setPatternType={setSearchPatternType}
                         setCaseSensitivity={setSearchCaseSensitivity}
                         submitSearchOnToggle={submitSearchOnChange}
-                        queryState={userQueryState}
-                        onChange={setUserQueryState}
+                        queryState={props.queryState}
+                        onChange={props.setQueryState}
                         onSubmit={onSubmit}
                         autoFocus={!isTouchOnlyDevice && props.autoFocus !== false}
                         isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}


### PR DESCRIPTION
https://user-images.githubusercontent.com/6417322/183012603-0e123a71-62d8-4feb-ab62-2be5a95f5522.mov


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Enable Simple UI
* Go to the search homepage
* Clicking on a query example should add the query to the search input and focus it
* Clicking on a query example with a tip should fade in the tip after a second

## App preview:

- [Web](https://sg-web-rn-query-examples-homepage.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kuwcbzfbon.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
