### PR TITLE
Code monitors: escape backticks in code monitor code blocks

### DIFF
--- a/enterprise/internal/codemonitors/background/slack.go
+++ b/enterprise/internal/codemonitors/background/slack.go
@@ -55,7 +55,7 @@ func slackPayload(args actionArgs) *slack.WebhookMessage {
 			} else {
 				contentRaw = truncateString(result.MessagePreview.Content, 10)
 			}
-			blocks = append(blocks, newMarkdownSection(fmt.Sprintf("```%s```", contentRaw)))
+			blocks = append(blocks, newMarkdownSection(formatCodeBlock(contentRaw)))
 		}
 		if truncatedCount > 0 {
 			blocks = append(blocks, newMarkdownSection(fmt.Sprintf(
@@ -79,6 +79,10 @@ func slackPayload(args actionArgs) *slack.WebhookMessage {
 		)),
 	)
 	return &slack.WebhookMessage{Blocks: &slack.Blocks{BlockSet: blocks}}
+}
+
+func formatCodeBlock(s string) string {
+	return fmt.Sprintf("```%s```", strings.ReplaceAll(s, "```", "\\`\\`\\`"))
 }
 
 func truncateString(input string, lines int) string {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/security-issues/issues/292#event-7173601812

Slack doesn't actually support escaping backticks, so this will look very ugly, but it won't break out of the code block formatting.

## Test plan

Manually tested that backticks in the code do not break out of slack's formatting.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
