### PR TITLE
search: rename `repo:contains` predicates to be consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The password policy has been updated and is now part of the standard featureset configurable by site-admins. [#39213](https://github.com/sourcegraph/sourcegraph/pull/39213).
 - Replaced the `ALLOW_DECRYPT_MIGRATION` envvar with `ALLOW_DECRYPTION`. See [updated documentation](https://docs.sourcegraph.com/admin/config/encryption). [#39984](https://github.com/sourcegraph/sourcegraph/pull/39984)
 - Compute-powered insight now supports only one series custom colors for compute series bars [40038](https://github.com/sourcegraph/sourcegraph/pull/40038)
+- **IMPORTANT:** `repo:contains(file:foo content:bar)` has been renamed to `repo:contains.file(path:foo content:bar)`. `repo:contains.file(foo)` has been renamed to `repo:contains.path(foo)`. `repo:contains()` **is no longer a valid predicate. Saved searches using** `repo:contains()` **will need to be updated to use the new syntax.** [#40389](https://github.com/sourcegraph/sourcegraph/pull/40389)
 
 ### Fixed
 

--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -179,10 +179,10 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         ],
     },
     {
-        ...createQueryExampleFromString('contains.file({path})'),
+        ...createQueryExampleFromString('contains.path({path})'),
         field: FilterType.repo,
         description: 'Search only inside repositories that contain a file path matching the regular expression.',
-        examples: ['repo:contains.file(README)'],
+        examples: ['repo:contains.path(README)', 'repo:contains.path(src/main/)'],
         showSuggestions: false,
     },
     {
@@ -193,11 +193,11 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         showSuggestions: false,
     },
     {
-        ...createQueryExampleFromString('contains({file:path content:content})'),
+        ...createQueryExampleFromString('contains.file({path:path content:content})'),
         field: FilterType.repo,
         description:
-            'Search only inside repositories that contain a file matching the `file:` with `content:` filters.',
-        examples: ['repo:contains(file:CHANGELOG content:fix)'],
+            'Search only inside repositories that contain a file path matching the `path:` and/or `content:` filters.',
+        examples: ['repo:contains.file(path:README content:fix)'],
         showSuggestions: false,
     },
     {

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -377,9 +377,9 @@ describe('getCompletionItems()', () => {
             )?.suggestions.map(({ insertText }) => insertText)
         ).toMatchInlineSnapshot(`
             [
-              "contains.file(\${1:CHANGELOG}) ",
+              "contains.path(\${1:CHANGELOG}) ",
               "contains.content(\${1:TODO}) ",
-              "contains(file:\${1:CHANGELOG} content:\${2:fix}) ",
+              "contains.file(path:\${1:CHANGELOG} content:\${2:fix}) ",
               "contains.commit.after(\${1:1 month ago}) ",
               "deps(\${1}) ",
               "dependencies(\${1}) ",
@@ -403,9 +403,9 @@ describe('getCompletionItems()', () => {
               "^github\\\\.com/\${1:ORGANIZATION}/.* ",
               "^github\\\\.com/\${1:ORGANIZATION}/\${2:REPO-NAME}$ ",
               "\${1:STRING} ",
-              "contains.file(\${1:CHANGELOG}) ",
+              "contains.path(\${1:CHANGELOG}) ",
               "contains.content(\${1:TODO}) ",
-              "contains(file:\${1:CHANGELOG} content:\${2:fix}) ",
+              "contains.file(path:\${1:CHANGELOG} content:\${2:fix}) ",
               "contains.commit.after(\${1:1 month ago}) ",
               "deps(\${1}) ",
               "dependencies(\${1}) ",

--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1371,7 +1371,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('highlight recognized predicate with body as regexp', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains.file(README.md)')))).toMatchInlineSnapshot(`
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains.path(README.md)')))).toMatchInlineSnapshot(`
             [
               {
                 "startIndex": 0,
@@ -1418,7 +1418,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('highlight recognized predicate with multiple fields', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains(file:README.md content:^fix$)'))))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains.file(path:README.md content:^fix$)'))))
             .toMatchInlineSnapshot(`
             [
               {
@@ -1435,50 +1435,58 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 13,
-                "scopes": "metaPredicateParenthesis"
+                "scopes": "metaPredicateDot"
               },
               {
                 "startIndex": 14,
-                "scopes": "field"
+                "scopes": "metaPredicateNameAccess"
               },
               {
                 "startIndex": 18,
-                "scopes": "metaFilterSeparator"
+                "scopes": "metaPredicateParenthesis"
               },
               {
                 "startIndex": 19,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 25,
-                "scopes": "metaRegexpCharacterSet"
-              },
-              {
-                "startIndex": 26,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 28,
-                "scopes": "whitespace"
-              },
-              {
-                "startIndex": 29,
                 "scopes": "field"
               },
               {
-                "startIndex": 37,
-                "scopes": "metaRegexpAssertion"
+                "startIndex": 23,
+                "scopes": "metaFilterSeparator"
               },
               {
-                "startIndex": 38,
+                "startIndex": 24,
                 "scopes": "identifier"
               },
               {
-                "startIndex": 41,
-                "scopes": "metaRegexpAssertion"
+                "startIndex": 30,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 31,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 33,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 34,
+                "scopes": "field"
               },
               {
                 "startIndex": 42,
+                "scopes": "metaRegexpAssertion"
+              },
+              {
+                "startIndex": 43,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 46,
+                "scopes": "metaRegexpAssertion"
+              },
+              {
+                "startIndex": 47,
                 "scopes": "metaPredicateParenthesis"
               }
             ]

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -799,6 +799,7 @@ export const hasRegexpValue = (field: string): boolean => {
         case 'r':
         case 'file':
         case 'f':
+        case 'path':
         case 'repohasfile':
         case 'message':
         case 'msg':
@@ -881,12 +882,12 @@ const mapOffset = (token: Token, offset: number): Token => {
 }
 
 /**
- * Returns true if a `contains(...)` predicate is valid. This predicate is currently valid when one of
- * `file:` or `content:` is specified, or both. Any additional filters or tokens besides whitespace
+ * Returns true if a `contains.file(...)` predicate is valid. This predicate is currently valid when one of
+ * `path:` or `content:` is specified, or both. Any additional filters or tokens besides whitespace
  * makes this body invalid.
  */
-const validContainsBody = (tokens: Token[]): boolean => {
-    const fileIndex = tokens.findIndex(token => token.type === 'filter' && token.field.value === 'file')
+const validContainsFileBody = (tokens: Token[]): boolean => {
+    const fileIndex = tokens.findIndex(token => token.type === 'filter' && token.field.value === 'path')
     if (fileIndex !== -1) {
         tokens.splice(fileIndex, 1)
     }
@@ -901,21 +902,21 @@ const validContainsBody = (tokens: Token[]): boolean => {
 }
 
 /**
- * Attempts to decorate `contains(file:foo content:bar)` syntax. Fails if
+ * Attempts to decorate `contains.file(path:foo content:bar)` syntax. Fails if
  * the body contains unsupported syntax. This function takes care to
- * decorate `content:` values as regular expression syntax.
+ * decorate `path:` and `content:` values as regular expression syntax.
  */
-const decorateContainsBody = (body: string, offset: number): DecoratedToken[] | undefined => {
+const decorateContainsFileBody = (body: string, offset: number): DecoratedToken[] | undefined => {
     const result = scanSearchQuery(body, false, SearchPatternType.regexp)
     if (result.type === 'error') {
         return undefined
     }
-    if (!validContainsBody([...result.term])) {
+    if (!validContainsFileBody([...result.term])) {
         // There are more things in this query than we support.
         return undefined
     }
     const decorated: DecoratedToken[] = result.term.flatMap(token => {
-        if (token.type === 'filter' && token.field.value === 'file') {
+        if (token.type === 'filter' && token.field.value === 'path') {
             return decorate(mapOffset(token, offset))
         }
         if (token.type === 'filter' && token.field.value === 'content') {
@@ -978,14 +979,14 @@ const decorateRepoHasBody = (body: string, offset: number): DecoratedToken[] | u
 const decoratePredicateBody = (path: string[], body: string, offset: number): DecoratedToken[] => {
     const decorated: DecoratedToken[] = []
     switch (path.join('.')) {
-        case 'contains': {
-            const result = decorateContainsBody(body, offset)
+        case 'contains.file': {
+            const result = decorateContainsFileBody(body, offset)
             if (result !== undefined) {
                 return result
             }
             break
         }
-        case 'contains.file':
+        case 'contains.path':
         case 'contains.content':
         case 'has.description':
             return mapRegexpMetaSucceed({

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -469,6 +469,7 @@ export const hasPathLikeValue = (field: string): boolean => {
         case 'r':
         case 'file':
         case 'f':
+        case 'path':
         case 'repohasfile':
             return true
         default:

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -3,7 +3,7 @@ import { editor, Position } from 'monaco-editor'
 import { SearchPatternType } from '../../graphql-operations'
 
 import { getHoverResult } from './hover'
-import { scanSearchQuery, ScanSuccess, ScanResult } from './scanner'
+import { ScanResult, scanSearchQuery, ScanSuccess } from './scanner'
 import { Token } from './token'
 
 expect.addSnapshotSerializer({
@@ -619,8 +619,8 @@ test('returns hover contents for select', () => {
     `)
 })
 
-test('returns repo:contains hovers', () => {
-    const input = 'repo:contains.file(foo)'
+test('returns repo:contains.path hovers', () => {
+    const input = 'repo:contains.path(foo)'
     const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.standard))
 
     expect(getHoverResult(scannedQuery, new Position(1, 8), editor.createModel(input))).toMatchInlineSnapshot(`
@@ -640,9 +640,30 @@ test('returns repo:contains hovers', () => {
     `)
 })
 
+test('returns repo:contains.file hovers', () => {
+    const input = 'repo:contains.file(path:foo)'
+    const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.standard))
+
+    expect(getHoverResult(scannedQuery, new Position(1, 8), editor.createModel(input))).toMatchInlineSnapshot(`
+        {
+          "contents": [
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that satisfy the specified \`path:\` and \`content:\` filters. \`path:\` and \`content:\` filters should be regular expressions."
+            }
+          ],
+          "range": {
+            "startLineNumber": 1,
+            "endLineNumber": 1,
+            "startColumn": 6,
+            "endColumn": 29
+          }
+        }
+    `)
+})
+
 test('returns multiline hovers', () => {
-    const input = `repo:contains(
-      file:foo
+    const input = `repo:contains.file(
+      path:foo
       content:bar
 )`
     const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.standard))
@@ -651,7 +672,7 @@ test('returns multiline hovers', () => {
         {
           "contents": [
             {
-              "value": "**Built-in predicate**. Search only inside repositories that satisfy the specified \`file:\` and \`content:\` filters. \`file:\` and \`content:\` filters should be regular expressions."
+              "value": "**Built-in predicate**. Search only inside repositories that satisfy the specified \`path:\` and \`content:\` filters. \`path:\` and \`content:\` filters should be regular expressions."
             }
           ],
           "range": {

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -158,9 +158,9 @@ const toSelectorHover = (token: MetaSelector): string => {
 const toPredicateHover = (token: MetaPredicate): string => {
     const parameters = token.value.parameters.slice(1, -1)
     switch (token.value.path.join('.')) {
-        case 'contains':
-            return '**Built-in predicate**. Search only inside repositories that satisfy the specified `file:` and `content:` filters. `file:` and `content:` filters should be regular expressions.'
         case 'contains.file':
+            return '**Built-in predicate**. Search only inside repositories that satisfy the specified `path:` and `content:` filters. `path:` and `content:` filters should be regular expressions.'
+        case 'contains.path':
             return `**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`${parameters}\`.`
         case 'contains.content':
             return `**Built-in predicate**. Search only inside repositories that contain **file content** matching the regular expression \`${parameters}\`.`

--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -7,8 +7,8 @@ expect.addSnapshotSerializer({
 
 describe('scanPredicate', () => {
     test('scan recognized and valid syntax', () => {
-        expect(scanPredicate('repo', 'contains(stuff)')).toMatchInlineSnapshot(
-            '{"path":["contains"],"parameters":"(stuff)"}'
+        expect(scanPredicate('repo', 'contains.file(content:stuff)')).toMatchInlineSnapshot(
+            '{"path":["contains","file"],"parameters":"(content:stuff)"}'
         )
     })
 
@@ -19,17 +19,17 @@ describe('scanPredicate', () => {
     })
 
     test('scan recognized and valid syntax with escapes', () => {
-        expect(scanPredicate('repo', 'contains(\\((stuff))')).toMatchInlineSnapshot(
-            '{"path":["contains"],"parameters":"(\\\\((stuff))"}'
+        expect(scanPredicate('repo', 'contains.file(content:\\((stuff))')).toMatchInlineSnapshot(
+            '{"path":["contains","file"],"parameters":"(content:\\\\((stuff))"}'
         )
     })
 
     test('scan valid syntax but not recognized', () => {
-        expect(scanPredicate('foo', 'contains(stuff)')).toMatchInlineSnapshot('invalid')
+        expect(scanPredicate('foo', 'contains.path(stuff)')).toMatchInlineSnapshot('invalid')
     })
 
     test('scan unbalanced syntax', () => {
-        expect(scanPredicate('repo', 'contains(')).toMatchInlineSnapshot('invalid')
+        expect(scanPredicate('repo', 'contains.file(content:')).toMatchInlineSnapshot('invalid')
     })
 
     test('scan invalid nonalphanumeric name', () => {
@@ -37,8 +37,8 @@ describe('scanPredicate', () => {
     })
 
     test('resolve field aliases for predicates', () => {
-        expect(scanPredicate('r', 'contains.file(stuff)')).toMatchInlineSnapshot(
-            '{"path":["contains","file"],"parameters":"(stuff)"}'
+        expect(scanPredicate('r', 'contains.file(content:stuff)')).toMatchInlineSnapshot(
+            '{"path":["contains","file"],"parameters":"(content:stuff)"}'
         )
     })
 

--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -52,7 +52,7 @@ describe('scanPredicate', () => {
 describe('resolveAccess', () => {
     test('resolves partial access tree', () => {
         expect(resolveAccess(['repo', 'contains'], PREDICATES)).toMatchInlineSnapshot(
-            '[{"name":"file"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]'
+            '[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]'
         )
     })
 

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -67,6 +67,11 @@ export const resolveAccess = (path: string[], tree: Access[]): Access[] | undefi
     if (path.length === 0) {
         return tree
     }
+    // repo:contains() is not supported, use repo:contains.file() or repo:contains.path()
+    if (path.length === 1 && path[0] === 'contains') {
+        return undefined
+    }
+
     const subtree = tree.find(value => value.name === path[0])
     if (!subtree) {
         return undefined

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -67,11 +67,6 @@ export const resolveAccess = (path: string[], tree: Access[]): Access[] | undefi
     if (path.length === 0) {
         return tree
     }
-    // repo:contains() is not supported, use repo:contains.file() or repo:contains.path()
-    if (path.length === 1 && path[0] === 'contains') {
-        return undefined
-    }
-
     const subtree = tree.find(value => value.name === path[0])
     if (!subtree) {
         return undefined

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -19,6 +19,7 @@ export const PREDICATES: Access[] = [
                 name: 'contains',
                 fields: [
                     { name: 'file' },
+                    { name: 'path' },
                     { name: 'content' },
                     {
                         name: 'commit',
@@ -161,8 +162,8 @@ export const predicateCompletion = (field: string): Completion[] => {
     if (field === 'repo') {
         return [
             {
-                label: 'contains.file(...)',
-                insertText: 'contains.file(${1:CHANGELOG})',
+                label: 'contains.path(...)',
+                insertText: 'contains.path(${1:CHANGELOG})',
                 asSnippet: true,
             },
             {
@@ -171,8 +172,8 @@ export const predicateCompletion = (field: string): Completion[] => {
                 asSnippet: true,
             },
             {
-                label: 'contains(...)',
-                insertText: 'contains(file:${1:CHANGELOG} content:${2:fix})',
+                label: 'contains.file(...)',
+                insertText: 'contains.file(path:${1:CHANGELOG} content:${2:fix})',
                 asSnippet: true,
             },
             {

--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -230,20 +230,20 @@ thing`
 
 describe('scanSearchQuery() with predicate', () => {
     test('recognize predicate', () => {
-        expect(scanSearchQuery('repo:contains(file:README.md)')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":29},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"contains(file:README.md)","range":{"start":5,"end":29},"quoted":false},"negated":false}]}'
+        expect(scanSearchQuery('repo:contains.file(path:README.md)')).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":34},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"contains.file(path:README.md)","range":{"start":5,"end":34},"quoted":false},"negated":false}]}'
         )
     })
 
     test('recognize multiple predicates over whitespace', () => {
-        expect(scanSearchQuery('repo:contains(file:README.md)\n\nrepo:contains.file(foo)')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":29},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"contains(file:README.md)","range":{"start":5,"end":29},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":29,"end":31}},{"type":"filter","range":{"start":31,"end":54},"field":{"type":"literal","value":"repo","range":{"start":31,"end":35}},"value":{"type":"literal","value":"contains.file(foo)","range":{"start":36,"end":54},"quoted":false},"negated":false}]}'
+        expect(scanSearchQuery('repo:contains.file(path:README.md)\n\nrepo:contains.path(foo)')).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":34},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"contains.file(path:README.md)","range":{"start":5,"end":34},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":34,"end":36}},{"type":"filter","range":{"start":36,"end":59},"field":{"type":"literal","value":"repo","range":{"start":36,"end":40}},"value":{"type":"literal","value":"contains.path(foo)","range":{"start":41,"end":59},"quoted":false},"negated":false}]}'
         )
     })
 
     test('recognize parenthesized predicate', () => {
-        expect(scanSearchQuery('(repo:contains(file:bar))')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"filter","range":{"start":1,"end":24},"field":{"type":"literal","value":"repo","range":{"start":1,"end":5}},"value":{"type":"literal","value":"contains(file:bar)","range":{"start":6,"end":24},"quoted":false},"negated":false},{"type":"closingParen","range":{"start":24,"end":25}}]}'
+        expect(scanSearchQuery('(repo:contains.file(path:bar))')).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"filter","range":{"start":1,"end":29},"field":{"type":"literal","value":"repo","range":{"start":1,"end":5}},"value":{"type":"literal","value":"contains.file(path:bar)","range":{"start":6,"end":29},"quoted":false},"negated":false},{"type":"closingParen","range":{"start":29,"end":30}}]}'
         )
     })
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1107,22 +1107,22 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}{
 			{
 				name:   `repo contains file`,
-				query:  `repo:contains(file:go\.mod)`,
+				query:  `repo:contains.file(path:go\.mod)`,
 				counts: counts{Repo: 2},
 			},
 			{
 				name:   `no repo contains file`,
-				query:  `repo:contains(file:noexist.go)`,
+				query:  `repo:contains.file(path:noexist.go)`,
 				counts: counts{},
 			},
 			{
 				name:   `no repo contains file with pattern`,
-				query:  `repo:contains(file:noexist.go) test`,
+				query:  `repo:contains.file(path:noexist.go) test`,
 				counts: counts{},
 			},
 			{
 				name:   `repo contains content`,
-				query:  `repo:contains(content:nextFileFirstLine)`,
+				query:  `repo:contains.file(content:nextFileFirstLine)`,
 				counts: counts{Repo: 1},
 			},
 			{
@@ -1131,38 +1131,38 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Repo: 1},
 			},
 			{
-				name:   `or-expression on repo:contains`,
-				query:  `repo:contains(content:does-not-exist-D2E1E74C7279) or repo:contains(content:nextFileFirstLine)`,
+				name:   `or-expression on repo:contains.file`,
+				query:  `repo:contains.file(content:does-not-exist-D2E1E74C7279) or repo:contains.file(content:nextFileFirstLine)`,
 				counts: counts{Repo: 1},
 			},
 			{
-				name:   `and-expression on repo:contains`,
-				query:  `repo:contains(content:does-not-exist-D2E1E74C7279) and repo:contains(content:nextFileFirstLine)`,
+				name:   `and-expression on repo:contains.file`,
+				query:  `repo:contains.file(content:does-not-exist-D2E1E74C7279) and repo:contains.file(content:nextFileFirstLine)`,
 				counts: counts{Repo: 0},
 			},
 			{
 				name:   `repo contains file then search common`,
-				query:  `repo:contains(file:go.mod) count:100 fmt`,
+				query:  `repo:contains.file(path:go.mod) count:100 fmt`,
 				counts: counts{Content: 61},
 			},
 			{
-				name:   `repo contains file scoped predicate`,
-				query:  `repo:contains.file(go.mod) count:100 fmt`,
+				name:   `repo contains path`,
+				query:  `repo:contains.path(go.mod) count:100 fmt`,
 				counts: counts{Content: 61},
 			},
 			{
-				name:   `repo contains with matching repo filter`,
-				query:  `repo:go-diff repo:contains(file:diff.proto)`,
+				name:   `repo contains file with matching repo filter`,
+				query:  `repo:go-diff repo:contains.file(path:diff.proto)`,
 				counts: counts{Repo: 1},
 			},
 			{
-				name:   `repo contains with non-matching repo filter`,
-				query:  `repo:nonexist repo:contains(file:diff.proto)`,
+				name:   `repo contains file with non-matching repo filter`,
+				query:  `repo:nonexist repo:contains.file(path:diff.proto)`,
 				counts: counts{Repo: 0},
 			},
 			{
-				name:   `repo contains respects parameters that affect repo search (fork)`,
-				query:  `repo:sgtest/mux fork:yes repo:contains.file(README)`,
+				name:   `repo contains path respects parameters that affect repo search (fork)`,
+				query:  `repo:sgtest/mux fork:yes repo:contains.path(README)`,
 				counts: counts{Repo: 1},
 			},
 			{
@@ -1172,7 +1172,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:   `commit results with repo filter`,
-				query:  `repo:contains(file:diff.pb.go) type:commit LSIF`,
+				query:  `repo:contains.file(path:diff.pb.go) type:commit LSIF`,
 				counts: counts{Commit: 1},
 			},
 			{

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -347,8 +347,8 @@ func TestIsSingleRepoQuery(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:       "repo contains",
-			inputQuery: "repo:contains.file(CHANGELOG) TEST",
+			name:       "repo contains path",
+			inputQuery: "repo:contains.path(CHANGELOG) TEST",
 			mapType:    Lang,
 			want:       false,
 		},

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -553,10 +553,10 @@ func TestNewPlanJob(t *testing.T) {
           NoopJob)))))`),
 	},
 		{
-			query:      `repo:contains.file(a) repo:contains.content(b)`,
+			query:      `repo:contains.path(a) repo:contains.content(b)`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeRegex,
-			want: autogold.Want("repo contains file and repo contains content", `
+			want: autogold.Want("repo contains path and repo contains content", `
 (ALERT
   (query . )
   (originalQuery . )
@@ -571,10 +571,10 @@ func TestNewPlanJob(t *testing.T) {
         (REPOSEARCH
           (repoOpts.hasFileContent[0].path . a)(repoOpts.hasFileContent[1].content . b))))))`),
 		}, {
-			query:      `repo:contains(file:a content:b)`,
+			query:      `repo:contains.file(path:a content:b)`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeRegex,
-			want: autogold.Want("repo contains file and content", `
+			want: autogold.Want("repo contains path and content", `
 (ALERT
   (query . )
   (originalQuery . )
@@ -772,16 +772,16 @@ func TestToTextPatternInfo(t *testing.T) {
 		input:  `(repo:^github\.com/sgtest/sourcegraph-typescript$ or repo:^github\.com/sgtest/go-diff$) package diff provides`,
 		output: autogold.Want("79", `{"Pattern":"package diff provides","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
 	}, {
-		input:  `repo:contains(file:noexist.go) test`,
+		input:  `repo:contains.file(path:noexist.go) test`,
 		output: autogold.Want("83", `{"Pattern":"test","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
 	}, {
-		input:  `repo:contains(file:go.mod) count:100 fmt`,
+		input:  `repo:contains.file(path:go.mod) count:100 fmt`,
 		output: autogold.Want("87", `{"Pattern":"fmt","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":100,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
 	}, {
 		input:  `type:commit LSIF`,
 		output: autogold.Want("90", `{"Pattern":"LSIF","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":false,"PatternMatchesPath":false,"Languages":null}`),
 	}, {
-		input:  `repo:contains(file:diff.pb.go) type:commit LSIF`,
+		input:  `repo:contains.file(path:diff.pb.go) type:commit LSIF`,
 		output: autogold.Want("91", `{"Pattern":"LSIF","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":false,"PatternMatchesPath":false,"Languages":null}`),
 	}, {
 		input:  `repo:go-diff patterntype:literal HunkNoChunksize select:repo`,
@@ -811,7 +811,7 @@ func TestToTextPatternInfo(t *testing.T) {
 		input:  `patterntype:regexp // literal slash`,
 		output: autogold.Want("107", `{"Pattern":"(?://).*?(?:literal).*?(?:slash)","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
 	}, {
-		input:  `repo:contains.file(Dockerfile)`,
+		input:  `repo:contains.path(Dockerfile)`,
 		output: autogold.Want("108", `{"Pattern":"","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
 	}, {
 		input:  `repohasfile:Dockerfile`,

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -207,10 +207,15 @@ func TestScanPredicate(t *testing.T) {
 		}
 	}
 
-	autogold.Want("Repo contains predicate", value{
-		Result:       `{"field":"repo","value":"contains(file:test)","negated":false}`,
+	autogold.Want("Repo contains file predicate", value{
+		Result:       `{"field":"repo","value":"contains.file(path:test)","negated":false}`,
 		ResultLabels: "IsPredicate",
-	}).Equal(t, test(`repo:contains(file:test)`))
+	}).Equal(t, test(`repo:contains.file(path:test)`))
+
+	autogold.Want("Repo contains path predicate", value{
+		Result:       `{"field":"repo","value":"contains.path(test)","negated":false}`,
+		ResultLabels: "IsPredicate",
+	}).Equal(t, test(`repo:contains.path(test)`))
 
 	autogold.Want("Repo contains commit after predicate", value{
 		Result:       `{"field":"repo","value":"contains.commit.after(last thursday)","negated":false}`,
@@ -223,14 +228,14 @@ func TestScanPredicate(t *testing.T) {
 	}).Equal(t, test(`repo:contains.commit.before(yesterday)`))
 
 	autogold.Want("Predicate contains escaped paranthesis", value{
-		Result:       `{"field":"repo","value":"contains(\\()","negated":false}`,
+		Result:       `{"field":"repo","value":"contains.file(content:\\()","negated":false}`,
 		ResultLabels: "IsPredicate",
-	}).Equal(t, test(`repo:contains(\()`))
+	}).Equal(t, test(`repo:contains.file(content:\()`))
 
-	autogold.Want("Repo contains not predicate", value{
-		Result:       `{"field":"repo","value":"contains","negated":false}`,
+	autogold.Want("Repo contains file not predicate", value{
+		Result:       `{"field":"repo","value":"contains.file","negated":false}`,
 		ResultLabels: "None",
-	}).Equal(t, test(`repo:contains`))
+	}).Equal(t, test(`repo:contains.file`))
 
 	autogold.Want("Repo with something that looks kinda like predicate", value{
 		Result:       `{"Kind":1,"Operands":[{"field":"repo","value":"nopredicate","negated":false},{"value":"(file:foo","negated":false}],"Annotation":{"labels":0,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}}}`,

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -24,8 +24,8 @@ type Predicate interface {
 
 var DefaultPredicateRegistry = PredicateRegistry{
 	FieldRepo: {
-		"contains":              func() Predicate { return &RepoContainsPredicate{} },
 		"contains.file":         func() Predicate { return &RepoContainsFilePredicate{} },
+		"contains.path":         func() Predicate { return &RepoContainsPathPredicate{} },
 		"contains.content":      func() Predicate { return &RepoContainsContentPredicate{} },
 		"contains.commit.after": func() Predicate { return &RepoContainsCommitAfterPredicate{} },
 		"has.description":       func() Predicate { return &RepoHasDescriptionPredicate{} },
@@ -85,14 +85,14 @@ func (EmptyPredicate) Field() string            { return "" }
 func (EmptyPredicate) Name() string             { return "" }
 func (EmptyPredicate) ParseParams(string) error { return nil }
 
-// RepoContainsPredicate represents the `repo:contains()` predicate,
-// which filters to repos that contain either a file or content
-type RepoContainsPredicate struct {
-	File    string
+// RepoContainsFilePredicate represents the `repo:contains.file()` predicate,
+// which filters to repos that contain a path and/or content
+type RepoContainsFilePredicate struct {
+	Path    string
 	Content string
 }
 
-func (f *RepoContainsPredicate) ParseParams(params string) error {
+func (f *RepoContainsFilePredicate) ParseParams(params string) error {
 	nodes, err := Parse(params, SearchTypeRegex)
 	if err != nil {
 		return err
@@ -104,41 +104,41 @@ func (f *RepoContainsPredicate) ParseParams(params string) error {
 		}
 	}
 
-	if f.File == "" && f.Content == "" {
-		return errors.New("one of file or content must be set")
+	if f.Path == "" && f.Content == "" {
+		return errors.New("one of path or content must be set")
 	}
 
 	return nil
 }
 
-func (f *RepoContainsPredicate) parseNode(n Node) error {
+func (f *RepoContainsFilePredicate) parseNode(n Node) error {
 	switch v := n.(type) {
 	case Parameter:
 		if v.Negated {
 			return errors.New("predicates do not currently support negated values")
 		}
 		switch strings.ToLower(v.Field) {
-		case "file":
-			if f.File != "" {
-				return errors.New("cannot specify file multiple times")
+		case "path":
+			if f.Path != "" {
+				return errors.New("cannot specify path multiple times")
 			}
 			if _, err := regexp.Compile(v.Value); err != nil {
-				return errors.Errorf("`contains` predicate has invalid `file` argument: %w", err)
+				return errors.Errorf("`contains.file` predicate has invalid `path` argument: %w", err)
 			}
-			f.File = v.Value
+			f.Path = v.Value
 		case "content":
 			if f.Content != "" {
 				return errors.New("cannot specify content multiple times")
 			}
 			if _, err := regexp.Compile(v.Value); err != nil {
-				return errors.Errorf("`contains` predicate has invalid `content` argument: %w", err)
+				return errors.Errorf("`contains.file` predicate has invalid `content` argument: %w", err)
 			}
 			f.Content = v.Value
 		default:
 			return errors.Errorf("unsupported option %q", v.Field)
 		}
 	case Pattern:
-		return errors.Errorf(`prepend 'file:' or 'content:' to "%s" to search repositories containing files or content respectively.`, v.Value)
+		return errors.Errorf(`prepend 'path:' or 'content:' to "%s" to search repositories containing path or content respectively.`, v.Value)
 	case Operator:
 		if v.Kind == Or {
 			return errors.New("predicates do not currently support 'or' queries")
@@ -154,8 +154,8 @@ func (f *RepoContainsPredicate) parseNode(n Node) error {
 	return nil
 }
 
-func (f *RepoContainsPredicate) Field() string { return FieldRepo }
-func (f *RepoContainsPredicate) Name() string  { return "contains" }
+func (f *RepoContainsFilePredicate) Field() string { return FieldRepo }
+func (f *RepoContainsFilePredicate) Name() string  { return "contains.file" }
 
 /* repo:contains.content(pattern) */
 
@@ -177,25 +177,25 @@ func (f *RepoContainsContentPredicate) ParseParams(params string) error {
 func (f *RepoContainsContentPredicate) Field() string { return FieldRepo }
 func (f *RepoContainsContentPredicate) Name() string  { return "contains.content" }
 
-/* repo:contains.file(pattern) */
+/* repo:contains.path(pattern) */
 
-type RepoContainsFilePredicate struct {
+type RepoContainsPathPredicate struct {
 	Pattern string
 }
 
-func (f *RepoContainsFilePredicate) ParseParams(params string) error {
+func (f *RepoContainsPathPredicate) ParseParams(params string) error {
 	if _, err := regexp.Compile(params); err != nil {
-		return errors.Errorf("contains.file argument: %w", err)
+		return errors.Errorf("contains.path argument: %w", err)
 	}
 	if params == "" {
-		return errors.Errorf("contains.file argument should not be empty")
+		return errors.Errorf("contains.path argument should not be empty")
 	}
 	f.Pattern = params
 	return nil
 }
 
-func (f *RepoContainsFilePredicate) Field() string { return FieldRepo }
-func (f *RepoContainsFilePredicate) Name() string  { return "contains.file" }
+func (f *RepoContainsPathPredicate) Field() string { return FieldRepo }
+func (f *RepoContainsPathPredicate) Name() string  { return "contains.path" }
 
 /* repo:contains.commit.after(...) */
 

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -5,25 +5,25 @@ import (
 	"testing"
 )
 
-func TestRepoContainsPredicate(t *testing.T) {
+func TestRepoContainsFilePredicate(t *testing.T) {
 	t.Run("ParseParams", func(t *testing.T) {
 		type test struct {
 			name     string
 			params   string
-			expected *RepoContainsPredicate
+			expected *RepoContainsFilePredicate
 		}
 
 		valid := []test{
-			{`file`, `file:test`, &RepoContainsPredicate{File: "test"}},
-			{`file regex`, `file:test(a|b)*.go`, &RepoContainsPredicate{File: "test(a|b)*.go"}},
-			{`content`, `content:test`, &RepoContainsPredicate{Content: "test"}},
-			{`file and content`, `file:test.go content:abc`, &RepoContainsPredicate{File: "test.go", Content: "abc"}},
-			{`content and file`, `content:abc file:test.go`, &RepoContainsPredicate{File: "test.go", Content: "abc"}},
+			{`path`, `path:test`, &RepoContainsFilePredicate{Path: "test"}},
+			{`path regex`, `path:test(a|b)*.go`, &RepoContainsFilePredicate{Path: "test(a|b)*.go"}},
+			{`content`, `content:test`, &RepoContainsFilePredicate{Content: "test"}},
+			{`path and content`, `path:test.go content:abc`, &RepoContainsFilePredicate{Path: "test.go", Content: "abc"}},
+			{`content and path`, `content:abc path:test.go`, &RepoContainsFilePredicate{Path: "test.go", Content: "abc"}},
 		}
 
 		for _, tc := range valid {
 			t.Run(tc.name, func(t *testing.T) {
-				p := &RepoContainsPredicate{}
+				p := &RepoContainsFilePredicate{}
 				err := p.ParseParams(tc.params)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
@@ -37,16 +37,16 @@ func TestRepoContainsPredicate(t *testing.T) {
 
 		invalid := []test{
 			{`empty`, ``, nil},
-			{`negated file`, `-file:test`, nil},
+			{`negated path`, `-path:test`, nil},
 			{`negated content`, `-content:test`, nil},
 			{`unsupported syntax`, `abc:test`, nil},
 			{`unnamed content`, `test`, nil},
-			{`catch invalid content regexp`, `file:foo content:([)`, nil},
+			{`catch invalid content regexp`, `path:foo content:([)`, nil},
 		}
 
 		for _, tc := range invalid {
 			t.Run(tc.name, func(t *testing.T) {
-				p := &RepoContainsPredicate{}
+				p := &RepoContainsFilePredicate{}
 				err := p.ParseParams(tc.params)
 				if err == nil {
 					t.Fatal("expected error but got none")

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -12,7 +12,7 @@ func TestPipelineStructural(t *testing.T) {
 		return pipelinePlan.ToQ().String()
 	}
 
-	autogold.Want("contains(...) spans newlines", `"repo:contains.file(\nfoo\n)"`).Equal(t, test("repo:contains.file(\nfoo\n)"))
+	autogold.Want("contains(...) spans newlines", `"repo:contains.path(\nfoo\n)"`).Equal(t, test("repo:contains.path(\nfoo\n)"))
 }
 
 func TestSubstituteSearchContexts(t *testing.T) {
@@ -41,6 +41,6 @@ func TestSubstituteSearchContexts(t *testing.T) {
 	})
 
 	t.Run("preserve predicate label", func(t *testing.T) {
-		autogold.Equal(t, autogold.Raw(test("context:gordo repo:contains.file(gordo)", true)))
+		autogold.Equal(t, autogold.Raw(test("context:gordo repo:contains.path(gordo)", true)))
 	})
 }

--- a/internal/search/query/testdata/TestSubstituteSearchContexts/preserve_predicate_label.golden
+++ b/internal/search/query/testdata/TestSubstituteSearchContexts/preserve_predicate_label.golden
@@ -23,7 +23,7 @@
           },
           {
             "field": "repo",
-            "value": "contains.file(gordo)",
+            "value": "contains.path(gordo)",
             "negated": false,
             "labels": [
               "IsPredicate"
@@ -63,7 +63,7 @@
           },
           {
             "field": "repo",
-            "value": "contains.file(gordo)",
+            "value": "contains.path(gordo)",
             "negated": false,
             "labels": [
               "IsPredicate"

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -360,7 +360,7 @@ func (p Parameters) RepoHasFileContent() (res []RepoHasFileContentArgs) {
 		})
 	})
 
-	VisitTypedPredicate(nodes, func(pred *RepoContainsFilePredicate, negated bool) {
+	VisitTypedPredicate(nodes, func(pred *RepoContainsPathPredicate, negated bool) {
 		res = append(res, RepoHasFileContentArgs{
 			Path:    pred.Pattern,
 			Negated: negated,
@@ -374,9 +374,9 @@ func (p Parameters) RepoHasFileContent() (res []RepoHasFileContentArgs) {
 		})
 	})
 
-	VisitTypedPredicate(nodes, func(pred *RepoContainsPredicate, negated bool) {
+	VisitTypedPredicate(nodes, func(pred *RepoContainsFilePredicate, negated bool) {
 		res = append(res, RepoHasFileContentArgs{
-			Path:    pred.File,
+			Path:    pred.Path,
 			Content: pred.Content,
 			Negated: negated,
 		})

--- a/internal/search/query/visitor_test.go
+++ b/internal/search/query/visitor_test.go
@@ -11,16 +11,16 @@ func TestSubstitute(t *testing.T) {
 		q, _ := ParseLiteral(input)
 		var result string
 		VisitPredicate(q, func(field, name, value string) {
-			if field == FieldRepo && name == "contains" {
-				result = "contains value is " + value
+			if field == FieldRepo && name == "contains.file" {
+				result = "contains.file value is " + value
 			}
 		})
 		return result
 	}
 
 	autogold.Want("VisitPredicate visits predicates",
-		"contains value is file:foo").
-		Equal(t, test("repo:contains(file:foo)"))
+		"contains.file value is path:foo").
+		Equal(t, test("repo:contains.file(path:foo)"))
 }
 
 func TestVisitTypedPredicate(t *testing.T) {
@@ -31,8 +31,8 @@ func TestVisitTypedPredicate(t *testing.T) {
 		"repo:test",
 		autogold.Want("no predicates", []*RepoContainsFilePredicate{}),
 	}, {
-		"repo:test repo:contains.file(test)",
-		autogold.Want("one predicate", []*RepoContainsFilePredicate{{Pattern: "test"}}),
+		"repo:test repo:contains.file(path:test)",
+		autogold.Want("one predicate", []*RepoContainsFilePredicate{{Path: "test"}}),
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Part of #39767

As described in the linked issue, this PR:

- Renames `repo:contains(file:a content:b)` to `repo:contains.file(path:a content:b)`
- Renames `repo:contains.file(a)` to `repo:contains.path(a)`
- Removes support for `repo:contains(file:a content:b)`

Note that if we think keeping `repo:contains` around is actually the way to go, it will be easy to add it back.

This PR includes corresponding frontend changes to syntax highlighting, hovers, and the search reference panel.

## Test plan
Updated unit tests. Integration tests. Manually tested hovers/suggestions/syntax highlighting/reference panel
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
