### PR TITLE
Search backend: simplify `repo:contains` resolution

### DIFF
--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -65,7 +65,7 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 		repoHasFilters = append(repoHasFilters, QueryForFileContentArgs(filter, isCaseSensitive))
 	}
 	if len(repoHasFilters) > 0 {
-		and = append(and, &zoekt.Type{Type: zoekt.TypeRepo, Child: zoekt.NewAnd(repoHasFilters...)})
+		and = append(and, zoekt.NewAnd(repoHasFilters...))
 	}
 
 	// Languages are already partially expressed with IncludePatterns, but Zoekt creates
@@ -99,6 +99,7 @@ func QueryForFileContentArgs(opt query.RepoHasFileContentArgs, caseSensitive boo
 		children = append(children, &zoekt.Regexp{Regexp: re, Content: true, CaseSensitive: caseSensitive})
 	}
 	q := zoekt.NewAnd(children...)
+	q = &zoekt.Type{Type: zoekt.TypeRepo, Child: q}
 	if opt.Negated {
 		q = &zoekt.Not{Child: q}
 	}


### PR DESCRIPTION
I think I figured out the right way to use Zoekt's `Type` and `List()` queries, which simplifies the `repo:contains...` resolution during repo resolution. This change is also required for correct behavior of the negated form of the predicate (which is in the works).

Stacked on https://github.com/sourcegraph/sourcegraph/pull/40239

## Test plan

Integration tests, manual testing, pulled this off another larger change that I've been testing more extensively.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
