### PR TITLE
serach: Fix query syntax highlighting for lazy quantifier

### DIFF
--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -92,7 +92,7 @@ kbd {
 }
 
 .search-regexp-meta-lazy-quantifier {
-    color: var(--search-regexp-meta-character-lazy-quantifier-color);
+    color: var(--search-regexp-meta-lazy-quantifier-color);
 }
 
 .search-regexp-meta-range-quantifier {


### PR DESCRIPTION
Fixes #39387 

The class was using the wrong color name (not a CodeMirror issue)

## Test plan

<img width="263" alt="2022-08-11_19-44" src="https://user-images.githubusercontent.com/179026/184226315-aaee46b1-fd2d-4548-bc14-355bd0d00139.png">

## App preview:

- [Web](https://sg-web-fkling-39387-fix-query-syntax.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xjndfhiuix.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
