### PR TITLE
batches: better responsiveness in y direction

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.module.scss
@@ -44,7 +44,7 @@
     margin-bottom: 1.5rem;
     flex-shrink: 0;
 
-    & > span {
+    > span {
         display: block;
         max-height: max(15vh, 80px);
         overflow-y: auto;

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.module.scss
@@ -4,19 +4,19 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    // Default of min-height: auto when this element is display: flex allows children to
-    // set its height. We want to keep this fixed and have children overflow: auto
-    // instead.
-    min-height: 0;
+    min-height: 720px;
     width: 100%;
     margin-top: 1.5rem;
+    margin-bottom: -1.5rem;
+    padding-bottom: 1.5rem;
 
     @media (--lg-breakpoint-down) {
         overflow-x: auto;
+        min-height: max(720px, 80vh);
     }
 
     @media (--md-breakpoint-down) {
-        min-height: 95vh;
+        min-height: max(720px, 95vh);
     }
 }
 
@@ -43,13 +43,22 @@
 .errors {
     margin-bottom: 1.5rem;
     flex-shrink: 0;
+
+    & > span {
+        display: block;
+        max-height: max(15vh, 80px);
+        overflow-y: auto;
+    }
 }
 
 .inner {
     display: flex;
     flex: 1;
     min-height: 0;
+}
 
+.errors,
+.inner {
     @media (--lg-breakpoint-down) {
         min-width: min(50rem, 165vw);
     }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39902.

I was feeling the need to actually do something with our codebase this week that wasn't docs or hacking around with compute stuff. So, here's a fix to the UI issue reported on screens with limited vertical real estate when there's a lot of errors.

Changes:
- Caps the max height of the error banner, after which point it's scrollable. Like the feedback panel underneath the SSBC Monaco editor is.
- Enforces minimum heights on the workspaces list and details container all the time, not just after breakpoints.

Demo with a long error message at various screen sizes with decreasing vertical heights:

https://user-images.githubusercontent.com/8942601/183159753-e0c4034c-1647-4c4c-b03f-0a6e29ad17f5.mov

## Test plan

Manual testing at different resolutions with many workspaces and a large error message.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-no-squishy-screen.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wnaezsqjkq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
