### PR TITLE
search: fix logging non-empty results

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -162,25 +162,24 @@ export const StreamingSearchResults: React.FunctionComponent<
                     },
                 },
             })
+            if (results.results.length > 0) {
+                telemetryService.log('SearchResultsNonEmpty')
+            }
         } else if (results?.state === 'error') {
             telemetryService.log('SearchResultsFetchFailed', {
                 code_search: { error_message: asError(results.error).message },
             })
         }
-
-        if (resultsFound) {
-            telemetryService.log('SearchResultsNonEmpty')
-        }
-    }, [results, resultsFound, telemetryService])
+    }, [results, telemetryService])
 
     // Log lucky search events. To be removed at latest by 12/2022.
     const [luckySearchEnabled] = useFeatureFlag('ab-lucky-search')
     useEffect(() => {
         if (luckySearchEnabled && results?.state === 'complete') {
             telemetryService.log('SearchResultsFetchedAuto')
-        }
-        if (luckySearchEnabled && resultsFound) {
-            telemetryService.log('SearchResultsNonEmptyAuto')
+            if (results.results.length > 0) {
+                telemetryService.log('SearchResultsNonEmptyAuto')
+            }
         }
         if (
             luckySearchEnabled &&
@@ -196,7 +195,7 @@ export const StreamingSearchResults: React.FunctionComponent<
                 telemetryService.log(event)
             }
         }
-    }, [results, resultsFound, luckySearchEnabled, telemetryService])
+    }, [results, luckySearchEnabled, telemetryService])
 
     useNotepad(
         useMemo(


### PR DESCRIPTION
fix logging to record when one search operation completes and returns non-empty results (previously I logged partial progress for each piece of nonempty streamed results, which is not what I wanted)

## Test plan
logging, no tests

## App preview:

- [Web](https://sg-web-rvt-log-complete-non-empty.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wjhfdvmzul.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

