### PR TITLE
web: add OTel console-batch-exporter for the development environment

### DIFF
--- a/client/web/src/monitoring/opentelemetry/exporters/consoleBatchSpanExporter.ts
+++ b/client/web/src/monitoring/opentelemetry/exporters/consoleBatchSpanExporter.ts
@@ -1,0 +1,85 @@
+import { Attributes } from '@opentelemetry/api'
+import { ExportResultCode, hrTimeToMilliseconds, ExportResult } from '@opentelemetry/core'
+import { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base'
+
+import { parseAttributes } from './utils'
+
+interface FormattedSpan {
+    name?: string
+    raw?: ReadableSpan
+    attrs?: Attributes
+    children?: FormattedSpan[]
+}
+
+/**
+ * Nests spans using `parentSpanId` fields on a span batch and logs them into the console.
+ *
+ * Used in the development environment for a faster feedback cycle
+ * and better span explorability during experimentation with new OTel instrumentations.
+ */
+export class ConsoleBatchSpanExporter implements SpanExporter {
+    private formatDuration(span: ReadableSpan): string {
+        return hrTimeToMilliseconds(span.duration).toString() + 'ms'
+    }
+
+    private groupSpans(spans: ReadableSpan[]): FormattedSpan[] {
+        const rootSpans: FormattedSpan[] = []
+        const formattedSpans: Record<string, FormattedSpan> = {}
+
+        for (const span of spans) {
+            const { parentSpanId, attributes } = span
+            const { spanId } = span.spanContext()
+
+            const formattedSpan: FormattedSpan = formattedSpans[spanId] ?? {
+                children: [],
+            }
+
+            formattedSpan.raw = span
+            formattedSpan.attrs = parseAttributes(attributes)
+            formattedSpan.name = `${span.name} - ${this.formatDuration(span)}`
+
+            if (parentSpanId) {
+                const parentSpan = formattedSpans[parentSpanId]
+
+                if (parentSpan) {
+                    parentSpan.children?.push(formattedSpan)
+                } else {
+                    formattedSpans[parentSpanId] = { children: [formattedSpan] }
+                }
+            } else {
+                rootSpans.push(formattedSpan)
+            }
+
+            formattedSpans[spanId] = formattedSpan
+        }
+
+        return rootSpans
+    }
+
+    private nestSpans = (span: FormattedSpan): Record<string, FormattedSpan> => {
+        const { attrs, raw, children, name = 'unknown' } = span
+        const spanDetails: FormattedSpan = { attrs, raw }
+
+        if (children?.length) {
+            spanDetails.children = children.map(spanChildren => this.nestSpans(spanChildren))
+        }
+
+        return {
+            [name]: spanDetails,
+        }
+    }
+
+    public export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+        const formattedSpans = this.groupSpans(spans).map(this.nestSpans)
+
+        for (const span of formattedSpans) {
+            console.debug(span)
+        }
+
+        return resultCallback({ code: ExportResultCode.SUCCESS })
+    }
+
+    public shutdown(): Promise<void> {
+        return Promise.resolve()
+    }
+}

--- a/client/web/src/monitoring/opentelemetry/exporters/utils.ts
+++ b/client/web/src/monitoring/opentelemetry/exporters/utils.ts
@@ -1,0 +1,13 @@
+import { Attributes } from '@opentelemetry/api'
+
+export function parseAttributes(attributes: Attributes): Attributes {
+    return Object.fromEntries(
+        Object.entries(attributes).map(([key, value]) => {
+            try {
+                return [key, JSON.parse(value as string)]
+            } catch {
+                return [key, value]
+            }
+        })
+    )
+}

--- a/client/web/src/monitoring/opentelemetry/initZones.ts
+++ b/client/web/src/monitoring/opentelemetry/initZones.ts
@@ -1,0 +1,4 @@
+// Use passive event listeners by default to improve perf and remove Chrome warning.
+// https://github.com/angular/angular/blob/main/aio/content/guide/event-binding.md#binding-to-passive-events
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+;(window as any).__zone_symbol__PASSIVE_EVENTS = ['scroll', 'touchstart', 'touchmove']


### PR DESCRIPTION
## Context 

Add `ConsoleBatchSpanExporter` that nests spans using `parentSpanId` fields on a span batch and logs them into the console. Used in the development environment for a faster feedback cycle and better span explorability during experimentation with new OTel instrumentation.

<img width="712" alt="Screen Shot 2022-08-08 at 21 02 43" src="https://user-images.githubusercontent.com/3846380/183424311-814d66b1-f902-4648-84f0-2af56f2d181f.png">

Also, fixes the warning about using non-passive scroll event listeners by `zone.js` library.

## Test plan

1. `ENABLE_OPEN_TELEMETRY=true sg start web-standalone` 
2. Refresh the page.
3. See OTel spans in the console.

## App preview:

- [Web](https://sg-web-vb-otel-console-batch-exporter.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ougadszzmr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

