### PR TITLE
executor: Publish AMI to more regions

### DIFF
--- a/enterprise/cmd/executor/docker-mirror/docker-mirror.json
+++ b/enterprise/cmd/executor/docker-mirror/docker-mirror.json
@@ -50,6 +50,7 @@
         "max_attempts": "{{user `awsMaxAttempts`}}"
       },
       "shutdown_behavior": "terminate",
+      "ami_regions": ["us-west-1", "us-west-2", "us-east-1", "us-east-2"],
       "tags": {
         "Name": "{{user `name`}}",
         "OS_Version": "Ubuntu",

--- a/enterprise/cmd/executor/vm-image/executor.json
+++ b/enterprise/cmd/executor/vm-image/executor.json
@@ -52,6 +52,7 @@
         "max_attempts": "{{user `awsMaxAttempts`}}"
       },
       "shutdown_behavior": "terminate",
+      "ami_regions": ["us-west-1", "us-west-2", "us-east-1", "us-east-2"],
       "tags": {
         "Name": "{{user `name`}}",
         "OS_Version": "Ubuntu",

--- a/enterprise/cmd/executor/vm-image/release.sh
+++ b/enterprise/cmd/executor/vm-image/release.sh
@@ -16,7 +16,7 @@ GOOGLE_IMAGE_NAME="${NAME}"
 gcloud compute images add-iam-policy-binding --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
 gcloud compute images update --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --family="${IMAGE_FAMILY}"
 
-for region in $(cat executor.json | jq -r '.builders[1].ami_regions[]'); do
+for region in $(jq -r '.builders[1].ami_regions[]' <executor.json); do
   AWS_AMI_ID=$(aws ec2 --region="${region}" describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
   # Make executor AMI usable outside of Sourcegraph.
   aws ec2 --region="${region}" modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"

--- a/enterprise/cmd/executor/vm-image/release.sh
+++ b/enterprise/cmd/executor/vm-image/release.sh
@@ -11,14 +11,16 @@ export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
 # Point to GCP boot disk image/AMI built by build.sh script
 NAME="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
 GOOGLE_IMAGE_NAME="${NAME}"
-AWS_AMI_ID=$(aws ec2 describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
 
 # Mark GCP boot disk as released and make it usable outside of Sourcegraph.
 gcloud compute images add-iam-policy-binding --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
 gcloud compute images update --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --family="${IMAGE_FAMILY}"
 
-# Make executor AMI usable outside of Sourcegraph.
-aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"
+for region in $(cat executor.json | jq -r '.builders[1].ami_regions[]'); do
+  AWS_AMI_ID=$(aws ec2 --region="${region}" describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
+  # Make executor AMI usable outside of Sourcegraph.
+  aws ec2 --region="${region}" modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"
+done
 
 # Copy uploaded binary to 'latest'
 gsutil rm -rf gs://sourcegraph-artifacts/executor/latest || true


### PR DESCRIPTION
Initial list, will tweak later as we learn what customers need, but makes it a bit more usable outside of our own testbed and easy to adopt more later.

## Test plan

Triggered a nopatch build for this change.