### PR TITLE
codemirror file view: Use new /scip highlighting endpoint

### DIFF
--- a/client/web/src/lsif/html.ts
+++ b/client/web/src/lsif/html.ts
@@ -70,6 +70,10 @@ function highlightSlice(html: HtmlBuilder, kind: SyntaxKind | undefined, slice: 
 
 // Currently assumes that no ranges overlap in the occurrences.
 export function render(lsif_json: string, content: string): string {
+    if (!lsif_json.trim()) {
+        return ''
+    }
+
     const occurrences = (JSON.parse(lsif_json) as JsonDocument).occurrences?.map(occ => new Occurrence(occ))
     if (!occurrences) {
         return ''

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -13,7 +13,7 @@ import { ErrorLike, isErrorLike, asError } from '@sourcegraph/common'
 import { SearchContextProps } from '@sourcegraph/search'
 import { StreamingSearchResultsListProps } from '@sourcegraph/search-ui'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { HighlightResponseFormat, Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -158,7 +158,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                 return of(undefined)
             }
 
-            return fetchBlob({ repoName, commitID, filePath, formatOnly: true }).pipe(
+            return fetchBlob({ repoName, commitID, filePath, format: HighlightResponseFormat.HTML_PLAINTEXT }).pipe(
                 map(blob => {
                     if (blob === null) {
                         return blob
@@ -166,7 +166,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
 
                     const blobInfo: BlobPageInfo = {
                         content: blob.content,
-                        html: blob.highlight.html,
+                        html: blob.highlight.html ?? '',
                         repoName,
                         revision,
                         commitID,
@@ -202,6 +202,9 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                             commitID,
                             filePath,
                             disableTimeout,
+                            format: enableCodeMirror
+                                ? HighlightResponseFormat.JSON_SCIP
+                                : HighlightResponseFormat.HTML_HIGHLIGHT,
                         })
                     ),
                     map(blob => {
@@ -219,8 +222,8 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
 
                         const blobInfo: BlobPageInfo = {
                             content: blob.content,
-                            html: blob.highlight.html,
-                            lsif: blob.highlight.lsif,
+                            html: blob.highlight.html ?? '',
+                            lsif: blob.highlight.lsif ?? '',
                             repoName,
                             revision,
                             commitID,

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -6,18 +6,17 @@ import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { ParsedRepoURI, makeRepoURI } from '@sourcegraph/shared/src/util/url'
 
 import { requestGraphQL } from '../../backend/graphql'
-import { BlobFileFields, BlobResult, BlobVariables } from '../../graphql-operations'
+import { BlobFileFields, BlobResult, BlobVariables, HighlightResponseFormat } from '../../graphql-operations'
 
-function fetchBlobCacheKey(parsed: ParsedRepoURI & { disableTimeout?: boolean; formatOnly?: boolean }): string {
-    return `${makeRepoURI(parsed)}?disableTimeout=${parsed.disableTimeout}&formatOnly=${parsed.formatOnly}`
+function fetchBlobCacheKey(parsed: ParsedRepoURI & { disableTimeout?: boolean; format?: string }): string {
+    return `${makeRepoURI(parsed)}?disableTimeout=${parsed.disableTimeout}&=${parsed.format}`
 }
-
 interface FetchBlobArguments {
     repoName: string
     commitID: string
     filePath: string
     disableTimeout?: boolean
-    formatOnly?: boolean
+    format?: HighlightResponseFormat
 }
 
 export const fetchBlob = memoizeObservable(
@@ -26,16 +25,24 @@ export const fetchBlob = memoizeObservable(
         commitID,
         filePath,
         disableTimeout = false,
-        formatOnly = false,
-    }: FetchBlobArguments): Observable<BlobFileFields | null> =>
-        requestGraphQL<BlobResult, BlobVariables>(
+        format = HighlightResponseFormat.HTML_HIGHLIGHT,
+    }: FetchBlobArguments): Observable<BlobFileFields | null> => {
+        // We only want to include HTML data if explicitly requested. We always
+        // include LSIF because this is used for languages that are configured
+        // to be processed with tree sitter (and is used when explicitly
+        // requested via JSON_SCIP).
+        const html =
+            format === HighlightResponseFormat.HTML_PLAINTEXT || format === HighlightResponseFormat.HTML_HIGHLIGHT
+
+        return requestGraphQL<BlobResult, BlobVariables>(
             gql`
                 query Blob(
                     $repoName: String!
                     $commitID: String!
                     $filePath: String!
                     $disableTimeout: Boolean!
-                    $formatOnly: Boolean!
+                    $format: HighlightResponseFormat!
+                    $html: Boolean!
                 ) {
                     repository(name: $repoName) {
                         commit(rev: $commitID) {
@@ -49,14 +56,14 @@ export const fetchBlob = memoizeObservable(
                 fragment BlobFileFields on File2 {
                     content
                     richHTML
-                    highlight(disableTimeout: $disableTimeout, formatOnly: $formatOnly) {
+                    highlight(disableTimeout: $disableTimeout, format: $format) {
                         aborted
-                        html
+                        html @include(if: $html)
                         lsif
                     }
                 }
             `,
-            { repoName, commitID, filePath, disableTimeout, formatOnly }
+            { repoName, commitID, filePath, disableTimeout, format, html }
         ).pipe(
             map(dataOrThrowErrors),
             map(data => {
@@ -65,6 +72,7 @@ export const fetchBlob = memoizeObservable(
                 }
                 return data.repository.commit.file
             })
-        ),
+        )
+    },
     fetchBlobCacheKey
 )

--- a/client/web/src/repo/tree/HomeTab.tsx
+++ b/client/web/src/repo/tree/HomeTab.tsx
@@ -106,7 +106,7 @@ export const HomeTab: React.FunctionComponent<React.PropsWithChildren<Props>> = 
 
                         const blobInfo: BlobInfo & { richHTML: string; aborted: boolean } = {
                             content: blob.content,
-                            html: blob.highlight.html,
+                            html: blob.highlight.html ?? '',
                             repoName: repo.name,
                             revision,
                             commitID,

--- a/cmd/frontend/graphqlbackend/highlight.go
+++ b/cmd/frontend/graphqlbackend/highlight.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
+	"github.com/sourcegraph/sourcegraph/internal/gosyntect"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -35,7 +36,7 @@ type HighlightArgs struct {
 	DisableTimeout     bool
 	IsLightTheme       *bool
 	HighlightLongLines bool
-	FormatOnly         bool
+	Format             string
 }
 
 type highlightedFileResolver struct {
@@ -92,7 +93,7 @@ func highlightContent(ctx context.Context, args *HighlightArgs, content, path st
 		HighlightLongLines: args.HighlightLongLines,
 		SimulateTimeout:    simulateTimeout,
 		Metadata:           metadata,
-		FormatOnly:         args.FormatOnly,
+		Format:             gosyntect.GetResponseFormat(args.Format),
 	})
 
 	result.aborted = aborted

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4327,6 +4327,24 @@ type GitTree implements TreeEntry {
 }
 
 """
+The format and highlighting to use when requesting highlighting information for a file.
+"""
+enum HighlightResponseFormat {
+    """
+    HTML formatted file content without syntax highlighting.
+    """
+    HTML_PLAINTEXT
+    """
+    HTML formatted file content with syntax highlighting.
+    """
+    HTML_HIGHLIGHT
+    """
+    SCIP highlighting information as JSON.
+    """
+    JSON_SCIP
+}
+
+"""
 A file.
 In a future version of Sourcegraph, a repository's files may be distinct from a repository's blobs
 (for example, to support searching/browsing generated files that aren't committed and don't exist
@@ -4393,9 +4411,9 @@ interface File2 {
         """
         highlightLongLines: Boolean = false
         """
-        Return un-highlighted blob contents that are only formatted as a table for use in our blob views.
+        Specifies which format/highlighting technique to use.
         """
-        formatOnly: Boolean = false
+        format: HighlightResponseFormat = HTML_HIGHLIGHT
     ): HighlightedFile!
 }
 
@@ -4460,9 +4478,9 @@ type VirtualFile implements File2 {
         """
         highlightLongLines: Boolean = false
         """
-        Return un-highlighted blob contents that are only formatted as a table for use in our blob views.
+        Specifies which format/highlighting technique to use.
         """
-        formatOnly: Boolean = false
+        format: HighlightResponseFormat = HTML_HIGHLIGHT
     ): HighlightedFile!
 }
 
@@ -4565,9 +4583,9 @@ type GitBlob implements TreeEntry & File2 {
         """
         highlightLongLines: Boolean = false
         """
-        Return un-highlighted blob contents that are only formatted as a table for use in our blob views.
+        Specifies which format/highlighting technique to use.
         """
-        formatOnly: Boolean = false
+        format: HighlightResponseFormat = HTML_HIGHLIGHT
     ): HighlightedFile!
     """
     Submodule metadata if this tree points to a submodule

--- a/cmd/frontend/internal/highlight/language.go
+++ b/cmd/frontend/internal/highlight/language.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/gosyntect"
 )
 
 type EngineType int
@@ -19,6 +20,15 @@ const (
 	EngineTreeSitter
 	EngineSyntect
 )
+
+// Converts an engine type to the corresponding parameter value for the syntax
+// highlighting request. Defaults to "syntec".
+func getEngineParameter(engine EngineType) string {
+	if engine == EngineTreeSitter {
+		return gosyntect.SyntaxEngineTreesitter
+	}
+	return gosyntect.SyntaxEngineSyntect
+}
 
 type SyntaxEngineQuery struct {
 	Engine           EngineType

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -253,7 +253,7 @@ func (c *Client) Highlight(ctx context.Context, q *Query, format HighlightRespon
 		}
 		return nil, errors.Wrap(err, c.syntectServer)
 	}
-	var response = &Response{
+	response := &Response{
 		Data:      r.Data,
 		Plaintext: r.Plaintext,
 	}

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -14,6 +14,32 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+const (
+	SyntaxEngineSyntect    = "syntect"
+	SyntaxEngineTreesitter = "tree-sitter"
+)
+
+type HighlightResponseType string
+
+// The different response formats supported by the syntax highlighter.
+const (
+	FormatHTMLPlaintext HighlightResponseType = "HTML_PLAINTEXT"
+	FormatHTMLHighlight HighlightResponseType = "HTML_HIGHLIGHT"
+	FormatJSONSCIP      HighlightResponseType = "JSON_SCIP"
+)
+
+// Returns corresponding format type for the request format. Defaults to
+// FormatHTMLHighlight
+func GetResponseFormat(format string) HighlightResponseType {
+	if format == string(FormatHTMLPlaintext) {
+		return FormatHTMLPlaintext
+	}
+	if format == string(FormatJSONSCIP) {
+		return FormatJSONSCIP
+	}
+	return FormatHTMLHighlight
+}
+
 // Query represents a code highlighting query to the syntect_server.
 type Query struct {
 	// Filepath is the file path of the code. It can be the full file path, or
@@ -57,15 +83,15 @@ type Query struct {
 
 	// Tracer, if not nil, will be used to record opentracing spans associated with the query.
 	Tracer opentracing.Tracer
+
+	// Which highlighting engine to use
+	Engine string `json:"engine"`
 }
 
 // Response represents a response to a code highlighting query.
 type Response struct {
 	// Data is the actual highlighted HTML version of Query.Code.
 	Data string
-
-	// LSIF is the base64 encoded byte array of an LSIF Typed payload containing highlighting data.
-	LSIF string
 
 	// Plaintext indicates whether or not a syntax could not be found for the
 	// file and instead it was rendered as plain text.
@@ -94,7 +120,9 @@ var (
 
 type response struct {
 	// Successful response fields.
-	Data      string `json:"data"`
+	Data string `json:"data"`
+	// Used by the /scip endpoint
+	Scip      string `json:"scip"`
 	Plaintext bool   `json:"plaintext"`
 
 	// Error response fields.
@@ -141,11 +169,11 @@ func (c *Client) IsTreesitterSupported(filetype string) bool {
 // automatically do this via the query or something else. It feels a bit goofy
 // to be a separate param. But I need to clean up these other deprecated
 // options later, so it's OK for the first iteration.
-func (c *Client) Highlight(ctx context.Context, q *Query, useTreeSitter bool) (*Response, error) {
+func (c *Client) Highlight(ctx context.Context, q *Query, format HighlightResponseType) (*Response, error) {
 	// Normalize filetype
 	q.Filetype = normalizeFiletype(q.Filetype)
 
-	if useTreeSitter && !c.IsTreesitterSupported(q.Filetype) {
+	if q.Engine == SyntaxEngineTreesitter && !c.IsTreesitterSupported(q.Filetype) {
 		return nil, errors.New("Not a valid treesitter filetype")
 	}
 
@@ -156,7 +184,11 @@ func (c *Client) Highlight(ctx context.Context, q *Query, useTreeSitter bool) (*
 	}
 
 	var url string
-	if useTreeSitter {
+	if format == FormatJSONSCIP {
+		url = "/scip"
+	} else if q.Engine == SyntaxEngineTreesitter {
+		// "Legacy SCIP mode" for the HTML blob view and languages configured to
+		// be processed with tree sitter.
 		url = "/lsif"
 	} else {
 		url = "/"
@@ -221,10 +253,17 @@ func (c *Client) Highlight(ctx context.Context, q *Query, useTreeSitter bool) (*
 		}
 		return nil, errors.Wrap(err, c.syntectServer)
 	}
-	return &Response{
+	var response = &Response{
 		Data:      r.Data,
 		Plaintext: r.Plaintext,
-	}, nil
+	}
+
+	// If SCIP is set, prefer it over HTML
+	if r.Scip != "" {
+		response.Data = r.Scip
+	}
+
+	return response, nil
 }
 
 func (c *Client) url(path string) string {


### PR DESCRIPTION
Based on #39850 

This commit makes minimal and additive changes to the frontend and Go
backend to make the new /scip highlighting endpoint available through GraphQL.

There are currently three possible scenarios how a file might get
highlighted:

- HTML blob view, default: Highlighted HTML is generated by syntect
- HTML blob view, tree sitter: SCIP data is generated by tree sitter,
  HTML is generated on the client side
- CodeMirror blob view, default: SCIP is generated by either syntect or
  tree sitter

So far SCIP data was only generated for specific languages, determined
by the server. With CodeMirror, SCIP also needs to be generated when the
client requests it.
My preferred solution would have been to let the server determine this
based on the requested fields in the GraphQL request, but the library we
are using [does not support that yet](https://github.com/graph-gophers/graphql-go/issues/17).
Making the highlighting requests in the field resolvers (i.e. `HTML()`
and `LSIF()`) is also not possible without additional changes because
the `Aborted()` field depends on the result of the request.

This led me change the `formatOnly` field from a boolean to an enum,
with which the client can now request:

- `HTML_PLAINTEXT`
- `HTML_HIGHLIGHT`
- `JSON_SCIP`

It's not ideal because the server can still return SCIP data depending
on whether tree sitter is configured for the language (see second bullet
point at the beginning) but I think this is still better than
introducing a new field for highlighting.

So, if CodeMirror is *disabled*, everything works as before. When
CodeMirror is *enabled* it will explicitly request `JSON_SCIP` data and
only include the `lsif` field in the GraphQL request. The server will
route that request to the new `/scip` endpoint.


Demo: 

https://user-images.githubusercontent.com/179026/183742538-8bded4b5-fa82-439e-b934-6e33c7b3ca68.mp4




## Test plan

- With CodeMirror file view disabled, inspect search results and file views. Highlighting should work as before.
- With CodeMirror file view enabled, inspect search results and file views. Both should be highlighted.

GraphQL response inspection (can be done via devtools and filtering for `graphql?Blob` requests:

- With CodeMirror enabled
  - Testing treesitter
    - Load https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@bd796dc/-/blob/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/larger.cs
    - The blob GraphQL response should include a non-empty `lsif` field and no `html` field.
  - Testing syntec
    - Load https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@bd796dc/-/blob/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/small.c .
    - The blob GraphQL response should include a non-empty `lsif` field and no `html` field.
- With CodeMirror disabled
  - Testing treesitter
    - Load https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@bd796dc/-/blob/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/larger.cs
    - The blob GraphQL response should include a non-empty `lsif` field and a non-empty `html` field.
  - Testing syntext
    - Load https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@bd796dc/-/blob/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/small.c
    - The blob GraphQL response should include an empty `lsif` field and a non-empty `html` field.