### PR TITLE
web: prioritize `browser` typings for `@opentelemetry` packages

### DIFF
--- a/client/web/src/monitoring/opentelemetry/initOpenTelemetry.ts
+++ b/client/web/src/monitoring/opentelemetry/initOpenTelemetry.ts
@@ -1,6 +1,6 @@
 import { ZoneContextManager } from '@opentelemetry/context-zone'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import { registerInstrumentations } from '@opentelemetry/instrumentation'
+import { InstrumentationOption, registerInstrumentations } from '@opentelemetry/instrumentation'
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch'
 import { Resource } from '@opentelemetry/resources'
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
@@ -34,7 +34,8 @@ export function initOpenTelemetry(): void {
         })
 
         registerInstrumentations({
-            instrumentations: [new FetchInstrumentation()],
+            // Type-casting is required since the `FetchInstrumentation` is wrongly typed internally as `node.js` instrumentation.
+            instrumentations: [(new FetchInstrumentation() as unknown) as InstrumentationOption],
         })
     }
 }

--- a/client/web/src/types/@opentelemetry/api/index.d.ts
+++ b/client/web/src/types/@opentelemetry/api/index.d.ts
@@ -1,0 +1,4 @@
+declare module '@opentelemetry/api' {
+    export * from '@opentelemetry/api/build/src/platform/browser'
+    export * from '@opentelemetry/api/build/src'
+}

--- a/client/web/src/types/@opentelemetry/core/index.d.ts
+++ b/client/web/src/types/@opentelemetry/core/index.d.ts
@@ -1,0 +1,4 @@
+declare module '@opentelemetry/core' {
+    export * from '@opentelemetry/core/build/src/platform/browser'
+    export * from '@opentelemetry/core/build/src'
+}

--- a/client/web/src/types/@opentelemetry/exporter-trace-otlp-http/index.d.ts
+++ b/client/web/src/types/@opentelemetry/exporter-trace-otlp-http/index.d.ts
@@ -1,0 +1,4 @@
+declare module '@opentelemetry/exporter-trace-otlp-http' {
+    export * from '@opentelemetry/exporter-trace-otlp-http/build/src/platform/browser'
+    export * from '@opentelemetry/exporter-trace-otlp-http/build/src'
+}

--- a/client/web/src/types/@opentelemetry/instrumentation/index.d.ts
+++ b/client/web/src/types/@opentelemetry/instrumentation/index.d.ts
@@ -1,0 +1,4 @@
+declare module '@opentelemetry/instrumentation' {
+    export * from '@opentelemetry/instrumentation/build/src/platform/browser'
+    export * from '@opentelemetry/instrumentation/build/src'
+}

--- a/client/web/src/types/@opentelemetry/resources/index.d.ts
+++ b/client/web/src/types/@opentelemetry/resources/index.d.ts
@@ -1,0 +1,4 @@
+declare module '@opentelemetry/resources' {
+    export * from '@opentelemetry/resources/build/src/platform/browser'
+    export * from '@opentelemetry/resources/build/src'
+}

--- a/client/web/src/types/@opentelemetry/sdk-trace-base/index.d.ts
+++ b/client/web/src/types/@opentelemetry/sdk-trace-base/index.d.ts
@@ -1,0 +1,4 @@
+declare module '@opentelemetry/sdk-trace-base' {
+    export * from '@opentelemetry/sdk-trace-base/build/src/platform/browser'
+    export * from '@opentelemetry/sdk-trace-base/build/src'
+}

--- a/client/web/src/types/@opentelemetry/semantic-conventions/index.d.ts
+++ b/client/web/src/types/@opentelemetry/semantic-conventions/index.d.ts
@@ -1,0 +1,4 @@
+declare module '@opentelemetry/semantic-conventions' {
+    export * from '@opentelemetry/semantic-conventions/build/src/platform/browser'
+    export * from '@opentelemetry/semantic-conventions/build/src'
+}


### PR DESCRIPTION
## Context

Prioritize `browser` typings for `@opentelemetry` packages. The `browser` field in the `package.json` is used to load the browser code, but Typescript typings are specific to the `node.js` environment by default. This PR fixes it by augmenting third-party typings.

There's [no easy way](https://github.com/Microsoft/TypeScript/issues/29128) to patch in the source repo.

## Test plan

Ensure that `browser` types are used. (e.g., try looking at the `OTLPTraceExporter` type)

## App preview:

- [Web](https://sg-web-vb-otel-typings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ozhtqtgxow.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
