### PR TITLE
Performance: Reduce waterfall fetching by making repo and resolvedRev optional

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -245,7 +245,7 @@ export interface RepoFile extends RepoSpec, RevisionSpec, Partial<ResolvedRevisi
 /**
  * A file at an exact commit
  */
-export interface AbsoluteRepoFile extends RepoSpec, RevisionSpec, ResolvedRevisionSpec, FileSpec {}
+export interface AbsoluteRepoFile extends RepoSpec, RevisionSpec, Partial<ResolvedRevisionSpec>, FileSpec {}
 
 /**
  * A position in file at an exact commit

--- a/client/web/src/repo/FilePathBreadcrumbs.tsx
+++ b/client/web/src/repo/FilePathBreadcrumbs.tsx
@@ -13,7 +13,6 @@ import styles from './FilePathBreadcrumbs.module.scss'
 interface Props extends RepoRevision, TelemetryProps {
     filePath: string
     isDir: boolean
-    repoUrl: string
 }
 
 /**

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -132,7 +132,7 @@ interface Props extends PlatformContextProps, TelemetryProps, BreadcrumbsProps, 
     /**
      * The repository that this header is for.
      */
-    repo:
+    repo?:
         | GQL.IRepository
         | {
               /** The repository's ID, if it has one.
@@ -145,7 +145,10 @@ interface Props extends PlatformContextProps, TelemetryProps, BreadcrumbsProps, 
           }
 
     /** Information about the revision of the repository. */
-    resolvedRev: ResolvedRevision | ErrorLike | undefined
+    resolvedRev?: ResolvedRevision | ErrorLike | undefined
+
+    /** The repoName from the URL */
+    repoName: string
 
     /** The URI-decoded revision (e.g., "my#branch" in "my/repo@my%23branch"). */
     revision?: string
@@ -188,10 +191,10 @@ export const RepoHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
 
     const context: Omit<RepoHeaderContext, 'actionType'> = useMemo(
         () => ({
-            repoName: repo.name,
+            repoName: props.repoName,
             encodedRev: props.revision,
         }),
-        [repo.name, props.revision]
+        [props.repoName, props.revision]
     )
 
     const leftActions = useMemo(

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -34,7 +34,7 @@ import { RepoRevisionSidebarSymbols } from './RepoRevisionSidebarSymbols'
 import styles from './RepoRevisionSidebar.module.scss'
 
 interface Props extends AbsoluteRepoFile, ExtensionsControllerProps, ThemeProps, TelemetryProps {
-    repoID: Scalars['ID']
+    repoID?: Scalars['ID']
     isDir: boolean
     defaultBranch: string
     className: string
@@ -140,37 +140,40 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
                         )}
                     </TabList>
                     <div className={classNames('flex w-100 overflow-auto explorer', styles.tabpanels)} tabIndex={-1}>
-                        <TabPanels>
-                            <TabPanel>
-                                <Tree
-                                    key="files"
-                                    repoName={props.repoName}
-                                    repoID={props.repoID}
-                                    revision={props.revision}
-                                    commitID={props.commitID}
-                                    history={props.history}
-                                    location={props.location}
-                                    scrollRootSelector=".explorer"
-                                    activePath={props.filePath}
-                                    activePathIsDir={props.isDir}
-                                    sizeKey={`Resizable:${SIZE_STORAGE_KEY}`}
-                                    extensionsController={props.extensionsController}
-                                    isLightTheme={props.isLightTheme}
-                                    telemetryService={props.telemetryService}
-                                />
-                            </TabPanel>
-                            {!coreWorkflowImprovementsEnabled && (
+                        {/* TODO: See if we can render more here, instead of waiting for these props */}
+                        {props.repoID && props.commitID && (
+                            <TabPanels>
                                 <TabPanel>
-                                    <RepoRevisionSidebarSymbols
-                                        key="symbols"
+                                    <Tree
+                                        key="files"
+                                        repoName={props.repoName}
                                         repoID={props.repoID}
                                         revision={props.revision}
+                                        commitID={props.commitID}
+                                        history={props.history}
+                                        location={props.location}
+                                        scrollRootSelector=".explorer"
                                         activePath={props.filePath}
-                                        onHandleSymbolClick={handleSymbolClick}
+                                        activePathIsDir={props.isDir}
+                                        sizeKey={`Resizable:${SIZE_STORAGE_KEY}`}
+                                        extensionsController={props.extensionsController}
+                                        isLightTheme={props.isLightTheme}
+                                        telemetryService={props.telemetryService}
                                     />
                                 </TabPanel>
-                            )}
-                        </TabPanels>
+                                {!coreWorkflowImprovementsEnabled && (
+                                    <TabPanel>
+                                        <RepoRevisionSidebarSymbols
+                                            key="symbols"
+                                            repoID={props.repoID}
+                                            revision={props.revision}
+                                            activePath={props.filePath}
+                                            onHandleSymbolClick={handleSymbolClick}
+                                        />
+                                    </TabPanel>
+                                )}
+                            </TabPanels>
+                        )}
                     </div>
                 </Tabs>
             </div>

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -33,13 +33,7 @@ const hideRepoRevisionContent = localStorage.getItem('hideRepoRevContent')
 export const RepositoryFileTreePage: React.FunctionComponent<
     React.PropsWithChildren<RepositoryFileTreePageProps>
 > = props => {
-    const {
-        repo,
-        resolvedRev: { commitID, defaultBranch },
-        match,
-        globbing,
-        ...context
-    } = props
+    const { repo, resolvedRev, repoName, match, globbing, ...context } = props
 
     // The decoding depends on the pinned `history` version.
     // See https://github.com/sourcegraph/sourcegraph/issues/4408
@@ -47,7 +41,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
     const filePath = decodeURIComponent(match.params.filePath || '') // empty string is root
     // Redirect tree and blob routes pointing to the root to the repo page
     if (match.params.objectType && filePath.replace(/\/+$/g, '') === '') {
-        return <Redirect to={toRepoURL({ repoName: repo.name, revision: context.revision })} />
+        return <Redirect to={toRepoURL({ repoName, revision: context.revision })} />
     }
 
     const objectType: 'blob' | 'tree' = match.params.objectType || 'tree'
@@ -83,7 +77,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
     }
 
     const repoRevisionProps = {
-        commitID,
+        commitID: resolvedRev?.commitID,
         filePath,
         globbing,
     }
@@ -93,11 +87,11 @@ export const RepositoryFileTreePage: React.FunctionComponent<
             <RepoRevisionSidebar
                 {...context}
                 {...repoRevisionProps}
-                repoID={repo.id}
-                repoName={repo.name}
+                repoID={repo?.id}
+                repoName={repoName}
                 className="repo-revision-container__sidebar"
                 isDir={objectType === 'tree'}
-                defaultBranch={defaultBranch || 'HEAD'}
+                defaultBranch={resolvedRev?.defaultBranch || 'HEAD'}
             />
             {!hideRepoRevisionContent && (
                 // Add `.blob-status-bar__container` because this is the
@@ -110,9 +104,9 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                                 <BlobPage
                                     {...context}
                                     {...repoRevisionProps}
-                                    repoID={repo.id}
-                                    repoName={repo.name}
-                                    repoUrl={repo.url}
+                                    repoID={repo?.id}
+                                    repoName={repoName}
+                                    repoUrl={repo?.url}
                                     mode={mode}
                                     repoHeaderContributionsLifecycleProps={
                                         context.repoHeaderContributionsLifecycleProps
@@ -124,6 +118,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                                 {...props}
                                 {...repoRevisionProps}
                                 repo={repo}
+                                repoName={repoName}
                                 match={match}
                                 useActionItemsBar={context.useActionItemsBar}
                                 isSourcegraphDotCom={context.isSourcegraphDotCom}

--- a/client/web/src/repo/backend.ts
+++ b/client/web/src/repo/backend.ts
@@ -53,38 +53,35 @@ export const repositoryFragment = gql`
 /**
  * Fetch the repository.
  */
-export const fetchRepository = memoizeObservable(
-    (args: { repoName: string }): Observable<RepositoryFields> =>
-        requestGraphQL<RepositoryRedirectResult, RepositoryRedirectVariables>(
-            gql`
-                query RepositoryRedirect($repoName: String!) {
-                    repositoryRedirect(name: $repoName) {
-                        __typename
-                        ... on Repository {
-                            ...RepositoryFields
-                        }
-                        ... on Redirect {
-                            url
-                        }
+export const fetchRepository = (args: { repoName: string }): Observable<RepositoryFields> =>
+    requestGraphQL<RepositoryRedirectResult, RepositoryRedirectVariables>(
+        gql`
+            query RepositoryRedirect($repoName: String!) {
+                repositoryRedirect(name: $repoName) {
+                    __typename
+                    ... on Repository {
+                        ...RepositoryFields
+                    }
+                    ... on Redirect {
+                        url
                     }
                 }
-                ${repositoryFragment}
-            `,
-            args
-        ).pipe(
-            map(dataOrThrowErrors),
-            map(data => {
-                if (!data.repositoryRedirect) {
-                    throw new RepoNotFoundError(args.repoName)
-                }
-                if (data.repositoryRedirect.__typename === 'Redirect') {
-                    throw new RepoSeeOtherError(data.repositoryRedirect.url)
-                }
-                return data.repositoryRedirect
-            })
-        ),
-    makeRepoURI
-)
+            }
+            ${repositoryFragment}
+        `,
+        args
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => {
+            if (!data.repositoryRedirect) {
+                throw new RepoNotFoundError(args.repoName)
+            }
+            if (data.repositoryRedirect.__typename === 'Redirect') {
+                throw new RepoSeeOtherError(data.repositoryRedirect.url)
+            }
+            return data.repositoryRedirect
+        })
+    )
 
 export interface ResolvedRevision extends ResolvedRevisionSpec {
     defaultBranch: string
@@ -98,74 +95,71 @@ export interface ResolvedRevision extends ResolvedRevisionSpec {
  *
  * @returns Observable that emits the commit ID. Errors with a `CloneInProgressError` if the repo is still being cloned.
  */
-export const resolveRevision = memoizeObservable(
-    ({ repoName, revision }: RepoSpec & Partial<RevisionSpec>): Observable<ResolvedRevision> =>
-        queryGraphQL(
-            gql`
-                query ResolveRev($repoName: String!, $revision: String!) {
-                    repositoryRedirect(name: $repoName) {
-                        __typename
-                        ... on Repository {
-                            mirrorInfo {
-                                cloneInProgress
-                                cloneProgress
-                                cloned
-                            }
-                            commit(rev: $revision) {
-                                oid
-                                tree(path: "") {
-                                    url
-                                }
-                            }
-                            defaultBranch {
-                                abbrevName
+export const resolveRevision = ({
+    repoName,
+    revision,
+}: RepoSpec & Partial<RevisionSpec>): Observable<ResolvedRevision> =>
+    queryGraphQL(
+        gql`
+            query ResolveRev($repoName: String!, $revision: String!) {
+                repositoryRedirect(name: $repoName) {
+                    __typename
+                    ... on Repository {
+                        mirrorInfo {
+                            cloneInProgress
+                            cloneProgress
+                            cloned
+                        }
+                        commit(rev: $revision) {
+                            oid
+                            tree(path: "") {
+                                url
                             }
                         }
-                        ... on Redirect {
-                            url
+                        defaultBranch {
+                            abbrevName
                         }
                     }
+                    ... on Redirect {
+                        url
+                    }
                 }
-            `,
-            { repoName, revision: revision || '' }
-        ).pipe(
-            map(({ data, errors }) => {
-                if (!data) {
-                    throw createAggregateError(errors)
-                }
-                if (!data.repositoryRedirect) {
-                    throw new RepoNotFoundError(repoName)
-                }
-                if (data.repositoryRedirect.__typename === 'Redirect') {
-                    throw new RepoSeeOtherError(data.repositoryRedirect.url)
-                }
-                if (data.repositoryRedirect.mirrorInfo.cloneInProgress) {
-                    throw new CloneInProgressError(
-                        repoName,
-                        data.repositoryRedirect.mirrorInfo.cloneProgress || undefined
-                    )
-                }
-                if (!data.repositoryRedirect.mirrorInfo.cloned) {
-                    throw new CloneInProgressError(repoName, 'queued for cloning')
-                }
-                if (!data.repositoryRedirect.commit) {
-                    throw new RevisionNotFoundError(revision)
-                }
+            }
+        `,
+        { repoName, revision: revision || '' }
+    ).pipe(
+        map(({ data, errors }) => {
+            if (!data) {
+                throw createAggregateError(errors)
+            }
+            if (!data.repositoryRedirect) {
+                throw new RepoNotFoundError(repoName)
+            }
+            if (data.repositoryRedirect.__typename === 'Redirect') {
+                throw new RepoSeeOtherError(data.repositoryRedirect.url)
+            }
+            if (data.repositoryRedirect.mirrorInfo.cloneInProgress) {
+                throw new CloneInProgressError(repoName, data.repositoryRedirect.mirrorInfo.cloneProgress || undefined)
+            }
+            if (!data.repositoryRedirect.mirrorInfo.cloned) {
+                throw new CloneInProgressError(repoName, 'queued for cloning')
+            }
+            if (!data.repositoryRedirect.commit) {
+                throw new RevisionNotFoundError(revision)
+            }
 
-                const defaultBranch = data.repositoryRedirect.defaultBranch?.abbrevName || 'HEAD'
+            const defaultBranch = data.repositoryRedirect.defaultBranch?.abbrevName || 'HEAD'
 
-                if (!data.repositoryRedirect.commit.tree) {
-                    throw new RevisionNotFoundError(defaultBranch)
-                }
-                return {
-                    commitID: data.repositoryRedirect.commit.oid,
-                    defaultBranch,
-                    rootTreeURL: data.repositoryRedirect.commit.tree.url,
-                }
-            })
-        ),
-    makeRepoURI
-)
+            if (!data.repositoryRedirect.commit.tree) {
+                throw new RevisionNotFoundError(defaultBranch)
+            }
+            return {
+                commitID: data.repositoryRedirect.commit.oid,
+                defaultBranch,
+                rootTreeURL: data.repositoryRedirect.commit.tree.url,
+            }
+        })
+    )
 
 export const fetchFileExternalLinks = memoizeObservable(
     (context: RepoRevision & { filePath: string }): Observable<ExternalLinkFields[]> =>

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -32,7 +32,6 @@ import { useNotepad, useExperimentalFeatures } from '../../stores'
 import { basename } from '../../util/path'
 import { toTreeURL } from '../../util/url'
 import { ToggleBlameAction } from '../actions/ToggleBlameAction'
-import { useBlameDecorations } from '../blame/useBlameDecorations'
 import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 import { HoverThresholdProps } from '../RepoContainer'
 import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
@@ -46,7 +45,6 @@ import { fetchBlob } from './backend'
 import { Blob, BlobInfo } from './Blob'
 import { Blob as CodeMirrorBlob } from './CodeMirrorBlob'
 import { GoToRawAction } from './GoToRawAction'
-import { useBlobPanelViews } from './panel/BlobPanel'
 import { RenderedFile } from './RenderedFile'
 import { RenderedNotebookMarkdown, SEARCH_NOTEBOOK_FILE_EXTENSION } from './RenderedNotebookMarkdown'
 
@@ -68,12 +66,12 @@ interface Props
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'> {
     location: H.Location
     history: H.History
-    repoID: Scalars['ID']
     authenticatedUser: AuthenticatedUser | null
     globbing: boolean
     isMacPlatform: boolean
     isSourcegraphDotCom: boolean
-    repoUrl: string
+    repoID?: Scalars['ID']
+    repoUrl?: string
 }
 
 /**
@@ -139,12 +137,11 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                         revision={revision}
                         filePath={filePath}
                         isDir={false}
-                        repoUrl={repoUrl}
                         telemetryService={props.telemetryService}
                     />
                 ),
             }
-        }, [filePath, revision, repoName, repoUrl, props.telemetryService])
+        }, [filePath, revision, repoName, props.telemetryService])
     )
 
     /**
@@ -158,7 +155,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                 return of(undefined)
             }
 
-            return fetchBlob({ repoName, commitID, filePath, formatOnly: true }).pipe(
+            return fetchBlob({ repoName, revision, filePath, formatOnly: true }).pipe(
                 map(blob => {
                     if (blob === null) {
                         return blob
@@ -199,7 +196,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                     switchMap(disableTimeout =>
                         fetchBlob({
                             repoName,
-                            commitID,
+                            revision,
                             filePath,
                             disableTimeout,
                         })
@@ -261,9 +258,9 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
         return `${repoString}`
     }
 
-    useBlobPanelViews(props)
+    // useBlobPanelViews(props)
 
-    const blameDecorations = useBlameDecorations({ repoName, commitID, filePath })
+    // const blameDecorations = useBlameDecorations({ repoName, commitID, filePath })
 
     const isSearchNotebook =
         blobInfoOrError &&
@@ -455,7 +452,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                     disableDecorations={false}
                     role="region"
                     ariaLabel="File blob"
-                    blameDecorations={blameDecorations}
+                    // blameDecorations={blameDecorations}
                 />
             )}
         </>

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -14,7 +14,7 @@ function fetchBlobCacheKey(parsed: ParsedRepoURI & { disableTimeout?: boolean; f
 
 interface FetchBlobArguments {
     repoName: string
-    commitID: string
+    revision: string
     filePath: string
     disableTimeout?: boolean
     formatOnly?: boolean
@@ -23,7 +23,7 @@ interface FetchBlobArguments {
 export const fetchBlob = memoizeObservable(
     ({
         repoName,
-        commitID,
+        revision,
         filePath,
         disableTimeout = false,
         formatOnly = false,
@@ -32,13 +32,13 @@ export const fetchBlob = memoizeObservable(
             gql`
                 query Blob(
                     $repoName: String!
-                    $commitID: String!
+                    $revision: String!
                     $filePath: String!
                     $disableTimeout: Boolean!
                     $formatOnly: Boolean!
                 ) {
                     repository(name: $repoName) {
-                        commit(rev: $commitID) {
+                        commit(rev: $revision) {
                             file(path: $filePath) {
                                 ...BlobFileFields
                             }
@@ -56,7 +56,7 @@ export const fetchBlob = memoizeObservable(
                     }
                 }
             `,
-            { repoName, commitID, filePath, disableTimeout, formatOnly }
+            { repoName, revision, filePath, disableTimeout, formatOnly }
         ).pipe(
             map(dataOrThrowErrors),
             map(data => {


### PR DESCRIPTION
## Actions before merging this PR:
- Fix TS errors where `repo` or `resolvedRev` are now undefined
- Remove any more code that blocks rendering if `repo` or `resolvedRev` are undefined
- Use `repoName` and `revision` from URL (`parseBrowserRepoURL`) in components instead of waiting for these queries.
  - E.g., here we do this for the `fetchBlob` query.
  - Check that this is OK, with code intel. That there are no issues with doing this. The only one I can think is if our backend expects a specific commit ID or something, and we don't have that because the URL only contains a branch, or nothing.
    - [Slack thread](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1660580943115949)


## Description

Makes `repo` and `resolvedRev` optional.
- Components should try to render as much as they can to improve perceived perf here
- Queries such as `fetchBlob` should use the URL as a source of truth rather than the output of this query for improved perf.

## Screenshots

### Before
https://user-images.githubusercontent.com/9516420/184105613-fdbce4e4-c94d-452f-99f4-ab8827ea1b3e.mp4

### After
https://user-images.githubusercontent.com/9516420/184105651-e879e9a0-e8bd-4de5-b2c7-961bd386779d.mp4

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
