### PR TITLE
Performance: Enable fastResultLoading by default

### DIFF
--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -20,7 +20,6 @@ export interface IClient {
 export interface Settings {
     extensions?: { [extensionID: string]: boolean }
     experimentalFeatures?: {
-        enableFastResultLoading?: boolean
         batchChangesExecution?: boolean
         showSearchContext?: boolean
         showSearchContextManagement?: boolean

--- a/client/vscode/src/webview/search-panel/alias/FileMatchChildren.tsx
+++ b/client/vscode/src/webview/search-panel/alias/FileMatchChildren.tsx
@@ -10,7 +10,6 @@ import { Hoverifier } from '@sourcegraph/codeintellify'
 import {
     appendLineRangeQueryParameter,
     appendSubtreeQueryParameter,
-    isErrorLike,
     toPositionOrRangeQueryParameter,
 } from '@sourcegraph/common'
 import {
@@ -147,14 +146,6 @@ function navigateToFileOnMiddleMouseButtonClick(event: MouseEvent<HTMLElement>):
 }
 
 export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<FileMatchProps>> = props => {
-    // If optimizeHighlighting is enabled, compile a list of the highlighted file ranges we want to
-    // fetch (instead of the entire file.)
-    const optimizeHighlighting =
-        props.settingsCascade.final &&
-        !isErrorLike(props.settingsCascade.final) &&
-        props.settingsCascade.final.experimentalFeatures &&
-        props.settingsCascade.final.experimentalFeatures.enableFastResultLoading
-
     const { result, grouped, fetchHighlightedFileLineRanges, telemetryService, extensionsController } = props
 
     const { openFile, openSymbol } = useOpenSearchResultsContext()
@@ -168,14 +159,12 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
                     commitID: result.commit || '',
                     filePath: result.path,
                     disableTimeout: false,
-                    ranges: optimizeHighlighting
-                        ? grouped.map(
-                              (group): IHighlightLineRange => ({
-                                  startLine: group.startLine,
-                                  endLine: group.endLine,
-                              })
-                          )
-                        : [{ startLine: 0, endLine: 2147483647 }], // entire file,
+                    ranges: grouped.map(
+                        (group): IHighlightLineRange => ({
+                            startLine: group.startLine,
+                            endLine: group.endLine,
+                        })
+                    ),
                 },
                 false
             ).pipe(
@@ -185,13 +174,11 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
                         { durationMs: Date.now() - startTime },
                         { durationMs: Date.now() - startTime }
                     )
-                    return optimizeHighlighting
-                        ? lines[grouped.findIndex(group => group.startLine === startLine && group.endLine === endLine)]
-                        : lines[0].slice(startLine, endLine)
+                    return lines[grouped.findIndex(group => group.startLine === startLine && group.endLine === endLine)]
                 })
             )
         },
-        [result, fetchHighlightedFileLineRanges, grouped, optimizeHighlighting, telemetryService]
+        [result, fetchHighlightedFileLineRanges, grouped, telemetryService]
     )
 
     const createCodeExcerptLink = (group: MatchGroup): string => {


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/6992

## Actions before merging this PR:
- Check that there were no issues on S2. This has already been enabled fully on that instance. [Slack thread](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1660315649219639?thread_ts=1660310838.060039&cid=CHEKCRWKV)
- Check to see if we can remove the experimental feature entirely, or if this breaks anything. E.g. we have it in our current Sourcegraph.com config [here](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-cloud/-/blob/overlays/prod/frontend/files/global-settings.json?L66), if we delete the flag will it break something?

## Description

This PR:
- Enables `enableFastResultLoading` by default. This will fetch significantly less KB of data from each search result.

This seems like it should have been enabled a while ago, we just [didn't get around to it ](https://github.com/sourcegraph/sourcegraph/issues/17231#issuecomment-825798386).

> **Note**
> This is currently fully enabled on S2 for thorough testing, I don't see any reason why we can't enable this though.

## Test plan

Tested locally
