### PR TITLE
Fix bullet points in extensions deprecation docs

### DIFF
--- a/doc/extensions/deprecation.md
+++ b/doc/extensions/deprecation.md
@@ -9,6 +9,7 @@ We’re investing in a new model of integrations that allow deeper integration w
 This decision means that after the September 2022 release of Sourcegraph you can no longer create new extensions on our public registry. If you’re using a private registry, you are unaffected.
 
 After upgrading to the latest release you’ll notice the following changes:
+
 - Top extensions (code navigation, git-extras, open-in-editor and search-exports) will become native functionality of the code intelligence platform
 - A new feature flag will be introduced that turns on the extensions and the extension registry. This feature flag will be disabled by default.
 - You will no longer be able to create extensions on a private registry unless you have enabled the feature flag.


### PR DESCRIPTION
Looks like a `\n` is needed before the bullet list.

## Test plan

![Screenshot 2022-08-11 at 16 57 18](https://user-images.githubusercontent.com/458591/184164283-6762ed95-131d-4693-aa8b-090f493f0389.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
