### PR TITLE
fix nil pointer dereference during rate limiter sync 

### DIFF
--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -487,7 +487,7 @@ func GetLimitFromConfig(kind string, config any) (rate.Limit, error) {
 		}
 	case *schema.JVMPackagesConnection:
 		limit = rate.Limit(2)
-		if c != nil && c.Maven.RateLimit != nil {
+		if c != nil && c.Maven != nil && c.Maven.RateLimit != nil {
 			limit = limitOrInf(c.Maven.RateLimit.Enabled, c.Maven.RateLimit.RequestsPerHour)
 		}
 	case *schema.PagureConnection:

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -141,6 +141,12 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			kind:   KindBitbucketCloud,
 			want:   1.0,
 		},
+		{
+			name:   "Empty JVM config",
+			config: "",
+			kind:   KindJVMPackages,
+			want:   2.0,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rlc, err := ExtractRateLimit(tc.config, tc.kind)


### PR DESCRIPTION
for empty code host config of JVMPackagesConnection

Related Slack [discussion](https://sourcegraph.slack.com/archives/C02EDAQAJQZ/p1660061499625649)

## Test plan
New unit test added
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
