### PR TITLE
web: upload only `.map` files to Sentry

### DIFF
--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -190,11 +190,12 @@ const config = {
     VERSION &&
       SENTRY_UPLOAD_SOURCE_MAPS &&
       new SentryWebpackPlugin({
+        silent: true,
         org: SENTRY_ORGANIZATION,
         project: SENTRY_PROJECT,
         authToken: SENTRY_DOT_COM_AUTH_TOKEN,
         release: `frontend@${VERSION}`,
-        include: path.join(STATIC_ASSETS_PATH, 'scripts'),
+        include: path.join(STATIC_ASSETS_PATH, 'scripts', '*.map'),
       }),
   ].filter(Boolean),
   resolve: {


### PR DESCRIPTION
Currently we are uploading all files present in the `ui/assets/scripts` directory, which includes `.map` _and_ `.js` files. According to the [discussion here](https://forum.sentry.io/t/is-it-required-to-upload-both-js-and-map-files/11834), we don't need to upload `.js` files if the source maps contain the source code itself, which we do.

**Also**: silenced Sentry's upload logs to reduce noise.

<table>
<tr>
	<td>
	<td><strong>Files</strong>
	<td><strong>Size</strong>
<tr>
	<td><strong>With <code>.js</code></strong>
	<td>651
	<td>22 MB
<tr>
	<td><strong>Without <code>.js</code></strong>
	<td>228
	<td>8.73 MB
<tr>
	<td><strong>Change</strong>
	<td>🔻 65%
	<td>🔻 60%
</table>

## Test plan

Tested locally by uploading source maps to Sentry.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mihir-upload-only-map-files.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-byqafdoczd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

