### PR TITLE
Bump src-cli to 3.43.0 for upcoming release

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.42.3"
+const MinimumVersion = "3.43.0"


### PR DESCRIPTION
## Test plan

Will test executors manually later when they get a new version.