### PR TITLE
executors: Build ignite VM image outside of packer

### DIFF
--- a/enterprise/cmd/executor/vm-image/build.sh
+++ b/enterprise/cmd/executor/vm-image/build.sh
@@ -27,6 +27,13 @@ bin_name="$OUTPUT/$(basename $pkg)"
 go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$bin_name" "$pkg"
 popd 1>/dev/null
 
+echo "--- generate ubuntu-ignite image"
+./enterprise/cmd/executor/vm-image/ignite-ubuntu/build.sh
+
+echo "--- export ubuntu-ignite image"
+mkdir "$OUTPUT/ignite-state"
+./enterprise/cmd/executor/vm-image/ignite-ubuntu/makeimg.sh "$OUTPUT/ignite-state"
+
 echo "--- create binary artifacts"
 # Setup new release folder that contains binary, info text.
 mkdir -p "enterprise/cmd/executor/vm-image/artifacts/executor/$(git rev-parse HEAD)"
@@ -55,7 +62,6 @@ cp .tool-versions "$OUTPUT"
 pushd ./enterprise/cmd/executor/vm-image 1>/dev/null
 cp executor.json "$OUTPUT"
 cp install.sh "$OUTPUT"
-cp -R ignite-ubuntu "$OUTPUT"
 popd 1>/dev/null
 
 export NAME

--- a/enterprise/cmd/executor/vm-image/executor.json
+++ b/enterprise/cmd/executor/vm-image/executor.json
@@ -71,7 +71,7 @@
     {
       "type": "file",
       "sources": ["ignite-state"],
-      "destination": "/var/lib/firecracker"
+      "destination": "/var/lib/firecracker/"
     },
     {
       "type": "shell",

--- a/enterprise/cmd/executor/vm-image/executor.json
+++ b/enterprise/cmd/executor/vm-image/executor.json
@@ -65,18 +65,13 @@
   "provisioners": [
     {
       "type": "file",
-      "sources": ["builder-sa-key.json"],
-      "destination": "/tmp/"
-    },
-    {
-      "type": "file",
       "sources": ["executor"],
       "destination": "/tmp/"
     },
     {
       "type": "file",
-      "sources": ["ignite-ubuntu"],
-      "destination": "/tmp"
+      "sources": ["ignite-state"],
+      "destination": "/var/lib/firecracker"
     },
     {
       "type": "shell",

--- a/enterprise/cmd/executor/vm-image/executor.json
+++ b/enterprise/cmd/executor/vm-image/executor.json
@@ -71,7 +71,11 @@
     {
       "type": "file",
       "sources": ["ignite-state"],
-      "destination": "/var/lib/firecracker/"
+      "destination": "/tmp/firecracker/"
+    },
+    {
+      "type": "shell",
+      "inline": ["sudo -E bash -c 'mkdir -p /var/lib/firecracker && mv /tmp/firecracker /var/lib/firecracker'"]
     },
     {
       "type": "shell",

--- a/enterprise/cmd/executor/vm-image/ignite-ubuntu/build.sh
+++ b/enterprise/cmd/executor/vm-image/ignite-ubuntu/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"/../../../../..
+set -eu
+
+SRC_CLI_VERSION="$(go run ./internal/cmd/src-cli-version/main.go)"
+
+docker build --platform linux/amd64 -t "sourcegraph/ignite-ubuntu:insiders" --build-arg SRC_CLI_VERSION="${SRC_CLI_VERSION}" ./enterprise/cmd/executor/vm-image/ignite-ubuntu

--- a/enterprise/cmd/executor/vm-image/ignite-ubuntu/makeimg.sh
+++ b/enterprise/cmd/executor/vm-image/ignite-ubuntu/makeimg.sh
@@ -35,21 +35,17 @@ EOF
     --privileged \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "${TEMP_DATA_DIR}/script.sh:/script.sh:ro" \
-    -v "${TEMP_DATA_DIR}/out:/var/lib/firecracker" \
+    -v "$1:/var/lib/firecracker" \
     --cap-add=CAP_MKNOD \
     --entrypoint /bin/sh \
     docker \
     -- /script.sh
-
-  imageID="$(ls "${TEMP_DATA_DIR}"/out/image)"
-  mv "${TEMP_DATA_DIR}/out/image/${imageID}/image.ext4" "$1/image.ext4"
-  mv "${TEMP_DATA_DIR}/out/image/${imageID}/metadata.json" "$1/metadata.json"
 else
+  mkdir -p /var/lib/firecracker
+  mv /var/lib/firecracker /var/lib/firecracker.bak
   curl -fL https://github.com/weaveworks/ignite/releases/download/v0.10.0/ignite-amd64 --output "${TEMP_DATA_DIR}/ignite"
   chmod +x "${TEMP_DATA_DIR}/ignite"
   "${TEMP_DATA_DIR}/ignite" image import --runtime docker sourcegraph/ignite-ubuntu:insiders
-
-  imageID="$(ls /var/lib/firecracker/image)"
-  mv "/var/lib/firecracker/image/${imageID}/image.ext4" "$1/image.ext4"
-  mv "/var/lib/firecracker/image/${imageID}/metadata.json" "$1/metadata.json"
+  mv "/var/lib/firecracker" "$1"
+  mv /var/lib/firecracker.bak /var/lib/firecracker
 fi

--- a/enterprise/cmd/executor/vm-image/ignite-ubuntu/makeimg.sh
+++ b/enterprise/cmd/executor/vm-image/ignite-ubuntu/makeimg.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/../../../../..
-set -eux
+set -ex
 
-# TODO: Check $1 is set.
+if [[ -z $1 ]]; then
+  echo "Must set out dir as first arg."
+  exit 1
+fi
+
+set -u
 
 TEMP_DATA_DIR=$(mktemp -d -t sgdockerbuild_XXXXXXX)
 cleanup() {
@@ -13,7 +18,9 @@ trap cleanup EXIT
 
 mkdir "${TEMP_DATA_DIR}/out"
 
-cat <<EOF >"${TEMP_DATA_DIR}/script.sh"
+# On macOS we use docker to create the image file.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  cat <<EOF >"${TEMP_DATA_DIR}/script.sh"
 set -exu
 
 apk add curl e2fsprogs e2fsprogs-extra
@@ -22,18 +29,27 @@ chmod +x /usr/bin/ignite
 ignite image import --runtime docker sourcegraph/ignite-ubuntu:insiders
 EOF
 
-docker run \
-  --platform linux/amd64 \
-  --rm \
-  --privileged \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v "${TEMP_DATA_DIR}/script.sh:/script.sh:ro" \
-  -v "${TEMP_DATA_DIR}/out:/var/lib/firecracker" \
-  --cap-add=CAP_MKNOD \
-  --entrypoint /bin/sh \
-  docker \
-  -- /script.sh
+  docker run \
+    --platform linux/amd64 \
+    --rm \
+    --privileged \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "${TEMP_DATA_DIR}/script.sh:/script.sh:ro" \
+    -v "${TEMP_DATA_DIR}/out:/var/lib/firecracker" \
+    --cap-add=CAP_MKNOD \
+    --entrypoint /bin/sh \
+    docker \
+    -- /script.sh
 
-imageID="$(ls "${TEMP_DATA_DIR}"/out/image)"
-mv "${TEMP_DATA_DIR}/out/image/${imageID}/image.ext4" "$1/image.ext4"
-mv "${TEMP_DATA_DIR}/out/image/${imageID}/metadata.json" "$1/metadata.json"
+  imageID="$(ls "${TEMP_DATA_DIR}"/out/image)"
+  mv "${TEMP_DATA_DIR}/out/image/${imageID}/image.ext4" "$1/image.ext4"
+  mv "${TEMP_DATA_DIR}/out/image/${imageID}/metadata.json" "$1/metadata.json"
+else
+  curl -fL https://github.com/weaveworks/ignite/releases/download/v0.10.0/ignite-amd64 --output "${TEMP_DATA_DIR}/ignite"
+  chmod +x "${TEMP_DATA_DIR}/ignite"
+  "${TEMP_DATA_DIR}/ignite" image import --runtime docker sourcegraph/ignite-ubuntu:insiders
+
+  imageID="$(ls /var/lib/firecracker/image)"
+  mv "/var/lib/firecracker/image/${imageID}/image.ext4" "$1/image.ext4"
+  mv "/var/lib/firecracker/image/${imageID}/metadata.json" "$1/metadata.json"
+fi

--- a/enterprise/cmd/executor/vm-image/ignite-ubuntu/makeimg.sh
+++ b/enterprise/cmd/executor/vm-image/ignite-ubuntu/makeimg.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"/../../../../..
+set -eux
+
+# TODO: Check $1 is set.
+
+TEMP_DATA_DIR=$(mktemp -d -t sgdockerbuild_XXXXXXX)
+cleanup() {
+  rm -rf "$TEMP_DATA_DIR"
+}
+trap cleanup EXIT
+
+mkdir "${TEMP_DATA_DIR}/out"
+
+cat <<EOF >"${TEMP_DATA_DIR}/script.sh"
+set -exu
+
+apk add curl e2fsprogs e2fsprogs-extra
+curl -fL https://github.com/weaveworks/ignite/releases/download/v0.10.0/ignite-amd64 --output /usr/bin/ignite
+chmod +x /usr/bin/ignite
+ignite image import --runtime docker sourcegraph/ignite-ubuntu:insiders
+EOF
+
+docker run \
+  --platform linux/amd64 \
+  --rm \
+  --privileged \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "${TEMP_DATA_DIR}/script.sh:/script.sh:ro" \
+  -v "${TEMP_DATA_DIR}/out:/var/lib/firecracker" \
+  --cap-add=CAP_MKNOD \
+  --entrypoint /bin/sh \
+  docker \
+  -- /script.sh
+
+imageID="$(ls "${TEMP_DATA_DIR}"/out/image)"
+mv "${TEMP_DATA_DIR}/out/image/${imageID}/image.ext4" "$1/image.ext4"
+mv "${TEMP_DATA_DIR}/out/image/${imageID}/metadata.json" "$1/metadata.json"

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -195,16 +195,6 @@ function install_src_cli() {
   rm -rf src-cli.tar.gz
 }
 
-## Build the ignite-ubuntu image for use in firecracker.
-## Set SRC_CLI_VERSION to the minimum required version in internal/src-cli/consts.go
-function generate_ignite_base_image() {
-  docker build -t "${EXECUTOR_FIRECRACKER_IMAGE}" --build-arg SRC_CLI_VERSION="${SRC_CLI_VERSION}" /tmp/ignite-ubuntu
-  ignite image import --runtime docker "${EXECUTOR_FIRECRACKER_IMAGE}"
-  docker image rm "${EXECUTOR_FIRECRACKER_IMAGE}"
-  # Remove intermediate layers and base image used in ignite-ubuntu.
-  docker system prune --force
-}
-
 ## Loads the required kernel image so it doesn't have to happen on the first VM start.
 function preheat_kernel_image() {
   ignite kernel import --runtime docker "${KERNEL_IMAGE}"
@@ -361,7 +351,6 @@ install_executor
 install_node_exporter
 
 # Service prep and cleanup
-generate_ignite_base_image
 preheat_kernel_image
 configure_ignite
 cleanup


### PR DESCRIPTION
This PR extracts the process of building and importing the VM image for ignite. This in itself is not a huge improvement other than that the packer VMs don't have to do this all separately, but it will allow us to in the future release the artifacts of this separately. Good for use when using the binary, because customers don't need to reconstruct from our VM build process how this works. 

## Test plan

Verified on k8s that it still works correctly.