### PR TITLE
doc/admin: clean up tracing documentation

### DIFF
--- a/doc/admin/observability/tracing.md
+++ b/doc/admin/observability/tracing.md
@@ -1,8 +1,42 @@
 # Tracing
 
-## Prerequisites
+In site configuration, you can enable tracing globally by configuring a sampling mode in `observability.tracing`.
+There are currently three modes:
 
-### 1. Ensure Jaeger is running.
+* `"sampling": "selective"` (default) will cause a trace to be recorded only when `trace=1` is present as a URL parameter.
+* `"sampling": "all"` will cause a trace to be recorded on every request.
+* `"sampling": "none"` will disable all tracing.
+
+`"selective"` is the recommended default, because collecting traces on all requests can be quite memory- and network-intensive.
+If you have a large Sourcegraph instance (e.g,. more than 10k repositories), turn this on with caution.
+Note that the policies above are implemented at an application level - to sample all traces, please configure your tracing backend directly.
+
+We support the following tracing backend types:
+
+* [`"type": "jaeger"`](#jaeger) (default)
+* [`"type": "opentelemetry"](#opentelemetry) <span class="badge badge-experimental">Experimental</span>
+
+In addition, we also export some tracing [via net/trace](#nettrace).
+
+## Trace a search query
+
+To trace a search query, run a search on your Sourcegraph instance with the `?trace=1` query parameter.
+A link to the [exported trace](#tracing-backends) should be show up in the search results:
+
+![link to trace](https://user-images.githubusercontent.com/23356519/184953302-099bcb62-ccdb-4eed-be5d-801b7fe16d97.png)
+
+## Trace GraphQL requests
+
+To receive a traceID on a GraphQL request, include the header `X-Sourcegraph-Should-Trace: true` with the request.
+The response headers of the response will now include an `x-trace` entry, which will have a URL the [exported trace](#tracing-backends).
+
+## Tracing backends
+
+Tracing backends can be configured for Sourcegraph to export traces to.
+
+### Jaeger
+
+To configure Jaeger, first ensure Jeager is running:
 
 * **Single Docker container:** Jaeger will be integrated into the Sourcegraph single Docker container starting in 3.16.
 * **Docker Compose:** Jaeger is deployed if you use the provided `docker-compose.yaml`. Access it at
@@ -11,62 +45,25 @@
   browser. You must also [enable tracing](../deploy/docker-compose/index.md#enable-tracing).
 * **Kubernetes:** Jaeger is already deployed, unless you explicitly removed it from the Sourcegraph
   manifest. Jaeger can be accessed from the admin UI under Maintenance/Tracing. Or by running `kubectl port-forward svc/jaeger-query 16686` and going to
-  `http://localhost:16686` in your browser. 
-  
+  `http://localhost:16686` in your browser.
 
 The Jaeger UI should look something like this:
 
 ![Jaeger UI](https://user-images.githubusercontent.com/1646931/79700938-0586c600-824e-11ea-9c8c-a115df8b3a21.png)
 
-### 2. Turn on sending traces to Jaeger from Sourcegraph:
+Then, configure Jaeger as your tracing backend in site configuration:
 
-1. Go to [site configuration](../config/site_config.md), add the following, and save:
+```json
+{
+  "observability.tracing": {
+    "type": "jaeger"
+  }
+}
+```
 
-   ```
-   "observability.tracing": {
-     "sampling": "selective"
-   }
-   ```
-1. Go to Sourcegraph in your browser and do a search.
-1. Open Chrome dev tools.
-1. Append either `?trace=1` (in the case its first URL query param) or `&trace=1` (if other URL query params exist) to the end of the URL and hit `Enter`.
-1. In the Chrome dev tools Network tab, find the `graphql?Search` or `stream?` request. Click it and click on the
-   `Headers` tab. The value of the `x-trace` Response Header should be a trace ID, e.g.,
-   `7edb43f744c42fbf`.
+You can test the exporter by [tracing a search query](#trace-a-search-query).
 
-## Using Jaeger
-
-In site configuration, you can configure the Jaeger client to use different sampling modes. There
-are currently two modes:
-
-* `"selective"` (recommend) will cause a trace to be recorded only when `trace=1` is present as a
-  URL parameter.
-* `"all"` will cause a trace to be recorded on every request.
-
-`"selective"` is the recommended default, because collecting traces on all requests can be quite
-memory- and network-intensive. If you have a large Sourcegraph instance (e.g,. more than 10k
-repositories), turn this on with caution. You may need to increase the memory/CPU quota for the
-Jaeger instance or [set a downsampling rate in Jaeger
-itself](https://www.jaegertracing.io/docs/1.17/sampling/), and even then, the volume of network
-traffic caused by Jaeger spans being sent to the collector may disrupt the performance of the
-overall Sourcegraph instance.
-
-## Using Datadog (experimental)
-
-Modify the site configuration to specify type "datadog" within `observability.tracing`.
-
-  ```
-   "observability.tracing": {
-     "type": "datadog"
-   }
-  ```
-When Datadog tracing is enabled, the `sampling` field currently has no effect.
-
-### GraphQL Requests
-
-To receive a traceID on a GraphQL request, include the header `X-Sourcegraph-Should-Trace: true` with the request. The response headers of the response will now include an `x-trace` entry, which will have a URL to a Jaeger trace (e.g. `https://sourcegraph.example.com/-/debug/jaeger/trace/<trace_id>`).
-
-### Jaeger debugging algorithm
+#### Jaeger debugging algorithm
 
 Jaeger is a powerful debugging tool that can break down where time is spent over the lifecycle of a
 request and help pinpoint the source of high latency or errors. We generally follow the following
@@ -86,6 +83,13 @@ algorithm to root-cause issues with Jaeger:
 1. Report this information to Sourcegraph by screenshotting the relevant trace or by downloading the
    trace JSON.
 
+
+## OpenTelemetry
+
+<span class="badge badge-experimental">Experimental</span>
+
+> NOTE: Documentation coming soon!
+
 ## net/trace
 
 Sourcegraph uses the [`net/trace`](https://pkg.go.dev/golang.org/x/net/trace) package in its backend
@@ -94,8 +98,3 @@ alternative when Jaeger is not available or as a supplement to Jaeger.
 
 Site admins can access `net/trace` information at https://sourcegraph.example.com/-/debug/. From
 there, click **Requests** to view the traces for that service.
-
-## Use an external Jaeger instance
-See the following docs on how to connect Sourcegraph to an external Jaeger instance:
-  1. [For Kubernetes Deployments](../deploy/kubernetes/configure.md)
-  2. For Docker-Compose Deployments - Currently not available

--- a/doc/admin/observability/tracing.md
+++ b/doc/admin/observability/tracing.md
@@ -14,7 +14,7 @@ Note that the policies above are implemented at an application level - to sample
 We support the following tracing backend types:
 
 * [`"type": "jaeger"`](#jaeger) (default)
-* [`"type": "opentelemetry"](#opentelemetry) <span class="badge badge-experimental">Experimental</span>
+* [`"type": "opentelemetry"`](#opentelemetry) <span class="badge badge-experimental">Experimental</span>
 
 In addition, we also export some tracing [via net/trace](#nettrace).
 
@@ -84,13 +84,13 @@ algorithm to root-cause issues with Jaeger:
    trace JSON.
 
 
-## OpenTelemetry
+### OpenTelemetry
 
 <span class="badge badge-experimental">Experimental</span>
 
 > NOTE: Documentation coming soon!
 
-## net/trace
+### net/trace
 
 Sourcegraph uses the [`net/trace`](https://pkg.go.dev/golang.org/x/net/trace) package in its backend
 services. This provides simple tracing information within a single process. It can be used as an

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1296,7 +1296,7 @@ type ObservabilityTracing struct {
 	Debug bool `json:"debug,omitempty"`
 	// Sampling description: Determines the requests for which distributed traces are recorded. "none" (default) turns off tracing entirely. "selective" sends traces whenever `?trace=1` is present in the URL. "all" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. An appropriate tracing backend must be running for traces to be collected (for "opentracing", a Jaeger instance must be running as described in the Sourcegraph installation instructions). Additional downsampling can be configured in tracing backend (for Jaeger, see https://www.jaegertracing.io/docs/1.17/sampling).
 	Sampling string `json:"sampling,omitempty"`
-	// Type description: Determines what tracing provider to enable. For "opentracing", the required backend is a Jaeger instance. For "opentelemetry" (EXPERIMENTAL), the required backend is a OpenTelemetry collector instance. "datadog" support has been removed, and the configuration option will be removed in a future release.
+	// Type description: Determines what tracing provider to enable. For "jaeger", a Jaeger instance is required. For "opentelemetry" (EXPERIMENTAL), the required backend is a OpenTelemetry collector instance. "datadog" and "opentracing" options are deprecated, and the configuration option will be removed in a future release.
 	Type string `json:"type,omitempty"`
 	// UrlTemplate description: Template for linking to trace URLs - '{{ .TraceID }}' is replaced with the trace ID, and {{ .ExternalURL }} is replaced with the value of 'externalURL'.
 	UrlTemplate string `json:"urlTemplate,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1210,10 +1210,10 @@
       "type": "object",
       "properties": {
         "type": {
-          "description": "Determines what tracing provider to enable. For \"opentracing\", the required backend is a Jaeger instance. For \"opentelemetry\" (EXPERIMENTAL), the required backend is a OpenTelemetry collector instance. \"datadog\" support has been removed, and the configuration option will be removed in a future release.",
+          "description": "Determines what tracing provider to enable. For \"jaeger\", a Jaeger instance is required. For \"opentelemetry\" (EXPERIMENTAL), the required backend is a OpenTelemetry collector instance. \"datadog\" and \"opentracing\" options are deprecated, and the configuration option will be removed in a future release.",
           "type": "string",
-          "enum": ["opentracing", "opentelemetry", "datadog"],
-          "default": "opentracing"
+          "enum": ["jaeger", "opentelemetry", "opentracing", "datadog"],
+          "default": "jaeger"
         },
         "sampling": {
           "description": "Determines the requests for which distributed traces are recorded. \"none\" (default) turns off tracing entirely. \"selective\" sends traces whenever `?trace=1` is present in the URL. \"all\" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. An appropriate tracing backend must be running for traces to be collected (for \"opentracing\", a Jaeger instance must be running as described in the Sourcegraph installation instructions). Additional downsampling can be configured in tracing backend (for Jaeger, see https://www.jaegertracing.io/docs/1.17/sampling).",


### PR DESCRIPTION
Restructures the docs (right now it's all over the place), removes datadog (functionality has been removed), adds a mention of OpenTelemetry (experimental). Also see https://github.com/sourcegraph/sourcegraph/pull/40442 which outlines the goal here (move towards "Jaeger is just a backend, and with 4.0 you can still have Jaeger, just via the opentelemetry collector)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg run docsite`

<img width="1119" alt="image" src="https://user-images.githubusercontent.com/23356519/184954529-ce52e477-e2ad-48eb-901c-063ddbd929bd.png">
