### PR TITLE
Usage data/backend insert

### DIFF
--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -200,8 +200,8 @@ function createEvent(event: string, eventProperties?: unknown, publicArgument?: 
         source: EventSource.WEB,
         argument: eventProperties ? JSON.stringify(eventProperties) : null,
         publicArgument: publicArgument ? JSON.stringify(publicArgument) : null,
-        deviceID: window.context.sourcegraphDotComMode ? eventLogger.getDeviceID() : null,
-        eventID: window.context.sourcegraphDotComMode ? eventLogger.getEventID() : null,
-        insertID: window.context.sourcegraphDotComMode ? eventLogger.getInsertID() : null,
+        deviceID: eventLogger.getDeviceID(),
+        eventID: eventLogger.getEventID(),
+        insertID: eventLogger.getInsertID(),
     }
 }

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -344,22 +344,32 @@ func TestHandlerLoadsEventsWithAllowlist(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewDB(logger, dbHandle)
 
+	ptr := func(s string) *string {
+		return &s
+	}
+
 	initAllowedEvents(t, db, []string{"allowed"})
 	testData := []*database.Event{
 		{
-			Name:   "allowed",
-			UserID: 1,
-			Source: "test",
+			Name:     "allowed",
+			UserID:   1,
+			Source:   "test",
+			DeviceID: ptr("device"),
+			InsertID: ptr("insert"),
 		},
 		{
-			Name:   "not-allowed",
-			UserID: 2,
-			Source: "test",
+			Name:     "not-allowed",
+			UserID:   2,
+			Source:   "test",
+			DeviceID: ptr("device"),
+			InsertID: ptr("insert"),
 		},
 		{
-			Name:   "allowed",
-			UserID: 3,
-			Source: "test",
+			Name:     "allowed",
+			UserID:   3,
+			Source:   "test",
+			DeviceID: ptr("device"),
+			InsertID: ptr("insert"),
 		},
 	}
 	err := db.EventLogs().BulkInsert(ctx, testData)
@@ -383,20 +393,30 @@ func TestHandlerLoadsEventsWithAllowlist(t *testing.T) {
 		handler.sendEventsCallback = func(ctx context.Context, got []*database.Event, config topicConfig, metadata instanceMetadata) error {
 			autogold.Want("first execution of handler should return first event", []*database.Event{
 				{
-					ID:       1,
-					Name:     "allowed",
-					UserID:   1,
-					Argument: json.RawMessage("{}"),
+					ID:     1,
+					Name:   "allowed",
+					UserID: 1,
+					Argument: json.RawMessage{
+						123,
+						125,
+					},
 					Source:   "test",
 					Version:  "0.0.0+dev",
+					DeviceID: valast.Addr("device").(*string),
+					InsertID: valast.Addr("insert").(*string),
 				},
 				{
-					ID:       3,
-					Name:     "allowed",
-					UserID:   3,
-					Argument: json.RawMessage("{}"),
+					ID:     3,
+					Name:   "allowed",
+					UserID: 3,
+					Argument: json.RawMessage{
+						123,
+						125,
+					},
 					Source:   "test",
 					Version:  "0.0.0+dev",
+					DeviceID: valast.Addr("device").(*string),
+					InsertID: valast.Addr("insert").(*string),
 				},
 			}).Equal(t, got)
 			return nil

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -1205,6 +1205,10 @@ func TestEventLogs_LatestPing(t *testing.T) {
 		}
 	})
 
+	ptr := func(s string) *string {
+		return &s
+	}
+
 	t.Run("with existing pings in database", func(t *testing.T) {
 		userID := int32(0)
 		timestamp := timeutil.Now()
@@ -1219,6 +1223,8 @@ func TestEventLogs_LatestPing(t *testing.T) {
 				Source:          "test",
 				Timestamp:       timestamp,
 				Argument:        json.RawMessage(`{"key": "value1"}`),
+				DeviceID:        ptr("device-id"),
+				InsertID:        ptr("insert-id"),
 			}, {
 				UserID:          0,
 				Name:            "ping",
@@ -1227,6 +1233,8 @@ func TestEventLogs_LatestPing(t *testing.T) {
 				Source:          "test",
 				Timestamp:       timestamp,
 				Argument:        json.RawMessage(`{"key": "value2"}`),
+				DeviceID:        ptr("device-id"),
+				InsertID:        ptr("insert-id"),
 			},
 		}
 		for _, event := range events {
@@ -1250,6 +1258,8 @@ func TestEventLogs_LatestPing(t *testing.T) {
 			Source:          events[1].Source,
 			Timestamp:       timestamp,
 		}
+		expectedPing.DeviceID = ptr("device-id")
+		expectedPing.InsertID = ptr("insert-id") // set these values for test determinism
 		if diff := cmp.Diff(gotPing, expectedPing); diff != "" {
 			t.Fatal(diff)
 		}


### PR DESCRIPTION
Adds default values to the `InsertID` and `DeviceID` similar to how the webapp behaves for backend generated events. This is required such that downstream consumers can deduplicate these events.

## Test plan

Started Sourcegraph and ensured all backend events were inserting with ids

<img width="557" alt="image" src="https://user-images.githubusercontent.com/5090588/184756688-30e69220-e4c6-4948-a545-7dd3e9ddad61.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
