### PR TITLE
Insights/replace captured values in query

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/regexp.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp.go
@@ -113,6 +113,12 @@ func findGroups(pattern string) (groups []group) {
 			opens = append(opens, g)
 
 		} else if pattern[i] == ')' && !inCharClass {
+			if len(opens) == 0 {
+				// this shouldn't happen if we are parsing a well formed regexp since it
+				// effectively means we have encountered a closing parenthesis without a
+				// corresponding open, but for completeness here this will no-op
+				return nil
+			}
 			current := opens[len(opens)-1]
 			current.end = i
 			groups = append(groups, current)

--- a/enterprise/internal/insights/query/querybuilder/regexp.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp.go
@@ -1,74 +1,47 @@
 package querybuilder
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/grafana/regexp"
 )
 
-// replaceCaptureGroupsWithString will replace capturing groups in a regexp
-// pattern with their respective literal matches. This is somewhat an inverse
+// replaceCaptureGroupsWithString will replace the first capturing group in a regexp
+// pattern with a replacement literal. This is somewhat an inverse
 // operation of capture groups, with the goal being to produce a new regexp that
 // can match a specific instance of a captured value. For example, given the
-// pattern `(\w+)-(\w+)` and the text `cat-cow dog-pig` this would generate a
-// new regexp `(?:cat|dog)-(?:cow|pig)` The maxGroup argument allows
-// control over how many capture groups are replaced (up to and including capture group N, indexed at 1). If the value is
-// negative all capture groups will be replaced. Each capture group that is replaced will be converted
-// into a non-capturing group containing the literal matches.
-func replaceCaptureGroupsWithString(pattern string, groups []group, matches [][]string, maxGroup int) string {
+// pattern `(\w+)-(\w+)` and the replacement `cat` this would generate a
+// new regexp `(?:cat)-(\w+)` The capture group that is replaced will be converted
+// into a non-capturing group containing the literal replacement.
+func replaceCaptureGroupsWithString(pattern string, groups []group, replacement string) string {
 	if len(groups) < 1 {
-		return pattern
-	} else if len(matches) == 0 || len(matches[0]) == 0 {
 		return pattern
 	}
 	var sb strings.Builder
 
-	capturing := make([]group, 0, len(groups))
-	for _, g := range groups {
-		if g.capturing {
-			capturing = append(capturing, g)
-		}
-	}
-
-	// groups need to be in stable order
-	sort.Slice(capturing, func(i, j int) bool {
-		return capturing[i].start < capturing[j].start
-	})
-	// todo handle nested groups by generating a set of non-overlapping groups
-
-	// pivot the matches from [match][group_number] to [group_number][match] to more easily reference the set of literals
-	pivotMatches := make([][]string, len(matches[0]))
-	for i := range pivotMatches {
-		pivotMatches[i] = make([]string, 0, len(matches))
-	}
-	for _, match := range matches {
-		for inner, literal := range match {
-			pivotMatches[inner] = append(pivotMatches[inner], regexp.QuoteMeta(literal))
-		}
-	}
-
-	if maxGroup < 0 {
-		// even though the length of groups isn't necessarily the number of matched
-		// groups we can still use that as the max index here. The iteration will
-		// effectively become the minimum of this and the actual length. We
-		maxGroup = len(capturing)
-	}
-	offset := 0
-	for groupIndex, group := range capturing {
-		if !group.capturing {
+	// extract the first capturing group by finding the capturing group with the smallest group number
+	var firstCapturing *group
+	for i := range groups {
+		current := groups[i]
+		if !current.capturing {
 			continue
-		} else if groupIndex > (maxGroup - 1) {
-			// the -1 offset is because we reference regexp groups with submatches starting at 1, whereas the array offset is 0
-			break
 		}
-		sb.WriteString(pattern[offset:group.start])
-		sb.WriteString("(?:")
-		sb.WriteString(strings.Join(pivotMatches[group.number], "|"))
-		sb.WriteString(")")
-		offset = group.end + 1
+		if firstCapturing == nil || current.number < firstCapturing.number {
+			firstCapturing = &current
+		}
 	}
-	if offset < len(pattern) {
+	if firstCapturing == nil {
+		return pattern
+	}
+
+	offset := 0
+	sb.WriteString(pattern[offset:firstCapturing.start])
+	sb.WriteString("(?:")
+	sb.WriteString(regexp.QuoteMeta(replacement))
+	sb.WriteString(")")
+	offset = firstCapturing.end + 1
+
+	if firstCapturing.end+1 < len(pattern) {
 		// this will copy the rest of the pattern if the last group isn't the end of the pattern string
 		sb.WriteString(pattern[offset:])
 	}

--- a/enterprise/internal/insights/query/querybuilder/regexp.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp.go
@@ -75,7 +75,7 @@ type group struct {
 
 // findGroups will extract all capturing and non-capturing groups from a
 // **valid** regexp string. If the provided string is not a valid regexp this
-// function may panic.
+// function may panic or otherwise return undefined results.
 // This will return all groups (including nested), but not necessarily in any interesting order.
 func findGroups(pattern string) (groups []group) {
 	var opens []group

--- a/enterprise/internal/insights/query/querybuilder/regexp.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp.go
@@ -57,7 +57,7 @@ func replaceRange(pattern string, groups []group) string {
 	for _, group := range groups {
 		sb.WriteString(pattern[offset:group.start])
 		sb.WriteString(group.value)
-		offset = group.end
+		offset = group.end + 1
 	}
 	if offset < len(pattern) {
 		sb.WriteString(pattern[offset:])

--- a/enterprise/internal/insights/query/querybuilder/regexp.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp.go
@@ -1,0 +1,117 @@
+package querybuilder
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/regexp"
+)
+
+func main() {
+	pattern := `name:\((.*)\)(.*) [(] asdf`
+
+	text := `name:(test1) ( asdf`
+
+	reg, err := regexp.Compile(pattern)
+	if err != nil {
+		panic(err)
+	}
+
+	matches := reg.FindStringSubmatch(text)
+	// println(len(matches))
+	// for _, match := range matches {
+	// 	fmt.Println(match)
+	// }
+
+	groups := findGroups(pattern)
+
+	for _, g := range groups {
+		if !g.capturing {
+			continue
+		}
+		g.value = matches[g.number]
+	}
+
+	fmt.Println(groups)
+	// fmt.Println(pairs)
+	// fmt.Println(fmt.Sprintf("old_pattern: %s", pattern))
+	// fmt.Println(fmt.Sprintf("document: %s", text))
+	// fmt.Println(fmt.Sprintf("new_pattern: %s", replaceRange(pattern, matches[1], pairs)))
+}
+
+// func replaceCaptureGroups(pattern, replace string) (string, error) {
+//
+// }
+
+type pair struct {
+	x, y int
+}
+
+func replaceRange(pattern string, groups []group) string {
+	if len(groups) < 1 {
+		return pattern
+	}
+	var sb strings.Builder
+
+	offset := 0
+	for _, group := range groups {
+		sb.WriteString(pattern[offset:group.start])
+		sb.WriteString(group.value)
+		offset = group.end
+	}
+	if offset < len(pattern) {
+		sb.WriteString(pattern[offset:])
+	}
+	return sb.String()
+}
+
+type group struct {
+	start     int
+	end       int
+	capturing bool
+	number    int
+	value     string
+}
+
+func findGroups(pattern string) (groups []group) {
+	var opens []group
+	inCharClass := false
+	groupNumber := 0
+	for i := 0; i < len(pattern); i++ {
+		if pattern[i] == '\\' {
+			i += 1
+			continue
+		}
+		if pattern[i] == '[' {
+			inCharClass = true
+		} else if pattern[i] == ']' {
+			inCharClass = false
+		}
+
+		if pattern[i] == '(' && !inCharClass {
+			g := group{start: i, capturing: true}
+			if peek(pattern, i, 1) == '?' {
+				g.capturing = false
+				g.number = 0
+			} else {
+				groupNumber += 1
+				g.number = groupNumber
+			}
+			opens = append(opens, g)
+
+		} else if pattern[i] == ')' && !inCharClass {
+			current := opens[len(opens)-1]
+			current.end = i
+			groups = append(groups, current)
+			opens = opens[:len(opens)-1]
+		}
+	}
+	return groups
+}
+
+func peek(pattern string, currentIndex, peekOffset int) byte {
+	if peekOffset+currentIndex >= len(pattern) || peekOffset+currentIndex < 0 {
+		return 0
+	}
+	return pattern[peekOffset+currentIndex]
+}

--- a/enterprise/internal/insights/query/querybuilder/regexp_test.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp_test.go
@@ -144,6 +144,13 @@ func Test_replaceCaptureGroupsWithString(t *testing.T) {
 			expected: `(?:\\w)`,
 			maxGroup: -1,
 		},
+		{
+			name:     "fixed repeat pattern",
+			pattern:  `\w{3}(.{3})\w{3}`,
+			text:     `foobardog`,
+			expected: `\w{3}(?:bar)\w{3}`,
+			maxGroup: -1,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/enterprise/internal/insights/query/querybuilder/regexp_test.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp_test.go
@@ -130,6 +130,20 @@ func Test_replaceCaptureGroupsWithString(t *testing.T) {
 			expected: `(?:cat)-(?:\w+)-(\w+)`,
 			maxGroup: 1,
 		},
+		{
+			name:     "7 ensure non-capturing groups don't count towards group numbers",
+			pattern:  `(\w+)-(?:\w+)-(\w+)`,
+			text:     `cat-cow-camel`,
+			expected: `(?:cat)-(?:\w+)-(?:camel)`,
+			maxGroup: 2,
+		},
+		{
+			name:     "ensure literal values are escaped in the new pattern",
+			pattern:  `(.*)`,
+			text:     `\w`,
+			expected: `(?:\\w)`,
+			maxGroup: -1,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/enterprise/internal/insights/query/querybuilder/regexp_test.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp_test.go
@@ -5,7 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hexops/autogold"
 
 	"github.com/grafana/regexp"
 )
@@ -38,6 +40,11 @@ func Test_findGroups(t *testing.T) {
 		pattern  string
 		expected []group
 	}{
+		{
+			name:     "no groups in pattern",
+			pattern:  `\w*\s`,
+			expected: nil,
+		},
 		{
 			name:     "one group",
 			pattern:  "te(s)t",
@@ -82,87 +89,60 @@ func Test_findGroups(t *testing.T) {
 
 func Test_replaceCaptureGroupsWithString(t *testing.T) {
 	tests := []struct {
-		name     string
-		pattern  string
-		text     string
-		expected string
-		maxGroup int
+		pattern string
+		text    string
+		want    autogold.Value
 	}{
 		{
-			name:     "1",
-			pattern:  `(\w+)-(\w+)`,
-			text:     `cat-cow dog-bat`,
-			expected: `(?:cat|dog)-(?:cow|bat)`,
-			maxGroup: -1,
+			pattern: `(\w+)-(\w+)`,
+			text:    `cat-cow dog-bat`,
+			want:    autogold.Want("1", "(?:cat)-(\\w+)"),
 		},
 		{
-			name:     "2",
-			pattern:  `(\w+)-(\w+)`,
-			text:     `cat-cow dog-bat`,
-			expected: `(\w+)-(\w+)`,
-			maxGroup: 0,
+			pattern: `(\w+)-(?:\w+)-(\w+)`,
+			text:    `cat-cow-camel`,
+			want:    autogold.Want("middle non-capturing group", "(?:cat)-(?:\\w+)-(\\w+)"),
 		},
 		{
-			name:     "3",
-			pattern:  `(\w+)-(\w+)`,
-			text:     `cat-cow dog-bat`,
-			expected: `(?:cat|dog)-(\w+)`,
-			maxGroup: 1,
+			pattern: `(\w+)-(?:\w+)-(\w+)`,
+			text:    `cat-cow-camel`,
+			want:    autogold.Want("ensure non-capturing groups don't count towards group numbers", "(?:cat)-(?:\\w+)-(\\w+)"),
 		},
 		{
-			name:     "4",
-			pattern:  `(\w+)-(\w+)`,
-			text:     `cat-cow dog-bat`,
-			expected: `(?:cat|dog)-(?:cow|bat)`,
-			maxGroup: 2,
+			pattern: `(.*)`,
+			text:    `\w`,
+			want:    autogold.Want("ensure literal values are escaped in the new pattern", "(?:\\\\w)"),
 		},
 		{
-			name:     "5",
-			pattern:  `(\w+)-(?:\w+)-(\w+)`,
-			text:     `cat-cow-camel`,
-			expected: `(?:cat)-(?:\w+)-(?:camel)`,
-			maxGroup: -1,
-		},
-		{
-			name:     "6",
-			pattern:  `(\w+)-(?:\w+)-(\w+)`,
-			text:     `cat-cow-camel`,
-			expected: `(?:cat)-(?:\w+)-(\w+)`,
-			maxGroup: 1,
-		},
-		{
-			name:     "7 ensure non-capturing groups don't count towards group numbers",
-			pattern:  `(\w+)-(?:\w+)-(\w+)`,
-			text:     `cat-cow-camel`,
-			expected: `(?:cat)-(?:\w+)-(?:camel)`,
-			maxGroup: 2,
-		},
-		{
-			name:     "ensure literal values are escaped in the new pattern",
-			pattern:  `(.*)`,
-			text:     `\w`,
-			expected: `(?:\\w)`,
-			maxGroup: -1,
-		},
-		{
-			name:     "fixed repeat pattern",
-			pattern:  `\w{3}(.{3})\w{3}`,
-			text:     `foobardog`,
-			expected: `\w{3}(?:bar)\w{3}`,
-			maxGroup: -1,
+			pattern: `\w{3}(.{3})\w{3}`,
+			text:    `foobardog`,
+			want:    autogold.Want("fixed repeat pattern", "\\w{3}(?:bar)\\w{3}"),
 		},
 	}
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.want.Name(), func(t *testing.T) {
 			reg, err := regexp.Compile(test.pattern)
 			if err != nil {
 				return
 			}
-			matches := reg.FindAllStringSubmatch(test.text, -1)
+			matches := reg.FindStringSubmatch(test.text)
+			value := matches[1]
+
 			groups := findGroups(test.pattern)
-			if diff := cmp.Diff(test.expected, replaceCaptureGroupsWithString(test.pattern, groups, matches, test.maxGroup)); diff != "" {
-				t.Errorf("unexpected pattern (want/got): %s", diff)
-			}
+			got := replaceCaptureGroupsWithString(test.pattern, groups, value)
+			test.want.Equal(t, got)
 		})
 	}
+
+	t.Run("test explicitly a regexp with no groups", func(t *testing.T) {
+		pattern := `replaceme`
+		got := replaceCaptureGroupsWithString(pattern, nil, "no")
+		require.Equal(t, pattern, got)
+	})
+
+	t.Run("regexp with no capturing groups", func(t *testing.T) {
+		pattern := `(?:hello)(?:friend)`
+		got := replaceCaptureGroupsWithString(pattern, findGroups(pattern), "no")
+		require.Equal(t, pattern, got)
+	})
 }

--- a/enterprise/internal/insights/query/querybuilder/regexp_test.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp_test.go
@@ -1,0 +1,117 @@
+package querybuilder
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/grafana/regexp"
+)
+
+func Test_peek(t *testing.T) {
+	tests := []struct {
+		pattern       string
+		index, offset int
+		match         byte
+	}{
+		{
+			pattern: "test/a",
+			index:   0,
+			offset:  1,
+			match:   'e',
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%s:%d", t.Name(), i), func(t *testing.T) {
+			if peek(test.pattern, test.index, test.offset) != test.match {
+				t.Error()
+			}
+		})
+	}
+}
+
+func Test_findGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		expected []group
+	}{
+		{
+			name:     "one group",
+			pattern:  "te(s)t",
+			expected: []group{{start: 2, end: 4, capturing: true, number: 1}},
+		},
+		{
+			name:     "two groups",
+			pattern:  "te(s)(t)",
+			expected: []group{{start: 2, end: 4, capturing: true, number: 1}, {start: 5, end: 7, capturing: true, number: 2}},
+		},
+		{
+			name:     "two groups with non-capturing group",
+			pattern:  "te(s)(t)(?:asdf)",
+			expected: []group{{start: 2, end: 4, capturing: true, number: 1}, {start: 5, end: 7, capturing: true, number: 2}, {start: 8, end: 15, capturing: false, number: 0}},
+		},
+		{
+			name:     "two groups with non-capturing group and character class",
+			pattern:  "te(s)(t)(?:asdf)[(]",
+			expected: []group{{start: 2, end: 4, capturing: true, number: 1}, {start: 5, end: 7, capturing: true, number: 2}, {start: 8, end: 15, capturing: false, number: 0}},
+		},
+		{
+			name:    "two groups with non-capturing group and character class and nested",
+			pattern: "te(s)(t)(?:asdf)[(](())",
+			expected: []group{
+				{start: 2, end: 4, capturing: true, number: 1},
+				{start: 5, end: 7, capturing: true, number: 2},
+				{start: 8, end: 15, capturing: false, number: 0},
+				{start: 20, end: 21, capturing: true, number: 4},
+				{start: 19, end: 22, capturing: true, number: 3},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := findGroups(test.pattern)
+			if !reflect.DeepEqual(got, test.expected) {
+				t.Errorf("unexpected indices (want/got):\n%v \n%v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestThing(t *testing.T) {
+	pattern := `name:\((.*)\)(.*) [(] asdf`
+
+	text := `name:(test1)bob ( asdf`
+
+	reg, err := regexp.Compile(pattern)
+	if err != nil {
+		panic(err)
+	}
+
+	matches := reg.FindStringSubmatch(text)
+	println(len(matches))
+	for _, match := range matches {
+		fmt.Println(match)
+	}
+
+	groups := findGroups(pattern)
+
+	var replacements []group
+	for i := range groups {
+		if !groups[i].capturing {
+			continue
+		}
+		groups[i].value = matches[groups[i].number]
+		replacements = append(replacements, groups[i])
+	}
+
+	sort.Slice(replacements, func(i, j int) bool {
+		return replacements[i].number < replacements[j].number
+	})
+
+	fmt.Println(groups)
+	fmt.Println(fmt.Sprintf("old_pattern: %s", pattern))
+	fmt.Println(fmt.Sprintf("document: %s", text))
+	fmt.Println(fmt.Sprintf("new_pattern: %s", replaceRange(pattern, replacements)))
+}


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/40045

Adds support to "reverse engineer" a regexp from it's matches to regenerate new regexp strings that match more specific values. In this case only the first capturing group is eligible for replacement.

For example given a regexp `\w{3}(.{3})\w{3}` and the text `foobardog` generate `\w{3}(?:bar)\w{3}`

This will be used for drilldown when viewing Code Insights that are dynamically generated from a capture group.

A future [PR](https://github.com/sourcegraph/sourcegraph/pull/40533) is coming that will more clearly define the interface of how the aggregator client will use this.

## Test plan

Tests included and will be tested more once integrated with Sourcegraph queries
