### PR TITLE
cmd/gitserver/server: Handle warning error in handleRepoUpdate

### DIFF
--- a/internal/httpserver/status.go
+++ b/internal/httpserver/status.go
@@ -1,0 +1,4 @@
+package httpserver
+
+// When the HTTP server returns an embedded error that is of the type errors.Warning.
+const StatusWarningError = 500

--- a/lib/errors/warning.go
+++ b/lib/errors/warning.go
@@ -52,7 +52,7 @@ var _ Warning = (*warning)(nil)
 // if err != nil {
 //     return err
 // }
-func NewWarningError(err error) *warning {
+func NewWarning(err error) *warning {
 	return &warning{
 		error: err,
 	}

--- a/lib/errors/warning_test.go
+++ b/lib/errors/warning_test.go
@@ -14,7 +14,7 @@ func TestWarningError(t *testing.T) {
 	}
 
 	// Ensure that all warning type errors are indeed a Warning type error.
-	w := NewWarningError(err)
+	w := NewWarning(err)
 	if !As(w, &ref) {
 		t.Error(`Expected error "w" to be of type warning`)
 	}


### PR DESCRIPTION
In this commit we start handling a potential warning type error that
might be returned from underlying functions. To do this we have to
make some minor structural changes to this method:

- We start returning early at the cost of a little bit of repeated code
to JSON encode the response
- This also has the positive side effect of reducing nesting in the
code

## Test plan

TODO: Add tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
