### PR TITLE
Remove last traces of dependencies search from frontend code

### DIFF
--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -381,10 +381,6 @@ describe('getCompletionItems()', () => {
               "contains.content(\${1:TODO}) ",
               "contains(file:\${1:CHANGELOG} content:\${2:fix}) ",
               "contains.commit.after(\${1:1 month ago}) ",
-              "deps(\${1}) ",
-              "dependencies(\${1}) ",
-              "revdeps(\${1}) ",
-              "dependents(\${1}) ",
               "has.description(\${1}) ",
               "^repo/with\\\\ a\\\\ space$ "
             ]
@@ -407,10 +403,6 @@ describe('getCompletionItems()', () => {
               "contains.content(\${1:TODO}) ",
               "contains(file:\${1:CHANGELOG} content:\${2:fix}) ",
               "contains.commit.after(\${1:1 month ago}) ",
-              "deps(\${1}) ",
-              "dependencies(\${1}) ",
-              "revdeps(\${1}) ",
-              "dependents(\${1}) ",
               "has.description(\${1}) "
             ]
         `)

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -14,7 +14,6 @@ const filterCompletionItemKind = Monaco.languages.CompletionItemKind.Issue
 
 type PartialCompletionItem = Omit<Monaco.languages.CompletionItem, 'range'>
 
-export const REPO_DEPS_PREDICATE_REGEX = /^(deps|dependencies|revdeps|dependents)\((.*?)\)?$/
 export const PREDICATE_REGEX = /^([.A-Za-z]+)\((.*?)\)?$/
 
 /**
@@ -94,16 +93,7 @@ export const regexInsertText = (value: string, options: { globbing: boolean }): 
 export const repositoryInsertText = (
     { repository }: RepositoryMatch,
     options: { globbing: boolean; filterValue?: string }
-): string => {
-    const insertText = regexInsertText(repository, options)
-
-    const depsPredicateMatches = options.filterValue ? options.filterValue.match(REPO_DEPS_PREDICATE_REGEX) : null
-    if (depsPredicateMatches) {
-        // depsPredicateMatches[1] contains either `deps`, `dependencies`, `revdeps` or `dependents` based on the matched value.
-        return `${depsPredicateMatches[1]}(${insertText})`
-    }
-    return insertText
-}
+): string => regexInsertText(repository, options)
 
 /**
  * Maps Sourcegraph SymbolKinds to Monaco CompletionItemKinds.

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -248,7 +248,7 @@ async function completeFilterValue(
     const { value } = token
 
     // FIXME(tsenart): We need to refactor completions to work with
-    // complex predicates like repo:dependencies()
+    // complex predicates.
     // For now we just disable all static suggestions for a predicate's filter
     // if we are inside that predicate.
     const insidePredicate = value ? PREDICATE_REGEX.test(value.value) : false

--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1485,41 +1485,6 @@ describe('getMonacoTokens()', () => {
         `)
     })
 
-    test('highlight repo:dependencies predicate', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:dependencies(.*)')))).toMatchInlineSnapshot(`
-            [
-              {
-                "startIndex": 0,
-                "scopes": "field"
-              },
-              {
-                "startIndex": 4,
-                "scopes": "metaFilterSeparator"
-              },
-              {
-                "startIndex": 5,
-                "scopes": "metaPredicateNameAccess"
-              },
-              {
-                "startIndex": 17,
-                "scopes": "metaPredicateParenthesis"
-              },
-              {
-                "startIndex": 18,
-                "scopes": "metaRegexpCharacterSet"
-              },
-              {
-                "startIndex": 19,
-                "scopes": "metaRegexpRangeQuantifier"
-              },
-              {
-                "startIndex": 20,
-                "scopes": "metaPredicateParenthesis"
-              }
-            ]
-        `)
-    })
-
     test('highlight repo:has.description predicate', () => {
         expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:has.description(.*)')))).toMatchInlineSnapshot(`
             [

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -994,16 +994,6 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
                 value: body,
                 kind: PatternKind.Regexp,
             })
-        case 'dependencies':
-        case 'deps':
-        case 'dependents':
-        case 'revdeps':
-            return mapRegexpMetaSucceed({
-                type: 'pattern',
-                range: { start: offset, end: body.length },
-                value: body,
-                kind: PatternKind.Regexp,
-            })
         case 'has': {
             const result = decorateRepoHasBody(body, offset)
             if (result !== undefined) {

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -166,12 +166,6 @@ const toPredicateHover = (token: MetaPredicate): string => {
             return `**Built-in predicate**. Search only inside repositories that contain **file content** matching the regular expression \`${parameters}\`.`
         case 'contains.commit.after':
             return `**Built-in predicate**. Search only inside repositories that have been committed to since \`${parameters}\`.`
-        case 'dependencies':
-        case 'deps':
-            return '**Built-in predicate**. Search only repository dependencies of repositories matching the regular expression'
-        case 'dependents':
-        case 'revdeps':
-            return '**Built-in predicate**. Search only repositories depending on repositories matching the regular expression'
         case 'has.description':
             return '**Built-in predicate**. Search only inside repositories that have a **description** matching the given regular expression'
     }

--- a/client/shared/src/search/query/metrics.test.ts
+++ b/client/shared/src/search/query/metrics.test.ts
@@ -17,13 +17,10 @@ describe('collectMetrics', () => {
     })
 
     test('predicates', () => {
-        expect(
-            collectMetrics('repo:contains.file(foo) r:contains(file:foo content:bar) r:deps(foo) r:dependencies(bar)')
-        ).toMatchInlineSnapshot(`
+        expect(collectMetrics('repo:contains.file(foo) r:contains(file:foo content:bar)')).toMatchInlineSnapshot(`
             {
               "count_repo_contains": 1,
-              "count_repo_contains_file": 1,
-              "count_repo_dependencies": 2
+              "count_repo_contains_file": 1
             }
         `)
     })

--- a/client/shared/src/search/query/metrics.ts
+++ b/client/shared/src/search/query/metrics.ts
@@ -45,7 +45,7 @@ export const collectMetrics = (query: string): Metrics | undefined => {
     let count_repo_contains_file = 0
     let count_repo_contains_content = 0
     let count_repo_contains_commit_after = 0
-    let count_repo_dependencies = 0
+    const count_repo_dependencies = 0
     let count_count_all = 0
     let count_non_global_context = 0
     let count_only_patterns = 0
@@ -132,12 +132,6 @@ export const collectMetrics = (query: string): Metrics | undefined => {
                                 break
                             case 'contains.commit.after':
                                 count_repo_contains_commit_after += 1
-                                break
-                            case 'deps':
-                                count_repo_dependencies += 1
-                                break
-                            case 'dependencies':
-                                count_repo_dependencies += 1
                                 break
                         }
                     }

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -30,18 +30,6 @@ export const PREDICATES: Access[] = [
                 name: 'has',
                 fields: [{ name: 'description' }, { name: 'tag' }],
             },
-            {
-                name: 'dependencies',
-            },
-            {
-                name: 'deps',
-            },
-            {
-                name: 'dependents',
-            },
-            {
-                name: 'revdeps',
-            },
         ],
     },
     {
@@ -178,26 +166,6 @@ export const predicateCompletion = (field: string): Completion[] => {
             {
                 label: 'contains.commit.after(...)',
                 insertText: 'contains.commit.after(${1:1 month ago})',
-                asSnippet: true,
-            },
-            {
-                label: 'deps(...)',
-                insertText: 'deps(${1})',
-                asSnippet: true,
-            },
-            {
-                label: 'dependencies(...)',
-                insertText: 'dependencies(${1})',
-                asSnippet: true,
-            },
-            {
-                label: 'revdeps(...)',
-                insertText: 'revdeps(${1})',
-                asSnippet: true,
-            },
-            {
-                label: 'dependents(...)',
-                insertText: 'dependents(${1})',
                 asSnippet: true,
             },
             {

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -5,7 +5,7 @@ import { map, delay, takeUntil, switchMap } from 'rxjs/operators'
 import { SearchPatternType } from '../../graphql-operations'
 import { isSearchMatchOfType, SearchMatch } from '../stream'
 
-import { getCompletionItems, REPO_DEPS_PREDICATE_REGEX } from './completion'
+import { getCompletionItems } from './completion'
 import { getMonacoTokens } from './decoratedToken'
 import { FilterType } from './filters'
 import { getHoverResult } from './hover'
@@ -67,11 +67,8 @@ export function getSuggestionQuery(tokens: Token[], tokenAtColumn: Token, sugges
     }
 
     if (suggestionType === 'repo') {
-        const depsPredicateMatch = tokenValue.match(REPO_DEPS_PREDICATE_REGEX)
-        const repoValue = depsPredicateMatch ? depsPredicateMatch[2] : tokenValue
-        const relevantFilters =
-            !hasAndOrOperators && !depsPredicateMatch ? serializeFilters(tokens, REPO_SUGGESTION_FILTERS) : ''
-        return `${relevantFilters} repo:${repoValue} type:repo count:${MAX_SUGGESTION_COUNT}`.trimStart()
+        const relevantFilters = !hasAndOrOperators ? serializeFilters(tokens, REPO_SUGGESTION_FILTERS) : ''
+        return `${relevantFilters} repo:${tokenValue} type:repo count:${MAX_SUGGESTION_COUNT}`.trimStart()
     }
 
     // For the cases below, we are not handling queries with and/or operators. This is because we would need to figure out

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -264,21 +264,6 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                 </div>
                 {isNewRepoPageEnabled && (
                     <ButtonGroup>
-                        <Button
-                            to={`/search?q=${encodeURIPathComponent(
-                                `context:global count:all repo:dependencies(${repo.name.replaceAll('.', '\\.')}$) `
-                            )}`}
-                            variant="secondary"
-                            outline={true}
-                            as={Link}
-                            className="ml-1"
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiCodeJson} /> Search dependencies{' '}
-                            <Badge variant="info" className={classNames('text-uppercase')}>
-                                NEW
-                            </Badge>
-                        </Button>
-
                         {!isSourcegraphDotCom && batchChangesEnabled && (
                             <Button
                                 to="/batch-changes/create"

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useEffect, useState } from 'react'
 
-import { mdiCodeJson, mdiCog, mdiFolder, mdiSourceRepository } from '@mdi/js'
+import { mdiCog, mdiFolder, mdiSourceRepository } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom'
@@ -30,7 +30,6 @@ import {
     Icon,
     ButtonGroup,
     Button,
-    Badge,
     Text,
 } from '@sourcegraph/wildcard'
 

--- a/doc/code_search/reference/language.md
+++ b/doc/code_search/reference/language.md
@@ -664,26 +664,6 @@ commits past the specified time frame. This parameter is experimental.
 
 **Example:** [`repo:contains.commit.after(1 month ago)` ↗](https://sourcegraph.com/search?q=repo:.*sourcegraph.*+repo:contains.commit.after%281+month+ago%29&patternType=literal)
 
-### Repo dependencies
-
-<script>
-ComplexDiagram(
-    Choice(0,
-        Terminal("dependencies:"),
-        Terminal("deps:")),
-    Terminal("("),
-    Sequence(
-        Terminal("regexp", {href: "#regular-expression"}),
-        Terminal("@"),
-        Terminal("revision", {href: "#revision"})
-    ),
-    Terminal(")")).addTo();
-</script>
-
-Search only inside dependencies of repositories matching the given `regex@rev:a:b:c` input.
-
-**Example:** [`repo:dependencies(^github\.com/sourcegraph/sourcegraph$@3.36:3.35) count:all` ↗](https://sourcegraph.com/search?q=context:global+repo:dependencies%28%5Egithub%5C.com/sourcegraph/sourcegraph%24%403.36:3.35%29+count:all&patternType=literal)
-
 ### Repo has description
 
 <script>


### PR DESCRIPTION
This should've been part of
https://github.com/sourcegraph/sourcegraph/pull/39742 but I missed it.

@lguychard also removed something else I missed: https://github.com/sourcegraph/sourcegraph/pull/40164/files

This here now removes the highlighting/completion of the
`repo:deps|revdeps|dependencies|dependents` predicates.

I kept the metrics in as to not break anything.

This should fix #40160.

## Test plan

- Ran the unit tests locally
- CI
- Tested manually locally

## App preview:

- [Web](https://sg-web-mrn-rm-frontend-dep-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ofndaqqqjw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
