### PR TITLE
auto-indexing: Improve wording of queued banner

### DIFF
--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateBanner.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateBanner.tsx
@@ -8,7 +8,7 @@ import { CodeIntelStateDescription } from './CodeIntelStateDescription'
 
 export interface CodeIntelStateBannerProps {
     typeName: string
-    pluralTypeName: string
+    pluralTypeName?: string
     state: LSIFUploadState | LSIFIndexState
     placeInQueue?: number | null
     failure?: string | null

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateDescription.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateDescription.tsx
@@ -3,12 +3,13 @@ import { FunctionComponent } from 'react'
 import { upperFirst } from 'lodash'
 
 import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
+import { pluralize } from '@sourcegraph/common'
 
 import { LSIFIndexState, LSIFUploadState } from '../../../../graphql-operations'
 
 export interface CodeIntelStateDescriptionProps {
     typeName: string
-    pluralTypeName: string
+    pluralTypeName?: string
     state: LSIFUploadState | LSIFIndexState
     placeInQueue?: number | null
     failure?: string | null
@@ -30,7 +31,11 @@ export const CodeIntelStateDescription: FunctionComponent<React.PropsWithChildre
     ) : state === LSIFUploadState.QUEUED || state === LSIFIndexState.QUEUED ? (
         <span className={className}>
             {upperFirst(typeName)} is queued.{' '}
-            <CodeIntelStateDescriptionPlaceInQueue placeInQueue={placeInQueue} pluralTypeName={pluralTypeName} />
+            <CodeIntelStateDescriptionPlaceInQueue
+                placeInQueue={placeInQueue}
+                typeName={typeName}
+                pluralTypeName={pluralTypeName}
+            />
         </span>
     ) : state === LSIFUploadState.PROCESSING || state === LSIFIndexState.PROCESSING ? (
         <span className={className}>{upperFirst(typeName)} is currently being processed...</span>
@@ -46,11 +51,23 @@ export const CodeIntelStateDescription: FunctionComponent<React.PropsWithChildre
 
 export interface CodeIntelStateDescriptionPlaceInQueueProps {
     placeInQueue?: number | null
-    pluralTypeName: string
+    typeName: string
+    pluralTypeName?: string
 }
 
 const CodeIntelStateDescriptionPlaceInQueue: FunctionComponent<
     React.PropsWithChildren<CodeIntelStateDescriptionPlaceInQueueProps>
-> = ({ placeInQueue, pluralTypeName }) => (
-    <>{placeInQueue ? `There are ${placeInQueue} ${pluralTypeName} ahead of this one.` : ''}</>
-)
+> = ({ placeInQueue, typeName, pluralTypeName }) => {
+    if (placeInQueue === 1) {
+        return <>This {typeName} is up next for processing.</>
+    }
+    return (
+        <>
+            {placeInQueue
+                ? `There are ${placeInQueue - 1} ${
+                      pluralTypeName !== undefined ? pluralTypeName : pluralize(typeName, placeInQueue - 1)
+                  } ahead of this one.`
+                : ''}
+        </>
+    )
+}

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
@@ -212,7 +212,6 @@ export const CodeIntelUploadPage: FunctionComponent<React.PropsWithChildren<Code
                             placeInQueue={uploadOrError.placeInQueue}
                             failure={uploadOrError.failure}
                             typeName="upload"
-                            pluralTypeName="uploads"
                             variant={variantByState.get(uploadOrError.state)}
                         />
                         {uploadOrError.isLatestForRepo && (


### PR DESCRIPTION
Before it didn't account for singular in the `1` case and also said there was one more job in front of this, which is not necessarily true when an executor still spins up, so tweaked the wording there slightly to avoid confusion/fear that more than 1 job have been created.

## Test plan

Verified it looks alright.

## App preview:

- [Web](https://sg-web-es-ai-wording-queued-banner.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bwqfhvnkzo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
