### PR TITLE
codemirror file view: Cleanup/simplify sourcegraph extensions integration

### DIFF
--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -7,12 +7,12 @@
  */
 import React from 'react'
 
-import { Extension, Facet, StateEffect, StateEffectType, StateField } from '@codemirror/state'
+import { Extension, StateEffectType } from '@codemirror/state'
 import { EditorView, PluginValue, ViewPlugin, ViewUpdate } from '@codemirror/view'
 import { Remote } from 'comlink'
 import { createRoot, Root } from 'react-dom/client'
-import { combineLatest, Observable, of, ReplaySubject, Subject, Subscription } from 'rxjs'
-import { filter, map, catchError, switchMap, distinctUntilChanged, startWith } from 'rxjs/operators'
+import { combineLatest, EMPTY, from, Observable, of, Subject, Subscription } from 'rxjs'
+import { filter, map, catchError, switchMap, distinctUntilChanged, startWith, shareReplay } from 'rxjs/operators'
 import { TextDocumentDecorationType } from 'sourcegraph'
 
 import { DocumentHighlight, LOADER_DELAY, MaybeLoadingResult, emitLoading } from '@sourcegraph/codeintellify'
@@ -52,7 +52,6 @@ interface Context {
     extensionsController: ExtensionsControllerProps['extensionsController']
     extensionHostAPI: Remote<FlatExtensionHostAPI>
     blobInfo: BlobInfo
-    subscriptions: Subscription
 }
 
 /**
@@ -62,6 +61,7 @@ interface Context {
  * - Text document decorations
  * - Selection updates
  * - Status bar
+ * - Reference panel warmup
  */
 export function sourcegraphExtensions({
     blobInfo,
@@ -78,167 +78,106 @@ export function sourcegraphExtensions({
     disableDecorations?: boolean
     disableHovercards?: boolean
 }): Extension {
-    const context = extensionsController.extHostAPI.then(async extensionHostAPI => {
-        const uri = toURIWithPath(blobInfo)
+    const subscriptions = new Subscription()
 
-        const [, viewerId] = await Promise.all([
-            // This call should be made before adding viewer, but since
-            // messages to web worker are handled in order, we can use Promise.all
-            extensionHostAPI.addTextDocumentIfNotExists({
-                uri,
-                languageId: blobInfo.mode,
-                text: blobInfo.content,
-            }),
-            extensionHostAPI.addViewerIfNotExists({
-                type: 'CodeEditor' as const,
-                resource: uri,
-                selections: lprToSelectionsZeroIndexed(initialSelection),
-                isActive: true,
-            }),
-        ])
+    // Initialize document and viewer as early as possible and make context
+    // available as observable
+    const contextObservable = from(
+        extensionsController.extHostAPI.then(async extensionHostAPI => {
+            const uri = toURIWithPath(blobInfo)
 
-        return [viewerId, extensionHostAPI] as [ViewerId, Remote<FlatExtensionHostAPI>]
-    })
+            const [, viewerId] = await Promise.all([
+                // This call should be made before adding viewer, but since
+                // messages to web worker are handled in order, we can use Promise.all
+                extensionHostAPI.addTextDocumentIfNotExists({
+                    uri,
+                    languageId: blobInfo.mode,
+                    text: blobInfo.content,
+                }),
+                extensionHostAPI.addViewerIfNotExists({
+                    type: 'CodeEditor' as const,
+                    resource: uri,
+                    selections: lprToSelectionsZeroIndexed(initialSelection),
+                    isActive: true,
+                }),
+            ])
 
-    return [
-        // A view plugin is used to have a way to cleanup any resources via the
-        // `destroy` method.
-        ViewPlugin.define(view => {
-            context
-                .then(([viewerId, extensionHostAPI]) => {
-                    const subscriptions = new Subscription()
-
-                    // Cleanup on navigation between/away from viewers
-                    subscriptions.add(() => {
-                        extensionHostAPI
-                            .removeViewer(viewerId)
-                            .catch(error => console.error('Error removing viewer from extension host', error))
-                    })
-
-                    view.dispatch({
-                        effects: setContext.of({
-                            blobInfo,
-                            viewerId,
-                            extensionHostAPI,
-                            subscriptions,
-                            extensionsController,
-                        }),
-                    })
-                })
-                .catch(() => console.error('Unable to initialize extensions context'))
+            return [viewerId, extensionHostAPI] as [ViewerId, Remote<FlatExtensionHostAPI>]
+        })
+    ).pipe(
+        catchError(() => {
+            console.error('Unable to initialize extensions context')
+            return EMPTY
+        }),
+        map(([viewerId, extensionHostAPI]) => {
+            subscriptions.add(() => {
+                extensionHostAPI
+                    .removeViewer(viewerId)
+                    .catch(error => console.error('Error removing viewer from extension host', error))
+            })
 
             return {
+                blobInfo,
+                viewerId,
+                extensionHostAPI,
+                extensionsController,
+            }
+        }),
+        shareReplay(1)
+    )
+
+    return [
+        // This view plugin is used to have a way to cleanup any resources via the
+        // `destroy` method.
+        ViewPlugin.define(() => {
+            return {
                 destroy() {
-                    const context = view.state.field(sgExtensionsContextField, false)?.context
-                    context?.subscriptions.unsubscribe()
+                    subscriptions.unsubscribe()
                 },
             }
         }),
-        sgExtensionsContextField,
         // This needs to come before document highlights so that the hovered
         // token is highlighted differently
-        disableHovercards ? [] : hovercardDataSource(),
-        documentHighlightsDataSource(),
-        disableDecorations ? [] : textDocumentDecorations(),
-        updateSelection,
-        disableStatusBar ? [] : statusBar,
-        warmupReferences,
+        disableHovercards ? [] : hovercardDataSource(contextObservable),
+        documentHighlightsDataSource(contextObservable),
+        disableDecorations ? [] : textDocumentDecorations(contextObservable),
+        ViewPlugin.define(() => new SelectionManager(contextObservable)),
+        disableStatusBar ? [] : [
+            ViewPlugin.define(view => new StatusBarManager(view, contextObservable)),
+            bottomPadding,
+        ],
+        ViewPlugin.define(() => new WarmupReferencesManager(contextObservable)),
     ]
 }
-
-/**
- * Only used by sgExtenionContext to initialize the context.
- */
-const setContext = StateEffect.define<Context>()
-
-/**
- * Stores the context which is necessary to integrate with Sourcegraph
- * extensions. Since it takes some time to initialize the connection to the
- * extension host, CodeMirror extensions can either use the observable stored in
- * this field or the {@link updateOnContextChange} facet to be notified when the
- * context becomes available.
- */
-const sgExtensionsContextField = StateField.define<{ context: Context | null; contextObservable: Subject<Context> }>({
-    create() {
-        return {
-            context: null,
-            contextObservable: new ReplaySubject(1),
-        }
-    },
-    compare(previous, next) {
-        return previous.context === next.context
-    },
-    update(value, transaction) {
-        for (const effect of transaction.effects) {
-            if (effect.is(setContext)) {
-                value.contextObservable.next(effect.value)
-                return { ...value, context: effect.value }
-            }
-        }
-        return value
-    },
-})
-
-/**
- * Facet that allows other extensions to get notified when the Sourcegraph
- * extensions context is initialized.
- */
-const updateOnContextChange = Facet.define<
-    ViewPlugin<{ setContext(context: Context | null): void }> | ((context: Context | null) => void)
->({
-    enables: facet =>
-        EditorView.updateListener.of(update => {
-            const context = update.state.field(sgExtensionsContextField)
-            if (update.startState.field(sgExtensionsContextField) !== context) {
-                for (const listener of update.state.facet(facet)) {
-                    if (listener instanceof ViewPlugin) {
-                        update.view.plugin(listener)?.setContext(context.context)
-                    } else {
-                        listener(context.context)
-                    }
-                }
-            }
-        }),
-})
 
 //
 // Document highlights
 //
 
 /**
- * Listen to CodeMirror events and generating decorations for document
- * highlights is done completely independently of Sourcegraph extensions. The
- * integration happens by registering a "data source" that the input extension
- * can query.
- * See {@link DocumentHighlightsDataSource} and {@link documentHighlights\Sources}.
+ * documentHighlightsDataSource registers a callback function for retrieving
+ * document highlight information.
+ * See {@link DocumentHighlightsDataSource} and {@link documentHighlightsSource}.
  */
-function documentHighlightsDataSource(): Extension {
-    const nextContext: Subject<Context | null> = new ReplaySubject(1)
-    const EMPTY: DocumentHighlight[] = []
-
-    const createObservable = (position: Position): Observable<DocumentHighlight[]> =>
-        combineLatest([nextContext, of(position)]).pipe(
-            switchMap(([context, position]) =>
-                context
-                    ? wrapRemoteObservable(
-                          context.extensionHostAPI.getDocumentHighlights({
-                              textDocument: {
-                                  uri: toURIWithPath(context.blobInfo),
-                              },
-                              position: {
-                                  character: position.character - 1,
-                                  line: position.line - 1,
-                              },
-                          })
-                      )
-                    : of(EMPTY)
+function documentHighlightsDataSource(context: Observable<Context>): Extension {
+    return documentHighlightsSource.of(
+        (position: Position): Observable<DocumentHighlight[]> =>
+            combineLatest([context, of(position)]).pipe(
+                switchMap(([context, position]) =>
+                    wrapRemoteObservable(
+                        context.extensionHostAPI.getDocumentHighlights({
+                            textDocument: {
+                                uri: toURIWithPath(context.blobInfo),
+                            },
+                            position: {
+                                character: position.character - 1,
+                                line: position.line - 1,
+                            },
+                        })
+                    )
+                )
             )
-        )
-
-    return [
-        updateOnContextChange.of(context => nextContext.next(context)),
-        documentHighlightsSource.of(createObservable),
-    ]
+    )
 }
 
 //
@@ -252,24 +191,22 @@ function documentHighlightsDataSource(): Extension {
  * a state field to provide input values for the {@link showTextDocumentDecorations}
  * facet.
  */
-class TextDecorationManager {
+class TextDecorationManager implements PluginValue {
     private subscription: Subscription
 
     constructor(
-        private readonly view: EditorView,
-        private readonly setDecorations: StateEffectType<[TextDocumentDecorationType, TextDocumentDecoration[]][]>
+        view: EditorView,
+        context: Observable<Context>,
+        setDecorations: StateEffectType<[TextDocumentDecorationType, TextDocumentDecoration[]][]>
     ) {
-        this.subscription = this.view.state
-            .field(sgExtensionsContextField)
-            .contextObservable.pipe(
+        this.subscription = context
+            .pipe(
                 switchMap(context =>
-                    context
-                        ? wrapRemoteObservable(context.extensionHostAPI.getTextDecorations(context.viewerId))
-                        : of([])
+                    wrapRemoteObservable(context.extensionHostAPI.getTextDecorations(context.viewerId))
                 )
             )
             .subscribe(decorations => {
-                view.dispatch({ effects: this.setDecorations.of(decorations) })
+                view.dispatch({ effects: setDecorations.of(decorations) })
             })
     }
 
@@ -278,11 +215,11 @@ class TextDecorationManager {
     }
 }
 
-function textDocumentDecorations(): Extension {
+function textDocumentDecorations(context: Observable<Context>): Extension {
     const [decorationsField, , setDecorations] = createUpdateableField<
         [TextDocumentDecorationType, TextDocumentDecoration[]][]
     >([], field => showTextDocumentDecorations.from(field))
-    return [decorationsField, ViewPlugin.define(view => new TextDecorationManager(view, setDecorations))]
+    return [decorationsField, ViewPlugin.define(view => new TextDecorationManager(view, context, setDecorations))]
 }
 
 //
@@ -293,33 +230,28 @@ function textDocumentDecorations(): Extension {
  * The selection manager listens to CodeMirror selection changes and sends them
  * to the extensions host.
  */
-const updateSelection = ViewPlugin.fromClass(
-    class SelectionManager implements PluginValue {
-        private nextSelection: Subject<SelectedLineRange> = new Subject()
-        private subscription = new Subscription()
+class SelectionManager implements PluginValue {
+    private nextSelection: Subject<SelectedLineRange> = new Subject()
+    private subscription = new Subscription()
 
-        constructor(view: EditorView) {
-            this.subscription = combineLatest([
-                view.state.field(sgExtensionsContextField).contextObservable,
-                this.nextSelection,
-            ]).subscribe(([context, selection]) => {
-                context.extensionHostAPI
-                    .setEditorSelections(context.viewerId, lprToSelectionsZeroIndexed(selection ?? {}))
-                    .catch(error => console.error('Error updating editor selections on extension host', error))
-            })
-        }
+    constructor(context: Observable<Context>) {
+        this.subscription = combineLatest([context, this.nextSelection]).subscribe(([context, selection]) => {
+            context.extensionHostAPI
+                .setEditorSelections(context.viewerId, lprToSelectionsZeroIndexed(selection ?? {}))
+                .catch(error => console.error('Error updating editor selections on extension host', error))
+        })
+    }
 
-        public destroy(): void {
-            this.subscription.unsubscribe()
-        }
+    public destroy(): void {
+        this.subscription.unsubscribe()
+    }
 
-        public update(update: ViewUpdate): void {
-            if (update.state.field(selectedLines) !== update.startState.field(selectedLines)) {
-                this.nextSelection.next(update.state.field(selectedLines))
-            }
+    public update(update: ViewUpdate): void {
+        if (update.state.field(selectedLines) !== update.startState.field(selectedLines)) {
+            this.nextSelection.next(update.state.field(selectedLines))
         }
     }
-)
+}
 
 //
 // Hovercards
@@ -329,47 +261,45 @@ const updateSelection = ViewPlugin.fromClass(
  * hovercardDataSource uses the {@link hovercardSource} facet to provide a
  * callback function for querying the extension API for hover data.
  */
-function hovercardDataSource(): Extension {
-    const nextContext: Subject<Context | null> = new ReplaySubject(1)
+function hovercardDataSource(context: Observable<Context>): Extension {
+    return hovercardSource.of(
+        (
+            view: EditorView,
+            position: UIPositionSpec['position']
+        ): Observable<Pick<HoverOverlayBaseProps, 'hoverOrError' | 'actionsOrError'>> =>
+            context.pipe(
+                filter((context): context is Context => context !== null),
+                switchMap(context => {
+                    const hoverContext = {
+                        commitID: context.blobInfo.commitID,
+                        revision: context.blobInfo.revision,
+                        filePath: context.blobInfo.filePath,
+                        repoName: context.blobInfo.repoName,
+                    }
+                    const { extensionsController, platformContext } = view.state.facet(blobPropsFacet)
 
-    const createObservable = (
-        view: EditorView,
-        position: UIPositionSpec['position']
-    ): Observable<Pick<HoverOverlayBaseProps, 'hoverOrError' | 'actionsOrError'>> =>
-        nextContext.pipe(
-            filter((context): context is Context => context !== null),
-            switchMap(context => {
-                const hoverContext = {
-                    commitID: context.blobInfo.commitID,
-                    revision: context.blobInfo.revision,
-                    filePath: context.blobInfo.filePath,
-                    repoName: context.blobInfo.repoName,
-                }
-                const { extensionsController, platformContext } = view.state.facet(blobPropsFacet)
-
-                return combineLatest([
-                    getHover({ ...hoverContext, position }, { extensionsController }).pipe(
-                        catchError((error): [MaybeLoadingResult<ErrorLike>] => [
-                            { isLoading: false, result: asError(error) },
-                        ]),
-                        emitLoading<HoverOverlayBaseProps['hoverOrError'] | ErrorLike, null>(LOADER_DELAY, null)
-                    ),
-                    getHoverActions(
-                        { extensionsController, platformContext },
-                        {
-                            ...hoverContext,
-                            ...position,
-                        }
-                    ),
-                ])
-            }),
-            map(([hoverResult, actionsResult]) => ({
-                hoverOrError: hoverResult,
-                actionsOrError: actionsResult,
-            }))
-        )
-
-    return [updateOnContextChange.of(context => nextContext.next(context)), hovercardSource.of(createObservable)]
+                    return combineLatest([
+                        getHover({ ...hoverContext, position }, { extensionsController }).pipe(
+                            catchError((error): [MaybeLoadingResult<ErrorLike>] => [
+                                { isLoading: false, result: asError(error) },
+                            ]),
+                            emitLoading<HoverOverlayBaseProps['hoverOrError'] | ErrorLike, null>(LOADER_DELAY, null)
+                        ),
+                        getHoverActions(
+                            { extensionsController, platformContext },
+                            {
+                                ...hoverContext,
+                                ...position,
+                            }
+                        ),
+                    ])
+                }),
+                map(([hoverResult, actionsResult]) => ({
+                    hoverOrError: hoverResult,
+                    actionsOrError: actionsResult,
+                }))
+            )
+    )
 }
 
 //
@@ -381,104 +311,88 @@ function hovercardDataSource(): Extension {
  * capabilities of CodeMirror. It only attaches a container DOM element to the
  * editor's DOM and renders itself it that container.
  */
-const statusBar: Extension = [
-    // Ensures that the status bar doesn't cover any content
-    EditorView.theme({
-        '.cm-content': {
-            paddingBottom: 'calc(var(--blob-status-bar-height) + var(--blob-status-bar-vertical-gap))',
-        },
-    }),
-    ViewPlugin.fromClass(
-        class {
-            private container: HTMLDivElement
-            private reactRoot: Root
-            private subscription: Subscription
-            private nextProps = new Subject<BlobProps>()
+class StatusBarManager implements PluginValue {
+    private container: HTMLDivElement
+    private reactRoot: Root
+    private subscription: Subscription
+    private nextProps = new Subject<BlobProps>()
 
-            constructor(private readonly view: EditorView) {
-                this.container = document.createElement('div')
-                this.reactRoot = createRoot(this.container)
-                const contextUpdates = this.view.state.field(sgExtensionsContextField).contextObservable
+    constructor(view: EditorView, context: Observable<Context>) {
+        this.container = document.createElement('div')
+        this.reactRoot = createRoot(this.container)
 
-                const getStatusBarItems = (): Observable<'loading' | StatusBarItemWithKey[]> =>
-                    contextUpdates.pipe(
-                        switchMap(context => {
-                            if (!context) {
-                                return of('loading' as const)
-                            }
+        const getStatusBarItems = (): Observable<'loading' | StatusBarItemWithKey[]> =>
+            context.pipe(
+                switchMap(context => {
+                    if (!context) {
+                        return of('loading' as const)
+                    }
 
-                            return wrapRemoteObservable(context.extensionHostAPI.getStatusBarItems(context.viewerId))
-                        })
-                    )
-
-                this.subscription = combineLatest([
-                    contextUpdates,
-                    this.nextProps.pipe(
-                        distinctUntilChanged(
-                            (previous, next) => previous.location === next.location && previous.history === next.history
-                        ),
-                        startWith(view.state.facet(blobPropsFacet))
-                    ),
-                ]).subscribe(([context, props]) => {
-                    this.reactRoot.render(
-                        React.createElement(
-                            Container,
-                            { history: props.history },
-                            React.createElement(StatusBar, {
-                                getStatusBarItems,
-                                extensionsController: context.extensionsController,
-                                uri: toURIWithPath(context.blobInfo),
-                                location: props.location,
-                                className: blobStyles.blobStatusBarBody,
-                                statusBarRef: () => {},
-                                hideWhileInitializing: true,
-                                isBlobPage: true,
-                            })
-                        )
-                    )
+                    return wrapRemoteObservable(context.extensionHostAPI.getStatusBarItems(context.viewerId))
                 })
-
-                this.view.dom.append(this.container)
-            }
-
-            public update(update: ViewUpdate): void {
-                this.nextProps.next(update.state.facet(blobPropsFacet))
-            }
-
-            public destroy(): void {
-                this.subscription.unsubscribe()
-                this.container.remove()
-
-                // setTimeout seems necessary to prevent React from complaining that the
-                // root is synchronously unmounted while rendering is in progress
-                setTimeout(() => this.reactRoot.unmount(), 0)
-            }
-        }
-    ),
-]
-
-const warmupReferences = ViewPlugin.fromClass(
-    class {
-        private nextContext: Subject<Context> = new Subject()
-        private subscription: Subscription = new Subscription()
-
-        constructor() {
-            this.subscription.add(
-                this.nextContext
-                    .pipe(switchMap(context => haveInitialExtensionsLoaded(context.extensionsController.extHostAPI)))
-                    .subscribe()
             )
-        }
 
-        public setContext(context: Context): void {
-            this.nextContext.next(context)
-        }
+        this.subscription = combineLatest([
+            context,
+            this.nextProps.pipe(
+                distinctUntilChanged(
+                    (previous, next) => previous.location === next.location && previous.history === next.history
+                ),
+                startWith(view.state.facet(blobPropsFacet))
+            ),
+        ]).subscribe(([context, props]) => {
+            this.reactRoot.render(
+                React.createElement(
+                    Container,
+                    { history: props.history },
+                    React.createElement(StatusBar, {
+                        getStatusBarItems,
+                        extensionsController: context.extensionsController,
+                        uri: toURIWithPath(context.blobInfo),
+                        location: props.location,
+                        className: blobStyles.blobStatusBarBody,
+                        statusBarRef: () => {},
+                        hideWhileInitializing: true,
+                        isBlobPage: true,
+                    })
+                )
+            )
+        })
 
-        public destroy(): void {
-            this.subscription.unsubscribe()
-        }
-    },
-    {
-        provide: plugin => updateOnContextChange.of(plugin),
+        view.dom.append(this.container)
     }
-)
+
+    public update(update: ViewUpdate): void {
+        this.nextProps.next(update.state.facet(blobPropsFacet))
+    }
+
+    public destroy(): void {
+        this.subscription.unsubscribe()
+        this.container.remove()
+
+        // setTimeout seems necessary to prevent React from complaining that the
+        // root is synchronously unmounted while rendering is in progress
+        setTimeout(() => this.reactRoot.unmount(), 0)
+    }
+}
+
+// Ensures that the status bar doesn't conver any content
+const bottomPadding = EditorView.theme({
+    '.cm-content': {
+        paddingBottom: 'calc(var(--blob-status-bar-height) + var(--blob-status-bar-vertical-gap))',
+    },
+})
+
+class WarmupReferencesManager implements PluginValue {
+    private subscription: Subscription
+
+    constructor(context: Observable<Context>) {
+        this.subscription = context
+            .pipe(switchMap(context => haveInitialExtensionsLoaded(context.extensionsController.extHostAPI)))
+            .subscribe()
+    }
+
+    public destroy(): void {
+        this.subscription.unsubscribe()
+    }
+}

--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -140,10 +140,9 @@ export function sourcegraphExtensions({
         documentHighlightsDataSource(contextObservable),
         disableDecorations ? [] : textDocumentDecorations(contextObservable),
         ViewPlugin.define(() => new SelectionManager(contextObservable)),
-        disableStatusBar ? [] : [
-            ViewPlugin.define(view => new StatusBarManager(view, contextObservable)),
-            bottomPadding,
-        ],
+        disableStatusBar
+            ? []
+            : [ViewPlugin.define(view => new StatusBarManager(view, contextObservable)), bottomPadding],
         ViewPlugin.define(() => new WarmupReferencesManager(contextObservable)),
     ]
 }

--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -129,13 +129,11 @@ export function sourcegraphExtensions({
     return [
         // This view plugin is used to have a way to cleanup any resources via the
         // `destroy` method.
-        ViewPlugin.define(() => {
-            return {
-                destroy() {
-                    subscriptions.unsubscribe()
-                },
-            }
-        }),
+        ViewPlugin.define(() => ({
+            destroy() {
+                subscriptions.unsubscribe()
+            },
+        })),
         // This needs to come before document highlights so that the hovered
         // token is highlighted differently
         disableHovercards ? [] : hovercardDataSource(contextObservable),


### PR DESCRIPTION
**Note:** It helps to turn white-space differences off.

This commit simplifies the Sourcegraph extensions code. The different
integrations require access to the `context` object, which provides the
extensions API object. So far this was made available via a state field.
However since most of the integrations operate on observables it seems
much simpler and cleaner to pass that observable to the integrations
when they are created.



## Test plan

- Open a file, enable extensions that provide line decorations (e.g. git blame, codecov).
- If git blame is set to show information for selected lines, selecting a line will show the corresponding git blame information.
- The status bar will appear
- Hovering over tokens will show hovercards and document highlights.

## App preview:

- [Web](https://sg-web-fkling-cm-blob-view-cleanup.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bbiqoctlns.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
