### PR TITLE
vsce: temp disable integration tests

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -104,7 +104,6 @@ Base pipeline (more steps might be included based on branch changes):
 
 - ESLint (all)
 - Stylelint (all)
-- Puppeteer tests for VS Code extension
 - Upload build trace
 
 ### Tagged release

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -176,7 +176,8 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// If this is a VS Code extension nightly build, run the vsce-extension integration tests
 		ops = operations.NewSet(
 			addClientLintersForAllFiles,
-			addVsceIntegrationTests)
+			// addVsceIntegrationTests,
+		)
 
 	case runtype.ImagePatch:
 		// only build image for the specified image in the branch name


### PR DESCRIPTION
Disables integration tests for VSCE nightly build in order to [unlock the `main` branch](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1660523399134609).

## Test plan
VSCE checks pass in the pipeline.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
