### PR TITLE
Revert "all: rename go module google/zoekt to sourcegraph/zoekt (#40353)"

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 
 	"github.com/sourcegraph/log"
 

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
+	"github.com/google/zoekt/stream"
 	"github.com/grafana/regexp"
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
-	"github.com/sourcegraph/zoekt/stream"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"

--- a/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/zoekt"
+	"github.com/google/zoekt"
 
 	"github.com/sourcegraph/log/logtest"
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -10,8 +10,8 @@ import (
 
 	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/zoekt"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/sourcegraph/zoekt"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/web"
 	"github.com/graph-gophers/graphql-go"
-	"github.com/sourcegraph/zoekt"
-	"github.com/sourcegraph/zoekt/web"
 
 	"github.com/sourcegraph/log/logtest"
 

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/zoekt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"

--- a/cmd/frontend/internal/httpapi/search_test.go
+++ b/cmd/frontend/internal/httpapi/search_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/zoekt"
+	"github.com/google/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/cmd/searcher/internal/search/filter.go
+++ b/cmd/searcher/internal/search/filter.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/sourcegraph/zoekt/ignore"
+	"github.com/google/zoekt/ignore"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -8,10 +8,10 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 	"github.com/grafana/regexp"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/cmd/searcher/internal/search/hybrid_test.go
+++ b/cmd/searcher/internal/search/hybrid_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/query"
+	"github.com/google/zoekt/web"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/sourcegraph/zoekt"
-	"github.com/sourcegraph/zoekt/query"
-	"github.com/sourcegraph/zoekt/web"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/internal/search"
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -15,11 +15,11 @@ import (
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
+	zoektquery "github.com/google/zoekt/query"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -61,10 +61,10 @@ PACKAGES=(
   github.com/sourcegraph/sourcegraph/cmd/github-proxy
   github.com/sourcegraph/sourcegraph/cmd/gitserver
   github.com/sourcegraph/sourcegraph/cmd/searcher
-  github.com/sourcegraph/zoekt/cmd/zoekt-archive-index
-  github.com/sourcegraph/zoekt/cmd/zoekt-git-index
-  github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver
-  github.com/sourcegraph/zoekt/cmd/zoekt-webserver
+  github.com/google/zoekt/cmd/zoekt-archive-index
+  github.com/google/zoekt/cmd/zoekt-git-index
+  github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
+  github.com/google/zoekt/cmd/zoekt-webserver
 )
 
 PACKAGES+=("${additional_images[@]}")

--- a/dev/tools.go
+++ b/dev/tools.go
@@ -5,10 +5,10 @@ package main
 
 import (
 	// zoekt-* used in sourcegraph/server docker image build
-	_ "github.com/sourcegraph/zoekt/cmd/zoekt-archive-index"
-	_ "github.com/sourcegraph/zoekt/cmd/zoekt-git-index"
-	_ "github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver"
-	_ "github.com/sourcegraph/zoekt/cmd/zoekt-webserver"
+	_ "github.com/google/zoekt/cmd/zoekt-archive-index"
+	_ "github.com/google/zoekt/cmd/zoekt-git-index"
+	_ "github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver"
+	_ "github.com/google/zoekt/cmd/zoekt-webserver"
 
 	// go-mockgen is used to codegen mockable interfaces, used in precise code intel tests
 	_ "github.com/derision-test/go-mockgen/cmd/go-mockgen"

--- a/dev/zoekt/update
+++ b/dev/zoekt/update
@@ -5,19 +5,23 @@ set -e
 export GO111MODULE=on
 
 # Can specify a SHA pushed to our fork instead of master
-version="${1:-main}"
+version="${1:-master}"
 
-name="sourcegraph/zoekt"
-repo="github.com/${name}"
+upstream=github.com/google/zoekt
+fork=github.com/sourcegraph/zoekt
+forkname=sourcegraph/zoekt
 
 response="$(mktemp)"
 trap 'rm -f "$response"' EXIT
 
-curl --silent --fail "https://api.github.com/repos/${name}/commits?per_page=1&sha=${version}" >"${response}"
+curl --silent --fail "https://api.github.com/repos/${forkname}/commits?per_page=1&sha=${version}" >"${response}"
 newsha="$(jq -r '.[0].sha[:12]' <"${response}")"
-oldsha="$(go mod edit -print | grep "$repo" | grep -o '[a-f0-9]*$')"
+newts="$(jq -r '.[0].commit.committer.date | fromdate | strftime("%Y%m%d%H%M%S")' <"${response}")"
+module="${fork}@v0.0.0-${newts}-${newsha}"
 
-echo "https://$repo/compare/$oldsha...$newsha"
+oldsha="$(go mod edit -print | grep "$fork" | grep -o '[a-f0-9]*$')"
+
+echo "https://github.com/sourcegraph/zoekt/compare/$oldsha...$newsha"
 
 curl --silent --fail "https://api.github.com/repos/sourcegraph/zoekt/compare/$oldsha...$newsha" >"${response}"
 
@@ -30,8 +34,8 @@ jq -r '.commits[] | "- " + .sha[:10] + " " + (.commit.message | split("\n")[0])'
     sed 's/ (#[0-9]*)//g'
 
 echo
-go get "${repo}@${version}"
-go mod download ${repo}
+go mod edit "-replace=${upstream}=${module}"
+go mod download ${upstream}
 go mod tidy
 
 echo "Ensure we update go.sum by actually compiling some code which depends on zoekt."

--- a/doc/dev/background-information/architecture/indexed-ranking.md
+++ b/doc/dev/background-information/architecture/indexed-ranking.md
@@ -45,4 +45,4 @@ These are the main inputs for deciding the rank of a match. There is some minor 
 ## References
 
 - [RFC 359](https://docs.google.com/document/d/1EiD_dKkogqBNAbKN3BbanII4lQwROI7a0aGaZ7i-0AU/edit#heading=h.trqab8y0kufp): Search Result Ranking
-- Zoekt Design :: [Ranking](https://github.com/sourcegraph/zoekt/blob/master/doc/design.md#ranking)
+- Zoekt Design :: [Ranking](https://github.com/google/zoekt/blob/master/doc/design.md#ranking)

--- a/doc/dev/how-to/zoekt_local_dev.md
+++ b/doc/dev/how-to/zoekt_local_dev.md
@@ -13,7 +13,7 @@ Change at the bottom:
 ```
 replace (
     ...
-    github.com/sourcegraph/zoekt => <your zoekt repository directory>
+    github.com/google/zoekt => <your zoekt repository directory>
     ...
 )
 ```

--- a/docker-images/indexed-searcher/build.sh
+++ b/docker-images/indexed-searcher/build.sh
@@ -10,7 +10,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # The images are tagged using the same pseudo-versions as go mod, so we
 # extract the version from our go.mod
 
-version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($2, 2)}')
+version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')
 
 docker pull index.docker.io/sourcegraph/zoekt-webserver:"$version"
 docker tag index.docker.io/sourcegraph/zoekt-webserver:"$version" "$IMAGE"

--- a/docker-images/search-indexer/build.sh
+++ b/docker-images/search-indexer/build.sh
@@ -10,7 +10,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # The images are tagged using the same pseudo-versions as go mod, so we
 # extract the version from our go.mod
 
-version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($2, 2)}')
+version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')
 
 docker pull index.docker.io/sourcegraph/zoekt-indexserver:"$version"
 docker tag index.docker.io/sourcegraph/zoekt-indexserver:"$version" "$IMAGE"

--- a/enterprise/docs/glossary.md
+++ b/enterprise/docs/glossary.md
@@ -124,9 +124,9 @@ Microsoft's "Visual Studio Code", a fairly powerful and flexible programming edi
 
 A "bundler" which combines multiple source files (for instance, of javascript or CSS) into single unified files that can be more easily cached. Used in Sourcegraph to improve performance of some of the built-in web interface. Can also do translations, such as converting TypeScript to JavaScript.
 
-### [Zoekt](https://github.com/sourcegraph/zoekt)
+### [Zoekt](https://github.com/google/zoekt)
 
-Fast search program with indexing, used in Sourcegraph for some search functionality.
+Fast search program with indexing, used in Sourcegraph for some search functionality. We also maintain [a private fork](https://github.com/sourcegraph/zoekt).
 
 ### [Zoom](https://zoom.us/)
 

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/google/go-github/v43 v43.0.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.3.0
+	github.com/google/zoekt v0.0.0-20211108135652-f8e8ada171c7
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/csrf v1.7.1
 	github.com/gorilla/handlers v1.5.1
@@ -200,10 +201,7 @@ require (
 
 require github.com/hmarr/codeowners v0.4.0
 
-require (
-	github.com/sourcegraph/zoekt v0.0.0-20220815140312-5ee92f5abab3
-	github.com/stretchr/objx v0.4.0 // indirect
-)
+require github.com/stretchr/objx v0.4.0 // indirect
 
 require (
 	bitbucket.org/creachadair/shell v0.0.7 // indirect
@@ -430,6 +428,8 @@ require (
 // These entries indicate permanent replace directives due to significant changes from upstream
 // or intentional forks.
 replace (
+	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220719111241-09ac1ff91e8c
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -2074,8 +2074,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220815140312-5ee92f5abab3 h1:A0Dys06t9Q4RElANILq3CISGv0USFfpacog9BTu6uMQ=
-github.com/sourcegraph/zoekt v0.0.0-20220815140312-5ee92f5abab3/go.mod h1:tywNJNUYzGii1nvnfYSUn1zNhB3RAZQjAlZasNWdJ7M=
+github.com/sourcegraph/zoekt v0.0.0-20220719111241-09ac1ff91e8c h1:iFjo3rlPfOA2nAJgoEFjlJf2a4ASkEB5NJOGpZBNHfA=
+github.com/sourcegraph/zoekt v0.0.0-20220719111241-09ac1ff91e8c/go.mod h1:EvI7mOEF5BxYn5z2AgBXRFLjD9PxSB999bXeSHMDdPo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/zoekt"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"

--- a/internal/search/backend/cached.go
+++ b/internal/search/backend/cached.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 )
 
 // cachedSearcher wraps a zoekt.Searcher with caching of List call results.

--- a/internal/search/backend/cached_test.go
+++ b/internal/search/backend/cached_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 )
 
 func TestCachedSearcher(t *testing.T) {

--- a/internal/search/backend/fake.go
+++ b/internal/search/backend/fake.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 )
 
 // FakeSearcher is a zoekt.Searcher that returns a predefined search Result.

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -11,12 +11,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/query"
+	"github.com/google/zoekt/stream"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/sourcegraph/zoekt"
-	"github.com/sourcegraph/zoekt/query"
-	"github.com/sourcegraph/zoekt/stream"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/trace"

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/sourcegraph/zoekt"
+	"github.com/google/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"sort"
 
+	"github.com/google/zoekt"
 	"github.com/grafana/regexp"
 	"github.com/inconshreveable/log15"
-	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/schema"
 )

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/zoekt"
+	"github.com/google/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/internal/search/backend/indexers.go
+++ b/internal/search/backend/indexers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sourcegraph/zoekt"
+	"github.com/google/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"

--- a/internal/search/backend/indexers_test.go
+++ b/internal/search/backend/indexers_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/zoekt"
 )
 
 func TestReposSubset(t *testing.T) {

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -5,14 +5,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/query"
 	"github.com/keegancsmith/rpc"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	sglog "github.com/sourcegraph/log"
-	"github.com/sourcegraph/zoekt"
-	"github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/trace"

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -3,10 +3,10 @@ package backend
 import (
 	"sync"
 
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/rpc"
+	zoektstream "github.com/google/zoekt/stream"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/zoekt"
-	"github.com/sourcegraph/zoekt/rpc"
-	zoektstream "github.com/sourcegraph/zoekt/stream"
 )
 
 // We don't use the normal factory for internal requests because we disable

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/zoekt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sourcegraph/zoekt"
-	"github.com/sourcegraph/zoekt/query"
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf"

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -6,9 +6,9 @@ package job
 import (
 	"context"
 
+	"github.com/google/zoekt"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"

--- a/internal/search/repos/mocks_test.go
+++ b/internal/search/repos/mocks_test.go
@@ -10,12 +10,12 @@ import (
 	"context"
 	"sync"
 
-	zoekt "github.com/sourcegraph/zoekt"
-	query "github.com/sourcegraph/zoekt/query"
+	zoekt "github.com/google/zoekt"
+	query "github.com/google/zoekt/query"
 )
 
 // MockStreamer is a mock implementation of the Streamer interface (from the
-// package github.com/sourcegraph/zoekt) used for unit testing.
+// package github.com/google/zoekt) used for unit testing.
 type MockStreamer struct {
 	// CloseFunc is an instance of a mock function object controlling the
 	// behavior of the method Close.

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -9,12 +9,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 	"github.com/grafana/regexp"
 	regexpsyntax "github.com/grafana/regexp/syntax"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -12,8 +12,8 @@ import (
 
 	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/zoekt"
 	"github.com/grafana/regexp"
-	"github.com/sourcegraph/zoekt"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 	"github.com/grafana/regexp"
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	zoektquery "github.com/google/zoekt/query"
 	otlog "github.com/opentracing/opentracing-go/log"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -7,10 +7,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/RoaringBitmap/roaring"
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 	"go.uber.org/atomic"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 	"github.com/stretchr/testify/require"
 
 	"github.com/RoaringBitmap/roaring"

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
-	zoekt "github.com/sourcegraph/zoekt/query"
+	zoekt "github.com/google/zoekt/query"
 )
 
 func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Features, typ search.IndexedRequestType) (q zoekt.Q, err error) {

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 
-	zoekt "github.com/sourcegraph/zoekt/query"
+	zoekt "github.com/google/zoekt/query"
 )
 
 func TestQueryToZoektQuery(t *testing.T) {

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	zoektquery "github.com/google/zoekt/query"
 	"github.com/opentracing/opentracing-go/log"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -5,10 +5,10 @@ import (
 	"regexp/syntax" //nolint:depguard // zoekt requires this pkg
 	"time"
 
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
-	"github.com/sourcegraph/zoekt"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"

--- a/internal/search/zoekt/zoekt_global.go
+++ b/internal/search/zoekt/zoekt_global.go
@@ -1,8 +1,8 @@
 package zoekt
 
 import (
+	zoektquery "github.com/google/zoekt/query"
 	"github.com/grafana/regexp"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -3,8 +3,8 @@ package usagestats
 import (
 	"context"
 
-	"github.com/sourcegraph/zoekt"
-	"github.com/sourcegraph/zoekt/query"
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/mockgen.test.yaml
+++ b/mockgen.test.yaml
@@ -222,7 +222,7 @@
   interfaces:
     - ConfigurationSource
 - filename: internal/search/repos/mocks_test.go
-  path: github.com/sourcegraph/zoekt
+  path: github.com/google/zoekt
   interfaces:
     - Streamer
 - filename: enterprise/cmd/worker/internal/telemetry/mocks_test.go

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -391,9 +391,9 @@ commands:
     install: |
       mkdir -p .bin
       export GOBIN="${PWD}/.bin"
-      go install github.com/sourcegraph/zoekt/cmd/zoekt-archive-index
-      go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index
-      go install github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver
+      go install github.com/google/zoekt/cmd/zoekt-archive-index
+      go install github.com/google/zoekt/cmd/zoekt-git-index
+      go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
     checkBinary: .bin/zoekt-sourcegraph-indexserver
     env: &zoektenv
       CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
@@ -417,7 +417,7 @@ commands:
   zoekt-web-template: &zoekt_webserver_template
     install: |
       mkdir -p .bin
-      env GOBIN="${PWD}/.bin" go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver
+      env GOBIN="${PWD}/.bin" go install github.com/google/zoekt/cmd/zoekt-webserver
     checkBinary: .bin/zoekt-webserver
     env:
       JAEGER_DISABLED: false


### PR DESCRIPTION
This reverts commit 6d376d871afb9beba43b1ef2b5fd30c3bf52a62b.

See #inc-134-search-on-sourcegraphcom-fails-with-errors in Slack.

Current suspicion is that it causes gob-encoding/decoding problems in
production if the code below is not in sync with the zoekt cluster code.



## Test plan

- N/A
