### PR TITLE
fix panic when config object is null

### DIFF
--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
@@ -244,11 +244,11 @@ func isEnabled() bool {
 }
 
 func getBatchSize() int {
-	val := confClient.Get().ExportUsageTelemetry.BatchSize
-	if val <= 0 {
-		val = MaxEventsCountDefault
+	config := confClient.Get()
+	if config == nil || config.ExportUsageTelemetry == nil || config.ExportUsageTelemetry.BatchSize <= 0 {
+		return MaxEventsCountDefault
 	}
-	return val
+	return config.ExportUsageTelemetry.BatchSize
 }
 
 type topicConfig struct {

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -502,6 +502,49 @@ func noopHandler() sendEventsCallbackFunc {
 	}
 }
 
+func Test_getBatchSize(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *conf.Unified
+		want   int
+	}{
+		{
+			name:   "null config object",
+			config: nil,
+			want:   MaxEventsCountDefault,
+		},
+		{
+			name:   "null inner config object",
+			config: &conf.Unified{},
+			want:   MaxEventsCountDefault,
+		},
+		{
+			name:   "null export data object",
+			config: &conf.Unified{SiteConfiguration: schema.SiteConfiguration{}},
+			want:   MaxEventsCountDefault,
+		},
+		{
+			name:   "no batch size specified",
+			config: &conf.Unified{SiteConfiguration: validConfiguration()},
+			want:   MaxEventsCountDefault,
+		},
+		{
+			name:   "override batch size",
+			config: &conf.Unified{SiteConfiguration: schema.SiteConfiguration{ExportUsageTelemetry: &schema.ExportUsageTelemetry{BatchSize: 5}}},
+			want:   5,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			confClient.Mock(test.config)
+			got := getBatchSize()
+			if got != test.want {
+				t.Errorf("unexpected batch size want:%d, got:%d", test.want, got)
+			}
+		})
+	}
+}
+
 func TestGetBookmark(t *testing.T) {
 	logger := logtest.Scoped(t)
 	dbHandle := dbtest.NewDB(logger, t)


### PR DESCRIPTION
Fixes a panic when the config is null. This cropped up when I switched from a config object to environment variables and all of the test instances already had the object set.

## Test plan

Unit tests for all null possibilities

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
