### PR TITLE
user-management: follow-up fixes

### DIFF
--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react'
 
 import { mdiLogoutVariant, mdiArchive, mdiDelete, mdiLockReset, mdiClipboardMinus, mdiClipboardPlus } from '@mdi/js'
 import classNames from 'classnames'
-import { format as formatDate } from 'date-fns'
+import { formatDistanceToNowStrict } from 'date-fns'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
@@ -197,7 +197,7 @@ export const UsersList: React.FunctionComponent = () => {
                                     label: 'Events',
                                     align: 'right',
                                     tooltip:
-                                        '"Events" count is based on event_logs table which stores only last 93 days of logs.',
+                                        '"Events" count is cached and updated every 12 hours. It is based on event logs table and available for the last 93 days.',
                                 },
                                 sortable: true,
                                 align: 'right',
@@ -205,19 +205,22 @@ export const UsersList: React.FunctionComponent = () => {
                             {
                                 key: SiteUserOrderBy.LAST_ACTIVE_AT,
                                 accessor: item =>
-                                    item.lastActiveAt ? formatDate(new Date(item.lastActiveAt), 'dd/mm/yyyy') : '',
+                                    item.lastActiveAt
+                                        ? formatDistanceToNowStrict(new Date(item.lastActiveAt), { addSuffix: true })
+                                        : '',
                                 header: {
                                     label: 'Last Active',
                                     align: 'right',
                                     tooltip:
-                                        '"Last Active" is based on event_logs table which stores only last 93 days of logs.',
+                                        '"Last Active" is cached and updated every 12 hours. It is based on event logs table and available for the last 93 days.',
                                 },
                                 sortable: true,
                                 align: 'right',
                             },
                             {
                                 key: SiteUserOrderBy.CREATED_AT,
-                                accessor: item => formatDate(new Date(item.createdAt), 'dd/mm/yyyy'),
+                                accessor: item =>
+                                    formatDistanceToNowStrict(new Date(item.createdAt), { addSuffix: true }),
                                 header: { label: 'Created', align: 'right' },
                                 sortable: true,
                                 align: 'right',
@@ -225,7 +228,9 @@ export const UsersList: React.FunctionComponent = () => {
                             {
                                 key: SiteUserOrderBy.DELETED_AT,
                                 accessor: item =>
-                                    item.deletedAt ? formatDate(new Date(item.deletedAt), 'dd/mm/yyyy') : '',
+                                    item.deletedAt
+                                        ? formatDistanceToNowStrict(new Date(item.deletedAt), { addSuffix: true })
+                                        : '',
                                 header: { label: 'Deleted', align: 'right' },
                                 sortable: true,
                                 align: 'right',

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
@@ -89,7 +89,7 @@ export const UsersList: React.FunctionComponent = () => {
                         <Text as="label">Search users</Text>
                         <Input
                             className="flex-1 ml-2"
-                            placeholder="Search username or name"
+                            placeholder="Search username, display name, email"
                             value={searchText}
                             onChange={event => setSearchText(event.target.value)}
                         />

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
@@ -6,7 +6,7 @@ import { formatDistanceToNowStrict } from 'date-fns'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
-import { H2, LoadingSpinner, Text, Input, Button, Alert, useDebounce, Link } from '@sourcegraph/wildcard'
+import { H2, LoadingSpinner, Text, Input, Button, Alert, useDebounce, Link, Tooltip } from '@sourcegraph/wildcard'
 
 import { CopyableText } from '../../../../components/CopyableText'
 import {
@@ -260,12 +260,21 @@ export const UsersList: React.FunctionComponent = () => {
     )
 }
 
-function RenderUsernameAndEmail({ username, email }: SiteUser): JSX.Element {
+function RenderUsernameAndEmail({ username, email, displayName, deletedAt }: SiteUser): JSX.Element {
     return (
-        <div className={classNames('d-flex flex-column p-2', styles.usernameColumn)}>
-            <Text className={classNames(styles.linkColor, 'mb-0 text-truncate')}>{username}</Text>
-            <Text className="mb-0 text-truncate">{email}</Text>
-        </div>
+        <Tooltip content={username}>
+            <div className={classNames('d-flex flex-column p-2', styles.usernameColumn)}>
+                {!deletedAt ? (
+                    <Link to={`/users/${username}`} className="text-truncate">
+                        @{username}
+                    </Link>
+                ) : (
+                    <Text className="mb-0 text-truncate">@{username}</Text>
+                )}
+                <Text className="mb-0 text-truncate">{displayName}</Text>
+                <Text className="mb-0 text-truncate">{email}</Text>
+            </div>
+        </Tooltip>
     )
 }
 

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/queries.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/queries.tsx
@@ -35,6 +35,7 @@ export const USERS_MANAGEMENT_USERS_LIST = gql`
                 nodes(first: $first, orderBy: $orderBy, descending: $descending) {
                     id
                     username
+                    displayName
                     email
                     siteAdmin
                     eventsCount

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/queries.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/queries.tsx
@@ -8,8 +8,7 @@ export const USERS_MANAGEMENT_SUMMARY = gql`
                     userCount
                 }
             }
-            adminUsers: users(siteAdmin: true) {
-                # TODO: exclude deleted users
+            adminUsers: users(siteAdmin: true, deleted: false) {
                 totalCount
             }
             users {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5773,6 +5773,10 @@ type Site implements SettingsSubject {
         When omitted does NOT apply and returns for all period available.
         """
         lastActivePeriod: SiteUsersLastActivePeriod
+        """
+        Returns either deleted or not deleted users. Returns all users when omitted.
+        """
+        deleted: Boolean
     ): SiteUsers!
 
     """

--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -16,6 +16,7 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 	Username         *string
 	Email            *string
 	LastActivePeriod *string
+	Deleted          *bool
 }) (*siteUsersResolver, error) {
 	// 🚨 SECURITY: Only site admins can see users.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, s.db); err != nil {
@@ -29,6 +30,7 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 			Username:         args.Username,
 			Email:            args.Email,
 			LastActivePeriod: args.LastActivePeriod,
+			Deleted:          args.Deleted,
 		}}}, nil
 }
 

--- a/internal/users/stats.go
+++ b/internal/users/stats.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
@@ -17,6 +18,7 @@ type UsersStatsFilters struct {
 	Username         *string
 	Email            *string
 	LastActivePeriod *string
+	Deleted          *bool
 }
 
 type UsersStats struct {
@@ -38,6 +40,13 @@ func (s *UsersStats) makeQueryParameters() ([]*sqlf.Query, error) {
 	}
 	if s.Filters.Email != nil {
 		conds = append(conds, sqlf.Sprintf("primary_email ILIKE %s", "%"+*s.Filters.Email+"%"))
+	}
+	if s.Filters.Deleted != nil {
+		if *s.Filters.Deleted {
+			conds = append(conds, sqlf.Sprintf("deleted_at IS NOT NULL"))
+		} else {
+			conds = append(conds, sqlf.Sprintf("deleted_at IS NULL"))
+		}
 	}
 	if s.Filters.LastActivePeriod != nil && *s.Filters.LastActivePeriod != "ALL" {
 		lastActiveStartTime, err := makeLastActiveStartTime(*s.Filters.LastActivePeriod)
@@ -64,7 +73,7 @@ func makeLastActiveStartTime(lastActivePeriod string) (time.Time, error) {
 }
 
 var (
-	statsSubQuery = `
+	statsCTEQuery = `
 	WITH aggregated_stats AS (
 		SELECT
 			users.id AS id,
@@ -92,7 +101,9 @@ func (s *UsersStats) TotalCount(ctx context.Context) (float64, error) {
 		return 0, err
 	}
 
-	query := sqlf.Sprintf(statsSubQuery, sqlf.Sprintf(`SELECT COUNT(id) FROM aggregated_stats WHERE %s`, sqlf.Join(conds, "AND")))
+	query := sqlf.Sprintf(statsCTEQuery, sqlf.Sprintf(`SELECT COUNT(id) FROM aggregated_stats WHERE %s`, sqlf.Join(conds, "AND")))
+	fmt.Println(query.Query(sqlf.PostgresBindVar))
+	fmt.Println(query.Args())
 	if err := s.DB.QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...).Scan(&totalCount); err != nil {
 		return 0, err
 	}
@@ -135,7 +146,7 @@ func (s *UsersStats) ListUsers(ctx context.Context, filters *UsersStatsListUsers
 		return nil, err
 	}
 
-	query := sqlf.Sprintf(statsSubQuery, sqlf.Sprintf(`
+	query := sqlf.Sprintf(statsCTEQuery, sqlf.Sprintf(`
 	SELECT id, username, display_name, primary_email, created_at, last_active_at, deleted_at, site_admin, events_count FROM aggregated_stats WHERE %s ORDER BY %s LIMIT %s`, sqlf.Join(conds, "AND"), orderBy, limit))
 
 	rows, err := s.DB.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)

--- a/internal/users/stats.go
+++ b/internal/users/stats.go
@@ -30,7 +30,7 @@ func (s *UsersStats) makeQueryParameters() ([]*sqlf.Query, error) {
 	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
 	if s.Filters.Query != nil && *s.Filters.Query != "" {
 		query := "%" + *s.Filters.Query + "%"
-		conds = append(conds, sqlf.Sprintf("(username ILIKE %s OR display_name ILIKE %s)", query, query))
+		conds = append(conds, sqlf.Sprintf("(username ILIKE %s OR display_name ILIKE %s OR primary_email ILIKE %s)", query, query, query))
 	}
 	if s.Filters.SiteAdmin != nil {
 		conds = append(conds, sqlf.Sprintf("site_admin = %s", *s.Filters.SiteAdmin))


### PR DESCRIPTION
This PR:
- Update "Events" and "Last Active" table header tooltips
- Filter deleted users from "Administrators" metrics
- Update UserManagement table date time formatting
- Add searching over primary email
- Add a link to the user profile on the username field if the user is not deleted 
   - Add display name to the User column and minor style updates

## Test plan
- `sg start`
- Open http://localhost:3080/site-admin/users?feature-flag-key=user-management&feature-flag-value=true

## Screenshots
| BEFORE | AFTER |
| --: | :-- |
| <img width="928" alt="image" src="https://user-images.githubusercontent.com/6717049/184605124-8d528919-8e46-404a-b60e-22cde6d26656.png"> | <img width="928" alt="image" src="https://user-images.githubusercontent.com/6717049/184604942-491c5088-1427-44d9-985b-76df10ad8867.png"> |

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
