### PR TITLE
add no diff step

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -50,6 +50,10 @@ func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *oper
 	if targets := changed.GetLinterTargets(diff); len(targets) > 0 {
 		linterOps.Append(addSgLints(targets))
 	}
+	// Use for empty diff
+	if diff.Has(changed.None) {
+		linterOps.Append(noDiff)
+	}
 
 	ops.Merge(linterOps)
 
@@ -622,6 +626,11 @@ func testUpgrade(candidateTag, minimumUpgradeableVersion string) operations.Oper
 			bk.Cmd("dev/ci/integration/upgrade/run.sh"),
 			bk.ArtifactPaths("./*.png", "./*.mp4", "./*.log"))
 	}
+}
+
+func noDiff(pipeline *bk.Pipeline) {
+	pipeline.AddStep(":empty_nest: No valid diff found. No tests to run.",
+		bk.Cmd("echo 'No diff found on branch.'"))
 }
 
 func clusterQA(candidateTag string) operations.Operation {


### PR DESCRIPTION
Adds a very crude step to avoid empty pipelines trying to be uploaded if a user changes a file we don't yet capture by another linter eg: https://github.com/sourcegraph/sourcegraph/pull/40218

Current error:
```
2022-08-10 16:43:09 WARN   POST https://agent.buildkite.com/v3/jobs/018288a2-e0a3-4613-a6b9-4f62910c871b/pipelines: 422 The `steps` property is required for a group (Attempt 0/60 Retrying in -2562047h47m11.854775807s)
--
  | 2022-08-10 11:43:09 CST | 2022-08-10 16:43:09 ERROR  Unrecoverable error, skipping retries
  | 2022-08-10 11:43:09 CST | 2022-08-10 16:43:09 FATAL  Failed to upload and process pipeline: POST https://agent.buildkite.com/v3/jobs/018288a2-e0a3-4613-a6b9-4f62910c871b/pipelines: 422 The `steps` property is required for a group
  | 2022-08-10 11:43:09 CST | 🚨 Error: The command exited with status 1

```
## Test plan

![image](https://user-images.githubusercontent.com/2067825/184044448-207334fc-1358-407f-b4dd-393dd885c14f.png)


https://buildkite.com/sourcegraph/sourcegraph/builds/166470#01828a3a-5687-4ae8-b0bf-c91797492e94