### PR TITLE
oneclickexport: add REST API endpoint for archive download

### DIFF
--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -74,7 +74,7 @@ func NewHandler(db database.DB, githubAppCloudSetupHandler http.Handler) http.Ha
 	r.Get(router.UsageStatsDownload).Handler(trace.Route(http.HandlerFunc(usageStatsArchiveHandler(db))))
 
 	// One-click export ZIP download
-	r.Get(router.OneClickExportArchive).Handler(trace.Route(http.HandlerFunc(oneClickExportHandler(db))))
+	r.Get(router.OneClickExportArchive).Handler(trace.Route(oneClickExportHandler(db)))
 
 	// Ping retrieval
 	r.Get(router.LatestPing).Handler(trace.Route(http.HandlerFunc(latestPingHandler(db))))

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/NYTimes/gziphandler"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/errorutil"
@@ -22,7 +23,7 @@ import (
 //
 // 🚨 SECURITY: The caller MUST wrap the returned handler in middleware that checks authentication
 // and sets the actor in the request context.
-func NewHandler(db database.DB, githubAppCloudSetupHandler http.Handler) http.Handler {
+func NewHandler(db database.DB, logger log.Logger, githubAppCloudSetupHandler http.Handler) http.Handler {
 	session.SetSessionStore(session.NewRedisStore(func() bool {
 		return globals.ExternalURL().Scheme == "https"
 	}))
@@ -74,7 +75,7 @@ func NewHandler(db database.DB, githubAppCloudSetupHandler http.Handler) http.Ha
 	r.Get(router.UsageStatsDownload).Handler(trace.Route(http.HandlerFunc(usageStatsArchiveHandler(db))))
 
 	// One-click export ZIP download
-	r.Get(router.OneClickExportArchive).Handler(trace.Route(oneClickExportHandler(db)))
+	r.Get(router.OneClickExportArchive).Handler(trace.Route(oneClickExportHandler(db, logger)))
 
 	// Ping retrieval
 	r.Get(router.LatestPing).Handler(trace.Route(http.HandlerFunc(latestPingHandler(db))))

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -73,6 +73,9 @@ func NewHandler(db database.DB, githubAppCloudSetupHandler http.Handler) http.Ha
 	// Usage statistics ZIP download
 	r.Get(router.UsageStatsDownload).Handler(trace.Route(http.HandlerFunc(usageStatsArchiveHandler(db))))
 
+	// One-click export ZIP download
+	r.Get(router.OneClickExportArchive).Handler(trace.Route(http.HandlerFunc(oneClickExportHandler(db))))
+
 	// Ping retrieval
 	r.Get(router.LatestPing).Handler(trace.Route(http.HandlerFunc(latestPingHandler(db))))
 

--- a/cmd/frontend/internal/app/one_click_export.go
+++ b/cmd/frontend/internal/app/one_click_export.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+func oneClickExportHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// 🚨SECURITY: Only site admins may get this archive.
+		ctx := r.Context()
+		if err := backend.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Disposition", "attachment; filename=\"SourcegraphDataExport.zip\"")
+
+		var request oce.ExportRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		archive, err := oce.GlobalExporter.Export(ctx, request)
+		if err != nil {
+			log15.Error("OneClickExport", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		_, _ = w.Write(archive)
+	}
+}

--- a/cmd/frontend/internal/app/one_click_export.go
+++ b/cmd/frontend/internal/app/one_click_export.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
-func oneClickExportHandler(db database.DB) http.HandlerFunc {
+func oneClickExportHandler(db database.DB, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// 🚨SECURITY: Only site admins may get this archive.
 		ctx := r.Context()
@@ -30,7 +30,7 @@ func oneClickExportHandler(db database.DB) http.HandlerFunc {
 
 		archive, err := oce.GlobalExporter.Export(ctx, request)
 		if err != nil {
-			log15.Error("OneClickExport", "error", err)
+			logger.Error("OneClickExport", log.Error(err))
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -39,7 +39,7 @@ func oneClickExportHandler(db database.DB) http.HandlerFunc {
 		for len(archive) > 0 {
 			bytesWritten, err := w.Write(archive)
 			if err != nil {
-				log15.Error("OneClickExport output write", "error", err)
+				logger.Error("OneClickExport output write", log.Error(err))
 				return
 			}
 

--- a/cmd/frontend/internal/app/one_click_export_test.go
+++ b/cmd/frontend/internal/app/one_click_export_test.go
@@ -46,6 +46,10 @@ func TestOneClickExportHandler(t *testing.T) {
 			}},
 		}
 		data, err := json.Marshal(request)
+		if err != nil {
+			t.Errorf("Failed to marshal ExportRequest: %s", err)
+		}
+
 		req, _ := http.NewRequest("POST", "", bytes.NewBuffer(data))
 		rec := httptest.NewRecorder()
 		oneClickExportHandler(db)(rec, req.WithContext(actor.WithInternalActor(context.Background())))

--- a/cmd/frontend/internal/app/one_click_export_test.go
+++ b/cmd/frontend/internal/app/one_click_export_test.go
@@ -24,7 +24,7 @@ func TestOneClickExportHandler(t *testing.T) {
 	t.Run("non-admins cannot download the archive", func(t *testing.T) {
 		req, _ := http.NewRequest("POST", "", nil)
 		rec := httptest.NewRecorder()
-		oneClickExportHandler(db)(rec, req)
+		oneClickExportHandler(db, logger)(rec, req)
 
 		if have, want := rec.Code, http.StatusUnauthorized; have != want {
 			t.Errorf("status code: have %d, want %d", have, want)
@@ -52,7 +52,7 @@ func TestOneClickExportHandler(t *testing.T) {
 
 		req, _ := http.NewRequest("POST", "", bytes.NewBuffer(data))
 		rec := httptest.NewRecorder()
-		oneClickExportHandler(db)(rec, req.WithContext(actor.WithInternalActor(context.Background())))
+		oneClickExportHandler(db, logger)(rec, req.WithContext(actor.WithInternalActor(context.Background())))
 
 		contentType := rec.Header().Get("Content-Type")
 		if have, want := contentType, "application/zip"; have != want {

--- a/cmd/frontend/internal/app/one_click_export_test.go
+++ b/cmd/frontend/internal/app/one_click_export_test.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestOneClickExportHandler(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+	t.Run("non-admins cannot download the archive", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "", nil)
+		rec := httptest.NewRecorder()
+		oneClickExportHandler(db)(rec, req)
+
+		if have, want := rec.Code, http.StatusUnauthorized; have != want {
+			t.Errorf("status code: have %d, want %d", have, want)
+		}
+	})
+
+	t.Run("admins can download the archive", func(t *testing.T) {
+		oce.GlobalExporter = oce.NewDataExporter(db, logger)
+		t.Cleanup(func() {
+			oce.GlobalExporter = nil
+		})
+
+		request := oce.ExportRequest{
+			IncludeSiteConfig:     true,
+			IncludeCodeHostConfig: true,
+			DBQueries: []*oce.DBQueryRequest{{
+				TableName: "external_services",
+				Count:     10,
+			}},
+		}
+		data, err := json.Marshal(request)
+		req, _ := http.NewRequest("POST", "", bytes.NewBuffer(data))
+		rec := httptest.NewRecorder()
+		oneClickExportHandler(db)(rec, req.WithContext(actor.WithInternalActor(context.Background())))
+
+		contentType := rec.Header().Get("Content-Type")
+		if have, want := contentType, "application/zip"; have != want {
+			t.Errorf("Content-Type: have %q, want %q", have, want)
+		}
+
+		contentDisposition := rec.Header().Get("Content-Disposition")
+		if have, want := contentDisposition, "attachment; filename=\"SourcegraphDataExport.zip\""; have != want {
+			t.Errorf("Content-Disposition: have %q, want %q", have, want)
+		}
+
+		zr, err := zip.NewReader(bytes.NewReader(rec.Body.Bytes()), int64(rec.Body.Len()))
+		if err != nil {
+			t.Errorf("Body: Failed to open ZIP: %s", err)
+		}
+
+		if len(zr.File) == 0 {
+			t.Errorf("Zero files in ZIP archive")
+		}
+	})
+}

--- a/cmd/frontend/internal/app/router/router.go
+++ b/cmd/frontend/internal/app/router/router.go
@@ -36,6 +36,8 @@ const (
 
 	UsageStatsDownload = "usage-stats.download"
 
+	OneClickExportArchive = "one-click-export.archive"
+
 	LatestPing = "pings.latest"
 
 	SetupGitHubAppCloud = "setup.github.app.cloud"
@@ -95,6 +97,8 @@ func newRouter() *mux.Router {
 	base.Path("/tools").Methods("GET").Name(OldToolsRedirect)
 
 	base.Path("/site-admin/usage-statistics/archive").Methods("GET").Name(UsageStatsDownload)
+
+	base.Path("/site-admin/data-export/archive").Methods("POST").Name(OneClickExportArchive)
 
 	base.Path("/site-admin/pings/latest").Methods("GET").Name(LatestPing)
 

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -74,7 +74,8 @@ func newExternalHTTPHandler(
 	githubAppCloudSetupHandler := newGitHubAppCloudSetupHandler()
 
 	// App handler (HTML pages), the call order of middleware is LIFO.
-	appHandler := app.NewHandler(db, githubAppCloudSetupHandler)
+	logger := log.Scoped("external", "external http handlers")
+	appHandler := app.NewHandler(db, logger, githubAppCloudSetupHandler)
 	if hooks.PostAuthMiddleware != nil {
 		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
 		appHandler = hooks.PostAuthMiddleware(appHandler)
@@ -97,7 +98,6 @@ func newExternalHTTPHandler(
 
 	var h http.Handler = sm
 
-	logger := log.Scoped("external", "external http handlers")
 	// Wrap in middleware, first line is last to run.
 	//
 	// 🚨 SECURITY: Auth middleware that must run before other auth middlewares.

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keegancsmith/tmpfriend"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
 	"github.com/throttled/throttled/v2/store/redigostore"
 
 	sglog "github.com/sourcegraph/log"
@@ -313,6 +314,8 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 	if internalAPI != nil {
 		routines = append(routines, internalAPI)
 	}
+
+	oce.GlobalExporter = oce.NewDataExporter(db, logger)
 
 	if printLogo {
 		// This is not a log entry and is usually disabled


### PR DESCRIPTION
This commit wires up one-click export ZIP archive creation code with REST API layer of `frontend` service. The endpoint should be accessed with POST HTTP method by site admins only.

Test plan: new unit test for REST API layer is added. Manually verified that the archive with required contents is downloaded on local sg instance.

Closes https://github.com/sourcegraph/sourcegraph/issues/39590