### PR TITLE
batches: Isolate ssh credentials oobmigration

### DIFF
--- a/enterprise/internal/oobmigration/migrations/batches/migrations.go
+++ b/enterprise/internal/oobmigration/migrations/batches/migrations.go
@@ -40,7 +40,7 @@ func RegisterMigrations(db database.DB, outOfBandMigrationRunner *oobmigration.R
 // by batch changes with the migration runner.
 func Register(cstore *store.Store, outOfBandMigrationRunner *oobmigration.Runner) error {
 	migrations := map[int]oobmigration.Migrator{
-		BatchChangesSSHMigrationID: &sshMigrator{store: cstore},
+		BatchChangesSSHMigrationID: NewSSHMigratorWithDB(cstore),
 	}
 
 	for id, migrator := range migrations {

--- a/enterprise/internal/oobmigration/migrations/batches/migrations.go
+++ b/enterprise/internal/oobmigration/migrations/batches/migrations.go
@@ -8,15 +8,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-const (
-	// BatchChangesSSHMigrationID is the ID of row holding the ssh migration. It
-	// is defined in `1528395788_campaigns_ssh_key_migration.up`.
-	BatchChangesSSHMigrationID = 2
-)
-
 func RegisterMigrations(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) error {
+	sshMigrator := NewSSHMigratorWithDB(db, keyring.Default().BatchChangesCredentialKey)
 	migrations := map[int]oobmigration.Migrator{
-		BatchChangesSSHMigrationID: NewSSHMigratorWithDB(db, keyring.Default().BatchChangesCredentialKey),
+		sshMigrator.ID(): sshMigrator,
 	}
 
 	for id, migrator := range migrations {

--- a/enterprise/internal/oobmigration/migrations/batches/migrations.go
+++ b/enterprise/internal/oobmigration/migrations/batches/migrations.go
@@ -40,7 +40,7 @@ func RegisterMigrations(db database.DB, outOfBandMigrationRunner *oobmigration.R
 // by batch changes with the migration runner.
 func Register(cstore *store.Store, outOfBandMigrationRunner *oobmigration.Runner) error {
 	migrations := map[int]oobmigration.Migrator{
-		BatchChangesSSHMigrationID: NewSSHMigratorWithDB(cstore),
+		BatchChangesSSHMigrationID: NewSSHMigratorWithDB(cstore, keyring.Default().BatchChangesCredentialKey),
 	}
 
 	for id, migrator := range migrations {

--- a/enterprise/internal/oobmigration/migrations/batches/migrations.go
+++ b/enterprise/internal/oobmigration/migrations/batches/migrations.go
@@ -3,17 +3,9 @@ package batches
 import (
 	"time"
 
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/log"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 const (
@@ -23,24 +15,8 @@ const (
 )
 
 func RegisterMigrations(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) error {
-	observationContext := &observation.Context{
-		Logger:     log.Scoped("migrations", ""),
-		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
-		Registerer: prometheus.DefaultRegisterer,
-	}
-
-	// Initialize store.
-	cstore := store.New(db, observationContext, keyring.Default().BatchChangesCredentialKey)
-
-	// Register Batch Changes OOB migrations.
-	return Register(cstore, outOfBandMigrationRunner)
-}
-
-// Register registers all currently implemented out of band migrations
-// by batch changes with the migration runner.
-func Register(cstore *store.Store, outOfBandMigrationRunner *oobmigration.Runner) error {
 	migrations := map[int]oobmigration.Migrator{
-		BatchChangesSSHMigrationID: NewSSHMigratorWithDB(cstore, keyring.Default().BatchChangesCredentialKey),
+		BatchChangesSSHMigrationID: NewSSHMigratorWithDB(db, keyring.Default().BatchChangesCredentialKey),
 	}
 
 	for id, migrator := range migrations {

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -139,14 +139,14 @@ func (m *SSHMigrator) Down(ctx context.Context) (err error) {
 			return err
 		}
 
+		var newCred auth.Authenticator
 		switch a := a.(type) {
 		case *auth.OAuthBearerTokenWithSSH:
-			newCred := &a.OAuthBearerToken
-			if err := cred.SetAuthenticator(ctx, newCred); err != nil {
-				return err
-			}
+			newCred = &a.OAuthBearerToken
 		case *auth.BasicAuthWithSSH:
-			newCred := &a.BasicAuth
+			newCred = &a.BasicAuth
+		}
+		if newCred != nil {
 			if err := cred.SetAuthenticator(ctx, newCred); err != nil {
 				return err
 			}

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -66,7 +66,7 @@ func (m *SSHMigrator) Up(ctx context.Context) (err error) {
 		if err := json.Unmarshal([]byte(credential), &partial); err != nil {
 			return "", false, err
 		}
-		var a auth.Authenticator
+		var a any
 		switch partial.Type {
 		case "BasicAuth":
 			a = &auth.BasicAuth{}
@@ -141,7 +141,7 @@ func (m *SSHMigrator) Down(ctx context.Context) (err error) {
 		if err := json.Unmarshal([]byte(credential), &partial); err != nil {
 			return "", false, err
 		}
-		var a auth.Authenticator
+		var a any
 		switch partial.Type {
 		case "BasicAuthWithSSH":
 			a = &auth.BasicAuthWithSSH{}

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -113,8 +113,8 @@ func (m *SSHMigrator) run(ctx context.Context, sshMigrationsApplied bool, f func
 	defer func() { err = tx.Done(err) }()
 
 	type credential struct {
-		ID          int
-		Credentials string
+		ID         int
+		Credential string
 	}
 	credentials, err := func() (credentials []credential, err error) {
 		rows, err := tx.Query(ctx, sqlf.Sprintf(
@@ -143,7 +143,7 @@ func (m *SSHMigrator) run(ctx context.Context, sshMigrationsApplied bool, f func
 				rawCredential = decrypted
 			}
 
-			credentials = append(credentials, credential{ID: id, Credentials: rawCredential})
+			credentials = append(credentials, credential{ID: id, Credential: rawCredential})
 		}
 
 		return credentials, nil
@@ -152,8 +152,8 @@ func (m *SSHMigrator) run(ctx context.Context, sshMigrationsApplied bool, f func
 		return err
 	}
 
-	for _, cred := range credentials {
-		secret, id, ok, err := m.transform(ctx, cred.Credentials, f)
+	for _, credential := range credentials {
+		secret, id, ok, err := m.transform(ctx, credential.Credential, f)
 		if err != nil {
 			return err
 		}
@@ -161,7 +161,7 @@ func (m *SSHMigrator) run(ctx context.Context, sshMigrationsApplied bool, f func
 			continue
 		}
 
-		if err := tx.Exec(ctx, sqlf.Sprintf(sshMigratorUpdateQuery, secret, id, !sshMigrationsApplied, cred.ID)); err != nil {
+		if err := tx.Exec(ctx, sqlf.Sprintf(sshMigratorUpdateQuery, secret, id, !sshMigrationsApplied, credential.ID)); err != nil {
 			return err
 		}
 	}

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -62,46 +62,34 @@ FROM
 // Up generates a keypair for authenticators missing SSH credentials.
 func (m *SSHMigrator) Up(ctx context.Context) (err error) {
 	transformer := func(credential string) (string, bool, error) {
-		UnmarshalAuthenticator := func(raw string) (auth.Authenticator, error) {
-			// We do two unmarshals: the first just to get the type, and then the second
-			// to actually unmarshal the authenticator itself.
-			var partial struct {
-				Type database.AuthenticatorType
-				Auth json.RawMessage
-			}
-			if err := json.Unmarshal([]byte(raw), &partial); err != nil {
-				return nil, err
-			}
-
-			var a any
-			switch partial.Type {
-			case database.AuthenticatorTypeOAuthClient:
-				a = &auth.OAuthClient{}
-			case database.AuthenticatorTypeBasicAuth:
-				a = &auth.BasicAuth{}
-			case database.AuthenticatorTypeBasicAuthWithSSH:
-				a = &auth.BasicAuthWithSSH{}
-			case database.AuthenticatorTypeOAuthBearerToken:
-				a = &auth.OAuthBearerToken{}
-			case database.AuthenticatorTypeOAuthBearerTokenWithSSH:
-				a = &auth.OAuthBearerTokenWithSSH{}
-			case database.AuthenticatorTypeBitbucketServerSudoableOAuthClient:
-				a = &bitbucketserver.SudoableOAuthClient{}
-			case database.AuthenticatorTypeGitLabSudoableToken:
-				a = &gitlab.SudoableToken{}
-			default:
-				return nil, errors.Errorf("unknown credential type: %s", partial.Type)
-			}
-
-			if err := json.Unmarshal(partial.Auth, &a); err != nil {
-				return nil, err
-			}
-
-			return a.(auth.Authenticator), nil
+		var partial struct {
+			Type database.AuthenticatorType
+			Auth json.RawMessage
 		}
-		a, err := UnmarshalAuthenticator(credential)
-		if err != nil {
-			return "", false, errors.Wrap(err, "unmarshalling authenticator")
+		if err := json.Unmarshal([]byte(credential), &partial); err != nil {
+			return "", false, err
+		}
+		var a auth.Authenticator
+		switch partial.Type {
+		case database.AuthenticatorTypeOAuthClient:
+			a = &auth.OAuthClient{}
+		case database.AuthenticatorTypeBasicAuth:
+			a = &auth.BasicAuth{}
+		case database.AuthenticatorTypeBasicAuthWithSSH:
+			a = &auth.BasicAuthWithSSH{}
+		case database.AuthenticatorTypeOAuthBearerToken:
+			a = &auth.OAuthBearerToken{}
+		case database.AuthenticatorTypeOAuthBearerTokenWithSSH:
+			a = &auth.OAuthBearerTokenWithSSH{}
+		case database.AuthenticatorTypeBitbucketServerSudoableOAuthClient:
+			a = &bitbucketserver.SudoableOAuthClient{}
+		case database.AuthenticatorTypeGitLabSudoableToken:
+			a = &gitlab.SudoableToken{}
+		default:
+			return "", false, errors.Errorf("unknown credential type: %s", partial.Type)
+		}
+		if err := json.Unmarshal(partial.Auth, &a); err != nil {
+			return "", false, err
 		}
 
 		keypair, err := encryption.GenerateRSAKey()
@@ -159,46 +147,34 @@ func (m *SSHMigrator) Up(ctx context.Context) (err error) {
 // Down converts all credentials with an SSH key back to a historically supported version.
 func (m *SSHMigrator) Down(ctx context.Context) (err error) {
 	transformer := func(credential string) (string, bool, error) {
-		UnmarshalAuthenticator := func(raw string) (auth.Authenticator, error) {
-			// We do two unmarshals: the first just to get the type, and then the second
-			// to actually unmarshal the authenticator itself.
-			var partial struct {
-				Type database.AuthenticatorType
-				Auth json.RawMessage
-			}
-			if err := json.Unmarshal([]byte(raw), &partial); err != nil {
-				return nil, err
-			}
-
-			var a any
-			switch partial.Type {
-			case database.AuthenticatorTypeOAuthClient:
-				a = &auth.OAuthClient{}
-			case database.AuthenticatorTypeBasicAuth:
-				a = &auth.BasicAuth{}
-			case database.AuthenticatorTypeBasicAuthWithSSH:
-				a = &auth.BasicAuthWithSSH{}
-			case database.AuthenticatorTypeOAuthBearerToken:
-				a = &auth.OAuthBearerToken{}
-			case database.AuthenticatorTypeOAuthBearerTokenWithSSH:
-				a = &auth.OAuthBearerTokenWithSSH{}
-			case database.AuthenticatorTypeBitbucketServerSudoableOAuthClient:
-				a = &bitbucketserver.SudoableOAuthClient{}
-			case database.AuthenticatorTypeGitLabSudoableToken:
-				a = &gitlab.SudoableToken{}
-			default:
-				return nil, errors.Errorf("unknown credential type: %s", partial.Type)
-			}
-
-			if err := json.Unmarshal(partial.Auth, &a); err != nil {
-				return nil, err
-			}
-
-			return a.(auth.Authenticator), nil
+		var partial struct {
+			Type database.AuthenticatorType
+			Auth json.RawMessage
 		}
-		a, err := UnmarshalAuthenticator(credential)
-		if err != nil {
-			return "", false, errors.Wrap(err, "unmarshalling authenticator")
+		if err := json.Unmarshal([]byte(credential), &partial); err != nil {
+			return "", false, err
+		}
+		var a auth.Authenticator
+		switch partial.Type {
+		case database.AuthenticatorTypeOAuthClient:
+			a = &auth.OAuthClient{}
+		case database.AuthenticatorTypeBasicAuth:
+			a = &auth.BasicAuth{}
+		case database.AuthenticatorTypeBasicAuthWithSSH:
+			a = &auth.BasicAuthWithSSH{}
+		case database.AuthenticatorTypeOAuthBearerToken:
+			a = &auth.OAuthBearerToken{}
+		case database.AuthenticatorTypeOAuthBearerTokenWithSSH:
+			a = &auth.OAuthBearerTokenWithSSH{}
+		case database.AuthenticatorTypeBitbucketServerSudoableOAuthClient:
+			a = &bitbucketserver.SudoableOAuthClient{}
+		case database.AuthenticatorTypeGitLabSudoableToken:
+			a = &gitlab.SudoableToken{}
+		default:
+			return "", false, errors.Errorf("unknown credential type: %s", partial.Type)
+		}
+		if err := json.Unmarshal(partial.Auth, &a); err != nil {
+			return "", false, err
 		}
 
 		switch a := a.(type) {

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -82,28 +82,31 @@ func (m *SSHMigrator) Up(ctx context.Context) (err error) {
 			return err
 		}
 
+		var newCred auth.Authenticator
 		switch a := a.(type) {
 		case *auth.OAuthBearerToken:
-			newCred := &auth.OAuthBearerTokenWithSSH{OAuthBearerToken: *a}
+			cred := &auth.OAuthBearerTokenWithSSH{OAuthBearerToken: *a}
 			keypair, err := encryption.GenerateRSAKey()
 			if err != nil {
 				return err
 			}
-			newCred.PrivateKey = keypair.PrivateKey
-			newCred.PublicKey = keypair.PublicKey
-			newCred.Passphrase = keypair.Passphrase
-			if err := cred.SetAuthenticator(ctx, newCred); err != nil {
-				return err
-			}
+			cred.PrivateKey = keypair.PrivateKey
+			cred.PublicKey = keypair.PublicKey
+			cred.Passphrase = keypair.Passphrase
+			newCred = cred
+
 		case *auth.BasicAuth:
-			newCred := &auth.BasicAuthWithSSH{BasicAuth: *a}
+			cred := &auth.BasicAuthWithSSH{BasicAuth: *a}
 			keypair, err := encryption.GenerateRSAKey()
 			if err != nil {
 				return err
 			}
-			newCred.PrivateKey = keypair.PrivateKey
-			newCred.PublicKey = keypair.PublicKey
-			newCred.Passphrase = keypair.Passphrase
+			cred.PrivateKey = keypair.PrivateKey
+			cred.PublicKey = keypair.PublicKey
+			cred.Passphrase = keypair.Passphrase
+			newCred = cred
+		}
+		if newCred != nil {
 			if err := cred.SetAuthenticator(ctx, newCred); err != nil {
 				return err
 			}

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -82,29 +82,28 @@ func (m *SSHMigrator) Up(ctx context.Context) (err error) {
 			return err
 		}
 
+		keypair, err := encryption.GenerateRSAKey()
+		if err != nil {
+			return err
+		}
+
 		var newCred auth.Authenticator
 		switch a := a.(type) {
 		case *auth.OAuthBearerToken:
-			cred := &auth.OAuthBearerTokenWithSSH{OAuthBearerToken: *a}
-			keypair, err := encryption.GenerateRSAKey()
-			if err != nil {
-				return err
+			newCred = &auth.OAuthBearerTokenWithSSH{
+				OAuthBearerToken: *a,
+				PrivateKey:       keypair.PrivateKey,
+				PublicKey:        keypair.PublicKey,
+				Passphrase:       keypair.Passphrase,
 			}
-			cred.PrivateKey = keypair.PrivateKey
-			cred.PublicKey = keypair.PublicKey
-			cred.Passphrase = keypair.Passphrase
-			newCred = cred
 
 		case *auth.BasicAuth:
-			cred := &auth.BasicAuthWithSSH{BasicAuth: *a}
-			keypair, err := encryption.GenerateRSAKey()
-			if err != nil {
-				return err
+			newCred = &auth.BasicAuthWithSSH{
+				BasicAuth:  *a,
+				PrivateKey: keypair.PrivateKey,
+				PublicKey:  keypair.PublicKey,
+				Passphrase: keypair.Passphrase,
 			}
-			cred.PrivateKey = keypair.PrivateKey
-			cred.PublicKey = keypair.PublicKey
-			cred.Passphrase = keypair.Passphrase
-			newCred = cred
 		}
 		if newCred != nil {
 			if err := cred.SetAuthenticator(ctx, newCred); err != nil {

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
@@ -18,17 +17,17 @@ import (
 
 type SSHMigrator struct {
 	logger    log.Logger
-	store     *store.Store
+	store     *basestore.Store
 	BatchSize int
 	key       encryption.Key
 }
 
 var _ oobmigration.Migrator = &SSHMigrator{}
 
-func NewSSHMigratorWithDB(store *store.Store /* db database.DB */, key encryption.Key) *SSHMigrator {
+func NewSSHMigratorWithDB(db database.DB, key encryption.Key) *SSHMigrator {
 	return &SSHMigrator{
 		logger:    log.Scoped("SSHMigrator", ""),
-		store:     store, /* basestore.NewWithHandle(db.Handle()) */
+		store:     basestore.NewWithHandle(db.Handle()),
 		BatchSize: 5,
 		key:       key,
 	}

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -33,6 +33,10 @@ func NewSSHMigratorWithDB(db database.DB, key encryption.Key) *SSHMigrator {
 	}
 }
 
+func (m *SSHMigrator) ID() int {
+	return 2
+}
+
 // Progress returns the percentage (ranged [0, 1]) of external services without a marker
 // indicating that this migration has been applied to that row.
 func (m *SSHMigrator) Progress(ctx context.Context) (float64, error) {

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -110,7 +110,7 @@ func (m *SSHMigrator) Up(ctx context.Context) (err error) {
 			return errors.Wrap(err, "encrypting authenticator")
 		}
 
-		if err := tx.Exec(ctx, sqlf.Sprintf(sshMigratorUpUpdateQuery, secret, id, cred.ID)); err != nil {
+		if err := tx.Exec(ctx, sqlf.Sprintf(sshMigratorUpdateQuery, secret, id, true, cred.ID)); err != nil {
 			return err
 		}
 	}
@@ -118,14 +118,14 @@ func (m *SSHMigrator) Up(ctx context.Context) (err error) {
 	return nil
 }
 
-const sshMigratorUpUpdateQuery = `
+const sshMigratorUpdateQuery = `
 -- source: enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go:Up
 UPDATE user_credentials
 SET
 	credential = %s,
 	encryption_key_id = %s,
 	updated_at = NOW(),
-	ssh_migration_applied = true
+	ssh_migration_applied = %s
 WHERE id = %s
 `
 
@@ -166,21 +166,10 @@ func (m *SSHMigrator) Down(ctx context.Context) (err error) {
 			return errors.Wrap(err, "encrypting authenticator")
 		}
 
-		if err := tx.Exec(ctx, sqlf.Sprintf(sshMigratorDownUpdateQuery, secret, id, cred.ID)); err != nil {
+		if err := tx.Exec(ctx, sqlf.Sprintf(sshMigratorUpdateQuery, secret, id, false, cred.ID)); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-
-const sshMigratorDownUpdateQuery = `
--- source: enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go:Down
-UPDATE user_credentials
-SET
-	credential = %s,
-	encryption_key_id = %s,
-	updated_at = NOW(),
-	ssh_migration_applied = false
-WHERE id = %s
-`

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
-	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -26,12 +25,12 @@ type SSHMigrator struct {
 
 var _ oobmigration.Migrator = &SSHMigrator{}
 
-func NewSSHMigratorWithDB(store *store.Store /* db database.DB */) *SSHMigrator {
+func NewSSHMigratorWithDB(store *store.Store /* db database.DB */, key encryption.Key) *SSHMigrator {
 	return &SSHMigrator{
 		logger:    log.Scoped("SSHMigrator", ""),
 		store:     store, /* basestore.NewWithHandle(db.Handle()) */
 		BatchSize: 5,
-		key:       keyring.Default().BatchChangesCredentialKey, // TODO
+		key:       key,
 	}
 }
 

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -46,7 +46,7 @@ SELECT
 		CAST((c2.count - c1.count) AS float) / CAST(c2.count AS float)
 	END
 FROM
-	(SELECT COUNT(*) as count FROM user_credentials WHERE domain = %s AND ssh_migration_applied IS FALSE) c1,
+	(SELECT COUNT(*) as count FROM user_credentials WHERE domain = %s AND NOT ssh_migration_applied) c1,
 	(SELECT COUNT(*) as count FROM user_credentials WHERE domain = %s) c2
 `
 

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
@@ -27,7 +27,7 @@ func TestSSHMigrator(t *testing.T) {
 
 	cstore := store.New(db, &observation.TestContext, et.TestKey{})
 
-	migrator := &sshMigrator{cstore}
+	migrator := NewSSHMigratorWithDB(cstore)
 	progress, err := migrator.Progress(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
@@ -25,9 +25,10 @@ func TestSSHMigrator(t *testing.T) {
 
 	bt.MockRSAKeygen(t)
 
-	cstore := store.New(db, &observation.TestContext, et.TestKey{})
+	key := et.TestKey{}
+	cstore := store.New(db, &observation.TestContext, key)
 
-	migrator := NewSSHMigratorWithDB(cstore)
+	migrator := NewSSHMigratorWithDB(cstore, key)
 	progress, err := migrator.Progress(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
@@ -27,8 +27,7 @@ func TestSSHMigrator(t *testing.T) {
 
 	key := et.TestKey{}
 	cstore := store.New(db, &observation.TestContext, key)
-
-	migrator := NewSSHMigratorWithDB(cstore, key)
+	migrator := NewSSHMigratorWithDB(db, key)
 	progress, err := migrator.Progress(ctx)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR _isolates_ oobmigration [#2](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@aed4b515082b4374f7d14fceeee98790c08a1361/-/blob/enterprise/cmd/worker/internal/batches/migrations/ssh_migrator.go) so that it does not need any _behavioral_ imports that can change over time. This is in preparation for its deprecation, where it will run only as part of the migrator for historic upgrades. We want to *freeze* this migration as much as possible, because we want to treat it with consistent behavior over time to allow the migrator to make some assumptions (like the registered code for an oobmigration is valid at any point in its lifetime).

This PR makes progress towards #38052, but still needs to be fed configuration keys from the worker. A follow-up PR will take care of this.

## Test plan

Existing unit tests.