### PR TITLE
internal/gitserver/protocol: Set omitempty in RepoUpdateResponse

### DIFF
--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -171,14 +171,13 @@ type RepoUpdateRequest struct {
 	CloneFromShard string `json:"cloneFromShard"`
 }
 
-// RepoUpdateResponse returns meta information of the repo enqueued for
-// update.
-//
-// TODO just use RepoInfoResponse?
+// RepoUpdateResponse returns meta information of the repo enqueued for update.
 type RepoUpdateResponse struct {
-	LastFetched *time.Time
-	LastChanged *time.Time
-	Error       string // an error reported by the update, as opposed to a protocol error
+	LastFetched *time.Time `json:",omitempty"`
+	LastChanged *time.Time `json:",omitempty"`
+
+	// Error is an error reported by the update operation, and not a network protocol error.
+	Error string `json:",omitempty"`
 }
 
 type NotFoundPayload struct {


### PR DESCRIPTION
When the /repo-update endpoint clones a repo, the response returned is
an empty struct with zero-values encoded into the JSON string. Instead
we can omit the  fields completely.

Additionally, reword the docstring of the Error attribute of this
struct for clarity.

Also remove outdated comment about using RepoInfoResponse. There is no
other reference to this mythical struct apart from the one in this
comment.


## Note to reviewers:

Not sure why the commit's build icon is a red cross even though all checks have passed.

![image](https://user-images.githubusercontent.com/2682729/183620042-b311bee9-c2f0-4b3d-b921-4fe18a8defb4.png)



## Test plan

Existing tests should pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
