### PR TITLE
Search: remove inaccurate callout for sourcegraph.com

### DIFF
--- a/client/search-ui/src/input/SearchHelpDropdownButton.tsx
+++ b/client/search-ui/src/input/SearchHelpDropdownButton.tsx
@@ -68,7 +68,7 @@ export const SearchHelpDropdownButton: React.FunctionComponent<
                         <span className="text-muted small">Regexp:</span> <Code weight="bold">(read|write)File</Code>
                     </li>
                     <li>
-                        <span className="text-muted small">Exact:</span> <Code weight="bold">"fs.open(f)"</Code>
+                        <span className="text-muted small">Exact:</span> <Code weight="bold">fs.open(f)</Code>
                     </li>
                 </ul>
                 <MenuDivider />

--- a/client/search-ui/src/input/SearchHelpDropdownButton.tsx
+++ b/client/search-ui/src/input/SearchHelpDropdownButton.tsx
@@ -130,12 +130,6 @@ export const SearchHelpDropdownButton: React.FunctionComponent<
                 >
                     <Icon aria-hidden={true} className="small" svgPath={mdiOpenInNew} /> All search keywords
                 </MenuText>
-                {isSourcegraphDotCom && (
-                    <Alert className="small rounded-0 mb-0 mt-1" variant="info">
-                        On Sourcegraph.com, use a <Code>repo:</Code> filter to narrow your search to &le;500
-                        repositories.
-                    </Alert>
-                )}
             </PopoverContent>
         </Popover>
     )

--- a/client/search-ui/src/input/SearchHelpDropdownButton.tsx
+++ b/client/search-ui/src/input/SearchHelpDropdownButton.tsx
@@ -9,7 +9,6 @@ import {
     PopoverContent,
     Popover,
     Button,
-    Alert,
     Position,
     Link,
     MenuDivider,


### PR DESCRIPTION
This removes an alert from the information button on the home search page. Additionally, it unquotes the literal search example since, for an exact match, quotes should _not_ be used. 

I don't think this has been accurate since before I started at SG 😄 

<img width="330" alt="Screen Shot 2022-08-11 at 12 43 04" src="https://user-images.githubusercontent.com/12631702/184215486-7cb81c50-b1f5-4513-9cf0-6de2186420b6.png">

## Test plan

<img width="238" alt="Screen Shot 2022-08-11 at 12 47 08" src="https://user-images.githubusercontent.com/12631702/184216138-3ffdca2f-ff74-421b-934f-f9d2d8ccf1fa.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-remove-alert.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-egcfyaccaw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
