### PR TITLE
[gitserver] Initial version of removing repo directories that are not defined in Postgres

### DIFF
--- a/dev/redis-postgres.yml
+++ b/dev/redis-postgres.yml
@@ -20,7 +20,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-sourcegraph}
       - POSTGRES_USER=${POSTGRES_USER:-sourcegraph}
       - POSTGRES_DB=${PGDATABASE:-sourcegraph}
-      - 'POSTGRES_INITDB_ARGS= --encoding=UTF8 '
+      - "POSTGRES_INITDB_ARGS= --encoding=UTF8 "
     volumes:
       # Match PGDATA in Dockerfile
       # https://sourcegraph.com/search?q=context:%40sourcegraph/all+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Edocker-images/postgres.*/Dockerfile+PGDATA

--- a/dev/redis-postgres.yml
+++ b/dev/redis-postgres.yml
@@ -14,6 +14,7 @@ services:
       - ${REDIS_DATA_DIR:-redis_data}:/data
   postgresql:
     image: index.docker.io/sourcegraph/postgres-12-alpine:insiders
+    command: postgres -c log_statement=all -c log_destination=stderr
     ports:
       - 5432:5432
     environment:

--- a/dev/redis-postgres.yml
+++ b/dev/redis-postgres.yml
@@ -14,14 +14,13 @@ services:
       - ${REDIS_DATA_DIR:-redis_data}:/data
   postgresql:
     image: index.docker.io/sourcegraph/postgres-12-alpine:insiders
-    command: postgres -c log_statement=all -c log_destination=stderr
     ports:
       - 5432:5432
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-sourcegraph}
       - POSTGRES_USER=${POSTGRES_USER:-sourcegraph}
       - POSTGRES_DB=${PGDATABASE:-sourcegraph}
-      - "POSTGRES_INITDB_ARGS= --encoding=UTF8 "
+      - 'POSTGRES_INITDB_ARGS= --encoding=UTF8 '
     volumes:
       # Match PGDATA in Dockerfile
       # https://sourcegraph.com/search?q=context:%40sourcegraph/all+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Edocker-images/postgres.*/Dockerfile+PGDATA

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -4911,6 +4911,27 @@ Query: `sum by (instance) (rate(src_gitserver_repos_removed_disk_pressure[5m]))`
 
 <br />
 
+#### gitserver: non_existent_repos_removed
+
+<p class="subtitle">Repositories removed because they are not defined in the DB</p>
+
+Repositoriess removed because they are not defined in the DB
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100440` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (instance) (increase(src_gitserver_non_existing_repos_removed[5m]))`
+
+</details>
+
+<br />
+
 #### gitserver: sg_maintenance_reason
 
 <p class="subtitle">Successful sg maintenance jobs over 1h (by reason)</p>
@@ -4919,7 +4940,7 @@ the rate of successful sg maintenance jobs and the reason why they were triggere
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100440` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100450` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
@@ -4940,7 +4961,7 @@ the rate of successful git prune jobs over 1h and whether they were skipped
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100450` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100460` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -416,6 +416,17 @@ func GitServer() *monitoring.Dashboard {
 					},
 					{
 						{
+							Name:           "non_existent_repos_removed",
+							Description:    "repositories removed because they are not defined in the DB",
+							Query:          "sum by (instance) (increase(src_gitserver_non_existing_repos_removed[5m]))",
+							NoAlert:        true,
+							Panel:          monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
+							Owner:          monitoring.ObservableOwnerRepoManagement,
+							Interpretation: "Repositoriess removed because they are not defined in the DB",
+						},
+					},
+					{
+						{
 							Name:           "sg_maintenance_reason",
 							Description:    "successful sg maintenance jobs over 1h (by reason)",
 							Query:          `sum by (reason) (rate(src_gitserver_maintenance_status{success="true"}[1h]))`,


### PR DESCRIPTION
# Description

This PR is meant to cleanup the mess I have created on dotcom by manually removing repos from the DB with an SQL command. Instead of soft delete I did a hard delete, which seems to cause the repositories never to be removed from disk.

I think this new behavior is actually beneficial and can remove stale data from the disks, in case other inconsistencies between current disk state and what's defined in the DB exist.

# Screenshot

This is how the new metric looks like in the grafana dashboard:
<img width="730" alt="Screenshot 2022-08-09 at 18 08 03" src="https://user-images.githubusercontent.com/9974711/183939272-441dfb12-6b38-4708-84e7-004e9a579478.png">


## Test plan

This feature is behind an env flag `SRC_REMOVE_NON_EXISTING_REPOS` which by default is `false`.

So far tested locally and it seems to be working fine in these scenarios:
1. Flag is not set - nothing happened
2. Flag is set to false - nothing happened
3. Flag is set to true - removed repositories, that were on disk, but not defined in the DB
4.  Flag is set to true, 2nd run - nothing happened
5. Flag is set to true, deleted a row in the `repo` table - repo deleted from disk as well

Change has unit tests attached as well.

