### PR TITLE
Add section to CI caching docs

### DIFF
--- a/doc/dev/how-to/cache_ci_artefacts.md
+++ b/doc/dev/how-to/cache_ci_artefacts.md
@@ -93,6 +93,8 @@ While the [Cache Buildkite Plugin](https://github.com/sourcegraph/cache-buildkit
    aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
    aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
    ```
+   > NOTE: for `asdf install awscli` to succeed, a `.tool-versions` file containing the dependency and the desired version number must be present. You may replace `asdf` with any other installation method.
+
    > NOTE: the environment variables `$BUILDKITE_HMAC_KEY` and `$BUILDKITE_HMAC_SECRET` are set on the Buildkite agent already.
 
 1. Add the following snippet to the top of `pipeline.yaml`:

--- a/doc/dev/how-to/cache_ci_artefacts.md
+++ b/doc/dev/how-to/cache_ci_artefacts.md
@@ -10,8 +10,6 @@ Because [Buildkite agents are stateless](../background-information/ci/developmen
 
 A common strategy to address this problem of having to rebuild everything is to store objects that are commonly reused accross jobs and to download them again rather than rebuilding everything from scratch.
 
-Cached artefacts *are automatically expired after 30 days* (by an object lifecycle policy on the bucket).
-
 ## What and when to cache?
 
 In order to determine what we can cache and when to do it, we need to make sure to cover the following questions:
@@ -68,4 +66,4 @@ gsutil rm gs://sourcegraph_buildkite_cache/sourcegraph/sourcegraph/[MY-KEY].tar.
 
 ## When is the cache purged?
 
-The cached is purged every TODO
+Cached artefacts *are automatically expired after 30 days* (by an object lifecycle policy on the bucket).

--- a/doc/dev/how-to/cache_ci_artefacts.md
+++ b/doc/dev/how-to/cache_ci_artefacts.md
@@ -116,6 +116,8 @@ While the [Cache Buildkite Plugin](https://github.com/sourcegraph/cache-buildkit
      key: "<id>-<cache-key>"
      restore-keys:
        - "<id>-<cache-key>"
+       - "<id>-"
      compress: true
      <<: *s3-settings
    ```
+   Read the plugin doc section about [cache key templates](https://github.com/sourcegraph/cache-buildkite-plugin#cache-key-templates) and [hashing directories for keys](https://github.com/sourcegraph/cache-buildkite-plugin#hashing-checksum-against-directory) for pointers on effective caching. 

--- a/doc/dev/how-to/cache_ci_artefacts.md
+++ b/doc/dev/how-to/cache_ci_artefacts.md
@@ -42,7 +42,7 @@ pipeline.AddStep(":jest::chrome: Test browser extension",
 The important part here are:
 
 - The `Key` which defines how the cached version is named, so we can find it again on ulterior builds.
-  - It includes a `{{ checkusm 'yarn.lock' }}` segment in its name, which means that any changes in the `yarn.lock` will be reflected in the key name.
+  - It includes a `{{ checksum 'yarn.lock' }}` segment in its name, which means that any changes in the `yarn.lock` will be reflected in the key name.
   - It means that if the `yarn.lock` checksum would change because dependencies have changed, it should use a different version of the cached dependencies. If those were to not be present on the cache, it will simply rebuild them and upload the result to the cache.
 - The `RestoreKeys` lists the keys we can use to know if there is a cached version or not available. 99% of the time, that's the same exact thing as the `Key`.
 - The `Paths` lists the path to the files that needs to be cached. They **must be within the repository**, not outside.

--- a/doc/dev/how-to/cache_ci_artefacts.md
+++ b/doc/dev/how-to/cache_ci_artefacts.md
@@ -97,7 +97,7 @@ While the [Cache Buildkite Plugin](https://github.com/sourcegraph/cache-buildkit
 
    > NOTE: the environment variables `$BUILDKITE_HMAC_KEY` and `$BUILDKITE_HMAC_SECRET` are set on the Buildkite agent already.
 
-1. Add the following snippet to the top of `pipeline.yaml`:
+2. Add the following snippet to the top of `pipeline.yaml`:
    ```yaml
    s3-settings: &s3-settings
      backend: s3
@@ -108,16 +108,38 @@ While the [Cache Buildkite Plugin](https://github.com/sourcegraph/cache-buildkit
        region: us-central1
    ```
    
-1. For each build step where you would like to cache artifacts, add the following snippet. Decide what the key should be as described in [What and when to cache?](#what-and-when-to-cache):
-   ```yaml
-   plugins:
-   - https://github.com/sourcegraph/cache-buildkite-plugin.git#master:
-     id: <fitting ID>
-     key: "<id>-<cache-key>"
-     restore-keys:
-       - "<id>-<cache-key>"
-       - "<id>-"
-     compress: true
-     <<: *s3-settings
-   ```
-   Read the plugin doc section about [cache key templates](https://github.com/sourcegraph/cache-buildkite-plugin#cache-key-templates) and [hashing directories for keys](https://github.com/sourcegraph/cache-buildkite-plugin#hashing-checksum-against-directory) for pointers on effective caching. 
+3. For each build step where you would like to cache artifacts, define what to cache and how it should invalidate. Decide what the key should be as described in [What and when to cache?](#what-and-when-to-cache). Generally, consider these cache types:   
+   
+    * **Long-lived** caches. An example is a project's dependencies, which do not change frequently and may consume a significant portion of the build time when pulled from repositories. In this case, using the checksum of the dependency list (such as `go.mod` or `requirements.txt`) as a cache key will cause the cache to be recreated whenever the dependencies are updated. You may also hash [a directory instead of a file](https://github.com/sourcegraph/cache-buildkite-plugin#hashing-checksum-against-directory). **It is important to set the `paths` to the dependency directory to ensure only those files are cached**. This snippet shows an example configuration: 
+       ```yaml
+       plugins:
+         - https://github.com/sourcegraph/cache-buildkite-plugin.git#master:
+           id: <fitting ID> # e.g. go-mod
+           key: "{{ id }}-{{ git.branch }}-{{ checksum /path/to/dependency-file }}"
+           restore-keys:
+             - "{{ id }}-{{ git.branch }}-{{ checksum /path/to/dependency-file }}"
+             - "{{ id }}-{{ git.branch }}-"
+             - "{{ id }}-"
+           compress: true
+           compress-program: pigz
+           paths:
+             - "/path/to/dependencies"
+           <<: *s3-settings
+        ```
+   
+    * **Short-lived** caches. These contain artifacts of a project that are frequently changed, such as application code. These caches can be useful for e.g. rerunning a build on a network timeout. A cache key should be used that is unique across multiple builds. A good default is the build's git commit SHA. The following snippet demonstrates how to do this:
+      ```yaml
+      plugins:
+         - https://github.com/sourcegraph/cache-buildkite-plugin.git#master:
+           id: <fitting ID> # e.g. project name
+           key: "{{ id }}-{{ git.branch }}-{{ git.commit }}"
+           restore-keys:
+             - "{{ id }}-{{ git.branch }}-{{ git.commit }}"
+             - "{{ id }}-{{ git.branch }}-"
+             - "{{ id }}-"
+           compress: true
+           compress-program: pigz
+           <<: *s3-settings
+       ```
+
+    Add every plugin definition to the relevant steps in your `pipeline.yaml`. An example of a valid pipeline step with a plugin configured can be found [here](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/image-updater-pipeline/-/blob/.buildkite/image-updater/pipeline.yaml?L25).


### PR DESCRIPTION
Documentation about caching for new Buildkite pipelines was missing. This PR adds them.

## Test plan
Nothing, just docs
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
