### PR TITLE
[SG-40252] Replace absolute wildcard imports with relative imports

### DIFF
--- a/client/wildcard/src/components/Alert/Alert.test.tsx
+++ b/client/wildcard/src/components/Alert/Alert.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 
-import { H4 } from '@sourcegraph/wildcard'
+import { H4 } from '../Typography'
 
 import { Alert } from './Alert'
 import { ALERT_VARIANTS } from './constants'

--- a/client/wildcard/src/components/Badge/Badge.tsx
+++ b/client/wildcard/src/components/Badge/Badge.tsx
@@ -2,10 +2,9 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { Tooltip } from '@sourcegraph/wildcard'
-
 import { useWildcardTheme } from '../../hooks/useWildcardTheme'
 import { Link } from '../Link'
+import { Tooltip } from '../Tooltip'
 
 import { BADGE_VARIANTS } from './constants'
 

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
@@ -5,8 +5,8 @@ import { Key } from 'ts-key-enum'
 import { useMergeRefs } from 'use-callback-ref'
 
 import { isDefined } from '@sourcegraph/common'
-import { ForwardReferenceComponent } from '@sourcegraph/wildcard'
 
+import { ForwardReferenceComponent } from '../../types'
 import { Button, ButtonProps } from '../Button'
 import { Link, AnchorLink } from '../Link'
 

--- a/client/wildcard/src/components/Charts/core/utils/get-chart-content-sizes.ts
+++ b/client/wildcard/src/components/Charts/core/utils/get-chart-content-sizes.ts
@@ -1,5 +1,7 @@
 import { Optional } from 'utility-types'
 
+// In order to resolve cyclic deps in tests
+// see https://github.com/sourcegraph/sourcegraph/pull/40209#pullrequestreview-1069334480
 import { createRectangle, Rectangle } from '../../../Popover'
 
 interface GetChartContentSizesInput {

--- a/client/wildcard/src/components/Charts/core/utils/get-chart-content-sizes.ts
+++ b/client/wildcard/src/components/Charts/core/utils/get-chart-content-sizes.ts
@@ -1,10 +1,6 @@
 import { Optional } from 'utility-types'
 
-import { Rectangle } from '@sourcegraph/wildcard'
-
-// In order to resolve cyclic deps in tests
-// see https://github.com/sourcegraph/sourcegraph/pull/40209#pullrequestreview-1069334480
-import { createRectangle } from '../../../Popover'
+import { createRectangle, Rectangle } from '../../../Popover'
 
 interface GetChartContentSizesInput {
     width: number

--- a/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.story.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.story.tsx
@@ -2,7 +2,9 @@ import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
-import { PRODUCT_STATUSES, H1, Text } from '@sourcegraph/wildcard'
+
+import { PRODUCT_STATUSES } from '../../Badge'
+import { H1, Text } from '../../Typography'
 
 import { FeedbackBadge } from '.'
 

--- a/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { ProductStatusBadge, Link, BaseProductStatusBadgeProps } from '@sourcegraph/wildcard'
+import { ProductStatusBadge, BaseProductStatusBadgeProps } from '../../Badge'
+import { Link } from '../../Link'
 
 import styles from './FeedbackBadge.module.scss'
 

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
@@ -4,10 +4,10 @@ import { mdiClose, mdiCheck } from '@mdi/js'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { Icon } from '@sourcegraph/wildcard'
 
 import { Popover, PopoverContent, Position, Button, FlexTextArea, LoadingSpinner, Link, H3, Text } from '../..'
 import { useAutoFocus, useLocalStorage } from '../../..'
+import { Icon } from '../../Icon'
 import { Modal } from '../../Modal'
 
 import { Happy, Sad, VeryHappy, VerySad } from './FeedbackIcons'

--- a/client/wildcard/src/components/Feedback/FeedbackText/FeedbackText.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackText/FeedbackText.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
-import { Link, Text } from '@sourcegraph/wildcard'
+import { Link } from '../../Link'
+import { Text } from '../../Typography'
 
 interface FeedbackTextProps {
     /**

--- a/client/wildcard/src/components/Form/MultiSelect/ClearIndicator.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/ClearIndicator.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from 'react'
 import { mdiClose } from '@mdi/js'
 import { components, ClearIndicatorProps } from 'react-select'
 
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon } from '../../Icon'
 
 import { MultiSelectOption } from './types'
 

--- a/client/wildcard/src/components/Form/MultiSelect/DropdownIndicator.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/DropdownIndicator.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from 'react'
 import { mdiChevronDown } from '@mdi/js'
 import { components, DropdownIndicatorProps } from 'react-select'
 
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon } from '../../Icon'
 
 import { MultiSelectOption } from './types'
 

--- a/client/wildcard/src/components/Form/MultiSelect/MultiValueRemove.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/MultiValueRemove.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from 'react'
 import { mdiClose } from '@mdi/js'
 import { components, MultiValueRemoveProps } from 'react-select'
 
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon } from '../../Icon'
 
 import { MultiSelectOption } from './types'
 

--- a/client/wildcard/src/components/Link/AnchorLink/AnchorLink.tsx
+++ b/client/wildcard/src/components/Link/AnchorLink/AnchorLink.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { useWildcardTheme } from '@sourcegraph/wildcard'
-
+import { useWildcardTheme } from '../../../hooks'
 import type { Link } from '../Link'
 
 import styles from './AnchorLink.module.scss'

--- a/client/wildcard/src/components/Link/Link/Link.tsx
+++ b/client/wildcard/src/components/Link/Link/Link.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { ForwardReferenceExoticComponent } from '@sourcegraph/wildcard'
+import { ForwardReferenceExoticComponent } from '../../../types'
 
 export interface LinkProps
     extends Pick<

--- a/client/wildcard/src/components/Popover/README.md
+++ b/client/wildcard/src/components/Popover/README.md
@@ -7,7 +7,7 @@ This package provides special React components that allow you to build popovers,
 By default `<Popover />` component requires no props if you're using compound Popover components.
 
 ```tsx
-import { Popover, PopoverTrigger, PopoverContent } from '..'
+import { Popover, PopoverTrigger, PopoverContent } from '@sourcegraph/wildcard'
 
 function ComponentWithPopover() {
   return (
@@ -34,7 +34,7 @@ want to take control over this and render the popup by your own logic. For examp
 `PopoverContent` has been submitted, or any other async operation is over.
 
 ```tsx
-import { Popover, PopoverTrigger, PopoverContent } from '..'
+import { Popover, PopoverTrigger, PopoverContent } from '@sourcegraph/wildcard'
 
 function ComponentWithPopover() {
   const [open, setOpen] = useState<boolean>(false)

--- a/client/wildcard/src/components/Popover/README.md
+++ b/client/wildcard/src/components/Popover/README.md
@@ -7,7 +7,7 @@ This package provides special React components that allow you to build popovers,
 By default `<Popover />` component requires no props if you're using compound Popover components.
 
 ```tsx
-import { Popover, PopoverTrigger, PopoverContent } from '@sourcegraph/wildcard'
+import { Popover, PopoverTrigger, PopoverContent } from '..'
 
 function ComponentWithPopover() {
   return (
@@ -34,7 +34,7 @@ want to take control over this and render the popup by your own logic. For examp
 `PopoverContent` has been submitted, or any other async operation is over.
 
 ```tsx
-import { Popover, PopoverTrigger, PopoverContent } from '@sourcegraph/wildcard'
+import { Popover, PopoverTrigger, PopoverContent } from '..'
 
 function ComponentWithPopover() {
   const [open, setOpen] = useState<boolean>(false)

--- a/client/wildcard/src/components/Popover/story/Popover.story.tsx
+++ b/client/wildcard/src/components/Popover/story/Popover.story.tsx
@@ -7,9 +7,9 @@ import { noop } from 'rxjs'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
-import { Button, Position } from '@sourcegraph/wildcard'
 
-import { Popover, PopoverContent, PopoverOpenEvent, PopoverTail, PopoverTrigger } from '..'
+import { Popover, PopoverContent, PopoverOpenEvent, PopoverTail, PopoverTrigger, Position } from '..'
+import { Button } from '../../Button'
 import { createRectangle, Point, Strategy } from '../tether'
 
 import styles from './Popover.story.module.scss'

--- a/client/wildcard/src/components/Tabs/Tabs.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.tsx
@@ -15,8 +15,7 @@ import {
 } from '@reach/tabs'
 import classNames from 'classnames'
 
-import { useElementObscuredArea } from '@sourcegraph/wildcard'
-
+import { useElementObscuredArea } from '../../hooks'
 import { ForwardReferenceComponent } from '../../types'
 
 import { TabPanelIndexContext, TabsState, TabsStateContext, useTabsState } from './context'

--- a/client/wildcard/src/components/Tabs/useScrollBackToActive.ts
+++ b/client/wildcard/src/components/Tabs/useScrollBackToActive.ts
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { debounce } from 'lodash'
 
-import { useMatchMedia } from '@sourcegraph/wildcard'
+import { useMatchMedia } from '../../hooks'
 
 import { useTabsState } from './context'
 


### PR DESCRIPTION
### Description
We have absolute path in the package `wildcard`. We should not use absolute imports from the package inside of the package to avoid circular dependency issues.
### Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/40252)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-40252)
### Test Plan
Confirm that there are no internal imports like -> `import X from '@sourcegraph/wildcard'` in the wildcard package are replaced with relative imports.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-contractors-sg-40252.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pjolzekwwc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

