### PR TITLE
codemirror blob view: Add support for reference panel (and fix some things)

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -50,6 +50,7 @@ import {
 
 import { ReferencesPanelHighlightedBlobResult, ReferencesPanelHighlightedBlobVariables } from '../graphql-operations'
 import { Blob } from '../repo/blob/Blob'
+import { Blob as CodeMirrorBlob } from '../repo/blob/CodeMirrorBlob'
 import { HoverThresholdProps } from '../repo/RepoContainer'
 import { enableExtensionsDecorationsColumnViewFromSettings } from '../util/settings'
 import { parseBrowserRepoURL } from '../util/url'
@@ -65,6 +66,7 @@ import { useRepoAndBlob } from './useRepoAndBlob'
 import { isDefined } from './util/helpers'
 
 import styles from './ReferencesPanel.module.scss'
+import { useExperimentalFeatures } from '../stores'
 
 type Token = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
 
@@ -602,6 +604,10 @@ const SideBlob: React.FunctionComponent<
         }
     >
 > = props => {
+    const BlobComponent = useExperimentalFeatures(features => features.enableCodeMirrorFileView ?? false)
+        ? CodeMirrorBlob
+        : Blob
+
     const { data, error, loading } = useQuery<
         ReferencesPanelHighlightedBlobResult,
         ReferencesPanelHighlightedBlobVariables
@@ -660,7 +666,7 @@ const SideBlob: React.FunctionComponent<
     }
 
     return (
-        <Blob
+        <BlobComponent
             {...props}
             nav={props.blobNav}
             history={props.history}

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -672,6 +672,11 @@ const SideBlob: React.FunctionComponent<
             history={props.history}
             location={props.location}
             disableStatusBar={true}
+            // The CodeMirror-React integration uses its own <Router />
+            // component and therefore doesn't work with MemoryRouter as used by
+            // the reference panel (clicking on the buttons in the hovercard
+            // doesn't have any effect).
+            disableHovercards={true}
             disableDecorations={enableExtensionsDecorationsColumnViewFromSettings(props.settingsCascade)}
             wrapCode={true}
             className={styles.sideBlobCode}

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -52,6 +52,7 @@ import { ReferencesPanelHighlightedBlobResult, ReferencesPanelHighlightedBlobVar
 import { Blob } from '../repo/blob/Blob'
 import { Blob as CodeMirrorBlob } from '../repo/blob/CodeMirrorBlob'
 import { HoverThresholdProps } from '../repo/RepoContainer'
+import { useExperimentalFeatures } from '../stores'
 import { enableExtensionsDecorationsColumnViewFromSettings } from '../util/settings'
 import { parseBrowserRepoURL } from '../util/url'
 
@@ -66,7 +67,6 @@ import { useRepoAndBlob } from './useRepoAndBlob'
 import { isDefined } from './util/helpers'
 
 import styles from './ReferencesPanel.module.scss'
-import { useExperimentalFeatures } from '../stores'
 
 type Token = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
 

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -127,7 +127,7 @@ export interface BlobProps
     /**
      * Only used by CodeMirror implementation.
      */
-    disableHovercards: boolean
+    disableHovercards?: boolean
 
     // If set, nav is called when a user clicks on a token highlighted by
     // WebHoverOverlay

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -124,6 +124,10 @@ export interface BlobProps
     // Experimental reference panel
     disableStatusBar: boolean
     disableDecorations: boolean
+    /**
+     * Only used by CodeMirror implementation.
+     */
+    disableHovercards: boolean
 
     // If set, nav is called when a user clicks on a token highlighted by
     // WebHoverOverlay

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -22,9 +22,10 @@ import {
 } from './codemirror/decorations'
 import { syntaxHighlight } from './codemirror/highlight'
 import { hovercardRanges } from './codemirror/hovercard'
-import { selectLines, selectableLineNumbers, SelectedLineRange } from './codemirror/linenumbers'
+import { selectLines, selectableLineNumbers, SelectedLineRange, scrollIntoViewConfig } from './codemirror/linenumbers'
 import { sourcegraphExtensions } from './codemirror/sourcegraph-extensions'
 import { offsetToUIPosition, uiPositionToOffset } from './codemirror/utils'
+import { isEqual } from 'lodash'
 
 const staticExtensions: Extension = [
     // Using EditorState.readOnly instead of EditorView.editable allows us to
@@ -41,7 +42,7 @@ const staticExtensions: Extension = [
             backgroundColor: 'var(--code-selection-bg)',
         },
         '.cm-gutters': {
-            backgroundColor: 'initial',
+            backgroundColor: 'var(--code-bg)',
             borderRight: 'initial',
         },
     }),
@@ -64,7 +65,6 @@ const blobPropsCompartment = new Compartment()
 export const Blob: React.FunctionComponent<BlobProps> = props => {
     const {
         className,
-        blobInfo,
         wrapCode,
         isLightTheme,
         ariaLabel,
@@ -75,15 +75,17 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         history,
         blameDecorations: blameTextDocumentDecorations,
 
-        // These props don't have to be supported yet because the CodeMirror blob
-        // view is only used on the blob page where these are always true
-        // disableStatusBar
-        // disableDecorations
+        // Reference panel specific props
+        disableStatusBar,
+        disableDecorations,
     } = props
 
     const [container, setContainer] = useState<HTMLDivElement | null>(null)
-    const position = useMemo(() => parseQueryAndHash(location.search, location.hash), [location.search, location.hash])
+    // This is used to avoid reinitializing the editor when new locations in the
+    // same file are opened inside the reference panel.
+    const blobInfo = useDistinctBlob(props.blobInfo)
     const blobIsLoading = useBlobIsLoading(blobInfo, location.pathname)
+    const position = useMemo(() => parseQueryAndHash(location.search, location.hash), [location.search, location.hash])
     const hasPin = useMemo(() => urlIsPinned(location.search), [location.search])
 
     const blobProps = useMemo(() => blobPropsFacet.of(props), [props])
@@ -144,10 +146,16 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     const extensions = useMemo(
         () => [
             staticExtensions,
-            selectableLineNumbers({ onSelection }),
+            selectableLineNumbers({ onSelection, initialSelection: position.line !== undefined ? position : null }),
             syntaxHighlight.of(blobInfo),
             pinnedRangeField.init(() => (hasPin ? position : null)),
-            sourcegraphExtensions({ blobInfo, extensionsController }),
+            sourcegraphExtensions({
+                blobInfo,
+                initialSelection: position,
+                extensionsController,
+                disableStatusBar,
+                disableDecorations,
+            }),
             blobPropsCompartment.of(blobProps),
             blameDecorationsCompartment.of(blameDecorations),
             settingsCompartment.of(settings),
@@ -157,7 +165,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // further below. However they are still needed here because we need to
         // set initial values when we re-initialize the editor.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [onSelection, blobInfo, extensionsController]
+        [onSelection, blobInfo, extensionsController, disableStatusBar, disableDecorations]
     )
 
     const editor = useCodeMirror(container, blobInfo.content, extensions, {
@@ -218,7 +226,10 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         if (editor && !blobIsLoading) {
             selectLines(editor, position.line ? position : null)
         }
-    }, [editor, position, blobIsLoading])
+        // editor is not provided because this should only be triggered after the
+        // editor was created (i.e. not on first render)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [position, blobIsLoading])
 
     // Update pinned hovercard range
     useEffect(() => {
@@ -251,6 +262,20 @@ function useBlobIsLoading(blobInfo: BlobInfo, pathname: string): boolean {
     // pathname is intentionally ignored to make this functionality work
     // eslint-disable-next-line react-hooks/exhaustive-deps
     return pathname !== useMemo(() => pathname, [blobInfo])
+}
+
+/**
+ * Helper hook to prevent resetting the editor view if the blob contents hasn't
+ * changed.
+ */
+function useDistinctBlob(blobInfo: BlobInfo): BlobInfo {
+    const blobRef = useRef(blobInfo)
+    return useMemo(() => {
+        if (!isEqual(blobRef.current, blobInfo)) {
+            blobRef.current = blobInfo
+        }
+        return blobRef.current
+    }, [blobInfo])
 }
 
 /**

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { search, searchKeymap } from '@codemirror/search'
 import { Compartment, EditorState, Extension } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
+import { isEqual } from 'lodash'
 
 import { addLineRangeQueryParameter, LineOrPositionOrRange, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
 import { createUpdateableField, editorHeight, useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
@@ -22,10 +23,9 @@ import {
 } from './codemirror/decorations'
 import { syntaxHighlight } from './codemirror/highlight'
 import { hovercardRanges } from './codemirror/hovercard'
-import { selectLines, selectableLineNumbers, SelectedLineRange, scrollIntoViewConfig } from './codemirror/linenumbers'
+import { selectLines, selectableLineNumbers, SelectedLineRange } from './codemirror/linenumbers'
 import { sourcegraphExtensions } from './codemirror/sourcegraph-extensions'
 import { offsetToUIPosition, uiPositionToOffset } from './codemirror/utils'
-import { isEqual } from 'lodash'
 
 const staticExtensions: Extension = [
     // Using EditorState.readOnly instead of EditorView.editable allows us to

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -78,6 +78,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // Reference panel specific props
         disableStatusBar,
         disableDecorations,
+        disableHovercards,
     } = props
 
     const [container, setContainer] = useState<HTMLDivElement | null>(null)
@@ -155,6 +156,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                 extensionsController,
                 disableStatusBar,
                 disableDecorations,
+                disableHovercards,
             }),
             blobPropsCompartment.of(blobProps),
             blameDecorationsCompartment.of(blameDecorations),

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -1,5 +1,5 @@
-import { Extension, RangeSetBuilder, StateEffect, StateField } from '@codemirror/state'
-import { EditorView, Decoration, lineNumbers } from '@codemirror/view'
+import { Annotation, Extension, RangeSetBuilder, StateEffect, StateField } from '@codemirror/state'
+import { EditorView, Decoration, lineNumbers, ViewPlugin, PluginValue, ViewUpdate } from '@codemirror/view'
 
 /**
  * Represents the currently selected line range. null means no lines are
@@ -16,9 +16,12 @@ const setEndLine = StateEffect.define<number>()
  * This field stores the selected line range and provides the corresponding line
  * decorations.
  */
-const selectedLines = StateField.define<SelectedLineRange>({
+export const selectedLines = StateField.define<SelectedLineRange>({
     create() {
         return null
+    },
+    compare(previous, next): boolean {
+        return previous?.line === next?.line && previous?.endLine === next?.endLine
     },
     update(value, transaction) {
         for (const effect of transaction.effects) {
@@ -61,6 +64,51 @@ const selectedLines = StateField.define<SelectedLineRange>({
 })
 
 /**
+ * An annotation to indicate where a line selection is comming from.
+ * Transactions that set selected lines without this annotion are assumed to be
+ * "external" (e.g. from syncing with the URL).
+ */
+const lineSelectionSource = Annotation.define<'gutter'>()
+
+/**
+ * View plugin resonsible for scrolling the selected line(s) into view if/when
+ * necessary.
+ */
+const scrollIntoView = ViewPlugin.fromClass(
+    class implements PluginValue {
+        private lastSelectedLines: SelectedLineRange | null = null
+        constructor(private readonly view: EditorView) {}
+
+        update(update: ViewUpdate): void {
+            const currentSelectedLines = update.state.field(selectedLines)
+            if (
+                this.lastSelectedLines !== currentSelectedLines &&
+                update.transactions.some(transaction => transaction.annotation(lineSelectionSource) !== 'gutter')
+            ) {
+                // Only scroll selected lines into view when the user isn't
+                // currently selecting lines themselves (as indicated by the
+                // presence of the "gutter" annotation). Otherwise the scroll
+                // position might change while the user is selecting lines.
+                this.lastSelectedLines = currentSelectedLines
+                this.scrollIntoView(currentSelectedLines)
+            }
+        }
+
+        scrollIntoView(selection: SelectedLineRange) {
+            if (selection && shouldScrollIntoView(this.view, selection)) {
+                window.requestAnimationFrame(() => {
+                    this.view.dispatch({
+                        effects: EditorView.scrollIntoView(this.view.state.doc.line(selection.line).from, {
+                            y: 'center',
+                        }),
+                    })
+                })
+            }
+        }
+    }
+)
+
+/**
  * This extension provides a line gutter that allows selecting (ranges of) lines
  * by clicking (and dragging over) the line numbers. Shift+click to select a
  * range is also supported.
@@ -71,10 +119,15 @@ const selectedLines = StateField.define<SelectedLineRange>({
  * NOTE: Dragging to select on the gutter won't automatically scroll the
  * document.
  */
-export function selectableLineNumbers(config: { onSelection: (range: SelectedLineRange) => void }): Extension {
+export function selectableLineNumbers(config: {
+    onSelection: (range: SelectedLineRange) => void
+    initialSelection: SelectedLineRange | null
+}): Extension {
     let dragging = false
 
     return [
+        scrollIntoView,
+        selectedLines.init(() => config.initialSelection),
         lineNumbers({
             domEventHandlers: {
                 mousedown(view, block, event) {
@@ -85,6 +138,7 @@ export function selectableLineNumbers(config: { onSelection: (range: SelectedLin
                         effects: (event as MouseEvent).shiftKey
                             ? setEndLine.of(line)
                             : setSelectedLines.of(isSingleLine(range) && range?.line === line ? null : { line }),
+                        annotations: lineSelectionSource.of('gutter'),
                     })
 
                     dragging = true
@@ -117,7 +171,10 @@ export function selectableLineNumbers(config: { onSelection: (range: SelectedLin
                         const newEndline = view.state.doc.lineAt(line.from).number
                         const { endLine } = view.state.field(selectedLines) ?? {}
                         if (endLine !== newEndline) {
-                            view.dispatch({ effects: setEndLine.of(newEndline) })
+                            view.dispatch({
+                                effects: setEndLine.of(newEndline),
+                                annotations: lineSelectionSource.of('gutter'),
+                            })
                         }
                         return true
                     }
@@ -125,7 +182,6 @@ export function selectableLineNumbers(config: { onSelection: (range: SelectedLin
                 },
             },
         }),
-        selectedLines,
         EditorView.theme({
             '.cm-lineNumbers': {
                 cursor: 'pointer',
@@ -139,23 +195,10 @@ export function selectableLineNumbers(config: { onSelection: (range: SelectedLin
 }
 
 /**
- * Set selected lines (e.g. from the URL). The function won't trigger an update
- * if the same lines are already selected.
+ * Set selected lines (e.g. from the URL).
  */
 export function selectLines(view: EditorView, newRange: SelectedLineRange): void {
-    const currentRange = view.state.field(selectedLines)
-
-    if (currentRange?.line === newRange?.line && currentRange?.endLine === newRange?.endLine) {
-        return
-    }
-
-    const effects: StateEffect<unknown>[] = [setSelectedLines.of(newRange)]
-
-    if (newRange && shouldScrollIntoView(view, newRange)) {
-        effects.push(EditorView.scrollIntoView(view.state.doc.line(newRange.line).from, { y: 'center' }))
-    }
-
-    view.dispatch({ effects })
+    view.dispatch({ effects: setSelectedLines.of(newRange) })
 }
 
 /**

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -79,7 +79,7 @@ const scrollIntoView = ViewPlugin.fromClass(
         private lastSelectedLines: SelectedLineRange | null = null
         constructor(private readonly view: EditorView) {}
 
-        update(update: ViewUpdate): void {
+        public update(update: ViewUpdate): void {
             const currentSelectedLines = update.state.field(selectedLines)
             if (
                 this.lastSelectedLines !== currentSelectedLines &&
@@ -94,7 +94,7 @@ const scrollIntoView = ViewPlugin.fromClass(
             }
         }
 
-        scrollIntoView(selection: SelectedLineRange) {
+        public scrollIntoView(selection: SelectedLineRange): void {
             if (selection && shouldScrollIntoView(this.view, selection)) {
                 window.requestAnimationFrame(() => {
                     this.view.dispatch({

--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -8,21 +8,15 @@
 import React from 'react'
 
 import { Extension, Facet, StateEffect, StateEffectType, StateField } from '@codemirror/state'
-import { EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view'
+import { EditorView, PluginValue, ViewPlugin, ViewUpdate } from '@codemirror/view'
 import { Remote } from 'comlink'
 import { createRoot, Root } from 'react-dom/client'
 import { combineLatest, Observable, of, ReplaySubject, Subject, Subscription } from 'rxjs'
 import { filter, map, catchError, switchMap, distinctUntilChanged, startWith } from 'rxjs/operators'
 import { TextDocumentDecorationType } from 'sourcegraph'
 
-import {
-    DocumentHighlight,
-    LineOrPositionOrRange,
-    LOADER_DELAY,
-    MaybeLoadingResult,
-    emitLoading,
-} from '@sourcegraph/codeintellify'
-import { asError, ErrorLike, lprToSelectionsZeroIndexed } from '@sourcegraph/common'
+import { DocumentHighlight, LOADER_DELAY, MaybeLoadingResult, emitLoading } from '@sourcegraph/codeintellify'
+import { asError, ErrorLike, LineOrPositionOrRange, lprToSelectionsZeroIndexed } from '@sourcegraph/common'
 import { Position, TextDocumentDecoration } from '@sourcegraph/extension-api-types'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
@@ -47,6 +41,7 @@ import { Container } from './react-interop'
 import { blobPropsFacet } from '.'
 
 import blobStyles from '../Blob.module.scss'
+import { SelectedLineRange, selectedLines } from './linenumbers'
 
 /**
  * Context holds all the information needed for CodeMirror extensions to
@@ -70,10 +65,16 @@ interface Context {
  */
 export function sourcegraphExtensions({
     blobInfo,
+    initialSelection,
     extensionsController,
+    disableStatusBar,
+    disableDecorations,
 }: {
     blobInfo: BlobInfo
+    initialSelection: LineOrPositionOrRange
     extensionsController: ExtensionsControllerProps['extensionsController']
+    disableStatusBar?: boolean
+    disableDecorations?: boolean
 }): Extension {
     const context = extensionsController.extHostAPI.then(async extensionHostAPI => {
         const uri = toURIWithPath(blobInfo)
@@ -89,8 +90,7 @@ export function sourcegraphExtensions({
             extensionHostAPI.addViewerIfNotExists({
                 type: 'CodeEditor' as const,
                 resource: uri,
-                // TODO: set initial selection from selected lines
-                selections: [], // lprToSelectionsZeroIndexed(initialPosition),
+                selections: lprToSelectionsZeroIndexed(initialSelection),
                 isActive: true,
             }),
         ])
@@ -137,9 +137,9 @@ export function sourcegraphExtensions({
         // token is highlighted differently
         hovercardDataSource(),
         documentHighlightsDataSource(),
-        textDocumentDecorations(),
-        updateSelection(),
-        statusBar,
+        disableDecorations ? [] : textDocumentDecorations(),
+        updateSelection,
+        disableStatusBar ? [] : statusBar,
         warmupReferences,
     ]
 }
@@ -289,53 +289,35 @@ function textDocumentDecorations(): Extension {
 
 /**
  * The selection manager listens to CodeMirror selection changes and sends them
- * to the extensions host. This extension listens directly to selection changes
- * because it's a simple task and introducing an integration point with a
- * separate CodeMirror extension would just make things more complicated.
+ * to the extensions host.
  */
-class SelectionManager {
-    private context: Context | null = null
-    private selectionSet = false
+const updateSelection = ViewPlugin.fromClass(
+    class SelectionManager implements PluginValue {
+        private nextSelection: Subject<SelectedLineRange> = new Subject()
+        private subscription = new Subscription()
 
-    constructor(private readonly view: EditorView) {}
-
-    public update(viewUpdate: ViewUpdate): void {
-        if (viewUpdate.selectionSet) {
-            this.selectionSet = true
-            this.updatePosition()
+        constructor(view: EditorView) {
+            this.subscription = combineLatest([
+                view.state.field(sgExtensionsContextField).contextObservable,
+                this.nextSelection,
+            ]).subscribe(([context, selection]) => {
+                context.extensionHostAPI
+                    .setEditorSelections(context.viewerId, lprToSelectionsZeroIndexed(selection ?? {}))
+                    .catch(error => console.error('Error updating editor selections on extension host', error))
+            })
         }
-    }
 
-    public setContext(context: Context | null): void {
-        this.context = context
-        if (this.selectionSet) {
-            this.updatePosition()
+        public destroy(): void {
+            this.subscription.unsubscribe()
         }
-    }
 
-    private updatePosition(): void {
-        if (this.context) {
-            const selection = this.view.state.selection.main
-            const fromLine = this.view.state.doc.lineAt(selection.from)
-            const toLine = selection.from === selection.to ? fromLine : this.view.state.doc.lineAt(selection.to)
-
-            const position: LineOrPositionOrRange = {
-                line: fromLine.number,
-                endLine: toLine.number,
+        public update(update: ViewUpdate): void {
+            if (update.state.field(selectedLines) !== update.startState.field(selectedLines)) {
+                this.nextSelection.next(update.state.field(selectedLines))
             }
-
-            this.context.extensionHostAPI
-                .setEditorSelections(this.context.viewerId, lprToSelectionsZeroIndexed(position))
-                .catch(error => console.error('Error updating editor selections on extension host', error))
         }
     }
-}
-
-function updateSelection(): Extension {
-    return ViewPlugin.fromClass(SelectionManager, {
-        provide: plugin => updateOnContextChange.of(plugin),
-    })
-}
+)
 
 //
 // Hovercards

--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -36,12 +36,12 @@ import { BlobInfo, BlobProps } from '../Blob'
 import { showTextDocumentDecorations } from './decorations'
 import { documentHighlightsSource } from './document-highlights'
 import { hovercardSource } from './hovercard'
+import { SelectedLineRange, selectedLines } from './linenumbers'
 import { Container } from './react-interop'
 
 import { blobPropsFacet } from '.'
 
 import blobStyles from '../Blob.module.scss'
-import { SelectedLineRange, selectedLines } from './linenumbers'
 
 /**
  * Context holds all the information needed for CodeMirror extensions to

--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -69,12 +69,14 @@ export function sourcegraphExtensions({
     extensionsController,
     disableStatusBar,
     disableDecorations,
+    disableHovercards,
 }: {
     blobInfo: BlobInfo
     initialSelection: LineOrPositionOrRange
     extensionsController: ExtensionsControllerProps['extensionsController']
     disableStatusBar?: boolean
     disableDecorations?: boolean
+    disableHovercards?: boolean
 }): Extension {
     const context = extensionsController.extHostAPI.then(async extensionHostAPI => {
         const uri = toURIWithPath(blobInfo)
@@ -135,7 +137,7 @@ export function sourcegraphExtensions({
         sgExtensionsContextField,
         // This needs to come before document highlights so that the hovered
         // token is highlighted differently
-        hovercardDataSource(),
+        disableHovercards ? [] : hovercardDataSource(),
         documentHighlightsDataSource(),
         disableDecorations ? [] : textDocumentDecorations(),
         updateSelection,


### PR DESCRIPTION
This commit adds support for using the blob view in the reference
panel. Besides handling the reference panel specific props
(`disableStatusBar`, `disableDecorations`), I also had to make some
changes to make selecting lines and scrolling them into view work
properly.

The biggest change is which selection information is sent to the
extension host. Instead of sending the editor's cursor position, I'm now
sending the selected lines, which is what the old blob view does. This
also fixes the issue with showing line decorations for selected
lines (instead of just line where the current cursor is).

Having a real cursor is still enabled because we need that for search
(Meta+f) to work.

Demo: (the first part shows how line decorations are updated as the user selects additional lines)


https://user-images.githubusercontent.com/179026/183598410-b361f3ba-fef0-4446-abbf-8ef0af96302b.mp4




## Test plan

- Enable CodeMirror file view, enable the new references panel.
- Open a file, hover over a symbol and click "find references"
- Click on a couple of entries in the reference panel. The preview appears, scrolled to the selected line.
  - Clicking on other entries in the same file doesn't give the impression that the preview reloads.

## App preview:

- [Web](https://sg-web-fkling-cm-blob-view-reference.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gwwvodgwsp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
