### PR TITLE
repos: fix incorrect logging usage

### DIFF
--- a/internal/repos/github_webhook_handler.go
+++ b/internal/repos/github_webhook_handler.go
@@ -2,7 +2,6 @@ package repos
 
 import (
 	"context"
-	"fmt"
 
 	gh "github.com/google/go-github/v43/github"
 
@@ -15,9 +14,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type GitHubWebhookHandler struct{}
+type GitHubWebhookHandler struct {
+	logger log.Logger
+}
 
 func (g *GitHubWebhookHandler) Register(router *webhooks.GitHubWebhook) {
+	g.logger = log.Scoped("repos.GitHubWebhookHandler", "github webhook handler")
 	router.Register(g.handleGitHubWebhook, "push")
 }
 
@@ -37,7 +39,7 @@ func (g *GitHubWebhookHandler) handleGitHubWebhook(ctx context.Context, extSvc *
 		return errors.Wrap(err, "handleGitHubWebhook: EnqueueRepoUpdate failed")
 	}
 
-	log.Scoped("GitHubWebhookhandler", fmt.Sprintf("Successfully updated: %s", resp.Name))
+	g.logger.Info("successfully updated", log.String("name", resp.Name))
 	return nil
 }
 


### PR DESCRIPTION
`Scoped` is not meant to be used to log log entries. From the docstring of `Scoped`:

> Scoped returns the global logger and sets it up with the given scope and OpenTelemetry compliant implementation. Instead of using this everywhere a log is needed, callers should hold a reference to the Logger and pass it in to places that need to log.
>
> Scopes should be static values, NOT dynamic values like identifiers or parameters, and should generally be CamelCased with descriptions that follow our logging conventions - learn more: https://docs.sourcegraph.com/dev/how-to/add_logging#scoped-loggers

Additionally, as per https://docs.sourcegraph.com/dev/how-to/add_logging#scoped-loggers, structs should hold their own references to loggers. I do not see an obvious instantiation path here, so I just added it on `Register` for now. Feel free to follow up with a better instantiation path if desired.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

unit tests