### PR TITLE
FilterControl: `values` doesn't need a `FilteredConnectionFilterValue`

### DIFF
--- a/client/web/src/components/FilteredConnection/FilterControl.tsx
+++ b/client/web/src/components/FilteredConnection/FilterControl.tsx
@@ -40,7 +40,10 @@ interface FilterControlProps {
     /** Called when a filter is selected. */
     onValueSelect: (filter: FilteredConnectionFilter, value: FilteredConnectionFilterValue) => void
 
-    values: Map<string, FilteredConnectionFilterValue>
+    /** Default values for each filter: the key must match the ID of a filter in
+     * filters, and the value must match the value of one of that filter's
+     * FilteredConnectionFilterValue elements. */
+    values: Map<string, string>
 }
 
 export const FilterControl: React.FunctionComponent<React.PropsWithChildren<FilterControlProps>> = ({
@@ -69,7 +72,7 @@ export const FilterControl: React.FunctionComponent<React.PropsWithChildren<Filt
                             key={filter.id}
                             name={filter.id}
                             className="d-inline-flex flex-row"
-                            selected={values.get(filter.id)?.value}
+                            selected={values.get(filter.id)}
                             nodes={filter.values.map(({ value, label, tooltip }) => ({
                                 tooltip,
                                 label,
@@ -93,7 +96,7 @@ export const FilterControl: React.FunctionComponent<React.PropsWithChildren<Filt
                                     id=""
                                     name={filter.id}
                                     onChange={event => onChange(filter, event.currentTarget.value)}
-                                    value={values.get(filter.id)?.value}
+                                    value={values.get(filter.id)}
                                     className="mb-0"
                                 >
                                     {filter.values.map(value => (

--- a/client/web/src/components/FilteredConnection/ui/ConnectionForm.tsx
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionForm.tsx
@@ -47,7 +47,10 @@ export interface ConnectionFormProps {
     /** An element rendered as a sibling of the filters. */
     additionalFilterElement?: React.ReactElement
 
-    values?: Map<string, FilteredConnectionFilterValue>
+    /** Default values for each filter: the key must match the ID of a filter in
+     * filters, and the value must match the value of one of that filter's
+     * FilteredConnectionFilterValue elements. */
+    values?: Map<string, string>
 
     compact?: boolean
 }


### PR DESCRIPTION
The label and arguments that are otherwise included in `FilteredConnectionFilterValue` are unnecessary in `values`, since we only need the actual value to set the `selected` attributes appropriately. This saves some boilerplate when using filters with `ConnectionForm`.

This is a change I'm making in #40238 as part of moving the executor site admin page away from RxJS (and adding a bunch of new features), but I want to get a review on this separately because I can't help but feel like I'm missing something about the design of this. Basically, the difference here is that without this PR, you have to do something like this:

```ts
                <ConnectionForm
                    filters={filters}
                    values={new Map([['state', {value: state, args: [], label: "ignored"}]])}
                />
```

And with it, you can do this, with no functional difference:

```ts
                <ConnectionForm
                    filters={filters}
                    values={new Map([['state', state]])}
                />
```

(Which is still a bit wordy, since you have to instantiate a `Map` and all, but could be worse.)

## Test plan

There are no users of this right now, but this will be implicitly tested once #40238 lands.