### PR TITLE
docs: mark packages as experimental

### DIFF
--- a/doc/admin/external_service/go.md
+++ b/doc/admin/external_service/go.md
@@ -1,9 +1,16 @@
 # Go dependencies
 
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+</p>
+</aside>
+
 Site admins can sync Go modules from any from any Go module proxy, including open source code from proxy.golang.org or a private proxy such as [Athens](https://github.com/gomods/athens), to their Sourcegraph instance so that users can search and navigate the repositories.
 
 To add Go dependencies to Sourcegraph you need to setup a Go dependencies code host:
 
+1. As *site admin*: go to **Site admin > Global settings** and enable the experimental feature by adding: `{"experimentalFeatures": {"goPackages": "enabled"} }`
 1. As *site admin*: go to **Site admin > Manage code hosts**
 1. Select **JVM Dependencies**.
 1. Configure the connection by following the instructions above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).

--- a/doc/admin/external_service/jvm.md
+++ b/doc/admin/external_service/jvm.md
@@ -1,9 +1,16 @@
 # JVM dependencies
 
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+</p>
+</aside>
+
 Site admins can sync JVM dependencies from any Maven repository, including Maven Central, Sonatype, or Artifactory, to their Sourcegraph instance so that users can search and navigate the repositories.
 
 To add JVM dependencies to Sourcegraph you need to setup a JVM dependencies code host:
 
+1. As *site admin*: go to **Site admin > Global settings** and enable the experimental feature by adding: `{"experimentalFeatures": {"jvmPackages": "enabled"} }`
 1. As *site admin*: go to **Site admin > Manage code hosts**
 1. Select **JVM Dependencies**.
 1. [Configure the connection](#configuration) by following the instructions above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).

--- a/doc/admin/external_service/npm.md
+++ b/doc/admin/external_service/npm.md
@@ -1,9 +1,16 @@
 # npm dependencies
 
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+</p>
+</aside>
+
 Site admins can sync npm packages from any npm registry, including open source code from npmjs.com or a private registry such as Verdaccio, to their Sourcegraph instance so that users can search and navigate the repositories.
 
 To add npm dependencies to Sourcegraph you need to setup an npm dependencies code host:
 
+1. As *site admin*: go to **Site admin > Global settings** and enable the experimental feature by adding: `{"experimentalFeatures": {"npmPackages": "enabled"} }`
 1. As *site admin*: go to **Site admin > Manage code hosts**
 1. Select **npm Dependencies**.
 1. [Configure the connection](#configuration) by following the instructions above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).

--- a/doc/admin/external_service/python.md
+++ b/doc/admin/external_service/python.md
@@ -1,9 +1,16 @@
 # Python dependencies
 
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+</p>
+</aside>
+
 Site admins can sync Python packages from any Python package mirror, including open source code from pypi.org or a private mirror such as [Nexus](https://www.sonatype.com/products/nexus-repository), to their Sourcegraph instance so that users can search and navigate the repositories.
 
 To add Python dependencies to Sourcegraph you need to setup a Python dependencies code host:
 
+1. As *site admin*: go to **Site admin > Global settings** and enable the experimental feature by adding: `{"experimentalFeatures": {"pythonPackages": "enabled"} }`
 1. As *site admin*: go to **Site admin > Manage code hosts**
 1. Select **Python Dependencies**.
 1. [Configure the connection](#configuration) by following the instructions above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).


### PR DESCRIPTION
This is a follow-up to
https://github.com/sourcegraph/sourcegraph/pull/39678 in which the
feature was hidden behind a feature flag. This updates the docs to
mention that feature flag and to say that the feature is experimental by
using that disclaimer we use on other pages.

## Test plan

- Checked docs locally with `sg run docsite`