### PR TITLE
Fix handleKindGitHub, Change FindSyncWebhook

### DIFF
--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -847,19 +847,19 @@ func (c *V3Client) ListSyncWebhooks(ctx context.Context, repoName string) ([]Web
 }
 
 // FindSyncWebhook looks for any webhook with the targetURL ending in /github-webhooks
-func (c *V3Client) FindSyncWebhook(ctx context.Context, repoName string) (int, error) {
+func (c *V3Client) FindSyncWebhook(ctx context.Context, repoName string) (*WebhookPayload, error) {
 	payloads, err := c.ListSyncWebhooks(ctx, repoName)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	for _, payload := range payloads {
 		if strings.Contains(payload.Config.URL, "github-webhooks") {
-			return payload.ID, nil
+			return &payload, nil
 		}
 	}
 
-	return 0, errors.New("unable to find webhook")
+	return nil, errors.New("unable to find webhook")
 }
 
 // DeleteSyncWebhook returns a boolean answer as to whether the target repo was deleted or not

--- a/internal/repos/webhook_build_handler.go
+++ b/internal/repos/webhook_build_handler.go
@@ -76,8 +76,8 @@ func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.L
 	// found webhook from GitHub API
 	// don't build a new one
 	if webhookPayload != nil {
-		if err := addSecretToExtSvc(svc, conn, job.Org, webhookPayload.Config.Secret); err != nil {
-			logger.Error("handleKindGitHub: Webhook found but addSecretToExtSvc failed")
+		if err := addWebhookToExtSvc(svc, conn, job.Org, webhookPayload.Config.Secret); err != nil {
+			return errors.Wrap(err, "handleKindGitHub: Webhook found but addWebhookToExtSvc failed")
 		}
 
 		logger.Info("webhook found", log.Int("ID", webhookPayload.ID))
@@ -94,15 +94,15 @@ func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.L
 		return errors.Wrap(err, "handleKindGitHub: CreateSyncWebhook failed")
 	}
 
-	if err := addSecretToExtSvc(svc, conn, job.Org, secret); err != nil {
-		logger.Error("handleKindGitHub: Webhook created but addSecretToExtSvc failed")
+	if err := addWebhookToExtSvc(svc, conn, job.Org, secret); err != nil {
+		return errors.Wrap(err, "handleKindGitHub: Webhook created but addWebhookToExtSvc failed")
 	}
 
 	logger.Info("webhook created", log.Int("ID", id))
 	return nil
 }
 
-func addSecretToExtSvc(svc *types.ExternalService, conn *schema.GitHubConnection, org, secret string) error {
+func addWebhookToExtSvc(svc *types.ExternalService, conn *schema.GitHubConnection, org, secret string) error {
 	if webhookExistsInConfig(conn.Webhooks, org) {
 		return nil
 	}

--- a/internal/repos/webhook_build_handler.go
+++ b/internal/repos/webhook_build_handler.go
@@ -63,7 +63,7 @@ func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.L
 	}
 
 	if webhookExistsInConfig(conn.Webhooks, job.Org) {
-		logger.Info("Webhook found, no need to build new webhook")
+		logger.Info("Webhook found", log.String("Org", job.Org))
 		return nil
 	}
 

--- a/internal/repos/webhook_build_handler.go
+++ b/internal/repos/webhook_build_handler.go
@@ -67,34 +67,34 @@ func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.L
 		return nil
 	}
 
-	secret, err := randomHex(32)
-	if err != nil {
-		return errcode.MakeNonRetryable(errors.Wrap(err, "handleKindGitHub: secret generation failed"))
-	}
-
 	baseURL, err := url.Parse("")
 	if err != nil {
 		return errcode.MakeNonRetryable(errors.Wrap(err, "handleKindGitHub: parse baseURL failed"))
 	}
 	client := github.NewV3Client(logger, svc.URN(), baseURL, &auth.OAuthBearerToken{Token: conn.Token}, w.doer)
 
-	id, err := client.FindSyncWebhook(ctx, job.RepoName)
+	payload, err := client.FindSyncWebhook(ctx, job.RepoName)
 	if err != nil && err.Error() != "unable to find webhook" {
 		return errors.Wrap(err, "handleKindGitHub: FindSyncWebhook failed")
 	}
 
 	// found webhook from GitHub API
 	// don't build a new one
-	if id != 0 {
-		if err := addSecretToExtSvc(svc, conn, job.Org, secret); err != nil {
+	if payload != nil {
+		if err := addSecretToExtSvc(svc, conn, job.Org, payload.Config.Secret); err != nil {
 			logger.Error("handleKindGitHub: Webhook found but addSecretToExtSvc failed")
 		}
 
-		logger.Info(fmt.Sprintf("Webhook exists with ID: %d", id))
+		logger.Info("webhook found", log.Int("ID", payload.ID))
 		return nil
 	}
 
-	id, err = client.CreateSyncWebhook(ctx, job.RepoName, fmt.Sprintf("https://%s", globals.ExternalURL().Host), secret) // TODO: Add to DB
+	secret, err := randomHex(32)
+	if err != nil {
+		return errcode.MakeNonRetryable(errors.Wrap(err, "handleKindGitHub: secret generation failed"))
+	}
+
+	id, err := client.CreateSyncWebhook(ctx, job.RepoName, fmt.Sprintf("https://%s", globals.ExternalURL().Host), secret)
 	if err != nil {
 		return errors.Wrap(err, "handleKindGitHub: CreateSyncWebhook failed")
 	}
@@ -103,7 +103,7 @@ func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.L
 		logger.Error("handleKindGitHub: Webhook created but addSecretToExtSvc failed")
 	}
 
-	logger.Info(fmt.Sprintf("Created webhook with ID: %d", id))
+	logger.Info("webhook created", log.Int("ID", id))
 	return nil
 }
 


### PR DESCRIPTION
Fix a problem from previous PR where we were returning too early (return when a webhook was found in config). We will always call `FindSyncWebhook` to look for the webhook from GitHub API to determine whether we want to create a new webhook. In the process, we store the webhook in the extsvc `Config`.

TODO: maybe we should store the fact that a repo has a _sync webhook_ so we don't have to call `FindSyncWebhook` every time a job is dequeued (or everytime an external service is [synced](url)). This might be in the form of a boolean attribute on a repo, or storing this repo-webhook pair in the database somewhere.

Also in this PR is changing the `FindSyncWebhook` method to return the complete payload from GitHub instead of just the webhook ID. This is so we can get the `secret` from the `WebhookPayload` `Config` and add it into the extsvc `Config`

## Test plan
`go test -run TestWebhookBuildHandle`