### PR TITLE
web: disable flaky test

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -147,7 +147,7 @@ describe('Search', () => {
 
     describe('Suggestions', () => {
         withSearchQueryInput(editorName => {
-            test(`Typing in the search field shows relevant suggestions (${editorName})`, async () => {
+            test.skip(`Typing in the search field shows relevant suggestions (${editorName})`, async () => {
                 testContext.overrideGraphQL({
                     ...commonSearchGraphQLResults,
                     ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),


### PR DESCRIPTION
## Context

[Flaked](https://buildkite.com/sourcegraph/sourcegraph/builds/165888#01827d2d-4680-4c30-8eb6-0a8216207f75) on [the PR with Typescript types changes](https://github.com/sourcegraph/sourcegraph/pull/40073). 
The issue to re-enable https://github.com/sourcegraph/sourcegraph/issues/40084

## Test plan

n/a — disabled flaky test.

## App preview:

- [Web](https://sg-web-vb-disable-flaky-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vwhwtesqax.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
