### PR TITLE
search/coreworkflow: Show recent searches in autocompletion

### DIFF
--- a/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/search-ui/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -3,87 +3,12 @@ import React, { Fragment, useMemo } from 'react'
 import classNames from 'classnames'
 
 import { SearchPatternType } from '@sourcegraph/search'
-import { decorate, DecoratedToken, toCSSClassName } from '@sourcegraph/shared/src/search/query/decoratedToken'
+import { decorate, toDecoration } from '@sourcegraph/shared/src/search/query/decoratedToken'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 
 interface SyntaxHighlightedSearchQueryProps extends React.HTMLAttributes<HTMLSpanElement> {
     query: string
     searchPatternType?: SearchPatternType
-}
-
-interface decoration {
-    value: string
-    key: number
-    className: string
-}
-
-function toDecoration(query: string, token: DecoratedToken): decoration {
-    const className = toCSSClassName(token)
-
-    switch (token.type) {
-        case 'keyword':
-        case 'field':
-        case 'metaPath':
-        case 'metaRevision':
-        case 'metaRegexp':
-        case 'metaStructural':
-            return {
-                value: token.value,
-                key: token.range.start,
-                className,
-            }
-        case 'openingParen':
-            return {
-                value: '(',
-                key: token.range.start,
-                className,
-            }
-        case 'closingParen':
-            return {
-                value: ')',
-                key: token.range.start,
-                className,
-            }
-
-        case 'metaFilterSeparator':
-            return {
-                value: ':',
-                key: token.range.start,
-                className,
-            }
-        case 'metaRepoRevisionSeparator':
-        case 'metaContextPrefix':
-            return {
-                value: '@',
-                key: token.range.start,
-                className,
-            }
-
-        case 'metaPredicate': {
-            let value = ''
-            switch (token.kind) {
-                case 'NameAccess':
-                    value = query.slice(token.range.start, token.range.end)
-                    break
-                case 'Dot':
-                    value = '.'
-                    break
-                case 'Parenthesis':
-                    value = query.slice(token.range.start, token.range.end)
-                    break
-            }
-            return {
-                value,
-                key: token.range.start,
-                className,
-            }
-        }
-    }
-    return {
-        value: query.slice(token.range.start, token.range.end),
-        key: token.range.start,
-        className,
-    }
 }
 
 // A read-only syntax highlighted search query

--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -110,13 +110,14 @@
             max-width: 70vw;
 
             > ul {
+                font-size: var(--code-font-size);
                 font-family: var(--code-font-family);
                 max-height: 15rem;
 
                 > li {
+                    align-items: center;
                     box-sizing: content-box;
-                    padding-top: 0.25rem;
-                    padding-bottom: 0.25rem;
+                    padding: 0.25rem 0.375rem;
                     display: flex;
                     height: 1.25rem;
 
@@ -139,6 +140,7 @@
                         min-width: 0;
                         overflow: hidden;
                         text-overflow: ellipsis;
+                        font-style: initial;
                     }
 
                     :global(.cm-completionMatchedText) {

--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -106,9 +106,12 @@
             padding: 0;
             color: var(--search-query-text-color);
             background-color: var(--color-bg-1);
+            // Default is 50vw
+            max-width: 70vw;
 
             > ul {
                 font-family: var(--code-font-family);
+                max-height: 15rem;
 
                 > li {
                     box-sizing: content-box;

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { closeCompletion, CompletionResult, startCompletion } from '@codemirror/autocomplete'
+import { closeCompletion, startCompletion } from '@codemirror/autocomplete'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { Diagnostic as CMDiagnostic, linter } from '@codemirror/lint'
 import {

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -173,7 +173,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
             // listener to handle that case too.
             const TIMEOUT = 1000
             let timer: number | null = null
-            const clear = () => {
+            const clear = (): void => {
                 if (timer !== null) {
                     clearTimeout(timer)
                 }

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -171,7 +171,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
             // sure that. Since `showSuggestionsOnFocus` is currently only
             // enabled when we show search history suggestions, we use a single
             // listener to handle that case too.
-            const TIMEOUT = 500
+            const TIMEOUT = 1000
             let timer: number | null = null
             const clear = () => {
                 if (timer !== null) {

--- a/client/search-ui/src/input/MonacoQueryInput.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.tsx
@@ -20,11 +20,11 @@ import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transf
 import { fetchStreamSuggestions as defaultFetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
+import { StandardSuggestionSource } from './extensions'
 import { IEditor } from './LazyMonacoQueryInput'
 import { useQueryDiagnostics, useQueryIntelligence } from './useQueryIntelligence'
 
 import styles from './MonacoQueryInput.module.scss'
-import { StandardSuggestionSource } from './extensions'
 
 export const DEFAULT_MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
     readOnly: false,

--- a/client/search-ui/src/input/MonacoQueryInput.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.tsx
@@ -24,6 +24,7 @@ import { IEditor } from './LazyMonacoQueryInput'
 import { useQueryDiagnostics, useQueryIntelligence } from './useQueryIntelligence'
 
 import styles from './MonacoQueryInput.module.scss'
+import { StandardSuggestionSource } from './extensions'
 
 export const DEFAULT_MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
     readOnly: false,
@@ -106,6 +107,20 @@ export interface MonacoQueryInputProps
      * a suggestion by default. This is currently an experimental feature.
      */
     applySuggestionsOnEnter?: boolean
+    /**
+     * Additional sources to use for autocompletion.
+     */
+    suggestionSources?: StandardSuggestionSource[]
+    /**
+     * Show suggestions from default sources when query is empty. Defaults to
+     * true.
+     */
+    defaultSuggestionsShowWhenEmpty?: boolean
+    /**
+     * Automatically show suggestions when the input receives focus and it is
+     * empty. Defaults to false.
+     */
+    showSuggestionsOnFocus?: boolean
 }
 
 /**

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -22,33 +22,35 @@ export interface SearchBoxProps
         SearchContextInputProps,
         TelemetryProps,
         PlatformContextProps<'requestGraphQL'>,
-        Pick<LazyMonacoQueryInputProps, 'editorComponent' | 'applySuggestionsOnEnter'> {
+        Pick<
+            LazyMonacoQueryInputProps,
+            | 'editorComponent'
+            | 'autoFocus'
+            | 'onFocus'
+            | 'onSubmit'
+            | 'globbing'
+            | 'interpretComments'
+            | 'onChange'
+            | 'onCompletionItemSelected'
+            | 'onHandleFuzzyFinder'
+            | 'applySuggestionsOnEnter'
+            | 'suggestionSources'
+            | 'defaultSuggestionsShowWhenEmpty'
+            | 'showSuggestionsOnFocus'
+        > {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean // significant for query suggestions
     showSearchContext: boolean
     showSearchContextManagement: boolean
     queryState: QueryState
-    onChange: (newState: QueryState) => void
-    onSubmit: () => void
     submitSearchOnSearchContextChange?: SubmitSearchProps['submitSearch']
     submitSearchOnToggle?: SubmitSearchProps['submitSearch']
-    onFocus?: () => void
     fetchStreamSuggestions?: typeof defaultFetchStreamSuggestions // Alternate implementation is used in the VS Code extension.
-    onCompletionItemSelected?: () => void
-    autoFocus?: boolean
     className?: string
     containerClassName?: string
 
-    /** Whether globbing is enabled for filters. */
-    globbing: boolean
-
-    /** Whether comments are parsed and highlighted */
-    interpretComments?: boolean
-
     /** Don't show search help button */
     hideHelpButton?: boolean
-
-    onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
 
     /** Set in JSContext only available to the web app. */
     isExternalServicesUserModeAll?: boolean
@@ -123,9 +125,12 @@ export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBo
                         onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                         onSubmit={props.onSubmit}
                         patternType={props.patternType}
-                        queryState={props.queryState}
+                        queryState={queryState}
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         applySuggestionsOnEnter={props.applySuggestionsOnEnter}
+                        suggestionSources={props.suggestionSources}
+                        defaultSuggestionsShowWhenEmpty={props.defaultSuggestionsShowWhenEmpty}
+                        showSuggestionsOnFocus={props.showSuggestionsOnFocus}
                     />
                     <Toggles
                         patternType={props.patternType}

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -53,13 +53,13 @@ import {
 import { decorate, DecoratedToken, toDecoration } from '@sourcegraph/shared/src/search/query/decoratedToken'
 import { FILTERS, FilterType, resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { getSuggestionQuery } from '@sourcegraph/shared/src/search/query/providers'
+import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
 import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
 import { queryTokens } from './parsedQuery'
 
 import styles from '../CodeMirrorQueryInput.module.scss'
-import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 
 type CompletionType = SymbolKind | 'queryfilter' | 'repository'
 
@@ -178,19 +178,19 @@ export function searchQueryAutocompletion(
                     throw new Error('this should not happen')
                 }
                 const nodes = tokens.term
-                .flatMap(token => decorate(token))
-                .map(token => {
-                    const decoration = toDecoration(completion.label, token)
-                    const node = document.createElement('span')
-                    node.className = decoration.className
-                    node.textContent = decoration.value
-                    return node
-                })
+                    .flatMap(token => decorate(token))
+                    .map(token => {
+                        const decoration = toDecoration(completion.label, token)
+                        const node = document.createElement('span')
+                        node.className = decoration.className
+                        node.textContent = decoration.value
+                        return node
+                    })
 
                 const container = document.createElement('div')
                 container.style.whiteSpace = 'initial'
                 for (const node of nodes) {
-                    container.appendChild(node)
+                    container.append(node)
                 }
                 return container
             },

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -23,6 +23,7 @@ import {
     mdiFileDocument,
     mdiFilterOutline,
     mdiFunction,
+    mdiHistory,
     mdiKey,
     mdiLink,
     mdiMatrix,
@@ -61,7 +62,7 @@ import { queryTokens } from './parsedQuery'
 
 import styles from '../CodeMirrorQueryInput.module.scss'
 
-type CompletionType = SymbolKind | 'queryfilter' | 'repository'
+type CompletionType = SymbolKind | 'queryfilter' | 'repository' | 'searchhistory'
 
 // See SymbolIcon
 const typeIconMap: Record<CompletionType, string> = {
@@ -94,6 +95,7 @@ const typeIconMap: Record<CompletionType, string> = {
     UNKNOWN: mdiShape,
     queryfilter: mdiFilterOutline,
     repository: mdiSourceBranch,
+    searchhistory: mdiHistory,
 }
 
 function createIcon(pathSpec: string): Node {
@@ -155,9 +157,6 @@ export function searchQueryAutocompletion(
         // This renders the completion icon
         {
             render(completion) {
-                if (completion.type === 'search-history') {
-                    return null
-                }
                 return createIcon(
                     completion.type && completion.type in typeIconMap
                         ? typeIconMap[completion.type as CompletionType]
@@ -170,7 +169,7 @@ export function searchQueryAutocompletion(
         },
         {
             render(completion) {
-                if (completion.type !== 'search-history') {
+                if (completion.type !== 'searchhistory') {
                     return null
                 }
                 const tokens = scanSearchQuery(completion.label)
@@ -240,10 +239,10 @@ export function searchQueryAutocompletion(
             '.cm-tooltip-autocomplete svg path': {
                 fillOpacity: 0.6,
             },
-            '.completion-type-search-history > .cm-completionLabel': {
+            '.completion-type-searchhistory > .cm-completionLabel': {
                 display: 'none',
             },
-            'li.completion-type-search-history': {
+            'li.completion-type-searchhistory': {
                 height: 'initial !important',
                 minHeight: '1.3rem',
             },

--- a/client/search-ui/src/input/extensions/index.ts
+++ b/client/search-ui/src/input/extensions/index.ts
@@ -12,7 +12,6 @@ import {
     StandardSuggestionSource,
 } from './completion'
 import { loadingIndicator } from './loading-indicator'
-import { CompletionResult } from '@codemirror/autocomplete'
 
 export { createDefaultSuggestionSources, searchQueryAutocompletion, StandardSuggestionSource }
 
@@ -77,7 +76,7 @@ export const createDefaultSuggestions = ({
      * Whether or not to allow suggestions selection by Enter key.
      */
     applyOnEnter?: boolean
-}) => [
+}): Extension => [
     searchQueryAutocompletion(
         createDefaultSuggestionSources({
             fetchSuggestions: createCancelableFetchSuggestions(fetchSuggestions),

--- a/client/search-ui/src/input/extensions/index.ts
+++ b/client/search-ui/src/input/extensions/index.ts
@@ -5,10 +5,16 @@ import { Observable } from 'rxjs'
 import { createCancelableFetchSuggestions } from '@sourcegraph/shared/src/search/query/providers'
 import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
-import { createDefaultSuggestionSources, searchQueryAutocompletion } from './completion'
+import {
+    createDefaultSuggestionSources,
+    DefaultSuggestionSourcesOptions,
+    searchQueryAutocompletion,
+    StandardSuggestionSource,
+} from './completion'
 import { loadingIndicator } from './loading-indicator'
+import { CompletionResult } from '@codemirror/autocomplete'
 
-export { createDefaultSuggestionSources, searchQueryAutocompletion }
+export { createDefaultSuggestionSources, searchQueryAutocompletion, StandardSuggestionSource }
 
 /**
  * Creates an extension that calls the provided callback whenever the editor
@@ -62,14 +68,16 @@ export const createDefaultSuggestions = ({
     disableFilterCompletion,
     disableSymbolCompletion,
     applyOnEnter,
-}: {
-    isSourcegraphDotCom: boolean
-    globbing: boolean
+    showWhenEmpty,
+    additionalSources = [],
+}: Omit<DefaultSuggestionSourcesOptions, 'fetchSuggestions'> & {
     fetchSuggestions: (query: string) => Observable<SearchMatch[]>
-    disableSymbolCompletion?: true
-    disableFilterCompletion?: true
+    additionalSources?: StandardSuggestionSource[]
+    /**
+     * Whether or not to allow suggestions selection by Enter key.
+     */
     applyOnEnter?: boolean
-}): Extension => [
+}) => [
     searchQueryAutocompletion(
         createDefaultSuggestionSources({
             fetchSuggestions: createCancelableFetchSuggestions(fetchSuggestions),
@@ -77,7 +85,8 @@ export const createDefaultSuggestions = ({
             isSourcegraphDotCom,
             disableSymbolCompletion,
             disableFilterCompletion,
-        }),
+            showWhenEmpty,
+        }).concat(additionalSources),
         applyOnEnter
     ),
     loadingIndicator(),

--- a/client/search-ui/src/input/extensions/loading-indicator.ts
+++ b/client/search-ui/src/input/extensions/loading-indicator.ts
@@ -40,6 +40,10 @@ export function loadingIndicator({ timeout = DEFAULT_TIMEOUT }: { timeout?: numb
                     this.view.contentDOM.after(this.dom)
                 }
 
+                public destroy(): void {
+                    this.dom.remove()
+                }
+
                 public update(update: ViewUpdate): void {
                     const status = completionStatus(update.state)
                     if (status === 'pending') {

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -1157,6 +1157,81 @@ export const toCSSClassName = (token: DecoratedToken): string => {
     }
 }
 
+interface Decoration {
+    value: string
+    key: number
+    className: string
+}
+
+export function toDecoration(query: string, token: DecoratedToken): Decoration {
+    const className = toCSSClassName(token)
+
+    switch (token.type) {
+        case 'keyword':
+        case 'field':
+        case 'metaPath':
+        case 'metaRevision':
+        case 'metaRegexp':
+        case 'metaStructural':
+            return {
+                value: token.value,
+                key: token.range.start,
+                className,
+            }
+        case 'openingParen':
+            return {
+                value: '(',
+                key: token.range.start,
+                className,
+            }
+        case 'closingParen':
+            return {
+                value: ')',
+                key: token.range.start,
+                className,
+            }
+
+        case 'metaFilterSeparator':
+            return {
+                value: ':',
+                key: token.range.start,
+                className,
+            }
+        case 'metaRepoRevisionSeparator':
+        case 'metaContextPrefix':
+            return {
+                value: '@',
+                key: token.range.start,
+                className,
+            }
+
+        case 'metaPredicate': {
+            let value = ''
+            switch (token.kind) {
+                case 'NameAccess':
+                    value = query.slice(token.range.start, token.range.end)
+                    break
+                case 'Dot':
+                    value = '.'
+                    break
+                case 'Parenthesis':
+                    value = query.slice(token.range.start, token.range.end)
+                    break
+            }
+            return {
+                value,
+                key: token.range.start,
+                className,
+            }
+        }
+    }
+    return {
+        value: query.slice(token.range.start, token.range.end),
+        key: token.range.start,
+        className,
+    }
+}
+
 const decoratedToMonaco = (token: DecoratedToken): Monaco.languages.IToken => {
     switch (token.type) {
         case 'field':

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -79,9 +79,14 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
     const suggestionSources = useMemo(
         () =>
             coreWorkflowImprovementsEnabled && props.authenticatedUser
-                ? [searchQueryHistorySource(props.authenticatedUser.id)]
+                ? [
+                      searchQueryHistorySource({
+                          userId: props.authenticatedUser.id,
+                          selectedSearchContext: props.selectedSearchContextSpec,
+                      }),
+                  ]
                 : [],
-        [props.authenticatedUser, coreWorkflowImprovementsEnabled]
+        [props.authenticatedUser, props.selectedSearchContextSpec, coreWorkflowImprovementsEnabled]
     )
 
     const quickLinks =
@@ -146,7 +151,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         queryState={props.queryState}
                         onChange={props.setQueryState}
                         onSubmit={onSubmit}
-                        autoFocus={!isTouchOnlyDevice && props.autoFocus !== false}
+                        autoFocus={!coreWorkflowImprovementsEnabled && !isTouchOnlyDevice && props.autoFocus !== false}
                         isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
                         applySuggestionsOnEnter={applySuggestionsOnEnter}

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -18,6 +18,7 @@ import { ActivationProps } from '@sourcegraph/shared/src/components/activation/A
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps, isSettingsValid } from '@sourcegraph/shared/src/settings/settings'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
@@ -31,11 +32,10 @@ import {
 } from '../../stores'
 import { ThemePreferenceProps } from '../../theme'
 import { submitSearch } from '../helpers'
+import { searchQueryHistorySource } from '../input/completion'
 import { QuickLinks } from '../QuickLinks'
 
 import styles from './SearchPageInput.module.scss'
-import { searchQueryHistorySource } from '../input/completion'
-import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 
 interface Props
     extends SettingsCascadeProps<Settings>,

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import * as H from 'history'
 import { NavbarQueryState } from 'src/stores/navbarSearchQueryState'
@@ -34,6 +34,8 @@ import { submitSearch } from '../helpers'
 import { QuickLinks } from '../QuickLinks'
 
 import styles from './SearchPageInput.module.scss'
+import { searchQueryHistorySource } from '../input/completion'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 
 interface Props
     extends SettingsCascadeProps<Settings>,
@@ -71,6 +73,15 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
     const editorComponent = useExperimentalFeatures(features => features.editor ?? 'codemirror6')
     const applySuggestionsOnEnter = useExperimentalFeatures(
         features => features.applySearchQuerySuggestionOnEnter ?? false
+    )
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+
+    const suggestionSources = useMemo(
+        () =>
+            coreWorkflowImprovementsEnabled && props.authenticatedUser
+                ? [searchQueryHistorySource(props.authenticatedUser.id)]
+                : [],
+        [props.authenticatedUser, coreWorkflowImprovementsEnabled]
     )
 
     const quickLinks =
@@ -139,6 +150,9 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
                         applySuggestionsOnEnter={applySuggestionsOnEnter}
+                        suggestionSources={suggestionSources}
+                        defaultSuggestionsShowWhenEmpty={!coreWorkflowImprovementsEnabled}
+                        showSuggestionsOnFocus={coreWorkflowImprovementsEnabled}
                     />
                 </div>
                 <QuickLinks quickLinks={quickLinks} className={styles.inputSubContainer} />

--- a/client/web/src/search/input/completion.ts
+++ b/client/web/src/search/input/completion.ts
@@ -76,37 +76,39 @@ export function searchQueryHistorySource({
             return {
                 from: 0,
                 filter: false,
-                options: searches.map(search => {
-                    let query = search.searchText
+                options: searches
+                    .map(search => {
+                        let query = search.searchText
 
-                    {
-                        const result = scanSearchQuery(search.searchText)
-                        if (result.type === 'success') {
-                            query = stringHuman(
-                                result.term.filter(term => {
-                                    switch (term.type) {
-                                        case 'filter':
-                                            if (
-                                                term.field.value === 'context' &&
-                                                term.value?.value === selectedSearchContext
-                                            ) {
-                                                return false
-                                            }
-                                            return true
-                                        default:
-                                            return true
-                                    }
-                                })
-                            )
+                        {
+                            const result = scanSearchQuery(search.searchText)
+                            if (result.type === 'success') {
+                                query = stringHuman(
+                                    result.term.filter(term => {
+                                        switch (term.type) {
+                                            case 'filter':
+                                                if (
+                                                    term.field.value === 'context' &&
+                                                    term.value?.value === selectedSearchContext
+                                                ) {
+                                                    return false
+                                                }
+                                                return true
+                                            default:
+                                                return true
+                                        }
+                                    })
+                                )
+                            }
+                            // TODO: filter out invalid searches
                         }
-                    }
 
-                    return {
-                        // TODO: filter out invalid searches
-                        label: query,
-                        type: 'searchhistory',
-                    }
-                }),
+                        return {
+                            label: query,
+                            type: 'searchhistory',
+                        }
+                    })
+                    .filter(item => item.label.trim() !== ''),
             }
         } catch {
             return null

--- a/client/web/src/search/input/completion.ts
+++ b/client/web/src/search/input/completion.ts
@@ -1,0 +1,110 @@
+import { from } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
+import { StandardSuggestionSource } from '@sourcegraph/search-ui'
+
+import { requestGraphQL } from '../../backend/graphql'
+import { SearchHistoryQueryResult, SearchHistoryQueryVariables } from '../../graphql-operations'
+import { EventLogResult } from '../backend'
+
+interface RecentSearch {
+    count: number
+    searchText: string
+    timestamp: string
+}
+
+const SEARCH_HISTORY_QUERY = gql`
+    query SearchHistoryQuery($userId: ID!) {
+        node(id: $userId) {
+            __typename
+            ... on User {
+                recentSearchLogs: eventLogs(first: 20, eventName: "SearchResultsQueried") {
+                    nodes {
+                        argument
+                        timestamp
+                        url
+                    }
+                    totalCount
+                    pageInfo {
+                        hasNextPage
+                    }
+                }
+            }
+        }
+    }
+`
+
+export function searchQueryHistorySource(userId: string): StandardSuggestionSource {
+    return async (context, tokens) => {
+        if (tokens.length > 0) {
+            return null
+        }
+        // If there are no tokens we must be at position 0
+
+        try {
+            const searches = processRecentSearches(
+                (await from(
+                    requestGraphQL<SearchHistoryQueryResult, SearchHistoryQueryVariables>(SEARCH_HISTORY_QUERY, {
+                        userId,
+                    })
+                )
+                    .pipe(
+                        map(dataOrThrowErrors),
+                        map(({ node }) => {
+                            if (node?.__typename !== 'User') {
+                                return null
+                            }
+                            return node.recentSearchLogs
+                        })
+                    )
+                    .toPromise()) ?? undefined
+            )
+
+            if (!searches) {
+                return null
+            }
+
+            return {
+                from: 0,
+                filter: false,
+                options: searches.map(search => ({
+                    // TODO: filter out invalid searches
+                    label: search.searchText,
+                    type: 'search-history',
+                })),
+            }
+        } catch {
+            return null
+        }
+    }
+}
+
+function processRecentSearches(eventLogResult?: EventLogResult): RecentSearch[] | null {
+    if (!eventLogResult) {
+        return null
+    }
+
+    const recentSearches: Map<string, RecentSearch> = new Map()
+
+    for (const node of eventLogResult.nodes) {
+        if (node.argument) {
+            const parsedArguments = JSON.parse(node.argument)
+            const searchText: string | undefined = parsedArguments?.code_search?.query_data?.combined
+
+            if (searchText) {
+                if (recentSearches.has(searchText)) {
+                    recentSearches.get(searchText)!.count += 1
+                } else {
+                    recentSearches.set(searchText, {
+                        count: 1,
+                        searchText,
+                        timestamp: node.timestamp,
+                    })
+                }
+            }
+        }
+    }
+
+    return Array.from(recentSearches.values()).sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+}


### PR DESCRIPTION
This commit adds the feature to show recent searches in the
autocompletion input on the search homepage when the input is empty.



https://user-images.githubusercontent.com/179026/183091899-fc685dba-8e93-4adc-b244-9af54fc0ac5b.mp4





## Test plan

- Enable coreworkflow improvements
- Go to search homepage.
- Focusing the query input (without content) should show search history entries.

## App preview:

- [Web](https://sg-web-fkling-search-history.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cceqybbdxx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
