### PR TITLE
chore: Fix drop index name

### DIFF
--- a/migrations/frontend/1655481894_faster_ssbc_dequeue/down.sql
+++ b/migrations/frontend/1655481894_faster_ssbc_dequeue/down.sql
@@ -1,1 +1,1 @@
-DROP INDEX IF EXISTS batch_spec_workspace_execution_jobsbatch_spec_workspace_execution_jobs_last_dequeue;
+DROP INDEX IF EXISTS batch_spec_workspace_execution_jobs_last_dequeue;


### PR DESCRIPTION
Fix bad down migration (it works because it doesn't exist). This causes issues with drift after downgrades.

## Test plan

Existing CI pipelines.