### PR TITLE
gitserver: Rename ShortLog to ContributorCount

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -37,14 +37,14 @@ type repositoryContributorConnectionResolver struct {
 
 	// cache result because it is used by multiple fields
 	once    sync.Once
-	results []*gitdomain.PersonCount
+	results []*gitdomain.ContributorCount
 	err     error
 }
 
-func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) ([]*gitdomain.PersonCount, error) {
+func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) ([]*gitdomain.ContributorCount, error) {
 	r.once.Do(func() {
 		client := gitserver.NewClient(r.db)
-		var opt gitserver.ShortLogOptions
+		var opt gitserver.ContributorOptions
 		if r.args.RevisionRange != nil {
 			opt.Range = *r.args.RevisionRange
 		}
@@ -54,7 +54,7 @@ func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) (
 		if r.args.AfterDate != nil {
 			opt.After = *r.args.AfterDate
 		}
-		r.results, r.err = client.ShortLog(ctx, r.repo.RepoName(), opt)
+		r.results, r.err = client.ContributorCount(ctx, r.repo.RepoName(), opt)
 	})
 	return r.results, r.err
 }

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -356,9 +356,8 @@ type Client interface {
 	// revspecs).
 	GetBehindAhead(ctx context.Context, repo api.RepoName, left, right string) (*gitdomain.BehindAhead, error)
 
-	// ShortLog
-	// TODO: Rename to something like PersonCount?
-	ShortLog(ctx context.Context, repo api.RepoName, opt ShortLogOptions) ([]*gitdomain.PersonCount, error)
+	// ContributorCount returns the number of commits grouped by contributor
+	ContributorCount(ctx context.Context, repo api.RepoName, opt ContributorOptions) ([]*gitdomain.ContributorCount, error)
 
 	// LogReverseEach runs git log in reverse order and calls the given callback for each entry.
 	LogReverseEach(ctx context.Context, repo string, commit string, n int, onLogEntry func(entry gitdomain.LogEntry) error) error

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -33,7 +33,7 @@ func TestParseShortLog(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string // in the format of `git shortlog -sne`
-		want    []*gitdomain.PersonCount
+		want    []*gitdomain.ContributorCount
 		wantErr error
 	}{
 		{
@@ -42,7 +42,7 @@ func TestParseShortLog(t *testing.T) {
   1125	Jane Doe <jane@sourcegraph.com>
    390	Bot Of Doom <bot@doombot.com>
 `,
-			want: []*gitdomain.PersonCount{
+			want: []*gitdomain.ContributorCount{
 				{
 					Name:  "Jane Doe",
 					Email: "jane@sourcegraph.com",
@@ -60,7 +60,7 @@ func TestParseShortLog(t *testing.T) {
 			input: `  1125	jane@sourcegraph.com <jane@sourcegraph.com>
    390	Bot Of Doom <bot@doombot.com>
 `,
-			want: []*gitdomain.PersonCount{
+			want: []*gitdomain.ContributorCount{
 				{
 					Name:  "jane@sourcegraph.com",
 					Email: "jane@sourcegraph.com",

--- a/internal/gitserver/gitdomain/common.go
+++ b/internal/gitserver/gitdomain/common.go
@@ -147,14 +147,14 @@ type RefDescription struct {
 	CreatedDate     *time.Time
 }
 
-// A PersonCount is a contributor to a repository.
-type PersonCount struct {
+// A ContributorCount is a contributor to a repository.
+type ContributorCount struct {
 	Name  string
 	Email string
 	Count int32
 }
 
-func (p *PersonCount) String() string {
+func (p *ContributorCount) String() string {
 	return fmt.Sprintf("%d %s <%s>", p.Count, p.Name, p.Email)
 }
 


### PR DESCRIPTION
ShortLog is an implementation detail. The intent of the method is to
return contributor counts for a repo.

# Test Plan

Only renames, all tests pass