### PR TITLE
Updating deprecation notice based on feedback

### DIFF
--- a/doc/extensions/deprecation.md
+++ b/doc/extensions/deprecation.md
@@ -4,19 +4,15 @@ Sourcegraph extensions, originally released in 2018, create integrations with th
 
 As part of our commitment to enhance our platform and innovate to meet customer and market needs, we have been evaluating our current platform. In assessing our future vision for integrations and our current capabilities, we have decided to deprecate our current extensions framework.
 
-We’re investing in a new model of integrations that allow deeper integration with our code intelligence platform and surfacing code context during the ideal moments in a developer’s workflow.
+We’re investing in a new model of integrations that allow deeper integration with our code intelligence platform and surfacing code context during the ideal moments in a developer’s workflow.  
 
-This decision means that after the September 2022 release of Sourcegraph or if you’re using Sourcegraph.com, **extensions will be impacted in the following way**:
+This decision means that after the September 2022 release of Sourcegraph you can no longer create new extensions on our public registry. If you’re using a private registry, you are unaffected.
 
-- *If you’re on the September release or using Sourcegraph.com:*
-  - A new feature flag will be introduced that turns on the extensions and the extension registry, this will be disabled by default.
-  - You can no longer create new extensions on the public extension registry. If you have enabled the feature flag, you are able to create extensions on a private registry.
-  - Top extensions (code navigation, git-extras, open-in-editor and search-exports) will become core to the functionality of the code intelligence platform
-
-- *If you’re on an earlier release:*
-  - You can no longer create new extensions on our public registry. If you’re using a private registry, you are unaffected.
-  - Extensions and the extension registry will continue to work as expected.
-
+After upgrading to the latest release you’ll notice the following changes:
+- Top extensions (code navigation, git-extras, open-in-editor and search-exports) will become native functionality of the code intelligence platform
+- A new feature flag will be introduced that turns on the extensions and the extension registry. This feature flag will be disabled by default.
+- You will no longer be able to create extensions on a private registry unless you have enabled the feature flag.
+  
 Please note that this does not impact our IDE extensions, which will continue to allow you to search and navigate across all of your repositories without ever leaving your IDE or checking them out locally. Our Browser extensions will continue to have code navigation support, but will not provide other functionality to the code host (e.g. code coverage information).
 
-Integrations continue to be an important part of our code intelligence platform and are looking forward to investing in an even more powerful framework for the future.
+Integrations continue to be an important part of our code intelligence platform and are looking forward to investing in an even more powerful framework for the future. 

--- a/doc/extensions/deprecation.md
+++ b/doc/extensions/deprecation.md
@@ -4,7 +4,7 @@ Sourcegraph extensions, originally released in 2018, create integrations with th
 
 As part of our commitment to enhance our platform and innovate to meet customer and market needs, we have been evaluating our current platform. In assessing our future vision for integrations and our current capabilities, we have decided to deprecate our current extensions framework.
 
-We’re investing in a new model of integrations that allow deeper integration with our code intelligence platform and surfacing code context during the ideal moments in a developer’s workflow.  
+We’re investing in a new model of integrations that allow deeper integration with our code intelligence platform and surfacing code context during the ideal moments in a developer’s workflow.
 
 This decision means that after the September 2022 release of Sourcegraph you can no longer create new extensions on our public registry. If you’re using a private registry, you are unaffected.
 
@@ -12,7 +12,7 @@ After upgrading to the latest release you’ll notice the following changes:
 - Top extensions (code navigation, git-extras, open-in-editor and search-exports) will become native functionality of the code intelligence platform
 - A new feature flag will be introduced that turns on the extensions and the extension registry. This feature flag will be disabled by default.
 - You will no longer be able to create extensions on a private registry unless you have enabled the feature flag.
-  
+
 Please note that this does not impact our IDE extensions, which will continue to allow you to search and navigate across all of your repositories without ever leaving your IDE or checking them out locally. Our Browser extensions will continue to have code navigation support, but will not provide other functionality to the code host (e.g. code coverage information).
 
-Integrations continue to be an important part of our code intelligence platform and are looking forward to investing in an even more powerful framework for the future. 
+Integrations continue to be an important part of our code intelligence platform and are looking forward to investing in an even more powerful framework for the future.


### PR DESCRIPTION
Updates the deprecation notice for Sourcegraph extensions based on feedback.

## Test plan
- Read the docs to make sure they make sense.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
