### PR TITLE
web: increase bundlsize limit for the `app.bundle.js`

### DIFF
--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -14,7 +14,7 @@ const config = {
        * Primary cause is due to multiple ongoing migrations that mean we are duplicating similar dependencies.
        * Issue to track: https://github.com/sourcegraph/sourcegraph/issues/37845
        */
-      maxSize: '425kb',
+      maxSize: '430kb',
       compression: 'none',
     },
     {


### PR DESCRIPTION
## Context

Increasing the main bundle size limit a bit to allow small additions in the future PRs. @umpox spotted that we're close to the limit in [this PR](https://github.com/sourcegraph/sourcegraph/pull/40188).

## Test plan

n/a

## App preview:

- [Web](https://sg-web-vb-bundlesize-app-bundle-update.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

