### PR TITLE
metrics: fix broken error rate when count unset

### DIFF
--- a/internal/metrics/operation.go
+++ b/internal/metrics/operation.go
@@ -11,9 +11,10 @@ import (
 // It is modeled after the RED method, which defines three characteristics for
 // monitoring services:
 //
-//  - number (rate) of requests per second
-//  - number of errors/failed operations
-//  - amount of time per operation
+//   - number (rate) of requests per second
+//   - number of errors/failed operations
+//   - amount of time per operation
+//
 // https://thenewstack.io/monitoring-microservices-red-method/.
 type REDMetrics struct {
 	Count    *prometheus.CounterVec   // How many things were processed?
@@ -29,6 +30,7 @@ func (m *REDMetrics) Observe(secs, count float64, err *error, lvals ...string) {
 
 	if err != nil && *err != nil {
 		m.Errors.WithLabelValues(lvals...).Inc()
+		m.Count.WithLabelValues(lvals...).Add(0)
 	} else {
 		m.Duration.WithLabelValues(lvals...).Observe(secs)
 		m.Count.WithLabelValues(lvals...).Add(count)


### PR DESCRIPTION
We use a query something along the lines of `sum by (op) (increase(src_<root>_errors_total[5m])) / (sum by (op) (increase(src_<root>_total[5m])) + sum by (op) (increase(src_<root>_errors_total[5m]))) * 100` to determine the error rate. This works because on success, we increment a "success" counter (`src_<root>_total`), and on error, we increment an "error" counter (`src_<root>_errors_total`). 

This falls apart when the "success" counter has never been incremented, resulting in the metric series being "unset" (see the gaps in the "success" visualization on the right below), resulting in an apparent error rate of 0 with a non-zero error count.

This PR addresses the issue by always making sure the "success" counter is seeded with at least 0 in the error case by incrementing by 0.

![image](https://user-images.githubusercontent.com/18282288/184658645-00547f12-70f7-4d8b-9323-82cf11fd5f59.png)


## Test plan

Tested locally :+1: :+1: :+1: 
