### PR TITLE
admin-analytics: fix caching

### DIFF
--- a/internal/adminanalytics/cache.go
+++ b/internal/adminanalytics/cache.go
@@ -90,6 +90,7 @@ func setItemToCache[T interface{}](cacheKey string, summary *T) (bool, error) {
 }
 
 var dateRanges = []string{LastThreeMonths, LastMonth, LastWeek}
+var groupBys = []string{Weekly, Daily}
 
 type CacheAll interface {
 	CacheAll(ctx context.Context) error
@@ -97,17 +98,19 @@ type CacheAll interface {
 
 func refreshAnalyticsCache(ctx context.Context, db database.DB) error {
 	for _, dateRange := range dateRanges {
-		stores := []CacheAll{
-			&Search{DateRange: dateRange, DB: db, Cache: true},
-			&Users{DateRange: dateRange, DB: db, Cache: true},
-			&Notebooks{DateRange: dateRange, DB: db, Cache: true},
-			&CodeIntel{DateRange: dateRange, DB: db, Cache: true},
-			&Repos{DB: db, Cache: true},
-			&BatchChanges{DateRange: dateRange, DB: db, Cache: true},
-		}
-		for _, store := range stores {
-			if err := store.CacheAll(ctx); err != nil {
-				return err
+		for _, groupBy := range groupBys {
+			stores := []CacheAll{
+				&Search{DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
+				&Users{DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
+				&Notebooks{DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
+				&CodeIntel{DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
+				&Repos{DB: db, Cache: true},
+				&BatchChanges{Grouping: groupBy, DateRange: dateRange, DB: db, Cache: true},
+			}
+			for _, store := range stores {
+				if err := store.CacheAll(ctx); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -29,7 +29,7 @@ func makeDateParameters(dateRange string, grouping string, dateColumnName string
 	} else if grouping == Daily {
 		groupBy = "day"
 	} else {
-		return nil, nil, errors.New("Invalid date range")
+		return nil, nil, errors.New("Invalid groupBy")
 	}
 
 	return sqlf.Sprintf(fmt.Sprintf(`DATE_TRUNC('%s', %s::date)`, groupBy, dateColumnName)), sqlf.Sprintf(`BETWEEN %s AND %s`, from.Format(time.RFC3339), now.Format(time.RFC3339)), nil


### PR DESCRIPTION
Seems that caching was broken because `Grouping` field was not provided in the `internal/adminanalytics/cache.go`.

## Test plan
- `sg start`
- Check that Redis `adminanalytics` cache was updated/generated"
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
