### PR TITLE
feature flags: aligned rollout basis points slider spacing

### DIFF
--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -709,7 +709,7 @@ const FeatureFlagRolloutValueSettings: React.FunctionComponent<
             max="10000"
             className="mb-0"
             label={<H3>Value</H3>}
-            inputClassName="w-25 form-range"
+            inputClassName="p-0 w-25"
             value={value.rolloutBasisPoints}
             onChange={({ target }) => {
                 update({ rolloutBasisPoints: parseInt(target.value, 10) })

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -699,7 +699,7 @@ const FeatureFlagRolloutValueSettings: React.FunctionComponent<
         update: (next: FeatureFlagRolloutValue) => void
     }>
 > = ({ value, update }) => (
-    <div className="form-group d-flex flex-column">
+    <div className="form-group d-flex flex-column align-content-start">
         <Input
             type="range"
             id="rollout-value"
@@ -709,7 +709,7 @@ const FeatureFlagRolloutValueSettings: React.FunctionComponent<
             max="10000"
             className="mb-0"
             label={<H3>Value</H3>}
-            inputClassName="w-25"
+            inputClassName="w-25 form-range"
             value={value.rolloutBasisPoints}
             onChange={({ target }) => {
                 update({ rolloutBasisPoints: parseInt(target.value, 10) })

--- a/client/wildcard/src/components/Form/Input/Input.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.tsx
@@ -77,7 +77,8 @@ export const Input = forwardRef((props, reference) => {
                         inputClassName,
                         status === InputStatus.loading && styles.inputLoading,
                         'with-invalid-icon',
-                        {   'form-control' : type !== 'range',
+                        {
+                            'form-control': type !== 'range',
                             'is-valid': status === InputStatus.valid,
                             'is-invalid': error || status === InputStatus.error,
                             'form-control-sm': variant === 'small',

--- a/client/wildcard/src/components/Form/Input/Input.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.tsx
@@ -76,9 +76,8 @@ export const Input = forwardRef((props, reference) => {
                     className={classNames(
                         inputClassName,
                         status === InputStatus.loading && styles.inputLoading,
-                        'form-control',
                         'with-invalid-icon',
-                        {
+                        {   'form-control' : type !== 'range',
                             'is-valid': status === InputStatus.valid,
                             'is-invalid': error || status === InputStatus.error,
                             'form-control-sm': variant === 'small',

--- a/client/wildcard/src/components/Form/Input/Input.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.tsx
@@ -76,9 +76,9 @@ export const Input = forwardRef((props, reference) => {
                     className={classNames(
                         inputClassName,
                         status === InputStatus.loading && styles.inputLoading,
+                        'form-control',
                         'with-invalid-icon',
                         {
-                            'form-control': type !== 'range',
                             'is-valid': status === InputStatus.valid,
                             'is-invalid': error || status === InputStatus.error,
                             'form-control-sm': variant === 'small',


### PR DESCRIPTION
relates to: https://github.com/sourcegraph/sourcegraph/issues/40006

the 'form-control' class in bootstrap is used for textual inputs and selects and forces all the inputs to have the same formatting, and this formatting gives the slider that odd left and right padding on the mins and max values.

Set padding to 0 

## Test plan
tested locally
spacing before 
![image](https://user-images.githubusercontent.com/78464298/183160612-7862f98c-3e16-45b7-96bc-ce2abb25b671.png)
![image](https://user-images.githubusercontent.com/78464298/183160673-3d91426b-041c-4e21-b5fa-86a0b6bd77ad.png)
spacing after removing form-control from slider Input class:
<img width="959" alt="image" src="https://user-images.githubusercontent.com/78464298/183160898-55c99496-3d51-4afb-a8ad-e0c0585a8419.png">
<img width="959" alt="image" src="https://user-images.githubusercontent.com/78464298/183160930-bb3c993b-8e86-47f3-9734-f05a2fe28b6b.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-manny-feature-fag-slider.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vydsaodnlu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

