### PR TITLE
search: move ref={containerElement} onto the exact element being modified for repo description match highlighting

### DIFF
--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -106,9 +106,9 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                 {result.description && (
                     <>
                         <div className={styles.dividerVertical} />
-                        <div ref={containerElement}>
+                        <div>
                             <small>
-                                <em>
+                                <em ref={containerElement}>
                                     {result.description.length > REPO_DESCRIPTION_CHAR_LIMIT
                                         ? result.description.slice(0, REPO_DESCRIPTION_CHAR_LIMIT) + ' ...'
                                         : result.description}
@@ -123,15 +123,12 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
 
     useEffect((): void => {
         if (containerElement.current && result.descriptionMatches) {
-            const visibleDescription = containerElement.current.querySelector('small em')
-            if (visibleDescription) {
-                for (const range of result.descriptionMatches) {
-                    highlightNode(
-                        visibleDescription as HTMLElement,
-                        range.start.column,
-                        range.end.column - range.start.column
-                    )
-                }
+            for (const range of result.descriptionMatches) {
+                highlightNode(
+                    containerElement.current as HTMLElement,
+                    range.start.column,
+                    range.end.column - range.start.column
+                )
             }
         }
     }, [result.description, result.descriptionMatches, containerElement])


### PR DESCRIPTION
Use `containerElement.current` directly instead of `querySelector`.



## Test plan
Manually test that highlighting is unchanged in the UI.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tl-move-ref-containerelement.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pyytcbfrhf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
