### PR TITLE
batches: GitHub creation limit error message

### DIFF
--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -142,7 +142,13 @@ func (s GithubSource) createChangeset(ctx context.Context, c *Changeset, prInput
 	pr, err := s.client.CreatePullRequest(ctx, prInput)
 	if err != nil {
 		if err != github.ErrPullRequestAlreadyExists {
-			return exists, err
+			// There is a creation limit (undocumented) in GitHub. When reached, GitHub provides an unclear error
+			// message to users. See https://github.com/cli/cli/issues/4801.
+			if strings.Contains(err.Error(), "was submitted too quickly") {
+				return exists, errors.Wrap(err, "reached GitHub's internal creation limit: see https://docs.sourcegraph.com/admin/config/batch_changes#avoiding-hitting-rate-limits")
+			} else {
+				return exists, err
+			}
 		}
 		repo := c.TargetRepo.Metadata.(*github.Repository)
 		owner, name, err := github.SplitRepositoryNameWithOwner(repo.NameWithOwner)

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -146,9 +146,8 @@ func (s GithubSource) createChangeset(ctx context.Context, c *Changeset, prInput
 			// message to users. See https://github.com/cli/cli/issues/4801.
 			if strings.Contains(err.Error(), "was submitted too quickly") {
 				return exists, errors.Wrap(err, "reached GitHub's internal creation limit: see https://docs.sourcegraph.com/admin/config/batch_changes#avoiding-hitting-rate-limits")
-			} else {
-				return exists, err
 			}
+			return exists, err
 		}
 		repo := c.TargetRepo.Metadata.(*github.Repository)
 		owner, name, err := github.SplitRepositoryNameWithOwner(repo.NameWithOwner)

--- a/enterprise/internal/batches/sources/github_test.go
+++ b/enterprise/internal/batches/sources/github_test.go
@@ -1,14 +1,20 @@
 package sources
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/inconshreveable/log15"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -128,6 +134,80 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
 		})
 	}
+}
+
+func TestGithubSource_CreateChangeset_CreationLimit(t *testing.T) {
+	cli := new(mockDoer)
+	// Version lookup
+	versionMatchedBy := func(req *http.Request) bool {
+		return req.Method == http.MethodGet && req.URL.Path == "/"
+	}
+	cli.On("Do", mock.MatchedBy(versionMatchedBy)).
+		Once().
+		Return(
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Header: map[string][]string{
+					"X-GitHub-Enterprise-Version": {"99"},
+				},
+				Body: io.NopCloser(bytes.NewReader([]byte{})),
+			},
+			nil,
+		)
+	// Create Changeset mutation
+	createChangesetMatchedBy := func(req *http.Request) bool {
+		return req.Method == http.MethodPost && req.URL.Path == "/graphql"
+	}
+	cli.On("Do", mock.MatchedBy(createChangesetMatchedBy)).
+		Once().
+		Return(
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"errors": [{"message": "error in GraphQL response: was submitted too quickly"}]}`))),
+			},
+			nil,
+		)
+
+	apiURL, err := url.Parse("https://fake.api.github.com")
+	require.NoError(t, err)
+	client := github.NewV4Client("extsvc:github:0", apiURL, nil, cli)
+	source := &GithubSource{
+		client: client,
+	}
+
+	repo := &types.Repo{
+		Metadata: &github.Repository{
+			ID:            "bLAhBLAh",
+			NameWithOwner: "some-org/some-repo",
+		},
+	}
+	cs := &Changeset{
+		Title:      "This is a test PR",
+		Body:       "This is the description of the test PR",
+		HeadRef:    "refs/heads/always-open-pr",
+		BaseRef:    "refs/heads/master",
+		RemoteRepo: repo,
+		TargetRepo: repo,
+		Changeset:  &btypes.Changeset{},
+	}
+
+	exists, err := source.CreateChangeset(context.Background(), cs)
+	assert.False(t, exists)
+	assert.Error(t, err)
+	assert.Equal(
+		t,
+		"reached GitHub's internal creation limit: see https://docs.sourcegraph.com/admin/config/batch_changes#avoiding-hitting-rate-limits: error in GraphQL response: error in GraphQL response: was submitted too quickly",
+		err.Error(),
+	)
+}
+
+type mockDoer struct {
+	mock.Mock
+}
+
+func (d *mockDoer) Do(req *http.Request) (*http.Response, error) {
+	args := d.Called(req)
+	return args.Get(0).(*http.Response), args.Error(1)
 }
 
 func TestGithubSource_CloseChangeset(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -200,6 +200,8 @@ require (
 
 require github.com/hmarr/codeowners v0.4.0
 
+require github.com/stretchr/objx v0.4.0 // indirect
+
 require (
 	bitbucket.org/creachadair/shell v0.0.7 // indirect
 	cloud.google.com/go v0.101.0 // indirect


### PR DESCRIPTION
Closes #39847.

Simply check if the error message contains `was submitted too quickly`. If present. wrap the error and add link to rate limit docs.

Side note: I searched around to see if anyone deals with this issue, and I only found three examples.
* [(Java) Spring's `GithubAPI`](https://sourcegraph.com/github.com/spring-projects/spring-ldap/-/blob/buildSrc/src/main/java/org/springframework/security/convention/versions/GitHubApi.java?L136)
* [(Ruby) Random Library](https://sourcegraph.com/github.com/Pasters-Inc/github/-/blob/lib/github/rate_limited_creation.rb?L10)
* [(Go) A code review analyzer](https://sourcegraph.com/github.com/src-d/lookout/-/blob/provider/github/review.go?L20-25)

## Test plan

Add Go Unit Test