### PR TITLE
sg hacking hour: reduce log output from migrations in tests

### DIFF
--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -193,7 +193,7 @@ func wdHash() string {
 
 func dbConn(logger log.Logger, t testing.TB, cfg *url.URL, schemas ...*schemas.Schema) *sql.DB {
 	t.Helper()
-	db, err := connections.NewTestDB(logger, cfg.String(), schemas...)
+	db, err := connections.NewTestDB(t, logger, cfg.String(), schemas...)
 	if err != nil {
 		t.Fatalf("failed to connect to database %q: %s", cfg, err)
 	}


### PR DESCRIPTION
Previously the migrations would be really noisy in test and log every
time a test database would be migrated up.

This creates a seperate logger for the migrations runner with log level
set to Error (which should be enough for migrations).

## Before
<img width="1722" alt="screenshot_2022-08-05_17 43 03@2x" src="https://user-images.githubusercontent.com/1185253/183113111-68c21fb9-bb09-441d-8944-bef3d552718e.png">

## After
<img width="1090" alt="screenshot_2022-08-05_17 42 42@2x" src="https://user-images.githubusercontent.com/1185253/183113140-97f6af0c-373a-4258-81cd-47c92440d051.png">


## Test plan

Manual testing, see screenshots.