### PR TITLE
Web [Charts]: Fix line chart tooltip value formatters

### DIFF
--- a/client/web/src/charts/components/line-chart/components/tooltip/TooltipContent.tsx
+++ b/client/web/src/charts/components/line-chart/components/tooltip/TooltipContent.tsx
@@ -67,6 +67,7 @@ export function TooltipContent<Datum>(props: TooltipContentProps<Datum>): ReactE
                     <TooltipListBlankItem>... and {lines.leftRemaining} more</TooltipListBlankItem>
                 )}
                 {lines.window.map(line => {
+                    // TODO: Support stacked formatted value
                     const value = formatYTick(line.value)
                     const isActiveLine = activePoint.seriesId === line.id
 

--- a/client/web/src/charts/components/line-chart/components/tooltip/TooltipContent.tsx
+++ b/client/web/src/charts/components/line-chart/components/tooltip/TooltipContent.tsx
@@ -4,7 +4,7 @@ import { isDefined } from '@sourcegraph/common'
 import { H3 } from '@sourcegraph/wildcard'
 
 import { TooltipList, TooltipListBlankItem, TooltipListItem } from '../../../../core'
-import { formatDateTick } from '../../../../core/components/axis/tick-formatters'
+import { formatYTick } from '../../../../core/components/axis/tick-formatters'
 import { Point } from '../../types'
 import { isValidNumber, SeriesWithData, SeriesDatum, getDatumValue, getLineColor } from '../../utils'
 
@@ -67,10 +67,8 @@ export function TooltipContent<Datum>(props: TooltipContentProps<Datum>): ReactE
                     <TooltipListBlankItem>... and {lines.leftRemaining} more</TooltipListBlankItem>
                 )}
                 {lines.window.map(line => {
-                    const value = formatDateTick((line.value as unknown) as Date)
+                    const value = formatYTick(line.value)
                     const isActiveLine = activePoint.seriesId === line.id
-                    const stackedValue =
-                        isActiveLine && stacked ? formatDateTick((activePoint.value as unknown) as Date) : null
 
                     return (
                         <TooltipListItem
@@ -78,7 +76,6 @@ export function TooltipContent<Datum>(props: TooltipContentProps<Datum>): ReactE
                             isActive={isActiveLine}
                             name={line.name}
                             value={value}
-                            stackedValue={stackedValue}
                             color={getLineColor(line)}
                         />
                     )


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/39805

By accident, I misused label formatters in tooltip content component. 

## Test plan
- Make sure that the line chart tooltip has proper value for any hovered data point

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-line-chart-formatting-bug.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cbmqqvbquj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

