### PR TITLE
migrate to environment variables over site config

### DIFF
--- a/cmd/frontend/envvar/envvar.go
+++ b/cmd/frontend/envvar/envvar.go
@@ -20,7 +20,6 @@ var HTTPAddrInternal = env.Get(
 
 var sourcegraphDotComMode, _ = strconv.ParseBool(env.Get("SOURCEGRAPHDOTCOM_MODE", "false", "run as Sourcegraph.com, with add'l marketing and redirects"))
 var openGraphPreviewServiceURL = env.Get("OPENGRAPH_PREVIEW_SERVICE_URL", "", "The URL of the OpenGraph preview image generating service")
-var exportUsageData, _ = strconv.ParseBool(env.Get("EXPORT_USAGE_DATA", "false", "Export usage data from this Sourcegraph instance to centralized Sourcegraph analytics (requires restart)."))
 
 // SourcegraphDotComMode is true if this server is running Sourcegraph.com
 // (solely by checking the SOURCEGRAPHDOTCOM_MODE env var). Sourcegraph.com shows
@@ -29,22 +28,9 @@ func SourcegraphDotComMode() bool {
 	return sourcegraphDotComMode
 }
 
-func ExportUsageData() bool {
-	return exportUsageData
-}
-
 // MockSourcegraphDotComMode is used by tests to mock the result of SourcegraphDotComMode.
 func MockSourcegraphDotComMode(value bool) {
 	sourcegraphDotComMode = value
-}
-
-// MockExportUsageData is used by tests to mock the result of ExportUsageData.
-func MockExportUsageData(value bool) (resetFunc func()) {
-	old := value
-	exportUsageData = value
-	return func() {
-		value = old
-	}
 }
 
 func OpenGraphPreviewServiceURL() string {

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -101,15 +101,6 @@ func TestHandlerEnabledDisabled(t *testing.T) {
 				t.Errorf("unexpected error from Handle function, expected error: %v, received: %s", test.expectErr, err.Error())
 
 			}
-			// if err != nil {
-			// 	if !errors.Is(err, disabledErr) {
-			// 		t.Errorf("unexpected error from Handle function, expected disabled error: %s", err.Error())
-			// 	}
-			// } else {
-			// 	if test.expectErr != nil {
-			// 		t.Error("expected error but did not receive one")
-			// 	}
-			// }
 		})
 	}
 }

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 
 	"github.com/lib/pq"
@@ -64,9 +62,7 @@ func TestInitializeJob(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			reset := envvar.MockExportUsageData(test.setting)
-			defer reset()
-
+			mockEnvVars(t, test.setting)
 			if have, want := isEnabled(), test.shouldInit; have != want {
 				t.Errorf("unexpected isEnabled return value have=%t want=%t", have, want)
 			}
@@ -95,22 +91,25 @@ func TestHandlerEnabledDisabled(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			reset := envvar.MockExportUsageData(test.setting)
-			defer reset()
 			confClient.Mock(&conf.Unified{SiteConfiguration: validConfiguration()})
+			mockEnvVars(t, test.setting)
 			handler := mockTelemetryHandler(t, func(ctx context.Context, event []*database.Event, config topicConfig, metadata instanceMetadata) error {
 				return nil
 			})
 			err := handler.Handle(ctx)
-			if err != nil {
-				if !errors.Is(err, disabledErr) {
-					t.Error("unexpected error from Handle function, expected disabled error")
-				}
-			} else {
-				if test.expectErr != nil {
-					t.Error("expected error but did not receive one")
-				}
+			if !errors.Is(err, test.expectErr) {
+				t.Errorf("unexpected error from Handle function, expected error: %v, received: %s", test.expectErr, err.Error())
+
 			}
+			// if err != nil {
+			// 	if !errors.Is(err, disabledErr) {
+			// 		t.Errorf("unexpected error from Handle function, expected disabled error: %s", err.Error())
+			// 	}
+			// } else {
+			// 	if test.expectErr != nil {
+			// 		t.Error("expected error but did not receive one")
+			// 	}
+			// }
 		})
 	}
 }
@@ -122,8 +121,7 @@ func TestHandlerLoadsEvents(t *testing.T) {
 	db := database.NewDB(logger, dbHandle)
 
 	confClient.Mock(&conf.Unified{SiteConfiguration: validConfiguration()})
-	reset := envvar.MockExportUsageData(true)
-	defer reset()
+	mockEnvVars(t, true)
 
 	initAllowedEvents(t, db, []string{"event1", "event2"})
 
@@ -227,8 +225,6 @@ func TestHandlerLoadsEventsWithBookmarkState(t *testing.T) {
 	dbHandle := dbtest.NewDB(logger, t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbHandle)
-	reset := envvar.MockExportUsageData(true)
-	defer reset()
 
 	initAllowedEvents(t, db, []string{"event1", "event2", "event4"})
 	testData := []*database.Event{
@@ -255,6 +251,7 @@ func TestHandlerLoadsEventsWithBookmarkState(t *testing.T) {
 	config := validConfiguration()
 	config.ExportUsageTelemetry.BatchSize = 1
 	confClient.Mock(&conf.Unified{SiteConfiguration: config})
+	mockEnvVars(t, true)
 
 	handler := mockTelemetryHandler(t, noopHandler())
 	handler.eventLogStore = db.EventLogs() // replace mocks with real stores for a partially mocked handler
@@ -316,8 +313,6 @@ func TestHandlerLoadsEventsWithAllowlist(t *testing.T) {
 	dbHandle := dbtest.NewDB(logger, t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbHandle)
-	reset := envvar.MockExportUsageData(true)
-	defer reset()
 
 	initAllowedEvents(t, db, []string{"allowed"})
 	testData := []*database.Event{
@@ -348,6 +343,7 @@ func TestHandlerLoadsEventsWithAllowlist(t *testing.T) {
 
 	config := validConfiguration()
 	confClient.Mock(&conf.Unified{SiteConfiguration: config})
+	mockEnvVars(t, true)
 
 	handler := mockTelemetryHandler(t, noopHandler())
 	handler.eventLogStore = db.EventLogs() // replace mocks with real stores for a partially mocked handler
@@ -384,10 +380,7 @@ func TestHandlerLoadsEventsWithAllowlist(t *testing.T) {
 }
 
 func validConfiguration() schema.SiteConfiguration {
-	return schema.SiteConfiguration{ExportUsageTelemetry: &schema.ExportUsageTelemetry{
-		TopicName:        "test-topic",
-		TopicProjectName: "test-project",
-	}}
+	return schema.SiteConfiguration{ExportUsageTelemetry: &schema.ExportUsageTelemetry{}}
 }
 
 func TestHandleInvalidConfig(t *testing.T) {
@@ -398,8 +391,7 @@ func TestHandleInvalidConfig(t *testing.T) {
 	bookmarkStore := newBookmarkStore(db)
 
 	confClient.Mock(&conf.Unified{SiteConfiguration: validConfiguration()})
-	reset := envvar.MockExportUsageData(true)
-	defer reset()
+	mockEnvVars(t, true)
 
 	obsContext := &observation.Context{
 		Logger:       logger,
@@ -409,20 +401,14 @@ func TestHandleInvalidConfig(t *testing.T) {
 	}
 
 	t.Run("handle fails when missing project name", func(t *testing.T) {
-		config := validConfiguration()
-		config.ExportUsageTelemetry.TopicProjectName = ""
-		confClient.Mock(&conf.Unified{SiteConfiguration: config})
-
+		projectName = ""
 		handler := newTelemetryHandler(logger, db.EventLogs(), db.UserEmails(), db.GlobalState(), bookmarkStore, noopHandler(), newHandlerMetrics(obsContext))
 		err := handler.Handle(ctx)
 
 		autogold.Want("handle fails when missing project name", "getTopicConfig: missing project name to export usage data").Equal(t, err.Error())
 	})
 	t.Run("handle fails when missing topic name", func(t *testing.T) {
-		config := validConfiguration()
-		config.ExportUsageTelemetry.TopicName = ""
-		confClient.Mock(&conf.Unified{SiteConfiguration: config})
-
+		topicName = ""
 		handler := newTelemetryHandler(logger, db.EventLogs(), db.UserEmails(), db.GlobalState(), bookmarkStore, noopHandler(), newHandlerMetrics(obsContext))
 		err := handler.Handle(ctx)
 
@@ -496,6 +482,7 @@ func TestGetInstanceMetadata(t *testing.T) {
 	version.Mock("fake-Version-1")
 	confClient.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{LicenseKey: "mock-license"}})
 	deploy.Mock("fake-deploy-type")
+	mockEnvVars(t, true)
 
 	stateStore.GetFunc.SetDefaultReturn(database.GlobalState{
 		SiteID:      "fake-site-id",
@@ -644,4 +631,20 @@ func initAllowedEvents(t *testing.T, db database.DB, names []string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func mockEnvVars(t *testing.T, flag bool) {
+	prevEnabled := enabled
+	prevTopicName := topicName
+	prevProjectName := projectName
+
+	t.Cleanup(func() {
+		enabled = prevEnabled
+		topicName = prevTopicName
+		projectName = prevProjectName
+	})
+
+	enabled = flag
+	topicName = "test-name"
+	projectName = "project-name"
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -663,9 +663,9 @@ type ExportUsageTelemetry struct {
 	// Enabled description: Toggles whether or not to export Sourcegraph telemetry. If enabled events will be scraped and sent to an analytics store. This is an opt-in setting, and only should only be enabled for customers that have agreed to event level data collection.
 	Enabled bool `json:"enabled,omitempty"`
 	// TopicName description: Destination pubsub topic name to export usage data
-	TopicName string `json:"topicName"`
+	TopicName string `json:"topicName,omitempty"`
 	// TopicProjectName description: GCP project name containing the usage data pubsub topic
-	TopicProjectName string `json:"topicProjectName"`
+	TopicProjectName string `json:"topicProjectName,omitempty"`
 }
 
 // Extensions description: Configures Sourcegraph extensions.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -68,13 +68,12 @@
     "exportUsageTelemetry": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["topicName", "topicProjectName"],
       "properties": {
         "enabled": {
           "description": "Toggles whether or not to export Sourcegraph telemetry. If enabled events will be scraped and sent to an analytics store. This is an opt-in setting, and only should only be enabled for customers that have agreed to event level data collection.",
           "type": "boolean",
           "default": false,
-          "deprecationMessage": "Deprecated in favor of an environment variable EXPORT_USAGE_DATA."
+          "deprecationMessage": "Deprecated in favor of an environment variable EXPORT_USAGE_DATA_ENABLED."
         },
         "batchSize": {
           "description": "Maximum number of events scraped from the events table in a single scrape.",
@@ -84,11 +83,13 @@
         },
         "topicProjectName": {
           "type": "string",
-          "description": "GCP project name containing the usage data pubsub topic"
+          "description": "GCP project name containing the usage data pubsub topic",
+          "deprecationMessage": "Deprecated in favor of an environment variable EXPORT_USAGE_DATA_TOPIC_PROJECT."
         },
         "topicName": {
           "type": "string",
-          "description": "Destination pubsub topic name to export usage data"
+          "description": "Destination pubsub topic name to export usage data",
+          "deprecationMessage": "Deprecated in favor of an environment variable EXPORT_USAGE_DATA_TOPIC_NAME."
         }
       }
     },


### PR DESCRIPTION
Site config is not trivial to manipulate in managed instances, and is not restricted to Sourcegraph employees (or license checks, for example). This migrates all the required config to environment variables.

## Test plan

```
EXPORT_USAGE_DATA_ENABLED=true EXPORT_USAGE_DATA_TOPIC_NAME=usage-data-testing EXPORT_USAGE_DATA_TOPIC_PROJECT=sourcegraph-dogfood gogo

[         worker] INFO worker.export-usage-telemetry telemetry/telemetry_job.go:196 fetching events from bookmark {"bookmark_id": 21816}
[         worker] INFO worker.export-usage-telemetry telemetry/telemetry_job.go:207 telemetryHandler executed {"event count": 4, "maxId": 21821}

```
