### PR TITLE
Search: Add aggregation panel mock UI

### DIFF
--- a/client/search-ui/.eslintignore
+++ b/client/search-ui/.eslintignore
@@ -1,1 +1,2 @@
 out/
+src/graphql-operations.ts

--- a/client/search-ui/src/results/sidebar/SearchAggregations.module.scss
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.module.scss
@@ -1,0 +1,21 @@
+.button-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.chart-container {
+    min-height: 18.75rem;
+    width: 100%;
+}
+
+.actions {
+    margin-top: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.details-action {
+    margin-right: auto;
+}

--- a/client/search-ui/src/results/sidebar/SearchAggregations.module.scss
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.module.scss
@@ -1,11 +1,6 @@
-.button-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-}
 
 .chart-container {
-    min-height: 18.75rem;
+    min-height: 12rem;
     width: 100%;
 }
 

--- a/client/search-ui/src/results/sidebar/SearchAggregations.module.scss
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.module.scss
@@ -1,4 +1,3 @@
-
 .chart-container {
     min-height: 12rem;
     width: 100%;
@@ -9,6 +8,11 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.25rem;
+}
+
+.aggregation-type-control {
+    padding-left: 0.375rem;
+    padding-right: 0.375rem;
 }
 
 .details-action {

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 
 import { mdiArrowExpand, mdiPlus } from '@mdi/js'
 import { ParentSize } from '@visx/responsive'
@@ -6,7 +6,7 @@ import { ParentSize } from '@visx/responsive'
 // TODO: import Chart UI from the wildcard, see https://github.com/sourcegraph/sourcegraph/issues/40136
 // eslint-disable-next-line no-restricted-imports
 import { BarChart } from '@sourcegraph/web/src/charts'
-import { Button, Icon } from '@sourcegraph/wildcard'
+import { ButtonGroup, Button, Icon } from '@sourcegraph/wildcard'
 
 import styles from './SearchAggregations.module.scss'
 
@@ -29,72 +29,142 @@ const LANGUAGE_USAGE_DATA: LanguageUsageDatum[] = [
     {
         name: 'JavaScript',
         value: 422,
-        fill: '#f1e05a',
+        fill: 'var(--primary)',
         linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
     },
     {
         name: 'CSS',
         value: 273,
-        fill: '#563d7c',
+        fill: 'var(--primary)',
         linkURL: 'https://en.wikipedia.org/wiki/CSS',
     },
     {
         name: 'HTML',
         value: 129,
-        fill: '#e34c26',
+        fill: 'var(--primary)',
         linkURL: 'https://en.wikipedia.org/wiki/HTML',
+    },
+    {
+        name: 'С++',
+        value: 110,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'TypeScript',
+        value: 95,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'Elm',
+        value: 84,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'Rust',
+        value: 60,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'Go',
+        value: 45,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
     },
     {
         name: 'Markdown',
         value: 35,
-        fill: '#083fa1',
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'Zig',
+        value: 20,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'XML',
+        value: 5,
+        fill: 'var(--primary)',
         linkURL: 'https://en.wikipedia.org/wiki/Markdown',
     },
 ]
 
+enum AggregationModes {
+    Repository,
+    FilePath,
+    Author,
+    CaptureGroups,
+}
+
 interface SearchAggregationsProps {}
 
-export const SearchAggregations: FC<SearchAggregationsProps> = props => (
-    <div>
-        <header className={styles.buttonGroup}>
-            <Button variant="secondary" size="sm">
-                Repository
-            </Button>
+export const SearchAggregations: FC<SearchAggregationsProps> = props => {
+    const [aggregationMode, setAggregationMode] = useState(AggregationModes.Repository)
 
-            <Button variant="secondary" size="sm">
-                Capture group
-            </Button>
+    return (
+        <article className='pt-2'>
+            <ButtonGroup className='mb-3'>
+                <Button
+                    variant="secondary"
+                    size="sm"
+                    outline={aggregationMode !== AggregationModes.Repository}
+                    onClick={() => setAggregationMode(AggregationModes.Repository)}
+                >
+                    Repo
+                </Button>
 
-            <Button variant="secondary" size="sm">
-                Author
-            </Button>
-            <Button variant="secondary" size="sm">
-                File path
-            </Button>
-        </header>
+                <Button
+                    variant="secondary"
+                    size="sm"
+                    outline={aggregationMode !== AggregationModes.FilePath}
+                    onClick={() => setAggregationMode(AggregationModes.FilePath)}>
+                    File
+                </Button>
 
-        <ParentSize className={styles.chartContainer}>
-            {parent => (
-                <BarChart
-                    width={parent.width}
-                    height={parent.height}
-                    data={LANGUAGE_USAGE_DATA}
-                    getDatumName={getName}
-                    getDatumValue={getValue}
-                    getDatumColor={getColor}
-                    getDatumLink={getLink}
-                />
-            )}
-        </ParentSize>
+                <Button
+                    variant="secondary"
+                    size="sm"
+                    outline={aggregationMode !== AggregationModes.Author}
+                    onClick={() => setAggregationMode(AggregationModes.Author)}>
+                    Author
+                </Button>
+                <Button
+                    variant="secondary"
+                    size="sm"
+                    outline={aggregationMode !== AggregationModes.CaptureGroups}
+                    onClick={() => setAggregationMode(AggregationModes.CaptureGroups)}>
+                    Group
+                </Button>
+            </ButtonGroup>
 
-        <footer className={styles.actions}>
-            <Button variant="secondary" size="sm" className={styles.detailsAction}>
-                <Icon aria-hidden={true} svgPath={mdiArrowExpand} /> Details
-            </Button>
+            <ParentSize className={styles.chartContainer}>
+                {parent => (
+                    <BarChart
+                        width={parent.width}
+                        height={parent.height}
+                        data={LANGUAGE_USAGE_DATA}
+                        getDatumName={getName}
+                        getDatumValue={getValue}
+                        getDatumColor={getColor}
+                        getDatumLink={getLink}
+                    />
+                )}
+            </ParentSize>
 
-            <Button variant="primary" size="sm">
-                <Icon aria-hidden={true} svgPath={mdiPlus} /> Create code insight
-            </Button>
-        </footer>
-    </div>
-)
+            <footer className={styles.actions}>
+                <Button variant="secondary" size="sm" outline={true} className={styles.detailsAction}>
+                    <Icon aria-hidden={true} svgPath={mdiArrowExpand} /> Expand
+                </Button>
+
+                <Button variant="secondary" outline={true} size="sm">
+                    <Icon aria-hidden={true} svgPath={mdiPlus} /> Save insight
+                </Button>
+            </footer>
+        </article>
+    )
+}

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -123,7 +123,7 @@ const getTruncatedTickFromTheEnd = (tick: string): string =>
 
 const getTruncationFormatter = (aggregationMode: AggregationModes): ((tick: string) => string) => {
     switch (aggregationMode) {
-        // These types possible have long labels with the same pattern at the start of the string,
+        // These types possibly have long labels with the same pattern at the start of the string,
         // so we truncate their labels from the end
         case AggregationModes.Repository:
         case AggregationModes.FilePath:

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -3,10 +3,7 @@ import { FC, useState } from 'react'
 import { mdiArrowExpand, mdiPlus } from '@mdi/js'
 import { ParentSize } from '@visx/responsive'
 
-// TODO: import Chart UI from the wildcard, see https://github.com/sourcegraph/sourcegraph/issues/40136
-// eslint-disable-next-line no-restricted-imports
-import { BarChart } from '@sourcegraph/web/src/charts'
-import { ButtonGroup, Button, Icon } from '@sourcegraph/wildcard'
+import { ButtonGroup, Button, Icon, BarChart } from '@sourcegraph/wildcard'
 
 import styles from './SearchAggregations.module.scss'
 
@@ -26,6 +23,30 @@ const getName = (datum: LanguageUsageDatum): string => datum.name
 // Mock data for bar chart, will be removed and replace with
 // actual data in https://github.com/sourcegraph/sourcegraph/issues/39956
 const LANGUAGE_USAGE_DATA: LanguageUsageDatum[] = [
+    {
+        name: 'Julia',
+        value: 1000,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'Erlang',
+        value: 700,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'SQL',
+        value: 550,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'Cobol',
+        value: 500,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
     {
         name: 'JavaScript',
         value: 422,
@@ -107,9 +128,10 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
     const [aggregationMode, setAggregationMode] = useState(AggregationModes.Repository)
 
     return (
-        <article className='pt-2'>
-            <ButtonGroup className='mb-3'>
+        <article className="pt-2">
+            <ButtonGroup className="mb-3">
                 <Button
+                    className={styles.aggregationTypeControl}
                     variant="secondary"
                     size="sm"
                     outline={aggregationMode !== AggregationModes.Repository}
@@ -119,26 +141,32 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                 </Button>
 
                 <Button
+                    className={styles.aggregationTypeControl}
                     variant="secondary"
                     size="sm"
                     outline={aggregationMode !== AggregationModes.FilePath}
-                    onClick={() => setAggregationMode(AggregationModes.FilePath)}>
+                    onClick={() => setAggregationMode(AggregationModes.FilePath)}
+                >
                     File
                 </Button>
 
                 <Button
+                    className={styles.aggregationTypeControl}
                     variant="secondary"
                     size="sm"
                     outline={aggregationMode !== AggregationModes.Author}
-                    onClick={() => setAggregationMode(AggregationModes.Author)}>
+                    onClick={() => setAggregationMode(AggregationModes.Author)}
+                >
                     Author
                 </Button>
                 <Button
+                    className={styles.aggregationTypeControl}
                     variant="secondary"
                     size="sm"
                     outline={aggregationMode !== AggregationModes.CaptureGroups}
-                    onClick={() => setAggregationMode(AggregationModes.CaptureGroups)}>
-                    Group
+                    onClick={() => setAggregationMode(AggregationModes.CaptureGroups)}
+                >
+                    Capture group
                 </Button>
             </ButtonGroup>
 
@@ -152,6 +180,9 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                         getDatumValue={getValue}
                         getDatumColor={getColor}
                         getDatumLink={getLink}
+                        pixelsPerYTick={20}
+                        pixelsPerXTick={20}
+                        maxAngleXTick={45}
                     />
                 )}
             </ParentSize>

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -1,0 +1,100 @@
+import { FC } from 'react'
+
+import { mdiArrowExpand, mdiPlus } from '@mdi/js'
+import { ParentSize } from '@visx/responsive'
+
+// TODO: import Chart UI from the wildcard, see https://github.com/sourcegraph/sourcegraph/issues/40136
+// eslint-disable-next-line no-restricted-imports
+import { BarChart } from '@sourcegraph/web/src/charts'
+import { Button, Icon } from '@sourcegraph/wildcard'
+
+import styles from './SearchAggregations.module.scss'
+
+interface LanguageUsageDatum {
+    name: string
+    value: number
+    fill: string
+    linkURL: string
+    group?: string
+}
+
+const getValue = (datum: LanguageUsageDatum): number => datum.value
+const getColor = (datum: LanguageUsageDatum): string => datum.fill
+const getLink = (datum: LanguageUsageDatum): string => datum.linkURL
+const getName = (datum: LanguageUsageDatum): string => datum.name
+
+// Mock data for bar chart, will be removed and replace with
+// actual data in https://github.com/sourcegraph/sourcegraph/issues/39956
+const LANGUAGE_USAGE_DATA: LanguageUsageDatum[] = [
+    {
+        name: 'JavaScript',
+        value: 422,
+        fill: '#f1e05a',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'CSS',
+        value: 273,
+        fill: '#563d7c',
+        linkURL: 'https://en.wikipedia.org/wiki/CSS',
+    },
+    {
+        name: 'HTML',
+        value: 129,
+        fill: '#e34c26',
+        linkURL: 'https://en.wikipedia.org/wiki/HTML',
+    },
+    {
+        name: 'Markdown',
+        value: 35,
+        fill: '#083fa1',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+]
+
+interface SearchAggregationsProps {}
+
+export const SearchAggregations: FC<SearchAggregationsProps> = props => (
+    <div>
+        <header className={styles.buttonGroup}>
+            <Button variant="secondary" size="sm">
+                Repository
+            </Button>
+
+            <Button variant="secondary" size="sm">
+                Capture group
+            </Button>
+
+            <Button variant="secondary" size="sm">
+                Author
+            </Button>
+            <Button variant="secondary" size="sm">
+                File path
+            </Button>
+        </header>
+
+        <ParentSize className={styles.chartContainer}>
+            {parent => (
+                <BarChart
+                    width={parent.width}
+                    height={parent.height}
+                    data={LANGUAGE_USAGE_DATA}
+                    getDatumName={getName}
+                    getDatumValue={getValue}
+                    getDatumColor={getColor}
+                    getDatumLink={getLink}
+                />
+            )}
+        </ParentSize>
+
+        <footer className={styles.actions}>
+            <Button variant="secondary" size="sm" className={styles.detailsAction}>
+                <Icon aria-hidden={true} svgPath={mdiArrowExpand} /> Details
+            </Button>
+
+            <Button variant="primary" size="sm">
+                <Icon aria-hidden={true} svgPath={mdiPlus} /> Create code insight
+            </Button>
+        </footer>
+    </div>
+)

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -1,15 +1,17 @@
 import { FC, useCallback, useMemo } from 'react'
 
-import { gql, useQuery } from '@apollo/client';
+import { gql, useQuery } from '@apollo/client'
 import { mdiArrowExpand, mdiPlus } from '@mdi/js'
 import { ParentSize } from '@visx/responsive'
-import { useHistory, useLocation } from 'react-router';
+import { getTicks } from '@visx/scale'
+import { AnyD3Scale } from '@visx/scale/lib/types/Scale'
+import { useHistory, useLocation } from 'react-router'
 
 import { ButtonGroup, Button, Icon, BarChart } from '@sourcegraph/wildcard'
 
-import { IsCodeInsightsEnabledResult } from '../../graphql-operations';
+import { IsCodeInsightsEnabledResult } from '../../graphql-operations'
 
-import { LANGUAGE_USAGE_DATA, LanguageUsageDatum } from './search-aggregation-mock-data';
+import { LANGUAGE_USAGE_DATA, LanguageUsageDatum } from './search-aggregation-mock-data'
 
 import styles from './SearchAggregations.module.scss'
 
@@ -20,8 +22,8 @@ const IS_CODE_INSIGHTS_ENABLED_QUERY = gql`
 `
 
 interface URLStateOptions<State> {
-    urlKey: string,
-    deserializer: (value: string | null) => State,
+    urlKey: string
+    deserializer: (value: string | null) => State
     serializer: (state: State) => string
 }
 
@@ -37,16 +39,20 @@ function useSyncedWithURLState<State>(options: URLStateOptions<State>): SetState
     const { search } = useLocation()
 
     const urlSearchParameters = useMemo(() => new URLSearchParams(search), [search])
-    const queryParameter = useMemo(
-        () => deserializer(urlSearchParameters.get(urlKey)),
-        [urlSearchParameters, urlKey, deserializer]
+    const queryParameter = useMemo(() => deserializer(urlSearchParameters.get(urlKey)), [
+        urlSearchParameters,
+        urlKey,
+        deserializer,
+    ])
+
+    const setNextState = useCallback(
+        (nextState: State) => {
+            urlSearchParameters.set(urlKey, serializer(nextState))
+
+            history.replace({ search: `?${urlSearchParameters.toString()}` })
+        },
+        [history, serializer, urlKey, urlSearchParameters]
     )
-
-    const setNextState = useCallback((nextState: State) => {
-        urlSearchParameters.set(urlKey, serializer(nextState))
-
-        history.replace({ search: `?${urlSearchParameters.toString()}`})
-    }, [history, serializer, urlKey, urlSearchParameters])
 
     return [queryParameter, setNextState]
 }
@@ -62,12 +68,17 @@ const AGGREGATION_MODE_URL_KEY = 'aggregation_mode'
 
 const aggregationModeDeserializer = (serializedValue: string | null): AggregationModes => {
     switch (serializedValue) {
-        case 'repo': return AggregationModes.Repository
-        case 'file': return AggregationModes.FilePath
-        case 'author': return AggregationModes.Author
-        case 'groups': return AggregationModes.CaptureGroups
+        case 'repo':
+            return AggregationModes.Repository
+        case 'file':
+            return AggregationModes.FilePath
+        case 'author':
+            return AggregationModes.Author
+        case 'groups':
+            return AggregationModes.CaptureGroups
 
-        default: return AggregationModes.Repository
+        default:
+            return AggregationModes.Repository
     }
 }
 
@@ -78,11 +89,48 @@ const getColor = (datum: LanguageUsageDatum): string => datum.fill
 const getLink = (datum: LanguageUsageDatum): string => datum.linkURL
 const getName = (datum: LanguageUsageDatum): string => datum.name
 
-const MAX_TRUNCATED_LABEL_LENGTH = 10
-const getTruncatedTick = (tick: string): string => (tick.length >= MAX_TRUNCATED_LABEL_LENGTH ? `${tick.slice(0, MAX_TRUNCATED_LABEL_LENGTH)}...` : tick)
-const getTruncatedTickFromTheEnd = (tick: string): string => (tick.length >= MAX_TRUNCATED_LABEL_LENGTH ? `...${tick.slice(-MAX_TRUNCATED_LABEL_LENGTH)}` : tick)
+interface GetScaleTicksOptions {
+    scale: AnyD3Scale
+    space: number
+    pixelsPerTick?: number
+}
 
-const getTruncationFormatter = (aggregationMode: AggregationModes): (tick: string) => string => {
+/**
+ * Custom tick generator for search result aggregation bar. Double down tick
+ * labels count every until their count fits in a given available space.
+ *
+ * ```
+ * Before
+ * ─┬──┬──┬──┬──┬──┬──┬──┬──┬──┬───▶
+ *  1  2  3  4  5  6  7  8  9  10
+ *
+ * After
+ * ─┬─────┬─────┬─────┬─────┬──────▶
+ *  1     3     5     7     9
+ * ```
+ */
+const getXScaleTicks = <T,>(options: GetScaleTicksOptions): T[] => {
+    const { scale, space, pixelsPerTick = 80 } = options
+
+    // Calculate desirable number of ticks
+    const numberTicks = Math.max(2, Math.floor(space / pixelsPerTick))
+
+    let filteredTicks = getTicks(scale)
+
+    while (filteredTicks.length > numberTicks) {
+        filteredTicks = filteredTicks.filter((tick, index) => index % 2 === 0)
+    }
+
+    return filteredTicks
+}
+
+const MAX_TRUNCATED_LABEL_LENGTH = 10
+const getTruncatedTick = (tick: string): string =>
+    tick.length >= MAX_TRUNCATED_LABEL_LENGTH ? `${tick.slice(0, MAX_TRUNCATED_LABEL_LENGTH)}...` : tick
+const getTruncatedTickFromTheEnd = (tick: string): string =>
+    tick.length >= MAX_TRUNCATED_LABEL_LENGTH ? `...${tick.slice(-MAX_TRUNCATED_LABEL_LENGTH)}` : tick
+
+const getTruncationFormatter = (aggregationMode: AggregationModes): ((tick: string) => string) => {
     switch (aggregationMode) {
         // These types possible have long labels with the same pattern at the start of the string,
         // so we truncate their labels from the end
@@ -95,15 +143,16 @@ const getTruncationFormatter = (aggregationMode: AggregationModes): (tick: strin
     }
 }
 
-interface SearchAggregationsProps {
-}
+interface SearchAggregationsProps {}
 
 export const SearchAggregations: FC<SearchAggregationsProps> = props => {
-    const { data } = useQuery<IsCodeInsightsEnabledResult>(IS_CODE_INSIGHTS_ENABLED_QUERY, { fetchPolicy: 'cache-first' })
+    const { data } = useQuery<IsCodeInsightsEnabledResult>(IS_CODE_INSIGHTS_ENABLED_QUERY, {
+        fetchPolicy: 'cache-first',
+    })
     const [aggregationMode, setAggregationMode] = useSyncedWithURLState({
         urlKey: AGGREGATION_MODE_URL_KEY,
         serializer: aggregationModeSerializer,
-        deserializer: aggregationModeDeserializer
+        deserializer: aggregationModeDeserializer,
     })
 
     const getTruncatedXLabel = useMemo(() => getTruncationFormatter(aggregationMode), [aggregationMode])
@@ -164,6 +213,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                         pixelsPerYTick={20}
                         pixelsPerXTick={20}
                         maxAngleXTick={45}
+                        getScaleXTicks={getXScaleTicks}
                         getTruncatedXTick={getTruncatedXLabel}
                     />
                 )}
@@ -171,15 +221,14 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
 
             <footer className={styles.actions}>
                 <Button variant="secondary" size="sm" outline={true} className={styles.detailsAction}>
-                    <Icon aria-hidden={true} svgPath={mdiArrowExpand}/> Expand
+                    <Icon aria-hidden={true} svgPath={mdiArrowExpand} /> Expand
                 </Button>
 
-                {
-                    data?.enterpriseLicenseHasFeature &&
+                {data?.enterpriseLicenseHasFeature && (
                     <Button variant="secondary" outline={true} size="sm">
-                        <Icon aria-hidden={true} svgPath={mdiPlus}/> Save insight
+                        <Icon aria-hidden={true} svgPath={mdiPlus} /> Save insight
                     </Button>
-                }
+                )}
             </footer>
         </article>
     )

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -1,11 +1,18 @@
 import { FC, useState } from 'react'
 
+import { gql, useQuery } from '@apollo/client';
 import { mdiArrowExpand, mdiPlus } from '@mdi/js'
 import { ParentSize } from '@visx/responsive'
 
 import { ButtonGroup, Button, Icon, BarChart } from '@sourcegraph/wildcard'
 
 import styles from './SearchAggregations.module.scss'
+
+const IS_CODE_INSIGHTS_ENABLED_QUERY = gql`
+    query IsCodeInsightsEnabled {
+        enterpriseLicenseHasFeature(feature: "code-insights")
+    }
+`
 
 interface LanguageUsageDatum {
     name: string
@@ -126,6 +133,7 @@ interface SearchAggregationsProps {}
 
 export const SearchAggregations: FC<SearchAggregationsProps> = props => {
     const [aggregationMode, setAggregationMode] = useState(AggregationModes.Repository)
+    const { data } = useQuery<{ enterpriseLicenseHasFeature: boolean }>(IS_CODE_INSIGHTS_ENABLED_QUERY, { fetchPolicy: 'cache-first' })
 
     return (
         <article className="pt-2">
@@ -192,9 +200,12 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                     <Icon aria-hidden={true} svgPath={mdiArrowExpand} /> Expand
                 </Button>
 
-                <Button variant="secondary" outline={true} size="sm">
-                    <Icon aria-hidden={true} svgPath={mdiPlus} /> Save insight
-                </Button>
+                {
+                    data?.enterpriseLicenseHasFeature &&
+                    <Button variant="secondary" outline={true} size="sm">
+                        <Icon aria-hidden={true} svgPath={mdiPlus} /> Save insight
+                    </Button>
+                }
             </footer>
         </article>
     )

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -52,7 +52,7 @@ enum AggregationModes {
     Repository = 'repo',
     FilePath = 'file',
     Author = 'author',
-    CaptureGroups = 'groups',
+    CaptureGroups = 'captureGroup',
 }
 
 const AGGREGATION_MODE_URL_KEY = 'groupBy'
@@ -65,7 +65,7 @@ const aggregationModeDeserializer = (serializedValue: string | null): Aggregatio
             return AggregationModes.FilePath
         case 'author':
             return AggregationModes.Author
-        case 'groups':
+        case 'captureGroup':
             return AggregationModes.CaptureGroups
 
         default:

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -1,6 +1,5 @@
 import { FC, useCallback, useMemo } from 'react'
 
-import { gql, useQuery } from '@apollo/client'
 import { mdiArrowExpand, mdiPlus } from '@mdi/js'
 import { ParentSize } from '@visx/responsive'
 import { getTicks } from '@visx/scale'
@@ -9,17 +8,9 @@ import { useHistory, useLocation } from 'react-router'
 
 import { ButtonGroup, Button, Icon, BarChart } from '@sourcegraph/wildcard'
 
-import { IsCodeInsightsEnabledResult } from '../../graphql-operations'
-
 import { LANGUAGE_USAGE_DATA, LanguageUsageDatum } from './search-aggregation-mock-data'
 
 import styles from './SearchAggregations.module.scss'
-
-const IS_CODE_INSIGHTS_ENABLED_QUERY = gql`
-    query IsCodeInsightsEnabled {
-        enterpriseLicenseHasFeature(feature: "code-insights")
-    }
-`
 
 interface URLStateOptions<State> {
     urlKey: string
@@ -64,7 +55,7 @@ enum AggregationModes {
     CaptureGroups = 'groups',
 }
 
-const AGGREGATION_MODE_URL_KEY = 'aggregation_mode'
+const AGGREGATION_MODE_URL_KEY = 'groupBy'
 
 const aggregationModeDeserializer = (serializedValue: string | null): AggregationModes => {
     switch (serializedValue) {
@@ -146,9 +137,6 @@ const getTruncationFormatter = (aggregationMode: AggregationModes): ((tick: stri
 interface SearchAggregationsProps {}
 
 export const SearchAggregations: FC<SearchAggregationsProps> = props => {
-    const { data } = useQuery<IsCodeInsightsEnabledResult>(IS_CODE_INSIGHTS_ENABLED_QUERY, {
-        fetchPolicy: 'cache-first',
-    })
     const [aggregationMode, setAggregationMode] = useSyncedWithURLState({
         urlKey: AGGREGATION_MODE_URL_KEY,
         serializer: aggregationModeSerializer,
@@ -224,11 +212,9 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                     <Icon aria-hidden={true} svgPath={mdiArrowExpand} /> Expand
                 </Button>
 
-                {data?.enterpriseLicenseHasFeature && (
-                    <Button variant="secondary" outline={true} size="sm">
-                        <Icon aria-hidden={true} svgPath={mdiPlus} /> Save insight
-                    </Button>
-                )}
+                <Button variant="secondary" outline={true} size="sm">
+                    <Icon aria-hidden={true} svgPath={mdiPlus} /> Save insight
+                </Button>
             </footer>
         </article>
     )

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -27,6 +27,7 @@ import { getDynamicFilterLinks, getRepoFilterLinks, getSearchSnippetLinks } from
 import { getFiltersOfKind, useLastRepoName } from './helpers'
 import { getQuickLinks } from './QuickLink'
 import { RevisionsProps } from './revisions'
+import { SearchAggregations } from './SearchAggregations'
 import { getSearchReferenceFactory } from './SearchReference'
 import { SearchSidebarSection } from './SearchSidebarSection'
 import { getSearchTypeLinks } from './SearchTypeLink'
@@ -57,6 +58,11 @@ export interface SearchSidebarProps
      * Used e.g. in the VS Code extension to update search query state.
      */
     forceButton?: boolean
+
+    /**
+     * Enables search compute-based aggregations filter panel
+     */
+    enableSearchAggregation?: boolean
 }
 
 const selectFromQueryState = ({
@@ -73,7 +79,7 @@ const selectFromQueryState = ({
     submitSearch,
 })
 
-export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<SearchSidebarProps>> = props => {
+export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props => {
     const history = useHistory()
     const [collapsedSections, setCollapsedSections] = useTemporarySetting('search.collapsedSidebarSections', {})
     const [, setSelectedTab] = useTemporarySetting('search.sidebar.selectedTab', 'filters')
@@ -169,6 +175,18 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
     if (collapsedSections) {
         body = (
             <>
+                {props.enableSearchAggregation && (
+                    <SearchSidebarSection
+                        sectionId={SectionID.GROUPED_BY}
+                        className={styles.item}
+                        header="Grouped by"
+                        startCollapsed={collapsedSections?.[SectionID.GROUPED_BY]}
+                        onToggle={persistToggleState}
+                    >
+                        <SearchAggregations />
+                    </SearchSidebarSection>
+                )}
+
                 <SearchSidebarSection
                     sectionId={SectionID.SEARCH_TYPES}
                     className={styles.item}

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -179,7 +179,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                     <SearchSidebarSection
                         sectionId={SectionID.GROUPED_BY}
                         className={styles.item}
-                        header="Grouped by"
+                        header="Aggregate results by"
                         startCollapsed={collapsedSections?.[SectionID.GROUPED_BY]}
                         onToggle={persistToggleState}
                     >

--- a/client/search-ui/src/results/sidebar/search-aggregation-mock-data.ts
+++ b/client/search-ui/src/results/sidebar/search-aggregation-mock-data.ts
@@ -1,0 +1,102 @@
+export interface LanguageUsageDatum {
+    name: string
+    value: number
+    fill: string
+    linkURL: string
+    group?: string
+}
+
+// Mock data for bar chart, will be removed and replace with
+// actual data in https://github.com/sourcegraph/sourcegraph/issues/39956
+export const LANGUAGE_USAGE_DATA: LanguageUsageDatum[] = [
+    {
+        name: 'github/sourcegraph/Julia',
+        value: 1000,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/Erlang',
+        value: 700,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/SQL',
+        value: 550,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/Cobol',
+        value: 500,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/JavaScript',
+        value: 422,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/CSS',
+        value: 273,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/CSS',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/HTML',
+        value: 129,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/HTML',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/С++',
+        value: 110,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/TypeScript',
+        value: 95,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/Elm',
+        value: 84,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/Rust',
+        value: 60,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/Go',
+        value: 45,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/Markdown',
+        value: 35,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/Zig',
+        value: 20,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+    {
+        name: 'github/sourcegraph/sourcegraph/XML',
+        value: 5,
+        fill: 'var(--primary)',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+]

--- a/client/shared/dev/generateGraphQlOperations.js
+++ b/client/shared/dev/generateGraphQlOperations.js
@@ -10,6 +10,7 @@ const WEB_FOLDER = path.resolve(ROOT_FOLDER, './client/web')
 const BROWSER_FOLDER = path.resolve(ROOT_FOLDER, './client/browser')
 const SHARED_FOLDER = path.resolve(ROOT_FOLDER, './client/shared')
 const SEARCH_FOLDER = path.resolve(ROOT_FOLDER, './client/search')
+const SEARCH_UI_FOLDER = path.resolve(ROOT_FOLDER, './client/search-ui')
 const VSCODE_FOLDER = path.resolve(ROOT_FOLDER, './client/vscode')
 const JETBRAINS_FOLDER = path.resolve(ROOT_FOLDER, './client/jetbrains')
 const SCHEMA_PATH = path.join(ROOT_FOLDER, './cmd/frontend/graphqlbackend/*.graphql')
@@ -33,6 +34,7 @@ const BROWSER_DOCUMENTS_GLOB = [
 ]
 
 const SEARCH_DOCUMENTS_GLOB = [`${SEARCH_FOLDER}/src/**/*.{ts,tsx}`]
+const SEARCH_UI_DOCUMENTS_GLOB = [`${SEARCH_UI_FOLDER}/src/**/*.{ts,tsx}`]
 
 const VSCODE_DOCUMENTS_GLOB = [`${VSCODE_FOLDER}/src/**/*.{ts,tsx}`]
 
@@ -45,6 +47,7 @@ const ALL_DOCUMENTS_GLOB = [
     ...WEB_DOCUMENTS_GLOB,
     ...BROWSER_DOCUMENTS_GLOB,
     ...SEARCH_DOCUMENTS_GLOB,
+    ...SEARCH_UI_DOCUMENTS_GLOB,
     ...VSCODE_DOCUMENTS_GLOB,
     ...JETBRAINS_DOCUMENTS_GLOB,
   ]),
@@ -127,6 +130,17 @@ async function generateGraphQlOperations() {
 
         [path.join(SEARCH_FOLDER, './src/graphql-operations.ts')]: {
           documents: SEARCH_DOCUMENTS_GLOB,
+          config: {
+            onlyOperationTypes: true,
+            noExport: false,
+            enumValues: '@sourcegraph/shared/src/graphql-operations',
+            interfaceNameForOperations: 'SearchGraphQlOperations',
+          },
+          plugins: SHARED_PLUGINS,
+        },
+
+        [path.join(SEARCH_UI_FOLDER, './src/graphql-operations.ts')]: {
+          documents: SEARCH_UI_DOCUMENTS_GLOB,
           config: {
             onlyOperationTypes: true,
             noExport: false,

--- a/client/shared/dev/generateGraphQlOperations.js
+++ b/client/shared/dev/generateGraphQlOperations.js
@@ -10,7 +10,6 @@ const WEB_FOLDER = path.resolve(ROOT_FOLDER, './client/web')
 const BROWSER_FOLDER = path.resolve(ROOT_FOLDER, './client/browser')
 const SHARED_FOLDER = path.resolve(ROOT_FOLDER, './client/shared')
 const SEARCH_FOLDER = path.resolve(ROOT_FOLDER, './client/search')
-const SEARCH_UI_FOLDER = path.resolve(ROOT_FOLDER, './client/search-ui')
 const VSCODE_FOLDER = path.resolve(ROOT_FOLDER, './client/vscode')
 const JETBRAINS_FOLDER = path.resolve(ROOT_FOLDER, './client/jetbrains')
 const SCHEMA_PATH = path.join(ROOT_FOLDER, './cmd/frontend/graphqlbackend/*.graphql')
@@ -34,7 +33,6 @@ const BROWSER_DOCUMENTS_GLOB = [
 ]
 
 const SEARCH_DOCUMENTS_GLOB = [`${SEARCH_FOLDER}/src/**/*.{ts,tsx}`]
-const SEARCH_UI_DOCUMENTS_GLOB = [`${SEARCH_UI_FOLDER}/src/**/*.{ts,tsx}`]
 
 const VSCODE_DOCUMENTS_GLOB = [`${VSCODE_FOLDER}/src/**/*.{ts,tsx}`]
 
@@ -47,7 +45,6 @@ const ALL_DOCUMENTS_GLOB = [
     ...WEB_DOCUMENTS_GLOB,
     ...BROWSER_DOCUMENTS_GLOB,
     ...SEARCH_DOCUMENTS_GLOB,
-    ...SEARCH_UI_DOCUMENTS_GLOB,
     ...VSCODE_DOCUMENTS_GLOB,
     ...JETBRAINS_DOCUMENTS_GLOB,
   ]),
@@ -130,17 +127,6 @@ async function generateGraphQlOperations() {
 
         [path.join(SEARCH_FOLDER, './src/graphql-operations.ts')]: {
           documents: SEARCH_DOCUMENTS_GLOB,
-          config: {
-            onlyOperationTypes: true,
-            noExport: false,
-            enumValues: '@sourcegraph/shared/src/graphql-operations',
-            interfaceNameForOperations: 'SearchGraphQlOperations',
-          },
-          plugins: SHARED_PLUGINS,
-        },
-
-        [path.join(SEARCH_UI_FOLDER, './src/graphql-operations.ts')]: {
-          documents: SEARCH_UI_DOCUMENTS_GLOB,
           config: {
             onlyOperationTypes: true,
             noExport: false,

--- a/client/shared/src/settings/temporary/searchSidebar.ts
+++ b/client/shared/src/settings/temporary/searchSidebar.ts
@@ -1,4 +1,5 @@
 export enum SectionID {
+    GROUPED_BY = 'grouped-by',
     SEARCH_REFERENCE = 'reference',
     SEARCH_TYPES = 'types',
     DYNAMIC_FILTERS = 'filters', // Deprecated

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -14,6 +14,7 @@ export type FeatureFlagName =
     | 'contrast-compliant-syntax-highlighting'
     | 'admin-analytics-disabled'
     | 'admin-analytics-cache-disabled'
+    | 'search-aggregation-filters'
     | 'ab-lucky-search' // To be removed at latest by 12/2022.
     | 'user-management-disabled'
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -83,6 +83,7 @@ export const StreamingSearchResults: React.FunctionComponent<
     } = props
     const extensionHostAPI = extensionsController !== null ? extensionsController.extHostAPI : null
 
+    const [enableSearchAggregations] = useFeatureFlag('search-aggregation-filters', false)
     const enableCodeMonitoring = useExperimentalFeatures(features => features.codeMonitoring ?? false)
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext ?? false)
     const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)
@@ -255,6 +256,7 @@ export const StreamingSearchResults: React.FunctionComponent<
             <SidebarButtonStrip className={styles.sidebarButtonStrip} />
 
             <SearchSidebar
+                enableSearchAggregation={enableSearchAggregations}
                 activation={props.activation}
                 caseSensitive={caseSensitive}
                 patternType={patternType}

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -16,6 +16,9 @@ interface BarChartProps<Datum> extends CategoricalLikeChart<Datum>, SVGProps<SVG
     width: number
     height: number
     stacked?: boolean
+    pixelsPerYTick?: number
+    pixelsPerXTick?: number
+    maxAngleXTick?: number
     getCategory?: (datum: Datum) => string | undefined
 }
 
@@ -24,6 +27,9 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         width: outerWidth,
         height: outerHeight,
         data,
+        pixelsPerYTick,
+        pixelsPerXTick,
+        maxAngleXTick,
         stacked = false,
         getDatumHover,
         getDatumName,
@@ -69,8 +75,8 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
 
     return (
         <SvgRoot {...attributes} width={outerWidth} height={outerHeight} xScale={xScale} yScale={yScale}>
-            <SvgAxisLeft />
-            <SvgAxisBottom />
+            <SvgAxisLeft pixelsPerTick={pixelsPerYTick} />
+            <SvgAxisBottom pixelsPerTick={pixelsPerXTick} maxRotateAngle={maxAngleXTick} />
 
             <SvgContent<ScaleBand<string>, any>>
                 {({ yScale, xScale, content }) => (

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -17,6 +17,9 @@ interface BarChartProps<Datum> extends CategoricalLikeChart<Datum>, SVGProps<SVG
     width: number
     height: number
     stacked?: boolean
+
+    // TODO: Move these specific only to the axis label UI props to the axis components
+    // see https://github.com/sourcegraph/sourcegraph/issues/40009
     pixelsPerYTick?: number
     pixelsPerXTick?: number
     maxAngleXTick?: number

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -19,6 +19,7 @@ interface BarChartProps<Datum> extends CategoricalLikeChart<Datum>, SVGProps<SVG
     pixelsPerYTick?: number
     pixelsPerXTick?: number
     maxAngleXTick?: number
+    getTruncatedXTick?: (formattedTick: string) => string
     getCategory?: (datum: Datum) => string | undefined
 }
 
@@ -32,6 +33,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         maxAngleXTick,
         stacked = false,
         getDatumHover,
+        getTruncatedXTick,
         getDatumName,
         getDatumValue,
         getDatumColor,
@@ -76,7 +78,11 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
     return (
         <SvgRoot {...attributes} width={outerWidth} height={outerHeight} xScale={xScale} yScale={yScale}>
             <SvgAxisLeft pixelsPerTick={pixelsPerYTick} />
-            <SvgAxisBottom pixelsPerTick={pixelsPerXTick} maxRotateAngle={maxAngleXTick} />
+            <SvgAxisBottom
+                pixelsPerTick={pixelsPerXTick}
+                maxRotateAngle={maxAngleXTick}
+                getTruncatedTick={getTruncatedXTick}
+            />
 
             <SvgContent<ScaleBand<string>, any>>
                 {({ yScale, xScale, content }) => (

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -4,6 +4,7 @@ import { scaleBand, scaleLinear } from '@visx/scale'
 import { ScaleBand } from 'd3-scale'
 import { noop } from 'lodash'
 
+import { GetScaleTicksOptions } from '../../core/components/axis/tick-formatters'
 import { SvgAxisBottom, SvgAxisLeft, SvgContent, SvgRoot } from '../../core/components/SvgRoot'
 import { CategoricalLikeChart } from '../../types'
 
@@ -19,6 +20,7 @@ interface BarChartProps<Datum> extends CategoricalLikeChart<Datum>, SVGProps<SVG
     pixelsPerYTick?: number
     pixelsPerXTick?: number
     maxAngleXTick?: number
+    getScaleXTicks?: <T>(options: GetScaleTicksOptions) => T[]
     getTruncatedXTick?: (formattedTick: string) => string
     getCategory?: (datum: Datum) => string | undefined
 }
@@ -33,6 +35,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         maxAngleXTick,
         stacked = false,
         getDatumHover,
+        getScaleXTicks,
         getTruncatedXTick,
         getDatumName,
         getDatumValue,
@@ -82,6 +85,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
                 pixelsPerTick={pixelsPerXTick}
                 maxRotateAngle={maxAngleXTick}
                 getTruncatedTick={getTruncatedXTick}
+                getScaleTicks={getScaleXTicks}
             />
 
             <SvgContent<ScaleBand<string>, any>>

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
@@ -9,14 +9,10 @@ import { Tooltip } from '../../core'
 import { GroupedBars } from './components/GroupedBars'
 import { StackedBars } from './components/StackedBars'
 import { BarTooltipContent } from './components/TooltipContent'
+import { ActiveSegment } from './types'
 import { Category } from './utils/get-grouped-categories'
 
 import styles from './BarChartContent.module.scss'
-
-interface ActiveSegment<Datum> {
-    category: Category<Datum>
-    datum: Datum
-}
 
 interface BarChartContentProps<Datum> extends SVGProps<SVGGElement> {
     stacked: boolean
@@ -81,6 +77,7 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
                 />
             ) : (
                 <GroupedBars
+                    activeSegment={activeSegment}
                     categories={categories}
                     xScale={xScale}
                     yScale={yScale}

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
@@ -5,9 +5,11 @@ import { scaleBand } from '@visx/scale'
 import { ScaleBand, ScaleLinear } from 'd3-scale'
 
 import { MaybeLink } from '../../../core'
+import { ActiveSegment } from '../types'
 import { Category } from '../utils/get-grouped-categories'
 
 interface GroupedBarsProps<Datum> extends ComponentProps<typeof Group> {
+    activeSegment: ActiveSegment<Datum> | null
     categories: Category<Datum>[]
     height: number
     xScale: ScaleBand<string>
@@ -24,6 +26,7 @@ interface GroupedBarsProps<Datum> extends ComponentProps<typeof Group> {
 export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement {
     const {
         width,
+        activeSegment,
         categories,
         height,
         xScale,
@@ -89,6 +92,9 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
                                     height={barHeight}
                                     fill={getDatumColor(datum)}
                                     rx={4}
+                                    // TODO: Move hardcoded to the public API and make it overridable
+                                    // see https://github.com/sourcegraph/sourcegraph/issues/40259
+                                    opacity={activeSegment ? (activeSegment.category.id === category.id ? 1 : 0.5) : 1}
                                 />
                             </MaybeLink>
                         )

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.module.scss
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.module.scss
@@ -1,0 +1,7 @@
+.one-line-tooltip {
+    display: flex;
+    justify-content: space-between;
+    gap: 2rem;
+    // Be default Text (which is p element) has bottom margin
+    margin: 0;
+}

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.module.scss
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.module.scss
@@ -2,6 +2,6 @@
     display: flex;
     justify-content: space-between;
     gap: 2rem;
-    // Be default Text (which is p element) has bottom margin
+    // The default Text (which is p element) has bottom margin
     margin: 0;
 }

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
@@ -1,9 +1,11 @@
 import { ReactElement } from 'react'
 
-import { H3 } from '../../../../Typography'
+import { H3, Text } from '../../../../Typography'
 import { DEFAULT_FALLBACK_COLOR } from '../../../constants'
 import { TooltipList, TooltipListItem } from '../../../core'
 import { Category } from '../utils/get-grouped-categories'
+
+import styles from './TooltipContent.module.scss'
 
 interface BarTooltipContentProps<Datum> {
     category: Category<Datum>
@@ -19,9 +21,23 @@ export function BarTooltipContent<Datum>(props: BarTooltipContentProps<Datum>): 
     const getName = getDatumHover ?? getDatumName
     const activeDatumHover = getName(activeBar)
 
+    // Handle a special case when we don't have any multiple datum per group
+    if (category.data.length === 1) {
+        const datum = category.data[0]
+        const name = getDatumName(datum)
+        const value = getDatumValue(datum)
+
+        return (
+            <Text className={styles.oneLineTooltip}>
+                <span>{name}</span>
+                <span>{value}</span>
+            </Text>
+        )
+    }
+
     return (
         <>
-            {category.data.length > 1} <H3>{category.id}</H3>
+            {category.data.length > 1 && <H3>{category.id}</H3>}
             <TooltipList>
                 {category.data.map(item => {
                     const hover = getName(item)

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
@@ -37,7 +37,7 @@ export function BarTooltipContent<Datum>(props: BarTooltipContentProps<Datum>): 
 
     return (
         <>
-            {category.data.length > 1 && <H3>{category.id}</H3>}
+            <H3>{category.id}</H3>
             <TooltipList>
                 {category.data.map(item => {
                     const hover = getName(item)

--- a/client/wildcard/src/components/Charts/components/bar-chart/types.ts
+++ b/client/wildcard/src/components/Charts/components/bar-chart/types.ts
@@ -1,0 +1,6 @@
+import { Category } from './utils/get-grouped-categories'
+
+export interface ActiveSegment<Datum> {
+    category: Category<Datum>
+    datum: Datum
+}

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
@@ -114,7 +114,9 @@ export const SvgRoot: FC<PropsWithChildren<SvgRootProps>> = props => {
     )
 }
 
-interface SvgAxisLeftProps {}
+interface SvgAxisLeftProps {
+    pixelsPerTick?: number
+}
 
 export const SvgAxisLeft: FC<SvgAxisLeftProps> = props => {
     const { content, yScale, setPadding } = useContext(SVGRootContext)
@@ -154,7 +156,7 @@ interface SvgAxisBottomProps<Tick> {
 export function SvgAxisBottom<Tick = string>(props: SvgAxisBottomProps<Tick>): ReactElement {
     const {
         pixelsPerTick = 0,
-        maxRotateAngle = 90,
+        maxRotateAngle = 45,
         tickFormat = defaultToString,
         getTruncatedTick = defaultTruncatedTick,
     } = props

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
@@ -26,7 +26,7 @@ import { createRectangle, EMPTY_RECTANGLE, Rectangle } from '../../../Popover'
 
 import { AxisBottom, AxisLeft } from './axis/Axis'
 import { getMaxTickWidth, Tick, TickProps } from './axis/Tick'
-import { getXScaleTicks } from './axis/tick-formatters'
+import { GetScaleTicksOptions, getXScaleTicks } from './axis/tick-formatters'
 
 const DEFAULT_PADDING = { top: 16, right: 36, bottom: 0, left: 0 }
 
@@ -151,6 +151,7 @@ interface SvgAxisBottomProps<Tick> {
     pixelsPerTick?: number
     maxRotateAngle?: number
     getTruncatedTick?: (formattedTick: string) => string
+    getScaleTicks?: <T>(options: GetScaleTicksOptions) => T[]
 }
 
 export function SvgAxisBottom<Tick = string>(props: SvgAxisBottomProps<Tick>): ReactElement {
@@ -159,6 +160,7 @@ export function SvgAxisBottom<Tick = string>(props: SvgAxisBottomProps<Tick>): R
         maxRotateAngle = 45,
         tickFormat = defaultToString,
         getTruncatedTick = defaultTruncatedTick,
+        getScaleTicks = getXScaleTicks,
     } = props
     const { content, xScale, setPadding } = useContext(SVGRootContext)
 
@@ -169,7 +171,7 @@ export function SvgAxisBottom<Tick = string>(props: SvgAxisBottomProps<Tick>): R
     })
 
     const [, upperRangeBound] = xScale.range() as [number, number]
-    const ticks = getXScaleTicks<Tick>({ scale: xScale, space: content.width, pixelsPerTick })
+    const ticks = getScaleTicks<Tick>({ scale: xScale, space: content.width, pixelsPerTick })
 
     const maxWidth = useMemo(() => {
         const axisGroup = axisGroupRef.current

--- a/client/wildcard/src/components/Charts/core/components/axis/Axis.tsx
+++ b/client/wildcard/src/components/Charts/core/components/axis/Axis.tsx
@@ -29,6 +29,7 @@ type OwnSharedAxisProps = Omit<SharedAxisProps<AxisScale>, 'tickLabelProps'>
 export interface AxisLeftProps extends OwnSharedAxisProps {
     width: number
     height: number
+    pixelsPerTick?: number
 }
 
 export const AxisLeft = memo(
@@ -39,9 +40,10 @@ export const AxisLeft = memo(
             top,
             width,
             height,
+            pixelsPerTick = 40,
             tickComponent = Tick,
             tickFormat = formatYTick,
-            tickValues = getYScaleTicks({ scale, space: height }),
+            tickValues = getYScaleTicks({ scale, space: height, pixelsPerTick }),
             ...attributes
         } = props
 

--- a/client/wildcard/src/components/Charts/core/components/axis/tick-formatters.ts
+++ b/client/wildcard/src/components/Charts/core/components/axis/tick-formatters.ts
@@ -31,13 +31,13 @@ export const formatXLabel = timeFormat('%d %B %A')
 
 const MINIMUM_NUMBER_OF_TICKS = 2
 
-interface GetScaleTicksInput {
+export interface GetScaleTicksOptions {
     scale: AnyD3Scale
     space: number
     pixelsPerTick?: number
 }
 
-export function getXScaleTicks<T>(input: GetScaleTicksInput): T[] {
+export function getXScaleTicks<T>(input: GetScaleTicksOptions): T[] {
     const { scale, space, pixelsPerTick = 80 } = input
 
     // Calculate desirable number of ticks
@@ -63,7 +63,7 @@ export function getXScaleTicks<T>(input: GetScaleTicksInput): T[] {
  * Ticks are constrained to integers.
  */
 
-export function getYScaleTicks(input: GetScaleTicksInput): number[] {
+export function getYScaleTicks(input: GetScaleTicksOptions): number[] {
     const { scale, space, pixelsPerTick = 40 } = input
 
     // Generate max density ticks (d3 scale generation)

--- a/client/wildcard/src/components/Charts/index.ts
+++ b/client/wildcard/src/components/Charts/index.ts
@@ -4,6 +4,7 @@ export { ParentSize } from '@visx/responsive'
 export * from './components/bar-chart'
 export * from './components/line-chart'
 export * from './components/pie-chart'
+export * from './components/bar-chart'
 
 // Low-level chart related (core) components
 export * from './core/components/scroll-box'

--- a/client/wildcard/src/components/Charts/index.ts
+++ b/client/wildcard/src/components/Charts/index.ts
@@ -1,7 +1,6 @@
 export { ParentSize } from '@visx/responsive'
 
 // Low-level chart components
-export * from './components/bar-chart'
 export * from './components/line-chart'
 export * from './components/pie-chart'
 export * from './components/bar-chart'


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39954
Closes https://github.com/sourcegraph/sourcegraph/issues/40088

[RFC](https://docs.google.com/document/d/1yLV7MGOEXYT3yPvBxHHm8y2-p737KIrju_QPqlhBYz4/edit#)
[Figma designs](https://www.figma.com/file/cKSeCtmBh9aiPsAVoKsLgM/Aggregation-insights%3A-display-%22grouped%22-insights-for-existing-searches-%2339126?node-id=275%3A1628)

## Background 
New aggregation UI on the search result page

| Standard UI  | Simple UI mode |
| ------------- | ------------- |
| <img width="1128" alt="Screenshot 2022-08-12 at 14 33 21" src="https://user-images.githubusercontent.com/18492575/184363454-5c370c3c-fe22-4956-8145-49710f48fa2d.png"> | <img width="1128" alt="Screenshot 2022-08-12 at 14 38 24" src="https://user-images.githubusercontent.com/18492575/184363565-03e01331-6561-4e79-b6be-05e392d5e740.png"> |

This PR adds mock (no data) UI for aggregation panel UI on the search result page. 

## For reviewers 
In order to make it change as simple as possible and put all parts of this UI in just one single file. Further steps around codebase quality will be addressed in follow issue about refactoring search-ui components API here https://github.com/sourcegraph/sourcegraph/issues/40285

## Follow-ups
- Refactor search UI components API in order to decouple UI and business logic in reusable search UI components https://github.com/sourcegraph/sourcegraph/issues/40285
- The sidebar panel is stored in the `search-ui` package. Currently, chart UI components are stored in the `web` package. Because of this, PR introduces a cyclic link since we import chart UI into search from `web` and the `web` package imports `search-ui` for the search result page. Webpack can handle this, and this is how it works at the moment, but we should move chart UI into Wildcard (or another separate package) to resolve this problem in our codebase https://github.com/sourcegraph/sourcegraph/issues/40136. _**Update: this issue has been resolved**_

## Test plan
- Go to the search result page 
- See that nothing is changed and the side panel layout looks correct for mobile and desktop 
- Turn on the global feature flag `search-aggregation-filters.`
- See that you can see mock UI for the aggregation panel, panel should look properly for mobile and desktop 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-aggregation-panel-mock-ui.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tpflzxyoqe.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

