### PR TITLE
admin-analytics: add users administration export CSV backend API

### DIFF
--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -2,16 +2,12 @@ package graphqlbackend
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
-	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/timeutil"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/internal/users"
 )
 
 func (s *siteResolver) Users(ctx context.Context, args *struct {
@@ -20,203 +16,76 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 	Username         *string
 	Email            *string
 	LastActivePeriod *string
-}) (*SiteUsersResolver, error) {
+}) (*siteUsersResolver, error) {
 	// 🚨 SECURITY: Only site admins can see users.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, s.db); err != nil {
 		return nil, err
 	}
 
-	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
-	tables := []*sqlf.Query{sqlf.Sprintf(`users`)}
-
-	if args.Query != nil && *args.Query != "" {
-		query := "%" + *args.Query + "%"
-		conds = append(conds, sqlf.Sprintf("(username ILIKE %s OR display_name ILIKE %s)", query, query))
-	}
-	if args.SiteAdmin != nil {
-		conds = append(conds, sqlf.Sprintf("site_admin = %s", *args.SiteAdmin))
-	}
-	if args.Username != nil {
-		conds = append(conds, sqlf.Sprintf("username ILIKE %s", "%"+*args.Username+"%"))
-	}
-	if args.Email != nil {
-		tables = append(tables, sqlf.Sprintf("LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true"))
-		conds = append(conds, sqlf.Sprintf("email ILIKE %s", "%"+*args.Email+"%"))
-	}
-	if args.LastActivePeriod != nil {
-		lastActiveStartTime, err := makeLastActiveStartTime(*args.LastActivePeriod)
-		if err != nil {
-			return nil, err
-		}
-		tables = append(tables, sqlf.Sprintf("LEFT JOIN event_logs events ON events.user_id = users.id"))
-		conds = append(conds, sqlf.Sprintf("events.timestamp >= %s", lastActiveStartTime))
-	}
-	totalsQuery := sqlf.Sprintf(`SELECT COUNT(DISTINCT users.id) FROM %s WHERE %s`, sqlf.Join(tables, " "), sqlf.Join(conds, "AND"))
-	return &SiteUsersResolver{s.db, conds, totalsQuery}, nil
+	return &siteUsersResolver{
+		&users.UsersStats{DB: s.db, Cache: false, Filters: users.UsersStatsFilters{
+			Query:            args.Query,
+			SiteAdmin:        args.SiteAdmin,
+			Username:         args.Username,
+			Email:            args.Email,
+			LastActivePeriod: args.LastActivePeriod,
+		}}}, nil
 }
 
-func makeLastActiveStartTime(lastActivePeriod string) (time.Time, error) {
-	now := time.Now()
-	switch lastActivePeriod {
-	case "TODAY":
-		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC), nil
-	case "THIS_WEEK":
-		return timeutil.StartOfWeek(timeNow().UTC(), 0), nil
-	case "THIS_MONTH":
-		return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC), nil
-	default:
-		return now, errors.Newf("invalid lastActivePeriod: %s", lastActivePeriod)
-	}
+type siteUsersResolver struct {
+	userStats *users.UsersStats
 }
 
-type SiteUsersResolver struct {
-	db          database.DB
-	conds       []*sqlf.Query
-	totalsQuery *sqlf.Query
+func (s *siteUsersResolver) TotalCount(ctx context.Context) (float64, error) {
+	return s.userStats.TotalCount(ctx)
 }
 
-func (s *SiteUsersResolver) TotalCount(ctx context.Context) (float64, error) {
-	var totalCount float64
-
-	if err := s.db.QueryRowContext(ctx, s.totalsQuery.Query(sqlf.PostgresBindVar), s.totalsQuery.Args()...).Scan(&totalCount); err != nil {
-		return 0, err
-	}
-
-	return totalCount, nil
-}
-
-func (s *SiteUsersResolver) Nodes(ctx context.Context, args *struct {
+func (s *siteUsersResolver) Nodes(ctx context.Context, args *struct {
 	OrderBy    *string
 	Descending *bool
 	First      *int32
-}) ([]*SiteUserResolver, error) {
-	// ORDER BY
-	orderDirection := "ASC"
-	if args.Descending != nil && *args.Descending {
-		orderDirection = "DESC"
-	}
-	orderBy := sqlf.Sprintf("id " + orderDirection)
-	if args.OrderBy != nil {
-		newOrderBy, err := toUsersField(*args.OrderBy)
-		orderBy = sqlf.Sprintf(newOrderBy + " " + orderDirection)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// LIMIT
-	limit := int32(100)
-	if args.First != nil {
-		limit = *args.First
-	}
-
-	query := sqlf.Sprintf(`
-	SELECT
-		users.id,
-		users.username,
-		emails.email,
-		users.created_at,
-		MAX(events.timestamp) AS last_active_at,
-		users.deleted_at,
-		users.site_admin,
-		COUNT(events.*) AS events_count
-	FROM
-		users
-		LEFT JOIN event_logs events ON events.user_id = users.id
-		LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true
-	WHERE %s
-	GROUP BY
-		users.id,
-		users.username,
-		emails.email,
-		users.created_at,
-		users.deleted_at,
-		users.site_admin
-	ORDER BY %s
-	LIMIT %s`, sqlf.Join(s.conds, "AND"), orderBy, limit)
-	fmt.Println(query.Query(sqlf.PostgresBindVar))
-	fmt.Println(query.Args())
-
-	rows, err := s.db.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
-
+}) ([]*siteUserResolver, error) {
+	users, err := s.userStats.ListUsers(ctx, &users.UsersStatsListUsersFilters{OrderBy: args.OrderBy, Descending: args.Descending, First: args.First})
 	if err != nil {
 		return nil, err
 	}
-
-	defer rows.Close()
-
-	nodes := make([]*SiteUserResolver, 0)
-	for rows.Next() {
-		var node SiteUserResolver
-
-		if err := rows.Scan(&node.id, &node.username, &node.email, &node.createdAt, &node.lastActiveAt, &node.deletedAt, &node.siteAdmin, &node.eventsCount); err != nil {
-			return nil, err
-		}
-
-		nodes = append(nodes, &node)
+	userResolvers := make([]*siteUserResolver, len(users))
+	for i, user := range users {
+		userResolvers[i] = &siteUserResolver{user}
 	}
-
-	return nodes, nil
+	return userResolvers, nil
 }
 
-func toUsersField(orderBy string) (string, error) {
-	switch orderBy {
-	case "USERNAME":
-		return "username", nil
-	case "EMAIL":
-		return "emails.email", nil
-	case "CREATED_AT":
-		return "users.created_at", nil
-	case "LAST_ACTIVE_AT":
-		return "last_active_at", nil
-	case "DELETED_AT":
-		return "users.deleted_at", nil
-	case "EVENTS_COUNT":
-		return "events_count", nil
-	case "SITE_ADMIN":
-		return "site_admin", nil
-	default:
-		return "", errors.New("invalid orderBy")
-	}
+type siteUserResolver struct {
+	user *users.UserStatItem
 }
 
-type SiteUserResolver struct {
-	id           int32
-	username     string
-	email        *string
-	createdAt    time.Time
-	lastActiveAt *time.Time
-	deletedAt    *time.Time
-	siteAdmin    bool
-	eventsCount  float64
+func (s *siteUserResolver) ID(ctx context.Context) graphql.ID { return MarshalUserID(s.user.Id) }
+
+func (s *siteUserResolver) Username(ctx context.Context) string { return s.user.Username }
+
+func (s *siteUserResolver) Email(ctx context.Context) *string { return s.user.Email }
+
+func (s *siteUserResolver) CreatedAt(ctx context.Context) string {
+	return s.user.CreatedAt.Format(time.RFC3339)
 }
 
-func (s *SiteUserResolver) ID(ctx context.Context) graphql.ID { return MarshalUserID(s.id) }
-
-func (s *SiteUserResolver) Username(ctx context.Context) string { return s.username }
-
-func (s *SiteUserResolver) Email(ctx context.Context) *string { return s.email }
-
-func (s *SiteUserResolver) CreatedAt(ctx context.Context) string {
-	return s.createdAt.Format(time.RFC3339)
-}
-
-func (s *SiteUserResolver) LastActiveAt(ctx context.Context) *string {
-	if s.lastActiveAt != nil {
-		result := s.lastActiveAt.Format(time.RFC3339)
+func (s *siteUserResolver) LastActiveAt(ctx context.Context) *string {
+	if s.user.LastActiveAt != nil {
+		result := s.user.LastActiveAt.Format(time.RFC3339)
 		return &result
 	}
 	return nil
 }
 
-func (s *SiteUserResolver) DeletedAt(ctx context.Context) *string {
-	if s.deletedAt != nil {
-		result := s.deletedAt.Format(time.RFC3339)
+func (s *siteUserResolver) DeletedAt(ctx context.Context) *string {
+	if s.user.DeletedAt != nil {
+		result := s.user.DeletedAt.Format(time.RFC3339)
 		return &result
 	}
 	return nil
 }
 
-func (s *SiteUserResolver) SiteAdmin(ctx context.Context) bool { return s.siteAdmin }
+func (s *siteUserResolver) SiteAdmin(ctx context.Context) bool { return s.user.SiteAdmin }
 
-func (s *SiteUserResolver) EventsCount(ctx context.Context) float64 { return s.eventsCount }
+func (s *siteUserResolver) EventsCount(ctx context.Context) float64 { return s.user.EventsCount }

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -72,6 +72,7 @@ func NewHandler(db database.DB, githubAppCloudSetupHandler http.Handler) http.Ha
 
 	// Usage statistics ZIP download
 	r.Get(router.UsageStatsDownload).Handler(trace.Route(http.HandlerFunc(usageStatsArchiveHandler(db))))
+	r.Get(router.UsersStatsDownload).Handler(trace.Route(http.HandlerFunc(usersStatsArchiveHandler(db))))
 
 	// Ping retrieval
 	r.Get(router.LatestPing).Handler(trace.Route(http.HandlerFunc(latestPingHandler(db))))

--- a/cmd/frontend/internal/app/router/router.go
+++ b/cmd/frontend/internal/app/router/router.go
@@ -35,6 +35,7 @@ const (
 	RegistryExtensionBundle = "registry.extension.bundle"
 
 	UsageStatsDownload = "usage-stats.download"
+	UsersStatsDownload = "users-stats.download"
 
 	LatestPing = "pings.latest"
 
@@ -95,6 +96,7 @@ func newRouter() *mux.Router {
 	base.Path("/tools").Methods("GET").Name(OldToolsRedirect)
 
 	base.Path("/site-admin/usage-statistics/archive").Methods("GET").Name(UsageStatsDownload)
+	base.Path("/site-admin/users-statistics/archive").Methods("GET").Name(UsersStatsDownload)
 
 	base.Path("/site-admin/pings/latest").Methods("GET").Name(LatestPing)
 

--- a/cmd/frontend/internal/app/users_stats.go
+++ b/cmd/frontend/internal/app/users_stats.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"net/http"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/users"
+)
+
+func usersStatsArchiveHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// 🚨SECURITY: Only site admins may get this archive.
+		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), db); err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Disposition", "attachment; filename=\"SourcegraphUsersStatsArchive.zip\"")
+
+		usersStats := users.UsersStats{DB: db}
+		archive, err := usersStats.GetArchive(r.Context())
+		if err != nil {
+			log15.Error("users_stats.WriteArchive", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		_, _ = w.Write(archive)
+	}
+}

--- a/internal/users/stats.go
+++ b/internal/users/stats.go
@@ -1,0 +1,260 @@
+package users
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/csv"
+	"strconv"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type UsersStatsFilters struct {
+	Query            *string
+	SiteAdmin        *bool
+	Username         *string
+	Email            *string
+	LastActivePeriod *string
+}
+
+type UsersStats struct {
+	Cache   bool // TODO: implement caching
+	DB      database.DB
+	Filters UsersStatsFilters
+}
+
+func (s *UsersStats) makeQueryParameters() ([]*sqlf.Query, []*sqlf.Query, error) {
+	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
+	tables := []*sqlf.Query{sqlf.Sprintf(`users`)}
+	if s.Filters.Query != nil && *s.Filters.Query != "" {
+		query := "%" + *s.Filters.Query + "%"
+		conds = append(conds, sqlf.Sprintf("(username ILIKE %s OR display_name ILIKE %s)", query, query))
+	}
+	if s.Filters.SiteAdmin != nil {
+		conds = append(conds, sqlf.Sprintf("site_admin = %s", *s.Filters.SiteAdmin))
+	}
+	if s.Filters.Username != nil {
+		conds = append(conds, sqlf.Sprintf("username ILIKE %s", "%"+*s.Filters.Username+"%"))
+	}
+	if s.Filters.Email != nil {
+		tables = append(tables, sqlf.Sprintf("LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true"))
+		conds = append(conds, sqlf.Sprintf("email ILIKE %s", "%"+*s.Filters.Email+"%"))
+	}
+	if s.Filters.LastActivePeriod != nil {
+		lastActiveStartTime, err := makeLastActiveStartTime(*s.Filters.LastActivePeriod)
+		if err != nil {
+			return nil, nil, err
+		}
+		tables = append(tables, sqlf.Sprintf("LEFT JOIN event_logs events ON events.user_id = users.id"))
+		conds = append(conds, sqlf.Sprintf("events.timestamp >= %s", lastActiveStartTime))
+	}
+	return tables, conds, nil
+}
+
+func makeLastActiveStartTime(lastActivePeriod string) (time.Time, error) {
+	now := time.Now()
+	switch lastActivePeriod {
+	case "TODAY":
+		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC), nil
+	case "THIS_WEEK":
+		return timeutil.StartOfWeek(now.UTC(), 0), nil
+	case "THIS_MONTH":
+		return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC), nil
+	default:
+		return now, errors.Newf("invalid lastActivePeriod: %s", lastActivePeriod)
+	}
+}
+
+func (s *UsersStats) TotalCount(ctx context.Context) (float64, error) {
+	var totalCount float64
+
+	tables, conds, err := s.makeQueryParameters()
+	if err != nil {
+		return 0, err
+	}
+
+	query := sqlf.Sprintf(`SELECT COUNT(DISTINCT users.id) FROM %s WHERE %s`, sqlf.Join(tables, " "), sqlf.Join(conds, "AND"))
+	if err := s.DB.QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...).Scan(&totalCount); err != nil {
+		return 0, err
+	}
+
+	return totalCount, nil
+}
+
+type UsersStatsListUsersFilters struct {
+	OrderBy    *string
+	Descending *bool
+	First      *int32
+}
+
+func (s *UsersStats) ListUsers(ctx context.Context, filters *UsersStatsListUsersFilters) ([]*UserStatItem, error) {
+	// ORDER BY
+	orderDirection := "ASC"
+	if filters == nil {
+		filters = &UsersStatsListUsersFilters{}
+	}
+	if filters.Descending != nil && *filters.Descending {
+		orderDirection = "DESC"
+	}
+	orderBy := sqlf.Sprintf("id " + orderDirection)
+	if filters.OrderBy != nil {
+		newOrderColumn, err := toUsersField(*filters.OrderBy)
+		orderBy = sqlf.Sprintf(newOrderColumn + " " + orderDirection)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// LIMIT
+	limit := int32(100)
+	if filters.First != nil {
+		limit = *filters.First
+	}
+
+	_, conds, err := s.makeQueryParameters()
+	if err != nil {
+		return nil, err
+	}
+
+	query := sqlf.Sprintf(`
+	SELECT
+		users.id,
+		users.username,
+		emails.email,
+		users.created_at,
+		MAX(events.timestamp) AS last_active_at,
+		users.deleted_at,
+		users.site_admin,
+		COUNT(events.*) AS events_count
+	FROM
+		users
+		LEFT JOIN event_logs events ON events.user_id = users.id
+		LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true
+	WHERE %s
+	GROUP BY
+		users.id,
+		users.username,
+		emails.email,
+		users.created_at,
+		users.deleted_at,
+		users.site_admin
+	ORDER BY %s
+	LIMIT %s`, sqlf.Join(conds, "AND"), orderBy, limit)
+
+	rows, err := s.DB.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	nodes := make([]*UserStatItem, 0)
+	for rows.Next() {
+		var node UserStatItem
+
+		if err := rows.Scan(&node.Id, &node.Username, &node.Email, &node.CreatedAt, &node.LastActiveAt, &node.DeletedAt, &node.SiteAdmin, &node.EventsCount); err != nil {
+			return nil, err
+		}
+
+		nodes = append(nodes, &node)
+	}
+
+	return nodes, nil
+}
+
+func toUsersField(orderBy string) (string, error) {
+	switch orderBy {
+	case "USERNAME":
+		return "username", nil
+	case "EMAIL":
+		return "emails.email", nil
+	case "CREATED_AT":
+		return "users.created_at", nil
+	case "LAST_ACTIVE_AT":
+		return "last_active_at", nil
+	case "DELETED_AT":
+		return "users.deleted_at", nil
+	case "EVENTS_COUNT":
+		return "events_count", nil
+	case "SITE_ADMIN":
+		return "site_admin", nil
+	default:
+		return "", errors.New("invalid orderBy")
+	}
+}
+
+type UserStatItem struct {
+	Id           int32
+	Username     string
+	Email        *string
+	CreatedAt    time.Time
+	LastActiveAt *time.Time
+	DeletedAt    *time.Time
+	SiteAdmin    bool
+	EventsCount  float64
+}
+
+// GetArchive generates and returns a usage statistics ZIP archive containing the CSV
+// files defined in RFC 145, or an error in case of failure.
+func (s *UsersStats) GetArchive(ctx context.Context) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	file, err := zw.Create("UsersStats.csv")
+	if err != nil {
+		return nil, err
+	}
+
+	writer := csv.NewWriter(file)
+
+	record := []string{
+		"user_id",
+		"created_at",
+		"events_count",
+		"last_active_at",
+		"deleted_at",
+	}
+
+	if err := writer.Write(record); err != nil {
+		return nil, err
+	}
+
+	users, err := s.ListUsers(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, user := range users {
+		record[0] = strconv.FormatUint(uint64(user.Id), 10)
+		record[1] = user.CreatedAt.Format(time.RFC3339)
+		record[2] = strconv.FormatInt(int64(user.EventsCount), 10)
+		if user.LastActiveAt == nil {
+			record[3] = "NULL"
+		} else {
+			record[3] = user.LastActiveAt.Format(time.RFC3339)
+		}
+		if user.DeletedAt == nil {
+			record[4] = "NULL"
+		} else {
+			record[4] = user.DeletedAt.Format(time.RFC3339)
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
This PR adds "user administration" export CSV backend API. 
> Also, this moves all querying logic from the `cmd/frontend/graphqlbackend/site_users.go` resolver file to reuse in the export CSV API

## Test plan
- `sg start`
- http://localhost:3080/site-admin/users-statistics/archive
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
