### PR TITLE
batches: Debug message when namespace deleted

### DIFF
--- a/enterprise/internal/batches/sources/sources.go
+++ b/enterprise/internal/batches/sources/sources.go
@@ -177,7 +177,7 @@ func GitserverPushConfig(ctx context.Context, store database.ExternalServiceStor
 	return &protocol.PushConfig{RemoteURL: u.String()}, nil
 }
 
-// DraftChangesetSource returns a DraftChangesetSource, if the underlying
+// ToDraftChangesetSource returns a DraftChangesetSource, if the underlying
 // source supports it. Returns an error if not.
 func ToDraftChangesetSource(css ChangesetSource) (DraftChangesetSource, error) {
 	draftCss, ok := css.(DraftChangesetSource)

--- a/enterprise/internal/batches/store/integration_test.go
+++ b/enterprise/internal/batches/store/integration_test.go
@@ -23,6 +23,7 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("Store", func(t *testing.T) {
 		t.Run("BatchChanges", storeTest(db, nil, testStoreBatchChanges))
+		t.Run("BatchChangesDeletedNamespace", storeTest(db, nil, testBatchChangesDeletedNamespace))
 		t.Run("Changesets", storeTest(db, nil, testStoreChangesets))
 		t.Run("ChangesetEvents", storeTest(db, nil, testStoreChangesetEvents))
 		t.Run("ChangesetScheduling", storeTest(db, nil, testStoreChangesetScheduling))

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -485,6 +485,10 @@ func (s *changesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 
 	source, err := loadChangesetSource(ctx, s.httpFactory, s.syncStore, cs, repo)
 	if err != nil {
+		if errors.Is(err, store.ErrDeletedNamespace) {
+			syncLogger.Debug("SyncChangeset skipping changeset: namespace deleted")
+			return nil
+		}
 		return err
 	}
 

--- a/enterprise/internal/batches/syncer/syncer_test.go
+++ b/enterprise/internal/batches/syncer/syncer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/log"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log/logtest"
@@ -158,6 +159,63 @@ func TestSyncerRun(t *testing.T) {
 		case <-time.After(100 * time.Millisecond):
 			t.Fatal("Sync not called")
 		}
+	})
+
+	t.Run("Sync due but reenqueued when no namespace deleted", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		now := time.Now()
+		updateCalled := false
+		syncStore := newTestStore()
+
+		syncStore.ListChangesetSyncDataFunc.SetDefaultReturn([]*btypes.ChangesetSyncData{
+			{
+				ChangesetID:       1,
+				UpdatedAt:         now.Add(-2 * maxSyncDelay),
+				LatestEvent:       now.Add(-2 * maxSyncDelay),
+				ExternalUpdatedAt: now.Add(-2 * maxSyncDelay),
+			},
+		}, nil)
+		syncStore.GetChangesetFunc.SetDefaultReturn(&btypes.Changeset{RepoID: 1, OwnedByBatchChangeID: 1}, nil)
+
+		rstore := database.NewMockRepoStore()
+		syncStore.ReposFunc.SetDefaultReturn(rstore)
+		rstore.GetFunc.SetDefaultReturn(&types.Repo{ID: 1, Name: "github.com/u/r"}, nil)
+
+		ess := database.NewMockExternalServiceStore()
+		ess.ListFunc.SetDefaultHook(func(ctx context.Context, options database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+			return []*types.ExternalService{{
+				ID:          1,
+				Kind:        extsvc.KindGitHub,
+				DisplayName: "GitHub.com",
+				Config:      `{"url": "https://github.com", "token": "123", "authorization": {}}`,
+			}}, nil
+		})
+		syncStore.ExternalServicesFunc.SetDefaultReturn(ess)
+
+		// Return ErrDeletedNamespace to simulate that a namespace (user or org) has been deleted.
+		syncStore.GetBatchChangeFunc.SetDefaultReturn(nil, store.ErrDeletedNamespace)
+
+		syncStore.UpdateChangesetCodeHostStateFunc.SetDefaultHook(func(context.Context, *btypes.Changeset) error {
+			updateCalled = true
+			return nil
+		})
+
+		capturingLogger, export := logtest.Captured(t)
+		syncer := &changesetSyncer{
+			logger:           capturingLogger,
+			syncStore:        syncStore,
+			scheduleInterval: 10 * time.Minute,
+			metrics:          makeMetrics(&observation.TestContext),
+		}
+		syncer.Run(ctx)
+		assert.False(t, updateCalled)
+
+		// ensure the deleted namespace error is logged as a debug
+		captured := export()
+		assert.Greater(t, len(captured), 0)
+		assert.Equal(t, log.LevelDebug, captured[2].Level)
+		assert.Equal(t, "SyncChangeset skipping changeset: namespace deleted", captured[2].Message)
 	})
 }
 

--- a/enterprise/internal/batches/syncer/syncer_test.go
+++ b/enterprise/internal/batches/syncer/syncer_test.go
@@ -161,7 +161,7 @@ func TestSyncerRun(t *testing.T) {
 		}
 	})
 
-	t.Run("Sync due but reenqueued when no namespace deleted", func(t *testing.T) {
+	t.Run("Sync due but reenqueued when namespace deleted", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
 		now := time.Now()


### PR DESCRIPTION
Closes #39723.

When calling `GetBatchChange`, removed the requirement to that the org and user `deleted_at` be `null`. Instead, during the `scan` call, setting the `deleted_at` values into 2 variables. If these variables are not "zero," then a new error (`ErrDeletedNamespace`) is returned to signify that the namespace has been deleted.

With this error, we can now check if the error is `ErrDeletedNamespace` and log a debug message saying that the changeset is being skipped.

## Test plan

Added Go Unit Tests