### PR TITLE
Remove repo dependency example

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
+++ b/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
@@ -116,7 +116,6 @@ const SearchSymbol: React.FunctionComponent<React.PropsWithChildren<Omit<SearchT
 }
 
 const repoExample = createQueryExampleFromString('{regexp-pattern}')
-const repoDependenciesExample = createQueryExampleFromString('deps({})')
 
 export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] => {
     function updateQueryWithRepoExample(): void {
@@ -133,19 +132,6 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
         })
     }
 
-    function updateQueryWithRepoDependenciesExample(): void {
-        const updatedQuery = updateQueryWithFilterAndExample(props.query, FilterType.repo, repoDependenciesExample, {
-            singular: true,
-            negate: false,
-            emptyValue: false,
-        })
-        props.onNavbarQueryChange({
-            query: updatedQuery.query,
-            selectionRange: updatedQuery.placeholderRange,
-            revealRange: updatedQuery.filterRange,
-        })
-    }
-
     const SearchTypeLinkOrButton = props.forceButton ? SearchTypeButton : SearchTypeLink
 
     /** Click handler for `SearchTypeLinkOrButton` (when rendered as button) */
@@ -158,9 +144,6 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
     return [
         <SearchTypeButton onClick={updateQueryWithRepoExample} key="repo" data-testid="search-type-suggest">
             Search repos by org or name
-        </SearchTypeButton>,
-        <SearchTypeButton onClick={updateQueryWithRepoDependenciesExample} key="repo-dependencies">
-            Search repo dependencies
         </SearchTypeButton>,
         <SearchSymbol {...props} key="symbol">
             Find a symbol


### PR DESCRIPTION
Partial fix for #40160

## Test plan

Manual testing: verify that "search repo dependencies" is no longer included in search types sidebar component. Also tested through Percy.

## App preview:

- [Web](https://sg-web-lg-remove-repo-dependency-example.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zmryyczsej.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

