### PR TITLE
unskip perforce sub-repo perms integration test

### DIFF
--- a/dev/gqltest/bitbucket_projects_perms_sync_test.go
+++ b/dev/gqltest/bitbucket_projects_perms_sync_test.go
@@ -30,12 +30,7 @@ func TestBitbucketProjectsPermsSync_SetUnrestrictedPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Cleanup(func() {
-		err := client.DeleteExternalService(esID, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+	removeExternalServiceAfterTest(t, esID)
 
 	// Triggering the sync job
 	unrestricted := true
@@ -78,12 +73,7 @@ func TestBitbucketProjectsPermsSync_FromRestrictedToUnrestrictedPermissions(t *t
 		t.Fatal(err)
 	}
 
-	t.Cleanup(func() {
-		err := client.DeleteExternalService(esID, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+	removeExternalServiceAfterTest(t, esID)
 
 	// Triggering the sync job to set permissions for existing user
 	unrestricted := false
@@ -145,12 +135,7 @@ func TestBitbucketProjectsPermsSync_SetPendingPermissions_NonExistentUsersOnly(t
 		t.Fatal(err)
 	}
 
-	t.Cleanup(func() {
-		err := client.DeleteExternalService(esID, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+	removeExternalServiceAfterTest(t, esID)
 
 	// Triggering the sync job
 	unrestricted := false
@@ -215,12 +200,7 @@ func TestBitbucketProjectsPermsSync_SetPendingPermissions_ExistentAndNonExistent
 		t.Fatal(err)
 	}
 
-	t.Cleanup(func() {
-		err := client.DeleteExternalService(esID, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+	removeExternalServiceAfterTest(t, esID)
 
 	// Triggering the sync job
 	unrestricted := false

--- a/dev/gqltest/bitbucket_projects_perms_sync_test.go
+++ b/dev/gqltest/bitbucket_projects_perms_sync_test.go
@@ -30,12 +30,12 @@ func TestBitbucketProjectsPermsSync_SetUnrestrictedPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer func() {
+	t.Cleanup(func() {
 		err := client.DeleteExternalService(esID, false)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	// Triggering the sync job
 	unrestricted := true
@@ -78,12 +78,12 @@ func TestBitbucketProjectsPermsSync_FromRestrictedToUnrestrictedPermissions(t *t
 		t.Fatal(err)
 	}
 
-	defer func() {
+	t.Cleanup(func() {
 		err := client.DeleteExternalService(esID, false)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	// Triggering the sync job to set permissions for existing user
 	unrestricted := false
@@ -145,12 +145,12 @@ func TestBitbucketProjectsPermsSync_SetPendingPermissions_NonExistentUsersOnly(t
 		t.Fatal(err)
 	}
 
-	defer func() {
+	t.Cleanup(func() {
 		err := client.DeleteExternalService(esID, false)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	// Triggering the sync job
 	unrestricted := false
@@ -215,12 +215,12 @@ func TestBitbucketProjectsPermsSync_SetPendingPermissions_ExistentAndNonExistent
 		t.Fatal(err)
 	}
 
-	defer func() {
+	t.Cleanup(func() {
 		err := client.DeleteExternalService(esID, false)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	// Triggering the sync job
 	unrestricted := false

--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -40,12 +40,7 @@ func TestExternalService(t *testing.T) {
 		if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 			t.Fatal(err)
 		}
-		t.Cleanup(func() {
-			err := client.DeleteExternalService(esID, false)
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
+		removeExternalServiceAfterTest(t, esID)
 
 		err = client.WaitForReposToBeCloned(slug)
 		if err != nil {
@@ -99,12 +94,7 @@ func TestExternalService_AWSCodeCommit(t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		err := client.DeleteExternalService(esID, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+	removeExternalServiceAfterTest(t, esID)
 
 	const repoName = "aws/test"
 	err = client.WaitForReposToBeCloned(repoName)
@@ -151,12 +141,7 @@ func TestExternalService_BitbucketServer(t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		err := client.DeleteExternalService(esID, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+	removeExternalServiceAfterTest(t, esID)
 
 	const repoName = "bbs/SOURCEGRAPH/jsonrpc2"
 	err = client.WaitForReposToBeCloned(repoName)
@@ -238,12 +223,7 @@ func createPerforceExternalService(t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		err := client.DeleteExternalService(esID, true)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+	removeExternalServiceAfterTest(t, esID)
 }
 
 func TestExternalService_AsyncDeletion(t *testing.T) {
@@ -293,4 +273,13 @@ func TestExternalService_AsyncDeletion(t *testing.T) {
 	if !strings.Contains(err.Error(), "external service not found") {
 		t.Fatalf("Not found error should be returned, got: %s", err.Error())
 	}
+}
+
+func removeExternalServiceAfterTest(t *testing.T, esID string) {
+	t.Cleanup(func() {
+		err := client.DeleteExternalService(esID, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -40,12 +40,12 @@ func TestExternalService(t *testing.T) {
 		if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 			t.Fatal(err)
 		}
-		defer func() {
+		t.Cleanup(func() {
 			err := client.DeleteExternalService(esID, false)
 			if err != nil {
 				t.Fatal(err)
 			}
-		}()
+		})
 
 		err = client.WaitForReposToBeCloned(slug)
 		if err != nil {
@@ -99,12 +99,12 @@ func TestExternalService_AWSCodeCommit(t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 		t.Fatal(err)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		err := client.DeleteExternalService(esID, false)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	const repoName = "aws/test"
 	err = client.WaitForReposToBeCloned(repoName)
@@ -151,12 +151,12 @@ func TestExternalService_BitbucketServer(t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 		t.Fatal(err)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		err := client.DeleteExternalService(esID, false)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	const repoName = "bbs/SOURCEGRAPH/jsonrpc2"
 	err = client.WaitForReposToBeCloned(repoName)
@@ -198,11 +198,6 @@ func TestExternalService_Perforce(t *testing.T) {
 }
 
 func checkPerforceEnvironment(t *testing.T) {
-	// context: https://sourcegraph.slack.com/archives/C07KZF47K/p1658178309055259
-	// But it seems that there is still an issue with P4 and they're currently timing out.
-	// cc @mollylogue
-	t.Skip("Currently broken")
-
 	if len(*perforcePort) == 0 || len(*perforceUser) == 0 || len(*perforcePassword) == 0 {
 		t.Skip("Environment variables PERFORCE_PORT, PERFORCE_USER or PERFORCE_PASSWORD are not set")
 	}

--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -276,6 +276,7 @@ func TestExternalService_AsyncDeletion(t *testing.T) {
 }
 
 func removeExternalServiceAfterTest(t *testing.T, esID string) {
+	t.Helper()
 	t.Cleanup(func() {
 		err := client.DeleteExternalService(esID, true)
 		if err != nil {

--- a/dev/gqltest/feature_flag_test.go
+++ b/dev/gqltest/feature_flag_test.go
@@ -10,7 +10,7 @@ func TestFeatureFlags(t *testing.T) {
 	const featureFlagOverrideFragment = `fragment FeatureFlagOverrideData on FeatureFlagOverride {
 		id
 		namespace {
-			id 
+			id
 		}
 		targetFlag {
 			...on FeatureFlagBoolean {
@@ -107,7 +107,7 @@ func TestFeatureFlags(t *testing.T) {
 			deleteFeatureFlag(
 				name: $name,
 			) {
-				alwaysNil		
+				alwaysNil
 			}
 		}`
 		params := map[string]any{"name": name}
@@ -311,9 +311,7 @@ func TestFeatureFlags(t *testing.T) {
 
 		userID, err := client.CreateUser("testuseroverrides", "test@override.com")
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			client.DeleteUser(userID, true)
-		})
+		removeTestUserAfterTest(t, userID)
 
 		boolTrue := true
 		flag, err := createFeatureFlag("test_override", &boolTrue, nil)

--- a/dev/gqltest/repository_test.go
+++ b/dev/gqltest/repository_test.go
@@ -36,12 +36,7 @@ func TestRepository(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		err := client.DeleteExternalService(esID, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
+	removeExternalServiceAfterTest(t, esID)
 
 	err = client.WaitForReposToBeCloned(
 		"github.com/sgtest/go-diff",
@@ -99,12 +94,7 @@ func TestRepository_NameWithSpace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		err := client.DeleteExternalService(esID, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
+	removeExternalServiceAfterTest(t, esID)
 
 	err = client.WaitForReposToBeCloned(
 		"sourcegraph.visualstudio.com/Test Repo",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -23,7 +23,7 @@ func TestSearch(t *testing.T) {
 	}
 
 	// Set up external service
-	_, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
+	esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "gqltest-github-search",
 		Config: mustMarshalJSONString(struct {
@@ -50,6 +50,7 @@ func TestSearch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	removeExternalServiceAfterTest(t, esID)
 
 	err = client.WaitForReposToBeCloned(
 		"github.com/sgtest/java-langserver",

--- a/dev/gqltest/site_config_test.go
+++ b/dev/gqltest/site_config_test.go
@@ -67,6 +67,7 @@ func TestSiteConfig(t *testing.T) {
 }
 
 func removeTestUserAfterTest(t *testing.T, userID string) {
+	t.Helper()
 	t.Cleanup(func() {
 		if err := client.DeleteUser(userID, true); err != nil {
 			t.Fatal(err)

--- a/dev/gqltest/site_config_test.go
+++ b/dev/gqltest/site_config_test.go
@@ -17,12 +17,7 @@ func TestSiteConfig(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			err := client.DeleteUser(testClient1.AuthenticatedUserID(), true)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		removeTestUserAfterTest(t, testClient1.AuthenticatedUserID())
 
 		// Update site configuration to not allow sign up for builtin auth provider.
 		siteConfig, err := client.SiteConfiguration()
@@ -62,15 +57,18 @@ func TestSiteConfig(t *testing.T) {
 				}
 				t.Fatal(err)
 			}
-			defer func() {
-				err := client.DeleteUser(testClient2.AuthenticatedUserID(), true)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}()
+			removeTestUserAfterTest(t, testClient2.AuthenticatedUserID())
 			return gqltestutil.ErrContinueRetry
 		})
 		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func removeTestUserAfterTest(t *testing.T, userID string) {
+	t.Cleanup(func() {
+		if err := client.DeleteUser(userID, true); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -15,6 +16,7 @@ import (
 const (
 	perforceRepoName = "perforce/test-perms"
 	aliceEmail       = "alice@perforce.sgdev.org"
+	aliceUsername    = "alice"
 )
 
 func TestSubRepoPermissionsPerforce(t *testing.T) {
@@ -204,9 +206,10 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 		}
 		// Alice should have access to only 1 commit at the moment (other 2 commits modify hack.sh which is
 		// inaccessible for Alice)
+		// TODO: Alice now has access to 2 commits with recent code changes to update the filtering of commits when sub-repo perms are enabled
 		commitsNumber := len(results.Results)
-		if commitsNumber != 1 {
-			t.Fatalf("Should have access to 1 commit but got %d", commitsNumber)
+		if commitsNumber != 2 {
+			t.Fatalf("Should have access to 2 commits but got %d", commitsNumber)
 		}
 	})
 
@@ -216,6 +219,7 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 		hasAccess bool
 	}{
 		{
+			// I'm not seeing this commit at all in the commit history. Is it just a commit that doesn't exist at all?
 			name:     "direct access to inaccessible commit",
 			revision: "87440329a7bae580b90280aaaafdc14ee7c1f8ef",
 		},
@@ -224,10 +228,13 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 			revision:  "36d7eda16b9a881ef153126a4036efc4f6afb0c1",
 			hasAccess: true,
 		},
-		{
-			name:     "direct access to inaccessible commit-2",
-			revision: "d9d835aa4b08e1dcb06a21a6dffe6e44f0a141d1",
-		},
+		// TODO: this commit now can be accessed since we've updated our handling of commit filtering to show commits that modify _any_ file the user has access to
+		// we just filter out the files the user doesn't have access to when showing the diff. The todo is to add a new commit that modifies _only_ a file that the user
+		// doesn't have access to, and add that here instead.
+		//{
+		//	name:     "direct access to inaccessible commit-2",
+		//	revision: "d9d835aa4b08e1dcb06a21a6dffe6e44f0a141d1",
+		//},
 	}
 
 	for _, test := range commitAccessTests {
@@ -279,7 +286,7 @@ func createTestUserAndWaitForRepo(t *testing.T) (*gqltestutil.Client, string) {
 	// Alice doesn't have access to Security directory. (there is a .sh file)
 	alicePassword := "alicessupersecurepassword"
 	t.Log("Creating Alice")
-	userClient, err := gqltestutil.SignUp(*baseURL, aliceEmail, "alice", alicePassword)
+	userClient, err := gqltestutil.SignUpOrSignIn(*baseURL, aliceEmail, aliceUsername, alicePassword)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +306,33 @@ func createTestUserAndWaitForRepo(t *testing.T) (*gqltestutil.Client, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	syncUserPerms(t, aliceID, aliceUsername)
 	return userClient, perforceRepoName
+}
+
+func syncUserPerms(t *testing.T, userID, userName string) {
+	t.Helper()
+	err := client.ScheduleUserPermissionsSync(userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait up to 30 seconds for the user to have permissions synced
+	// from the code host at least once.
+	err = gqltestutil.Retry(30*time.Second, func() error {
+		userPermsInfo, err := client.UserPermissionsInfo(userName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if userPermsInfo != nil && !userPermsInfo.SyncedAt.IsZero() {
+			return nil
+		}
+		return gqltestutil.ErrContinueRetry
+	})
+	if err != nil {
+		t.Fatal("Waiting for user permissions to be synced:", err)
+	}
 }
 
 func enableSubRepoPermissions(t *testing.T) {

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -292,11 +292,7 @@ func createTestUserAndWaitForRepo(t *testing.T) (*gqltestutil.Client, string) {
 	}
 
 	aliceID := userClient.AuthenticatedUserID()
-	t.Cleanup(func() {
-		if err := client.DeleteUser(aliceID, true); err != nil {
-			t.Fatal(err)
-		}
-	})
+	removeTestUserAfterTest(t, aliceID)
 
 	if err := client.SetUserEmailVerified(aliceID, aliceEmail, true); err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -802,20 +802,6 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		p.IDs[int32(externalServicesRepoIDs[i])] = struct{}{}
 	}
 
-	// NOTE: Please read the docstring of permsUpdateLock field for reasoning of the lock.
-	s.permsUpdateLock.Lock()
-	defer s.permsUpdateLock.Unlock()
-
-	err = s.permsStore.SetUserPermissions(ctx, p)
-	if err != nil {
-		return errors.Wrap(err, "set user permissions")
-	}
-
-	logger.Debug("synced",
-		log.Int("count", len(p.IDs)),
-		log.Object("fetchOpts", log.Bool("InvalidateCache", fetchOpts.InvalidateCaches)),
-	)
-
 	// Set sub-repository permissions
 	srp := s.db.SubRepoPerms()
 	for spec, perm := range subRepoPerms {
@@ -829,6 +815,20 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 			log.Int("count", len(subRepoPerms)),
 		)
 	}
+
+	// NOTE: Please read the docstring of permsUpdateLock field for reasoning of the lock.
+	s.permsUpdateLock.Lock()
+	defer s.permsUpdateLock.Unlock()
+
+	err = s.permsStore.SetUserPermissions(ctx, p)
+	if err != nil {
+		return errors.Wrap(err, "set user permissions")
+	}
+
+	logger.Debug("synced",
+		log.Int("count", len(p.IDs)),
+		log.Object("fetchOpts", log.Bool("InvalidateCache", fetchOpts.InvalidateCaches)),
+	)
 
 	return nil
 }

--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -48,6 +48,14 @@ func SignUp(baseURL, email, username, password string) (*Client, error) {
 	})
 }
 
+func SignUpOrSignIn(baseURL, email, username, password string) (*Client, error) {
+	client, err := SignUp(baseURL, email, username, password)
+	if err != nil {
+		return SignIn(baseURL, email, password)
+	}
+	return client, err
+}
+
 // SignIn performs the sign in with given user credentials.
 // It returns an authenticated client as the user for doing testing.
 func SignIn(baseURL, email, password string) (*Client, error) {

--- a/internal/gqltestutil/permissions.go
+++ b/internal/gqltestutil/permissions.go
@@ -27,6 +27,61 @@ mutation ScheduleRepositoryPermissionsSync($repository: ID!) {
 	return nil
 }
 
+// ScheduleUserPermissionsSync schedules a permissions syncing request for
+// the given user.
+func (c *Client) ScheduleUserPermissionsSync(id string) error {
+	const query = `
+mutation ScheduleUserPermissionsSync($user: ID!) {
+	scheduleUserPermissionsSync(user: $user) {
+		alwaysNil
+	}
+}
+`
+	variables := map[string]any{
+		"user": id,
+	}
+	err := c.GraphQL("", query, variables, nil)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+	return nil
+}
+
+// UserPermissionsInfo returns permissions information of the given
+// user.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) UserPermissionsInfo(name string) (*PermissionsInfo, error) {
+	const query = `
+query UserPermissionsInfo($name: String!) {
+	user(username: $name) {
+		permissionsInfo {
+			syncedAt
+			updatedAt
+			permissions
+			unrestricted
+		}
+	}
+}
+`
+	variables := map[string]any{
+		"name": name,
+	}
+	var resp struct {
+		Data struct {
+			User struct {
+				*PermissionsInfo `json:"permissionsInfo"`
+			} `json:"user"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.User.PermissionsInfo, nil
+}
+
 type BitbucketProjectPermsSyncArgs struct {
 	ProjectKey      string
 	CodeHost        string


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/40149

Fixed the integration tests and unskip

What was fixed:
- `PERFORCE_PASSWORD` set to correct value
-  p4 protects table in test perforce instance issues resolved
- Test flakiness resolved by forcing permissions sync before running test cases

## Test plan
Tested locally and it works. Validated that integration tests now pass in CI as well.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
