### PR TITLE
Server-side part of src-cli cleanup for 4.0

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.tsx
@@ -150,6 +150,11 @@ export class MonacoBatchSpecEditor extends React.PureComponent<Props, State> {
 
 function setDiagnosticsOptions(editor: typeof monaco, batchChangeName: string): void {
     const schema = cloneDeep(batchSpecSchemaJSON)
+    // We don't allow env forwarding in src-cli so we remove it from the schema
+    // so that monaco can show the error inline.
+    schema.properties.steps.items.properties.env.oneOf[2].items!.oneOf = schema.properties.steps.items.properties.env.oneOf[2].items!.oneOf.filter(
+        type => type.type !== 'string'
+    )
 
     // Temporarily remove the mount field from the schema, so it does not show up in the auto-suggestion.
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.tsx
@@ -150,11 +150,6 @@ export class MonacoBatchSpecEditor extends React.PureComponent<Props, State> {
 
 function setDiagnosticsOptions(editor: typeof monaco, batchChangeName: string): void {
     const schema = cloneDeep(batchSpecSchemaJSON)
-    // We don't allow env forwarding in src-cli so we remove it from the schema
-    // so that monaco can show the error inline.
-    schema.properties.steps.items.properties.env.oneOf[2].items!.oneOf = schema.properties.steps.items.properties.env.oneOf[2].items!.oneOf.filter(
-        type => type.type !== 'string'
-    )
 
     // Temporarily remove the mount field from the schema, so it does not show up in the auto-suggestion.
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -215,11 +215,7 @@ func (r *Resolver) ResolveWorkspacesForBatchSpec(ctx context.Context, args *grap
 	}
 
 	// Parse the batch spec.
-	evaluatableSpec, err := batcheslib.ParseBatchSpec([]byte(args.BatchSpec), batcheslib.ParseBatchSpecOptions{
-		AllowTransformChanges:  true,
-		AllowConditionalExec:   true,
-		AllowArrayEnvironments: true,
-	})
+	evaluatableSpec, err := batcheslib.ParseBatchSpec([]byte(args.BatchSpec))
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -65,12 +65,6 @@ func (r *batchSpecWorkspaceCreator) process(
 	}
 
 	evaluatableSpec, err := batcheslib.ParseBatchSpec([]byte(spec.RawSpec))
-	// TODO: What about this?
-	// , batcheslib.ParseBatchSpecOptions{
-	// 	// The global env is always mocked to be empty for executors, so we just
-	// 	// want to throw a validation error here for now.
-	// 	AllowArrayEnvironments: false,
-	// })
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -64,13 +64,13 @@ func (r *batchSpecWorkspaceCreator) process(
 		return err
 	}
 
-	evaluatableSpec, err := batcheslib.ParseBatchSpec([]byte(spec.RawSpec), batcheslib.ParseBatchSpecOptions{
-		AllowTransformChanges: true,
-		AllowConditionalExec:  true,
-		// The global env is always mocked to be empty for executors, so we just
-		// want to throw a validation error here for now.
-		AllowArrayEnvironments: false,
-	})
+	evaluatableSpec, err := batcheslib.ParseBatchSpec([]byte(spec.RawSpec))
+	// TODO: What about this?
+	// , batcheslib.ParseBatchSpecOptions{
+	// 	// The global env is always mocked to be empty for executors, so we just
+	// 	// want to throw a validation error here for now.
+	// 	AllowArrayEnvironments: false,
+	// })
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -469,6 +469,18 @@ func (s *Service) createBatchSpecForExecution(ctx context.Context, tx *store.Sto
 		return errors.New("mounts are not allowed for server-side processing")
 	}
 
+	// The global env is always mocked to be empty for executors, so we just
+	// want to throw a validation error here for now.
+	var errs error
+	for i, step := range opts.spec.Spec.Steps {
+		if !step.Env.IsStatic() {
+			errs = errors.Append(errs, batcheslib.NewValidationError(errors.Errorf("step %d includes one or more dynamic environment variables, which are unsupported in this Sourcegraph version", i+1)))
+		}
+	}
+	if errs != nil {
+		return errs
+	}
+
 	opts.spec.CreatedFromRaw = true
 	opts.spec.AllowIgnored = opts.allowIgnored
 	opts.spec.AllowUnsupported = opts.allowUnsupported

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -175,7 +175,7 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 		return nil, errors.Wrap(err, "marshalling name")
 	}
 	// TODO: Should name require a minimum length?
-	spec, err := batcheslib.ParseBatchSpec(rawSpec, batcheslib.ParseBatchSpecOptions{})
+	spec, err := batcheslib.ParseBatchSpec(rawSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 		return nil, errors.Wrap(err, "marshalling name")
 	}
 
-	spec, err := batcheslib.ParseBatchSpec(rawSpec, batcheslib.ParseBatchSpecOptions{})
+	spec, err := batcheslib.ParseBatchSpec(rawSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/batches/types/batch_spec.go
+++ b/enterprise/internal/batches/types/batch_spec.go
@@ -12,12 +12,7 @@ import (
 func NewBatchSpecFromRaw(rawSpec string) (_ *BatchSpec, err error) {
 	c := &BatchSpec{RawSpec: rawSpec}
 
-	c.Spec, err = batcheslib.ParseBatchSpec([]byte(rawSpec), batcheslib.ParseBatchSpecOptions{
-		// Backend always supports all latest features.
-		AllowArrayEnvironments: true,
-		AllowTransformChanges:  true,
-		AllowConditionalExec:   true,
-	})
+	c.Spec, err = batcheslib.ParseBatchSpec([]byte(rawSpec))
 
 	return c, err
 }

--- a/lib/batches/batch_spec_test.go
+++ b/lib/batches/batch_spec_test.go
@@ -28,7 +28,7 @@ changesetTemplate:
   published: false
 `
 
-		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{})
+		_, err := ParseBatchSpec([]byte(spec))
 		if err != nil {
 			t.Fatalf("parsing valid spec returned error: %s", err)
 		}
@@ -45,7 +45,7 @@ steps:
     container: alpine:3
 `
 
-		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{})
+		_, err := ParseBatchSpec([]byte(spec))
 		if err == nil {
 			t.Fatal("no error returned")
 		}
@@ -75,7 +75,7 @@ changesetTemplate:
   published: false
 `
 
-		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{})
+		_, err := ParseBatchSpec([]byte(spec))
 		if err == nil {
 			t.Fatal("no error returned")
 		}
@@ -83,38 +83,6 @@ changesetTemplate:
 		// We expect this error to be user-friendly, which is why we test for
 		// it specifically here.
 		wantErr := `The batch change name can only contain word characters, dots and dashes. No whitespace or newlines allowed.`
-		haveErr := err.Error()
-		if haveErr != wantErr {
-			t.Fatalf("wrong error. want=%q, have=%q", wantErr, haveErr)
-		}
-	})
-
-	t.Run("uses unsupported conditional exec", func(t *testing.T) {
-		const spec = `
-name: hello-world
-description: Add Hello World to READMEs
-on:
-  - repositoriesMatchingQuery: file:README.md
-steps:
-  - run: echo Hello World | tee -a $(find -name README.md)
-    if: "false"
-    container: alpine:3
-
-changesetTemplate:
-  title: Hello World
-  body: My first batch change!
-  branch: hello-world
-  commit:
-    message: Append Hello World to all README.md files
-  published: false
-`
-
-		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{})
-		if err == nil {
-			t.Fatal("no error returned")
-		}
-
-		wantErr := `step 1 in batch spec uses the 'if' attribute for conditional execution, which is not supported in this Sourcegraph version`
 		haveErr := err.Error()
 		if haveErr != wantErr {
 			t.Fatalf("wrong error. want=%q, have=%q", wantErr, haveErr)
@@ -154,7 +122,7 @@ changesetTemplate:
 			{raw: `foobar`, want: "foobar"},
 		} {
 			spec := fmt.Sprintf(specTemplate, tt.raw)
-			batchSpec, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{AllowConditionalExec: true})
+			batchSpec, err := ParseBatchSpec([]byte(spec))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -185,7 +153,7 @@ changesetTemplate:
   published: false
 `
 
-		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{})
+		_, err := ParseBatchSpec([]byte(spec))
 		if err == nil {
 			t.Fatal("no error returned")
 		}
@@ -217,7 +185,7 @@ changesetTemplate:
   commit:
     message: Test
 `
-		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{})
+		_, err := ParseBatchSpec([]byte(spec))
 		assert.Equal(t, "step 1 mount path contains invalid characters", err.Error())
 	})
 
@@ -238,7 +206,7 @@ changesetTemplate:
   commit:
     message: Test
 `
-		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{})
+		_, err := ParseBatchSpec([]byte(spec))
 		assert.Equal(t, "step 1 mount mountpoint contains invalid characters", err.Error())
 	})
 }

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -168,8 +168,5 @@ func ChangesetSpecsFromCache(spec *batches.BatchSpec, r batches.Repository, resu
 		Path:             path,
 	}
 
-	return batches.BuildChangesetSpecs(input, batches.ChangesetSpecFeatureFlags{
-		IncludeAutoAuthorDetails: true,
-		AllowOptionalPublished:   true,
-	})
+	return batches.BuildChangesetSpecs(input)
 }


### PR DESCRIPTION
The server-side counterpart to https://github.com/sourcegraph/src-cli/pull/822, this PR removes flags we no longer need.

## Test plan

Go test suite and ran a manual test.