### PR TITLE
Remove unnecessary polyfills

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -39,9 +39,6 @@ module.exports = api => {
             'web.immediate',
             // Always define Symbol.observable before libraries are loaded, ensuring interopability between different libraries.
             'esnext.symbol.observable',
-            // Webpack v4 chokes on optional chaining and nullish coalescing syntax, fix will be released with webpack v5.
-            '@babel/plugin-proposal-optional-chaining',
-            '@babel/plugin-proposal-nullish-coalescing-operator',
           ],
           // See https://github.com/zloirock/core-js#babelpreset-env
           corejs: semver.minVersion(require('./package.json').dependencies['core-js']),


### PR DESCRIPTION
Removes polyfills that were added in https://github.com/sourcegraph/sourcegraph/pull/14086 but are no longer needed since we have upgraded to webpack 5.

## Test plan

Existing build and tests pass with no errors

## App preview:

- [Web](https://sg-web-ns-babelconfig.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-edhpsvrlho.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
