### PR TITLE
codemirror file view: Fix non-extension decorations

### DIFF
--- a/client/web/src/repo/blame/useBlameDecorations.ts
+++ b/client/web/src/repo/blame/useBlameDecorations.ts
@@ -135,15 +135,20 @@ export const useBlameDecorations = (args?: {
     commitID: string
     filePath: string
 }): TextDocumentDecoration[] | undefined => {
+    const { repoName, commitID, filePath } = args ?? {}
     const extensionsAsCoreFeatures = useExperimentalFeatures(features => features.extensionsAsCoreFeatures)
     const [isBlameVisible] = useBlameVisibility()
     const hunks = useObservable(
-        useMemo(() => (extensionsAsCoreFeatures && args && isBlameVisible ? fetchBlame(args) : of(undefined)), [
-            extensionsAsCoreFeatures,
-            isBlameVisible,
-            args,
-        ])
+        useMemo(
+            () =>
+                extensionsAsCoreFeatures && commitID && repoName && filePath && isBlameVisible
+                    ? fetchBlame({ commitID, repoName, filePath }).pipe(
+                          map(hunks => (hunks ? getBlameDecorations(hunks) : undefined))
+                      )
+                    : of(undefined),
+            [extensionsAsCoreFeatures, isBlameVisible, commitID, repoName, filePath]
+        )
     )
 
-    return hunks ? getBlameDecorations(hunks) : undefined
+    return hunks
 }


### PR DESCRIPTION
While working on deprecating the extension API @philipp-spiess
discovered that blame view data wasn't shown properly when it was
enabled.

The reason for this was that the view plugin used to generate the
CodeMirror decorations didn't do that when the plugin was instantiated.
I can only assume that with extensions enabled it "worked" because the
plugin was instantiated prior to receiving the git blame data. But when
extensions are disabled the plugin is only created once the data is
provided.

This also fixes a subtle bug with how the gutter renders selected lines.

Before: 
<img width="729" alt="2022-08-12_15-22" src="https://user-images.githubusercontent.com/179026/184391787-d178ad3b-5b8b-47f1-95ce-c90726a3aa4f.png">


Demo: 

https://user-images.githubusercontent.com/179026/184391821-392d3fd3-a6c0-4445-ac76-de0af43ea2f3.mp4



---

The second commit makes a change to how blame information is computed.
While working on this I noticed that selecting a line (and thus changing
the URL) caused new decorations data to be fetch/generated.
I changed the implementation of `useBlameDecorations` to only recompute
the data when necessary. The only consequence is that the relative time
won't be updated anymore on rerenders, but that's probably fine?

## Test plan

- Enable `"extensionsAsCoreFeatures": true` in user settings.
- Comment out the `sourcegraphExtensions(...)` call in `CodeMirrorBlob`
- Open a file and toggle the git button

## App preview:

- [Web](https://sg-web-fkling-cm-file-view-fix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wbeswcymnx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
