### PR TITLE
executors: Limit maximum bandwidth per VM

### DIFF
--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -215,6 +215,8 @@ function preheat_kernel_image() {
 ## Configures the CNI explicitly and adds the isolation plugin to the chain.
 ## This is to prevent cross-network communication (which currently doesn't happen
 ## as we only have 1 bridge).
+## We also set the maximum bandwidth usable per VM to 500 MBit to avoid abuse and
+## to make sure multiple VMs on the same host won't starve others.
 function configure_cni() {
   mkdir -p /etc/cni/net.d
   cat <<EOF >/etc/cni/net.d/10-ignite.conflist
@@ -245,6 +247,14 @@ function configure_cni() {
     },
     {
       "type": "isolation"
+    },
+    {
+      "name": "slowdown",
+      "type": "bandwidth",
+      "ingressRate": 524288000,
+      "ingressBurst": 1048576000,
+      "egressRate": 524288000,
+      "egressBurst": 1048576000
     }
   ]
 }


### PR DESCRIPTION
This is an experiment, but since we already have the config for CNI at hand now, I figured why not give it a try. I want to run this on k8s and Cloud for a while and see if it has a negative impact. Ideally, this won't be noticeable, but it'll prevent excessive use of the network and hopefully also packet starvation on the host. Potential very low risk attack vector, that could prevent other jobs from updating their heartbeats in time so they are reset?

If this has a negative effect, I'll make sure to revert this PR before the next release.

## Test plan

Verified in a test VM that the bandwidth is indeed limited correctly.