### PR TITLE
flake: re-disable flake from #37233

### DIFF
--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -595,7 +595,7 @@ describe('Batches', () => {
     // See https://github.com/sourcegraph/sourcegraph/issues/37233
     describe('Batch changes details', () => {
         for (const entityType of ['user', 'org'] as const) {
-            it(`displays a single batch change for ${entityType}`, async () => {
+            it.skip(`displays a single batch change for ${entityType}`, async () => {
                 testContext.overrideGraphQL({
                     ...commonWebGraphQlResults,
                     ...batchChangeLicenseGraphQlResults,


### PR DESCRIPTION
Re disable #37233

See https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22builder%22,%22expr%22:%22%7Bapp%3D%5C%22buildkite%5C%22%7D%20%7C%3D%20%60.test-file-diff-node%60%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D failed a lot over the past few days

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Flaky test isn't run

## App preview:

- [Web](https://sg-web-flake-disable-displays-a-single.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jkhajhmyns.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
