### PR TITLE
Search backend: allow repo:contains in global searches

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -908,17 +908,11 @@ func isGlobal(op search.RepoOptions) bool {
 		return false
 	}
 
-	// For now, we handle all repo:has.file and repo:has.content during repo
-	// pagination. Zoekt can handle this, so we should push this down to Zoekt
-	// and allow global search with these filters.
-	if len(op.HasFileContent) > 0 {
-		return false
-	}
-
 	// All the fields not mentioned above can be handled by Zoekt global search.
 	// Listing them here for posterity:
 	// - MinusRepoFilters
 	// - CaseSensitiveRepoFilters
+	// - HasFileContent
 	// - Visibility
 	// - Limit
 	// - ForkSet

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -60,6 +60,14 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 		and = append(and, &zoekt.Not{Child: q})
 	}
 
+	var repoHasFilters []zoekt.Q
+	for _, filter := range b.RepoHasFileContent() {
+		repoHasFilters = append(repoHasFilters, QueryForFileContentArgs(filter, isCaseSensitive))
+	}
+	if len(repoHasFilters) > 0 {
+		and = append(and, &zoekt.Type{Type: zoekt.TypeRepo, Child: zoekt.NewAnd(repoHasFilters...)})
+	}
+
 	// Languages are already partially expressed with IncludePatterns, but Zoekt creates
 	// more precise language metadata based on file contents analyzed by go-enry, so it's
 	// useful to pass lang: queries down.

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -1,6 +1,8 @@
 package zoekt
 
 import (
+	"regexp/syntax"
+
 	"github.com/go-enry/go-enry/v2"
 	"github.com/grafana/regexp"
 
@@ -76,6 +78,24 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 	}
 
 	return zoekt.Simplify(zoekt.NewAnd(and...)), nil
+}
+
+func QueryForFileContentArgs(opt query.RepoHasFileContentArgs, caseSensitive bool) zoekt.Q {
+	var children []zoekt.Q
+	if opt.Path != "" {
+		re, _ := syntax.Parse(opt.Path, 0)
+		children = append(children, &zoekt.Regexp{Regexp: re, FileName: true, CaseSensitive: caseSensitive})
+	}
+	if opt.Content != "" {
+		re, _ := syntax.Parse(opt.Content, 0)
+		children = append(children, &zoekt.Regexp{Regexp: re, Content: true, CaseSensitive: caseSensitive})
+	}
+	q := zoekt.NewAnd(children...)
+	if opt.Negated {
+		q = &zoekt.Not{Child: q}
+	}
+	q = zoekt.Simplify(q)
+	return q
 }
 
 func toZoektPattern(


### PR DESCRIPTION
This updates our global search and zoekt logic to allow `repo:contains.file()` and `repo:contains.content()` in global searches. 

This is a followup from @keegancsmith's [comment](https://github.com/sourcegraph/sourcegraph/issuese/39392#issuecomment-1195127618). Basically, it makes these searches _way_ faster when the only `repo:` filters are `repo:contains.file()` or `repo:contains.content()` because we don't have to paginate through all the repos 4k at a time. I didn't do this at the time because I was just trying to untangle concerns, but this turns out to be a fairly minimal change. 

Stacked on #40236 
Related to https://github.com/sourcegraph/sourcegraph/issues/39392

## Test plan

Backend integration tests + manual smoke testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
