### PR TITLE
admin-analytics: optimize user management data layer

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6379,6 +6379,10 @@ type SiteUser {
     """
     email: String
     """
+    User's display name
+    """
+    displayName: String
+    """
     The datetime when user was created in the system.
     """
     createdAt: String!

--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -2,16 +2,12 @@ package graphqlbackend
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
-	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/timeutil"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/internal/users"
 )
 
 func (s *siteResolver) Users(ctx context.Context, args *struct {
@@ -20,203 +16,76 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 	Username         *string
 	Email            *string
 	LastActivePeriod *string
-}) (*SiteUsersResolver, error) {
+}) (*siteUsersResolver, error) {
 	// 🚨 SECURITY: Only site admins can see users.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, s.db); err != nil {
 		return nil, err
 	}
 
-	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
-	tables := []*sqlf.Query{sqlf.Sprintf(`users`)}
-
-	if args.Query != nil && *args.Query != "" {
-		query := "%" + *args.Query + "%"
-		conds = append(conds, sqlf.Sprintf("(username ILIKE %s OR display_name ILIKE %s)", query, query))
-	}
-	if args.SiteAdmin != nil {
-		conds = append(conds, sqlf.Sprintf("site_admin = %s", *args.SiteAdmin))
-	}
-	if args.Username != nil {
-		conds = append(conds, sqlf.Sprintf("username ILIKE %s", "%"+*args.Username+"%"))
-	}
-	if args.Email != nil {
-		tables = append(tables, sqlf.Sprintf("LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true"))
-		conds = append(conds, sqlf.Sprintf("email ILIKE %s", "%"+*args.Email+"%"))
-	}
-	if args.LastActivePeriod != nil && *args.LastActivePeriod != "ALL" {
-		lastActiveStartTime, err := makeLastActiveStartTime(*args.LastActivePeriod)
-		if err != nil {
-			return nil, err
-		}
-		tables = append(tables, sqlf.Sprintf("LEFT JOIN event_logs events ON events.user_id = users.id"))
-		conds = append(conds, sqlf.Sprintf("events.timestamp >= %s", lastActiveStartTime))
-	}
-	totalsQuery := sqlf.Sprintf(`SELECT COUNT(DISTINCT users.id) FROM %s WHERE %s`, sqlf.Join(tables, " "), sqlf.Join(conds, "AND"))
-	return &SiteUsersResolver{s.db, conds, totalsQuery}, nil
+	return &siteUsersResolver{
+		&users.UsersStats{DB: s.db, Cache: false, Filters: users.UsersStatsFilters{
+			Query:            args.Query,
+			SiteAdmin:        args.SiteAdmin,
+			Username:         args.Username,
+			Email:            args.Email,
+			LastActivePeriod: args.LastActivePeriod,
+		}}}, nil
 }
 
-func makeLastActiveStartTime(lastActivePeriod string) (time.Time, error) {
-	now := time.Now()
-	switch lastActivePeriod {
-	case "TODAY":
-		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC), nil
-	case "THIS_WEEK":
-		return timeutil.StartOfWeek(timeNow().UTC(), 0), nil
-	case "THIS_MONTH":
-		return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC), nil
-	default:
-		return now, errors.Newf("invalid lastActivePeriod: %s", lastActivePeriod)
-	}
+type siteUsersResolver struct {
+	userStats *users.UsersStats
 }
 
-type SiteUsersResolver struct {
-	db          database.DB
-	conds       []*sqlf.Query
-	totalsQuery *sqlf.Query
+func (s *siteUsersResolver) TotalCount(ctx context.Context) (float64, error) {
+	return s.userStats.TotalCount(ctx)
 }
 
-func (s *SiteUsersResolver) TotalCount(ctx context.Context) (float64, error) {
-	var totalCount float64
-
-	if err := s.db.QueryRowContext(ctx, s.totalsQuery.Query(sqlf.PostgresBindVar), s.totalsQuery.Args()...).Scan(&totalCount); err != nil {
-		return 0, err
-	}
-
-	return totalCount, nil
-}
-
-func (s *SiteUsersResolver) Nodes(ctx context.Context, args *struct {
+func (s *siteUsersResolver) Nodes(ctx context.Context, args *struct {
 	OrderBy    *string
 	Descending *bool
 	First      *int32
-}) ([]*SiteUserResolver, error) {
-	// ORDER BY
-	orderDirection := "ASC"
-	if args.Descending != nil && *args.Descending {
-		orderDirection = "DESC"
-	}
-	orderBy := sqlf.Sprintf("id " + orderDirection)
-	if args.OrderBy != nil {
-		newOrderBy, err := toUsersField(*args.OrderBy)
-		orderBy = sqlf.Sprintf(newOrderBy + " " + orderDirection)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// LIMIT
-	limit := int32(100)
-	if args.First != nil {
-		limit = *args.First
-	}
-
-	query := sqlf.Sprintf(`
-	SELECT
-		users.id,
-		users.username,
-		emails.email,
-		users.created_at,
-		MAX(events.timestamp) AS last_active_at,
-		users.deleted_at,
-		users.site_admin,
-		COUNT(events.*) AS events_count
-	FROM
-		users
-		LEFT JOIN event_logs events ON events.user_id = users.id
-		LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true
-	WHERE %s
-	GROUP BY
-		users.id,
-		users.username,
-		emails.email,
-		users.created_at,
-		users.deleted_at,
-		users.site_admin
-	ORDER BY %s
-	LIMIT %s`, sqlf.Join(s.conds, "AND"), orderBy, limit)
-	fmt.Println(query.Query(sqlf.PostgresBindVar))
-	fmt.Println(query.Args())
-
-	rows, err := s.db.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
-
+}) ([]*siteUserResolver, error) {
+	users, err := s.userStats.ListUsers(ctx, &users.UsersStatsListUsersFilters{OrderBy: args.OrderBy, Descending: args.Descending, First: args.First})
 	if err != nil {
 		return nil, err
 	}
-
-	defer rows.Close()
-
-	nodes := make([]*SiteUserResolver, 0)
-	for rows.Next() {
-		var node SiteUserResolver
-
-		if err := rows.Scan(&node.id, &node.username, &node.email, &node.createdAt, &node.lastActiveAt, &node.deletedAt, &node.siteAdmin, &node.eventsCount); err != nil {
-			return nil, err
-		}
-
-		nodes = append(nodes, &node)
+	userResolvers := make([]*siteUserResolver, len(users))
+	for i, user := range users {
+		userResolvers[i] = &siteUserResolver{user}
 	}
-
-	return nodes, nil
+	return userResolvers, nil
 }
 
-func toUsersField(orderBy string) (string, error) {
-	switch orderBy {
-	case "USERNAME":
-		return "username", nil
-	case "EMAIL":
-		return "emails.email", nil
-	case "CREATED_AT":
-		return "users.created_at", nil
-	case "LAST_ACTIVE_AT":
-		return "last_active_at", nil
-	case "DELETED_AT":
-		return "users.deleted_at", nil
-	case "EVENTS_COUNT":
-		return "events_count", nil
-	case "SITE_ADMIN":
-		return "site_admin", nil
-	default:
-		return "", errors.New("invalid orderBy")
-	}
+type siteUserResolver struct {
+	user *users.UserStatItem
 }
 
-type SiteUserResolver struct {
-	id           int32
-	username     string
-	email        *string
-	createdAt    time.Time
-	lastActiveAt *time.Time
-	deletedAt    *time.Time
-	siteAdmin    bool
-	eventsCount  float64
+func (s *siteUserResolver) ID(ctx context.Context) graphql.ID { return MarshalUserID(s.user.Id) }
+
+func (s *siteUserResolver) Username(ctx context.Context) string { return s.user.Username }
+
+func (s *siteUserResolver) Email(ctx context.Context) *string { return s.user.Email }
+
+func (s *siteUserResolver) CreatedAt(ctx context.Context) string {
+	return s.user.CreatedAt.Format(time.RFC3339)
 }
 
-func (s *SiteUserResolver) ID(ctx context.Context) graphql.ID { return MarshalUserID(s.id) }
-
-func (s *SiteUserResolver) Username(ctx context.Context) string { return s.username }
-
-func (s *SiteUserResolver) Email(ctx context.Context) *string { return s.email }
-
-func (s *SiteUserResolver) CreatedAt(ctx context.Context) string {
-	return s.createdAt.Format(time.RFC3339)
-}
-
-func (s *SiteUserResolver) LastActiveAt(ctx context.Context) *string {
-	if s.lastActiveAt != nil {
-		result := s.lastActiveAt.Format(time.RFC3339)
+func (s *siteUserResolver) LastActiveAt(ctx context.Context) *string {
+	if s.user.LastActiveAt != nil {
+		result := s.user.LastActiveAt.Format(time.RFC3339)
 		return &result
 	}
 	return nil
 }
 
-func (s *SiteUserResolver) DeletedAt(ctx context.Context) *string {
-	if s.deletedAt != nil {
-		result := s.deletedAt.Format(time.RFC3339)
+func (s *siteUserResolver) DeletedAt(ctx context.Context) *string {
+	if s.user.DeletedAt != nil {
+		result := s.user.DeletedAt.Format(time.RFC3339)
 		return &result
 	}
 	return nil
 }
 
-func (s *SiteUserResolver) SiteAdmin(ctx context.Context) bool { return s.siteAdmin }
+func (s *siteUserResolver) SiteAdmin(ctx context.Context) bool { return s.user.SiteAdmin }
 
-func (s *SiteUserResolver) EventsCount(ctx context.Context) float64 { return s.eventsCount }
+func (s *siteUserResolver) EventsCount(ctx context.Context) float64 { return s.user.EventsCount }

--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -23,7 +23,7 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 	}
 
 	return &siteUsersResolver{
-		&users.UsersStats{DB: s.db, Cache: false, Filters: users.UsersStatsFilters{
+		&users.UsersStats{DB: s.db, Filters: users.UsersStatsFilters{
 			Query:            args.Query,
 			SiteAdmin:        args.SiteAdmin,
 			Username:         args.Username,
@@ -64,7 +64,9 @@ func (s *siteUserResolver) ID(ctx context.Context) graphql.ID { return MarshalUs
 
 func (s *siteUserResolver) Username(ctx context.Context) string { return s.user.Username }
 
-func (s *siteUserResolver) Email(ctx context.Context) *string { return s.user.Email }
+func (s *siteUserResolver) DisplayName(ctx context.Context) *string { return s.user.DisplayName }
+
+func (s *siteUserResolver) Email(ctx context.Context) *string { return s.user.PrimaryEmail }
 
 func (s *siteUserResolver) CreatedAt(ctx context.Context) string {
 	return s.user.CreatedAt.Format(time.RFC3339)

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -18,8 +18,9 @@ import (
 	"github.com/keegancsmith/tmpfriend"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
-	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
 	"github.com/throttled/throttled/v2/store/redigostore"
+
+	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
 
 	sglog "github.com/sourcegraph/log"
 
@@ -58,6 +59,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/sysreq"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
+	"github.com/sourcegraph/sourcegraph/internal/users"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/internal/version/upgradestore"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -277,6 +279,7 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 	goroutine.Go(func() { bg.DeleteOldSecurityEventLogsInPostgres(context.Background(), db) })
 	goroutine.Go(func() { updatecheck.Start(db) })
 	goroutine.Go(func() { adminanalytics.StartAnalyticsCacheRefresh(context.Background(), db) })
+	goroutine.Go(func() { users.StartUpdateAggregatedUsersStatisticsTable(context.Background(), db) })
 
 	schema, err := graphqlbackend.NewSchema(db,
 		enterprise.BatchChangesResolver,

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -1015,6 +1015,99 @@
       "Triggers": []
     },
     {
+      "Name": "aggregated_user_statistics",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "created_at",
+          "Index": 2,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "updated_at",
+          "Index": 3,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "user_events_count",
+          "Index": 5,
+          "TypeName": "bigint",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "user_id",
+          "Index": 1,
+          "TypeName": "bigint",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "user_last_active_at",
+          "Index": 4,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "aggregated_user_statistics_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX aggregated_user_statistics_pkey ON aggregated_user_statistics USING btree (user_id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (user_id)"
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "aggregated_user_statistics_user_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "users",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+        }
+      ],
+      "Triggers": []
+    },
+    {
       "Name": "batch_changes",
       "Comment": "",
       "Columns": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -22,6 +22,22 @@ Foreign-key constraints:
 
 ```
 
+# Table "public.aggregated_user_statistics"
+```
+       Column        |           Type           | Collation | Nullable | Default 
+---------------------+--------------------------+-----------+----------+---------
+ user_id             | bigint                   |           | not null | 
+ created_at          | timestamp with time zone |           | not null | now()
+ updated_at          | timestamp with time zone |           | not null | now()
+ user_last_active_at | timestamp with time zone |           |          | 
+ user_events_count   | bigint                   |           |          | 
+Indexes:
+    "aggregated_user_statistics_pkey" PRIMARY KEY, btree (user_id)
+Foreign-key constraints:
+    "aggregated_user_statistics_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+
+```
+
 # Table "public.batch_changes"
 ```
       Column       |           Type           | Collation | Nullable |                  Default                  
@@ -2780,6 +2796,7 @@ Check constraints:
 Referenced by:
     TABLE "access_tokens" CONSTRAINT "access_tokens_creator_user_id_fkey" FOREIGN KEY (creator_user_id) REFERENCES users(id)
     TABLE "access_tokens" CONSTRAINT "access_tokens_subject_user_id_fkey" FOREIGN KEY (subject_user_id) REFERENCES users(id)
+    TABLE "aggregated_user_statistics" CONSTRAINT "aggregated_user_statistics_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     TABLE "batch_changes" CONSTRAINT "batch_changes_initial_applier_id_fkey" FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "batch_changes" CONSTRAINT "batch_changes_last_applier_id_fkey" FOREIGN KEY (last_applier_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "batch_changes" CONSTRAINT "batch_changes_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE

--- a/internal/users/stats.go
+++ b/internal/users/stats.go
@@ -1,0 +1,260 @@
+package users
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/csv"
+	"strconv"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type UsersStatsFilters struct {
+	Query            *string
+	SiteAdmin        *bool
+	Username         *string
+	Email            *string
+	LastActivePeriod *string
+}
+
+type UsersStats struct {
+	Cache   bool // TODO: implement caching
+	DB      database.DB
+	Filters UsersStatsFilters
+}
+
+func (s *UsersStats) makeQueryParameters() ([]*sqlf.Query, []*sqlf.Query, error) {
+	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
+	tables := []*sqlf.Query{sqlf.Sprintf(`users`)}
+	if s.Filters.Query != nil && *s.Filters.Query != "" {
+		query := "%" + *s.Filters.Query + "%"
+		conds = append(conds, sqlf.Sprintf("(username ILIKE %s OR display_name ILIKE %s)", query, query))
+	}
+	if s.Filters.SiteAdmin != nil {
+		conds = append(conds, sqlf.Sprintf("site_admin = %s", *s.Filters.SiteAdmin))
+	}
+	if s.Filters.Username != nil {
+		conds = append(conds, sqlf.Sprintf("username ILIKE %s", "%"+*s.Filters.Username+"%"))
+	}
+	if s.Filters.Email != nil {
+		tables = append(tables, sqlf.Sprintf("LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true"))
+		conds = append(conds, sqlf.Sprintf("email ILIKE %s", "%"+*s.Filters.Email+"%"))
+	}
+	if s.Filters.LastActivePeriod != nil && *s.Filters.LastActivePeriod != "ALL" {
+		lastActiveStartTime, err := makeLastActiveStartTime(*s.Filters.LastActivePeriod)
+		if err != nil {
+			return nil, nil, err
+		}
+		tables = append(tables, sqlf.Sprintf("LEFT JOIN event_logs events ON events.user_id = users.id"))
+		conds = append(conds, sqlf.Sprintf("events.timestamp >= %s", lastActiveStartTime))
+	}
+	return tables, conds, nil
+}
+
+func makeLastActiveStartTime(lastActivePeriod string) (time.Time, error) {
+	now := time.Now()
+	switch lastActivePeriod {
+	case "TODAY":
+		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC), nil
+	case "THIS_WEEK":
+		return timeutil.StartOfWeek(now.UTC(), 0), nil
+	case "THIS_MONTH":
+		return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC), nil
+	default:
+		return now, errors.Newf("invalid lastActivePeriod: %s", lastActivePeriod)
+	}
+}
+
+func (s *UsersStats) TotalCount(ctx context.Context) (float64, error) {
+	var totalCount float64
+
+	tables, conds, err := s.makeQueryParameters()
+	if err != nil {
+		return 0, err
+	}
+
+	query := sqlf.Sprintf(`SELECT COUNT(DISTINCT users.id) FROM %s WHERE %s`, sqlf.Join(tables, " "), sqlf.Join(conds, "AND"))
+	if err := s.DB.QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...).Scan(&totalCount); err != nil {
+		return 0, err
+	}
+
+	return totalCount, nil
+}
+
+type UsersStatsListUsersFilters struct {
+	OrderBy    *string
+	Descending *bool
+	First      *int32
+}
+
+func (s *UsersStats) ListUsers(ctx context.Context, filters *UsersStatsListUsersFilters) ([]*UserStatItem, error) {
+	// ORDER BY
+	orderDirection := "ASC"
+	if filters == nil {
+		filters = &UsersStatsListUsersFilters{}
+	}
+	if filters.Descending != nil && *filters.Descending {
+		orderDirection = "DESC"
+	}
+	orderBy := sqlf.Sprintf("id " + orderDirection)
+	if filters.OrderBy != nil {
+		newOrderColumn, err := toUsersField(*filters.OrderBy)
+		orderBy = sqlf.Sprintf(newOrderColumn + " " + orderDirection)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// LIMIT
+	limit := int32(100)
+	if filters.First != nil {
+		limit = *filters.First
+	}
+
+	_, conds, err := s.makeQueryParameters()
+	if err != nil {
+		return nil, err
+	}
+
+	query := sqlf.Sprintf(`
+	SELECT
+		users.id,
+		users.username,
+		emails.email,
+		users.created_at,
+		MAX(events.timestamp) AS last_active_at,
+		users.deleted_at,
+		users.site_admin,
+		COUNT(events.*) AS events_count
+	FROM
+		users
+		LEFT JOIN event_logs events ON events.user_id = users.id
+		LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true
+	WHERE %s
+	GROUP BY
+		users.id,
+		users.username,
+		emails.email,
+		users.created_at,
+		users.deleted_at,
+		users.site_admin
+	ORDER BY %s
+	LIMIT %s`, sqlf.Join(conds, "AND"), orderBy, limit)
+
+	rows, err := s.DB.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	nodes := make([]*UserStatItem, 0)
+	for rows.Next() {
+		var node UserStatItem
+
+		if err := rows.Scan(&node.Id, &node.Username, &node.Email, &node.CreatedAt, &node.LastActiveAt, &node.DeletedAt, &node.SiteAdmin, &node.EventsCount); err != nil {
+			return nil, err
+		}
+
+		nodes = append(nodes, &node)
+	}
+
+	return nodes, nil
+}
+
+func toUsersField(orderBy string) (string, error) {
+	switch orderBy {
+	case "USERNAME":
+		return "username", nil
+	case "EMAIL":
+		return "emails.email", nil
+	case "CREATED_AT":
+		return "users.created_at", nil
+	case "LAST_ACTIVE_AT":
+		return "last_active_at", nil
+	case "DELETED_AT":
+		return "users.deleted_at", nil
+	case "EVENTS_COUNT":
+		return "events_count", nil
+	case "SITE_ADMIN":
+		return "site_admin", nil
+	default:
+		return "", errors.New("invalid orderBy")
+	}
+}
+
+type UserStatItem struct {
+	Id           int32
+	Username     string
+	Email        *string
+	CreatedAt    time.Time
+	LastActiveAt *time.Time
+	DeletedAt    *time.Time
+	SiteAdmin    bool
+	EventsCount  float64
+}
+
+// GetArchive generates and returns a usage statistics ZIP archive containing the CSV
+// files defined in RFC 145, or an error in case of failure.
+func (s *UsersStats) GetArchive(ctx context.Context) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	file, err := zw.Create("UsersStats.csv")
+	if err != nil {
+		return nil, err
+	}
+
+	writer := csv.NewWriter(file)
+
+	record := []string{
+		"user_id",
+		"created_at",
+		"events_count",
+		"last_active_at",
+		"deleted_at",
+	}
+
+	if err := writer.Write(record); err != nil {
+		return nil, err
+	}
+
+	users, err := s.ListUsers(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, user := range users {
+		record[0] = strconv.FormatUint(uint64(user.Id), 10)
+		record[1] = user.CreatedAt.Format(time.RFC3339)
+		record[2] = strconv.FormatInt(int64(user.EventsCount), 10)
+		if user.LastActiveAt == nil {
+			record[3] = "NULL"
+		} else {
+			record[3] = user.LastActiveAt.Format(time.RFC3339)
+		}
+		if user.DeletedAt == nil {
+			record[4] = "NULL"
+		} else {
+			record[4] = user.DeletedAt.Format(time.RFC3339)
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/internal/users/stats.go
+++ b/internal/users/stats.go
@@ -75,7 +75,7 @@ var (
 			stats.user_last_active_at AS last_active_at,
 			users.deleted_at,
 			users.site_admin,
-			stats.user_events_count AS events_count
+			COALESCE(stats.user_events_count, 0) AS events_count
 		FROM users
 			LEFT JOIN aggregated_user_statistics stats ON stats.user_id = users.id
 			LEFT JOIN user_emails emails ON emails.user_id = users.id AND emails.is_primary = true

--- a/internal/users/update_aggregated_stats_job.go
+++ b/internal/users/update_aggregated_stats_job.go
@@ -1,0 +1,75 @@
+package users
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+)
+
+var (
+	updateAggregatedUsersStatisticsQuery = `
+	INSERT INTO aggregated_user_statistics (user_id, user_last_active_at, user_events_count)
+	SELECT
+		user_id,
+		last_active_at,
+		events_count
+	FROM
+		(
+			SELECT
+				user_id,
+				MAX(timestamp) AS last_active_at,
+				COUNT(*) AS events_count
+			FROM
+				event_logs
+			GROUP BY
+				user_id
+		) AS events
+		INNER JOIN users ON users.id = events.user_id
+	ON CONFLICT (user_id) DO UPDATE
+		SET
+			user_last_active_at = EXCLUDED.user_last_active_at,
+			user_events_count = EXCLUDED.user_events_count;
+	`
+)
+
+func updateAggregatedUsersStatisticsTable(ctx context.Context, db database.DB) error {
+	if _, err := db.ExecContext(ctx, updateAggregatedUsersStatisticsQuery); err != nil {
+		return err
+	}
+	return nil
+}
+
+var started bool
+
+func StartUpdateAggregatedUsersStatisticsTable(ctx context.Context, db database.DB) {
+	logger := log.Scoped("aggregated_user_statistics:cache-refresh", "aggregated_user_statistics cache refresh")
+
+	if started {
+		panic("already started")
+	}
+
+	started = true
+
+	// Wait until table creation migration finishes
+	time.Sleep(5 * time.Minute)
+
+	ctx = featureflag.WithFlags(ctx, db.FeatureFlags())
+
+	const delay = 12 * time.Hour
+	for {
+		if !featureflag.FromContext(ctx).GetBoolOr("user_management_cache_disabled", false) {
+			if err := updateAggregatedUsersStatisticsTable(ctx, db); err != nil {
+				logger.Error("Error refreshing aggregated_user_statistics cache", log.Error(err))
+			}
+		}
+
+		// Randomize sleep to prevent thundering herds.
+		randomDelay := time.Duration(rand.Intn(600)) * time.Second
+		time.Sleep(delay + randomDelay)
+	}
+}

--- a/internal/users/update_aggregated_stats_job.go
+++ b/internal/users/update_aggregated_stats_job.go
@@ -33,7 +33,8 @@ var (
 	ON CONFLICT (user_id) DO UPDATE
 		SET
 			user_last_active_at = EXCLUDED.user_last_active_at,
-			user_events_count = EXCLUDED.user_events_count;
+			user_events_count = EXCLUDED.user_events_count,
+			updated_at = NOW();
 	`
 )
 

--- a/migrations/frontend/1660312877_add_aggregated_user_statistics_table/down.sql
+++ b/migrations/frontend/1660312877_add_aggregated_user_statistics_table/down.sql
@@ -1,0 +1,3 @@
+-- Undo the changes made in the up migration
+
+DROP TABLE IF EXISTS aggregated_user_statistics;

--- a/migrations/frontend/1660312877_add_aggregated_user_statistics_table/metadata.yaml
+++ b/migrations/frontend/1660312877_add_aggregated_user_statistics_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: add aggregated user statistics table
+parents: [1659459805, 1660132915]

--- a/migrations/frontend/1660312877_add_aggregated_user_statistics_table/up.sql
+++ b/migrations/frontend/1660312877_add_aggregated_user_statistics_table/up.sql
@@ -1,0 +1,10 @@
+-- Perform migration here.
+
+CREATE TABLE IF NOT EXISTS aggregated_user_statistics (
+    user_id BIGINT NOT NULL PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    user_last_active_at TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+    user_events_count BIGINT DEFAULT NULL,
+    CONSTRAINT aggregated_user_statistics_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -555,6 +555,14 @@ CREATE SEQUENCE access_tokens_id_seq
 
 ALTER SEQUENCE access_tokens_id_seq OWNED BY access_tokens.id;
 
+CREATE TABLE aggregated_user_statistics (
+    user_id bigint NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    user_last_active_at timestamp with time zone,
+    user_events_count bigint
+);
+
 CREATE TABLE batch_changes (
     id bigint NOT NULL,
     name text NOT NULL,
@@ -3334,6 +3342,9 @@ ALTER TABLE ONLY access_tokens
 ALTER TABLE ONLY access_tokens
     ADD CONSTRAINT access_tokens_value_sha256_key UNIQUE (value_sha256);
 
+ALTER TABLE ONLY aggregated_user_statistics
+    ADD CONSTRAINT aggregated_user_statistics_pkey PRIMARY KEY (user_id);
+
 ALTER TABLE ONLY batch_changes
     ADD CONSTRAINT batch_changes_pkey PRIMARY KEY (id);
 
@@ -4016,6 +4027,9 @@ ALTER TABLE ONLY access_tokens
 
 ALTER TABLE ONLY access_tokens
     ADD CONSTRAINT access_tokens_subject_user_id_fkey FOREIGN KEY (subject_user_id) REFERENCES users(id);
+
+ALTER TABLE ONLY aggregated_user_statistics
+    ADD CONSTRAINT aggregated_user_statistics_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY batch_changes
     ADD CONSTRAINT batch_changes_batch_spec_id_fkey FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) DEFERRABLE;


### PR DESCRIPTION
It seems that because user management SQL queries use `join` large event_logs and users tables to create a full in-memory table, the GQL API response is slow and even fails with a time-out exception.

This PR:
- Extracts query logic into separate `internal/users/stats.go` file
- Adds `aggregated_user_statistics` table which is updated/seeded every 12 hours
- Adds `SiteUser.displayName` GQL field

## Test plan
- `sg start`
- http://localhost:3080/api/console
```graphql
query UsersManagementUsersList {
  site {
    users(query: null, lastActivePeriod: THIS_MONTH) {
      totalCount
      nodes(first: 25, orderBy: EVENTS_COUNT, descending: true) {
        id
        username
        email
        siteAdmin
        eventsCount
        createdAt
        lastActiveAt
        deletedAt
      }
    }
  }
}

```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
