### PR TITLE
executors: Use latest packer version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -6,7 +6,7 @@ shfmt 3.5.0
 shellcheck 0.7.1
 kubectl 1.21.7
 github-cli 2.0.0
-packer 1.7.10
+packer 1.8.3
 trivy 0.30.3
 kustomize 4.0.5
 awscli 2.4.7


### PR DESCRIPTION
Little hygiene thing that allows me to give AWS AMIs a proper name.

## Test plan

Did a patch build before to validate it still passes.