### PR TITLE
Make repo size walker logging less noisy

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -570,7 +570,7 @@ func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]i
 		return nil
 	}
 
-	logger.Info("directory sizes calculated during file system walk",
+	logger.Debug("directory sizes calculated during file system walk",
 		log.Int("repoToSize", reposNumber))
 
 	// repos number is limited in order not to overwhelm the database with massive batch updates


### PR DESCRIPTION
This message doesn't indicate a rare event or something problematic, so causes quite some log spam on the info level. I think debug is fine, what do people think?



## Test plan

Verified it isn't logged in info mode anymore.