### PR TITLE
batches: Handle unbalanced quote

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
@@ -1,4 +1,10 @@
-import { excludeRepo, haveMatchingWorkspaces, insertFieldIntoLibraryItem, quoteYAMLString } from './yaml-util'
+import {
+    excludeRepo,
+    haveMatchingWorkspaces,
+    insertFieldIntoLibraryItem,
+    insertQueryIntoLibraryItem,
+    quoteYAMLString,
+} from './yaml-util'
 
 const SPEC_WITH_ONE_REPOSITORY = `name: hello-world
 on:
@@ -338,6 +344,80 @@ describe('Batch spec yaml utils', () => {
                     SPEC_WITH_ONE_REPOSITORY.replace('hello-world', newName)
                 )
             }
+        })
+    })
+
+    describe('insertQueryIntoLibraryItem', () => {
+        it('should add simple query', () => {
+            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global hello patternType:standard')
+            expect(spec).toEqual(
+                'name: hello-world\n' +
+                    'on:\n' +
+                    '    - repositoriesMatchingQuery: context:global hello patternType:standard\n\n'
+            )
+        })
+
+        it('should add quoted query', () => {
+            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global "hello" patternType:standard')
+            expect(spec).toEqual(
+                'name: hello-world\n' +
+                    'on:\n' +
+                    '    - repositoriesMatchingQuery: context:global "hello" patternType:standard\n\n'
+            )
+        })
+
+        it('should add unbalanced quoted query', () => {
+            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global "hello patternType:standard')
+            expect(spec).toEqual(
+                'name: hello-world\n' +
+                    'on:\n' +
+                    '    - repositoriesMatchingQuery: context:global "hello patternType:standard\n\n'
+            )
+        })
+
+        it('should add query with colon', () => {
+            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global hello: world patternType:standard')
+            expect(spec).toEqual(
+                'name: hello-world\n' +
+                    'on:\n' +
+                    '    - repositoriesMatchingQuery: "context:global hello: world patternType:standard"\n\n'
+            )
+        })
+
+        it('should add query with colon and quotes', () => {
+            const spec = insertQueryIntoLibraryItem(
+                SPEC_WITH_QUERY,
+                'context:global hello: "world" patternType:standard'
+            )
+            expect(spec).toEqual(
+                'name: hello-world\n' +
+                    'on:\n' +
+                    '    - repositoriesMatchingQuery: "context:global hello: \\"world\\" patternType:standard"\n\n'
+            )
+        })
+
+        it('should add query with colon and unbalanced quotes', () => {
+            const spec = insertQueryIntoLibraryItem(
+                SPEC_WITH_QUERY,
+                'context:global hello: "world patternType:standard'
+            )
+            expect(spec).toEqual(
+                'name: hello-world\n' +
+                    'on:\n' +
+                    '    - repositoriesMatchingQuery: "context:global hello: \\"world patternType:standard"\n\n'
+            )
+        })
+
+        it('should add query with colon and double unbalanced quotes', () => {
+            const spec = insertQueryIntoLibraryItem(
+                SPEC_WITH_QUERY,
+                'context:global "hello": "world patternType:standard'
+            )
+            expect(spec).toEqual(
+                'name: hello-world\n' +
+                    'on:\n' +
+                    '    - repositoriesMatchingQuery: "context:global \\"hello\\": \\"world patternType:standard"\n\n'
+            )
         })
     })
 

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -363,8 +363,12 @@ export function quoteYAMLString(value: string): string {
         needsQuotes = true
 
         // We don't bail out here, we assume some characters in the value needs escaping,
-        // we set the value of `needsEscaping` to true
-        if (!isYAMLMap(ast) || ast.errors.length > 0) {
+        // we set the value of `needsEscaping` to true.
+        // Also, check if there are more than one mapping. If there are, then the string value has a colon in it and an
+        // unbalanced quote - for example, "name": "value
+        // The unbalanced quote tricks the second load to think it is valid YAML since the value is closed with the
+        // ending quote.
+        if (!isYAMLMap(ast) || ast.errors.length > 0 || ast.mappings.length > 1) {
             needsQuotes = false
             needsEscaping = true
         }


### PR DESCRIPTION
Closes #40415.

A search query that contains a colon (`:`) and unbalanced quotes (`"foo`) causes an edge case where the string does not get escaped properly.

Take the example search query - `"license": "Apache-2.0`.

When determining whether to escape this string, when the value is tested to be loaded with double quotes (after failing the test load with no quotes) . This causes the YAML to be loaded/parsed successfully (it makes the YAML parser think there are 2 separate mappings instead of 1).

The logic,
1. `name: context:global "license": "Apache-2.0 patternType:standard` fails to be parsed.
2. Try to parse `name: "context:global "license": "Apache-2.0 patternType:standard"`
3. The new YAML is parsed successfully with 2 mappings
    * `name: "context:global "`
    * `license": ""Apache-2.0 patternType:standard"`
4. The logic decides there is no need to escape any quotes since everything is parsed correctly.

I updated the code to check if there are more than one mappings. I assume that since we are trying to escape a string that there should only ever be a single mapping.

## Test plan

Added new Jest Unit Tests and did functional testing.
![Screen Shot 2022-08-16 at 09 58 29](https://user-images.githubusercontent.com/38407415/184927885-32ce853b-80d0-46fa-8af9-94d6f985cb5f.png)


## App preview:

- [Web](https://sg-web-rc-search-batch-change-quote.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tyjnvaxmrf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
