### PR TITLE
web: add `history` `opentelemetry` auto-instrumentation

### DIFF
--- a/client/observability-client/src/index.ts
+++ b/client/observability-client/src/index.ts
@@ -2,4 +2,7 @@ export * from './sdk'
 
 export * from './exporters/consoleBatchSpanExporter'
 
+export * from './processors/sharedSpanStoreProcessor'
+
 export * from './instrumentations/window-load'
+export * from './instrumentations/history'

--- a/client/observability-client/src/instrumentations/history.ts
+++ b/client/observability-client/src/instrumentations/history.ts
@@ -13,6 +13,9 @@ type PatchedKeys = typeof PATCHED_HISTORY_METHODS[number]
  * Having top-level navigation allows grouping other spans in one trace bound to
  * the page view, which helps analyze data in Honeycomb. This experimental approach
  * will be improved based on our experience with events received from the production environment.
+ *
+ * Implementation is based on the `opentelemetry-instrumentation-user-interaction` instrumentation:
+ * https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts#L377
  */
 export class HistoryInstrumentation extends InstrumentationBaseWeb {
     public static instrumentationName = '@sourcegraph/instrumentation-history'

--- a/client/observability-client/src/instrumentations/history.ts
+++ b/client/observability-client/src/instrumentations/history.ts
@@ -1,0 +1,71 @@
+import { otperformance } from '@opentelemetry/core'
+
+import { SharedSpanName, ActiveSpanConfig, InstrumentationBaseWeb, sharedSpanStore } from '../sdk'
+
+const PATCHED_HISTORY_METHODS = ['replaceState', 'pushState', 'back', 'forward', 'go'] as const
+type PatchedKeys = typeof PATCHED_HISTORY_METHODS[number]
+
+/**
+ * Auto instrumentation of the window `popstate` event and history API that
+ * creates the `PageView` span on every URL change. These navigation spans are
+ * used as parents for other spans created by the application.
+ *
+ * It allows to group spans together in one trace bound to the page view,
+ * which helps analyze data in Honeycomb.
+ *
+ * This experimental approach will be improved based on our experience
+ * with events received from the production environment.
+ */
+export class HistoryInstrumentation extends InstrumentationBaseWeb {
+    public static instrumentationName = '@sourcegraph/instrumentation-history'
+    public static version = '0.1'
+
+    constructor() {
+        super(HistoryInstrumentation.instrumentationName, HistoryInstrumentation.version)
+    }
+
+    private patchHistoryMethod = (original: History[PatchedKeys]): History[PatchedKeys] => {
+        // eslint-disable-next-line unicorn/no-this-assignment, @typescript-eslint/no-this-alias
+        const instrumentation = this
+
+        return function historyMethod(this: History, ...args: unknown[]) {
+            const navigationSpan = sharedSpanStore.getRootNavigationSpan()
+
+            const spanConfig: ActiveSpanConfig = {
+                name: SharedSpanName.PageView,
+                // Link new navigation span to the previous navigation span.
+                links: navigationSpan ? [{ context: navigationSpan.spanContext() }] : [],
+            }
+
+            return instrumentation.createActiveSpan(spanConfig, pageViewSpan => {
+                const result = original.apply(this, args as any)
+                pageViewSpan.end()
+
+                return result
+            })
+        }
+    }
+
+    private handlePopState = (): void => {
+        this.createFinishedSpan({
+            name: SharedSpanName.PageView,
+            startTime: otperformance.now(),
+        })
+    }
+
+    private patchHistoryApi(): void {
+        // The spread operator in the array is required to please TS.
+        this._massWrap([history], [...PATCHED_HISTORY_METHODS], this.patchHistoryMethod)
+    }
+
+    public enable(): void {
+        this.patchHistoryApi()
+        window.addEventListener('popstate', this.handlePopState)
+    }
+
+    public disable(): void {
+        // The spread operator in the array is required to please TS.
+        this._massUnwrap([history], [...PATCHED_HISTORY_METHODS])
+        window.removeEventListener('popstate', this.handlePopState)
+    }
+}

--- a/client/observability-client/src/instrumentations/history.ts
+++ b/client/observability-client/src/instrumentations/history.ts
@@ -10,11 +10,9 @@ type PatchedKeys = typeof PATCHED_HISTORY_METHODS[number]
  * creates the `PageView` span on every URL change. These navigation spans are
  * used as parents for other spans created by the application.
  *
- * It allows to group spans together in one trace bound to the page view,
- * which helps analyze data in Honeycomb.
- *
- * This experimental approach will be improved based on our experience
- * with events received from the production environment.
+ * Having top-level navigation allows grouping other spans in one trace bound to
+ * the page view, which helps analyze data in Honeycomb. This experimental approach
+ * will be improved based on our experience with events received from the production environment.
  */
 export class HistoryInstrumentation extends InstrumentationBaseWeb {
     public static instrumentationName = '@sourcegraph/instrumentation-history'

--- a/client/observability-client/src/processors/sharedSpanStoreProcessor.ts
+++ b/client/observability-client/src/processors/sharedSpanStoreProcessor.ts
@@ -1,0 +1,31 @@
+import { Span } from '@opentelemetry/api'
+import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base'
+
+import { sharedSpanStore, SharedSpanName } from '../sdk'
+
+/**
+ * Saves created navigation spans to the `sharedSpanStore` for other spans
+ * to used them later as parents.
+ *
+ * Filters spans by `span.name` using the `SharedSpanName` enum to find spans to save.
+ */
+export class SharedSpanStoreProcessor implements SpanProcessor {
+    public onStart(span: Span): void {
+        const { name: spanName } = (span as unknown) as ReadableSpan
+
+        if (Object.values(SharedSpanName).some(name => name === spanName)) {
+            sharedSpanStore.set(spanName as SharedSpanName, span)
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public onEnd(): void {}
+
+    public forceFlush(): Promise<void> {
+        return Promise.resolve()
+    }
+
+    public shutdown(): Promise<void> {
+        return Promise.resolve()
+    }
+}

--- a/client/observability-client/src/sdk/sharedSpanStore.ts
+++ b/client/observability-client/src/sdk/sharedSpanStore.ts
@@ -1,4 +1,45 @@
+import { Span, trace, context, Context } from '@opentelemetry/api'
+
 export enum SharedSpanName {
     PageView = 'PageView',
     WindowLoad = 'WindowLoad',
 }
+
+type SharedSpanNames = keyof typeof SharedSpanName
+
+/**
+ * Used to store recent navigation spans to group other types of spans
+ * under them, which helps analyze data in Honeycomb.
+ *
+ * Shared spans are set via the `SharedSpanStoreProcessor`.
+ */
+class SharedSpanStore {
+    private spanMap: { [key in SharedSpanNames]?: Context } = {}
+
+    public set(spanName: SharedSpanName, span: Span): void {
+        this.spanMap[spanName] = trace.setSpan(context.active(), span)
+    }
+
+    /**
+     * Get context created by the most recent navigation span.
+     * Context created by either `PageView` or `WindowLoad` spans.
+     */
+    public getRootNavigationContext(): Context | undefined {
+        return this.spanMap.PageView || this.spanMap.WindowLoad
+    }
+
+    /**
+     * Get the most recent navigation span: either `PageView` or `WindowLoad` spans.
+     */
+    public getRootNavigationSpan(): Span | undefined {
+        const navigationContext = this.getRootNavigationContext()
+
+        if (navigationContext) {
+            return trace.getSpan(navigationContext)
+        }
+
+        return undefined
+    }
+}
+
+export const sharedSpanStore = new SharedSpanStore()

--- a/client/observability-client/src/sdk/sharedSpanStore.ts
+++ b/client/observability-client/src/sdk/sharedSpanStore.ts
@@ -11,7 +11,17 @@ type SharedSpanNames = keyof typeof SharedSpanName
  * Used to store recent navigation spans to group other types of spans
  * under them, which helps analyze data in Honeycomb.
  *
- * Shared spans are set via the `SharedSpanStoreProcessor`.
+ * Question: Why having a separate store instead of sharing via context manager?
+ *
+ * The OpenTelemetry context is immutable and can only be passed down
+ * with a callback. If there's no way to wrap the function execution into a
+ * parent span via callback we need to implement another sharing mechanism like
+ * a store. This issue is raised in the OpenTelemetry repo and currently does not
+ * have a recommended solution.
+ *
+ * Example issues:
+ * 1. https://github.com/open-telemetry/opentelemetry-js-contrib/issues/995#issuecomment-1138367723
+ * 2. https://github.com/open-telemetry/opentelemetry-js-contrib/issues/732
  */
 class SharedSpanStore {
     private spanMap: { [key in SharedSpanNames]?: Context } = {}

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -5,12 +5,16 @@ import { formatISO, startOfWeek } from 'date-fns'
  */
 export function stripURLParameters(url: string, parametersToRemove: string[] = []): void {
     const parsedUrl = new URL(url)
-    for (const key of parametersToRemove) {
-        if (parsedUrl.searchParams.has(key)) {
+    const existingParameters = parametersToRemove.filter(key => parsedUrl.searchParams.has(key))
+
+    // Update history state only if we have parameters to remove in the url.
+    if (existingParameters.length !== 0) {
+        for (const key of existingParameters) {
             parsedUrl.searchParams.delete(key)
         }
+
+        window.history.replaceState(window.history.state, window.document.title, parsedUrl.href)
     }
-    window.history.replaceState(window.history.state, window.document.title, parsedUrl.href)
 }
 
 /**


### PR DESCRIPTION
## Context

This PR adds OpenTelemetry auto-instrumentation of the [window `popstate` event](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event) and history API that creates the `PageView` span on every URL change. These navigation spans are later used as parents for other spans created by the application.

Having top-level navigation allows grouping other spans in one trace bound to the page view, which helps analyze data in Honeycomb. This experimental approach will be improved based on our experience with events received from the production environment.

Closes https://github.com/sourcegraph/sourcegraph/issues/40466

## Example

[Honeycomb trace link](https://ui.honeycomb.io/sourcegraph/environments/valery-testing/datasets/web-app/result/ASQJGDYnfQc/trace/BcHbCfT9HMb?fields[]=c_name&fields[]=c_http.url&span=d6bc2068ca0e414b)

<img width="1206" alt="Screen Shot 2022-08-17 at 17 05 11" src="https://user-images.githubusercontent.com/3846380/185080013-11a105a6-6b25-4a73-be9b-5c9732585be6.png">

## Why have a separate store instead of sharing via context manager?
 
[The OpenTelemetry context](https://opentelemetry.io/docs/instrumentation/js/api/context/) is immutable and [can only be passed down with a callback](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/995#issuecomment-1138367723). If there's no way to wrap the function execution into a parent span via callback, we need to implement another sharing mechanism like a store. This issue is raised in the OpenTelemetry repo and currently does not have a recommended solution.

## Test plan

1. `ENABLE_OPEN_TELEMETRY=true sg start web-standalone`
2. `sg start otel` in a separate terminal window
3. Navigate between pages using links and back-forward browser buttons. 
4. See navigation events logged into the console for each navigation action.

## App preview:

- [Web](https://sg-web-vb-history-instrumentation.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hagazjlvyd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

