### PR TITLE
encryption: Introduce `Encryptable`

### DIFF
--- a/internal/encryption/encryptable.go
+++ b/internal/encryption/encryptable.go
@@ -8,8 +8,7 @@ import (
 )
 
 type Encryptable struct {
-	sync.Mutex
-
+	mutex          sync.Mutex
 	decryptedValue *string
 	encryptedValue *EncryptedValue
 	key            Key
@@ -39,8 +38,8 @@ func NewEncrypted(cipher, keyID string, key Key) *Encryptable {
 }
 
 func (e *Encryptable) Decrypted(ctx context.Context) (string, error) {
-	e.Lock()
-	defer e.Unlock()
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
 
 	return e.decrypted(ctx)
 }
@@ -67,8 +66,8 @@ func (e *Encryptable) Encrypted(ctx context.Context, key Key) (string, string, e
 		return "", "", err
 	}
 
-	e.Lock()
-	defer e.Unlock()
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
 
 	if e.encryptedValue != nil {
 		return e.encryptedValue.Cipher, e.encryptedValue.KeyID, nil
@@ -87,15 +86,15 @@ func (e *Encryptable) Encrypted(ctx context.Context, key Key) (string, string, e
 }
 
 func (e *Encryptable) Set(value string) {
-	e.Lock()
+	e.mutex.Lock()
 	e.decryptedValue = &value
 	e.encryptedValue = nil
-	e.Unlock()
+	e.mutex.Unlock()
 }
 
 func (e *Encryptable) SetKey(ctx context.Context, key Key) error {
-	e.Lock()
-	defer e.Unlock()
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
 
 	if e.key == key {
 		return nil

--- a/internal/encryption/encryptable.go
+++ b/internal/encryption/encryptable.go
@@ -1,0 +1,111 @@
+package encryption
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Encryptable struct {
+	sync.Mutex
+
+	decryptedValue *string
+	encryptedValue *EncryptedValue
+	key            Key
+}
+
+type EncryptedValue struct {
+	Cipher string
+	KeyID  string
+}
+
+func NewUnencrypted(value string) *Encryptable {
+	return NewUnencryptedWithKey(value, nil)
+}
+
+func NewUnencryptedWithKey(value string, key Key) *Encryptable {
+	return &Encryptable{
+		decryptedValue: &value,
+		key:            key,
+	}
+}
+
+func NewEncrypted(cipher, keyID string, key Key) *Encryptable {
+	return &Encryptable{
+		encryptedValue: &EncryptedValue{cipher, keyID},
+		key:            key,
+	}
+}
+
+func (e *Encryptable) Decrypted(ctx context.Context) (string, error) {
+	e.Lock()
+	defer e.Unlock()
+
+	return e.decrypted(ctx)
+}
+
+func (e *Encryptable) decrypted(ctx context.Context) (string, error) {
+	if e.decryptedValue != nil {
+		return *e.decryptedValue, nil
+	}
+	if e.encryptedValue == nil {
+		return "", errors.New("no encrypted value")
+	}
+
+	value, err := MaybeDecrypt(ctx, e.key, e.encryptedValue.Cipher, e.encryptedValue.KeyID)
+	if err != nil {
+		return "", err
+	}
+
+	e.decryptedValue = &value
+	return value, nil
+}
+
+func (e *Encryptable) Encrypted(ctx context.Context, key Key) (string, string, error) {
+	if err := e.SetKey(ctx, key); err != nil {
+		return "", "", err
+	}
+
+	e.Lock()
+	defer e.Unlock()
+
+	if e.encryptedValue != nil {
+		return e.encryptedValue.Cipher, e.encryptedValue.KeyID, nil
+	}
+	if e.decryptedValue == nil {
+		return "", "", errors.New("nothing to encrypt")
+	}
+
+	cipher, keyID, err := MaybeEncrypt(ctx, e.key, *e.decryptedValue)
+	if err != nil {
+		return "", "", err
+	}
+
+	e.encryptedValue = &EncryptedValue{cipher, keyID}
+	return cipher, keyID, err
+}
+
+func (e *Encryptable) Set(value string) {
+	e.Lock()
+	e.decryptedValue = &value
+	e.encryptedValue = nil
+	e.Unlock()
+}
+
+func (e *Encryptable) SetKey(ctx context.Context, key Key) error {
+	e.Lock()
+	defer e.Unlock()
+
+	if e.key == key {
+		return nil
+	}
+
+	if _, err := e.decrypted(ctx); err != nil {
+		return err
+	}
+
+	e.key = key
+	e.encryptedValue = nil
+	return nil
+}

--- a/internal/encryption/encryptable.go
+++ b/internal/encryption/encryptable.go
@@ -88,9 +88,10 @@ func (e *Encryptable) Encrypted(ctx context.Context, key Key) (string, string, e
 
 func (e *Encryptable) Set(value string) {
 	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
 	e.decrypted = &decryptedValue{value, nil}
 	e.encrypted = nil
-	e.mutex.Unlock()
 }
 
 func (e *Encryptable) SetKey(ctx context.Context, key Key) error {

--- a/internal/encryption/encryptable_test.go
+++ b/internal/encryption/encryptable_test.go
@@ -1,0 +1,78 @@
+package encryption
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestEncryptable(t *testing.T) {
+	ctx := context.Background()
+	base64Key := base64Key{}
+	base64Key2 := base64PlusJunkKey{}
+	keyID, _ := json.Marshal(base64KeyVersion)
+
+	for _, encryptable := range []*Encryptable{
+		NewUnencrypted("foobar"),
+		NewEncrypted("Zm9vYmFy", string(keyID), base64Key),
+	} {
+		// Test Decrypt
+		decrypted, err := encryptable.Decrypt(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error encrypting: %s", err.Error())
+		}
+		if want := "foobar"; decrypted != want {
+			t.Fatalf("unexpected decrypted value. want=%q have=%q", want, decrypted)
+		}
+
+		// Test Encrypt
+		encrypted, keyID, err := encryptable.Encrypt(ctx, base64Key)
+		if err != nil {
+			t.Fatalf("unexpected error encrypting: %s", err.Error())
+		}
+		if want := "Zm9vYmFy"; encrypted != want {
+			t.Fatalf("unexpected encrypted value. want=%q have=%q", want, encrypted)
+		}
+		if want := base64KeyVersion.Type; keyType(t, keyID) != want {
+			t.Fatalf("unexpected key identifier. want=%q have=%q", want, keyType(t, keyID))
+		}
+
+		// Test SetKey
+		if err := encryptable.SetKey(ctx, base64Key2); err != nil {
+			t.Fatalf("unexpected error setting key: %s", err.Error())
+		}
+
+		// Re-test Decrypt
+		decrypted, err = encryptable.Decrypt(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error encrypting: %s", err.Error())
+		}
+		if want := "foobar"; decrypted != want {
+			t.Fatalf("unexpected decrypted value. want=%q have=%q", want, decrypted)
+		}
+
+		// Test Set
+		encryptable.Set("barbaz")
+
+		// Re-test Decrypt
+		decrypted, err = encryptable.Decrypt(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error encrypting: %s", err.Error())
+		}
+		if want := "barbaz"; decrypted != want {
+			t.Fatalf("unexpected decrypted value. want=%q have=%q", want, decrypted)
+		}
+
+		// Re-test Encrypt
+		encrypted, keyID, err = encryptable.Encrypt(ctx, base64Key)
+		if err != nil {
+			t.Fatalf("unexpected error encrypting: %s", err.Error())
+		}
+		if want := "YmFyYmF6"; encrypted != want {
+			t.Fatalf("unexpected encrypted value. want=%q have=%q", want, encrypted)
+		}
+		if want := base64KeyVersion.Type; keyType(t, keyID) != want {
+			t.Fatalf("unexpected key identifier. want=%q have=%q", want, keyType(t, keyID))
+		}
+	}
+}

--- a/internal/encryption/json_encryptable.go
+++ b/internal/encryption/json_encryptable.go
@@ -1,0 +1,68 @@
+package encryption
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type JSONEncryptable[T any] struct {
+	*Encryptable
+}
+
+func NewUnencryptedJSON[T any](value T) (*JSONEncryptable[T], error) {
+	return NewUnencryptedJSONWithKey(value, nil)
+}
+
+func NewUnencryptedJSONWithKey[T any](value T, key Key) (*JSONEncryptable[T], error) {
+	serialized, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &JSONEncryptable[T]{Encryptable: NewUnencryptedWithKey(string(serialized), key)}, nil
+}
+
+func NewEncryptedJSON[T any](cipher, keyID string, key Key) *JSONEncryptable[T] {
+	return &JSONEncryptable[T]{Encryptable: NewEncrypted(cipher, keyID, key)}
+}
+
+func (e *JSONEncryptable[T]) Decrypted(ctx context.Context) (value T, _ error) {
+	serialized, err := e.Encryptable.Decrypted(ctx)
+	if err != nil {
+		return value, err
+	}
+
+	if err := json.Unmarshal([]byte(serialized), &value); err != nil {
+		return value, err
+	}
+
+	return value, nil
+}
+
+func (e *JSONEncryptable[T]) DecryptedInto(ctx context.Context, value T) error {
+	serialized, err := e.Encryptable.Decrypted(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal([]byte(serialized), &value); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *JSONEncryptable[T]) Set(value T) error {
+	serialized, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	str := string(serialized)
+
+	e.Lock()
+	defer e.Unlock()
+
+	e.decryptedValue = &str
+	e.encryptedValue = nil
+	return nil
+}

--- a/internal/encryption/json_encryptable.go
+++ b/internal/encryption/json_encryptable.go
@@ -59,8 +59,8 @@ func (e *JSONEncryptable[T]) Set(value T) error {
 	}
 	str := string(serialized)
 
-	e.Lock()
-	defer e.Unlock()
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
 
 	e.decryptedValue = &str
 	e.encryptedValue = nil

--- a/internal/encryption/json_encryptable.go
+++ b/internal/encryption/json_encryptable.go
@@ -57,12 +57,11 @@ func (e *JSONEncryptable[T]) Set(value T) error {
 	if err != nil {
 		return err
 	}
-	str := string(serialized)
 
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
-	e.decryptedValue = &str
+	e.decryptedValue = &decryptedValue{string(serialized), nil}
 	e.encryptedValue = nil
 	return nil
 }

--- a/internal/encryption/json_encryptable.go
+++ b/internal/encryption/json_encryptable.go
@@ -61,7 +61,7 @@ func (e *JSONEncryptable[T]) Set(value T) error {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
-	e.decryptedValue = &decryptedValue{string(serialized), nil}
-	e.encryptedValue = nil
+	e.decrypted = &decryptedValue{string(serialized), nil}
+	e.encrypted = nil
 	return nil
 }

--- a/internal/encryption/json_encryptable.go
+++ b/internal/encryption/json_encryptable.go
@@ -5,10 +5,16 @@ import (
 	"encoding/json"
 )
 
+// JSONEncryptable wraps a value of type T and an encryption key and handles lazily encoding/encrypting
+// and decrypting/decoding that value. This struct should be used in all places where a JSON-serialized
+// value is encrypted at-rest to maintain a consistent handling of data with security concerns.
+//
+// This struct should always be passed by reference.
 type JSONEncryptable[T any] struct {
 	*Encryptable
 }
 
+// NewUnencryptedJSON creates a new JSON encryptable from the given value.
 func NewUnencryptedJSON[T any](value T) (*JSONEncryptable[T], error) {
 	return NewUnencryptedJSONWithKey(value, nil)
 }
@@ -22,12 +28,16 @@ func NewUnencryptedJSONWithKey[T any](value T, key Key) (*JSONEncryptable[T], er
 	return &JSONEncryptable[T]{Encryptable: NewUnencryptedWithKey(string(serialized), key)}, nil
 }
 
+// NewEncryptedJSON creates a new JSON encryptable an encrypted value and a relevant encryption key.
 func NewEncryptedJSON[T any](cipher, keyID string, key Key) *JSONEncryptable[T] {
 	return &JSONEncryptable[T]{Encryptable: NewEncrypted(cipher, keyID, key)}
 }
 
-func (e *JSONEncryptable[T]) Decrypted(ctx context.Context) (value T, _ error) {
-	serialized, err := e.Encryptable.Decrypted(ctx)
+// Decrypt decrypts and returns the underlying value as a T. This method may make an external API call
+// to decrypt the underlying encrypted value, but will memoize the result so that subsequent calls will
+// be cheap.
+func (e *JSONEncryptable[T]) Decrypt(ctx context.Context) (value T, _ error) {
+	serialized, err := e.Encryptable.Decrypt(ctx)
 	if err != nil {
 		return value, err
 	}
@@ -39,8 +49,11 @@ func (e *JSONEncryptable[T]) Decrypted(ctx context.Context) (value T, _ error) {
 	return value, nil
 }
 
-func (e *JSONEncryptable[T]) DecryptedInto(ctx context.Context, value T) error {
-	serialized, err := e.Encryptable.Decrypted(ctx)
+// DecryptInto decrypts the underlying value and updates the given value. This method may make an external
+// API call to decrypt the underlying encrypted value, but will memoize the result so that subsequent calls
+// will be cheap.
+func (e *JSONEncryptable[T]) DecryptInto(ctx context.Context, value T) error {
+	serialized, err := e.Encryptable.Decrypt(ctx)
 	if err != nil {
 		return err
 	}
@@ -52,6 +65,7 @@ func (e *JSONEncryptable[T]) DecryptedInto(ctx context.Context, value T) error {
 	return nil
 }
 
+// Set updates the underlying value.
 func (e *JSONEncryptable[T]) Set(value T) error {
 	serialized, err := json.Marshal(value)
 	if err != nil {

--- a/internal/encryption/json_encryptable_test.go
+++ b/internal/encryption/json_encryptable_test.go
@@ -1,0 +1,85 @@
+package encryption
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestJSONEncryptable(t *testing.T) {
+	ctx := context.Background()
+	base64Key := base64Key{}
+	keyID, _ := json.Marshal(base64KeyVersion)
+
+	keyType := func(t *testing.T, keyID string) string {
+		var key KeyVersion
+		if err := json.Unmarshal([]byte(keyID), &key); err != nil {
+			t.Fatalf("unexpected key identifier - not json: %s", err.Error())
+		}
+
+		return key.Type
+	}
+
+	type T struct {
+		Foo int `json:"foo"`
+		Bar int `json:"bar"`
+		Baz int `json:"baz"`
+	}
+	v1 := T{1, 2, 3}
+	v2 := T{7, 8, 9}
+
+	unencrypted, err := NewUnencryptedJSON(v1)
+	if err != nil {
+		t.Fatalf("unexpected error creating encryptable: %s", err.Error())
+	}
+
+	for _, encryptable := range []*JSONEncryptable[T]{
+		unencrypted,
+		NewEncryptedJSON[T]("eyJmb28iOjEsImJhciI6MiwiYmF6IjozfQ==", string(keyID), base64Key),
+	} {
+		// Test Decrypt
+		decrypted, err := encryptable.Decrypt(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error encrypting: %s", err.Error())
+		}
+		if want := v1; decrypted != want {
+			t.Fatalf("unexpected decrypted value. want=%q have=%q", want, decrypted)
+		}
+
+		// Test Encrypt
+		encrypted, keyID, err := encryptable.Encrypt(ctx, base64Key)
+		if err != nil {
+			t.Fatalf("unexpected error encrypting: %s", err.Error())
+		}
+		if want := "eyJmb28iOjEsImJhciI6MiwiYmF6IjozfQ=="; encrypted != want {
+			t.Fatalf("unexpected encrypted value. want=%q have=%q", want, encrypted)
+		}
+		if want := base64KeyVersion.Type; keyType(t, keyID) != want {
+			t.Fatalf("unexpected key identifier. want=%q have=%q", want, keyType(t, keyID))
+		}
+
+		// Test Set
+		encryptable.Set(v2)
+
+		// Re-test Decrypt
+		decrypted, err = encryptable.Decrypt(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error encrypting: %s", err.Error())
+		}
+		if want := v2; decrypted != want {
+			t.Fatalf("unexpected decrypted value. want=%q have=%q", want, decrypted)
+		}
+
+		// Re-test Encrypt
+		encrypted, keyID, err = encryptable.Encrypt(ctx, base64Key)
+		if err != nil {
+			t.Fatalf("unexpected error encrypting: %s", err.Error())
+		}
+		if want := "eyJmb28iOjcsImJhciI6OCwiYmF6Ijo5fQ=="; encrypted != want {
+			t.Fatalf("unexpected encrypted value. want=%q have=%q", want, encrypted)
+		}
+		if want := base64KeyVersion.Type; keyType(t, keyID) != want {
+			t.Fatalf("unexpected key identifier. want=%q have=%q", want, keyType(t, keyID))
+		}
+	}
+}

--- a/internal/encryption/testing/compare.go
+++ b/internal/encryption/testing/compare.go
@@ -16,12 +16,12 @@ var CompareEncryptable = cmp.Comparer(func(a, b *encryption.Encryptable) bool {
 		return false
 	}
 
-	aValue, err := a.Decrypted(context.Background())
+	aValue, err := a.Decrypt(context.Background())
 	if err != nil {
 		return false
 	}
 
-	bValue, err := b.Decrypted(context.Background())
+	bValue, err := b.Decrypt(context.Background())
 	if err != nil {
 		return false
 	}

--- a/internal/encryption/testing/compare.go
+++ b/internal/encryption/testing/compare.go
@@ -1,0 +1,30 @@
+package testing
+
+import (
+	"context"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+)
+
+var CompareEncryptable = cmp.Comparer(func(a, b *encryption.Encryptable) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	aValue, err := a.Decrypted(context.Background())
+	if err != nil {
+		return false
+	}
+
+	bValue, err := b.Decrypted(context.Background())
+	if err != nil {
+		return false
+	}
+
+	return cmp.Diff(aValue, bValue) == ""
+})

--- a/internal/encryption/utils_test.go
+++ b/internal/encryption/utils_test.go
@@ -1,0 +1,52 @@
+package encryption
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+type base64Key struct{}
+
+var base64KeyVersion = KeyVersion{Type: "base64"}
+
+func (k base64Key) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	return []byte(base64.StdEncoding.EncodeToString(plaintext)), nil
+}
+
+func (k base64Key) Decrypt(ctx context.Context, ciphertext []byte) (*Secret, error) {
+	decoded, err := base64.StdEncoding.DecodeString(string(ciphertext))
+	s := NewSecret(string(decoded))
+	return &s, err
+}
+
+func (k base64Key) Version(ctx context.Context) (KeyVersion, error) {
+	return base64KeyVersion, nil
+}
+
+type base64PlusJunkKey struct{ base64Key }
+
+var base64PlusJunkKeyVersion = KeyVersion{Type: "base64-plus-junk"}
+
+func (k base64PlusJunkKey) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	encrypted, err := k.base64Key.Encrypt(ctx, plaintext)
+	return append([]byte(`!@#$`), encrypted...), err
+}
+
+func (k base64PlusJunkKey) Decrypt(ctx context.Context, ciphertext []byte) (*Secret, error) {
+	return k.base64Key.Decrypt(ctx, ciphertext[4:])
+}
+
+func (k base64PlusJunkKey) Version(ctx context.Context) (KeyVersion, error) {
+	return base64PlusJunkKeyVersion, nil
+}
+
+func keyType(t *testing.T, keyID string) string {
+	var key KeyVersion
+	if err := json.Unmarshal([]byte(keyID), &key); err != nil {
+		t.Fatalf("unexpected key identifier - not json: %s", err.Error())
+	}
+
+	return key.Type
+}


### PR DESCRIPTION
Introduces a type to manage lazy/on-demand encrypting/decrypting of values encryptable at-rest in the database.

Several new uses are stacked on top of this definition.

- https://github.com/sourcegraph/sourcegraph/pull/40292
- https://github.com/sourcegraph/sourcegraph/pull/40177
- https://github.com/sourcegraph/sourcegraph/pull/40228
- https://github.com/sourcegraph/sourcegraph/pull/40233
- https://github.com/sourcegraph/sourcegraph/pull/40237

## Test plan

Test coverage in linked PRs.