### PR TITLE
batches: fix wrong read-only namespace selector value

### DIFF
--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -63,7 +63,10 @@ const batchChangeDefaults: BatchChangeFields = {
     id: 'specid',
     url: '/users/alice/batch-changes/specid',
     namespace: {
+        __typename: 'User',
         id: '1234',
+        displayName: null,
+        username: 'alice',
         namespaceName: 'alice',
         url: '/users/alice',
     },

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
@@ -87,6 +87,8 @@ export const ExistingBatchChange: Story = () => (
                         namespace: {
                             __typename: 'Org',
                             namespaceName: 'Sourcegraph',
+                            displayName: null,
+                            name: 'sourcegraph',
                             url: '/orgs/sourcegraph',
                             id: 'test1234',
                         },
@@ -112,6 +114,8 @@ export const LicenseAlert: Story = () => (
                         namespace: {
                             __typename: 'Org',
                             namespaceName: 'Sourcegraph',
+                            displayName: null,
+                            name: 'sourcegraph',
                             url: '/orgs/sourcegraph',
                             id: 'test1234',
                         },

--- a/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
+++ b/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
@@ -5,7 +5,11 @@ import { mdiInformationOutline } from '@mdi/js'
 import { SettingsOrgSubject, SettingsUserSubject } from '@sourcegraph/shared/src/settings/settings'
 import { Icon, Select, Tooltip } from '@sourcegraph/wildcard'
 
-const getNamespaceDisplayName = (namespace: SettingsUserSubject | SettingsOrgSubject): string => {
+type PartialNamespace =
+    | Pick<SettingsUserSubject, '__typename' | 'id' | 'username' | 'displayName'>
+    | Pick<SettingsOrgSubject, '__typename' | 'id' | 'name' | 'displayName'>
+
+const getNamespaceDisplayName = (namespace: PartialNamespace): string => {
     switch (namespace.__typename) {
         case 'User':
             return namespace.displayName ?? namespace.username
@@ -16,12 +20,11 @@ const getNamespaceDisplayName = (namespace: SettingsUserSubject | SettingsOrgSub
 
 const NAMESPACE_SELECTOR_ID = 'batch-spec-execution-namespace-selector'
 
-interface NamespaceSelectorProps {
-    namespaces: (SettingsUserSubject | SettingsOrgSubject)[]
+type NamespaceSelectorProps = {
+    namespaces: PartialNamespace[]
     selectedNamespace: string
-    disabled?: boolean
-    onSelect: (namespace: SettingsUserSubject | SettingsOrgSubject) => void
-}
+} & // Either the selector is disabled and there's on onSelect, or the selector is enabled and there is one.
+({ disabled: true; onSelect?: undefined } | { disabled?: false; onSelect: (namespace: PartialNamespace) => void })
 
 export const NamespaceSelector: React.FunctionComponent<React.PropsWithChildren<NamespaceSelectorProps>> = ({
     namespaces,
@@ -31,13 +34,17 @@ export const NamespaceSelector: React.FunctionComponent<React.PropsWithChildren<
 }) => {
     const onSelectNamespace = useCallback<React.ChangeEventHandler<HTMLSelectElement>>(
         event => {
+            if (disabled) {
+                return
+            }
+
             const selectedNamespace = namespaces.find(
                 (namespace): namespace is SettingsUserSubject | SettingsOrgSubject =>
                     namespace.id === event.target.value
             )
             onSelect(selectedNamespace || namespaces[0])
         },
-        [onSelect, namespaces]
+        [disabled, onSelect, namespaces]
     )
 
     return (

--- a/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
+++ b/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
@@ -23,8 +23,7 @@ const NAMESPACE_SELECTOR_ID = 'batch-spec-execution-namespace-selector'
 type NamespaceSelectorProps = {
     namespaces: PartialNamespace[]
     selectedNamespace: string
-} & // Either the selector is disabled and there's on onSelect, or the selector is enabled and there is one.
-({ disabled: true; onSelect?: undefined } | { disabled?: false; onSelect: (namespace: PartialNamespace) => void })
+} & ({ disabled: true; onSelect?: undefined } | { disabled?: false; onSelect: (namespace: PartialNamespace) => void }) // Either the selector is disabled and there's on onSelect, or the selector is enabled and there is one.
 
 export const NamespaceSelector: React.FunctionComponent<React.PropsWithChildren<NamespaceSelectorProps>> = ({
     namespaces,

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
@@ -40,8 +40,11 @@ export const MOCK_BATCH_CHANGE: BatchChangeFields = {
     id: 'specid',
     url: '/users/alice/batch-changes/awesome-batch-change',
     namespace: {
+        __typename: 'User',
         id: '1234',
         namespaceName: 'alice',
+        displayName: null,
+        username: 'alice',
         url: '/users/alice',
     },
     viewerCanAdminister: true,

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -103,9 +103,18 @@ const batchChangeFragment = gql`
         url
         name
         namespace {
+            __typename
             id
             namespaceName
             url
+            ... on User {
+                displayName
+                username
+            }
+            ... on Org {
+                displayName
+                name
+            }
         }
         description
 

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -369,11 +369,24 @@ function mockCommonGraphQLResponses(
                     username: 'alice',
                 },
                 name: 'test-batch-change',
-                namespace: {
-                    id: '1234',
-                    namespaceName: entityType === 'user' ? 'alice' : 'test-org',
-                    url: namespaceURL,
-                },
+                namespace:
+                    entityType === 'user'
+                        ? {
+                              __typename: 'User',
+                              id: '1234',
+                              displayName: null,
+                              namespaceName: 'alice',
+                              url: namespaceURL,
+                              username: 'alice',
+                          }
+                        : {
+                              __typename: 'Org',
+                              id: '1234',
+                              displayName: null,
+                              namespaceName: 'test-org',
+                              url: namespaceURL,
+                              name: 'test-org',
+                          },
                 diffStat: { added: 1000, changed: 2000, deleted: 1000, __typename: 'DiffStat' },
                 url: `${namespaceURL}/batch-changes/test-batch-change`,
                 viewerCanAdminister: true,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/40158.

Before we had a read-only version of the configuration page, the only options available in the namespace dropdown selector are those namespaces in which the current user is able to create batch changes: namely, their own user namespace and any org namespaces they are part of. But if a user is viewing another user's batch change and the read-only configuration page, that namespace isn't going to be one they technically have access to, so we need to populate it differently. This just fixes that.

I also tightened up some component prop type definitions while I was here to eliminate impossible combinations. The type definitions got grosser as a result, of course, but I think with the effect of better type feedback is still net positive.

## Test plan

Manually tested.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-readonly-namespace-selector.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lisgmmculy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
