### PR TITLE
Remove d3 ignore

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -76,7 +76,5 @@ module.exports = api => {
         },
       ],
     ],
-    // Required for d3-array v1.2 (dependency of recharts). See https://github.com/babel/babel/issues/11038
-    ignore: [new RegExp('d3-array/src/cumsum.js')],
   }
 }


### PR DESCRIPTION
Remove an ignore directive that is no longer needed.

This ignore configuration was added in https://github.com/sourcegraph/sourcegraph/pull/20267 as a result of [this issue](https://github.com/babel/babel/issues/11038#issuecomment-890470216) which was fixed in babel/parser 7.14.9.

We already started locking to babel/parser 7.18.0 (which is > 7.14.9), so this exclude should no longer be necessary.
https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/yarn.lock?L417-420

## Test plan

All existing tests pass

## App preview:

- [Web](https://sg-web-ns-d3.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-perowwydvr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
