### PR TITLE
database: ListIndexableReposOptions can take CloneStatus

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -539,7 +539,7 @@ func syncScheduler(ctx context.Context, logger log.Logger, sched *repos.UpdateSc
 		// Fetch ALL indexable repos that are NOT cloned so that we can add them to the
 		// scheduler
 		opts := database.ListIndexableReposOptions{
-			OnlyUncloned:   true,
+			CloneStatus:    types.CloneStatusNotCloned,
 			IncludePrivate: true,
 		}
 		if u, err := baseRepoStore.ListIndexableRepos(ctx, opts); err != nil {

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1175,8 +1175,10 @@ SELECT repo_id as id FROM user_public_repos WHERE user_id = %d
 `
 
 type ListIndexableReposOptions struct {
-	// If true, will only include uncloned indexable repos
-	OnlyUncloned bool
+	// CloneStatus if set will only return indexable repos of that clone
+	// status.
+	CloneStatus types.CloneStatus
+
 	// If true, we include user added private repos
 	IncludePrivate bool
 
@@ -1200,12 +1202,12 @@ func (s *repoStore) ListIndexableRepos(ctx context.Context, opts ListIndexableRe
 
 	var where, joins []*sqlf.Query
 
-	if opts.OnlyUncloned {
+	if opts.CloneStatus != types.CloneStatusUnknown {
 		joins = append(joins, sqlf.Sprintf(
 			"JOIN gitserver_repos gr ON gr.repo_id = repo.id",
 		))
 		where = append(where, sqlf.Sprintf(
-			"gr.clone_status = %s", types.CloneStatusNotCloned,
+			"gr.clone_status = %s", opts.CloneStatus,
 		))
 	}
 

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -501,7 +501,7 @@ func TestListIndexableRepos(t *testing.T) {
 		},
 		{
 			name: "only uncloned",
-			opts: ListIndexableReposOptions{OnlyUncloned: true},
+			opts: ListIndexableReposOptions{CloneStatus: types.CloneStatusNotCloned},
 			want: []api.RepoID{1},
 		},
 		{


### PR DESCRIPTION
Instead of a boolean field OnlyUncloned, we can make this take the
underlying enum. I intend to use this to only return cloned repos in
another call site.

This should not change any behaviour. CloneStatusUnknown is the empty
string, which is the default value. That should have the same behaviour
as when OnlyUncloned was false (the default value).

Test Plan: CI

plz-review-url: https://plz.review/review/9961