### PR TITLE
Search backend: add support for negated predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Replaced the `ALLOW_DECRYPT_MIGRATION` envvar with `ALLOW_DECRYPTION`. See [updated documentation](https://docs.sourcegraph.com/admin/config/encryption). [#39984](https://github.com/sourcegraph/sourcegraph/pull/39984)
 - Compute-powered insight now supports only one series custom colors for compute series bars [40038](https://github.com/sourcegraph/sourcegraph/pull/40038)
 - **IMPORTANT:** `repo:contains(file:foo content:bar)` has been renamed to `repo:contains.file(path:foo content:bar)`. `repo:contains.file(foo)` has been renamed to `repo:contains.path(foo)`. `repo:contains()` **is no longer a valid predicate. Saved searches using** `repo:contains()` **will need to be updated to use the new syntax.** [#40389](https://github.com/sourcegraph/sourcegraph/pull/40389)
-- Significant performance improvements to the search predicates `repo:contains.file()`, `repo:contains.content()`, and `file:contains.content()`. [#40239](https://github.com/sourcegraph/sourcegraph/pull/40239), [#39501](https://github.com/sourcegraph/sourcegraph/pull/39501), [#38988](https://github.com/sourcegraph/sourcegraph/pull/38988)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added experimental support for exporting traces to an OpenTelemetry collector with `"observability.tracing": { "type": "opentelemetry" }` [#37984](https://github.com/sourcegraph/sourcegraph/pull/37984)
 - Added `ROCKSKIP_MIN_REPO_SIZE_MB` to automatically use [Rockskip](https://docs.sourcegraph.com/code_intelligence/explanations/rockskip) for repositories over a certain size. [#38192](https://github.com/sourcegraph/sourcegraph/pull/38192)
 - `"observability.tracing": { "urlTemplate": "..." }` can now be set to configure generated trace URLs (for example those generated via `&trace=1`). [#39765](https://github.com/sourcegraph/sourcegraph/pull/39765)
+- Negation support for the search predicates `-repo:contains.file(path)` and `-repo:contains.content(needle)`. [#40283](https://github.com/sourcegraph/sourcegraph/pull/40283)
 
 ### Changed
 
@@ -71,6 +72,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Replaced the `ALLOW_DECRYPT_MIGRATION` envvar with `ALLOW_DECRYPTION`. See [updated documentation](https://docs.sourcegraph.com/admin/config/encryption). [#39984](https://github.com/sourcegraph/sourcegraph/pull/39984)
 - Compute-powered insight now supports only one series custom colors for compute series bars [40038](https://github.com/sourcegraph/sourcegraph/pull/40038)
 - **IMPORTANT:** `repo:contains(file:foo content:bar)` has been renamed to `repo:contains.file(path:foo content:bar)`. `repo:contains.file(foo)` has been renamed to `repo:contains.path(foo)`. `repo:contains()` **is no longer a valid predicate. Saved searches using** `repo:contains()` **will need to be updated to use the new syntax.** [#40389](https://github.com/sourcegraph/sourcegraph/pull/40389)
+- Significant performance improvements to the search predicates `repo:contains.file()`, `repo:contains.content()`, and `file:contains.content()`. [#40239](https://github.com/sourcegraph/sourcegraph/pull/40239), [#39501](https://github.com/sourcegraph/sourcegraph/pull/39501), [#38988](https://github.com/sourcegraph/sourcegraph/pull/38988)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 - A new [multi-version upgrade](https://docs.sourcegraph.com/admin/updates#multi-version-upgrades) process now allows Sourcegraph instances to upgrade more than a single minor version. Instances at version 3.20 or later can now jump directly to 4.0. [#40628](https://github.com/sourcegraph/sourcegraph/pull/40628)
 - Matching ranges in file paths are now highlighted for path results and content results. [#41296](https://github.com/sourcegraph/sourcegraph/pull/41296) [#41385](https://github.com/sourcegraph/sourcegraph/pull/41385)
 - Aggregations by repository, file, author, and capture group are now provided for search results. [#39643](https://github.com/sourcegraph/sourcegraph/issues/39643)
+- Negation support for the search predicates `-repo:has.path()` and `-repo:has.content()`. [#40283](https://github.com/sourcegraph/sourcegraph/pull/40283)
 
 ### Changed
 
@@ -63,7 +64,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Added experimental support for exporting traces to an OpenTelemetry collector with `"observability.tracing": { "type": "opentelemetry" }` [#37984](https://github.com/sourcegraph/sourcegraph/pull/37984)
 - Added `ROCKSKIP_MIN_REPO_SIZE_MB` to automatically use [Rockskip](https://docs.sourcegraph.com/code_intelligence/explanations/rockskip) for repositories over a certain size. [#38192](https://github.com/sourcegraph/sourcegraph/pull/38192)
 - `"observability.tracing": { "urlTemplate": "..." }` can now be set to configure generated trace URLs (for example those generated via `&trace=1`). [#39765](https://github.com/sourcegraph/sourcegraph/pull/39765)
-- Negation support for the search predicates `-repo:contains.file(path)` and `-repo:contains.content(needle)`. [#40283](https://github.com/sourcegraph/sourcegraph/pull/40283)
 
 ### Changed
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1246,6 +1246,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Repo: 1},
 			},
 			{
+				name:   `repo has tag and not nonexistent tag`,
+				query:  `repo:has.tag(testtag) -repo:has.tag(noexist)`,
+				counts: counts{Repo: 1},
+			},
+			{
 				name:   `repo has kvp that does not exist`,
 				query:  `repo:has(noexist:false)`,
 				counts: counts{Repo: 0},
@@ -1253,6 +1258,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:   `repo has kvp`,
 				query:  `repo:has(testkey:testval)`,
+				counts: counts{Repo: 2},
+			},
+			{
+				name:   `repo has kvp and not nonexistent kvp`,
+				query:  `repo:has(testkey:testval) -repo:has(noexist:false)`,
 				counts: counts{Repo: 2},
 			},
 		}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1112,6 +1112,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Repo: 2},
 			},
 			{
+				name:   `repo contains file but not content`,
+				query:  `repo:contains.file(go\.mod) -repo:contains.content(go-diff)`,
+				counts: counts{Repo: 1},
+			},
+			{
 				name:   `no repo contains file`,
 				query:  `repo:contains.file(path:noexist.go)`,
 				counts: counts{},
@@ -1134,6 +1139,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:   `or-expression on repo:contains.file`,
 				query:  `repo:contains.file(content:does-not-exist-D2E1E74C7279) or repo:contains.file(content:nextFileFirstLine)`,
+				counts: counts{Repo: 1},
+			},
+			{
+				name:   `negated repo:contains with another repo:contains`,
+				query:  `-repo:contains.content(does-not-exist-D2E1E74C7279) and repo:contains.content(nextFileFirstLine)`,
 				counts: counts{Repo: 1},
 			},
 			{

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1113,14 +1113,14 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:   `repo contains file but not content`,
-				query:  `repo:contains.file(go\.mod) -repo:contains.content(go-diff)`,
+				query:  `repo:contains.path(go\.mod) -repo:contains.content(go-diff)`,
 				counts: counts{Repo: 1},
 			},
 			{
 				name: `repo does not contain file, but search for another file`,
 				// reader_util_test.go exists in go-diff
 				// appdash.go exists in appdash
-				query:  `-repo:contains.file(reader_util_test.go) file:appdash.go`,
+				query:  `-repo:contains.path(reader_util_test.go) file:appdash.go`,
 				counts: counts{File: 1},
 			},
 			{

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1117,6 +1117,34 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Repo: 1},
 			},
 			{
+				name: `repo does not contain file, but search for another file`,
+				// reader_util_test.go exists in go-diff
+				// appdash.go exists in appdash
+				query:  `-repo:contains.file(reader_util_test.go) file:appdash.go`,
+				counts: counts{File: 1},
+			},
+			{
+				name: `repo does not contain content, but search for another file`,
+				// TestHunkNoChunksize exists in go-diff
+				// appdash.go exists in appdash
+				query:  `-repo:contains.content(TestParseHunkNoChunksize) file:appdash.go`,
+				counts: counts{File: 1},
+			},
+			{
+				name: `repo does not contain content, but search for another file`,
+				// reader_util_test.go exists in go-diff
+				// TestHunkNoChunksize exists in go-diff
+				query:  `-repo:contains.content(TestParseHunkNoChunksize) file:reader_util_test.go`,
+				counts: counts{},
+			},
+			{
+				name: `repo does not contain content, but search for another file`,
+				// reader_util_test.go exists in go-diff
+				// TestHunkNoChunksize exists in go-diff
+				query:  `-repo:contains.file(reader_util_test.go) TestHunkNoChunksize`,
+				counts: counts{},
+			},
+			{
 				name:   `no repo contains file`,
 				query:  `repo:contains.file(path:noexist.go)`,
 				counts: counts{},

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -17,9 +17,9 @@ type Predicate interface {
 	// For example, with `repo:contains.file`, Name returns "contains.file".
 	Name() string
 
-	// ParseParams parses the contents of the predicate arguments
+	// Unmarshal parses the contents of the predicate arguments
 	// into the predicate object.
-	ParseParams(string) error
+	Unmarshal(string) error
 }
 
 var DefaultPredicateRegistry = PredicateRegistry{
@@ -85,9 +85,9 @@ func ParseAsPredicate(value string) (name, params string) {
 // EmptyPredicate is a noop value that satisfies the Predicate interface.
 type EmptyPredicate struct{}
 
-func (EmptyPredicate) Field() string            { return "" }
-func (EmptyPredicate) Name() string             { return "" }
-func (EmptyPredicate) ParseParams(string) error { return nil }
+func (EmptyPredicate) Field() string          { return "" }
+func (EmptyPredicate) Name() string           { return "" }
+func (EmptyPredicate) Unmarshal(string) error { return nil }
 
 // RepoContainsFilePredicate represents the `repo:contains.file()` predicate,
 // which filters to repos that contain a path and/or content
@@ -96,7 +96,7 @@ type RepoContainsFilePredicate struct {
 	Content string
 }
 
-func (f *RepoContainsFilePredicate) ParseParams(params string) error {
+func (f *RepoContainsFilePredicate) Unmarshal(params string) error {
 	nodes, err := Parse(params, SearchTypeRegex)
 	if err != nil {
 		return err
@@ -167,7 +167,7 @@ type RepoContainsContentPredicate struct {
 	Pattern string
 }
 
-func (f *RepoContainsContentPredicate) ParseParams(params string) error {
+func (f *RepoContainsContentPredicate) Unmarshal(params string) error {
 	if _, err := regexp.Compile(params); err != nil {
 		return errors.Errorf("contains.content argument: %w", err)
 	}
@@ -187,7 +187,7 @@ type RepoContainsPathPredicate struct {
 	Pattern string
 }
 
-func (f *RepoContainsPathPredicate) ParseParams(params string) error {
+func (f *RepoContainsPathPredicate) Unmarshal(params string) error {
 	if _, err := regexp.Compile(params); err != nil {
 		return errors.Errorf("contains.path argument: %w", err)
 	}
@@ -207,7 +207,7 @@ type RepoContainsCommitAfterPredicate struct {
 	TimeRef string
 }
 
-func (f *RepoContainsCommitAfterPredicate) ParseParams(params string) error {
+func (f *RepoContainsCommitAfterPredicate) Unmarshal(params string) error {
 	f.TimeRef = params
 	return nil
 }
@@ -223,7 +223,7 @@ type RepoHasDescriptionPredicate struct {
 	Pattern string
 }
 
-func (f *RepoHasDescriptionPredicate) ParseParams(params string) (err error) {
+func (f *RepoHasDescriptionPredicate) Unmarshal(params string) (err error) {
 	if _, err := regexp.Compile(params); err != nil {
 		return errors.Errorf("invalid repo:has.description() argument: %w", err)
 	}
@@ -241,7 +241,7 @@ type RepoHasTagPredicate struct {
 	Key string
 }
 
-func (f *RepoHasTagPredicate) ParseParams(params string) (err error) {
+func (f *RepoHasTagPredicate) Unmarshal(params string) (err error) {
 	if len(params) == 0 {
 		return errors.New("tag must be non-empty")
 	}
@@ -257,7 +257,7 @@ type RepoHasKVPPredicate struct {
 	Value string
 }
 
-func (p *RepoHasKVPPredicate) ParseParams(params string) (err error) {
+func (p *RepoHasKVPPredicate) Unmarshal(params string) (err error) {
 	split := strings.Split(params, ":")
 	if len(split) != 2 || len(split[0]) == 0 || len(split[1]) == 0 {
 		return errors.New("expected params in the form of key:value")
@@ -276,7 +276,7 @@ type FileContainsContentPredicate struct {
 	Pattern string
 }
 
-func (f *FileContainsContentPredicate) ParseParams(params string) error {
+func (f *FileContainsContentPredicate) Unmarshal(params string) error {
 	if _, err := regexp.Compile(params); err != nil {
 		return errors.Errorf("file:contains.content argument: %w", err)
 	}
@@ -296,7 +296,7 @@ type FileHasOwnerPredicate struct {
 	Owner string
 }
 
-func (f *FileHasOwnerPredicate) ParseParams(params string) error {
+func (f *FileHasOwnerPredicate) Unmarshal(params string) error {
 	if params == "" {
 		return errors.Errorf("file:has.owner argument should not be empty")
 	}

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -102,13 +102,10 @@ func (EmptyPredicate) Unmarshal(_ string, negated bool) error {
 type RepoContainsFilePredicate struct {
 	Path    string
 	Content string
+	Negated bool
 }
 
 func (f *RepoContainsFilePredicate) Unmarshal(params string, negated bool) error {
-	if negated {
-		return ErrNegatedPredicate
-	}
-
 	nodes, err := Parse(params, SearchTypeRegex)
 	if err != nil {
 		return err
@@ -123,7 +120,7 @@ func (f *RepoContainsFilePredicate) Unmarshal(params string, negated bool) error
 	if f.Path == "" && f.Content == "" {
 		return errors.New("one of path or content must be set")
 	}
-
+	f.Negated = negated
 	return nil
 }
 
@@ -177,13 +174,10 @@ func (f *RepoContainsFilePredicate) Name() string  { return "contains.file" }
 
 type RepoContainsContentPredicate struct {
 	Pattern string
+	Negated bool
 }
 
 func (f *RepoContainsContentPredicate) Unmarshal(params string, negated bool) error {
-	if negated {
-		return ErrNegatedPredicate
-	}
-
 	if _, err := regexp.Compile(params); err != nil {
 		return errors.Errorf("contains.content argument: %w", err)
 	}
@@ -191,6 +185,7 @@ func (f *RepoContainsContentPredicate) Unmarshal(params string, negated bool) er
 		return errors.Errorf("contains.content argument should not be empty")
 	}
 	f.Pattern = params
+	f.Negated = negated
 	return nil
 }
 
@@ -201,13 +196,10 @@ func (f *RepoContainsContentPredicate) Name() string  { return "contains.content
 
 type RepoContainsPathPredicate struct {
 	Pattern string
+	Negated bool
 }
 
 func (f *RepoContainsPathPredicate) Unmarshal(params string, negated bool) error {
-	if negated {
-		return ErrNegatedPredicate
-	}
-
 	if _, err := regexp.Compile(params); err != nil {
 		return errors.Errorf("contains.path argument: %w", err)
 	}
@@ -215,6 +207,7 @@ func (f *RepoContainsPathPredicate) Unmarshal(params string, negated bool) error
 		return errors.Errorf("contains.path argument should not be empty")
 	}
 	f.Pattern = params
+	f.Negated = negated
 	return nil
 }
 
@@ -266,18 +259,16 @@ func (f *RepoHasDescriptionPredicate) Field() string { return FieldRepo }
 func (f *RepoHasDescriptionPredicate) Name() string  { return "has.description" }
 
 type RepoHasTagPredicate struct {
-	Key string
+	Key     string
+	Negated bool
 }
 
 func (f *RepoHasTagPredicate) Unmarshal(params string, negated bool) (err error) {
-	if negated {
-		return ErrNegatedPredicate
-	}
-
 	if len(params) == 0 {
 		return errors.New("tag must be non-empty")
 	}
 	f.Key = params
+	f.Negated = negated
 	return nil
 }
 
@@ -285,20 +276,19 @@ func (f *RepoHasTagPredicate) Field() string { return FieldRepo }
 func (f *RepoHasTagPredicate) Name() string  { return "has.tag" }
 
 type RepoHasKVPPredicate struct {
-	Key   string
-	Value string
+	Key     string
+	Value   string
+	Negated bool
 }
 
 func (p *RepoHasKVPPredicate) Unmarshal(params string, negated bool) (err error) {
-	if negated {
-		return ErrNegatedPredicate
-	}
 	split := strings.Split(params, ":")
 	if len(split) != 2 || len(split[0]) == 0 || len(split[1]) == 0 {
 		return errors.New("expected params in the form of key:value")
 	}
 	p.Key = split[0]
 	p.Value = split[1]
+	p.Negated = negated
 	return nil
 }
 
@@ -332,18 +322,16 @@ func (f FileContainsContentPredicate) Name() string  { return "contains.content"
 /* file:has.owner(pattern) */
 
 type FileHasOwnerPredicate struct {
-	Owner string
+	Owner   string
+	Negated bool
 }
 
 func (f *FileHasOwnerPredicate) Unmarshal(params string, negated bool) error {
-	if negated {
-		return ErrNegatedPredicate
-	}
-
 	if params == "" {
 		return errors.Errorf("file:has.owner argument should not be empty")
 	}
 	f.Owner = params
+	f.Negated = negated
 	return nil
 }
 

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -334,6 +334,9 @@ type FileHasOwnerPredicate struct {
 }
 
 func (f *FileHasOwnerPredicate) Unmarshal(params string, negated bool) error {
+	if negated {
+		return &NegatedPredicateError{f.Field() + ":" + f.Name()}
+	}
 	if params == "" {
 		return errors.Errorf("file:has.owner argument should not be empty")
 	}

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -43,7 +44,13 @@ var DefaultPredicateRegistry = PredicateRegistry{
 	},
 }
 
-var ErrNegatedPredicate = errors.New("predicates do not support negation")
+type NegatedPredicateError struct {
+	name string
+}
+
+func (e *NegatedPredicateError) Error() string {
+	return fmt.Sprintf("search predicate %q does not support negation", e.name)
+}
 
 // PredicateTable is a lookup map of one or more predicate names that resolve to the Predicate type.
 type PredicateTable map[string]func() Predicate
@@ -91,7 +98,7 @@ func (EmptyPredicate) Field() string { return "" }
 func (EmptyPredicate) Name() string  { return "" }
 func (EmptyPredicate) Unmarshal(_ string, negated bool) error {
 	if negated {
-		return ErrNegatedPredicate
+		return &NegatedPredicateError{"empty"}
 	}
 
 	return nil
@@ -222,7 +229,7 @@ type RepoContainsCommitAfterPredicate struct {
 
 func (f *RepoContainsCommitAfterPredicate) Unmarshal(params string, negated bool) error {
 	if negated {
-		return ErrNegatedPredicate
+		return &NegatedPredicateError{f.Field() + ":" + f.Name()}
 	}
 
 	f.TimeRef = params
@@ -242,7 +249,7 @@ type RepoHasDescriptionPredicate struct {
 
 func (f *RepoHasDescriptionPredicate) Unmarshal(params string, negated bool) (err error) {
 	if negated {
-		return ErrNegatedPredicate
+		return &NegatedPredicateError{f.Field() + ":" + f.Name()}
 	}
 
 	if _, err := regexp.Compile(params); err != nil {
@@ -303,7 +310,7 @@ type FileContainsContentPredicate struct {
 
 func (f *FileContainsContentPredicate) Unmarshal(params string, negated bool) error {
 	if negated {
-		return ErrNegatedPredicate
+		return &NegatedPredicateError{f.Field() + ":" + f.Name()}
 	}
 
 	if _, err := regexp.Compile(params); err != nil {

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRepoContainsFilePredicate(t *testing.T) {
-	t.Run("ParseParams", func(t *testing.T) {
+	t.Run("Unmarshal", func(t *testing.T) {
 		type test struct {
 			name     string
 			params   string
@@ -24,7 +24,7 @@ func TestRepoContainsFilePredicate(t *testing.T) {
 		for _, tc := range valid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &RepoContainsFilePredicate{}
-				err := p.ParseParams(tc.params)
+				err := p.Unmarshal(tc.params)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
 				}
@@ -47,7 +47,7 @@ func TestRepoContainsFilePredicate(t *testing.T) {
 		for _, tc := range invalid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &RepoContainsFilePredicate{}
-				err := p.ParseParams(tc.params)
+				err := p.Unmarshal(tc.params)
 				if err == nil {
 					t.Fatal("expected error but got none")
 				}
@@ -82,7 +82,7 @@ func TestParseAsPredicate(t *testing.T) {
 }
 
 func TestRepoHasDescriptionPredicate(t *testing.T) {
-	t.Run("ParseParams", func(t *testing.T) {
+	t.Run("Unmarshal", func(t *testing.T) {
 		type test struct {
 			name     string
 			params   string
@@ -97,7 +97,7 @@ func TestRepoHasDescriptionPredicate(t *testing.T) {
 		for _, tc := range valid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &RepoHasDescriptionPredicate{}
-				err := p.ParseParams(tc.params)
+				err := p.Unmarshal(tc.params)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
 				}
@@ -116,7 +116,7 @@ func TestRepoHasDescriptionPredicate(t *testing.T) {
 		for _, tc := range invalid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &RepoHasDescriptionPredicate{}
-				err := p.ParseParams(tc.params)
+				err := p.Unmarshal(tc.params)
 				if err == nil {
 					t.Fatal("expected error but got none")
 				}
@@ -126,7 +126,7 @@ func TestRepoHasDescriptionPredicate(t *testing.T) {
 }
 
 func TestFileHasOwnerPredicate(t *testing.T) {
-	t.Run("ParseParams", func(t *testing.T) {
+	t.Run("Unmarshal", func(t *testing.T) {
 		type test struct {
 			name     string
 			params   string
@@ -142,7 +142,7 @@ func TestFileHasOwnerPredicate(t *testing.T) {
 		for _, tc := range valid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &FileHasOwnerPredicate{}
-				err := p.ParseParams(tc.params)
+				err := p.Unmarshal(tc.params)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
 				}
@@ -160,7 +160,7 @@ func TestFileHasOwnerPredicate(t *testing.T) {
 		for _, tc := range invalid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &FileHasOwnerPredicate{}
-				err := p.ParseParams(tc.params)
+				err := p.Unmarshal(tc.params)
 				if err == nil {
 					t.Fatal("expected error but got none")
 				}

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -24,7 +24,7 @@ func TestRepoContainsFilePredicate(t *testing.T) {
 		for _, tc := range valid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &RepoContainsFilePredicate{}
-				err := p.Unmarshal(tc.params)
+				err := p.Unmarshal(tc.params, false)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
 				}
@@ -47,7 +47,7 @@ func TestRepoContainsFilePredicate(t *testing.T) {
 		for _, tc := range invalid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &RepoContainsFilePredicate{}
-				err := p.Unmarshal(tc.params)
+				err := p.Unmarshal(tc.params, false)
 				if err == nil {
 					t.Fatal("expected error but got none")
 				}
@@ -97,7 +97,7 @@ func TestRepoHasDescriptionPredicate(t *testing.T) {
 		for _, tc := range valid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &RepoHasDescriptionPredicate{}
-				err := p.Unmarshal(tc.params)
+				err := p.Unmarshal(tc.params, false)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
 				}
@@ -116,7 +116,7 @@ func TestRepoHasDescriptionPredicate(t *testing.T) {
 		for _, tc := range invalid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &RepoHasDescriptionPredicate{}
-				err := p.Unmarshal(tc.params)
+				err := p.Unmarshal(tc.params, false)
 				if err == nil {
 					t.Fatal("expected error but got none")
 				}
@@ -142,7 +142,7 @@ func TestFileHasOwnerPredicate(t *testing.T) {
 		for _, tc := range valid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &FileHasOwnerPredicate{}
-				err := p.Unmarshal(tc.params)
+				err := p.Unmarshal(tc.params, false)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
 				}
@@ -160,7 +160,7 @@ func TestFileHasOwnerPredicate(t *testing.T) {
 		for _, tc := range invalid {
 			t.Run(tc.name, func(t *testing.T) {
 				p := &FileHasOwnerPredicate{}
-				err := p.Unmarshal(tc.params)
+				err := p.Unmarshal(tc.params, false)
 				if err == nil {
 					t.Fatal("expected error but got none")
 				}

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -360,25 +360,25 @@ func (p Parameters) RepoHasFileContent() (res []RepoHasFileContentArgs) {
 		})
 	})
 
-	VisitTypedPredicate(nodes, func(pred *RepoContainsPathPredicate, negated bool) {
+	VisitTypedPredicate(nodes, func(pred *RepoContainsPathPredicate) {
 		res = append(res, RepoHasFileContentArgs{
 			Path:    pred.Pattern,
-			Negated: negated,
+			Negated: pred.Negated,
 		})
 	})
 
-	VisitTypedPredicate(nodes, func(pred *RepoContainsContentPredicate, negated bool) {
+	VisitTypedPredicate(nodes, func(pred *RepoContainsContentPredicate) {
 		res = append(res, RepoHasFileContentArgs{
 			Content: pred.Pattern,
-			Negated: negated,
+			Negated: pred.Negated,
 		})
 	})
 
-	VisitTypedPredicate(nodes, func(pred *RepoContainsFilePredicate, negated bool) {
+	VisitTypedPredicate(nodes, func(pred *RepoContainsFilePredicate) {
 		res = append(res, RepoHasFileContentArgs{
 			Path:    pred.Path,
 			Content: pred.Content,
-			Negated: negated,
+			Negated: pred.Negated,
 		})
 	})
 
@@ -386,7 +386,7 @@ func (p Parameters) RepoHasFileContent() (res []RepoHasFileContentArgs) {
 }
 
 func (p Parameters) FileContainsContent() (include []string) {
-	VisitTypedPredicate(toNodes(p), func(pred *FileContainsContentPredicate, negated bool) {
+	VisitTypedPredicate(toNodes(p), func(pred *FileContainsContentPredicate) {
 		include = append(include, pred.Pattern)
 	})
 	return include
@@ -399,7 +399,7 @@ func (p Parameters) RepoContainsCommitAfter() (value string) {
 	value = p.FindValue(FieldRepoHasCommitAfter)
 
 	// Look for values of repo:contains.commit.after()
-	VisitTypedPredicate(nodes, func(pred *RepoContainsCommitAfterPredicate, _ bool) {
+	VisitTypedPredicate(nodes, func(pred *RepoContainsCommitAfterPredicate) {
 		value = pred.TimeRef
 	})
 
@@ -413,18 +413,18 @@ type RepoKVPFilter struct {
 }
 
 func (p Parameters) RepoHasKVPs() (res []RepoKVPFilter) {
-	VisitTypedPredicate(toNodes(p), func(pred *RepoHasKVPPredicate, negated bool) {
+	VisitTypedPredicate(toNodes(p), func(pred *RepoHasKVPPredicate) {
 		res = append(res, RepoKVPFilter{
 			Key:     pred.Key,
 			Value:   &pred.Value,
-			Negated: negated,
+			Negated: pred.Negated,
 		})
 	})
 
-	VisitTypedPredicate(toNodes(p), func(pred *RepoHasTagPredicate, negated bool) {
+	VisitTypedPredicate(toNodes(p), func(pred *RepoHasTagPredicate) {
 		res = append(res, RepoKVPFilter{
 			Key:     pred.Key,
-			Negated: negated,
+			Negated: pred.Negated,
 		})
 	})
 
@@ -432,8 +432,8 @@ func (p Parameters) RepoHasKVPs() (res []RepoKVPFilter) {
 }
 
 func (p Parameters) FileHasOwner() (include, exclude []string) {
-	VisitTypedPredicate(toNodes(p), func(pred *FileHasOwnerPredicate, negated bool) {
-		if negated {
+	VisitTypedPredicate(toNodes(p), func(pred *FileHasOwnerPredicate) {
+		if pred.Negated {
 			exclude = append(exclude, pred.Owner)
 		} else {
 			include = append(include, pred.Owner)
@@ -453,7 +453,7 @@ func (p Parameters) Exists(field string) bool {
 }
 
 func (p Parameters) RepoHasDescription() (descriptionPatterns []string) {
-	VisitTypedPredicate(toNodes(p), func(pred *RepoHasDescriptionPredicate, _ bool) {
+	VisitTypedPredicate(toNodes(p), func(pred *RepoHasDescriptionPredicate) {
 		split := strings.Split(pred.Pattern, " ")
 		descriptionPatterns = append(descriptionPatterns, "(?:"+strings.Join(split, ").*?(?:")+")")
 	})

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -154,7 +154,7 @@ func (q Q) Repositories() (repos []string, negatedRepos []string) {
 }
 
 func (q Q) Dependencies() (dependencies []string) {
-	VisitPredicate(q, func(field, name, value string) {
+	VisitPredicate(q, func(field, name, value string, _ bool) {
 		if field == FieldRepo && (name == "dependencies" || name == "deps") {
 			dependencies = append(dependencies, value)
 		}
@@ -163,7 +163,7 @@ func (q Q) Dependencies() (dependencies []string) {
 }
 
 func (q Q) Dependents() (dependents []string) {
-	VisitPredicate(q, func(field, name, value string) {
+	VisitPredicate(q, func(field, name, value string, _ bool) {
 		if field == FieldRepo && (name == "dependents" || name == "revdeps") {
 			dependents = append(dependents, value)
 		}

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -397,7 +397,7 @@ func validatePredicate(field, value string, negated bool) error {
 	}
 	name, params := ParseAsPredicate(value)                // guaranteed to succeed
 	predicate := DefaultPredicateRegistry.Get(field, name) // guaranteed to succeed
-	if err := predicate.Unmarshal(params); err != nil {
+	if err := predicate.Unmarshal(params, negated); err != nil {
 		return errors.Errorf("invalid predicate value: %s", err)
 	}
 	return nil

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -392,9 +392,6 @@ func validateRefGlobs(nodes []Node) error {
 
 // validatePredicates validates predicate parameters with respect to their validation logic.
 func validatePredicate(field, value string, negated bool) error {
-	if negated {
-		return errors.New("predicates do not currently support negation")
-	}
 	name, params := ParseAsPredicate(value)                // guaranteed to succeed
 	predicate := DefaultPredicateRegistry.Get(field, name) // guaranteed to succeed
 	if err := predicate.Unmarshal(params, negated); err != nil {

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -397,7 +397,7 @@ func validatePredicate(field, value string, negated bool) error {
 	}
 	name, params := ParseAsPredicate(value)                // guaranteed to succeed
 	predicate := DefaultPredicateRegistry.Get(field, name) // guaranteed to succeed
-	if err := predicate.ParseParams(params); err != nil {
+	if err := predicate.Unmarshal(params); err != nil {
 		return errors.Errorf("invalid predicate value: %s", err)
 	}
 	return nil

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -74,11 +74,11 @@ func VisitField(nodes []Node, field string, f func(value string, negated bool, a
 
 // VisitPredicate convenience function that calls `f` on all query predicates,
 // supplying the node's field and predicate info.
-func VisitPredicate(nodes []Node, f func(field, name, value string)) {
-	VisitParameter(nodes, func(gotField, value string, _ bool, annotation Annotation) {
+func VisitPredicate(nodes []Node, f func(field, name, value string, negated bool)) {
+	VisitParameter(nodes, func(gotField, value string, negated bool, annotation Annotation) {
 		if annotation.Labels.IsSet(IsPredicate) {
 			name, predValue := ParseAsPredicate(value)
-			f(gotField, name, predValue)
+			f(gotField, name, predValue, negated)
 		}
 	})
 }
@@ -107,7 +107,7 @@ func VisitTypedPredicate[T any, PT predicatePointer[T]](nodes []Node, f func(pre
 		}
 
 		newPred := PT(new(T))
-		err := newPred.Unmarshal(predArgs)
+		err := newPred.Unmarshal(predArgs, negated)
 		if err != nil {
 			panic(err) // should already be validated
 		}

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -107,7 +107,7 @@ func VisitTypedPredicate[T any, PT predicatePointer[T]](nodes []Node, f func(pre
 		}
 
 		newPred := PT(new(T))
-		err := newPred.ParseParams(predArgs)
+		err := newPred.Unmarshal(predArgs)
 		if err != nil {
 			panic(err) // should already be validated
 		}

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -94,7 +94,7 @@ type predicatePointer[T any] interface {
 
 // VisitTypedPredicate visits every predicate of the type given to the callback function. The callback
 // will be called with a value of the predicate with its fields populated with its parsed arguments.
-func VisitTypedPredicate[T any, PT predicatePointer[T]](nodes []Node, f func(pred PT, negated bool)) {
+func VisitTypedPredicate[T any, PT predicatePointer[T]](nodes []Node, f func(pred PT)) {
 	zeroPred := PT(new(T))
 	VisitField(nodes, zeroPred.Field(), func(value string, negated bool, annotation Annotation) {
 		if !annotation.Labels.IsSet(IsPredicate) {
@@ -111,6 +111,6 @@ func VisitTypedPredicate[T any, PT predicatePointer[T]](nodes []Node, f func(pre
 		if err != nil {
 			panic(err) // should already be validated
 		}
-		f(newPred, negated)
+		f(newPred)
 	})
 }

--- a/internal/search/query/visitor_test.go
+++ b/internal/search/query/visitor_test.go
@@ -10,7 +10,7 @@ func TestSubstitute(t *testing.T) {
 	test := func(input string) string {
 		q, _ := ParseLiteral(input)
 		var result string
-		VisitPredicate(q, func(field, name, value string) {
+		VisitPredicate(q, func(field, name, value string, negated bool) {
 			if field == FieldRepo && name == "contains.file" {
 				result = "contains.file value is " + value
 			}

--- a/internal/search/query/visitor_test.go
+++ b/internal/search/query/visitor_test.go
@@ -42,7 +42,7 @@ func TestVisitTypedPredicate(t *testing.T) {
 		t.Run(tc.output.Name(), func(t *testing.T) {
 			q, _ := ParseLiteral(tc.query)
 			var result []*RepoContainsFilePredicate
-			VisitTypedPredicate(q, func(pred *RepoContainsFilePredicate, negated bool) {
+			VisitTypedPredicate(q, func(pred *RepoContainsFilePredicate) {
 				result = append(result, pred)
 			})
 			tc.output.Equal(t, result)

--- a/schema/stringdata.go
+++ b/schema/stringdata.go
@@ -3,81 +3,101 @@ package schema
 import _ "embed"
 
 // AWSCodeCommitSchemaJSON is the content of the file "aws_codecommit.schema.json".
+//
 //go:embed aws_codecommit.schema.json
 var AWSCodeCommitSchemaJSON string
 
 // BatchSpecSchemaJSON is the content of the file "batch_spec.schema.json".
+//
 //go:embed batch_spec.schema.json
 var BatchSpecSchemaJSON string
 
 // BitbucketCloudSchemaJSON is the content of the file "bitbucket_cloud.schema.json".
+//
 //go:embed bitbucket_cloud.schema.json
 var BitbucketCloudSchemaJSON string
 
 // BitbucketServerSchemaJSON is the content of the file "bitbucket_server.schema.json".
+//
 //go:embed bitbucket_server.schema.json
 var BitbucketServerSchemaJSON string
 
 // ChangesetSpecSchemaJSON is the content of the file "changeset_spec.schema.json".
+//
 //go:embed changeset_spec.schema.json
 var ChangesetSpecSchemaJSON string
 
 // GerritSchemaJSON is the content of the file "gerrit.schema.json".
+//
 //go:embed gerrit.schema.json
 var GerritSchemaJSON string
 
 // GitHubSchemaJSON is the content of the file "github.schema.json".
+//
 //go:embed github.schema.json
 var GitHubSchemaJSON string
 
 // GitLabSchemaJSON is the content of the file "gitlab.schema.json".
+//
 //go:embed gitlab.schema.json
 var GitLabSchemaJSON string
 
 // GitoliteSchemaJSON is the content of the file "gitolite.schema.json".
+//
 //go:embed gitolite.schema.json
 var GitoliteSchemaJSON string
 
 // GoModulesSchemaJSON is the content of the file "go-modules.schema.json".
+//
 //go:embed go-modules.schema.json
 var GoModulesSchemaJSON string
 
 // JVMPackagesSchemaJSON is the content of the file "jvm-packages.schema.json".
+//
 //go:embed jvm-packages.schema.json
 var JVMPackagesSchemaJSON string
 
 // NpmPackagesSchemaJSON is the content of the file "npm-packages.schema.json".
+//
 //go:embed npm-packages.schema.json
 var NpmPackagesSchemaJSON string
 
 // PythonPackagesSchemaJSON is the content of the file "python-packages.schema.json".
+//
 //go:embed python-packages.schema.json
 var PythonPackagesSchemaJSON string
 
 // RustPackagesSchemaJSON is the content of the file "python-packages.schema.json".
+//
 //go:embed rust-packages.schema.json
 var RustPackagesSchemaJSON string
 
 // OtherExternalServiceSchemaJSON is the content of the file "other_external_service.schema.json".
+//
 //go:embed other_external_service.schema.json
 var OtherExternalServiceSchemaJSON string
 
 // PerforceSchemaJSON is the content of the file "perforce.schema.json".
+//
 //go:embed perforce.schema.json
 var PerforceSchemaJSON string
 
 // PhabricatorSchemaJSON is the content of the file "phabricator.schema.json".
+//
 //go:embed phabricator.schema.json
 var PhabricatorSchemaJSON string
 
 // PagureSchemaJSON is the content of the file "pagure.schema.json".
+//
 //go:embed pagure.schema.json
 var PagureSchemaJSON string
 
 // SettingsSchemaJSON is the content of the file "settings.schema.json".
+//
 //go:embed settings.schema.json
 var SettingsSchemaJSON string
 
 // SiteSchemaJSON is the content of the file "site.schema.json".
+//
 //go:embed site.schema.json
 var SiteSchemaJSON string

--- a/schema/stringdata.go
+++ b/schema/stringdata.go
@@ -3,101 +3,81 @@ package schema
 import _ "embed"
 
 // AWSCodeCommitSchemaJSON is the content of the file "aws_codecommit.schema.json".
-//
 //go:embed aws_codecommit.schema.json
 var AWSCodeCommitSchemaJSON string
 
 // BatchSpecSchemaJSON is the content of the file "batch_spec.schema.json".
-//
 //go:embed batch_spec.schema.json
 var BatchSpecSchemaJSON string
 
 // BitbucketCloudSchemaJSON is the content of the file "bitbucket_cloud.schema.json".
-//
 //go:embed bitbucket_cloud.schema.json
 var BitbucketCloudSchemaJSON string
 
 // BitbucketServerSchemaJSON is the content of the file "bitbucket_server.schema.json".
-//
 //go:embed bitbucket_server.schema.json
 var BitbucketServerSchemaJSON string
 
 // ChangesetSpecSchemaJSON is the content of the file "changeset_spec.schema.json".
-//
 //go:embed changeset_spec.schema.json
 var ChangesetSpecSchemaJSON string
 
 // GerritSchemaJSON is the content of the file "gerrit.schema.json".
-//
 //go:embed gerrit.schema.json
 var GerritSchemaJSON string
 
 // GitHubSchemaJSON is the content of the file "github.schema.json".
-//
 //go:embed github.schema.json
 var GitHubSchemaJSON string
 
 // GitLabSchemaJSON is the content of the file "gitlab.schema.json".
-//
 //go:embed gitlab.schema.json
 var GitLabSchemaJSON string
 
 // GitoliteSchemaJSON is the content of the file "gitolite.schema.json".
-//
 //go:embed gitolite.schema.json
 var GitoliteSchemaJSON string
 
 // GoModulesSchemaJSON is the content of the file "go-modules.schema.json".
-//
 //go:embed go-modules.schema.json
 var GoModulesSchemaJSON string
 
 // JVMPackagesSchemaJSON is the content of the file "jvm-packages.schema.json".
-//
 //go:embed jvm-packages.schema.json
 var JVMPackagesSchemaJSON string
 
 // NpmPackagesSchemaJSON is the content of the file "npm-packages.schema.json".
-//
 //go:embed npm-packages.schema.json
 var NpmPackagesSchemaJSON string
 
 // PythonPackagesSchemaJSON is the content of the file "python-packages.schema.json".
-//
 //go:embed python-packages.schema.json
 var PythonPackagesSchemaJSON string
 
 // RustPackagesSchemaJSON is the content of the file "python-packages.schema.json".
-//
 //go:embed rust-packages.schema.json
 var RustPackagesSchemaJSON string
 
 // OtherExternalServiceSchemaJSON is the content of the file "other_external_service.schema.json".
-//
 //go:embed other_external_service.schema.json
 var OtherExternalServiceSchemaJSON string
 
 // PerforceSchemaJSON is the content of the file "perforce.schema.json".
-//
 //go:embed perforce.schema.json
 var PerforceSchemaJSON string
 
 // PhabricatorSchemaJSON is the content of the file "phabricator.schema.json".
-//
 //go:embed phabricator.schema.json
 var PhabricatorSchemaJSON string
 
 // PagureSchemaJSON is the content of the file "pagure.schema.json".
-//
 //go:embed pagure.schema.json
 var PagureSchemaJSON string
 
 // SettingsSchemaJSON is the content of the file "settings.schema.json".
-//
 //go:embed settings.schema.json
 var SettingsSchemaJSON string
 
 // SiteSchemaJSON is the content of the file "site.schema.json".
-//
 //go:embed site.schema.json
 var SiteSchemaJSON string


### PR DESCRIPTION
For most of our predicates, we can theoretically support negation. Up until now, we've explicitly disallowed negating predicates because their implementation (expanding the predicate in the query) was not performant enough to work _at all_ unless the negation somehow excluded almost everything (`-repo:contains.file(.*)`?). 

Now that we implement all our predicates natively, negation is actually within reach. In fact, when I rewrote our predicates, I rewrote most of them with negation in mind, so it's not a super big lift to start enabling it. 

This PR removes the "predicates are not allowed to be negated" rule and enables negation for `repo:contains.file()`, `repo:contains.content()`, `repo:has(key:value)`, and `repo:has.tag(t)`. 

Stacked on https://github.com/sourcegraph/sourcegraph/pull/40280
Closes #24325
Fixes https://github.com/sourcegraph/sourcegraph/issues/41475

## Test plan

Added many integration tests. Manually tested with local repo set.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
