### PR TITLE
admin-analytics: add "site.users" "lastActivePeriod" query filter

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5715,6 +5715,11 @@ type Site implements SettingsSubject {
         Returns users that contain filter in the email field.
         """
         email: String
+        """
+        Returns users for the given lastActive enum period.
+        When omitted does NOT apply and returns for all period available.
+        """
+        lastActivePeriod: SiteUsersLastActivePeriod
     ): SiteUsers!
 
     """
@@ -6371,6 +6376,15 @@ enum SiteUserOrderBy {
     Whether the user is site admin or not.
     """
     SITE_ADMIN
+}
+
+"""
+SiteUsersLastActivePeriod enumerates the ways to filter based on users' last active date
+"""
+enum SiteUsersLastActivePeriod {
+    TODAY
+    THIS_WEEK
+    THIS_MONTH
 }
 
 """


### PR DESCRIPTION
Follow-up https://github.com/sourcegraph/sourcegraph/issues/39820.
## Test plan
- `sg start`
- Open API console http://localhost:3080/api/console
```graphql

fragment SiteUsersFragment on SiteUsers {
  totalCount
  nodes {
    id
    username
    email
    createdAt
    lastActiveAt
    deletedAt
    siteAdmin
    eventsCount
  }
}

{
  site {
    # last active today
    activeTodayUsers: users(lastActivePeriod: TODAY) {
      ... SiteUsersFragment
    }
    # last active this week
    activeThisWeekUsers: users(lastActivePeriod: THIS_WEEK) {
      ... SiteUsersFragment
    }
    # last active this month
    activeThisMonthUsers: users(lastActivePeriod: THIS_MONTH) {
      ... SiteUsersFragment
    }
    # all time
    allUsers: users {
      ... SiteUsersFragment
    }
  }
}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
