### PR TITLE
site admin: Add search functionality to pings JSON view

### DIFF
--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react'
 
 import { json } from '@codemirror/lang-json'
 import { foldGutter } from '@codemirror/language'
+import { search, searchKeymap } from '@codemirror/search'
+import { EditorState } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
 import { isEmpty } from 'lodash'
 import { RouteComponentProps } from 'react-router-dom'
@@ -19,8 +21,6 @@ import { LoadingSpinner, H2, H3, Text, useObservable } from '@sourcegraph/wildca
 
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
-import { search, searchKeymap } from '@codemirror/search'
-import { EditorState } from '@codemirror/state'
 
 interface Props extends RouteComponentProps, ThemeProps {}
 

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 
 import { json } from '@codemirror/lang-json'
 import { foldGutter } from '@codemirror/language'
-import { EditorView } from '@codemirror/view'
+import { EditorView, keymap } from '@codemirror/view'
 import { isEmpty } from 'lodash'
 import { RouteComponentProps } from 'react-router-dom'
 import { fromFetch } from 'rxjs/fetch'
@@ -19,6 +19,8 @@ import { LoadingSpinner, H2, H3, Text, useObservable } from '@sourcegraph/wildca
 
 import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
+import { search, searchKeymap } from '@codemirror/search'
+import { EditorState } from '@codemirror/state'
 
 interface Props extends RouteComponentProps, ThemeProps {}
 
@@ -46,7 +48,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
         useMemo(
             () => [
                 EditorView.darkTheme.of(isLightTheme === false),
-                EditorView.editable.of(false),
+                EditorState.readOnly.of(true),
                 json(),
                 foldGutter(),
                 editorHeight({ height: '300px' }),
@@ -60,6 +62,8 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                 }),
                 defaultEditorTheme,
                 jsonHighlighting,
+                search({ top: true }),
+                keymap.of(searchKeymap),
             ],
             [isLightTheme]
         )


### PR DESCRIPTION
This adds search functionality to the JSON view, which was built into
Monaco, but has to be enabled separately with CodeMirror.

This requires `EditorState.readOnly.of(true)` instead of
`EditorView.editable.of(false)` so that the editor is focusable and
Meta+f can enable the search feature.

<img width="715" alt="2022-08-05_12-49" src="https://user-images.githubusercontent.com/179026/183062789-fe600a82-1238-4445-b2ff-7d6fffa4a104.png">

Note: the UI of the search input doesn't match the rest of the page, but that was already the case with Monaco, so it should be fine. Since CodeMirror allows us to render our own search input we could consider doing that in the future.


## Test plan

Go to `https://sourcegraph.test:3443/site-admin/pings`, focus editor and press Meta+f.

## App preview:

- [Web](https://sg-web-fkling-cm-pings-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ploiwdandm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
