### PR TITLE
Pass kernel flags to ignite to speed up VM boot

### DIFF
--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -329,7 +329,7 @@ spec:
       # pci: Default
       # ip: Default
       # random.trust_cpu: Found in https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/random-for-clones.md, this makes RNG initialization much faster (saves ~1s on startup).
-      # i8042.X: Makes boot faster, doesn't wait for device that doesn't exist.
+      # i8042.X: Makes boot faster, doesn't poll on the i8042 device on boot. See https://github.com/firecracker-microvm/firecracker/blob/main/docs/api_requests/actions.md#intel-and-amd-only-sendctrlaltdel.
       cmdLine: "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp random.trust_cpu=on i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd"
 EOF
 }

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -322,6 +322,15 @@ spec:
       oci: "${RUNTIME_IMAGE}"
     kernel:
       oci: "${KERNEL_IMAGE}"
+      # Explanation of arguments passed here:
+      # console: Default
+      # reboot: Default
+      # panic: Default
+      # pci: Default
+      # ip: Default
+      # random.trust_cpu: Found in https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/random-for-clones.md, this makes RNG initialization much faster (saves ~1s on startup).
+      # i8042.X: Makes boot faster, doesn't wait for device that doesn't exist.
+      cmdLine: "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp random.trust_cpu=on i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd"
 EOF
 }
 


### PR DESCRIPTION
There are two new flags added here, the i8042 list and enabling trust in the CPU for random numbers for much faster entropy collection. This combined shaves off about 1.5s of the VM boot time.



## Test plan

Rolled out on k8s, doesn't break things.