### PR TITLE
repo-updater: Fetch deleted external services for sync

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -793,12 +793,12 @@ func TestServer_handleExternalServiceSync(t *testing.T) {
 					return test.err
 				},
 			}
-			r := httptest.NewRequest("POST", "/sync-external-service", strings.NewReader(`{"ExternalService": {"ID":1,"kind":"GITHUB"}}}`))
+			r := httptest.NewRequest("POST", "/sync-external-service", strings.NewReader(`{"ExternalServiceID": 1}`))
 			w := httptest.NewRecorder()
 			s := repos.NewMockStore()
 			es := database.NewMockExternalServiceStore()
 			s.ExternalServiceStoreFunc.SetDefaultReturn(es)
-			es.GetByIDFunc.PushReturn(&types.ExternalService{ID: 1, Kind: extsvc.KindGitHub}, nil)
+			es.ListFunc.PushReturn([]*types.ExternalService{{ID: 1, Kind: extsvc.KindGitHub}}, nil)
 
 			srv := &Server{Logger: logtest.Scoped(t), Store: s, Syncer: &repos.Syncer{Sourcer: repos.NewFakeSourcer(nil, src)}}
 			srv.handleExternalServiceSync(w, r)


### PR DESCRIPTION
When we refactored to not sending the entire external service over the wire anymore, it was missed that the final sync happens after it is soft-deleted. This PR fixes the final sync after deleting an external service by also fetching deleted external services.



## Test plan

Added tests and verified no error is logged when deleting an external service.