### PR TITLE
sg ops: add gcr image tag updates

### DIFF
--- a/dev/sg/internal/gcr/gcr.go
+++ b/dev/sg/internal/gcr/gcr.go
@@ -1,0 +1,115 @@
+package gcr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+	"google.golang.org/api/transport"
+)
+
+const (
+	registry = "gcr.io"
+)
+
+type TagListResp struct {
+	Child    []string
+	Manifest map[string]Manifest
+	Name     string
+	Tags     []string
+}
+type Manifest struct {
+	ImageSizeBytes string
+	LayerID        string
+	MediaType      string
+	Tag            []string
+	TimeCreatedMs  string
+	TimeUploadedMs string
+}
+
+func fetchAuthToken(ctx context.Context) (string, error) {
+	creds, err := transport.Creds(ctx, option.WithScopes(compute.CloudPlatformScope))
+	if err != nil {
+		return "", err
+	}
+	token, err := creds.TokenSource.Token()
+	if err != nil {
+		return "", err
+	}
+	accessToken := token.AccessToken
+
+	return accessToken, nil
+}
+func findUpdatedTag(tagsList []string) string {
+	var tags []string
+	//var updatedManifest manifest
+	for _, tag := range tagsList {
+		if strings.Contains(tag, "-") || strings.Contains(tag, "latest") {
+			continue
+		}
+		tags = append(tags, tag)
+	}
+	updatedTag := tags[len(tags)-1]
+	return updatedTag
+}
+
+func findUpdatedManifest(manifest map[string]Manifest, tag string) string {
+	for sha, manifest := range manifest {
+		if len(manifest.Tag) > 0 {
+			if manifest.Tag[0] == tag {
+				return sha
+			}
+
+		}
+	}
+	return ""
+}
+
+func fetchUpdatedImage(imageName string, currentTag string) (string, error) {
+	ctx := context.Background()
+	token, err := fetchAuthToken(ctx)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/v2/%s/tags/list", registry, imageName), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	//req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", errors.New("the access token may have expired")
+	}
+
+	if resp.StatusCode != 200 {
+		data, _ := io.ReadAll(resp.Body)
+		return "", errors.Newf("GET https://%s/v2/%s/tags/list", registry, imageName, string(data))
+	}
+
+	result := TagListResp{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return "", err
+	}
+	updatedTag := findUpdatedTag(result.Tags)
+	updatedManifest := findUpdatedManifest(result.Manifest, updatedTag)
+	if updatedTag == "" || updatedManifest == "" {
+		return "", errors.New("updated image not found")
+	}
+	updatedImage := registry + "/" + imageName + ":" + updatedTag + "@" + updatedManifest
+	return updatedImage, nil
+}

--- a/dev/sg/internal/images/gcr.go
+++ b/dev/sg/internal/images/gcr.go
@@ -1,4 +1,4 @@
-package gcr
+package images
 
 import (
 	"context"
@@ -34,7 +34,7 @@ type Manifest struct {
 	TimeUploadedMs string
 }
 
-func fetchAuthToken(ctx context.Context) (string, error) {
+func fetchAuthTokenGCR(ctx context.Context) (string, error) {
 	creds, err := transport.Creds(ctx, option.WithScopes(compute.CloudPlatformScope))
 	if err != nil {
 		return "", err
@@ -47,7 +47,7 @@ func fetchAuthToken(ctx context.Context) (string, error) {
 
 	return accessToken, nil
 }
-func findUpdatedTag(tagsList []string) string {
+func findUpdatedTagGCR(tagsList []string) string {
 	var tags []string
 	//var updatedManifest manifest
 	for _, tag := range tagsList {
@@ -60,7 +60,7 @@ func findUpdatedTag(tagsList []string) string {
 	return updatedTag
 }
 
-func findUpdatedManifest(manifest map[string]Manifest, tag string) string {
+func findUpdatedManifestGCR(manifest map[string]Manifest, tag string) string {
 	for sha, manifest := range manifest {
 		if len(manifest.Tag) > 0 {
 			if manifest.Tag[0] == tag {
@@ -72,9 +72,9 @@ func findUpdatedManifest(manifest map[string]Manifest, tag string) string {
 	return ""
 }
 
-func fetchUpdatedImage(imageName string, currentTag string) (string, error) {
+func fetchUpdatedImageGCR(imageName string) (string, error) {
 	ctx := context.Background()
-	token, err := fetchAuthToken(ctx)
+	token, err := fetchAuthTokenGCR(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -83,7 +83,6 @@ func fetchUpdatedImage(imageName string, currentTag string) (string, error) {
 		return "", err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	//req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -105,10 +104,10 @@ func fetchUpdatedImage(imageName string, currentTag string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	updatedTag := findUpdatedTag(result.Tags)
-	updatedManifest := findUpdatedManifest(result.Manifest, updatedTag)
+	updatedTag := findUpdatedTagGCR(result.Tags)
+	updatedManifest := findUpdatedManifestGCR(result.Manifest, updatedTag)
 	if updatedTag == "" || updatedManifest == "" {
-		return "", errors.New("updated image not found")
+		return "", errors.New("an updated gcr image not found")
 	}
 	updatedImage := registry + "/" + imageName + ":" + updatedTag + "@" + updatedManifest
 	return updatedImage, nil

--- a/dev/sg/internal/images/gcr.go
+++ b/dev/sg/internal/images/gcr.go
@@ -49,7 +49,7 @@ func fetchAuthTokenGCR(ctx context.Context) (string, error) {
 }
 func findUpdatedTagGCR(tagsList []string) string {
 	var tags []string
-	//var updatedManifest manifest
+
 	for _, tag := range tagsList {
 		if strings.Contains(tag, "-") || strings.Contains(tag, "latest") {
 			continue


### PR DESCRIPTION
relates to: https://github.com/sourcegraph/sourcegraph/issues/39102

sg-cli doesn't functionality to update the gcr images that we use
<img width="1339" alt="image" src="https://user-images.githubusercontent.com/78464298/184260154-b138c27f-b0bb-4568-a900-78f142cde04c.png">

after adding gcr implementation, cloud SQL images are able to get upgraded without the use of renovate 
<img width="1309" alt="image" src="https://user-images.githubusercontent.com/78464298/184261020-2e498a42-a005-4d80-b758-01238c264f84.png">

## Test plan
tested locally
`go run ./dev/sg ops update-images -cr-username $CR_USERNAME -cr-password $CR_PASSWORD -k k8s ../deploy-sourcegraph-cloud/base`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
