### PR TITLE
ci: run linters on dev/release changes

### DIFF
--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -104,6 +104,10 @@ func ParseDiff(files []string) (diff Diff) {
 		if strings.HasPrefix(p, "doc/") && p != "CHANGELOG.md" {
 			diff |= Docs
 		}
+		// dev/release contains a nodejs script that doesn't have tests but needs to be linted
+		if strings.HasPrefix(p, "dev/release/") {
+			diff |= Docs
+		}
 
 		// Affects Dockerfiles (which assumes images are being changed as well)
 		if strings.HasPrefix(p, "Dockerfile") || strings.HasSuffix(p, "Dockerfile") {

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -147,13 +147,6 @@ func addGraphQLLint(pipeline *bk.Pipeline) {
 		bk.Cmd("dev/ci/yarn-run.sh lint:graphql"))
 }
 
-// yarn ~41s + ~30s
-func addPrettier(pipeline *bk.Pipeline) {
-	pipeline.AddStep(":lipstick: Prettier",
-		withYarnCache(),
-		bk.Cmd("dev/ci/yarn-run.sh format:check"))
-}
-
 // Adds Typescript check.
 func addTypescriptCheck(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":typescript: Build TS",


### PR DESCRIPTION
As mentioned by @leonore in https://github.com/sourcegraph/sourcegraph/pull/40019, making changes on the releases script is broken in CI because the diff detection sees no changes in the pr build type. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg ci preview` with on 8845f1b215b7ebd18b6e35e8e50c0f4367d077f4