### PR TITLE
admin-analytics: make user management enabled by default

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -15,7 +15,7 @@ export type FeatureFlagName =
     | 'admin-analytics-disabled'
     | 'admin-analytics-cache-disabled'
     | 'ab-lucky-search' // To be removed at latest by 12/2022.
-    | 'user-management'
+    | 'user-management-disabled'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/FeatureFlaggedUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/FeatureFlaggedUsersPage.tsx
@@ -4,4 +4,8 @@ import { UsersManagement } from './UserManagement'
 
 import { SiteAdminAllUsersPage } from '.'
 
-export const FeatureFlaggedUsersPage = withFeatureFlag('user-management', UsersManagement, SiteAdminAllUsersPage)
+export const FeatureFlaggedUsersPage = withFeatureFlag(
+    'user-management-disabled',
+    SiteAdminAllUsersPage,
+    UsersManagement
+)

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersSummary.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersSummary.tsx
@@ -22,18 +22,11 @@ export const UsersSummary: React.FunctionComponent = () => {
 
         const legends: ValueLegendListProps['items'] = [
             {
-                value: data.registeredUsers.totalCount,
+                value: data.site.registeredUsers.totalCount,
                 description: 'Registered Users',
                 color: 'var(--purple)',
                 position: 'left',
-                tooltip: 'Total number of not-deleted users.',
-            },
-            {
-                value: data.site.users.totalCount,
-                description: 'Total Users',
-                color: 'var(--body-color)',
-                position: 'right',
-                tooltip: 'Total number of all users. This includes those who were soft deleted.',
+                tooltip: 'Total number of registered and not deleted users.',
             },
             {
                 value: data.site.productSubscription.license?.userCount ?? 0,

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/queries.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/queries.tsx
@@ -11,12 +11,9 @@ export const USERS_MANAGEMENT_SUMMARY = gql`
             adminUsers: users(siteAdmin: true, deleted: false) {
                 totalCount
             }
-            users {
+            registeredUsers: users(deleted: false) {
                 totalCount
             }
-        }
-        registeredUsers: users {
-            totalCount
         }
     }
 `

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-dom-props */
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import classNames from 'classnames'
 
@@ -16,23 +16,29 @@ interface ValueLegendItemProps {
     tooltip?: string
 }
 
-const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({ value, color, description, tooltip }) => (
-    <div className="d-flex flex-column align-items-center mr-4 justify-content-center">
-        <span style={{ color }} className={styles.count}>
-            {formatNumber(value)}
-        </span>
-        <Tooltip content={tooltip}>
-            <Text
-                as="span"
-                alignment="center"
-                className={classNames(styles.textWrap, tooltip && 'cursor-pointer', 'text-muted')}
-            >
-                {description}
-                {tooltip && <span className={styles.linkColor}>*</span>}
-            </Text>
-        </Tooltip>
-    </div>
-)
+const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({ value, color, description, tooltip }) => {
+    const formattedNumber = useMemo(() => formatNumber(value), [value])
+    const unformattedNumber = `${value}`
+    return (
+        <div className="d-flex flex-column align-items-center mr-4 justify-content-center">
+            <Tooltip content={formattedNumber !== unformattedNumber ? unformattedNumber : undefined}>
+                <span style={{ color }} className={styles.count}>
+                    {formattedNumber}
+                </span>
+            </Tooltip>
+            <Tooltip content={tooltip}>
+                <Text
+                    as="span"
+                    alignment="center"
+                    className={classNames(styles.textWrap, tooltip && 'cursor-pointer', 'text-muted')}
+                >
+                    {description}
+                    {tooltip && <span className={styles.linkColor}>*</span>}
+                </Text>
+            </Tooltip>
+        </div>
+    )
+}
 
 export interface ValueLegendListProps {
     className?: string


### PR DESCRIPTION
This PR:
- Make user management enabled by default
- Add tooltips to legend formatted numbers
- Remove the "Total users" value

## Test plan
- `sg start`
- open http://localhost:3080/site-admin/users
  - Check that the NEW user management is rendered
- Open http://localhost:3080/site-admin/users?feature-flag-key=user-management-disabled&feature-flag-value=true
  - Check that the OLD user management is rendered
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
