### PR TITLE
extsvc: Fix error in update with redacted config

### DIFF
--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -108,11 +108,11 @@ func (e *ExternalService) UnredactConfig(ctx context.Context, old *ExternalServi
 
 	eConfig, err := e.Config.Decrypt(ctx)
 	if err != nil || eConfig == "" {
-		return nil
+		return err
 	}
 	oldConfig, err := old.Config.Decrypt(ctx)
 	if err != nil || oldConfig == "" {
-		return nil
+		return err
 	}
 
 	if old.Kind != e.Kind {

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -117,7 +117,7 @@ func (e *ExternalService) UnredactConfig(ctx context.Context, old *ExternalServi
 
 	if old.Kind != e.Kind {
 		return errors.Errorf(
-			"UnRedactExternalServiceConfig: unmatched external service kinds, old: %q, e: %q",
+			"UnredactExternalServiceConfig: unmatched external service kinds, old: %q, e: %q",
 			old.Kind,
 			e.Kind,
 		)


### PR DESCRIPTION
#40237 accidentally began ignoring the result of the config after unredaction, making it impossible to update an extsvc via the UI. This PR fixes that mistake.

## Test plan

Existing unit tests, tested update of extsvc by hand.