### PR TITLE
admin-analytics: add extensions page

### DIFF
--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -94,12 +94,12 @@ export const analyticsGroup: SiteAdminSideBarGroup = {
             to: '/site-admin/analytics/notebooks',
         },
         {
-            label: 'Code insights (soon)',
-            to: '/site-admin/analytics/code-insights',
+            label: 'Extensions',
+            to: '/site-admin/analytics/extensions',
         },
         {
-            label: 'Extensions (soon)',
-            to: '/site-admin/analytics/extensions',
+            label: 'Code insights (soon)',
+            to: '/site-admin/analytics/code-insights',
         },
         {
             label: 'Overview (soon)',
@@ -118,6 +118,11 @@ export const analyticsRoutes: readonly SiteAdminAreaRoute[] = [
     {
         path: '/analytics/code-intel',
         render: lazyComponent(() => import('./analytics/AnalyticsCodeIntelPage'), 'AnalyticsCodeIntelPage'),
+        exact: true,
+    },
+    {
+        path: '/analytics/extensions',
+        render: lazyComponent(() => import('./analytics/AnalyticsExtensionsPage'), 'AnalyticsExtensionsPage'),
         exact: true,
     },
     {

--- a/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.module.scss
+++ b/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.module.scss
@@ -1,0 +1,9 @@
+.border {
+    border-bottom: 1px solid var(--border-color-2);
+}
+
+.suggestion-box {
+    padding-left: 4rem;
+    padding-right: 4rem;
+    margin-top: 1.5rem;
+}

--- a/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
@@ -1,0 +1,243 @@
+import React, { useMemo, useEffect } from 'react'
+
+import classNames from 'classnames'
+import { startCase } from 'lodash'
+import { RouteComponentProps } from 'react-router'
+
+import { useQuery } from '@sourcegraph/http-client'
+import { Card, H2, Text, LoadingSpinner, AnchorLink, H4, LineChart, Series } from '@sourcegraph/wildcard'
+
+import { ExtensionsStatisticsResult, ExtensionsStatisticsVariables } from '../../../graphql-operations'
+import { eventLogger } from '../../../tracking/eventLogger'
+import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
+import { ChartContainer } from '../components/ChartContainer'
+import { HorizontalSelect } from '../components/HorizontalSelect'
+import { TimeSavedCalculatorGroup } from '../components/TimeSavedCalculatorGroup'
+import { ToggleSelect } from '../components/ToggleSelect'
+import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
+import { useChartFilters } from '../useChartFilters'
+import { StandardDatum } from '../utils'
+
+import { EXTENSIONS_STATISTICS } from './queries'
+
+import styles from './index.module.scss'
+
+export const AnalyticsExtensionsPage: React.FunctionComponent<RouteComponentProps<{}>> = () => {
+    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Extensions' })
+    const { data, error, loading } = useQuery<ExtensionsStatisticsResult, ExtensionsStatisticsVariables>(
+        EXTENSIONS_STATISTICS,
+        {
+            variables: {
+                dateRange: dateRange.value,
+                grouping: grouping.value,
+            },
+        }
+    )
+    useEffect(() => {
+        eventLogger.logPageView('AdminAnalyticsExtensions')
+    }, [])
+    const [stats, legends, calculatorProps, installationStats] = useMemo(() => {
+        if (!data) {
+            return []
+        }
+        const { jetbrains, vscode, browser } = data.site.analytics.extensions
+
+        const totalEvents = vscode.summary.totalCount + jetbrains.summary.totalCount + browser.summary.totalCount
+
+        const stats: Series<StandardDatum>[] = [
+            {
+                id: 'jetbrains',
+                name: aggregation.selected === 'count' ? 'JetBrains IDE plugin' : 'Users using JetBrains IDE plugin',
+                color: 'var(--cyan)',
+                data: jetbrains.nodes.map(
+                    node => ({
+                        date: new Date(node.date),
+                        value: node[aggregation.selected],
+                    }),
+                    dateRange.value
+                ),
+                getXValue: ({ date }) => date,
+                getYValue: ({ value }) => value,
+            },
+            {
+                id: 'vscode',
+                name: aggregation.selected === 'count' ? 'VsCode IDE extension' : 'Users using VsCode IDE extension',
+                color: 'var(--purple)',
+                data: vscode.nodes.map(
+                    node => ({
+                        date: new Date(node.date),
+                        value: node[aggregation.selected],
+                    }),
+                    dateRange.value
+                ),
+                getXValue: ({ date }) => date,
+                getYValue: ({ value }) => value,
+            },
+            {
+                id: 'browser',
+                name: aggregation.selected === 'count' ? 'Browser extension' : 'Users using browser extension',
+                color: 'var(--orange)',
+                data: browser.nodes.map(
+                    node => ({
+                        date: new Date(node.date),
+                        value: node[aggregation.selected],
+                    }),
+                    dateRange.value
+                ),
+                getXValue: ({ date }) => date,
+                getYValue: ({ value }) => value,
+            },
+        ]
+        const legends: ValueLegendListProps['items'] = [
+            {
+                value: jetbrains.summary[aggregation.selected === 'count' ? 'totalCount' : 'totalUniqueUsers'],
+                description:
+                    aggregation.selected === 'count' ? 'JetBrains\nIDE plugin' : 'Users using\nJetBrains IDE plugin',
+                color: 'var(--cyan)',
+                tooltip:
+                    aggregation.selected === 'count'
+                        ? 'The number searches in JetBrains IDE plugin.'
+                        : 'The number of users searched in JetBrains IDE plugin.',
+            },
+            {
+                value: vscode.summary[aggregation.selected === 'count' ? 'totalCount' : 'totalUniqueUsers'],
+                description:
+                    aggregation.selected === 'count' ? 'VsCode\nIDE extension' : 'Users using\nVsCode IDE extension',
+                color: 'var(--purple)',
+                tooltip:
+                    aggregation.selected === 'count'
+                        ? 'The number searches in VsCode IDE extension.'
+                        : 'The number of users searched in IDE extension.',
+            },
+            {
+                value: browser.summary[aggregation.selected === 'count' ? 'totalCount' : 'totalUniqueUsers'],
+                description: aggregation.selected === 'count' ? 'Browser\nextension' : 'Users using\nbrowser extension',
+                color: 'var(--orange)',
+                tooltip:
+                    aggregation.selected === 'count'
+                        ? 'The number of code navigation events in code hosts via Browser extensions.'
+                        : 'The number of users using code navigation  events in code hosts via Browser extensions',
+            },
+        ]
+
+        const calculatorProps = {
+            page: 'Extensions',
+            label: 'Total events',
+            dateRange: dateRange.value,
+            color: 'var(--purple)',
+            description:
+                'Our extensions allow users to complete their goals without switching tools and context. We’ve calculated the value of maintaining momentum and using the tools users prefer. ',
+            value: totalEvents,
+            items: [
+                {
+                    label: 'Browser extension',
+                    minPerItem: 0.5,
+                    value: browser.summary.totalCount,
+                    description:
+                        'Code navigation events (e.g. go to definition, find references) that have occurred on your code host. These make it easier to understand code and provide feedback during code reviews.',
+                },
+                {
+                    label: 'JetBrains IDE plugin',
+                    minPerItem: 1.5,
+                    value: jetbrains.summary.totalCount,
+                    description:
+                        "Searches from JetBrains across all of your company's code across code hosts, without locally cloning repositories or complex scripting.",
+                },
+                {
+                    label: 'VsCode IDE extension',
+                    minPerItem: 3,
+                    value: vscode.summary.totalCount,
+                    description:
+                        "Searches from VS Code across all of your company's code across code hosts, without locally cloning repositories or complex scripting.",
+                },
+            ],
+        }
+        const totalUsersCount = data?.site.users.totalCount
+        const installationStats =
+            totalUsersCount > 0
+                ? {
+                      vscode: Math.floor((vscode.summary.totalUniqueUsers * 100) / totalUsersCount),
+                      jetbrains: Math.floor((jetbrains.summary.totalUniqueUsers * 100) / totalUsersCount),
+                      browser: Math.floor((browser.summary.totalUniqueUsers * 100) / totalUsersCount),
+                  }
+                : undefined
+
+        return [stats, legends, calculatorProps, installationStats]
+    }, [data, dateRange.value, aggregation.selected])
+
+    if (error) {
+        throw error
+    }
+
+    if (loading) {
+        return <LoadingSpinner />
+    }
+
+    const groupingLabel = startCase(grouping.value.toLowerCase())
+
+    return (
+        <>
+            <AnalyticsPageTitle>Analytics / Extensions</AnalyticsPageTitle>
+
+            <Card className="p-3 position-relative">
+                <div className="d-flex justify-content-end align-items-stretch mb-2 text-nowrap">
+                    <HorizontalSelect<typeof dateRange.value> {...dateRange} />
+                </div>
+                {legends && <ValueLegendList className="mb-3" items={legends} />}
+                {stats && (
+                    <div>
+                        <ChartContainer
+                            title={
+                                aggregation.selected === 'count'
+                                    ? `${groupingLabel} activity`
+                                    : `${groupingLabel} unique users`
+                            }
+                            labelX="Time"
+                            labelY={aggregation.selected === 'count' ? 'Activity' : 'Unique users'}
+                        >
+                            {width => <LineChart width={width} height={300} series={stats} />}
+                        </ChartContainer>
+                        <div className="d-flex justify-content-end align-items-stretch mb-2 text-nowrap">
+                            <HorizontalSelect<typeof grouping.value> {...grouping} className="mr-4" />
+                            <ToggleSelect<typeof aggregation.selected> {...aggregation} />
+                        </div>
+                    </div>
+                )}
+                <H2 className="my-3">Total time saved</H2>
+                {calculatorProps && <TimeSavedCalculatorGroup {...calculatorProps} />}
+                <div className={styles.suggestionBox}>
+                    <H4 className="my-3">Suggestions</H4>
+                    <div className={classNames(styles.border, 'mb-3')} />
+                    {installationStats && (
+                        <ul className="mb-3 pl-3">
+                            <Text as="li">
+                                {installationStats.vscode}% of users have installed the{' '}
+                                <AnchorLink to="/help/integration/browser_extension" target="_blank">
+                                    VSCode IDE extension
+                                </AnchorLink>
+                                . Promote installation to increase the value.
+                            </Text>
+                            <Text as="li">
+                                {installationStats.jetbrains}% of users have installed the{' '}
+                                <AnchorLink to="/help/integration/editor" target="_blank">
+                                    JetBrains IDE plugin
+                                </AnchorLink>
+                                . Promote installation to increase the value.
+                            </Text>
+                            <Text as="li">
+                                {installationStats.browser}% of users have installed the{' '}
+                                <AnchorLink to="/help/integration/editor" target="_blank">
+                                    Browser extension
+                                </AnchorLink>
+                                . Promote installation to increase the value.
+                            </Text>
+                        </ul>
+                    )}
+                </div>
+            </Card>
+            <Text className="font-italic text-center mt-2">
+                All events are generated from entries in the event logs table and are updated every 24 hours.
+            </Text>
+        </>
+    )
+}

--- a/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/queries.ts
@@ -1,0 +1,39 @@
+import { gql } from '@sourcegraph/http-client'
+
+const analyticsStatItemFragment = gql`
+    fragment AnalyticsStatItemFragment on AnalyticsStatItem {
+        nodes {
+            date
+            count
+            uniqueUsers
+        }
+        summary {
+            totalCount
+            totalUniqueUsers
+        }
+    }
+`
+
+export const EXTENSIONS_STATISTICS = gql`
+    query ExtensionsStatistics($dateRange: AnalyticsDateRange!, $grouping: AnalyticsGrouping!) {
+        site {
+            analytics {
+                extensions(dateRange: $dateRange, grouping: $grouping) {
+                    jetbrains {
+                        ...AnalyticsStatItemFragment
+                    }
+                    vscode {
+                        ...AnalyticsStatItemFragment
+                    }
+                    browser {
+                        ...AnalyticsStatItemFragment
+                    }
+                }
+            }
+            users(deleted: false) {
+                totalCount
+            }
+        }
+    }
+    ${analyticsStatItemFragment}
+`

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6338,6 +6338,25 @@ type AnalyticsBatchChangesResult {
 }
 
 """
+Extentions analytics.
+"""
+type AnalyticsExtensionsResult {
+    """
+    JetBrains IDE plugin search events.
+    """
+    jetbrains: AnalyticsStatItem!
+    """
+    VsCode IDE extension search events.
+    """
+    vscode: AnalyticsStatItem!
+    """
+    Browser (chrome, firefox, safari) extensions code navigation events.
+    This includes events like "Go to Def", "Find ref" and "Find implementation"
+    """
+    browser: AnalyticsStatItem!
+}
+
+"""
 Analytics describes a new site statistics.
 """
 type Analytics {
@@ -6365,6 +6384,10 @@ type Analytics {
     Batch changes statistics
     """
     batchChanges(dateRange: AnalyticsDateRange, grouping: AnalyticsGrouping): AnalyticsBatchChangesResult!
+    """
+    Extensions statistics
+    """
+    extensions(dateRange: AnalyticsDateRange, grouping: AnalyticsGrouping): AnalyticsExtensionsResult!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/site_analytics.go
+++ b/cmd/frontend/graphqlbackend/site_analytics.go
@@ -82,3 +82,12 @@ func (r *siteAnalyticsResolver) BatchChanges(ctx context.Context, args *struct {
 }) *adminanalytics.BatchChanges {
 	return &adminanalytics.BatchChanges{DateRange: *args.DateRange, Grouping: *args.Grouping, DB: r.db, Cache: r.cache}
 }
+
+/* Extensions */
+
+func (r *siteAnalyticsResolver) Extensions(ctx context.Context, args *struct {
+	DateRange *string
+	Grouping  *string
+}) *adminanalytics.Extensions {
+	return &adminanalytics.Extensions{DateRange: *args.DateRange, Grouping: *args.Grouping, DB: r.db, Cache: r.cache}
+}

--- a/internal/adminanalytics/cache.go
+++ b/internal/adminanalytics/cache.go
@@ -106,6 +106,7 @@ func refreshAnalyticsCache(ctx context.Context, db database.DB) error {
 				&CodeIntel{DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
 				&Repos{DB: db, Cache: true},
 				&BatchChanges{Grouping: groupBy, DateRange: dateRange, DB: db, Cache: true},
+				&Extensions{Grouping: groupBy, DateRange: dateRange, DB: db, Cache: true},
 			}
 			for _, store := range stores {
 				if err := store.CacheAll(ctx); err != nil {

--- a/internal/adminanalytics/extensions.go
+++ b/internal/adminanalytics/extensions.go
@@ -1,0 +1,100 @@
+package adminanalytics
+
+import (
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+type Extensions struct {
+	DateRange string
+	Grouping  string
+	DB        database.DB
+	Cache     bool
+}
+
+func (e *Extensions) Jetbrains() (*AnalyticsFetcher, error) {
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(
+		e.DateRange,
+		e.Grouping,
+		[]string{"IDESearchSubmitted", "VSCESearchSubmitted"},
+		sqlf.Sprintf("source = 'IDEEXTENSION' AND referrer = 'JETBRAINS'"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AnalyticsFetcher{
+		db:           e.DB,
+		dateRange:    e.DateRange,
+		grouping:     e.Grouping,
+		nodesQuery:   nodesQuery,
+		summaryQuery: summaryQuery,
+		group:        "Extensions:Jetbrains",
+	}, nil
+}
+
+func (e *Extensions) Vscode() (*AnalyticsFetcher, error) {
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(
+		e.DateRange,
+		e.Grouping,
+		[]string{"IDESearchSubmitted", "VSCESearchSubmitted"},
+		sqlf.Sprintf("source = 'IDEEXTENSION' AND referrer = 'VSCE'"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AnalyticsFetcher{
+		db:           e.DB,
+		dateRange:    e.DateRange,
+		grouping:     e.Grouping,
+		nodesQuery:   nodesQuery,
+		summaryQuery: summaryQuery,
+		group:        "Extensions:Vscode",
+		cache:        e.Cache,
+	}, nil
+}
+
+func (e *Extensions) Browser() (*AnalyticsFetcher, error) {
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(
+		e.DateRange,
+		e.Grouping,
+		[]string{"goToDefinition.preloaded", "goToDefinition", "findReferences"},
+		sqlf.Sprintf("source = 'CODEHOSTINTEGRATION'"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AnalyticsFetcher{
+		db:           e.DB,
+		dateRange:    e.DateRange,
+		grouping:     e.Grouping,
+		nodesQuery:   nodesQuery,
+		summaryQuery: summaryQuery,
+		group:        "Extensions:Browser",
+		cache:        e.Cache,
+	}, nil
+}
+
+func (e *Extensions) CacheAll(ctx context.Context) error {
+	fetcherBuilders := []func() (*AnalyticsFetcher, error){e.Jetbrains, e.Vscode, e.Browser}
+	for _, buildFetcher := range fetcherBuilders {
+		fetcher, err := buildFetcher()
+		if err != nil {
+			return err
+		}
+
+		if _, err := fetcher.Nodes(ctx); err != nil {
+			return err
+		}
+
+		if _, err := fetcher.Summary(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/40349.

## Test plan
- `sg start`
- Open http://localhost:3080/site-admin/analytics/extensions

## Screenshots
| Before | After |
| --: | :-- |
| n/a |  <img width="582" alt="image" src="https://user-images.githubusercontent.com/6717049/184857388-dc52dea4-6a66-4ffc-bf86-506afcc0a8ad.png"> |
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
