### PR TITLE
dev/sg: add 'sg news' that just shows changelog for now

### DIFF
--- a/dev/sg/internal/repo/sg.go
+++ b/dev/sg/internal/repo/sg.go
@@ -1,0 +1,58 @@
+package repo
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+)
+
+type RecentChangesOpts struct {
+	Count int
+	Next  bool
+	Color bool
+}
+
+// RecentSGChanges provides a summary and list of changes to sg-related code (inferred).
+func RecentSGChanges(build string, opts RecentChangesOpts) (string, []string, error) {
+	var (
+		title   string
+		logArgs = []string{
+			// Format nicely
+			"log", "--pretty=%C(reset)%s %C(dim)%h by %an, %ar",
+			// Filter out stuff we don't want
+			"--no-merges",
+			// Limit entries
+			fmt.Sprintf("--max-count=%d", opts.Count),
+		}
+	)
+	if opts.Color {
+		logArgs = append(logArgs, "--color=always")
+	} else {
+		logArgs = append(logArgs, "--color=never")
+	}
+	if build != "dev" {
+		current := strings.TrimPrefix(build, "dev-")
+		if opts.Next {
+			logArgs = append(logArgs, current+"..origin/main")
+			title = fmt.Sprintf("Changes since sg release %s", build)
+		} else {
+			logArgs = append(logArgs, current)
+			title = fmt.Sprintf("Changes in sg release %s", build)
+		}
+	} else {
+		std.Out.WriteWarningf("Dev version detected - just showing recent changes.")
+		title = "Recent sg changes"
+	}
+
+	gitLog := exec.Command("git", append(logArgs, "--", "./dev/sg")...)
+	gitLog.Env = os.Environ()
+	out, err := run.InRoot(gitLog)
+	if err != nil {
+		return title, nil, err
+	}
+	return title, strings.Split(strings.TrimSpace(out), "\n"), nil
+}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -265,6 +265,7 @@ var sg = &cli.App{
 		setupCommand,
 
 		// Company
+		newsCommand,
 		teammateCommand,
 		rfcCommand,
 		adrCommand,

--- a/dev/sg/news/news.go
+++ b/dev/sg/news/news.go
@@ -1,0 +1,30 @@
+package news
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+)
+
+func Render(ctx context.Context, build string) (string, error) {
+	var md strings.Builder
+
+	md.WriteString("# 📰 sg news\n")
+
+	// Render some recent changes
+	title, changes, err := repo.RecentSGChanges(build, repo.RecentChangesOpts{
+		Count: 5,
+		Color: false, // we render markdown
+	})
+	if err != nil {
+		return "", err
+	}
+	md.WriteString("## " + title + "\n")
+	for _, change := range changes {
+		md.WriteString("- " + change + "\n")
+	}
+
+	// Render the final output
+	return md.String(), nil
+}

--- a/dev/sg/sg_news.go
+++ b/dev/sg/sg_news.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/news"
+)
+
+var newsCommand = &cli.Command{
+	Name:     "news",
+	Category: CategoryCompany,
+	Action: func(cmd *cli.Context) error {
+		content, err := news.Render(cmd.Context, BuildCommit)
+		if err != nil {
+			return err
+		}
+		return std.Out.WriteMarkdown(content)
+	},
+}

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -15,9 +13,6 @@ import (
 )
 
 var (
-	versionChangelogNext    bool
-	versionChangelogEntries int
-
 	versionCommand = &cli.Command{
 		Name:     "version",
 		Usage:    "View details for this installation of sg",
@@ -30,18 +25,41 @@ var (
 				Usage:   "See what's changed in or since this version of sg",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "next",
-						Usage:       "Show changelog for changes you would get if you upgrade.",
-						Destination: &versionChangelogNext,
+						Name:  "next",
+						Usage: "Show changelog for changes you would get if you upgrade.",
 					},
 					&cli.IntFlag{
-						Name:        "limit",
-						Usage:       "Number of changelog entries to show.",
-						Value:       5,
-						Destination: &versionChangelogEntries,
+						Name:  "count",
+						Usage: "Number of changelog entries to show.",
+						Value: 10,
 					},
 				},
-				Action: changelogExec,
+				Action: func(cmd *cli.Context) error {
+					if _, err := run.GitCmd("fetch", "origin", "main"); err != nil {
+						return errors.Newf("failed to update main: %s", err)
+					}
+
+					count := cmd.Int("count")
+					title, changes, err := repo.RecentSGChanges(BuildCommit, repo.RecentChangesOpts{
+						Count: count,
+						Next:  cmd.Bool("next"),
+					})
+					if err != nil {
+						return err
+					}
+
+					block := std.Out.Block(output.Styled(output.StyleSearchQuery, title))
+					if len(changes) == 0 {
+						block.Write("No changes found.")
+					} else {
+						block.Write(strings.Join(changes, "\n") + "\n...")
+					}
+					block.Close()
+
+					std.Out.WriteLine(output.Styledf(output.StyleSuggestion,
+						"Only showing %d entries - configure with 'sg version changelog -limit=50'", count))
+					return nil
+				},
 			},
 		},
 	}
@@ -49,54 +67,5 @@ var (
 
 func versionExec(ctx *cli.Context) error {
 	std.Out.Write(BuildCommit)
-	return nil
-}
-
-func changelogExec(ctx *cli.Context) error {
-	if _, err := run.GitCmd("fetch", "origin", "main"); err != nil {
-		return errors.Newf("failed to update main: %s", err)
-	}
-
-	logArgs := []string{
-		// Format nicely
-		"log", "--pretty=%C(reset)%s %C(dim)%h by %an, %ar",
-		"--color=always",
-		// Filter out stuff we don't want
-		"--no-merges",
-		// Limit entries
-		fmt.Sprintf("--max-count=%d", versionChangelogEntries),
-	}
-	var title string
-	if BuildCommit != "dev" {
-		current := strings.TrimPrefix(BuildCommit, "dev-")
-		if versionChangelogNext {
-			logArgs = append(logArgs, current+"..origin/main")
-			title = fmt.Sprintf("Changes since sg release %s", BuildCommit)
-		} else {
-			logArgs = append(logArgs, current)
-			title = fmt.Sprintf("Changes in sg release %s", BuildCommit)
-		}
-	} else {
-		std.Out.WriteWarningf("Dev version detected - just showing recent changes.")
-		title = "Recent sg changes"
-	}
-
-	gitLog := exec.Command("git", append(logArgs, "--", "./dev/sg")...)
-	gitLog.Env = os.Environ()
-	out, err := run.InRoot(gitLog)
-	if err != nil {
-		return err
-	}
-
-	block := std.Out.Block(output.Styled(output.StyleSearchQuery, title))
-	if len(out) == 0 {
-		block.Write("No changes found.")
-	} else {
-		block.Write(out + "...")
-	}
-	block.Close()
-
-	std.Out.WriteLine(output.Styledf(output.StyleSuggestion,
-		"Only showing %d entries - configure with 'sg version changelog -limit=50'", versionChangelogEntries))
 	return nil
 }


### PR DESCRIPTION
Simple start to `sg news` that features some changelog items.

From an onsite hack hour - this is the first step towards an idea for pushing announcements to `sg` users: https://github.com/sourcegraph/sourcegraph/pull/39990

## Test plan

`go run ./dev/sg news`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
