### PR TITLE
usage-data: remove dotcom condition for populating certain telemetry fields

### DIFF
--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -200,8 +200,8 @@ function createEvent(event: string, eventProperties?: unknown, publicArgument?: 
         source: EventSource.WEB,
         argument: eventProperties ? JSON.stringify(eventProperties) : null,
         publicArgument: publicArgument ? JSON.stringify(publicArgument) : null,
-        deviceID: window.context.sourcegraphDotComMode ? eventLogger.getDeviceID() : null,
-        eventID: window.context.sourcegraphDotComMode ? eventLogger.getEventID() : null,
-        insertID: window.context.sourcegraphDotComMode ? eventLogger.getInsertID() : null,
+        deviceID: eventLogger.getDeviceID(),
+        eventID: eventLogger.getEventID(),
+        insertID: eventLogger.getInsertID(),
     }
 }


### PR DESCRIPTION
Some fields were not getting set due to an unnecessary dot-com check in the webapp.

## Test plan
Started and verified events saved to the DB have `insertID`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
<img width="573" alt="image" src="https://user-images.githubusercontent.com/5090588/184721473-57664aaf-6332-4ef3-a262-64896f33e68a.png">

## App preview:

- [Web](https://sg-web-usage-data-populate-fields.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-givnypsnxr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
