### PR TITLE
oneclickexport: change output type from []byte to io.Reader

### DIFF
--- a/cmd/frontend/oneclickexport/export.go
+++ b/cmd/frontend/oneclickexport/export.go
@@ -13,9 +13,9 @@ import (
 )
 
 type Exporter interface {
-	// Export accepts an ExportRequest and returns bytes of a zip archive
+	// Export accepts an ExportRequest and returns io.Reader of a zip archive
 	// with requested data.
-	Export(ctx context.Context, request ExportRequest) ([]byte, error)
+	Export(ctx context.Context, request ExportRequest) (io.Reader, error)
 }
 
 var _ Exporter = &DataExporter{}
@@ -86,7 +86,7 @@ type ExportRequest struct {
 // this directory is zipped in the end)
 // 2) ExportRequest is read and each corresponding processor is invoked
 // 3) Tmp directory is zipped after all the Processors finished their job
-func (e *DataExporter) Export(ctx context.Context, request ExportRequest) ([]byte, error) {
+func (e *DataExporter) Export(ctx context.Context, request ExportRequest) (io.Reader, error) {
 	// 1) creating a tmp dir
 	dir, err := os.MkdirTemp(os.TempDir(), "export-*")
 	if err != nil {
@@ -150,5 +150,5 @@ func (e *DataExporter) Export(ctx context.Context, request ExportRequest) ([]byt
 		return nil, err
 	}
 
-	return buf.Bytes(), nil
+	return bytes.NewReader(buf.Bytes()), nil
 }

--- a/cmd/frontend/oneclickexport/export.go
+++ b/cmd/frontend/oneclickexport/export.go
@@ -150,5 +150,5 @@ func (e *DataExporter) Export(ctx context.Context, request ExportRequest) (io.Re
 		return nil, err
 	}
 
-	return bytes.NewReader(buf.Bytes()), nil
+	return &buf, nil
 }

--- a/cmd/frontend/oneclickexport/export_test.go
+++ b/cmd/frontend/oneclickexport/export_test.go
@@ -247,7 +247,7 @@ func TestExport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	zr, err := getArchiveReader(archive)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +349,7 @@ func TestExport_CumulativeTest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	zr, err := getArchiveReader(archive)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -413,7 +413,7 @@ func TestExport_CodeHostConfigs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	zr, err := getArchiveReader(archive)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -533,7 +533,7 @@ func TestExport_DB_ExternalServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	zr, err := getArchiveReader(archive)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -615,7 +615,7 @@ func TestExport_DB_ExternalServiceRepos(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	zr, err := getArchiveReader(archive)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -647,4 +647,13 @@ func TestExport_DB_ExternalServiceRepos(t *testing.T) {
 	if !found {
 		t.Fatal(errors.New("external services file not found in exported zip archive"))
 	}
+}
+
+func getArchiveReader(archive io.Reader) (*zip.Reader, error) {
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(archive)
+	if err != nil {
+		return nil, err
+	}
+	return zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/40096

## Test plan
Existing tests should pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
