### PR TITLE
insights: add a new insightsCount compute command to support insights work in aggregating search results

### DIFF
--- a/enterprise/internal/compute/command.go
+++ b/enterprise/internal/compute/command.go
@@ -18,8 +18,10 @@ var (
 	_ Command = (*MatchOnly)(nil)
 	_ Command = (*Replace)(nil)
 	_ Command = (*Output)(nil)
+	_ Command = (*InsightsCount)(nil)
 )
 
-func (MatchOnly) command() {}
-func (Replace) command()   {}
-func (Output) command()    {}
+func (MatchOnly) command()     {}
+func (Replace) command()       {}
+func (Output) command()        {}
+func (InsightsCount) command() {}

--- a/enterprise/internal/compute/insights_commands.go
+++ b/enterprise/internal/compute/insights_commands.go
@@ -20,7 +20,7 @@ func (c *InsightsCount) ToSearchPattern() string {
 }
 
 func (c *InsightsCount) String() string {
-	return fmt.Sprintf("insightsCount search pattern: %s", c.SearchPattern)
+	return fmt.Sprintf("insights.count search pattern: %s", c.SearchPattern)
 }
 
 func (c *InsightsCount) Run(ctx context.Context, db database.DB, r result.Match) (Result, error) {
@@ -30,7 +30,7 @@ func (c *InsightsCount) Run(ctx context.Context, db database.DB, r result.Match)
 func insightsCount(ctx context.Context, outputPattern string, r result.Match) (Result, error) {
 	countFunc, ok := insightCommandOutputRegistry[strings.ToUpper(outputPattern)]
 	if !ok {
-		return nil, errors.New("unknown ouput pattern for insightsCount command")
+		return nil, errors.New("unknown ouput pattern for insights.count command")
 	}
 
 	return countFunc(r)

--- a/enterprise/internal/compute/insights_commands.go
+++ b/enterprise/internal/compute/insights_commands.go
@@ -1,0 +1,78 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type InsightsCount struct {
+	SearchPattern string
+	OutputPattern string
+}
+
+func (c *InsightsCount) ToSearchPattern() string {
+	return c.SearchPattern
+}
+
+func (c *InsightsCount) String() string {
+	return fmt.Sprintf("insightsCount search pattern: %s", c.SearchPattern)
+}
+
+func (c *InsightsCount) Run(ctx context.Context, db database.DB, r result.Match) (Result, error) {
+	return insightsCount(ctx, c.OutputPattern, r)
+}
+
+func insightsCount(ctx context.Context, outputPattern string, r result.Match) (Result, error) {
+	countFunc, ok := insightCommandOutputRegistry[strings.ToUpper(outputPattern)]
+	if !ok {
+		return nil, errors.New("unknown ouput pattern for insightsCount command")
+	}
+
+	return countFunc(r)
+}
+
+type insightsCountFunc func(result.Match) (Result, error)
+
+// Map of functions that resolves a count for all available output options
+var insightCommandOutputRegistry map[string]insightsCountFunc = map[string]insightsCountFunc{
+	"$REPO":   countRepo,
+	"$LANG":   countLang,
+	"$PATH":   countPath,
+	"$AUTHOR": countAuthor,
+}
+
+func countRepo(r result.Match) (Result, error) {
+	if r.RepoName().Name != "" {
+		return &InsightsCountResult{Value: string(r.RepoName().Name), Count: r.ResultCount()}, nil
+	}
+	return nil, nil
+}
+
+func countLang(r result.Match) (Result, error) {
+	env := NewMetaEnvironment(r, "")
+	if env.Lang != "" {
+		return &InsightsCountResult{Value: env.Lang, Count: r.ResultCount()}, nil
+	}
+	return nil, nil
+}
+
+func countPath(r result.Match) (Result, error) {
+	env := NewMetaEnvironment(r, "")
+	if env.Path != "" {
+		return &InsightsCountResult{Value: env.Path, Count: r.ResultCount()}, nil
+	}
+	return nil, nil
+}
+
+func countAuthor(r result.Match) (Result, error) {
+	env := NewMetaEnvironment(r, "")
+	if env.Author != "" {
+		return &InsightsCountResult{Value: env.Author, Count: r.ResultCount()}, nil
+	}
+	return nil, nil
+}

--- a/enterprise/internal/compute/insights_commands_test.go
+++ b/enterprise/internal/compute/insights_commands_test.go
@@ -1,0 +1,64 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hexops/autogold"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+)
+
+func Test_insightsCount(t *testing.T) {
+
+	test := func(output string, match result.Match) string {
+
+		result, err := insightsCount(context.Background(), output, match)
+
+		var errMsg string
+		if err != nil {
+			errMsg = err.Error()
+		}
+
+		w := struct {
+			Result any
+			Error  string
+		}{
+			Result: result,
+			Error:  errMsg,
+		}
+		v, _ := json.Marshal(w)
+		return string(v)
+	}
+
+	testCases := []struct {
+		outputPattern string
+		match         result.Match
+		want          autogold.Value
+	}{
+		{
+			"$REPO", fileMatch("abc123", "def456"),
+			autogold.Want("$REPO multiple chunk matches", `{"Result":{"value":"my/awesome/repo","count":2},"Error":""}`),
+		},
+		{
+			"$REPO", fileMatch("abc123"),
+			autogold.Want("$REPO single chunk matches", `{"Result":{"value":"my/awesome/repo","count":1},"Error":""}`),
+		},
+		{
+			"$NOT_AN_OUTPUT", fileMatch("abc123"),
+			autogold.Want("errors on bad output", `{"Result":null,"Error":"unknown ouput pattern for insights command"}`),
+		},
+		{
+			"$AUTHOR", fileMatch("abc123"),
+			autogold.Want("null if not available for match type", `{"Result":null,"Error":""}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.want.Name(), func(t *testing.T) {
+			tc.want.Equal(t, test(tc.outputPattern, tc.match))
+		})
+	}
+
+}

--- a/enterprise/internal/compute/insights_commands_test.go
+++ b/enterprise/internal/compute/insights_commands_test.go
@@ -47,7 +47,7 @@ func Test_insightsCount(t *testing.T) {
 		},
 		{
 			"$NOT_AN_OUTPUT", fileMatch("abc123"),
-			autogold.Want("errors on bad output", `{"Result":null,"Error":"unknown ouput pattern for insights command"}`),
+			autogold.Want("errors on bad output", `{"Result":null,"Error":"unknown ouput pattern for insights.count command"}`),
 		},
 		{
 			"$AUTHOR", fileMatch("abc123"),

--- a/enterprise/internal/compute/insights_results.go
+++ b/enterprise/internal/compute/insights_results.go
@@ -1,0 +1,6 @@
+package compute
+
+type InsightsCountResult struct {
+	Value string `json:"value"`
+	Count int    `json:"count"`
+}

--- a/enterprise/internal/compute/query.go
+++ b/enterprise/internal/compute/query.go
@@ -2,7 +2,6 @@ package compute
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/grafana/regexp"
 
@@ -105,7 +104,7 @@ var ComputePredicateRegistry = query.PredicateRegistry{
 		"output.regexp":      func() query.Predicate { return query.EmptyPredicate{} },
 		"output.structural":  func() query.Predicate { return query.EmptyPredicate{} },
 		"output.extra":       func() query.Predicate { return query.EmptyPredicate{} },
-		"insights":           func() query.Predicate { return query.EmptyPredicate{} },
+		"insights.count":     func() query.Predicate { return query.EmptyPredicate{} },
 	},
 }
 
@@ -256,7 +255,7 @@ func parseInsightsCount(q *query.Basic) (Command, bool, error) {
 		return nil, false, err
 	}
 
-	if strings.EqualFold(name, "insightsCount") {
+	if name != "insights.count" {
 		// unrecognized name
 		return nil, false, nil
 	}

--- a/enterprise/internal/compute/result.go
+++ b/enterprise/internal/compute/result.go
@@ -8,8 +8,10 @@ var (
 	_ Result = (*MatchContext)(nil)
 	_ Result = (*Text)(nil)
 	_ Result = (*TextExtra)(nil)
+	_ Result = (*InsightsCountResult)(nil)
 )
 
-func (*MatchContext) result() {}
-func (*Text) result()         {}
-func (*TextExtra) result()    {}
+func (*MatchContext) result()        {}
+func (*Text) result()                {}
+func (*TextExtra) result()           {}
+func (*InsightsCountResult) result() {}


### PR DESCRIPTION
This adds a new compute command for use by Code Insights to support on going work to provide aggregates of search results.  

This initial pr adds the command and the ability to return counts that can be summed by a calling client for Repo, Path, Author, and Language.  Additional work will extend this command's return type to optionally include a repo id so it can be used for insights that are persisted as well as add the ability to count capture group matches like the `MatchOnly` command currently does.

typical usage: 
```
repo:^github.com/org/myrepo$ lang:Go content:insights.count(my search -> $REPO) count:all patterntype:standard
```

I choose to add a new command because I wanted to constrain the behaviors of the command to the minimum needed to support the code insights functionality under development.  

Known issues:

- Currently search queries passed to compute are initially parsed as `patterntype:regexp`, this can lead to parsing errors if the search pattern contains an invalid regex.  For example `i++`.  I think this is something that can be resolved in followup work.
- Currently search queries passed to compute without a patterntype run as a regexp patterntype and do not follow the same default logic that search does which would run as `patterntype:standard`

There is a very similar issue raised in https://github.com/sourcegraph/sourcegraph/issues/40125
 
## Test plan
Unit tests pass

GET - `q= content:insights.count(todo -> $REPO) patterntype:literal count:10`

```
event: results
data: [{"value":"github.com/sourcegraph/sourcegraph","count":10}]

event: progress
data: {"done":false,"matchCount":0,"durationMs":33,"skipped":[{"reason":"shard-match-limit","title":"result limit hit","message":"Not all results have been returned due to hitting a match limit. Sourcegraph has limits for the number of results returned from a line, document and repository.","severity":"info","suggested":{"title":"increase limit","queryExpression":"count:1000"}}]}

event: progress
data: {"done":true,"matchCount":0,"durationMs":33,"skipped":[{"reason":"shard-match-limit","title":"result limit hit","message":"Not all results have been returned due to hitting a match limit. Sourcegraph has limits for the number of results returned from a line, document and repository.","severity":"info","suggested":{"title":"increase limit","queryExpression":"count:1000"}}]}

event: done
data: {}

```

Closes https://github.com/sourcegraph/sourcegraph/issues/39776
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
