### PR TITLE
dev/sg: discussions in news

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/usershell"
 	"github.com/sourcegraph/sourcegraph/dev/sg/interrupt"
+	"github.com/sourcegraph/sourcegraph/dev/sg/news"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -243,6 +244,8 @@ var sg = &cli.App{
 			background.Wait(cmd.Context, std.Out)
 			// Persist analytics
 			analytics.Persist(cmd.Context)
+			// Prompt user to check news if anything important is there
+			news.Prompt(cmd.Context, std.Out)
 		}
 
 		return nil

--- a/dev/sg/news/discussions.go
+++ b/dev/sg/news/discussions.go
@@ -1,0 +1,41 @@
+package news
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/shurcooL/githubv4"
+)
+
+type label struct {
+	Name string
+}
+
+type discussion struct {
+	Title  string
+	Body   string
+	Author struct {
+		Login string
+	}
+	Labels struct {
+		Nodes []label
+	} `graphql:"labels(first:5)"`
+}
+
+func getDiscussions(ctx context.Context) ([]discussion, error) {
+	client := githubv4.NewClient(http.DefaultClient)
+
+	var q struct {
+		Repository struct {
+			Discussions struct {
+				Nodes []discussion
+			} `graphql:"discussions(categoryId:\"DIC_kwDOAnYEBM4B_WVJ\",first:10)"`
+		} `graphql:"repository(owner:\"sourcegraph\",name:\"sourcegraph\")"`
+	}
+
+	err := client.Query(ctx, &q, map[string]any{})
+	if err != nil {
+		return nil, err
+	}
+	return q.Repository.Discussions.Nodes, nil
+}

--- a/dev/sg/news/news.go
+++ b/dev/sg/news/news.go
@@ -5,12 +5,27 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 )
+
+func Prompt(ctx context.Context, out *std.Output) {
+	// TODO
+}
 
 func Render(ctx context.Context, build string) (string, error) {
 	var md strings.Builder
 
-	md.WriteString("# 📰 sg news\n")
+	md.WriteString("# 📰 sg and DX news\n")
+
+	// Find GitHub discussions
+	md.WriteString("# 📰 DX discussions\n")
+	discussions, err := getDiscussions(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, d := range discussions {
+		md.WriteString("- " + d.Title + "\n")
+	}
 
 	// Render some recent changes
 	title, changes, err := repo.RecentSGChanges(build, repo.RecentChangesOpts{

--- a/go.mod
+++ b/go.mod
@@ -201,6 +201,11 @@ require (
 require github.com/hmarr/codeowners v0.4.0
 
 require (
+	github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00 // indirect
+	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
+)
+
+require (
 	bitbucket.org/creachadair/shell v0.0.7 // indirect
 	cloud.google.com/go v0.101.0 // indirect
 	cloud.google.com/go/compute v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1994,11 +1994,15 @@ github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXY
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20210228213109-c3a9aa474629 h1:86e54L0i3pH3dAIA8OxBbfLrVyhoGpnNk1iJCigAWYs=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20210228213109-c3a9aa474629/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=
+github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00 h1:fiFvD4lT0aWjuuAb64LlZ/67v87m+Kc9Qsu5cMFNK0w=
+github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636 h1:aSISeOcal5irEhJd1M+IrApc0PdcN7e7Aj4yuEnOrfQ=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/go-goon v0.0.0-20210110234559-7585751d9a17 h1:lRAUE0dIvigSSFAmaM2dfg7OH8T+a8zJ5smEh09a/GI=
 github.com/shurcooL/go-goon v0.0.0-20210110234559-7585751d9a17/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
+github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 h1:B1PEwpArrNp4dkQrfxh/abbBAOZBVp0ds+fBEOUOqOc=
+github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/shurcooL/highlight_diff v0.0.0-20181222201841-111da2e7d480 h1:KaKXZldeYH73dpQL+Nr38j1r5BgpAYQjYvENOUpIZDQ=
 github.com/shurcooL/highlight_diff v0.0.0-20181222201841-111da2e7d480/go.mod h1:ZpfEhSmds4ytuByIcDnOLkTHGUI6KNqRNPDLHDk+mUU=
 github.com/shurcooL/highlight_go v0.0.0-20191220051317-782971ddf21b h1:rBIwpb5ggtqf0uZZY5BPs1sL7njUMM7I8qD2jiou70E=


### PR DESCRIPTION
Trying to add discussions integrations to `sg news`:

- If `dx-announce` discussion, prompt user to check `sg news` and feature it prominently in `sg news`
- Otherwise, have a listing of recent discussions

Part of onsite hack hour. This currently doesn't work because the GraphQL API requires a token, and it seems only the GraphQL API has a discussions API :(

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
