### PR TITLE
search: Do not show search history if input doesn't have focus

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -188,7 +188,9 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
                         } else if (update.docChanged) {
                             timer = window.setTimeout(() => {
                                 timer = null
-                                startCompletion(update.view)
+                                if (update.view.hasFocus) {
+                                    startCompletion(update.view)
+                                }
                             }, TIMEOUT)
                         }
                     } else {


### PR DESCRIPTION
Fixes #40075 

## Test plan

Enter query and delete everything. Click outside input. Search history does not appear.

## App preview:

- [Web](https://sg-web-fkling-40075-history.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bvvaonugpd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
