### PR TITLE
Search backend: make isGlobal operate on search.RepoOptions

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -86,7 +86,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 		resultTypes := computeResultTypes(types, b, inputs.PatternType)
 		fileMatchLimit := int32(computeFileMatchLimit(b, inputs.Protocol))
 		selector, _ := filter.SelectPathFromString(b.FindValue(query.FieldSelect)) // Invariant: select is validated
-		repoOptions := ToRepoOptions(b, inputs.UserSettings)
+		repoOptions := toRepoOptions(b, inputs.UserSettings)
 		repoUniverseSearch, skipRepoSubsetSearch, runZoektOverRepos := jobMode(b, repoOptions, resultTypes, inputs.PatternType, inputs.OnSourcegraphDotCom)
 
 		builder := &jobBuilder{
@@ -294,7 +294,7 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 	fileMatchLimit := int32(computeFileMatchLimit(f.ToBasic(), searchInputs.Protocol))
 	selector, _ := filter.SelectPathFromString(f.FindValue(query.FieldSelect)) // Invariant: select is validated
 
-	repoOptions := ToRepoOptions(f.ToBasic(), searchInputs.UserSettings)
+	repoOptions := toRepoOptions(f.ToBasic(), searchInputs.UserSettings)
 
 	_, skipRepoSubsetSearch, _ := jobMode(f.ToBasic(), repoOptions, resultTypes, searchInputs.PatternType, searchInputs.OnSourcegraphDotCom)
 
@@ -597,7 +597,7 @@ func computeResultTypes(types []string, b query.Basic, searchType query.SearchTy
 	return rts
 }
 
-func ToRepoOptions(b query.Basic, userSettings *schema.Settings) search.RepoOptions {
+func toRepoOptions(b query.Basic, userSettings *schema.Settings) search.RepoOptions {
 	repoFilters, minusRepoFilters := b.Repositories()
 
 	var settingForks, settingArchived bool

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/structural"
 	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
@@ -749,7 +748,7 @@ func jobMode(b query.Basic, repoOptions search.RepoOptions, resultTypes result.T
 	noLang := !b.Exists(query.FieldLang)
 	isEmpty := noPattern && noFile && noLang
 
-	repoUniverseSearch = isGlobalSearch() && isIndexedSearch && hasGlobalSearchResultType && !isEmpty
+	repoUniverseSearch = isGlobalSearch && isIndexedSearch && hasGlobalSearchResultType && !isEmpty
 	// skipRepoSubsetSearch is a value that controls whether to
 	// run unindexed search in a specific scenario of queries that
 	// contain no repo-affecting filters (global mode). When on

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -345,6 +346,9 @@ func (f *Features) String() string {
 	return flagMap.String()
 }
 
+// RepoOptions is the source of truth for the options a user specified
+// in their search query that affect which repos should be searched.
+// When adding fields to this struct, be sure to update IsGlobal().
 type RepoOptions struct {
 	RepoFilters         []string
 	MinusRepoFilters    []string

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -79,6 +79,8 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 	return zoekt.Simplify(zoekt.NewAnd(and...)), nil
 }
 
+// IsGlobal returns whether a given set of repo options can be fulfilled
+// with a global search with Zoekt.
 func IsGlobal(op search.RepoOptions) bool {
 	// We do not do global searches if a repo: filter was specified. I
 	// (@camdencheek) could not find any documentation or historical reasons

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	zoekt "github.com/google/zoekt/query"
@@ -76,6 +77,84 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 	}
 
 	return zoekt.Simplify(zoekt.NewAnd(and...)), nil
+}
+
+func IsGlobal(op search.RepoOptions) bool {
+	// We do not do global searches if a repo: filter was specified. I
+	// (@camdencheek) could not find any documentation or historical reasons
+	// for why this is, so I'm going to speculate here for future wanderers.
+	//
+	// If a user specifies a single repo, that repo may or may not be indexed
+	// but we still want to search it. A Zoekt search will not tell us that a
+	// search returned no results because the repo filtered to was unindexed,
+	// it will just return no results.
+	//
+	// Additionally, if a user specifies a repo: filter, they are likely
+	// targeting only a few repos, so the benefits of running a filtered global
+	// search vs just paging over the few repos that match the query are
+	// probably do not outweigh the cost of potentially skipping unindexed
+	// repos.
+	//
+	// We see this assumption break down with filters like `repo:github.com/`
+	// or `repo:.*`, in which case a global search would be much faster than
+	// paging through all the repos.
+	if len(op.RepoFilters) > 0 {
+		return false
+	}
+
+	// Zoekt does not know about repo descriptions, so we depend on the
+	// database to handle this filter.
+	if len(op.DescriptionPatterns) > 0 {
+		return false
+	}
+
+	// If a search context is specified, we do not know ahead of time whether
+	// the repos in the context are indexed and we need to go through the repo
+	// resolution process.
+	if !searchcontexts.IsGlobalSearchContextSpec(op.SearchContextSpec) {
+		return false
+	}
+
+	// repo:has.commit.after() is handled during the repo resolution step,
+	// and we cannot depend on Zoekt for this information.
+	if op.CommitAfter != "" {
+		return false
+	}
+
+	// There should be no cursors when calling this, but if there are that
+	// means we're already paginating. Cursors should probably not live on this
+	// struct since they are an implementation detail of pagination.
+	if len(op.Cursors) > 0 {
+		return false
+	}
+
+	// If indexed search is explicitly disabled, that implicitly means global
+	// search is also disabled since global search means Zoekt.
+	if op.UseIndex == query.No {
+		return false
+	}
+
+	// For now, we handle all repo:has.file and repo:has.content during repo
+	// pagination. Zoekt can handle this, so we should push this down to Zoekt
+	// and allow global search with these filters.
+	if len(op.HasFileContent) > 0 {
+		return false
+	}
+
+	// All the fields not mentioned above can be handled by Zoekt global search.
+	// Listing them here for posterity:
+	// - MinusRepoFilters
+	// - CaseSensitiveRepoFilters
+	// - Visibility
+	// - Limit
+	// - ForkSet
+	// - NoForks
+	// - OnlyForks
+	// - OnlyCloned
+	// - ArchivedSet
+	// - NoArchived
+	// - OnlyArchived
+	return true
 }
 
 func toZoektPattern(

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	zoekt "github.com/google/zoekt/query"
@@ -77,86 +76,6 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 	}
 
 	return zoekt.Simplify(zoekt.NewAnd(and...)), nil
-}
-
-// IsGlobal returns whether a given set of repo options can be fulfilled
-// with a global search with Zoekt.
-func IsGlobal(op search.RepoOptions) bool {
-	// We do not do global searches if a repo: filter was specified. I
-	// (@camdencheek) could not find any documentation or historical reasons
-	// for why this is, so I'm going to speculate here for future wanderers.
-	//
-	// If a user specifies a single repo, that repo may or may not be indexed
-	// but we still want to search it. A Zoekt search will not tell us that a
-	// search returned no results because the repo filtered to was unindexed,
-	// it will just return no results.
-	//
-	// Additionally, if a user specifies a repo: filter, they are likely
-	// targeting only a few repos, so the benefits of running a filtered global
-	// search vs just paging over the few repos that match the query are
-	// probably do not outweigh the cost of potentially skipping unindexed
-	// repos.
-	//
-	// We see this assumption break down with filters like `repo:github.com/`
-	// or `repo:.*`, in which case a global search would be much faster than
-	// paging through all the repos.
-	if len(op.RepoFilters) > 0 {
-		return false
-	}
-
-	// Zoekt does not know about repo descriptions, so we depend on the
-	// database to handle this filter.
-	if len(op.DescriptionPatterns) > 0 {
-		return false
-	}
-
-	// If a search context is specified, we do not know ahead of time whether
-	// the repos in the context are indexed and we need to go through the repo
-	// resolution process.
-	if !searchcontexts.IsGlobalSearchContextSpec(op.SearchContextSpec) {
-		return false
-	}
-
-	// repo:has.commit.after() is handled during the repo resolution step,
-	// and we cannot depend on Zoekt for this information.
-	if op.CommitAfter != "" {
-		return false
-	}
-
-	// There should be no cursors when calling this, but if there are that
-	// means we're already paginating. Cursors should probably not live on this
-	// struct since they are an implementation detail of pagination.
-	if len(op.Cursors) > 0 {
-		return false
-	}
-
-	// If indexed search is explicitly disabled, that implicitly means global
-	// search is also disabled since global search means Zoekt.
-	if op.UseIndex == query.No {
-		return false
-	}
-
-	// For now, we handle all repo:has.file and repo:has.content during repo
-	// pagination. Zoekt can handle this, so we should push this down to Zoekt
-	// and allow global search with these filters.
-	if len(op.HasFileContent) > 0 {
-		return false
-	}
-
-	// All the fields not mentioned above can be handled by Zoekt global search.
-	// Listing them here for posterity:
-	// - MinusRepoFilters
-	// - CaseSensitiveRepoFilters
-	// - Visibility
-	// - Limit
-	// - ForkSet
-	// - NoForks
-	// - OnlyForks
-	// - OnlyCloned
-	// - ArchivedSet
-	// - NoArchived
-	// - OnlyArchived
-	return true
 }
 
 func toZoektPattern(


### PR DESCRIPTION
This is a followup from [this comment](https://github.com/sourcegraph/sourcegraph/pull/38988#discussion_r924834963). 

Basically, `isGlobal` should operate on the `RepoOptions` type rather than the raw query now that the repo options type has all information about what repositories should be searched.

`isGlobal` is not a method on `RepoOptions` because our backend packages are too intertwined and this causes circular import issues.

As part of this, I documented that method heavily because I've historically been quite confused about its behavior. 

## Test plan

Depending on existing tests. Should be semantics-preserving -- it's just moving logic around. 
