### PR TITLE
codemirror file view: Improve line selection UX

### DIFF
--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -193,7 +193,7 @@ export function selectableLineNumbers(config: {
                         config.onSelection(range)
                     }
 
-                    function onmousemove(event: MouseEvent) {
+                    function onmousemove(event: MouseEvent): void {
                         if (dragging) {
                             const newEndline = view.state.doc.lineAt(view.posAtCoords(event, false)).number
                             if (view.state.field(selectedLines)?.endLine !== newEndline) {

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -19,7 +19,7 @@ export type SelectedLineRange = { line: number; endLine?: number } | null
 
 const selectedLineDecoration = Decoration.line({ class: 'selected-line' })
 const selectedLineGutterMarker = new (class extends GutterMarker {
-    elementClass = 'selected-line'
+    public elementClass = 'selected-line'
 })()
 const setSelectedLines = StateEffect.define<SelectedLineRange>()
 const setEndLine = StateEffect.define<number>()


### PR DESCRIPTION
This PR makes two changes:

To achieve parity with the current (HTML-based) blob view, the background color of the line numbers of selected lines also changes.

Right now "select-by-drag" doesn't update the selected lines when the mouse cursor leaves the line number gutter during the process. This was changed by binding the corresponding event handler to `window` instead.

Before/after video:


https://user-images.githubusercontent.com/179026/183857589-9782b79f-6c97-4428-9692-4da4ba5d8bb7.mp4


## Test plan

Click and drag to select lines. Line decoration includes line number gutter and moving the mouse outside the line number gutter still updates the selected lines in real time.

## App preview:

- [Web](https://sg-web-fkling-cm-fv-sl.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yzozjfbwyd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
