### PR TITLE
Prevent command injection to docker in firecracker

### DIFF
--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -53,7 +53,7 @@ func dockerResourceFlags(options ResourceOptions) []string {
 	if options.NumCPUs != 0 {
 		flags = append(flags, "--cpus", strconv.Itoa(options.NumCPUs))
 	}
-	if options.Memory != "0" {
+	if options.Memory != "0" && options.Memory != "" {
 		flags = append(flags, "--memory", options.Memory)
 	}
 

--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/inconshreveable/log15"
 
+	shellquote "github.com/kballard/go-shellquote"
+
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -33,7 +35,7 @@ const firecrackerContainerDir = "/work"
 func formatFirecrackerCommand(spec CommandSpec, name string, options Options) command {
 	rawOrDockerCommand := formatRawOrDockerCommand(spec, firecrackerContainerDir, options)
 
-	innerCommand := strings.Join(rawOrDockerCommand.Command, " ")
+	innerCommand := shellquote.Join(rawOrDockerCommand.Command...)
 	if len(rawOrDockerCommand.Env) > 0 {
 		// If we have env vars that are arguments to the command we need to escape them
 		quotedEnv := quoteEnv(rawOrDockerCommand.Env)

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -68,9 +68,39 @@ func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 				"-v", "/work:/data",
 				"-w", "/data/subdir",
 				"-e", "TEST=true",
-				"-e", `CONTAINS_WHITESPACE="yes it does"`,
+				"-e", `'CONTAINS_WHITESPACE="yes it does"'`,
 				"--entrypoint /bin/sh",
 				"alpine:latest",
+				"/data/.sourcegraph-executor/myscript.sh",
+			}, " "),
+		},
+	}
+	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
+		t.Errorf("unexpected command (-want +got):\n%s", diff)
+	}
+}
+
+func TestFormatFirecrackerCommandDockerScript_NoInjection(t *testing.T) {
+	actual := formatFirecrackerCommand(
+		CommandSpec{
+			Image:      "--privileged alpine:latest",
+			ScriptPath: "myscript.sh",
+			Operation:  makeTestOperation(),
+		},
+		"deadbeef",
+		Options{},
+	)
+
+	expected := command{
+		Command: []string{
+			"ignite", "exec", "deadbeef", "--",
+			strings.Join([]string{
+				"docker", "run", "--rm",
+				"-v", "/work:/data",
+				"-w", "/data",
+				"--entrypoint /bin/sh",
+				// This has to be quoted, otherwise it allows to pass arbitrary params.
+				"'--privileged alpine:latest'",
 				"/data/.sourcegraph-executor/myscript.sh",
 			}, " "),
 		},

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible
 	github.com/json-iterator/go v1.1.12
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/keegancsmith/rpc v1.3.0
 	github.com/keegancsmith/sqlf v1.1.1
 	github.com/keegancsmith/tmpfriend v0.0.0-20180423180255-86e88902a513

--- a/go.sum
+++ b/go.sum
@@ -1493,6 +1493,8 @@ github.com/kataras/neffos v0.0.14/go.mod h1:8lqADm8PnbeFfL7CLXh1WHw53dG27MC3pgi2
 github.com/kataras/pio v0.0.0-20190103105442-ea782b38602d/go.mod h1:NV88laa9UiiDuX9AhMbDPkGYSPugBOV6yTZB1l2K9Z0=
 github.com/kataras/pio v0.0.2/go.mod h1:hAoW0t9UmXi4R5Oyq5Z4irTbaTsOemSrDGUtaTl7Dro=
 github.com/kataras/sitemap v0.0.5/go.mod h1:KY2eugMKiPwsJgx7+U103YZehfvNGOXURubcGyk0Bz8=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/keegancsmith/rpc v1.3.0 h1:wGWOpjcNrZaY8GDYZJfvyxmlLljm3YQWF+p918DXtDk=
 github.com/keegancsmith/rpc v1.3.0/go.mod h1:6O2xnOGjPyvIPbvp0MdrOe5r6cu1GZ4JoTzpzDhWeo0=
 github.com/keegancsmith/sqlf v1.1.1 h1:b3DZm7eILJYkj4igLMjIvUM8fI4Ey4LCV5Wk8JGL+uA=


### PR DESCRIPTION
Since we made this one string in the end, it is up to the shell to interpret args here.

Works on https://github.com/sourcegraph/security-issues/issues/297.

## Test plan

Tested on k8s.