### PR TITLE
remove p4 protects line which breaks integration tests

### DIFF
--- a/dev/perforce-testing-helpers/README.md
+++ b/dev/perforce-testing-helpers/README.md
@@ -57,6 +57,7 @@ A helper script that idempotently:
 - prompts the user to select which group(s) they'd like `P4_TEST_USERNAME` to be a member of, then applies those selections
 - uploads the [bundled protections table](./templates/p4_protects.tmpl)
 
+
 **Run this script whenever you run a new test case and need to change the group membership.**
 
 _The address of the Perforce server, the superuser credentials to use, the test user credentials, and the depot name are all configurable via environment variables. See the beginning of [./p4-setup-protections.sh](./p4-setup-protections.sh) for more information._

--- a/dev/perforce-testing-helpers/templates/p4_protects.tmpl
+++ b/dev/perforce-testing-helpers/templates/p4_protects.tmpl
@@ -89,7 +89,6 @@ Protections:
 	write group Backend * //test-perms/Backend/...	## DO NOT DELETE This is used for backend integration tests
 	=read user alice * -//test-perms/Security/...	## DO NOT DELETE This is used for backend integration tests
 	write group Backend * //test-perms/Security/...
-	list group Everyone * -//...
 	=read group DocSiteDenyPath * -//dax-docsite/cmd/docsite/build.go
 	write group DocSiteWritePath * //dax-docsite/cmd/docsite/build.go
 	list group TestGroup * -//mike-test/...	## edge case testing


### PR DESCRIPTION
I manually removed this line from the p4 protects table on the test instance since it breaks integration tests. I want to ensure it doesn't get re-introduced accidentally. 
## Test plan
n/a

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
