### PR TITLE
codemirror file view: Enable hovercards in ref panel preview

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -209,6 +209,14 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
     )
 }
 
+interface BlobMemoryHistoryState {
+    /**
+     * Whether or not to sync this change from the blob history object to the
+     * panel's history object.
+     */
+    syncToPanel?: boolean
+}
+
 const SHOW_SPINNER_DELAY_MS = 100
 
 export const ReferencesList: React.FunctionComponent<
@@ -283,7 +291,7 @@ export const ReferencesList: React.FunctionComponent<
         activeLocation !== undefined && activeLocation.url === location.url
     // We create an in-memory history here so we don't modify the browser
     // location. This panel is detached from the URL state.
-    const blobMemoryHistory = useMemo(() => H.createMemoryHistory(), [])
+    const blobMemoryHistory = useMemo(() => H.createMemoryHistory<BlobMemoryHistoryState>(), [])
 
     // When the token for which we display data changed, we want to reset
     // activeLocation.
@@ -599,8 +607,8 @@ const SideBlob: React.FunctionComponent<
         ReferencesPanelProps & {
             activeLocation: Location
 
-            location: H.Location
-            history: H.History
+            location: H.Location<BlobMemoryHistoryState>
+            history: H.History<BlobMemoryHistoryState>
             blobNav: (url: string) => void
             panelHistory: H.History
         }
@@ -617,7 +625,7 @@ const SideBlob: React.FunctionComponent<
     useEffect(
         () =>
             history.listen((location, method) => {
-                if (useCodeMirror && (location.state as any)?.syncToPanel !== false) {
+                if (useCodeMirror && location.state?.syncToPanel !== false) {
                     switch (method) {
                         case 'PUSH':
                             panelHistory.push(location)

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -328,7 +328,6 @@ export const ReferencesList: React.FunctionComponent<
     // '?jumpToFirst=true' causes the panel to select the first reference and
     // open it in code blob on right.
     const onBlobNav = (url: string): void => {
-        console.log('on blob nav')
         // If we're going to navigate inside the same file in the same repo we
         // can optimistically jump to that position in the code blob.
         if (activeLocation !== undefined) {
@@ -619,7 +618,6 @@ const SideBlob: React.FunctionComponent<
         () =>
             history.listen((location, method) => {
                 if (useCodeMirror && (location.state as any)?.syncToPanel !== false) {
-                    console.log('sync to panel')
                     switch (method) {
                         case 'PUSH':
                             panelHistory.push(location)

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -124,10 +124,6 @@ export interface BlobProps
     // Experimental reference panel
     disableStatusBar: boolean
     disableDecorations: boolean
-    /**
-     * Only used by CodeMirror implementation.
-     */
-    disableHovercards?: boolean
 
     // If set, nav is called when a user clicks on a token highlighted by
     // WebHoverOverlay

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -25,7 +25,7 @@ import { syntaxHighlight } from './codemirror/highlight'
 import { hovercardRanges } from './codemirror/hovercard'
 import { selectLines, selectableLineNumbers, SelectedLineRange } from './codemirror/linenumbers'
 import { sourcegraphExtensions } from './codemirror/sourcegraph-extensions'
-import { offsetToUIPosition, uiPositionToOffset } from './codemirror/utils'
+import { isValidLineRange, offsetToUIPosition, uiPositionToOffset } from './codemirror/utils'
 
 const staticExtensions: Extension = [
     // Using EditorState.readOnly instead of EditorView.editable allows us to
@@ -79,14 +79,12 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // Reference panel specific props
         disableStatusBar,
         disableDecorations,
-        disableHovercards,
     } = props
 
     const [container, setContainer] = useState<HTMLDivElement | null>(null)
     // This is used to avoid reinitializing the editor when new locations in the
     // same file are opened inside the reference panel.
     const blobInfo = useDistinctBlob(props.blobInfo)
-    const blobIsLoading = useBlobIsLoading(blobInfo, location.pathname)
     const position = useMemo(() => parseQueryAndHash(location.search, location.hash), [location.search, location.hash])
     const hasPin = useMemo(() => urlIsPinned(location.search), [location.search])
 
@@ -157,7 +155,6 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                 extensionsController,
                 disableStatusBar,
                 disableDecorations,
-                disableHovercards,
             }),
             blobPropsCompartment.of(blobProps),
             blameDecorationsCompartment.of(blameDecorations),
@@ -226,23 +223,24 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
 
     // Update selected lines when URL changes
     useEffect(() => {
-        if (editor && !blobIsLoading) {
+        if (editor) {
             selectLines(editor, position.line ? position : null)
         }
         // editor is not provided because this should only be triggered after the
         // editor was created (i.e. not on first render)
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [position, blobIsLoading])
+    }, [position])
 
     // Update pinned hovercard range
     useEffect(() => {
-        if (editor && !blobIsLoading) {
+        if (editor && (!hasPin || (position.line && isValidLineRange(position, editor.state.doc)))) {
+            // Only update range if position is valid inside the document.
             updatePinnedRangeField(editor, hasPin ? position : null)
         }
         // editor is not provided because this should only be triggered after the
         // editor was created (i.e. not on first render)
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [position, hasPin, blobIsLoading])
+    }, [position, hasPin])
 
     return <div ref={setContainer} aria-label={ariaLabel} role={role} className={`${className} overflow-hidden`} />
 }
@@ -253,18 +251,6 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
  */
 function urlIsPinned(search: string): boolean {
     return new URLSearchParams(search).get('popover') === 'pinned'
-}
-
-/**
- * Because the location changes before new blob info is available we often apply
- * updates to the old document, which can be problematic or throw errors. This
- * helper hook keeps track of which path is set when the blob info updates
- * and compares it against the current path.
- */
-function useBlobIsLoading(blobInfo: BlobInfo, pathname: string): boolean {
-    // pathname is intentionally ignored to make this functionality work
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    return pathname !== useMemo(() => pathname, [blobInfo])
 }
 
 /**

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -143,6 +143,9 @@ const hovercardTheme = EditorView.theme({
         // Reset CodeMirror's default style
         border: 'initial',
         backgroundColor: 'initial',
+        // Needed to ensure that the hovercard is not covered by the reference
+        // panel header.
+        zIndex: 1024,
     },
 })
 

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -10,6 +10,8 @@ import {
     gutterLineClass,
 } from '@codemirror/view'
 
+import { isValidLineRange } from './utils'
+
 /**
  * Represents the currently selected line range. null means no lines are
  * selected. Line numbers are 1-based.
@@ -31,9 +33,6 @@ const setEndLine = StateEffect.define<number>()
 export const selectedLines = StateField.define<SelectedLineRange>({
     create() {
         return null
-    },
-    compare(previous, next): boolean {
-        return previous?.line === next?.line && previous?.endLine === next?.endLine
     },
     update(value, transaction) {
         for (const effect of transaction.effects) {
@@ -228,7 +227,9 @@ export function selectableLineNumbers(config: {
  * Set selected lines (e.g. from the URL).
  */
 export function selectLines(view: EditorView, newRange: SelectedLineRange): void {
-    view.dispatch({ effects: setSelectedLines.of(newRange) })
+    view.dispatch({
+        effects: setSelectedLines.of(newRange && isValidLineRange(newRange, view.state.doc) ? newRange : null),
+    })
 }
 
 /**

--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -69,14 +69,12 @@ export function sourcegraphExtensions({
     extensionsController,
     disableStatusBar,
     disableDecorations,
-    disableHovercards,
 }: {
     blobInfo: BlobInfo
     initialSelection: LineOrPositionOrRange
     extensionsController: ExtensionsControllerProps['extensionsController']
     disableStatusBar?: boolean
     disableDecorations?: boolean
-    disableHovercards?: boolean
 }): Extension {
     const subscriptions = new Subscription()
 
@@ -136,7 +134,7 @@ export function sourcegraphExtensions({
         })),
         // This needs to come before document highlights so that the hovered
         // token is highlighted differently
-        disableHovercards ? [] : hovercardDataSource(contextObservable),
+        hovercardDataSource(contextObservable),
         documentHighlightsDataSource(contextObservable),
         disableDecorations ? [] : textDocumentDecorations(contextObservable),
         ViewPlugin.define(() => new SelectionManager(contextObservable)),

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -146,3 +146,32 @@ export function distinctWordAtCoords(
         distinctUntilChanged()
     )
 }
+
+/**
+ * Verifies that the provided 1-based range is within the document range.
+ */
+export function isValidLineRange(
+    range: { line: number; character?: number; endLine?: number; endCharacter?: number },
+    textDocument: Text
+): boolean {
+    const { lines } = textDocument
+
+    // Return early if the document doesn't have as many lines
+    if ((range.endLine ?? range.line) > lines) {
+        return false
+    }
+
+    // Verify precise character positions (if present)
+    if (range.character && textDocument.line(range.line).to < range.line + range.character - 1) {
+        return false
+    }
+    if (
+        range.endLine &&
+        range.endCharacter &&
+        textDocument.line(range.endLine).to < range.endLine + range.endCharacter - 1
+    ) {
+        return false
+    }
+
+    return true
+}


### PR DESCRIPTION
Based on #40232 (for click to jump to def)

This was tricky to investiage/solve. The reason why hovercard actions
didn't work with CodeMirror wasn't because of the use of
`<MemoryRouter />` but because the blob view was passed a different
history object (`blobMemoryHistory`) than the `<MemoryRouter />` context
was using.

Because the CodeMirror/React integration establishes a new Router
context, the history context object for all Hovercard links was
`blobMemoryHistory`, but updating this one didn't update the panel's
history object:

![ref-panel-router](https://user-images.githubusercontent.com/179026/184118388-3d543b17-09a8-4169-a406-e68cc929a865.png)


I think this needs to be refactored overall to provide a clear flow of
history changes, but for the time being I fixed it by "forwarding"
history changes originating from withing the hovercard to the panel's
history (by listining to changes of `blobMemoryRouter`).

But even with this fixed I noticed that sometimes the blob view would
not select the line when clicking on another reference in the same file.
The reason for this was the logic of `useBlobIsLoading`. That hook made
the assumption that there is always a 1:1 relation between a URL
location and a blob view information. But that is not the case when we
are working on `main`/`master`. Long story short, in that case the blob
view is switching between URLs that contain and do not contain the
commit ID. To the CodeMirror blob view that looked like new blob data is
loading (location pathname changed) and it waited for new blob data to
arrive but that never happened.

The hook was originally introduced to prevent applying line selection
decoration that are outside of the current document, which did happen
when a new blob was loaded.
However, regardless of the issues with the reference panel, a more
robust implementation is to verify that the position from the URL is
valid in the current document.

---

I think I was able to replicate the current behavior of the ref panel:

- Clicking on any reference or definition in the list loads the preview
  and scrolls to the selected line.
- Clicking on the "Go to definition"/"Find references" buttons reloads
  the ref panel.
- Using "click to to go to definition" will keep the file open and jump
  to the correct position if the definition is in the same file.


Demo: 

https://user-images.githubusercontent.com/179026/184118429-65b21a99-c7ad-43de-a58d-ebe7f3b12b4b.mp4


## Test plan

- Hover over a token a click "find references"
- Inside the ref panel, select any reference. The blob view should appear.
- Hover over a reference whose definition is in the same document. Click on it. The blob view should directly jump to the definition.
- Clicking "Go to definition" or "Find References" inside a hover card should cause the ref panel to update with the corresponding data.
- Picking various references/definitions in the same/different files should scroll the corresponding lines into view.

## App preview:

- [Web](https://sg-web-fkling-cm-ref-panel-hovercard.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zahesticvg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
