### PR TITLE
charts: Support custom tooltip for bar charts

### DIFF
--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.story.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.story.tsx
@@ -129,6 +129,7 @@ export const BarChartVitrina: Story = () => (
             getDatumValue={getValue}
             getDatumColor={getColor}
             getDatumLink={getLink}
+            getDatumHover={datum => `custom text for ${datum.name}`}
         />
         <BarChart
             width={400}

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -25,6 +25,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         height: outerHeight,
         data,
         stacked = false,
+        getDatumHover,
         getDatumName,
         getDatumValue,
         getDatumColor,
@@ -84,6 +85,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
                         left={content.left}
                         stacked={stacked}
                         categories={categories}
+                        getDatumHover={getDatumHover}
                         getDatumName={getDatumName}
                         getDatumValue={getDatumValue}
                         getDatumColor={getDatumColor}

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
@@ -28,9 +28,9 @@ interface BarChartContentProps<Datum> extends SVGProps<SVGGElement> {
     yScale: ScaleLinear<number, number>
     categories: Category<Datum>[]
 
-    getDatumHover: (datum: Datum) => string
     getDatumName: (datum: Datum) => string
     getDatumValue: (datum: Datum) => number
+    getDatumHover?: (datum: Datum) => string
     getDatumColor: (datum: Datum) => string | undefined
     getDatumLink: (datum: Datum) => string | undefined | null
     onBarClick: (datum: Datum) => void

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
@@ -28,6 +28,7 @@ interface BarChartContentProps<Datum> extends SVGProps<SVGGElement> {
     yScale: ScaleLinear<number, number>
     categories: Category<Datum>[]
 
+    getDatumHover: (datum: Datum) => string
     getDatumName: (datum: Datum) => string
     getDatumValue: (datum: Datum) => number
     getDatumColor: (datum: Datum) => string | undefined
@@ -45,6 +46,7 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
         left,
         width = 0,
         height = 0,
+        getDatumHover,
         getDatumName,
         getDatumValue,
         getDatumColor,
@@ -102,6 +104,7 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
                         getDatumColor={getDatumColor}
                         getDatumValue={getDatumValue}
                         getDatumName={getDatumName}
+                        getDatumHover={getDatumHover}
                     />
                 </Tooltip>
             )}

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
@@ -8,22 +8,23 @@ import { Category } from '../utils/get-grouped-categories'
 interface BarTooltipContentProps<Datum> {
     category: Category<Datum>
     activeBar: Datum
-    getDatumHover: (datum: Datum) => string
     getDatumName: (datum: Datum) => string
     getDatumValue: (datum: Datum) => number
+    getDatumHover?: (datum: Datum) => string
     getDatumColor: (datum: Datum) => string | undefined
 }
 
 export function BarTooltipContent<Datum>(props: BarTooltipContentProps<Datum>): ReactElement {
-    const { category, getDatumHover, getDatumValue, getDatumColor, activeBar } = props
-    const activeDatumHover = getDatumHover(activeBar)
+    const { category, getDatumName, getDatumHover, getDatumValue, getDatumColor, activeBar } = props
+    const getName = getDatumHover ?? getDatumName
+    const activeDatumHover = getName(activeBar)
 
     return (
         <>
             {category.data.length > 1} <H3>{category.id}</H3>
             <TooltipList>
                 {category.data.map(item => {
-                    const hover = getDatumHover(item)
+                    const hover = getName(item)
 
                     return (
                         <TooltipListItem

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
@@ -8,27 +8,28 @@ import { Category } from '../utils/get-grouped-categories'
 interface BarTooltipContentProps<Datum> {
     category: Category<Datum>
     activeBar: Datum
+    getDatumHover: (datum: Datum) => string
     getDatumName: (datum: Datum) => string
     getDatumValue: (datum: Datum) => number
     getDatumColor: (datum: Datum) => string | undefined
 }
 
 export function BarTooltipContent<Datum>(props: BarTooltipContentProps<Datum>): ReactElement {
-    const { category, getDatumName, getDatumValue, getDatumColor, activeBar } = props
-    const activeDatumName = getDatumName(activeBar)
+    const { category, getDatumHover, getDatumValue, getDatumColor, activeBar } = props
+    const activeDatumHover = getDatumHover(activeBar)
 
     return (
         <>
             {category.data.length > 1} <H3>{category.id}</H3>
             <TooltipList>
                 {category.data.map(item => {
-                    const name = getDatumName(item)
+                    const hover = getDatumHover(item)
 
                     return (
                         <TooltipListItem
-                            key={name}
-                            isActive={activeDatumName === name}
-                            name={name}
+                            key={hover}
+                            isActive={activeDatumHover === hover}
+                            name={hover}
                             value={getDatumValue(item)}
                             color={getDatumColor(item) ?? DEFAULT_FALLBACK_COLOR}
                         />

--- a/client/wildcard/src/components/Charts/types.ts
+++ b/client/wildcard/src/components/Charts/types.ts
@@ -15,7 +15,7 @@ export interface CategoricalLikeChart<Datum> {
     data: Datum[]
     getDatumValue: (datum: Datum) => number
     getDatumName: (datum: Datum) => string
-    getDatumHover: (datum: Datum) => string
+    getDatumHover?: (datum: Datum) => string
     getDatumColor: (datum: Datum) => string | undefined
     getDatumLink?: (datum: Datum) => string | undefined
     onDatumLinkClick?: (event: React.MouseEvent) => void

--- a/client/wildcard/src/components/Charts/types.ts
+++ b/client/wildcard/src/components/Charts/types.ts
@@ -15,6 +15,7 @@ export interface CategoricalLikeChart<Datum> {
     data: Datum[]
     getDatumValue: (datum: Datum) => number
     getDatumName: (datum: Datum) => string
+    getDatumHover: (datum: Datum) => string
     getDatumColor: (datum: Datum) => string | undefined
     getDatumLink?: (datum: Datum) => string | undefined
     onDatumLinkClick?: (event: React.MouseEvent) => void


### PR DESCRIPTION
Previously, the tooltip showed the same name for all data for a given name.

Now the tooltip can show a custom value for each datum.

![CleanShot 2022-08-15 at 13 16 36](https://user-images.githubusercontent.com/1387653/184701988-b5cec0bc-f178-42fe-8ba9-bdb224951093.png)

## Test plan

Ran locally

## App preview:

- [Web](https://sg-web-barchart-custom-tooltip.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rsbmlvrttl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
