### PR TITLE
database: only tell zoekt to index cloned repos

### DIFF
--- a/internal/database/dbcache/cached_indexable_repos.go
+++ b/internal/database/dbcache/cached_indexable_repos.go
@@ -119,7 +119,10 @@ func (s *IndexableReposLister) refreshCache(ctx context.Context, onlyPublic bool
 		return repos, nil
 	}
 
-	opts := database.ListIndexableReposOptions{}
+	opts := database.ListIndexableReposOptions{
+		// Zoekt can only index a repo which has been cloned.
+		CloneStatus: types.CloneStatusCloned,
+	}
 	if !onlyPublic {
 		opts.IncludePrivate = true
 	}

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -55,24 +55,43 @@ func TestListIndexableRepos(t *testing.T) {
 			INSERT INTO repo(id, name, stars) VALUES (10, 'github.com/foo/bar10', 5);
 			INSERT INTO external_services(id, kind, display_name, config, namespace_user_id) VALUES (100, 'github', 'github', '{}', 1);
 			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (10, 100, '', 1);
+			UPDATE gitserver_repos SET clone_status = 'cloned' WHERE repo_id = 10;
 
 			-- insert one repo with more than 20 stars in the repo table
 			INSERT INTO repo(id, name, stars) VALUES (11, 'github.com/foo/bar11', 25);
 			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (11, 1, '', NULL);
+			UPDATE gitserver_repos SET clone_status = 'cloned' WHERE repo_id = 11;
 
 			-- insert a repo only referenced by a cloud_default external service
 			INSERT INTO repo(id, name, stars) VALUES (13, 'github.com/foo/bar13', 3);
 			INSERT INTO external_services(id, kind, display_name, config, cloud_default) VALUES (101, 'github', 'github', '{}', true);
 			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (13, 101, 'https://github.com/foo/bar13', NULL);
+			UPDATE gitserver_repos SET clone_status = 'cloned' WHERE repo_id = 13;
 
 			-- insert a repo only referenced by a cloud_default external service, but also in user_public_repos
 			INSERT INTO repo(id, name, stars) VALUES (14, 'github.com/foo/bar14', 2);
 			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (14, 101, 'https://github.com/foo/bar14', NULL);
 			INSERT INTO user_public_repos(user_id, repo_id, repo_uri) VALUES (1, 14, 'github.com/foo/bar/14');
+			UPDATE gitserver_repos SET clone_status = 'cloned' WHERE repo_id = 14;
 
 			-- insert one private user-added repo, i.e. a repo added by an external service owned by a user
 			INSERT INTO repo(id, name, private) VALUES (15, 'github.com/foo/bar15', true);
 			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (15, 100, 'example.com', 1);
+			UPDATE gitserver_repos SET clone_status = 'cloned' WHERE repo_id = 15;
+
+			-- insert one public cloning repo
+			INSERT INTO repo(id, name, stars) VALUES (20, 'github.com/foo/cloning', 100);
+			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (20, 101, 'https://github.com/foo/cloning', NULL);
+			UPDATE gitserver_repos SET clone_status = 'cloning' WHERE repo_id = 20;
+
+			-- insert one public not_cloned repo
+			INSERT INTO repo(id, name, stars) VALUES (21, 'github.com/foo/not_cloned', 100);
+			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (21, 101, 'https://github.com/foo/not_cloned', NULL);
+			UPDATE gitserver_repos SET clone_status = 'not_cloned' WHERE repo_id = 21;
+
+			-- insert one public repo which hasn't got an entry yet in gitserver_repos
+			INSERT INTO repo(id, name, stars) VALUES (22, 'github.com/foo/fresh', 100);
+			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url, user_id) VALUES (22, 101, 'https://github.com/foo/fresh', NULL);
 		`)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
We have a rather high error rate on sourcegraph.com around failing to
index cloning repositories. Currently we have code which ignores
failures due to uncloned repos and didn't handle cloning repos. However,
instead of updating that call site, we can now just tell zoekt to only
start indexing a repo once it is cloned. Historically this wasn't done
since when this was implemented we didn't have cloned state in the DB.

Test Plan: add a repo to the local dev env and see it appear in the
index. This will also be caught by our gqltests in CI.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/40321

plz-review-url: https://plz.review/review/9962