### PR TITLE
Add lucky generator for symbol types

### DIFF
--- a/internal/search/lucky/generator.go
+++ b/internal/search/lucky/generator.go
@@ -20,7 +20,7 @@ const (
 	THREE
 )
 
-// NewComboGenerator returns a generator for queries produces by a combination
+// NewComboGenerator returns a generator for queries produced by a combination
 // of rules on a seed query. The generator has a strategy over two kinds of rule
 // sets: narrowing and widening rules. You can read more below, but if you don't
 // care about this and just want to apply rules sequentially, simply pass in

--- a/internal/search/lucky/rules_test.go
+++ b/internal/search/lucky/rules_test.go
@@ -84,6 +84,25 @@ func Test_langPatterns(t *testing.T) {
 
 }
 
+func Test_symbolPatterns(t *testing.T) {
+	rule := transform{symbolPatterns}
+	test := func(input string) string {
+		return apply(input, rule)
+	}
+
+	cases := []string{
+		`context:global function`,
+		`context:global parse function`,
+	}
+
+	for _, c := range cases {
+		t.Run("symbol patterns", func(t *testing.T) {
+			autogold.Equal(t, autogold.Raw(test(c)))
+		})
+	}
+
+}
+
 func Test_typePatterns(t *testing.T) {
 	rule := transform{typePatterns}
 	test := func(input string) string {

--- a/internal/search/lucky/testdata/Test_symbolPatterns/symbol_patterns#01.golden
+++ b/internal/search/lucky/testdata/Test_symbolPatterns/symbol_patterns#01.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "context:global parse function",
+  "Query": "context:global select:symbol.function type:symbol parse"
+}

--- a/internal/search/lucky/testdata/Test_symbolPatterns/symbol_patterns.golden
+++ b/internal/search/lucky/testdata/Test_symbolPatterns/symbol_patterns.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "context:global function",
+  "Query": "context:global select:symbol.function type:symbol"
+}


### PR DESCRIPTION
I thought it would be reasonable if I typed `function foobar` to see results for functions matching "foobar". This would map to adding the `type:symbol select:symbol.function` query terms to the query.

The rule also incorporates lucky shorthands for all the `select:symbol.*` types.

## Test Plan

Added a test in the pattern of previous lucky rule tests. Manually tested by Camden.