### PR TITLE
Extension deprecation: Change enableLegacyExtensions flag to default to true

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -185,9 +185,6 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 	}
 
 	var enableLegacyExtensions = true
-	if siteConfig.ExperimentalFeatures != nil {
-		enableLegacyExtensions = siteConfig.ExperimentalFeatures.EnableLegacyExtensions
-	}
 	// 🚨 SECURITY: This struct is sent to all users regardless of whether or
 	// not they are logged in, for example on an auth.public=false private
 	// server. Including secret fields here is OK if it is based on the user's


### PR DESCRIPTION
This PR reverts #39661

Unfortunately fixing the typo revealed a mistake in the JSON struct parsing logic. Since `ExperimentalFeatures` is defined as a Go `struct`, its boolean members will always default to `false`. It appears that the JSON parsing logic is leaving the default value when no property is defined in the config file and thus `enableLegacyExtensions` is set to `false` potentially disabling the extensions (even though this should only be the behavior after 4.0)

## Test plan

![Screenshot 2022-08-08 at 14 31 19](https://user-images.githubusercontent.com/458591/183419010-e17fed0d-398e-410a-b92e-e94213763b5d.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
