### PR TITLE
database: Add ExcludeConfigField to extsvc.List

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
@@ -85,7 +85,8 @@ func (h *dependencyIndexingSchedulerHandler) Handle(ctx context.Context, logger 
 
 	if job.ExternalServiceKind != "" {
 		externalServices, err := h.extsvcStore.List(ctx, database.ExternalServicesListOptions{
-			Kinds: []string{job.ExternalServiceKind},
+			Kinds:              []string{job.ExternalServiceKind},
+			ExcludeConfigField: true,
 		})
 		if err != nil {
 			return errors.Wrap(err, "extsvcStore.List")

--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
@@ -137,7 +137,8 @@ func (h *dependencySyncSchedulerHandler) Handle(ctx context.Context, logger log.
 	if len(kindsArray) > 0 {
 		nextSync = time.Now()
 		externalServices, err := h.extsvcStore.List(ctx, database.ExternalServicesListOptions{
-			Kinds: kindsArray,
+			Kinds:              kindsArray,
+			ExcludeConfigField: true,
 		})
 		if err != nil {
 			if len(errs) == 0 {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -274,6 +274,9 @@ type ExternalServicesListOptions struct {
 	ForUpdate bool
 	// When true, soft-deleted external services will also be included in the results.
 	IncludeDeleted bool
+
+	// When true, do not attempt to fetch and decrypt the row's configuration.
+	ExcludeConfigField bool
 }
 
 func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
@@ -1381,6 +1384,14 @@ func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesLis
 	}
 	if err = rows.Err(); err != nil {
 		return nil, err
+	}
+
+	if opt.ExcludeConfigField {
+		for _, result := range results {
+			result.Config = ""
+		}
+
+		return results, nil
 	}
 
 	// Now we may need to decrypt config. Since each decrypt operation could make an


### PR DESCRIPTION
In the `dependency_{sync,index}_schedulers`, we list extsvcs but do not read their config. This might waste a number of decrypt calls we can skip.

This might help cut the KMS quota issues we've recently seen on k8s and cloud.

## Test plan

Existing unit tests.