### PR TITLE
Search: add query syntax highlighting for `repo:has()` and `repo:has.tag()`

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1563,6 +1563,84 @@ describe('getMonacoTokens()', () => {
         `)
     })
 
+    test('highlight repo:has predicate', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:has(key:value)')))).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "metaPredicateParenthesis"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "metaFilterSeparator"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "metaPredicateParenthesis"
+              }
+            ]
+        `)
+    })
+
+    test('highlight repo:has.tag predicate', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:has.tag(tag)')))).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "metaPredicateDot"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "metaPredicateParenthesis"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 16,
+                "scopes": "metaPredicateParenthesis"
+              }
+            ]
+        `)
+    })
+
     test('highlight regex delimited pattern for standard search', () => {
         expect(getMonacoTokens(toSuccess(scanSearchQuery('/f.*/ x', false, SearchPatternType.standard))))
             .toMatchInlineSnapshot(`

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -941,6 +941,38 @@ const decorateContainsBody = (body: string, offset: number): DecoratedToken[] | 
 }
 
 /**
+ * Attempts to decorate `repo:has(key:value)` syntax. Fails if
+ * the body contains unsupported syntax.
+ */
+const decorateRepoHasBody = (body: string, offset: number): DecoratedToken[] | undefined => {
+    const matches = body.match(/([^:]+):([^:]+)/)
+    if (!matches) {
+        return undefined
+    }
+    console.log(matches)
+
+    return [
+        {
+            type: 'literal',
+            value: matches[1],
+            range: { start: offset, end: offset + matches[1].length },
+            quoted: false,
+        },
+        {
+            type: 'metaFilterSeparator',
+            range: { start: offset + matches[1].length, end: offset + matches[1].length + 1 },
+            value: ':',
+        },
+        {
+            type: 'literal',
+            value: matches[1],
+            range: { start: offset + matches[1].length + 1, end: offset + matches[1].length + 1 + matches[2].length },
+            quoted: false,
+        },
+    ]
+}
+
+/**
  * Decorates the body part of predicate syntax `name(body)`.
  */
 const decoratePredicateBody = (path: string[], body: string, offset: number): DecoratedToken[] => {
@@ -972,6 +1004,21 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
                 value: body,
                 kind: PatternKind.Regexp,
             })
+        case 'has':
+            const decorateResult = decorateRepoHasBody(body, offset)
+            if (decorateResult !== undefined) {
+                return decorateResult
+            }
+            break
+        case 'has.tag':
+            return [
+                {
+                    type: 'literal',
+                    range: { start: offset, end: body.length },
+                    value: body,
+                    quoted: false,
+                },
+            ]
     }
     decorated.push({
         type: 'literal',

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -984,7 +984,6 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
                 return result
             }
             break
-
         }
         case 'contains.file':
         case 'contains.content':

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -978,13 +978,14 @@ const decorateRepoHasBody = (body: string, offset: number): DecoratedToken[] | u
 const decoratePredicateBody = (path: string[], body: string, offset: number): DecoratedToken[] => {
     const decorated: DecoratedToken[] = []
     switch (path.join('.')) {
-        case 'contains':
-            // eslint-disable-next-line no-case-declarations
+        case 'contains': {
             const result = decorateContainsBody(body, offset)
             if (result !== undefined) {
                 return result
             }
             break
+
+        }
         case 'contains.file':
         case 'contains.content':
         case 'has.description':
@@ -1004,12 +1005,13 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
                 value: body,
                 kind: PatternKind.Regexp,
             })
-        case 'has':
-            const decorateResult = decorateRepoHasBody(body, offset)
-            if (decorateResult !== undefined) {
-                return decorateResult
+        case 'has': {
+            const result = decorateRepoHasBody(body, offset)
+            if (result !== undefined) {
+                return result
             }
             break
+        }
         case 'has.tag':
             return [
                 {

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -1014,7 +1014,7 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
             return [
                 {
                     type: 'literal',
-                    range: { start: offset, end: body.length },
+                    range: { start: offset, end: offset + body.length },
                     value: body,
                     quoted: false,
                 },

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -28,7 +28,7 @@ export const PREDICATES: Access[] = [
             },
             {
                 name: 'has',
-                fields: [{ name: 'description' }],
+                fields: [{ name: 'description' }, { name: 'tag' }],
             },
             {
                 name: 'dependencies',


### PR DESCRIPTION
This adds decoration for `repo:has()` and `repo:has.tag()` in the search query bar.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/40112
Closes #40133 

<img width="222" alt="Screen Shot 2022-08-10 at 11 50 33" src="https://user-images.githubusercontent.com/12631702/183982035-f64baa51-ce44-449e-afe8-91d705a8bdb2.png">


## Test plan

Added tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-metadata-highlighting.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mdnhuktuyg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
