### PR TITLE
query examples homepage: align tip to baseline so text is aligned

### DIFF
--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -68,7 +68,8 @@
 .tip {
     color: var(--text-muted);
     display: flex;
-    align-items: center;
+    align-items: baseline;
+    align-content: center;
     justify-content: center;
     flex-wrap: wrap;
     min-height: 2rem;


### PR DESCRIPTION
The text in the chip button was not aligned with the outside text. Super minor but this was bugging me a bit 😅

Before:
![image](https://user-images.githubusercontent.com/206864/184210075-db249fac-dc30-4a39-9218-f205d55d2e6e.png)

After:
![image](https://user-images.githubusercontent.com/206864/184210027-881060d1-8956-4071-b434-1e3f02a2c868.png)


## Test plan

Verify visually

## App preview:

- [Web](https://sg-web-jp-alignbaseline.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zggpmrdpyj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
