### PR TITLE
internal/repos: Return early if ProjectRepos returns an error

### DIFF
--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -275,6 +275,7 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 			repos, err := s.client.ProjectRepos(ctx, q)
 			if err != nil {
 				ch <- batch{err: errors.Wrapf(err, "bitbucketserver.projectKeys: query=%q", q)}
+				return
 			}
 
 			ch <- batch{repos: repos}


### PR DESCRIPTION
It appears we're writing a nil repos into the channel even when
there's an error. Instead we should return early after writing the
error into the channel.

Related to investigation of #40153.

## Test plan

Existing tests should pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
