### PR TITLE
encryption: Do not proactively fetch version

### DIFF
--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -384,7 +384,7 @@ func TestExternalAccounts_Encryption(t *testing.T) {
 	}
 
 	// values encrypted should not be readable without the encrypting key
-	noopStore := store.WithEncryptionKey(&encryption.NoopKey{})
+	noopStore := store.WithEncryptionKey(&encryption.NoopKey{FailDecrypt: true})
 	if _, err := noopStore.List(ctx, ExternalAccountsListOptions{}); err == nil {
 		t.Fatalf("expected error decrypting with a different key")
 	}

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -1163,7 +1164,7 @@ func TestExternalServicesStore_GetByID_Encrypted(t *testing.T) {
 	}
 
 	// values encrypted should not be readable without the encrypting key
-	noopStore := store.WithEncryptionKey(&encryption.NoopKey{})
+	noopStore := store.WithEncryptionKey(&encryption.NoopKey{FailDecrypt: true})
 	if _, err := noopStore.GetByID(ctx, es.ID); err == nil {
 		t.Fatalf("expected error decrypting with a different key")
 	}
@@ -2004,7 +2005,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 		}
 
 		// values encrypted should not be readable without the encrypting key
-		noopStore := ExternalServicesWith(logger, tx).WithEncryptionKey(&encryption.NoopKey{})
+		noopStore := ExternalServicesWith(logger, tx).WithEncryptionKey(&encryption.NoopKey{FailDecrypt: true})
 
 		for _, e := range want {
 			if _, err := noopStore.GetByID(ctx, e.ID); err == nil {

--- a/internal/encryption/noop.go
+++ b/internal/encryption/noop.go
@@ -2,11 +2,14 @@ package encryption
 
 import (
 	"context"
+	"fmt"
 )
 
 var _ Key = &NoopKey{}
 
-type NoopKey struct{}
+type NoopKey struct {
+	FailDecrypt bool
+}
 
 func (k *NoopKey) Version(ctx context.Context) (KeyVersion, error) {
 	return KeyVersion{
@@ -21,6 +24,10 @@ func (k *NoopKey) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error)
 }
 
 func (k *NoopKey) Decrypt(ctx context.Context, ciphertext []byte) (*Secret, error) {
+	if k.FailDecrypt {
+		return nil, fmt.Errorf("unsupported decrypt")
+	}
+
 	s := NewSecret(string(ciphertext))
 	return &s, nil
 }

--- a/internal/encryption/noop.go
+++ b/internal/encryption/noop.go
@@ -2,7 +2,8 @@ package encryption
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var _ Key = &NoopKey{}
@@ -25,7 +26,7 @@ func (k *NoopKey) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error)
 
 func (k *NoopKey) Decrypt(ctx context.Context, ciphertext []byte) (*Secret, error) {
 	if k.FailDecrypt {
-		return nil, fmt.Errorf("unsupported decrypt")
+		return nil, errors.New("unsupported decrypt")
 	}
 
 	s := NewSecret(string(ciphertext))


### PR DESCRIPTION
Alternative to #40117, (see also [the slack context](https://sourcegraph.slack.com/archives/C07KZF47K/p1659970974264169)). This PR removes a proactive call of Version on decrypt, which easily doubles the number of KMS API calls we do on each decrypt.

## Test plan

Existing unit tests.