### PR TITLE
Show site alert for deprecation of older GitLab versions

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -17,6 +17,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/versions"
 	srcprometheus "github.com/sourcegraph/sourcegraph/internal/src-prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -171,6 +173,9 @@ func init() {
 		}
 		return alerts
 	})
+
+	// Warn if customer is using GitLab on a version < 12.0.
+	AlertFuncs = append(AlertFuncs, gitlabVersionAlert)
 }
 
 func updateAvailableAlert(args AlertFuncArgs) []*Alert {
@@ -330,6 +335,50 @@ func observabilityActiveAlertsAlert(prom srcprometheus.Client) func(AlertFuncArg
 			pluralize(status.ServicesCritical, "service", "services"))
 		return []*Alert{{TypeValue: AlertTypeError, MessageValue: msg}}
 	}
+}
+
+func gitlabVersionAlert(args AlertFuncArgs) []*Alert {
+	// We only show this alert to site admins.
+	if !args.IsSiteAdmin {
+		return nil
+	}
+
+	chvs, err := versions.GetVersions()
+	if err != nil {
+		log15.Warn("Failed to get code host versions for GitLab minimum version alert", "error", err)
+		return nil
+	}
+
+	// NOTE: It's necessary to include a "-0" prerelease suffix on each constraint so that
+	// prereleases of future versions are still considered to satisfy the constraint. See
+	// https://github.com/Masterminds/semver#working-with-prerelease-versions for more.
+	mv, err := semver.NewConstraint(">=12.0.0-0")
+	if err != nil {
+		log15.Warn("Failed to create minimum version constraint for GitLab minimum version alert", "error", err)
+	}
+
+	for _, chv := range chvs {
+		if chv.ExternalServiceKind != extsvc.KindGitLab {
+			continue
+		}
+
+		cv, err := semver.NewVersion(chv.Version)
+		if err != nil {
+			log15.Warn("Failed to parse code host version for GitLab minimum version alert", "error", err, "external_service_kind", chv.ExternalServiceKind)
+			continue
+		}
+
+		if !mv.Check(cv) {
+			log15.Debug("Detected GitLab instance running a version below 12.0.0", "version", chv.Version)
+
+			return []*Alert{{
+				TypeValue:    AlertTypeWarning,
+				MessageValue: "Warning: One or more of your code hosts is running a version of GitLab below 12.0. Sourcegraph will no longer support GitLab < 12.0 in the next major version. Please upgrade your GitLab instance(s) before upgrading Sourcegraph to version 4.0.",
+			}}
+		}
+	}
+
+	return nil
 }
 
 func pluralize(v int, singular, plural string) string {

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -16,7 +16,7 @@ To connect GitLab to Sourcegraph:
 ## Supported versions
 
 - GitLab.com
-- GitLab CE/EE (v10.0 and newer)
+- GitLab CE/EE (v12.0 and newer)
 
 ## Repository syncing
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/40106.

Adds a new site alert message for site admins only if we detect Sourcegraph is connected to at least one GitLab code host running a version earlier than 12.0. 

Helpfully, the `internal/extsvc/versions` package was already doing essentially exactly what we wanted here: it pings each code host once a day and persists the versions detected to redis. These are normally just sent as telemetry pings. For the site alert, we can just read from the versions and check that any for a GitLab code host are >= 12.0.0. 

## Test plan

I don't have a GitLab instance on a version < 12.0 to test on, but I tested with a constraint of 16.0 and the banner appeared for my connected instance on 15.3.0-pre. There aren't many site alert tests, and given this message will only be present for the next version of Sourcegraph, I didn't think it was necessarily worth the investment to set up a full test suite for this alert.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
