### PR TITLE
Sanitise base64 encoded SVGs in Markdown rendering

### DIFF
--- a/client/common/src/util/markdown/markdown.test.ts
+++ b/client/common/src/util/markdown/markdown.test.ts
@@ -82,10 +82,10 @@ describe('renderMarkdown', () => {
     it('sanitizes event handlers', () => {
         expect(renderMarkdown('<svg><rect onclick="evil()"></rect></svg>')).toBe('<p><svg><rect></rect></svg></p>\n')
     })
-    it('sanitizes non-SVG <object> tags', () => {
+    it('does not allow arbitrary <object> tags', () => {
         expect(renderMarkdown('<object data="something"></object>')).toBe('<p></p>\n')
     })
-    it('allows SVG <object> tags', () => {
+    it('does not allow SVG <object> tags', () => {
         expect(renderMarkdown('<object data="something" type="image/svg+xml"></object>')).toBe(
             '<p><object></object></p>\n'
         )
@@ -94,15 +94,6 @@ describe('renderMarkdown', () => {
         const input =
             '<svg viewbox="10 10 10 10" width="100"><rect x="37.5" y="7.5" width="675.0" height="16.875" fill="#e05d44" stroke="white" stroke-width="1"><title>/</title></rect></svg>'
         expect(renderMarkdown(input)).toBe(`<p>${input}</p>\n`)
-    })
-
-    it('filters base64 encoded <svg> tags', () => {
-        const input_prefix =
-            '<svg viewbox="10 10 10 10" width="100"><rect x="37.5" y="7.5" width="675.0" height="16.875" fill="#e05d44" stroke="white" stroke-width="1">'
-        const input_suffix = '<title>/</title></rect></svg>'
-        const input_base64 = window.btoa(input_prefix + '<script>alert(1)</script>' + input_suffix)
-        const object = `<object type="image/svg+xml" data="data:image/svg+xml;base64,${input_base64}"></object>`
-        expect(renderMarkdown(object)).toBe('<p><object></object></p>\n')
     })
 
     describe('allowDataUriLinksAndDownloads option', () => {

--- a/client/common/src/util/markdown/markdown.test.ts
+++ b/client/common/src/util/markdown/markdown.test.ts
@@ -87,7 +87,7 @@ describe('renderMarkdown', () => {
     })
     it('allows SVG <object> tags', () => {
         expect(renderMarkdown('<object data="something" type="image/svg+xml"></object>')).toBe(
-            '<p><object data="something" type="image/svg+xml"></object></p>\n'
+            '<p><object></object></p>\n'
         )
     })
     it('allows <svg> tags', () => {
@@ -96,23 +96,13 @@ describe('renderMarkdown', () => {
         expect(renderMarkdown(input)).toBe(`<p>${input}</p>\n`)
     })
 
-    it('filters XSS from <svg> tags', () => {
-        const input_prefix =
-            '<svg viewbox="10 10 10 10" width="100"><rect x="37.5" y="7.5" width="675.0" height="16.875" fill="#e05d44" stroke="white" stroke-width="1">'
-        const xss = '<script>alert(1)</script>'
-        const input_suffix = '<title>/</title></rect></svg>'
-        expect(renderMarkdown(input_prefix + xss + input_suffix)).toBe(`<p>${input_prefix + input_suffix}</p>\n`)
-    })
-
     it('filters base64 encoded <svg> tags', () => {
         const input_prefix =
             '<svg viewbox="10 10 10 10" width="100"><rect x="37.5" y="7.5" width="675.0" height="16.875" fill="#e05d44" stroke="white" stroke-width="1">'
         const input_suffix = '<title>/</title></rect></svg>'
         const input_base64 = window.btoa(input_prefix + '<script>alert(1)</script>' + input_suffix)
         const object = `<object type="image/svg+xml" data="data:image/svg+xml;base64,${input_base64}"></object>`
-        expect(renderMarkdown(object)).toBe(
-            '<p><object data="%3Csvg%3E%3C/svg%3E" type="image/svg+xml"></object></p>\n'
-        )
+        expect(renderMarkdown(object)).toBe('<p><object></object></p>\n')
     })
 
     describe('allowDataUriLinksAndDownloads option', () => {

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -163,53 +163,49 @@ export const renderMarkdown = (
                 },
             },
             transformTags: {
-                object: function (tagName, attribs) {
-                    if (!'base64,' in attribs['data']) {
+                object (tagName, attribs) {
+                    if (!attribs.data.includes('base64,')) {
                         return {
-                            tagName: tagName,
-                            attribs: attribs,
+                            tagName,
+                            attribs,
                         }
                     }
 
-                    var data = attribs['data'].split('base64,')
+                    const b64object = attribs.data.split('base64,')[1]
 
-                    if (data.length > 0) {
-                        var b64obj = data[1]
+                    const cleaned = sanitize(window.atob(b64object), {
+                        allowedTags: sanitize.defaults.allowedTags.concat([
+                            'svg',
+                            'xmlns',
+                            'path',
+                            'picture',
+                            'circle',
+                            'pattern',
+                            'rect',
+                        ]),
+                        allowedAttributes: {
+                            svg: ['width', 'height', 'viewbox', 'version', 'preserveaspectratio', 'style'],
+                            rect: ['x', 'y', 'width', 'height', 'transform', ...svgPresentationAttributes],
+                            path: ['d', ...svgPresentationAttributes],
+                            circle: ['cx', 'cy', ...svgPresentationAttributes],
+                        },
+                        allowedStyles: {
+                            svg: {
+                                flex: ALL_VALUES_ALLOWED,
+                                'flex-grow': ALL_VALUES_ALLOWED,
+                                'flex-shrink': ALL_VALUES_ALLOWED,
+                                'flex-basis': ALL_VALUES_ALLOWED,
+                            },
+                        },
+                    })
 
-                        var cleaned = sanitize(window.atob(b64obj), {
-                            allowedTags: sanitize.defaults.allowedTags.concat([
-                                'svg',
-                                'xmlns',
-                                'path',
-                                'picture',
-                                'circle',
-                                'pattern',
-                                'rect',
-                            ]),
-                            allowedAttributes: {
-                                svg: ['width', 'height', 'viewbox', 'version', 'preserveaspectratio', 'style'],
-                                rect: ['x', 'y', 'width', 'height', 'transform', ...svgPresentationAttributes],
-                                path: ['d', ...svgPresentationAttributes],
-                                circle: ['cx', 'cy', ...svgPresentationAttributes],
-                            },
-                            allowedStyles: {
-                                svg: {
-                                    flex: ALL_VALUES_ALLOWED,
-                                    'flex-grow': ALL_VALUES_ALLOWED,
-                                    'flex-shrink': ALL_VALUES_ALLOWED,
-                                    'flex-basis': ALL_VALUES_ALLOWED,
-                                },
-                            },
-                        })
-
-                        return {
-                            tagName: tagName,
-                            attribs: {
-                                type: attribs['type'],
-                                // reconstruct cleaned base64 blob
-                                data: 'data:image/svg+xml;base64,' + window.btoa(cleaned),
-                            },
-                        }
+                    return {
+                        tagName,
+                        attribs: {
+                            type: attribs.type,
+                            // reconstruct cleaned base64 blob
+                            data: 'data:image/svg+xml;base64,' + window.btoa(cleaned),
+                        },
                     }
                 },
             },

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -124,7 +124,6 @@ export const renderMarkdown = (
                 img: [...sanitize.defaults.allowedAttributes.img, 'alt', 'width', 'height', 'align', 'style'],
                 // Support different images depending on media queries (e.g. color theme, reduced motion)
                 source: ['srcset', 'media'],
-                // Support SVGs for code insights.
                 svg: ['width', 'height', 'viewbox', 'version', 'preserveaspectratio', 'style'],
                 rect: ['x', 'y', 'width', 'height', 'transform', ...svgPresentationAttributes],
                 path: ['d', ...svgPresentationAttributes],

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -201,7 +201,7 @@ export const renderMarkdown = (
                                 },
                             },
                         })
-                    } catch (any) {
+                    } catch (error) {
                         // this doesn't happen with benign base64 SVGs
                         cleaned = '<svg></svg>'
                     }

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -162,6 +162,32 @@ export const renderMarkdown = (
                     'flex-basis': ALL_VALUES_ALLOWED,
                 },
             },
+            transformTags: {
+                object: function (tagName, attribs) {
+                    var data = attribs['data'].split('base64,')
+
+                    if (data.length > 0) {
+                        var obj = data[1]
+                        var content = sanitize(window.atob(obj), {
+                            allowedTags: sanitize.defaults.allowedTags.concat(['svg', 'xmlns', 'path', 'picture']),
+                            allowedAttributes: false,
+                        })
+
+                        return {
+                            tagName: tagName,
+                            attribs: {
+                                type: 'image/svg+xml',
+                                data: 'data:image/svg+xml;base64,' + window.btoa(content),
+                            },
+                        }
+                    } else {
+                        return {
+                            tagName: tagName,
+                            attribs: attribs,
+                        }
+                    }
+                },
+            },
         }
         if (options.allowDataUriLinksAndDownloads) {
             sanitizeOptions.allowedAttributes.a = [...sanitizeOptions.allowedAttributes.a, 'download']

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -125,7 +125,6 @@ export const renderMarkdown = (
                 // Support different images depending on media queries (e.g. color theme, reduced motion)
                 source: ['srcset', 'media'],
                 // Support SVGs for code insights.
-                object: ['data', { name: 'type', values: ['image/svg+xml'] }, 'width'],
                 svg: ['width', 'height', 'viewbox', 'version', 'preserveaspectratio', 'style'],
                 rect: ['x', 'y', 'width', 'height', 'transform', ...svgPresentationAttributes],
                 path: ['d', ...svgPresentationAttributes],
@@ -160,72 +159,6 @@ export const renderMarkdown = (
                     'flex-grow': ALL_VALUES_ALLOWED,
                     'flex-shrink': ALL_VALUES_ALLOWED,
                     'flex-basis': ALL_VALUES_ALLOWED,
-                },
-            },
-            transformTags: {
-                object(tagName, attribs) {
-                    if (attribs.data.toLowerCase().includes(';base64,')) {
-                        return {
-                            tagName,
-                            attribs: {
-                                data: encodeURI('<svg></svg>'),
-                                type: attribs.type,
-                            },
-                        }
-                    }
-
-                    const index = attribs.data.indexOf(',')
-                    let data: string
-                    let data_prefix = ''
-
-                    if (index > -1) {
-                        const data_split = attribs.data.split(',')
-                        data_prefix = data_split[0] + ','
-                        data = data_split[1]
-                    } else {
-                        data = attribs.data
-                    }
-                    let cleaned
-
-                    try {
-                        cleaned = sanitize(decodeURI(data), {
-                            allowedTags: sanitize.defaults.allowedTags.concat([
-                                'svg',
-                                'path',
-                                'picture',
-                                'circle',
-                                'pattern',
-                                'rect',
-                            ]),
-                            allowedAttributes: {
-                                svg: ['width', 'height', 'viewbox', 'version', 'preserveaspectratio', 'style'],
-                                rect: ['x', 'y', 'width', 'height', 'transform', ...svgPresentationAttributes],
-                                path: ['d', ...svgPresentationAttributes],
-                                circle: ['cx', 'cy', ...svgPresentationAttributes],
-                            },
-                            allowedStyles: {
-                                svg: {
-                                    flex: ALL_VALUES_ALLOWED,
-                                    'flex-grow': ALL_VALUES_ALLOWED,
-                                    'flex-shrink': ALL_VALUES_ALLOWED,
-                                    'flex-basis': ALL_VALUES_ALLOWED,
-                                },
-                            },
-                        })
-                    } catch (error) {
-                        // this doesn't happen with benign SVGs
-                        console.error(error)
-                        cleaned = '<svg></svg>'
-                    }
-
-                    return {
-                        tagName,
-                        attribs: {
-                            // reconstruct cleaned SVG
-                            data: data_prefix + encodeURIComponent(cleaned),
-                            type: attribs.type,
-                        },
-                    }
                 },
             },
         }

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -203,6 +203,7 @@ export const renderMarkdown = (
                         })
                     } catch (error) {
                         // this doesn't happen with benign base64 SVGs
+                        console.error(error)
                         cleaned = '<svg></svg>'
                     }
 

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -163,7 +163,7 @@ export const renderMarkdown = (
                 },
             },
             transformTags: {
-                object (tagName, attribs) {
+                object(tagName, attribs) {
                     if (!attribs.data.includes('base64,')) {
                         return {
                             tagName,
@@ -171,33 +171,40 @@ export const renderMarkdown = (
                         }
                     }
 
-                    const b64object = attribs.data.split('base64,')[1]
+                    // Anchor tags can be used to invalidate base64 and bypass filters
+                    const b64object = attribs.data.split('base64,')[1].split('#')[0]
+                    let cleaned
 
-                    const cleaned = sanitize(window.atob(b64object), {
-                        allowedTags: sanitize.defaults.allowedTags.concat([
-                            'svg',
-                            'xmlns',
-                            'path',
-                            'picture',
-                            'circle',
-                            'pattern',
-                            'rect',
-                        ]),
-                        allowedAttributes: {
-                            svg: ['width', 'height', 'viewbox', 'version', 'preserveaspectratio', 'style'],
-                            rect: ['x', 'y', 'width', 'height', 'transform', ...svgPresentationAttributes],
-                            path: ['d', ...svgPresentationAttributes],
-                            circle: ['cx', 'cy', ...svgPresentationAttributes],
-                        },
-                        allowedStyles: {
-                            svg: {
-                                flex: ALL_VALUES_ALLOWED,
-                                'flex-grow': ALL_VALUES_ALLOWED,
-                                'flex-shrink': ALL_VALUES_ALLOWED,
-                                'flex-basis': ALL_VALUES_ALLOWED,
+                    try {
+                        cleaned = sanitize(window.atob(b64object), {
+                            allowedTags: sanitize.defaults.allowedTags.concat([
+                                'svg',
+                                'xmlns',
+                                'path',
+                                'picture',
+                                'circle',
+                                'pattern',
+                                'rect',
+                            ]),
+                            allowedAttributes: {
+                                svg: ['width', 'height', 'viewbox', 'version', 'preserveaspectratio', 'style'],
+                                rect: ['x', 'y', 'width', 'height', 'transform', ...svgPresentationAttributes],
+                                path: ['d', ...svgPresentationAttributes],
+                                circle: ['cx', 'cy', ...svgPresentationAttributes],
                             },
-                        },
-                    })
+                            allowedStyles: {
+                                svg: {
+                                    flex: ALL_VALUES_ALLOWED,
+                                    'flex-grow': ALL_VALUES_ALLOWED,
+                                    'flex-shrink': ALL_VALUES_ALLOWED,
+                                    'flex-basis': ALL_VALUES_ALLOWED,
+                                },
+                            },
+                        })
+                    } catch (any) {
+                        // this doesn't happen with benign base64 SVGs
+                        cleaned = '<svg></svg>'
+                    }
 
                     return {
                         tagName,


### PR DESCRIPTION
Added code to sanitise base64 encoded SVGs to prevent XSS. The SVGs are used in multiple places like code-insights, notebooks and extensions.

## Test plan

- [ ] test with code insights SVGs

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vincent-xss-data-sanitize.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dnzmokjczc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

