### PR TITLE
database: fix wrong assertions in nested-transactions test

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -140,20 +140,19 @@ func TestDBTransactions(t *testing.T) {
 			}
 
 			// After committing the transaction, repo 2 should be visible
-			// outside the transaction
+			// outside of tx2, in tx1, but not outside of that
 			r, err = tx1.Get(ctx, 2)
 			require.NoError(t, err)
 			require.Equal(t, api.RepoName("test2"), r.Name)
 
-			tx1.Done(nil)
+			_, err = db.Repos().Get(ctx, 2)
+			require.Error(t, err)
 
-			r, err = db.Repos().Get(ctx, 2)
-			require.NoError(t, err)
-			require.Equal(t, api.RepoName("test2"), r.Name)
+			tx1.Done(nil)
 		}
 
 		// After committing the transaction, repo 1 should be visible
-		// outisde the transaction
+		// outside of the transaction
 		r, err := db.Repos().Get(ctx, 1)
 		require.NoError(t, err)
 		require.Equal(t, api.RepoName("test1"), r.Name)
@@ -194,8 +193,11 @@ func TestDBTransactions(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, api.RepoName("test2"), r.Name)
 
-				// Before committing the transaction, repo 2 should not be visible
-				// outside the transaction
+				// Before committing the transaction, repo 2 should be visible inside tx1
+				r, err = tx1.Get(ctx, 2)
+				require.NoError(t, err)
+				require.Equal(t, api.RepoName("test2"), r.Name)
+				// but not outside the transaction
 				_, err = db.Repos().Get(ctx, 2)
 				require.Error(t, err)
 


### PR DESCRIPTION
The transactions weren't nested before, they were concurrent. This
change here makes them concurrent and also changes the assertions to
reflect the new (correct?) behaviour: an outer transaction can see
what's inside a nested transactions, since nested transactions are
implemented with savepoints.

## Test plan

- This test
