### PR TITLE
Code Insights: Support color for compute powered insight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - **IMPORTANT: Search queries with patterns surrounded by** `/.../` **will now be interpreted as regular expressions.** Existing search links or code monitors are unaffected. In the rare event where older links rely on the literal meaning of `/.../`, the string will be automatically quoted it in a `content` filter, preserving the original meaning. If you happen to use an existing older link and want `/.../` to work as a regular expression, add `patterntype:standard` to the query. New queries and code monitors will interpret `/.../` as regular expressions. [#38141](https://github.com/sourcegraph/sourcegraph/pull/38141).
 - The password policy has been updated and is now part of the standard featureset configurable by site-admins. [#39213](https://github.com/sourcegraph/sourcegraph/pull/39213).
 - Replaced the `ALLOW_DECRYPT_MIGRATION` envvar with `ALLOW_DECRYPTION`. See [updated documentation](https://docs.sourcegraph.com/admin/config/encryption). [#39984](https://github.com/sourcegraph/sourcegraph/pull/39984)
+- Compute-powered insight now supports only one series custom colors for compute series bars [40038](https://github.com/sourcegraph/sourcegraph/pull/40038)
 
 ### Fixed
 

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/FormSeries.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/FormSeries.tsx
@@ -28,11 +28,11 @@ export interface FormSeriesProps {
     queryFieldDescription?: ReactNode
 
     /**
-     * This prop hides color picker from the series form. This field is needed for
-     * compute powered insight creation UI, see https://github.com/sourcegraph/sourcegraph/issues/38832
-     * for more details compute doesn't have series colors
+     * For the compute-powered insight we do not support multi series, in order to enforce it
+     * we need to hide this functionality by hiding add new series button.
+     * More context in this issue https://github.com/sourcegraph/sourcegraph/issues/38832
      */
-    showColorPicker?: boolean
+    hasAddNewSeriesButton?: boolean
 }
 
 export const FormSeries: FC<FormSeriesProps> = props => {
@@ -41,7 +41,7 @@ export const FormSeries: FC<FormSeriesProps> = props => {
         showValidationErrorsOnMount,
         repositories,
         queryFieldDescription,
-        showColorPicker = true,
+        hasAddNewSeriesButton = true,
     } = props
 
     const { licensed } = useUiFeatures()
@@ -60,7 +60,6 @@ export const FormSeries: FC<FormSeriesProps> = props => {
                         autofocus={line.autofocus}
                         repositories={repositories}
                         queryFieldDescription={queryFieldDescription}
-                        showColorPicker={showColorPicker}
                         className={classNames('p-3', styles.formSeriesItem)}
                         onSubmit={editCommit}
                         onCancel={() => cancelEdit(line.id)}
@@ -74,7 +73,6 @@ export const FormSeries: FC<FormSeriesProps> = props => {
                             onEdit={() => editRequest(line.id)}
                             onRemove={() => deleteSeries(line.id)}
                             className={styles.formSeriesItem}
-                            showColor={showColorPicker}
                             {...line}
                         />
                     )
@@ -85,16 +83,18 @@ export const FormSeries: FC<FormSeriesProps> = props => {
                 <LimitedAccessLabel message="Unlock Code Insights for unlimited data series" className="mx-auto my-3" />
             )}
 
-            <Button
-                data-testid="add-series-button"
-                type="button"
-                onClick={() => editRequest()}
-                variant="link"
-                disabled={!licensed ? series.length >= 10 : false}
-                className={classNames(styles.formSeriesItem, styles.formSeriesAddButton, 'p-3')}
-            >
-                + Add another data series
-            </Button>
+            {hasAddNewSeriesButton && (
+                <Button
+                    data-testid="add-series-button"
+                    type="button"
+                    onClick={() => editRequest()}
+                    variant="link"
+                    disabled={!licensed ? series.length >= 10 : false}
+                    className={classNames(styles.formSeriesItem, styles.formSeriesAddButton, 'p-3')}
+                >
+                    + Add another data series
+                </Button>
+            )}
         </ul>
     )
 }

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/FormSeriesInput.tsx
@@ -36,13 +36,6 @@ interface FormSeriesInputProps {
      */
     queryFieldDescription?: ReactNode
 
-    /**
-     * This prop hides color picker from the series form. This field is needed for
-     * compute powered insight creation UI, see https://github.com/sourcegraph/sourcegraph/issues/38832
-     * for more details whe compute doesn't have series colors
-     */
-    showColorPicker: boolean
-
     /** Enable autofocus behavior of the first input element of series form. */
     autofocus?: boolean
 
@@ -72,7 +65,6 @@ export const FormSeriesInput: FC<FormSeriesInputProps> = props => {
         autofocus = true,
         repositories,
         queryFieldDescription,
-        showColorPicker,
         onCancel = noop,
         onSubmit = noop,
         onChange = noop,
@@ -156,15 +148,13 @@ export const FormSeriesInput: FC<FormSeriesInputProps> = props => {
                 {...getDefaultInputProps(queryField)}
             />
 
-            {showColorPicker && (
-                <FormColorInput
-                    name={`color group of ${index} series`}
-                    title="Color"
-                    className="mt-4"
-                    value={colorField.input.value}
-                    onChange={colorField.input.onChange}
-                />
-            )}
+            <FormColorInput
+                name={`color group of ${index} series`}
+                title="Color"
+                className="mt-4"
+                value={colorField.input.value}
+                onChange={colorField.input.onChange}
+            />
 
             <div className="mt-4">
                 <Button

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/series-card/SeriesCard.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/series-card/SeriesCard.tsx
@@ -18,13 +18,6 @@ interface SeriesCardProps {
     /** Color value of series. */
     stroke?: string
 
-    /**
-     * This prop hides color picker from the series form. This field is needed for
-     * compute powered insight creation UI, see https://github.com/sourcegraph/sourcegraph/issues/38832
-     * for more details whe compute doesn't have series colors
-     */
-    showColor?: boolean
-
     /** Custom class name for root button element. */
     className?: string
     /** Edit handler. */
@@ -37,16 +30,7 @@ interface SeriesCardProps {
  * Renders series card component, visual list item of series (name, color, query)
  * */
 export function SeriesCard(props: SeriesCardProps): ReactElement {
-    const {
-        disabled,
-        name,
-        query,
-        stroke: color = DEFAULT_DATA_SERIES_COLOR,
-        showColor = true,
-        className,
-        onEdit,
-        onRemove,
-    } = props
+    const { disabled, name, query, stroke: color = DEFAULT_DATA_SERIES_COLOR, className, onEdit, onRemove } = props
 
     return (
         <Card
@@ -58,14 +42,12 @@ export function SeriesCard(props: SeriesCardProps): ReactElement {
         >
             <div className={styles.cardInfo}>
                 <div className={classNames('mb-1 ', styles.cardTitle)}>
-                    {showColor && (
-                        <div
-                            data-testid="series-color-mark"
-                            /* eslint-disable-next-line react/forbid-dom-props */
-                            style={{ color: disabled ? 'var(--icon-muted)' : color }}
-                            className={styles.cardColorMark}
-                        />
-                    )}
+                    <div
+                        data-testid="series-color-mark"
+                        /* eslint-disable-next-line react/forbid-dom-props */
+                        style={{ color: disabled ? 'var(--icon-muted)' : color }}
+                        className={styles.cardColorMark}
+                    />
                     <span
                         data-testid="series-name"
                         title={name}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -32,8 +32,8 @@ import {
     DrillDownFiltersPopover,
     DrillDownInsightCreationFormValues,
     BackendInsightChart,
+    parseSeriesLimit,
 } from './components'
-import { parseSeriesLimit } from './components/drill-down-filters-panel/drill-down-filters/utils'
 
 import styles from './BackendInsight.module.scss'
 
@@ -185,19 +185,19 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
             onMouseEnter={trackMouseEnter}
             onMouseLeave={trackMouseLeave}
         >
-            <InsightCardHeader
-                title={
-                    <Link
-                        to={`${window.location.origin}/insights/insight/${insight.id}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
+            {isVisible && (
+                <>
+                    <InsightCardHeader
+                        title={
+                            <Link
+                                to={`${window.location.origin}/insights/insight/${insight.id}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                {insight.title}
+                            </Link>
+                        }
                     >
-                        {insight.title}
-                    </Link>
-                }
-            >
-                {isVisible && (
-                    <>
                         <DrillDownFiltersPopover
                             isOpen={isFiltersOpen}
                             anchor={insightCardReference}
@@ -215,30 +215,30 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                             zeroYAxisMin={zeroYAxisMin}
                             onToggleZeroYAxisMin={() => setZeroYAxisMin(!zeroYAxisMin)}
                         />
-                    </>
-                )}
-            </InsightCardHeader>
+                    </InsightCardHeader>
 
-            {resizing ? (
-                <InsightCardBanner>Resizing</InsightCardBanner>
-            ) : error ? (
-                <BackendInsightErrorAlert error={error} />
-            ) : loading || !isVisible || !insightData ? (
-                <InsightCardLoading>Loading code insight</InsightCardLoading>
-            ) : (
-                <BackendInsightChart
-                    {...insightData}
-                    locked={insight.isFrozen}
-                    zeroYAxisMin={zeroYAxisMin}
-                    seriesToggleState={seriesToggleState}
-                    onDatumClick={trackDatumClicks}
-                />
+                    {resizing ? (
+                        <InsightCardBanner>Resizing</InsightCardBanner>
+                    ) : error ? (
+                        <BackendInsightErrorAlert error={error} />
+                    ) : loading || !insightData ? (
+                        <InsightCardLoading>Loading code insight</InsightCardLoading>
+                    ) : (
+                        <BackendInsightChart
+                            {...insightData}
+                            locked={insight.isFrozen}
+                            zeroYAxisMin={zeroYAxisMin}
+                            seriesToggleState={seriesToggleState}
+                            onDatumClick={trackDatumClicks}
+                        />
+                    )}
+                    {
+                        // Passing children props explicitly to render any top-level content like
+                        // resize-handler from the react-grid-layout library
+                        otherProps.children
+                    }
+                </>
             )}
-            {
-                // Passing children props explicitly to render any top-level content like
-                // resize-handler from the react-grid-layout library
-                isVisible && otherProps.children
-            }
         </InsightCard>
     )
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -185,19 +185,19 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
             onMouseEnter={trackMouseEnter}
             onMouseLeave={trackMouseLeave}
         >
-            {isVisible && (
-                <>
-                    <InsightCardHeader
-                        title={
-                            <Link
-                                to={`${window.location.origin}/insights/insight/${insight.id}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                {insight.title}
-                            </Link>
-                        }
+            <InsightCardHeader
+                title={
+                    <Link
+                        to={`${window.location.origin}/insights/insight/${insight.id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
                     >
+                        {insight.title}
+                    </Link>
+                }
+            >
+                {isVisible && (
+                    <>
                         <DrillDownFiltersPopover
                             isOpen={isFiltersOpen}
                             anchor={insightCardReference}
@@ -215,30 +215,30 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                             zeroYAxisMin={zeroYAxisMin}
                             onToggleZeroYAxisMin={() => setZeroYAxisMin(!zeroYAxisMin)}
                         />
-                    </InsightCardHeader>
+                    </>
+                )}
+            </InsightCardHeader>
 
-                    {resizing ? (
-                        <InsightCardBanner>Resizing</InsightCardBanner>
-                    ) : error ? (
-                        <BackendInsightErrorAlert error={error} />
-                    ) : loading || !insightData ? (
-                        <InsightCardLoading>Loading code insight</InsightCardLoading>
-                    ) : (
-                        <BackendInsightChart
-                            {...insightData}
-                            locked={insight.isFrozen}
-                            zeroYAxisMin={zeroYAxisMin}
-                            seriesToggleState={seriesToggleState}
-                            onDatumClick={trackDatumClicks}
-                        />
-                    )}
-                    {
-                        // Passing children props explicitly to render any top-level content like
-                        // resize-handler from the react-grid-layout library
-                        otherProps.children
-                    }
-                </>
+            {resizing ? (
+                <InsightCardBanner>Resizing</InsightCardBanner>
+            ) : error ? (
+                <BackendInsightErrorAlert error={error} />
+            ) : loading || !isVisible || !insightData ? (
+                <InsightCardLoading>Loading code insight</InsightCardLoading>
+            ) : (
+                <BackendInsightChart
+                    {...insightData}
+                    locked={insight.isFrozen}
+                    zeroYAxisMin={zeroYAxisMin}
+                    seriesToggleState={seriesToggleState}
+                    onDatumClick={trackDatumClicks}
+                />
             )}
+            {
+                // Passing children props explicitly to render any top-level content like
+                // resize-handler from the react-grid-layout library
+                isVisible && otherProps.children
+            }
         </InsightCard>
     )
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -67,14 +67,9 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
     const mergedInsightCardReference = useMergeRefs([insightCardReference, innerRef])
     const { wasEverVisible, isVisible } = useVisibility(insightCardReference)
 
-    // Use deep copy check in case if a setting subject has re-created copy of
-    // the insight config with same structure and values. To avoid insight data
-    // re-fetching.
-    const cachedInsight = useDeepMemo(insight)
-
     // Original insight filters values that are stored in setting subject with insight
     // configuration object, They are updated  whenever the user clicks update/save button
-    const [originalInsightFilters, setOriginalInsightFilters] = useState(cachedInsight.filters)
+    const [originalInsightFilters, setOriginalInsightFilters] = useState(insight.filters)
 
     // Live valid filters from filter form. They are updated whenever the user is changing
     // filter value in filters fields.
@@ -181,8 +176,6 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
         insightType: getTrackingTypeByInsightType(insight.type),
     })
 
-    const shareableUrl = `${window.location.origin}/insights/insight/${insight.id}`
-
     return (
         <InsightCard
             {...otherProps}
@@ -194,7 +187,11 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
         >
             <InsightCardHeader
                 title={
-                    <Link to={shareableUrl} target="_blank" rel="noopener noreferrer">
+                    <Link
+                        to={`${window.location.origin}/insights/insight/${insight.id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
                         {insight.title}
                     </Link>
                 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
@@ -7,19 +7,30 @@
     grid-template-columns: auto minmax(10rem, 30%);
     grid-template-rows: auto 1fr;
     gap: 0.75rem;
+
     grid-template-areas:
         'chart chart'
-        'chart chart'
-        'legend legend';
+        'chart chart';
 
-    &--horizontal {
+    // Hack for generating a proper scoped css nested class
+    // see https://css-tricks.com/using-sass-control-scope-bem-naming/
+    $self: &;
+
+    &--withLegend {
         grid-template-areas:
-            'chart legend'
-            'chart legend';
+            'chart chart'
+            'chart chart'
+            'legend legend';
 
-        .legend-list {
-            flex-wrap: nowrap;
-            flex-direction: column;
+        &#{ $self }--horizontal {
+            grid-template-areas:
+                'chart legend'
+                'chart legend';
+
+            .legend-list {
+                flex-wrap: nowrap;
+                flex-direction: column;
+            }
         }
     }
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
@@ -16,6 +16,7 @@
     // see https://css-tricks.com/using-sass-control-scope-bem-naming/
     $self: &;
 
+    // stylelint-disable-next-line selector-class-pattern
     &--withLegend {
         grid-template-areas:
             'chart chart'

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -69,11 +69,7 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                 [styles.rootWithLegend]: isSeriesLikeInsight,
             })}
         >
-            <ParentSize
-                debounceTime={0}
-                enableDebounceLeadingCall={true}
-                className={styles.responsiveContainer}
-            >
+            <ParentSize debounceTime={0} enableDebounceLeadingCall={true} className={styles.responsiveContainer}>
                 {parent => (
                     <>
                         <BackendAlertOverlay

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -4,8 +4,6 @@ import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
 import useResizeObserver from 'use-resize-observer'
 
-import { useDebounce } from '@sourcegraph/wildcard'
-
 import { getLineColor, LegendItem, LegendList, ScrollBox, Series } from '../../../../../../../../charts'
 import { BarChart } from '../../../../../../../../charts/components/bar-chart/BarChart'
 import { UseSeriesToggleReturn } from '../../../../../../../../insights/utils/use-series-toggle'
@@ -51,7 +49,7 @@ interface BackendInsightChartProps<Datum> extends BackendInsightData {
 
 export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum>): React.ReactElement {
     const { locked, isFetchingHistoricalData, data, zeroYAxisMin, className, onDatumClick, seriesToggleState } = props
-    const { ref, width = 0 } = useDebounce(useResizeObserver(), 100)
+    const { ref, width = 0 } = useResizeObserver()
     const { setHoveredId } = seriesToggleState
 
     const isEmptyDataset = useMemo(() => hasNoData(data), [data])
@@ -69,38 +67,46 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                 [styles.rootWithLegend]: isSeriesLikeInsight,
             })}
         >
-            <ParentSize debounceTime={0} enableDebounceLeadingCall={true} className={styles.responsiveContainer}>
-                {parent => (
-                    <>
-                        <BackendAlertOverlay
-                            hasNoData={isEmptyDataset}
-                            isFetchingHistoricalData={isFetchingHistoricalData}
-                            className={styles.alertOverlay}
-                        />
+            {width && (
+                <>
+                    <ParentSize
+                        debounceTime={0}
+                        enableDebounceLeadingCall={true}
+                        className={styles.responsiveContainer}
+                    >
+                        {parent => (
+                            <>
+                                <BackendAlertOverlay
+                                    hasNoData={isEmptyDataset}
+                                    isFetchingHistoricalData={isFetchingHistoricalData}
+                                    className={styles.alertOverlay}
+                                />
 
-                        {data.type === InsightContentType.Series ? (
-                            <SeriesChart
-                                type={SeriesBasedChartTypes.Line}
-                                width={parent.width}
-                                height={parent.height}
-                                locked={locked}
-                                className={styles.chart}
-                                onDatumClick={onDatumClick}
-                                zeroYAxisMin={zeroYAxisMin}
-                                seriesToggleState={seriesToggleState}
-                                {...data.content}
-                            />
-                        ) : (
-                            <BarChart width={parent.width} height={parent.height} {...data.content} />
+                                {data.type === InsightContentType.Series ? (
+                                    <SeriesChart
+                                        type={SeriesBasedChartTypes.Line}
+                                        width={parent.width}
+                                        height={parent.height}
+                                        locked={locked}
+                                        className={styles.chart}
+                                        onDatumClick={onDatumClick}
+                                        zeroYAxisMin={zeroYAxisMin}
+                                        seriesToggleState={seriesToggleState}
+                                        {...data.content}
+                                    />
+                                ) : (
+                                    <BarChart width={parent.width} height={parent.height} {...data.content} />
+                                )}
+                            </>
                         )}
-                    </>
-                )}
-            </ParentSize>
+                    </ParentSize>
 
-            {isSeriesLikeInsight && (
-                <ScrollBox className={styles.legendListContainer} onMouseLeave={() => setHoveredId(undefined)}>
-                    <SeriesLegends series={data.content.series} seriesToggleState={seriesToggleState} />
-                </ScrollBox>
+                    {isSeriesLikeInsight && (
+                        <ScrollBox className={styles.legendListContainer} onMouseLeave={() => setHoveredId(undefined)}>
+                            <SeriesLegends series={data.content.series} seriesToggleState={seriesToggleState} />
+                        </ScrollBox>
+                    )}
+                </>
             )}
         </div>
     )

--- a/client/web/src/enterprise/insights/components/modals/ShareLinkModal/ShareLinkModal.tsx
+++ b/client/web/src/enterprise/insights/components/modals/ShareLinkModal/ShareLinkModal.tsx
@@ -17,7 +17,7 @@ import {
     isOrganizationOwner,
     isVirtualDashboard,
 } from '../../../core'
-import { useCopyURLHandler } from '../../../hooks/use-copy-url-handler'
+import { useCopyURLHandler } from '../../../hooks'
 
 import { decodeDashboardIds, GET_SHARABLE_INSIGHT_INFO_GQL } from './get-sharable-insight-info'
 

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/deserializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/deserializators.ts
@@ -2,7 +2,7 @@ import { InsightDataNode } from '../../../../../../../graphql-operations'
 import { BackendInsight, isComputeInsight } from '../../../../types'
 import { InsightContentType } from '../../../../types/insight/common'
 import { BackendInsightData } from '../../../code-insights-backend-types'
-import { createCategoricalChart } from '../../../utils/create-categorical-content'
+import { createComputeCategoricalChart } from '../../../utils/create-categorical-content'
 import { createLineChartContent } from '../../../utils/create-line-chart-content'
 
 export const MAX_NUMBER_OF_SERIES = 20
@@ -21,7 +21,7 @@ export const createBackendInsightData = (insight: BackendInsight, response: Insi
             isFetchingHistoricalData: isFetchingHistoricalData || seriesData.some(series => !series.label),
             data: {
                 type: InsightContentType.Categorical,
-                content: createCategoricalChart(seriesData),
+                content: createComputeCategoricalChart(insight, seriesData),
             },
         }
     }

--- a/client/web/src/enterprise/insights/core/backend/utils/create-categorical-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-categorical-content.ts
@@ -15,7 +15,7 @@ export function createComputeCategoricalChart(
     seriesData: InsightDataSeries[]
 ): CategoricalChartContent<CategoricalDatum> {
     const seriesGroups = groupBy(
-        seriesData.filter(series => series.label),
+        seriesData.filter(series => series.label && series.points.length),
         series => series.label
     )
 

--- a/client/web/src/enterprise/insights/core/backend/utils/create-categorical-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-categorical-content.ts
@@ -1,9 +1,8 @@
 import { groupBy } from 'lodash'
 
 import { InsightDataSeries } from '../../../../../graphql-operations'
+import { ComputeInsight } from '../../types'
 import { CategoricalChartContent } from '../code-insights-backend-types'
-
-import { DATA_SERIES_COLORS_LIST } from './create-line-chart-content'
 
 interface CategoricalDatum {
     name: string
@@ -11,14 +10,17 @@ interface CategoricalDatum {
     value: number
 }
 
-export function createCategoricalChart(seriesData: InsightDataSeries[]): CategoricalChartContent<CategoricalDatum> {
+export function createComputeCategoricalChart(
+    insight: ComputeInsight,
+    seriesData: InsightDataSeries[]
+): CategoricalChartContent<CategoricalDatum> {
     const seriesGroups = groupBy(
         seriesData.filter(series => series.label),
         series => series.label
     )
 
     // Group series result by seres name and sum up series value with the same name
-    const groups = Object.keys(seriesGroups).map((key, index) =>
+    const groups = Object.keys(seriesGroups).map(key =>
         seriesGroups[key].reduce(
             (memo, series) => {
                 memo.value += series.points.reduce((sum, datum) => sum + datum.value, 0)
@@ -27,7 +29,7 @@ export function createCategoricalChart(seriesData: InsightDataSeries[]): Categor
             },
             {
                 name: seriesGroups[key][0].label,
-                fill: DATA_SERIES_COLORS_LIST[index % DATA_SERIES_COLORS_LIST.length],
+                fill: insight.series[0]?.stroke ?? 'gray',
                 value: 0,
             }
         )

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
@@ -149,7 +149,7 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
                         seriesField={series}
                         repositories={repositories.input.value}
                         showValidationErrorsOnMount={formAPI.submitted}
-                        showColorPicker={false}
+                        hasAddNewSeriesButton={false}
                         queryFieldDescription={
                             <ul className="pl-3">
                                 <li>

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeLivePreview.tsx
@@ -91,7 +91,7 @@ export const ComputeLivePreview: React.FunctionComponent<ComputeLivePreviewProps
                                 <BarChart
                                     width={parent.width}
                                     height={parent.height}
-                                    data={mapSeriesToCompute(state.data.series)}
+                                    data={mapSeriesToCompute(settings.series, state.data.series)}
                                     getCategory={(datum: LanguageUsageDatum) => datum.group}
                                     getDatumName={(datum: LanguageUsageDatum) => datum.name}
                                     getDatumValue={(datum: LanguageUsageDatum) => datum.value}
@@ -117,8 +117,8 @@ export const ComputeLivePreview: React.FunctionComponent<ComputeLivePreviewProps
 
                 {state.status === StateStatus.Data && (
                     <LegendList className="mt-3">
-                        {mapSeriesToCompute(state.data.series).map(series => (
-                            <LegendItem key={series.name} color={series.fill} name={series.name} />
+                        {settings.series.map(series => (
+                            <LegendItem key={series.label} color={series.stroke} name={series.label} />
                         ))}
                     </LegendList>
                 )}
@@ -127,7 +127,10 @@ export const ComputeLivePreview: React.FunctionComponent<ComputeLivePreviewProps
     )
 }
 
-const mapSeriesToCompute = (series: Series<BackendInsightDatum>[]): LanguageUsageDatum[] => {
+const mapSeriesToCompute = (
+    seriesDefinitions: SeriesPreviewSettings[],
+    series: Series<BackendInsightDatum>[]
+): LanguageUsageDatum[] => {
     const seriesGroups = groupBy(
         series.filter(series => series.name),
         series => series.name
@@ -143,7 +146,9 @@ const mapSeriesToCompute = (series: Series<BackendInsightDatum>[]): LanguageUsag
             },
             {
                 name: getComputeSeriesName(seriesGroups[key][0]),
-                fill: getComputeSeriesColor(seriesGroups[key][0]),
+                // We pick color only from the first series since compute-powered insight
+                // can't have more than one series see https://github.com/sourcegraph/sourcegraph/issues/38832
+                fill: getComputeSeriesColor(seriesDefinitions[0]),
                 value: 0,
             }
         )
@@ -151,5 +156,4 @@ const mapSeriesToCompute = (series: Series<BackendInsightDatum>[]): LanguageUsag
 }
 
 const getComputeSeriesName = (series: Series<any>): string => (series.name ? series.name : 'Other')
-const getComputeSeriesColor = (series: Series<any>): string =>
-    series.name ? series.color ?? 'var(--blue)' : 'var(--oc-gray-4)'
+const getComputeSeriesColor = (series: SeriesPreviewSettings): string => series.stroke ?? 'var(--blue)'

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
@@ -76,8 +76,8 @@ export const ComputeInsightCard: React.FunctionComponent<React.PropsWithChildren
     <InsightCard {...props}>
         <ComputeInsightChart className={styles.chart} />
         <InsightCardBody title="Group results" className="mb-3">
-            Insight that <b>groups results</b> by repository, path, author or date. You will define each data series
-            manually.
+            Insight based on a custom Sourcegraph search query that <b>groups results by</b> repository, path, author or
+            date.
         </InsightCardBody>
 
         <InsightCardExampleBlock>Tracking a migration by repository.</InsightCardExampleBlock>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/38832
Fixes https://github.com/sourcegraph/sourcegraph/issues/39917

## Background 
Considering a given timeframe for Sourcegraph 4.0, we disable multi-series support for compute-powered insight. This PR 
- hides add a new series button in the creation UI
- adds colour picker to series creation form
- adjust the insight card layout for the compute-powered insight. Now it doesn't render legend block (see related comment https://github.com/sourcegraph/sourcegraph/pull/39805#issuecomment-1205879211) 

## Test plan
- Go to the compute insight creation UI 
- Create compute insight (make sure that you can't have more than one series) 
- See that this insight was created correctly, and you can see it on the dashboard page. 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-one-series-compute-insight.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qgqlyenkco.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
