### PR TITLE
search: Add telemetry to search history in query input

### DIFF
--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -84,7 +84,10 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                           userId: props.authenticatedUser.id,
                           selectedSearchContext: props.selectedSearchContextSpec,
                           onSelection: index => {
-                              props.telemetryService.log('SearchHistoryAutcompleteSuggestionClicked', { index })
+                              props.telemetryService.log('SearchSuggestionItemClicked', {
+                                  type: 'SearchHistory',
+                                  index,
+                              })
                           },
                       }),
                   ]

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -83,10 +83,18 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                       searchQueryHistorySource({
                           userId: props.authenticatedUser.id,
                           selectedSearchContext: props.selectedSearchContextSpec,
+                          onSelection: index => {
+                              props.telemetryService.log('SearchHistoryAutcompleteSuggestionClicked', { index })
+                          },
                       }),
                   ]
                 : [],
-        [props.authenticatedUser, props.selectedSearchContextSpec, coreWorkflowImprovementsEnabled]
+        [
+            props.authenticatedUser,
+            props.selectedSearchContextSpec,
+            coreWorkflowImprovementsEnabled,
+            props.telemetryService,
+        ]
     )
 
     const quickLinks =

--- a/client/web/src/search/input/completion.ts
+++ b/client/web/src/search/input/completion.ts
@@ -92,7 +92,7 @@ export function searchQueryHistorySource({
                 filter: false,
                 options: searches
                     .map(
-                        (search, index): Completion => {
+                        (search): Completion => {
                             let query = search.searchText
 
                             {
@@ -124,12 +124,12 @@ export function searchQueryHistorySource({
                             }
                         }
                     )
-                    .filter(item => item.label.trim() !== '')
-                    .map((item, index) => {
+                    .filter(completion => completion.label.trim() !== '')
+                    .map((completion, index) => {
                         // This is here not in the .map call above so we can use
                         // the correct index after filtering out empty entries
-                        item.apply = createApplyCompletion(index)
-                        return item
+                        completion.apply = createApplyCompletion(index)
+                        return completion
                     }),
             }
         } catch {

--- a/client/web/src/search/input/completion.ts
+++ b/client/web/src/search/input/completion.ts
@@ -1,3 +1,5 @@
+import { Completion, insertCompletionText } from '@codemirror/autocomplete'
+import { EditorView } from '@codemirror/view'
 import { from } from 'rxjs'
 import { map } from 'rxjs/operators'
 
@@ -9,8 +11,6 @@ import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { requestGraphQL } from '../../backend/graphql'
 import { SearchHistoryQueryResult, SearchHistoryQueryVariables } from '../../graphql-operations'
 import { EventLogResult } from '../backend'
-import { Completion, insertCompletionText } from '@codemirror/autocomplete'
-import { EditorView } from '@codemirror/view'
 
 interface RecentSearch {
     count: number


### PR DESCRIPTION
Closes #40297 

This was easier than I thought...


## Test plan

- Enable simple UI
- Focus search input and select a search history entry
- Browser network tools should show a call to `graphql?LogEvent` with a request content similar to this (I removed irrelevant data):
```
{
	"query": "[...]",
	"variables": {
		"events": [{
			"event": "SearchHistoryAutcompleteSuggestionClicked",
			"argument": "{\"index\":2}",
			[...]
		}]
	}
}
```

## App preview:

- [Web](https://sg-web-fkling-40297-seach-history.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hclmhyztbm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
