### PR TITLE
Revert "Eliminate usagestatsdeprecated package (#38826)"

### DIFF
--- a/client/browser/src/integration/graphql.ts
+++ b/client/browser/src/integration/graphql.ts
@@ -13,4 +13,9 @@ export const commonBrowserGraphQlResults: Partial<BrowserGraphQlOperations & Sha
             alwaysNil: null,
         },
     }),
+    logUserEvent: () => ({
+        logUserEvent: {
+            alwaysNil: null,
+        },
+    }),
 }

--- a/client/browser/src/shared/backend/userEvents.tsx
+++ b/client/browser/src/shared/backend/userEvents.tsx
@@ -2,7 +2,42 @@ import { gql } from '@sourcegraph/http-client'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import * as GQL from '@sourcegraph/shared/src/schema'
 
-import { EventSource } from '../../graphql-operations'
+import { UserEvent, EventSource } from '../../graphql-operations'
+
+/**
+ * Log a user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
+ * Sourcegraph instance to see a count of unique users on a daily, weekly, and monthly basis).
+ *
+ * @deprecated Use logEvent
+ */
+export const logUserEvent = (
+    event: UserEvent,
+    uid: string,
+    url: string,
+    requestGraphQL: PlatformContext['requestGraphQL']
+): void => {
+    requestGraphQL<GQL.IMutation>({
+        request: gql`
+            mutation logUserEvent($event: UserEvent!, $userCookieID: String!) {
+                logUserEvent(event: $event, userCookieID: $userCookieID) {
+                    alwaysNil
+                }
+            }
+        `,
+        variables: { event, userCookieID: uid },
+        mightContainPrivateInfo: false,
+        // Events are best-effort and non-blocking
+        // eslint-disable-next-line rxjs/no-ignored-subscription
+    }).subscribe({
+        error: () => {
+            // Swallow errors. If a Sourcegraph instance isn't upgraded, this request may fail
+            // (e.g., if CODEINTELINTEGRATION user events aren't yet supported).
+            // However, end users shouldn't experience this failure, as their admin is
+            // responsible for updating the instance, and has been (or will be) notified
+            // that an upgrade is available via site-admin messaging.
+        },
+    })
+}
 
 /**
  * Log a raw user action on the associated Sourcegraph instance

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -172,6 +172,11 @@ export const commonWebGraphQlResults: Partial<
             alwaysNil: null,
         },
     }),
+    LogUserEvent: () => ({
+        logUserEvent: {
+            alwaysNil: null,
+        },
+    }),
     AutoDefinedSearchContexts: () => ({
         autoDefinedSearchContexts: [
             {

--- a/client/web/src/tracking/services/serverAdminWrapper.tsx
+++ b/client/web/src/tracking/services/serverAdminWrapper.tsx
@@ -1,11 +1,58 @@
-import { logEvent } from '../../user/settings/backend'
+import { UserEvent } from '@sourcegraph/shared/src/graphql-operations'
+
+import { authenticatedUser } from '../../auth'
+import { logUserEvent, logEvent } from '../../user/settings/backend'
 
 class ServerAdminWrapper {
-    public trackPageView(eventAction: string, eventProperties?: any, publicArgument?: any): void {
+    /**
+     * isAuthenicated is a flag that indicates if a user is signed in.
+     */
+    private isAuthenicated = false
+
+    constructor() {
+        // ServerAdminWrapper is never teared down
+        // eslint-disable-next-line rxjs/no-ignored-subscription
+        authenticatedUser.subscribe(user => {
+            if (user) {
+                this.isAuthenicated = true
+            }
+        })
+    }
+
+    public trackPageView(
+        eventAction: string,
+        logAsActiveUser: boolean = true,
+        eventProperties?: any,
+        publicArgument?: any
+    ): void {
+        if (logAsActiveUser) {
+            logUserEvent(UserEvent.PAGEVIEW)
+        }
+        if (this.isAuthenicated) {
+            if (eventAction === 'ViewRepository' || eventAction === 'ViewBlob' || eventAction === 'ViewTree') {
+                logUserEvent(UserEvent.STAGECODE)
+            }
+        }
         logEvent(eventAction, eventProperties, publicArgument)
     }
 
     public trackAction(eventAction: string, eventProperties?: any, publicArgument?: any): void {
+        if (this.isAuthenicated) {
+            if (eventAction === 'SearchResultsQueried') {
+                logUserEvent(UserEvent.SEARCHQUERY)
+                logUserEvent(UserEvent.STAGECODE)
+            } else if (
+                eventAction === 'goToDefinition' ||
+                eventAction === 'goToDefinition.preloaded' ||
+                eventAction === 'hover'
+            ) {
+                logUserEvent(UserEvent.CODEINTEL)
+            } else if (eventAction === 'SavedSearchEmailClicked' || eventAction === 'SavedSearchSlackClicked') {
+                logUserEvent(UserEvent.STAGEVERIFY)
+            } else if (eventAction === 'DiffSearchResultsQueried') {
+                logUserEvent(UserEvent.STAGEMONITOR)
+            }
+        }
         logEvent(eventAction, eventProperties, publicArgument)
     }
 }

--- a/client/web/src/tracking/withActivation.tsx
+++ b/client/web/src/tracking/withActivation.tsx
@@ -11,12 +11,13 @@ import {
     ActivationProps,
     ActivationStep,
 } from '@sourcegraph/shared/src/components/activation/Activation'
+import { UserEvent } from '@sourcegraph/shared/src/graphql-operations'
 import { Link } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { queryGraphQL } from '../backend/graphql'
 import { PageRoutes } from '../routes.constants'
-import { logEvent } from '../user/settings/backend'
+import { logUserEvent, logEvent } from '../user/settings/backend'
 
 /**
  * Fetches activation status from server.
@@ -182,6 +183,7 @@ const getActivationSteps = (authenticatedUser: AuthenticatedUser): ActivationSte
  */
 const recordUpdate = (update: Partial<ActivationCompletionStatus>): void => {
     if (update.FoundReferences) {
+        logUserEvent(UserEvent.CODEINTELREFS)
         logEvent('CodeIntelRefs')
     }
 }

--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -3,10 +3,12 @@ import { bufferTime, catchError, concatMap, map } from 'rxjs/operators'
 
 import { createAggregateError } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
-import { EventSource, Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { UserEvent, EventSource, Scalars } from '@sourcegraph/shared/src/graphql-operations'
 
 import { requestGraphQL } from '../../backend/graphql'
 import {
+    LogUserEventResult,
+    LogUserEventVariables,
     SetUserEmailVerifiedResult,
     SetUserEmailVerifiedVariables,
     UpdatePasswordResult,
@@ -85,6 +87,38 @@ export function setUserEmailVerified(user: Scalars['ID'], email: string, verifie
             }
         })
     )
+}
+
+/**
+ * Log a user action (used to allow site admins on a Sourcegraph instance
+ * to see a count of unique users on a daily, weekly, and monthly basis).
+ *
+ * Not used at all for public/sourcegraph.com usage.
+ *
+ * @deprecated Use logEvent
+ */
+export function logUserEvent(event: UserEvent): void {
+    requestGraphQL<LogUserEventResult, LogUserEventVariables>(
+        gql`
+            mutation LogUserEvent($event: UserEvent!, $userCookieID: String!) {
+                logUserEvent(event: $event, userCookieID: $userCookieID) {
+                    alwaysNil
+                }
+            }
+        `,
+        { event, userCookieID: eventLogger.getAnonymousUserID() }
+    )
+        .pipe(
+            map(({ data, errors }) => {
+                if (!data || (errors && errors.length > 0)) {
+                    throw createAggregateError(errors)
+                }
+                return
+            })
+        )
+        // Event logs are best-effort and non-blocking
+        // eslint-disable-next-line rxjs/no-ignored-subscription
+        .subscribe()
 }
 
 // Log events in batches.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -418,7 +418,7 @@ type Mutation {
         date: String
     ): GitCommit
     """
-    Logs a user event. No longer used, only here for backwards compatibility with IDE and browser extensions.
+    Logs a user event.
     """
     logUserEvent(event: UserEvent!, userCookieID: String!): EmptyResponse @deprecated(reason: "use logEvent instead")
     """

--- a/cmd/frontend/graphqlbackend/site_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/site_usage_stats.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestatsdeprecated"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
 
 func (r *siteResolver) UsageStatistics(ctx context.Context, args *struct {
@@ -18,7 +18,7 @@ func (r *siteResolver) UsageStatistics(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	opt := &usagestats.SiteUsageStatisticsOptions{}
+	opt := &usagestatsdeprecated.SiteUsageStatisticsOptions{}
 	if args.Days != nil {
 		d := int(*args.Days)
 		opt.DayPeriods = &d
@@ -31,7 +31,7 @@ func (r *siteResolver) UsageStatistics(ctx context.Context, args *struct {
 		m := int(*args.Months)
 		opt.MonthPeriods = &m
 	}
-	activity, err := usagestats.GetSiteUsageStatistics(ctx, r.db, opt)
+	activity, err := usagestatsdeprecated.GetSiteUsageStatistics(opt)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/user_usage_stats_test.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats_test.go
@@ -3,9 +3,9 @@ package graphqlbackend
 import (
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestatsdeprecated"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
 
 func TestUser_UsageStatistics(t *testing.T) {
@@ -15,12 +15,12 @@ func TestUser_UsageStatistics(t *testing.T) {
 	db := database.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
 
-	usagestats.MockGetByUserID = func(userID int32) (*types.UserUsageStatistics, error) {
+	usagestatsdeprecated.MockGetByUserID = func(userID int32) (*types.UserUsageStatistics, error) {
 		return &types.UserUsageStatistics{
 			SearchQueries: 2,
 		}, nil
 	}
-	defer func() { usagestats.MockGetByUserID = nil }()
+	defer func() { usagestatsdeprecated.MockGetByUserID = nil }()
 
 	RunTests(t, []*Test{
 		{

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestatsdeprecated"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -115,9 +116,9 @@ func hasRepos(ctx context.Context, db database.DB) (_ bool, err error) {
 	return len(rs) > 0, err
 }
 
-func getUsersActiveTodayCount(ctx context.Context, db database.DB) (_ int, err error) {
+func getUsersActiveTodayCount(ctx context.Context) (_ int, err error) {
 	defer recordOperation("getUsersActiveTodayCount")(&err)
-	return usagestats.GetUsersActiveTodayCount(ctx, db)
+	return usagestatsdeprecated.GetUsersActiveTodayCount(ctx)
 }
 
 func getInitialSiteAdminInfo(ctx context.Context, db database.DB) (_ string, _ bool, err error) {
@@ -426,7 +427,7 @@ func updateBody(ctx context.Context, db database.DB) (io.Reader, error) {
 		// For the time being, instances will report daily active users through the legacy package via this argument,
 		// as well as using the new package through the `act` argument below. This will allow comparison during the
 		// transition.
-		count, err := getUsersActiveTodayCount(ctx, db)
+		count, err := getUsersActiveTodayCount(ctx)
 		if err != nil {
 			logFunc("telemetry: updatecheck.getUsersActiveToday failed", "error", err)
 		}

--- a/cmd/frontend/internal/httpapi/telemetry.go
+++ b/cmd/frontend/internal/httpapi/telemetry.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestatsdeprecated"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/deviceid"
 	"github.com/sourcegraph/sourcegraph/internal/eventlogger"
@@ -23,6 +24,12 @@ func telemetryHandler(db database.DB) http.Handler {
 		err = usagestats.LogBackendEvent(db, tr.UserID, deviceid.FromContext(r.Context()), tr.EventName, tr.Argument, tr.PublicArgument, featureflag.GetEvaluatedFlagSet(r.Context()), nil)
 		if err != nil {
 			log15.Error("telemetryHandler: usagestats.LogBackendEvent", "error", err)
+		}
+		if tr.UserID != 0 && tr.EventName == "SavedSearchEmailNotificationSent" {
+			err = usagestatsdeprecated.LogActivity(true, tr.UserID, "", "STAGEVERIFY")
+			if err != nil {
+				log15.Error("telemetryHandler: usagestats.LogBackendEvent", "error", err)
+			}
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
@@ -1,0 +1,181 @@
+package usagestatsdeprecated
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var (
+	searchOccurred   = false
+	findRefsOccurred = false
+)
+
+// LogActivity logs any user activity (page view, integration usage, etc) to their "last active" time, and
+// adds their unique ID to the set of active users
+func LogActivity(isAuthenticated bool, userID int32, userCookieID, event string) error {
+	// Setup our GC of active key goroutine
+	gcOnce.Do(func() {
+		go gc()
+	})
+
+	c := pool.Get()
+	defer c.Close()
+
+	uniqueID := userCookieID
+
+	// If the user is authenticated, set uniqueID to their user ID, and store their "last active time" in the
+	// appropriate user ID-keyed cache.
+	if isAuthenticated {
+		userIDStr := strconv.Itoa(int(userID))
+		uniqueID = userIDStr
+		key := keyPrefix + uniqueID
+
+		// Set the user's last active time
+		now := timeNow().UTC()
+		if err := c.Send("HSET", key, fLastActive, now.Format(time.RFC3339)); err != nil {
+			return err
+		}
+	}
+
+	if uniqueID == "" {
+		log15.Warn("usagestats.LogActivity: no user ID provided")
+		return nil
+	}
+
+	// Regardless of authentication status, add the user's unique ID to the set of active users.
+	if err := c.Send("SADD", usersActiveKeyFromDaysAgo(0), uniqueID); err != nil {
+		return err
+	}
+
+	if handlers, ok := eventHandlers[event]; ok {
+		for _, handler := range handlers {
+			err := handler(userID, event, isAuthenticated)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return errors.Errorf("unknown user event %s", event)
+}
+
+// Custom event handlers
+type eventHandler = func(userID int32, event string, isAuthenticated bool) error
+
+var eventHandlers = map[string][]eventHandler{
+	"SEARCHQUERY":              {logSiteSearchOccurred, logSearchQuery},
+	"PAGEVIEW":                 {logPageView},
+	"CODEINTEL":                {logCodeIntelAction},
+	"CODEINTELREFS":            {logSiteFindRefsOccurred, logCodeIntelRefsAction},
+	"CODEINTELINTEGRATION":     {logCodeHostIntegrationUsage, logCodeIntelAction},
+	"CODEINTELINTEGRATIONREFS": {logSiteFindRefsOccurred, logCodeHostIntegrationUsage, logCodeIntelRefsAction},
+
+	"STAGEMANAGE":    {logStageEvent},
+	"STAGEPLAN":      {logStageEvent},
+	"STAGECODE":      {logStageEvent},
+	"STAGEREVIEW":    {logStageEvent},
+	"STAGEVERIFY":    {logStageEvent},
+	"STAGEPACKAGE":   {logStageEvent},
+	"STAGEDEPLOY":    {logStageEvent},
+	"STAGECONFIGURE": {logStageEvent},
+	"STAGEMONITOR":   {logStageEvent},
+	"STAGESECURE":    {logStageEvent},
+	"STAGEAUTOMATE":  {logStageEvent},
+}
+
+// logSiteSearchOccurred records that a search has occurred on the Sourcegraph instance.
+var logSiteSearchOccurred = func(_ int32, _ string, _ bool) error {
+	if searchOccurred {
+		return nil
+	}
+	key := keyPrefix + fSearchOccurred
+	c := pool.Get()
+	defer c.Close()
+	searchOccurred = true
+	return c.Send("SET", key, "true")
+}
+
+// logSiteFindRefsOccurred records that a search has occurred on the Sourcegraph instance.
+var logSiteFindRefsOccurred = func(_ int32, _ string, _ bool) error {
+	if findRefsOccurred {
+		return nil
+	}
+	key := keyPrefix + fFindRefsOccurred
+	c := pool.Get()
+	defer c.Close()
+	findRefsOccurred = true
+	return c.Send("SET", key, "true")
+}
+
+// logSearchQuery increments a user's search query count.
+var logSearchQuery = func(userID int32, _ string, isAuthenticated bool) error {
+	return incrementUserCounter(userID, isAuthenticated, fSearchQueries)
+}
+
+// logPageView increments a user's pageview count.
+var logPageView = func(userID int32, _ string, isAuthenticated bool) error {
+	return incrementUserCounter(userID, isAuthenticated, fPageViews)
+}
+
+// logCodeIntelAction increments a user's code intelligence usage count.
+var logCodeIntelAction = func(userID int32, _ string, isAuthenticated bool) error {
+	return incrementUserCounter(userID, isAuthenticated, fCodeIntelActions)
+}
+
+// logCodeIntelRefsAction increments a user's code intelligence usage count.
+// and their find refs action count.
+var logCodeIntelRefsAction = func(userID int32, _ string, isAuthenticated bool) error {
+	if err := incrementUserCounter(userID, isAuthenticated, fCodeIntelActions); err != nil {
+		return err
+	}
+	return incrementUserCounter(userID, isAuthenticated, fFindRefsActions)
+}
+
+// logCodeHostIntegrationUsage logs the last time a user was active on a code host integration.
+var logCodeHostIntegrationUsage = func(userID int32, _ string, isAuthenticated bool) error {
+	if !isAuthenticated {
+		return nil
+	}
+	key := keyPrefix + strconv.Itoa(int(userID))
+	c := pool.Get()
+	defer c.Close()
+
+	now := timeNow().UTC()
+	return c.Send("HSET", key, fLastActiveCodeHostIntegration, now.Format(time.RFC3339))
+}
+
+// logStageEvent logs the last time a user did an action from a specific stage.
+var logStageEvent = func(userID int32, event string, isAuthenticated bool) error {
+	if !isAuthenticated {
+		return nil
+	}
+	key := keyPrefix + strconv.Itoa(int(userID))
+	c := pool.Get()
+	defer c.Close()
+
+	now := timeNow().UTC()
+	return c.Send("HSET", key, keyFromStage(event), now.Format(time.RFC3339))
+}
+
+// LogEvent logs users events.
+func LogEvent(ctx context.Context, db database.DB, name, url string, userID int32, userCookieID, source string, argument json.RawMessage, evaluatedFlagSet featureflag.EvaluatedFlagSet) error {
+	info := &database.Event{
+		Name:             name,
+		URL:              url,
+		UserID:           uint32(userID),
+		AnonymousUserID:  userCookieID,
+		Source:           source,
+		Argument:         argument,
+		EvaluatedFlagSet: evaluatedFlagSet,
+	}
+	return db.EventLogs().Insert(ctx, info)
+}

--- a/cmd/frontend/internal/usagestatsdeprecated/doc.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/doc.go
@@ -1,0 +1,51 @@
+package usagestatsdeprecated
+
+// Usage data is stored in four categories of redis data structures.
+// Each key is prefixed by the value below.
+
+var keyPrefix = "user_activity:"
+
+//////////////////////////////////////////////////////
+// 1. Site-level aggregates
+//
+// We maintain a few site-level aggregate scalars, such as whether
+// a search has ever occurred on the instance.
+//
+// These are used to track site-level activation/onboarding for admins.
+//
+
+const (
+	fSearchOccurred   = "searchoccurred"
+	fFindRefsOccurred = "findrefsoccurred"
+)
+
+//////////////////////////////////////////////////////
+// 2. User-level aggregates
+//
+// We maintain a redis HASH for each user containing aggregates of their
+// activity. These include things like their total number of search
+// queries and code intel actions, their "last active" date, etc.
+//
+// These are used for admins to track individual user-level enagement.
+//
+
+const (
+	fPageViews                     = "pageviews"
+	fLastActive                    = "lastactive"
+	fSearchQueries                 = "searchqueries"
+	fCodeIntelActions              = "codeintelactions"
+	fFindRefsActions               = "codeintelactions:findrefs"
+	fLastActiveCodeHostIntegration = "lastactivecodehostintegration"
+)
+
+//////////////////////////////////////////////////////
+// 3. Site-level daily usage counters
+//
+// We maintain a redis SET for each of the last 93 days.
+// The SET contains a list of each user that was active on a given day.
+//
+// This is used for quickly calculating counts of daily, weekly, and
+// monthly unique users for site admins.
+//
+
+const fUsersActive = "usersactive"

--- a/cmd/frontend/internal/usagestatsdeprecated/usage_stats.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/usage_stats.go
@@ -1,0 +1,319 @@
+// Package usagestatsdeprecated is deprecated in favor of package usagestats.
+//
+// Package usagestatsdeprecated provides an interface to update and access information about
+// individual and aggregate Sourcegraph users' activity levels.
+//
+// Note that this package should not be used on sourcegraph.com, only on self-hosted
+// deployments.
+package usagestatsdeprecated
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+var (
+	gcOnce sync.Once // ensures we only have 1 redis gc goroutine
+
+	pool = redispool.Store
+
+	timeNow = time.Now
+)
+
+const (
+	defaultDays   = 14
+	defaultWeeks  = 10
+	defaultMonths = 3
+
+	maxStorageDays = 93
+)
+
+var MockGetByUserID func(userID int32) (*types.UserUsageStatistics, error)
+
+// GetByUserID returns a single user's UserUsageStatistics.
+func GetByUserID(userID int32) (*types.UserUsageStatistics, error) {
+	if MockGetByUserID != nil {
+		return MockGetByUserID(userID)
+	}
+
+	userIDStr := strconv.Itoa(int(userID))
+	key := keyPrefix + userIDStr
+
+	c := pool.Get()
+	defer c.Close()
+
+	values, err := redis.Values(c.Do("HMGET", key, fPageViews, fSearchQueries, fLastActive, fCodeIntelActions, fFindRefsActions, fLastActiveCodeHostIntegration))
+	if err != nil && err != redis.ErrNil {
+		return nil, err
+	}
+
+	var lastActiveStr, lastActiveCodeHostStr string
+	a := &types.UserUsageStatistics{
+		UserID: userID,
+	}
+	_, err = redis.Scan(values, &a.PageViews, &a.SearchQueries, &lastActiveStr, &a.CodeIntelligenceActions, &a.FindReferencesActions, &lastActiveCodeHostStr)
+	if err != nil && err != redis.ErrNil {
+		return nil, err
+	}
+
+	if lastActiveStr != "" {
+		t, err := time.Parse(time.RFC3339, lastActiveStr)
+		if err != nil {
+			return nil, err
+		}
+		a.LastActiveTime = &t
+	}
+
+	if lastActiveCodeHostStr != "" {
+		t, err := time.Parse(time.RFC3339, lastActiveCodeHostStr)
+		if err != nil {
+			return nil, err
+		}
+		a.LastCodeHostIntegrationTime = &t
+	}
+
+	return a, nil
+}
+
+// SiteUsageStatisticsOptions contains options for the number of daily, weekly, and monthly periods in
+// which to calculate the number of unique users (i.e., how many days of Daily Active Users, or DAUs,
+// how many weeks of Weekly Active Users, or WAUs, and how many months of Monthly Active Users, or MAUs).
+type SiteUsageStatisticsOptions struct {
+	DayPeriods   *int
+	WeekPeriods  *int
+	MonthPeriods *int
+}
+
+// UsageDuration in aggregate represents a duration of time over which to calculate a set of unique users.
+type UsageDuration struct {
+	Days   int
+	Months int
+}
+
+// ActiveUsers contains sets of unique user IDs.
+type ActiveUsers struct {
+	All              []string
+	Registered       []string
+	Anonymous        []string
+	UsedIntegrations []string
+}
+
+// GetSiteUsageStatistics returns the current site's SiteActivity.
+func GetSiteUsageStatistics(opt *SiteUsageStatisticsOptions) (*types.SiteUsageStatistics, error) {
+	var (
+		dayPeriods   = defaultDays
+		weekPeriods  = defaultWeeks
+		monthPeriods = defaultMonths
+	)
+
+	if opt != nil {
+		if opt.DayPeriods != nil {
+			dayPeriods = minIntOrZero(maxStorageDays, *opt.DayPeriods)
+		}
+		if opt.WeekPeriods != nil {
+			weekPeriods = minIntOrZero(maxStorageDays/7, *opt.WeekPeriods)
+		}
+		if opt.MonthPeriods != nil {
+			monthPeriods = minIntOrZero(maxStorageDays/31, *opt.MonthPeriods)
+		}
+	}
+
+	daus, err := daus(dayPeriods)
+	if err != nil {
+		return nil, err
+	}
+	waus, err := waus(weekPeriods)
+	if err != nil {
+		return nil, err
+	}
+	maus, err := maus(monthPeriods)
+	if err != nil {
+		return nil, err
+	}
+	return &types.SiteUsageStatistics{
+		DAUs: daus,
+		WAUs: waus,
+		MAUs: maus,
+	}, nil
+}
+
+// GetUsersActiveTodayCount returns a count of users that have been active today.
+func GetUsersActiveTodayCount(ctx context.Context) (int, error) {
+	c, err := pool.GetContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer c.Close()
+
+	count, err := redis.Int(c.Do("SCARD", usersActiveKeyFromDaysAgo(0)))
+	if err == redis.ErrNil {
+		err = nil
+	}
+	return count, err
+}
+
+// uniques calculates the list of unique users starting at 00:00:00 on a given UTC date over a
+// period of time.
+func uniques(dayStart time.Time, period *UsageDuration) (*ActiveUsers, error) {
+	c := pool.Get()
+	defer c.Close()
+
+	var (
+		allUniqueUserIDs   = map[string]bool{}
+		registeredUserIDs  = map[string]bool{}
+		anonymousUserIDs   = map[string]bool{}
+		integrationUserIDs = map[string]bool{}
+	)
+
+	dayStart = time.Date(dayStart.Year(), dayStart.Month(), dayStart.Day(), 0, 0, 0, 0, time.UTC)
+	dayEnd := dayStart.AddDate(0, period.Months, period.Days)
+
+	// Start at 00:00:00 UTC of the last day, and loop backwards until reaching the start
+	d := dayEnd.AddDate(0, 0, -1)
+	for d.After(dayStart) || d.Equal(dayStart) {
+		values, err := redis.Values(c.Do("SMEMBERS", usersActiveKeyFromDate(d)))
+		if err != nil && err != redis.ErrNil {
+			return nil, err
+		}
+	nextValue:
+		for _, id := range values {
+			sid := string(id.([]byte))
+			allUniqueUserIDs[sid] = true
+
+			// If any character is not a digit, then treat it as an anonymous user ID.
+			for _, s := range sid {
+				if s < '0' || s > '9' {
+					anonymousUserIDs[sid] = true
+					continue nextValue
+				}
+			}
+			registeredUserIDs[sid] = true
+		}
+
+		d = d.AddDate(0, 0, -1)
+	}
+
+	// Loop through all id'd unique users, determine if they were active in a code host integration in the time period.
+	//
+	// Despite O(n) Redis requests (n == # of users in a given period), this performs acceptably well at large instances.
+	// On an instance with 25K users, average GraphQL requests for default site activity data (14 days of DAUs, 10 weeks
+	// of WAUs, and 3 months of MAUs) takes ~1.2s.
+	for uid := range allUniqueUserIDs {
+		userKey := keyPrefix + uid
+		err := c.Send("HGET", userKey, fLastActiveCodeHostIntegration)
+		if err != nil && err != redis.ErrNil {
+			return nil, err
+		}
+	}
+	c.Flush()
+	for uid := range allUniqueUserIDs {
+		lastActiveCodeHostStr, err := redis.String(c.Receive())
+		if err != nil && err != redis.ErrNil {
+			return nil, err
+		}
+		if lastActiveCodeHostStr != "" {
+			t, err := time.Parse(time.RFC3339, lastActiveCodeHostStr)
+			if err != nil {
+				return nil, err
+			}
+			if (t.After(dayStart) || t.Equal(dayStart)) && t.Before(dayEnd) {
+				integrationUserIDs[uid] = true
+			}
+		}
+	}
+
+	return &ActiveUsers{
+		All:              keys(allUniqueUserIDs),
+		Registered:       keys(registeredUserIDs),
+		Anonymous:        keys(anonymousUserIDs),
+		UsedIntegrations: keys(integrationUserIDs),
+	}, nil
+}
+
+// uniquesCount calculates the number of unique users starting at 00:00:00 on a given UTC date over a
+// period of time (years, months, and days).
+func uniquesCount(dayStart time.Time, period *UsageDuration) (*types.SiteActivityPeriod, error) {
+	userIDs, err := uniques(dayStart, period)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.SiteActivityPeriod{
+		StartTime:            time.Date(dayStart.Year(), dayStart.Month(), dayStart.Day(), 0, 0, 0, 0, time.UTC),
+		UserCount:            int32(len(userIDs.All)),
+		RegisteredUserCount:  int32(len(userIDs.Registered)),
+		AnonymousUserCount:   int32(len(userIDs.Anonymous)),
+		IntegrationUserCount: int32(len(userIDs.UsedIntegrations)),
+	}, nil
+}
+
+// daus returns a count of daily active users for the last daysCount days (including the current, partial day).
+func daus(dayPeriods int) ([]*types.SiteActivityPeriod, error) {
+	var daus []*types.SiteActivityPeriod
+	now := timeNow().UTC()
+	for daysAgo := 0; daysAgo < dayPeriods; daysAgo++ {
+		uniques, err := uniquesCount(now.AddDate(0, 0, -daysAgo), &UsageDuration{Days: 1})
+		if err != nil {
+			return nil, err
+		}
+		daus = append(daus, uniques)
+	}
+	return daus, nil
+}
+
+// waus returns a count of daily active users for the last weeksCount calendar weeks (including the current, partial week).
+func waus(weekPeriods int) ([]*types.SiteActivityPeriod, error) {
+	var waus []*types.SiteActivityPeriod
+
+	for w := 0; w < weekPeriods; w++ {
+		weekStartDate := startOfWeek(w)
+		uniques, err := uniquesCount(weekStartDate, &UsageDuration{Days: 7})
+		if err != nil {
+			return nil, err
+		}
+		waus = append(waus, uniques)
+	}
+	return waus, nil
+}
+
+// maus returns a count of daily active users for the last monthsCount calendar months (including the current, partial month).
+func maus(monthPeriods int) ([]*types.SiteActivityPeriod, error) {
+	var maus []*types.SiteActivityPeriod
+
+	for m := 0; m < monthPeriods; m++ {
+		monthStartDate := startOfMonth(m)
+		uniques, err := uniquesCount(monthStartDate, &UsageDuration{Months: 1})
+		if err != nil {
+			return nil, err
+		}
+		maus = append(maus, uniques)
+	}
+	return maus, nil
+}
+
+// gc expires active user sets after the max of daysOfHistory, weeksOfHistory, and monthsOfHistory have passed.
+func gc() {
+	for {
+		key := usersActiveKeyFromDaysAgo(0)
+
+		c := pool.Get()
+		err := c.Send("EXPIRE", key, 60*60*24*int(maxStorageDays))
+		c.Close()
+
+		if err != nil {
+			log15.Warn("EXPIRE failed", "key", key, "error", err)
+		}
+
+		jitter := time.Duration(rand.Intn(600)) * time.Second
+		time.Sleep(time.Hour + jitter)
+	}
+}

--- a/cmd/frontend/internal/usagestatsdeprecated/usage_stats_test.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/usage_stats_test.go
@@ -1,0 +1,487 @@
+//nolint
+package usagestatsdeprecated
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/stvp/tempredis"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func init() {
+	// Prevent background GC from running
+	gcOnce.Do(func() {})
+}
+
+func TestUserUsageStatistics_None(t *testing.T) {
+	setupForTest(t)
+
+	want := &types.UserUsageStatistics{
+		UserID: 42,
+	}
+	got, err := GetByUserID(42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("got %+v != %+v", got, want)
+	}
+}
+
+func TestUserUsageStatistics_LogPageView(t *testing.T) {
+	setupForTest(t)
+
+	user := types.User{
+		ID: 1,
+	}
+	err := LogActivity(true, user.ID, "test-cookie-id", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := GetByUserID(user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wantViews := int32(1); a.PageViews != wantViews {
+		t.Errorf("got %d, want %d", a.PageViews, wantViews)
+	}
+	diff := (*a.LastActiveTime).Unix() - time.Now().Unix()
+	if wantMaxDiff := 10; diff > int64(wantMaxDiff) || diff < -int64(wantMaxDiff) {
+		t.Errorf("got %d seconds apart, wanted less than %d seconds apart", diff, wantMaxDiff)
+	}
+}
+
+func TestUserUsageStatistics_LogSearchQuery(t *testing.T) {
+	setupForTest(t)
+
+	user := types.User{
+		ID: 1,
+	}
+	err := LogActivity(true, user.ID, "test-cookie-id", "SEARCHQUERY")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := GetByUserID(user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int32(1); a.SearchQueries != want {
+		t.Errorf("got %d, want %d", a.SearchQueries, want)
+	}
+}
+
+func TestUserUsageStatistics_LogCodeIntelAction(t *testing.T) {
+	setupForTest(t)
+
+	user := types.User{
+		ID: 1,
+	}
+	err := LogActivity(true, user.ID, "test-cookie-id", "CODEINTEL")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := GetByUserID(user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int32(1); a.CodeIntelligenceActions != want {
+		t.Errorf("got %d, want %d", a.CodeIntelligenceActions, want)
+	}
+}
+
+func TestUserUsageStatistics_LogCodeHostIntegrationUsage(t *testing.T) {
+	setupForTest(t)
+
+	user := types.User{
+		ID: 1,
+	}
+	err := LogActivity(true, user.ID, "test-cookie-id", "CODEINTELINTEGRATION")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := GetByUserID(user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diff := (*a.LastCodeHostIntegrationTime).Unix() - time.Now().Unix()
+	if wantMaxDiff := 10; diff > int64(wantMaxDiff) || diff < -int64(wantMaxDiff) {
+		t.Errorf("got %d seconds apart, wanted less than %d seconds apart", diff, wantMaxDiff)
+	}
+}
+
+func TestUserUsageStatistics_getUsersActiveToday(t *testing.T) {
+	setupForTest(t)
+
+	user1 := types.User{
+		ID: 1,
+	}
+	user2 := types.User{
+		ID: 2,
+	}
+
+	// Test single user
+	err := LogActivity(true, user1.ID, "test-cookie-id-1", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	n, err := GetUsersActiveTodayCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 1; n != want {
+		t.Errorf("got %d, want %d", n, want)
+	}
+
+	// Test multiple users, with repeats
+	err = LogActivity(true, user2.ID, "test-cookie-id-2", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(true, user1.ID, "test-cookie-id-1", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(false, 0, "test-cookie-id-3", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(true, user2.ID, "test-cookie-id-2", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	n, err = GetUsersActiveTodayCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 3; n != want {
+		t.Errorf("got %d, want %d", n, want)
+	}
+}
+
+func TestUserUsageStatistics_DAUs_WAUs_MAUs(t *testing.T) {
+	defer func() {
+		timeNow = time.Now
+	}()
+
+	setupForTest(t)
+
+	user1 := types.User{
+		ID: 1,
+	}
+	user2 := types.User{
+		ID: 2,
+	}
+
+	// hardcode "now" as 2018/03/31
+	now := time.Date(2018, 3, 31, 12, 0, 0, 0, time.UTC)
+	oneMonthFourDaysAgo := now.AddDate(0, -1, -4)
+	oneMonthThreeDaysAgo := now.AddDate(0, -1, -3)
+	twoWeeksTwoDaysAgo := now.AddDate(0, 0, -2*7-2)
+	twoWeeksAgo := now.AddDate(0, 0, -2*7)
+	fiveDaysAgo := now.AddDate(0, 0, -5)
+	threeDaysAgo := now.AddDate(0, 0, -3)
+
+	// 2018/02/27 (2 users, 1 registered)
+	mockTimeNow(oneMonthFourDaysAgo)
+	err := LogActivity(true, user1.ID, "test-1", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(false, 0, "068ccbfa-8529-4fa7-859e-2c3514af2434", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This should not be visible, as code host integration usage is ONLY recorded for registered users.
+	err = LogActivity(false, 0, "068ccbfa-8529-4fa7-859e-2c3514af2434", "CODEINTELINTEGRATION")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2018/02/28 (2 users, 1 registered)
+	mockTimeNow(oneMonthThreeDaysAgo)
+	err = LogActivity(true, user1.ID, "test-1", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(false, 0, "30dd2661-2e73-4774-bc2b-7a126f360734", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2018/03/15 (2 users, 1 registered)
+	mockTimeNow(twoWeeksTwoDaysAgo)
+	err = LogActivity(true, user2.ID, "test-2", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(false, 0, "068ccbfa-8529-4fa7-859e-2c3514af2434", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2018/03/17 (2 users, 1 registered)
+	mockTimeNow(twoWeeksAgo)
+	err = LogActivity(true, user2.ID, "test-2", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(false, 0, "b309dad0-b6f9-440d-bf0a-4cf38030ca70", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(true, user2.ID, "test-2", "CODEINTELINTEGRATION")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2018/03/26 (1 user, 1 registered)
+	mockTimeNow(fiveDaysAgo)
+	err = LogActivity(true, user1.ID, "test-1", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2018/03/28 (2 users, 2 registered)
+	mockTimeNow(threeDaysAgo)
+	err = LogActivity(true, user1.ID, "test-1", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(true, user2.ID, "test-2", "PAGEVIEW")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = LogActivity(true, user1.ID, "test-1", "CODEINTELINTEGRATION")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantMAUs := []*types.SiteActivityPeriod{
+		{
+			StartTime:            time.Date(2018, 3, 1, 0, 0, 0, 0, time.UTC),
+			UserCount:            4,
+			RegisteredUserCount:  2,
+			AnonymousUserCount:   2,
+			IntegrationUserCount: 2,
+		},
+		{
+			StartTime:            time.Date(2018, 2, 1, 0, 0, 0, 0, time.UTC),
+			UserCount:            3,
+			RegisteredUserCount:  1,
+			AnonymousUserCount:   2,
+			IntegrationUserCount: 0,
+		},
+		{
+			StartTime: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	wantWAUs := []*types.SiteActivityPeriod{
+		{
+			StartTime:            time.Date(2018, 3, 25, 0, 0, 0, 0, time.UTC),
+			UserCount:            2,
+			RegisteredUserCount:  2,
+			AnonymousUserCount:   0,
+			IntegrationUserCount: 1,
+		},
+		{
+			StartTime: time.Date(2018, 3, 18, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			StartTime:            time.Date(2018, 3, 11, 0, 0, 0, 0, time.UTC),
+			UserCount:            3,
+			RegisteredUserCount:  1,
+			AnonymousUserCount:   2,
+			IntegrationUserCount: 1,
+		},
+		{
+			StartTime: time.Date(2018, 3, 04, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	wantDAUs := []*types.SiteActivityPeriod{
+		{
+			StartTime: time.Date(2018, 3, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			StartTime: time.Date(2018, 3, 30, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			StartTime: time.Date(2018, 3, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			StartTime:            time.Date(2018, 3, 28, 0, 0, 0, 0, time.UTC),
+			UserCount:            2,
+			RegisteredUserCount:  2,
+			AnonymousUserCount:   0,
+			IntegrationUserCount: 1,
+		},
+		{
+			StartTime: time.Date(2018, 3, 27, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			StartTime:            time.Date(2018, 3, 26, 0, 0, 0, 0, time.UTC),
+			UserCount:            1,
+			RegisteredUserCount:  1,
+			AnonymousUserCount:   0,
+			IntegrationUserCount: 0,
+		},
+		{
+			StartTime: time.Date(2018, 3, 25, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	want := &types.SiteUsageStatistics{
+		DAUs: wantDAUs,
+		WAUs: wantWAUs,
+		MAUs: wantMAUs,
+	}
+
+	mockTimeNow(now)
+	days, weeks, months := 7, 4, 3
+	siteActivity, err := GetSiteUsageStatistics(&SiteUsageStatisticsOptions{
+		DayPeriods:   &days,
+		WeekPeriods:  &weeks,
+		MonthPeriods: &months,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = siteActivityCompare(siteActivity, want)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func setupForTest(t *testing.T) {
+	t.Helper()
+
+	if testRedisErr != nil {
+		t.Fatal("failed to setup temporary redis", testRedisErr)
+	}
+	if testRedis == nil {
+		t.Skip()
+	}
+
+	keyPrefix = "__test__" + t.Name() + ":"
+	pool = &redis.Pool{
+		MaxIdle:     3,
+		IdleTimeout: 240 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			c, err := redis.Dial("unix", testRedis.Socket())
+			if err != nil {
+				return nil, err
+			}
+			return c, err
+		},
+		TestOnBorrow: func(c redis.Conn, t time.Time) error {
+			_, err := c.Do("PING")
+			return err
+		},
+	}
+	c := pool.Get()
+	defer c.Close()
+	_, err := c.Do("EVAL", `local keys = redis.call('keys', ARGV[1])
+if #keys > 0 then
+	return redis.call('del', unpack(keys))
+else
+	return ''
+end`, 0, keyPrefix+"*")
+	if err != nil {
+		t.Log("Could not clear test prefix:", err)
+	}
+}
+
+func mockTimeNow(t time.Time) {
+	timeNow = func() time.Time {
+		return t
+	}
+}
+
+func siteActivityCompare(a, b *types.SiteUsageStatistics) error {
+	if a == nil || b == nil {
+		return errors.New("site activities can not be nil")
+	}
+	if a == b {
+		return nil
+	}
+	if len(a.DAUs) != len(b.DAUs) || len(a.WAUs) != len(b.WAUs) || len(a.MAUs) != len(b.MAUs) {
+		return errors.Errorf("site activities must be same length, got %d want %d (DAUs), got %d want %d (WAUs), got %d want %d (MAUs)", len(a.DAUs), len(b.DAUs), len(a.WAUs), len(b.WAUs), len(a.MAUs), len(b.MAUs))
+	}
+	if err := siteActivityPeriodSliceCompare("DAUs", a.DAUs, b.DAUs); err != nil {
+		return err
+	}
+	if err := siteActivityPeriodSliceCompare("WAUs", a.WAUs, b.WAUs); err != nil {
+		return err
+	}
+	if err := siteActivityPeriodSliceCompare("MAUs", a.MAUs, b.MAUs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func siteActivityPeriodSliceCompare(label string, a, b []*types.SiteActivityPeriod) error {
+	if a == nil || b == nil {
+		return errors.Errorf("%v slices can not be nil", label)
+	}
+	for i, v := range a {
+		if err := siteActivityPeriodCompare(label, v, b[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func siteActivityPeriodCompare(label string, a, b *types.SiteActivityPeriod) error {
+	if a == nil || b == nil {
+		return errors.New("site activity periods can not be nil")
+	}
+	if a == b {
+		return nil
+	}
+	if a.StartTime != b.StartTime || a.UserCount != b.UserCount || a.RegisteredUserCount != b.RegisteredUserCount || a.AnonymousUserCount != b.AnonymousUserCount || a.IntegrationUserCount != b.IntegrationUserCount {
+		return errors.Errorf("[%v] got %+v want %+v", label, a, b)
+	}
+	return nil
+}
+
+var (
+	testRedis    *tempredis.Server
+	testRedisErr error
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if !testing.Short() {
+		testRedis, testRedisErr = tempredis.Start(nil)
+	}
+
+	code := m.Run()
+
+	if testRedis != nil {
+		err := testRedis.Kill()
+		if err != nil {
+			log.Fatal("failed to kill test redis: ", err)
+		}
+	}
+
+	os.Exit(code)
+}

--- a/cmd/frontend/internal/usagestatsdeprecated/util.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/util.go
@@ -1,0 +1,75 @@
+package usagestatsdeprecated
+
+import (
+	"strconv"
+	"time"
+)
+
+func keyFromDate(activity string, date time.Time) string {
+	return keyPrefix + ":" + activity + ":" + time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+}
+
+func usersActiveKeyFromDate(date time.Time) string {
+	return keyFromDate(fUsersActive, date)
+}
+
+func usersActiveKeyFromDaysAgo(daysAgo int) string {
+	now := timeNow().UTC()
+	return keyFromDate(fUsersActive, now.AddDate(0, 0, -daysAgo))
+}
+
+func startOfWeek(weeksAgo int) time.Time {
+	if weeksAgo > 0 {
+		return startOfWeek(0).AddDate(0, 0, -7*weeksAgo)
+	}
+
+	// If weeksAgo == 0, start at timeNow(), and loop back by day until we hit a Sunday
+	now := timeNow().UTC()
+	date := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	for date.Weekday() != time.Sunday {
+		date = date.AddDate(0, 0, -1)
+	}
+	return date
+}
+
+func startOfMonth(monthsAgo int) time.Time {
+	now := timeNow().UTC()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -monthsAgo, 0)
+}
+
+func keys(m map[string]bool) []string {
+	keys := make([]string, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+func minIntOrZero(a, b int) int {
+	min := b
+	if a < b {
+		min = a
+	}
+	if min < 0 {
+		return 0
+	}
+	return min
+}
+
+func incrementUserCounter(userID int32, isAuthenticated bool, counterKey string) error {
+	if !isAuthenticated {
+		return nil
+	}
+
+	key := keyPrefix + strconv.Itoa(int(userID))
+	c := pool.Get()
+	defer c.Close()
+
+	return c.Send("HINCRBY", key, counterKey, 1)
+}
+
+func keyFromStage(stage string) string {
+	return "user-last-active-" + stage
+}

--- a/dev/sg/linters/liblog.go
+++ b/dev/sg/linters/liblog.go
@@ -32,6 +32,8 @@ func lintLoggingLibraries() *linter {
 			"internal/observation/fields.go",
 			// Dependencies require direct usage of zap
 			"cmd/frontend/internal/app/otlpadapter",
+			// Not worth fixing the deprecated package
+			"cmd/frontend/internal/usagestatsdeprecated",
 		}
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -148,6 +148,7 @@ require (
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220511160847-5a43d3ea24eb
 	github.com/stretchr/testify v1.8.0
 	github.com/stripe/stripe-go v70.15.0+incompatible
+	github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203
 	github.com/temoto/robotstxt v1.1.2
 	github.com/throttled/throttled/v2 v2.9.0
 	github.com/tidwall/gjson v1.14.0

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -7936,7 +7936,7 @@ func NewMockEventLogStore() *MockEventLogStore {
 			},
 		},
 		CountUniqueUsersAllFunc: &EventLogStoreCountUniqueUsersAllFunc{
-			defaultHook: func(context.Context, time.Time, time.Time, *CountUniqueUsersOptions) (r0 int, r1 error) {
+			defaultHook: func(context.Context, time.Time, time.Time) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -8128,7 +8128,7 @@ func NewStrictMockEventLogStore() *MockEventLogStore {
 			},
 		},
 		CountUniqueUsersAllFunc: &EventLogStoreCountUniqueUsersAllFunc{
-			defaultHook: func(context.Context, time.Time, time.Time, *CountUniqueUsersOptions) (int, error) {
+			defaultHook: func(context.Context, time.Time, time.Time) (int, error) {
 				panic("unexpected invocation of MockEventLogStore.CountUniqueUsersAll")
 			},
 		},
@@ -10231,24 +10231,24 @@ func (c EventLogStoreCountByUserIDAndEventNamesFuncCall) Results() []interface{}
 // CountUniqueUsersAll method of the parent MockEventLogStore instance is
 // invoked.
 type EventLogStoreCountUniqueUsersAllFunc struct {
-	defaultHook func(context.Context, time.Time, time.Time, *CountUniqueUsersOptions) (int, error)
-	hooks       []func(context.Context, time.Time, time.Time, *CountUniqueUsersOptions) (int, error)
+	defaultHook func(context.Context, time.Time, time.Time) (int, error)
+	hooks       []func(context.Context, time.Time, time.Time) (int, error)
 	history     []EventLogStoreCountUniqueUsersAllFuncCall
 	mutex       sync.Mutex
 }
 
 // CountUniqueUsersAll delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockEventLogStore) CountUniqueUsersAll(v0 context.Context, v1 time.Time, v2 time.Time, v3 *CountUniqueUsersOptions) (int, error) {
-	r0, r1 := m.CountUniqueUsersAllFunc.nextHook()(v0, v1, v2, v3)
-	m.CountUniqueUsersAllFunc.appendCall(EventLogStoreCountUniqueUsersAllFuncCall{v0, v1, v2, v3, r0, r1})
+func (m *MockEventLogStore) CountUniqueUsersAll(v0 context.Context, v1 time.Time, v2 time.Time) (int, error) {
+	r0, r1 := m.CountUniqueUsersAllFunc.nextHook()(v0, v1, v2)
+	m.CountUniqueUsersAllFunc.appendCall(EventLogStoreCountUniqueUsersAllFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the CountUniqueUsersAll
 // method of the parent MockEventLogStore instance is invoked and the hook
 // queue is empty.
-func (f *EventLogStoreCountUniqueUsersAllFunc) SetDefaultHook(hook func(context.Context, time.Time, time.Time, *CountUniqueUsersOptions) (int, error)) {
+func (f *EventLogStoreCountUniqueUsersAllFunc) SetDefaultHook(hook func(context.Context, time.Time, time.Time) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -10257,7 +10257,7 @@ func (f *EventLogStoreCountUniqueUsersAllFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *EventLogStoreCountUniqueUsersAllFunc) PushHook(hook func(context.Context, time.Time, time.Time, *CountUniqueUsersOptions) (int, error)) {
+func (f *EventLogStoreCountUniqueUsersAllFunc) PushHook(hook func(context.Context, time.Time, time.Time) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -10266,19 +10266,19 @@ func (f *EventLogStoreCountUniqueUsersAllFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *EventLogStoreCountUniqueUsersAllFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, time.Time, time.Time, *CountUniqueUsersOptions) (int, error) {
+	f.SetDefaultHook(func(context.Context, time.Time, time.Time) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *EventLogStoreCountUniqueUsersAllFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, time.Time, time.Time, *CountUniqueUsersOptions) (int, error) {
+	f.PushHook(func(context.Context, time.Time, time.Time) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *EventLogStoreCountUniqueUsersAllFunc) nextHook() func(context.Context, time.Time, time.Time, *CountUniqueUsersOptions) (int, error) {
+func (f *EventLogStoreCountUniqueUsersAllFunc) nextHook() func(context.Context, time.Time, time.Time) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -10321,9 +10321,6 @@ type EventLogStoreCountUniqueUsersAllFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 time.Time
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 *CountUniqueUsersOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -10335,7 +10332,7 @@ type EventLogStoreCountUniqueUsersAllFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c EventLogStoreCountUniqueUsersAllFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/usagestats/usage_stats.go
+++ b/internal/usagestats/usage_stats.go
@@ -152,7 +152,7 @@ func GetByUserID(ctx context.Context, db database.DB, userID int32) (*types.User
 func GetUsersActiveTodayCount(ctx context.Context, db database.DB) (int, error) {
 	now := timeNow().UTC()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return db.EventLogs().CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1), &database.CountUniqueUsersOptions{ExcludeSystemUsers: true})
+	return db.EventLogs().CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1))
 }
 
 // ListRegisteredUsersToday returns a list of the registered users that were active today.
@@ -229,22 +229,18 @@ func activeUsers(ctx context.Context, db database.DB, periodType database.Period
 		return []*types.SiteActivityPeriod{}, nil
 	}
 
-	uniqueUsers, err := db.EventLogs().CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &database.CountUniqueUsersOptions{
-		ExcludeSystemUsers: true,
-	})
+	uniqueUsers, err := db.EventLogs().CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, nil)
 	if err != nil {
 		return nil, err
 	}
 	registeredUniqueUsers, err := db.EventLogs().CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &database.CountUniqueUsersOptions{
-		RegisteredOnly:     true,
-		ExcludeSystemUsers: true,
+		RegisteredOnly: true,
 	})
 	if err != nil {
 		return nil, err
 	}
 	integrationUniqueUsers, err := db.EventLogs().CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &database.CountUniqueUsersOptions{
-		IntegrationOnly:    true,
-		ExcludeSystemUsers: true,
+		IntegrationOnly: true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This reverts commit 890ad0626b710fb598a0e8709a030fae59e3a077 as it caused the WAU request to take more than 60s to finish on k8s and thus 504s.



## Test plan

Is a revert