### PR TITLE
Added proper check for bare repo on other codehost

### DIFF
--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -193,7 +193,7 @@ func (s OtherSource) srcExpose(ctx context.Context) ([]*types.Repo, error) {
 
 		cloneURL := clonePrefix + strings.TrimPrefix(r.URI, "/")
 		// If the repo is not a bare repo, add a .git
-		if !strings.HasSuffix(cloneURL, ".git") {
+		if !r.Bare {
 			cloneURL += "/.git"
 		}
 		r.Sources = map[string]*types.SourceInfo{

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -74,6 +74,8 @@ type Repo struct {
 	Metadata any
 	// Blocked contains the reason this repository was blocked and the timestamp of when it happened.
 	Blocked *RepoBlock `json:",omitempty"`
+	// IsBare used only for 'other' code host type, signifies if a repo is a bare repo.
+	Bare bool
 }
 
 // SearchedRepo is a collection of metadata about repos that is used to decorate search results

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -74,7 +74,7 @@ type Repo struct {
 	Metadata any
 	// Blocked contains the reason this repository was blocked and the timestamp of when it happened.
 	Blocked *RepoBlock `json:",omitempty"`
-	// IsBare used only for 'other' code host type, signifies if a repo is a bare repo.
+	// Bare used only for the 'other' code host type, signifies if a repo is a bare repo.
 	Bare bool
 }
 


### PR DESCRIPTION
Linked to the changes in this [PR](https://github.com/sourcegraph/src-cli/pull/810)

Not all bare repositories will necessarily end with .git in the name (i.e. if you just init a new bare repo it won't have .git in it's name), therefore it is more concrete to just get the info on if a repo is bare or not, from the src-cli itself because it knows this information.

## Test plan
Tested locally.