### PR TITLE
Add support for dynamic content in homepage query examples

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -36,6 +36,12 @@ export interface TemporarySettingsSchema {
     'onboarding.quickStartTour': TourListState
     'coreWorkflowImprovements.enabled': boolean
     'characterKeyShortcuts.enabled': boolean
+    'search.homepage.queryExamplesContent': {
+        lastCachedTimestamp: string
+        repositoryName: string
+        filePath: string
+        author: string
+    }
 }
 
 /**

--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -6,6 +6,8 @@
     border-radius: var(--border-radius);
     padding: 0.125rem 0.375rem;
     font-size: 0.75rem;
+    max-width: 20rem;
+    text-align: left;
 
     &:hover {
         border: 1px solid var(--border-color);

--- a/client/web/src/search/home/QueryExamplesHomepage.tsx
+++ b/client/web/src/search/home/QueryExamplesHomepage.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
 import { EditorHint, QueryState } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Icon, Link } from '@sourcegraph/wildcard'
+import { Button } from '@sourcegraph/wildcard'
+
+import { useQueryExamples } from './useQueryExamples'
 
 import styles from './QueryExamplesHomepage.module.scss'
 
@@ -14,58 +15,6 @@ export interface QueryExamplesHomepageProps extends TelemetryProps {
     queryState: QueryState
     setQueryState: (newState: QueryState) => void
 }
-
-const queryExampleSectionsColumns = [
-    [
-        {
-            title: 'Scope search to specific repos',
-            queryExamples: [
-                { id: 'single-repo', query: 'repo:awesomecorp/big-repo' },
-                { id: 'org-repos', query: 'repo:awesomecorp/*' },
-            ],
-        },
-        {
-            title: 'Jump into code navigation',
-            queryExamples: [
-                { id: 'file-filter', query: 'file:examplefile.go' },
-                { id: 'type-symbol', query: 'type:symbol Handler' },
-            ],
-        },
-        {
-            title: 'Get specific',
-            queryExamples: [
-                { id: 'author', query: 'author:logansmith' },
-                { id: 'before-after-filters', query: 'before:today after:earlydate' },
-            ],
-        },
-    ],
-    [
-        {
-            title: 'Find exact matches',
-            queryExamples: [{ id: 'exact-matches', query: 'some error message', helperText: 'No quotes needed' }],
-        },
-        {
-            title: 'Operators',
-            queryExamples: [
-                { id: 'or-operator', query: 'lang:javascript OR lang:typescript' },
-                { id: 'and-operator', query: 'example AND secondexample' },
-                { id: 'not-operator', query: 'lang:go NOT file:main.go' },
-            ],
-        },
-        {
-            title: 'Get advanced',
-            queryExamples: [{ id: 'contains-commit-after', query: 'repo:contains.commit.after(yesterday)' }],
-            footer: (
-                <small className="d-block mt-3">
-                    <Link target="blank" to="/help/code_search/reference/queries">
-                        Complete query reference{' '}
-                        <Icon role="img" aria-label="Open in a new tab" svgPath={mdiOpenInNew} />
-                    </Link>
-                </small>
-            ),
-        },
-    ],
-]
 
 type Tip = 'rev' | 'lang' | 'type-commit-diff'
 
@@ -91,6 +40,8 @@ export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepag
 }) => {
     const [selectedTip, setSelectedTip] = useState<Tip | null>(null)
     const [selectTipTimeout, setSelectTipTimeout] = useState<NodeJS.Timeout>()
+
+    const queryExampleSectionsColumns = useQueryExamples()
 
     const onQueryExampleClick = useCallback(
         (id: string | undefined, query: string) => {
@@ -190,15 +141,17 @@ export const QueryExamplesSection: React.FunctionComponent<QueryExamplesSection>
     <div className={styles.queryExamplesSection}>
         <div className={styles.queryExamplesSectionTitle}>{title}</div>
         <div className={styles.queryExamplesItems}>
-            {queryExamples.map(({ id, query, helperText }) => (
-                <QueryExampleChip
-                    id={id}
-                    key={query}
-                    query={query}
-                    helperText={helperText}
-                    onClick={onQueryExampleClick}
-                />
-            ))}
+            {queryExamples
+                .filter(({ query }) => query.length > 0)
+                .map(({ id, query, helperText }) => (
+                    <QueryExampleChip
+                        id={id}
+                        key={query}
+                        query={query}
+                        helperText={helperText}
+                        onClick={onQueryExampleClick}
+                    />
+                ))}
         </div>
         {footer}
     </div>

--- a/client/web/src/search/home/useQueryExamples.tsx
+++ b/client/web/src/search/home/useQueryExamples.tsx
@@ -1,0 +1,189 @@
+import React, { useMemo, useEffect, useState } from 'react'
+
+import { mdiOpenInNew } from '@mdi/js'
+import { differenceInHours, formatISO, parseISO } from 'date-fns'
+
+import { streamComputeQuery } from '@sourcegraph/shared/src/search/stream'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { Icon, Link } from '@sourcegraph/wildcard'
+
+export interface QueryExamplesContent {
+    repositoryName: string
+    filePath: string
+    author: string
+}
+
+interface QueryExample {
+    title: string
+    queryExamples: {
+        id: string
+        query: string
+        helperText?: string
+    }[]
+    footer?: React.ReactElement
+}
+
+interface ComputeResult {
+    kind: string
+    value: string
+}
+
+const defaultQueryExamplesContent = {
+    repositoryName: 'awesomecorp/big-repo',
+    author: 'logansmith',
+    filePath: 'examplefile.go',
+}
+
+function hasQueryExamplesContentCacheExpired(lastCachedTimestamp: string): boolean {
+    return differenceInHours(Date.now(), parseISO(lastCachedTimestamp)) > 24
+}
+
+function quoteIfNeeded(value: string): string {
+    return value.includes(' ') ? `"${value}"` : value
+}
+
+function getQueryExamplesContentFromComputeOutput(computeOutput: string): QueryExamplesContent {
+    const [repositoryName, author, filePath] = computeOutput.trim().split(',|')
+    return {
+        repositoryName,
+        filePath,
+        author,
+    }
+}
+
+function getRepoFilterExamples(repositoryName: string): { singleRepoExample: string; orgReposExample?: string } {
+    const repositoryNameParts = repositoryName.split('/')
+
+    if (repositoryNameParts.length <= 1) {
+        return { singleRepoExample: quoteIfNeeded(repositoryName) }
+    }
+
+    const repoName = repositoryNameParts[repositoryNameParts.length - 1]
+    const repoOrg = repositoryNameParts[repositoryNameParts.length - 2]
+    return {
+        singleRepoExample: quoteIfNeeded(`${repoOrg}/${repoName}`),
+        orgReposExample: quoteIfNeeded(`${repoOrg}/*`),
+    }
+}
+
+export function useQueryExamples(): QueryExample[][] {
+    const [queryExamplesContent, setQueryExamplesContent] = useState<QueryExamplesContent>()
+    const [
+        cachedQueryExamplesContent,
+        setCachedQueryExamplesContent,
+        cachedQueryExamplesContentLoadStatus,
+    ] = useTemporarySetting('search.homepage.queryExamplesContent')
+
+    useEffect(() => {
+        if (queryExamplesContent || cachedQueryExamplesContentLoadStatus === 'initial') {
+            return
+        }
+
+        if (
+            cachedQueryExamplesContentLoadStatus === 'loaded' &&
+            cachedQueryExamplesContent &&
+            !hasQueryExamplesContentCacheExpired(cachedQueryExamplesContent.lastCachedTimestamp)
+        ) {
+            setQueryExamplesContent(cachedQueryExamplesContent)
+            return
+        }
+
+        // We are using `,|` as the separator so we can "safely" split the compute output.
+        const subscription = streamComputeQuery(
+            'type:diff count:1 content:output((.|\n)* -> $repo,|$author,|$path)'
+        ).subscribe(
+            results => {
+                const firstComputeOutput = results
+                    .flatMap(result => JSON.parse(result) as ComputeResult)
+                    .find(result => result.kind === 'output')
+
+                const queryExamplesContent = firstComputeOutput
+                    ? getQueryExamplesContentFromComputeOutput(firstComputeOutput.value)
+                    : defaultQueryExamplesContent
+
+                setQueryExamplesContent(queryExamplesContent)
+                setCachedQueryExamplesContent({
+                    ...queryExamplesContent,
+                    lastCachedTimestamp: formatISO(Date.now()),
+                })
+            },
+            () => {
+                // In case of an error set default content.
+                setQueryExamplesContent(defaultQueryExamplesContent)
+            }
+        )
+
+        return () => subscription.unsubscribe()
+    }, [
+        queryExamplesContent,
+        cachedQueryExamplesContent,
+        setCachedQueryExamplesContent,
+        cachedQueryExamplesContentLoadStatus,
+    ])
+
+    return useMemo(() => {
+        if (!queryExamplesContent) {
+            return []
+        }
+        const { repositoryName, filePath, author } = queryExamplesContent
+
+        const { singleRepoExample, orgReposExample } = getRepoFilterExamples(repositoryName)
+        const filePathParts = filePath.split('/')
+        const fileName = quoteIfNeeded(filePathParts[filePathParts.length - 1])
+        const quotedAuthor = quoteIfNeeded(author)
+
+        return [
+            [
+                {
+                    title: 'Scope search to specific repos',
+                    queryExamples: [
+                        { id: 'single-repo', query: `repo:${singleRepoExample}` },
+                        { id: 'org-repos', query: orgReposExample ? `repo:${orgReposExample}` : '' },
+                    ],
+                },
+                {
+                    title: 'Jump into code navigation',
+                    queryExamples: [
+                        { id: 'file-filter', query: `file:${fileName}` },
+                        { id: 'type-symbol', query: 'type:symbol Handler' },
+                    ],
+                },
+                {
+                    title: 'Get specific',
+                    queryExamples: [
+                        { id: 'author', query: `author:${quotedAuthor}` },
+                        { id: 'before-after-filters', query: 'before:today after:earlydate' },
+                    ],
+                },
+            ],
+            [
+                {
+                    title: 'Find exact matches',
+                    queryExamples: [
+                        { id: 'exact-matches', query: 'some error message', helperText: 'No quotes needed' },
+                    ],
+                },
+                {
+                    title: 'Operators',
+                    queryExamples: [
+                        { id: 'or-operator', query: 'lang:javascript OR lang:typescript' },
+                        { id: 'and-operator', query: 'example AND secondexample' },
+                        { id: 'not-operator', query: 'lang:go NOT file:main.go' },
+                    ],
+                },
+                {
+                    title: 'Get advanced',
+                    queryExamples: [{ id: 'contains-commit-after', query: 'repo:contains.commit.after(yesterday)' }],
+                    footer: (
+                        <small className="d-block mt-3">
+                            <Link target="blank" to="/help/code_search/reference/queries">
+                                Complete query reference{' '}
+                                <Icon role="img" aria-label="Open in a new tab" svgPath={mdiOpenInNew} />
+                            </Link>
+                        </small>
+                    ),
+                },
+            ],
+        ]
+    }, [queryExamplesContent])
+}


### PR DESCRIPTION
Fixes #40013

This uses the compute API to gather the necessary data. The results are cached for 24 hours in temporary settings.

## Screenshots

<img width="667" alt="Screenshot 2022-08-11 at 08 08 24" src="https://user-images.githubusercontent.com/6417322/184073646-83a8b58a-1fca-4db4-9c18-517108841bd4.png">

Long query example:

<img width="753" alt="Screenshot 2022-08-11 at 08 20 15" src="https://user-images.githubusercontent.com/6417322/184075151-d67c4204-9f6a-4281-86e7-5bfbec1da129.png">


## Test plan
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Go to the home page
* You should see dynamic content in place of the repo, file, and author filters 

## App preview:

- [Web](https://sg-web-rn-homepage-query-examples.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zbzrorstlt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
