### PR TITLE
Remove reference to the extension page from the footer

### DIFF
--- a/client/web/src/search/home/SearchPageFooter.tsx
+++ b/client/web/src/search/home/SearchPageFooter.tsx
@@ -134,15 +134,19 @@ export const SearchPageFooter: React.FunctionComponent<
                     >
                         Browser extensions
                     </Link>
-                    <span aria-hidden="true" className="border-right d-none d-md-inline" />
-                    <Link
-                        className="px-3"
-                        to="/extensions"
-                        target="_blank"
-                        onClick={() => logLinkClicked('SourcegraphExtensions')}
-                    >
-                        Sourcegraph extensions
-                    </Link>
+                    {window.context.enableLegacyExtensions ? (
+                        <>
+                            <span aria-hidden="true" className="border-right d-none d-md-inline" />
+                            <Link
+                                className="px-3"
+                                to="/extensions"
+                                target="_blank"
+                                onClick={() => logLinkClicked('SourcegraphExtensions')}
+                            >
+                                Sourcegraph extensions
+                            </Link>
+                        </>
+                    ) : null}
                     <span aria-hidden="true" className="border-right d-none d-md-inline" />
                 </span>
                 <span className="d-flex flex-row">


### PR DESCRIPTION
I didn't even know we had this real estate for us, wow.

Anyway just an addition to the prior PRs that hide links to the extension page when  `enableLegacyExtensions` is `false`.

## Test plan

![Screenshot 2022-08-12 at 15 46 24](https://user-images.githubusercontent.com/458591/184366950-a18457cc-a942-47cc-bc95-34992ce8dff4.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-footer-cleanup.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-objqlrofzh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
