### PR TITLE
codemirror file view: Make view non-editable

### DIFF
--- a/client/web/src/repo/blob/BlobPage.module.scss
+++ b/client/web/src/repo/blob/BlobPage.module.scss
@@ -14,4 +14,9 @@
 .blob {
     flex: 1;
     position: relative;
+
+    &:focus-within {
+        outline: 0;
+        box-shadow: var(--focus-box-shadow);
+    }
 }

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -16,7 +16,7 @@ import { parseQueryAndHash, UIPositionSpec } from '@sourcegraph/shared/src/util/
 import { enableExtensionsDecorationsColumnViewFromSettings } from '../../util/settings'
 
 import { blameDecorationType, BlobInfo, BlobProps, updateBrowserHistoryIfChanged } from './Blob'
-import { blobPropsFacet, hideCaret } from './codemirror'
+import { blobPropsFacet } from './codemirror'
 import {
     enableExtensionsDecorationsColumnView as enableColumnView,
     showTextDocumentDecorations,
@@ -28,9 +28,14 @@ import { sourcegraphExtensions } from './codemirror/sourcegraph-extensions'
 import { offsetToUIPosition, uiPositionToOffset } from './codemirror/utils'
 
 const staticExtensions: Extension = [
-    // Using EditorState.readOnly instead of EditorView.editable allows us to
-    // focus the editor and placing a text cursor
     EditorState.readOnly.of(true),
+    EditorView.editable.of(false),
+    EditorView.contentAttributes.of({
+        // This is required to make the blob view focusable and to make
+        // triggering the in-document search (see below) work when Mod-f is
+        // pressed
+        tabindex: '0',
+    }),
     editorHeight({ height: '100%' }),
     EditorView.theme({
         '&': {
@@ -50,7 +55,6 @@ const staticExtensions: Extension = [
     // *focusable* but read-only (see EditorState.readOnly above).
     search({ top: true }),
     keymap.of(searchKeymap),
-    hideCaret,
 ]
 
 // Compartments are used to reconfigure some parts of the editor withoug

--- a/client/web/src/repo/blob/codemirror/index.ts
+++ b/client/web/src/repo/blob/codemirror/index.ts
@@ -1,5 +1,4 @@
 import { Facet } from '@codemirror/state'
-import { EditorView, keymap } from '@codemirror/view'
 
 import { BlobProps } from '../Blob'
 
@@ -10,37 +9,3 @@ import { BlobProps } from '../Blob'
 export const blobPropsFacet = Facet.define<BlobProps, BlobProps>({
     combine: props => props[0],
 })
-
-const noop = (): true => true
-
-/**
- * Extension to hide/disable the caret. This is needed if CodeMirror should stay
- * focusable (EditorView.editable is true) but we still want to hide the caret.
- */
-export const hideCaret = [
-    // Render caret invisible
-    EditorView.theme({
-        '.cm-line': {
-            caretColor: 'transparent !important',
-        },
-    }),
-    // Disable basic cursor movement keys
-    keymap.of([
-        {
-            key: 'ArrowUp',
-            run: noop,
-        },
-        {
-            key: 'ArrowDown',
-            run: noop,
-        },
-        {
-            key: 'ArrowLeft',
-            run: noop,
-        },
-        {
-            key: 'ArrowRight',
-            run: noop,
-        },
-    ]),
-]


### PR DESCRIPTION
The original reason for making the view editable (but readonly) was to
make it focusable so that Mod-f would trigger CodeMirror's search
functionality.

The side effect of this was that the view would show a real caret, which
is not desirable at this point. Furthermore it changes how the view can
be scrolled via the keyboard.

PR #40232 tried to solve the caret problem by simply hiding it, but the
keyboard scroll issues remained.

This PR makes the view non-editable (which solves caret and keyboard
scroll issues) but keeps it focusable (to keep Mod-f working) by adding
`tabindex=0` to its content element.

Without the CSS changes it wouldn't be apparent that/when the blob view has
focus.

CodeMirror behavior: 

https://user-images.githubusercontent.com/179026/184348757-1d093d08-c4a0-40a5-86c2-60a22e6bf1ae.mp4



Old blob view behavior (before/after): Before, clicking on the file didn't show the focus ring, the focus ring was only shown when a key (for scrolling?) was pressed. With these changes the focus ring is also always shown when the element has focus.

**Note:** If this change is not acceptable, we can remove it and tackle the focus in another PR.


https://user-images.githubusercontent.com/179026/184348740-d13b3825-e07c-4436-bbaf-15f752eeb521.mp4



## Test plan

- Enable CodeMirror file view
- Open a file and click inside it.
  - Focus ring should appear
  - Pressing up/down arrow, space, mod-up/dow arrow should scroll the file view
  - Pressing Mod-f opens CodeMirror's search functionality

## App preview:

- [Web](https://sg-web-fkling-cm-file-view-disable-caret.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hvmsqopkyi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
