### PR TITLE
tracer: make 'jaeger' the default, deprecate 'opentracing' option

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1296,7 +1296,7 @@ type ObservabilityTracing struct {
 	Debug bool `json:"debug,omitempty"`
 	// Sampling description: Determines the requests for which distributed traces are recorded. "none" (default) turns off tracing entirely. "selective" sends traces whenever `?trace=1` is present in the URL. "all" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. An appropriate tracing backend must be running for traces to be collected (for "opentracing", a Jaeger instance must be running as described in the Sourcegraph installation instructions). Additional downsampling can be configured in tracing backend (for Jaeger, see https://www.jaegertracing.io/docs/1.17/sampling).
 	Sampling string `json:"sampling,omitempty"`
-	// Type description: Determines what tracing provider to enable. For "opentracing", the required backend is a Jaeger instance. For "opentelemetry" (EXPERIMENTAL), the required backend is a OpenTelemetry collector instance. "datadog" support has been removed, and the configuration option will be removed in a future release.
+	// Type description: Determines what tracing provider to enable. For "jaeger", a Jaeger instance is required. For "opentelemetry" (EXPERIMENTAL), the required backend is a OpenTelemetry collector instance. "datadog" and "opentracing" options are deprecated, and the configuration option will be removed in a future release.
 	Type string `json:"type,omitempty"`
 	// UrlTemplate description: Template for linking to trace URLs - '{{ .TraceID }}' is replaced with the trace ID, and {{ .ExternalURL }} is replaced with the value of 'externalURL'.
 	UrlTemplate string `json:"urlTemplate,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1210,10 +1210,10 @@
       "type": "object",
       "properties": {
         "type": {
-          "description": "Determines what tracing provider to enable. For \"opentracing\", the required backend is a Jaeger instance. For \"opentelemetry\" (EXPERIMENTAL), the required backend is a OpenTelemetry collector instance. \"datadog\" support has been removed, and the configuration option will be removed in a future release.",
+          "description": "Determines what tracing provider to enable. For \"jaeger\", a Jaeger instance is required. For \"opentelemetry\" (EXPERIMENTAL), the required backend is a OpenTelemetry collector instance. \"datadog\" and \"opentracing\" options are deprecated, and the configuration option will be removed in a future release.",
           "type": "string",
-          "enum": ["opentracing", "opentelemetry", "datadog"],
-          "default": "opentracing"
+          "enum": ["jaeger", "opentelemetry", "opentracing", "datadog"],
+          "default": "jaeger"
         },
         "sampling": {
           "description": "Determines the requests for which distributed traces are recorded. \"none\" (default) turns off tracing entirely. \"selective\" sends traces whenever `?trace=1` is present in the URL. \"all\" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. An appropriate tracing backend must be running for traces to be collected (for \"opentracing\", a Jaeger instance must be running as described in the Sourcegraph installation instructions). Additional downsampling can be configured in tracing backend (for Jaeger, see https://www.jaegertracing.io/docs/1.17/sampling).",


### PR DESCRIPTION
See inline docstrings. This will also simplify things a bit when we cut over to otelcollector-by-default

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a