### PR TITLE
[docs] Clarify account linking from multiple auth providers

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -437,6 +437,10 @@ Some proxies add a prefix to the username header value. For example, Google IAP 
   ]
 }
 ```
+## Linking accounts from multiple auth providers
+Sourcegraph will automatically link accounts from multiple external auth providers, resulting in a single user account on Sourcegraph. That way a user can login with multiple auth methods and end up being logged in with the same Sourcegraph account. In general, to link accounts, the following condition needs to be met:
+
+At the time of signing in with the new account, any of the email addresses configured on the user account on the auth provider must match any of the **verified** email addresses on the user account on the Sourcegraph side. If there is a match, the accounts are linked, [otherwise a new user account is created if auth provider is configured to support user sign ups](#how-to-control-user-sign-up).
 
 ## Username normalization
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -634,7 +634,7 @@ query {
 If the Sourcegraph instance is configured to sync repositories from multiple code hosts (regardless of whether they are the same code host, e.g. `GitHub + GitHub` or `GitHub + GitLab`), Sourcegraph will enforce access to repositories from each code host with authorization enabled, so long as:
 
 - users log in to Sourcegraph at least once from each code host's [authentication provider](../auth/index.md)
-- users have the same primary email in Sourcegraph (under "User settings" > "Emails") as the code host at the time of the initial log in via that code host
+- users have the same verified email in Sourcegraph (under "User settings" > "Emails") as any of the emails on the user account from the code host at the time of the initial log in via that code host
 
 To attach a user's Sourcegraph account to all relevant code host accounts, a specific sign-in flow needs to be utilized when users are creating an account and signing into Sourcegraph for the first time.
 


### PR DESCRIPTION
This change clarifies how Sourcegraph links accounts from multiple auth providers to a single user account.

## Test plan

Docs changes. Tested preview of markdown locally.
