### PR TITLE
database: remove unused IndexableReposLister.ListPublic

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -184,8 +184,8 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 }
 
 // ListIndexable calls database.IndexableRepos.List, with tracing. It lists
-// ALL indexable repos which could include private user added repos. It only
-// lists cloned repositories.
+// ALL indexable repos which could include private user added repos.
+// In addition, it only lists cloned repositories.
 //
 // The intended call site for this is the logic which assigns repositories to
 // zoekt shards.

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -128,33 +128,6 @@ func TestListIndexableRepos(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
-
-		t.Run("List only public indexable repos", func(t *testing.T) {
-			repos, err := NewIndexableReposLister(logger, db.Repos()).ListPublic(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-			want := []types.MinimalRepo{
-				{
-					ID:    api.RepoID(11),
-					Name:  "github.com/foo/bar11",
-					Stars: 25,
-				},
-				{
-					ID:    api.RepoID(10),
-					Name:  "github.com/foo/bar10",
-					Stars: 5,
-				},
-				{
-					ID:    api.RepoID(14),
-					Name:  "github.com/foo/bar14",
-					Stars: 2,
-				},
-			}
-			if diff := cmp.Diff(want, repos, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
 	})
 }
 

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1179,7 +1179,7 @@ type ListIndexableReposOptions struct {
 	// status.
 	CloneStatus types.CloneStatus
 
-	// If true, we include user added private repos
+	// IncludePrivate when true will include user added private repos.
 	IncludePrivate bool
 
 	*LimitOffset


### PR DESCRIPTION
This function is unused. So we can simplify logic a bit (onlyPublic is
always false).

Test Plan: mechanical change only affecting sourcegraph.com, so just CI
and code review.

plz-review-url: https://plz.review/review/9963