### PR TITLE
web: use CSS named chunks for bundlesize observability

### DIFF
--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -148,7 +148,10 @@ const config = {
     getProvidePlugin(),
     new MiniCssExtractPlugin({
       // Do not [hash] for development -- see https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
-      filename: IS_PRODUCTION ? 'styles/[name].[contenthash].bundle.css' : 'styles/[name].bundle.css',
+      filename:
+        IS_PRODUCTION && !WEBPACK_USE_NAMED_CHUNKS
+          ? 'styles/[name].[contenthash].bundle.css'
+          : 'styles/[name].bundle.css',
     }),
     getMonacoWebpackPlugin(),
     !WEBPACK_SERVE_INDEX &&


### PR DESCRIPTION
## Context

Remove content hash from CSS chunk names if `WEBPACK_USE_NAMED_CHUNKS === true`.

Currently, we use this env variable only for JS chunks. Having content hash in CSS chunks makes monitoring CSS bundlesize harder. See [the Honeycomb dashboard](https://ui.honeycomb.io/sourcegraph/environments/client/board/8RjpcGkEvSq/Web-app-bundle-size).

<img width="675" alt="Screen Shot 2022-08-15 at 12 46 04" src="https://user-images.githubusercontent.com/3846380/184578308-6e924c75-277b-4544-8769-07f4eb126368.png">

## Test plan

Run `ENTERPRISE=1 NODE_ENV=production WEBPACK_USE_NAMED_CHUNKS=true yarn build` and ensure that CSS chunk names do not include content hash.

## App preview:

- [Web](https://sg-web-vb-use-named-css-chunks.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dkkqxucoqb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
