### PR TITLE
simple ui: combine search info dropdown and query time/results count

### DIFF
--- a/client/jetbrains/webview/src/search/StatusBar.tsx
+++ b/client/jetbrains/webview/src/search/StatusBar.tsx
@@ -14,12 +14,7 @@ interface Props {
 export const StatusBar: React.FunctionComponent<Props> = ({ progress, progressState }: Props) => (
     <div className={styles.statusBar}>
         {progressState !== null && (
-            <StreamingProgressCount
-                progress={progress}
-                state={progressState}
-                showTrace={false}
-                className={styles.progressCount}
-            />
+            <StreamingProgressCount progress={progress} state={progressState} className={styles.progressCount} />
         )}
         <div className={styles.spacer} />
     </div>

--- a/client/search-ui/src/results/progress/StreamingProgress.story.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgress.story.tsx
@@ -211,6 +211,53 @@ const render = () => (
             />
         </div>
 
+        <H2>2 results from 2 repositories, complete, skipped with warning, traced</H2>
+        <div className="d-flex align-items-center my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 1500,
+                    matchCount: 2,
+                    repositoriesCount: 2,
+                    skipped: [
+                        {
+                            reason: 'excluded-fork',
+                            message: '10k forked repositories excluded',
+                            severity: 'info',
+                            title: '10k forked repositories excluded',
+                            suggested: {
+                                title: 'forked:yes',
+                                queryExpression: 'forked:yes',
+                            },
+                        },
+                        {
+                            reason: 'excluded-archive',
+                            message: '60k archived repositories excluded',
+                            severity: 'info',
+                            title: '60k archived repositories excluded',
+                            suggested: {
+                                title: 'archived:yes',
+                                queryExpression: 'archived:yes',
+                            },
+                        },
+                        {
+                            reason: 'shard-timedout',
+                            message: 'Search timed out',
+                            severity: 'warn',
+                            title: 'Search timed out',
+                            suggested: {
+                                title: 'timeout:2m',
+                                queryExpression: 'timeout:2m',
+                            },
+                        },
+                    ],
+                    trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
+                }}
+                state="complete"
+                onSearchAgain={onSearchAgain}
+                showTrace={true}
+            />
+        </div>
+
         <H2>2 results from 2 repositories, loading, skipped with warning</H2>
         <div className="d-flex align-items-center my-2">
             <StreamingProgress

--- a/client/search-ui/src/results/progress/StreamingProgress.story.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgress.story.tsx
@@ -1,5 +1,5 @@
 import { Meta, Story } from '@storybook/react'
-import sinon from 'sinon'
+import { spy } from 'sinon'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
@@ -20,7 +20,7 @@ const config: Meta = {
 
 export default config
 
-const onSearchAgain = sinon.spy()
+const onSearchAgain = spy()
 
 const render = () => (
     <>
@@ -211,7 +211,7 @@ const render = () => (
             />
         </div>
 
-        <H2>2 results from 2 repositories, complete, skipped with warning, traced</H2>
+        <H2>2 results from 2 repositories, complete, skipped with warning, limit hit, traced</H2>
         <div className="d-flex align-items-center my-2">
             <StreamingProgress
                 progress={{
@@ -240,13 +240,13 @@ const render = () => (
                             },
                         },
                         {
-                            reason: 'shard-timedout',
-                            message: 'Search timed out',
+                            reason: 'shard-match-limit',
+                            message: 'Search limit hit',
                             severity: 'warn',
-                            title: 'Search timed out',
+                            title: 'Search limit hit',
                             suggested: {
-                                title: 'timeout:2m',
-                                queryExpression: 'timeout:2m',
+                                title: 'count:all',
+                                queryExpression: 'count:all',
                             },
                         },
                     ],

--- a/client/search-ui/src/results/progress/StreamingProgress.story.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgress.story.tsx
@@ -2,7 +2,8 @@ import { Meta, Story } from '@storybook/react'
 import sinon from 'sinon'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
-import { H2 } from '@sourcegraph/wildcard'
+import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
+import { H1, H2 } from '@sourcegraph/wildcard'
 
 import { StreamingProgress } from './StreamingProgress'
 
@@ -21,241 +22,253 @@ export default config
 
 const onSearchAgain = sinon.spy()
 
+const render = () => (
+    <>
+        <H2>0 results, in progress</H2>
+        <div className="d-flex align-items-center my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 0,
+                    matchCount: 0,
+                    skipped: [],
+                }}
+                state="loading"
+                onSearchAgain={onSearchAgain}
+            />
+        </div>
+
+        <H2>0 results, in progress, traced</H2>
+        <div className="d-flex align-items-center  my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 0,
+                    matchCount: 0,
+                    skipped: [],
+                    trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
+                }}
+                state="loading"
+                onSearchAgain={onSearchAgain}
+                showTrace={true}
+            />
+        </div>
+
+        <H2>1 result from 1 repository, in progress</H2>
+        <div className="d-flex align-items-center  my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 500,
+                    matchCount: 1,
+                    repositoriesCount: 1,
+                    skipped: [],
+                }}
+                state="loading"
+                onSearchAgain={onSearchAgain}
+            />
+        </div>
+
+        <H2>Big numbers, done</H2>
+        <div className="d-flex align-items-center my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 52500,
+                    matchCount: 1234567,
+                    repositoriesCount: 8901,
+                    skipped: [],
+                }}
+                state="complete"
+                onSearchAgain={onSearchAgain}
+            />
+        </div>
+
+        <H2>Big numbers, done, traced</H2>
+        <div className="d-flex align-items-center my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 52500,
+                    matchCount: 1234567,
+                    repositoriesCount: 8901,
+                    skipped: [],
+                    trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
+                }}
+                state="complete"
+                onSearchAgain={onSearchAgain}
+                showTrace={true}
+            />
+        </div>
+
+        <H2>2 results from 2 repositories, complete, skipped with info</H2>
+        <div className="d-flex align-items-center my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 1500,
+                    matchCount: 2,
+                    repositoriesCount: 2,
+                    skipped: [
+                        {
+                            reason: 'excluded-fork',
+                            message: '10k forked repositories excluded',
+                            severity: 'info',
+                            title: '10k forked repositories excluded',
+                            suggested: {
+                                title: 'forked:yes',
+                                queryExpression: 'forked:yes',
+                            },
+                        },
+                        {
+                            reason: 'excluded-archive',
+                            message: '60k archived repositories excluded',
+                            severity: 'info',
+                            title: '60k archived repositories excluded',
+                            suggested: {
+                                title: 'archived:yes',
+                                queryExpression: 'archived:yes',
+                            },
+                        },
+                    ],
+                }}
+                state="complete"
+                onSearchAgain={onSearchAgain}
+            />
+        </div>
+
+        <H2>2 results from 2 repositories, loading, skipped with info</H2>
+        <div className="d-flex align-items-center my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 1500,
+                    matchCount: 2,
+                    repositoriesCount: 2,
+                    skipped: [
+                        {
+                            reason: 'excluded-fork',
+                            message: '10k forked repositories excluded',
+                            severity: 'info',
+                            title: '10k forked repositories excluded',
+                            suggested: {
+                                title: 'forked:yes',
+                                queryExpression: 'forked:yes',
+                            },
+                        },
+                        {
+                            reason: 'excluded-archive',
+                            message: '60k archived repositories excluded',
+                            severity: 'info',
+                            title: '60k archived repositories excluded',
+                            suggested: {
+                                title: 'archived:yes',
+                                queryExpression: 'archived:yes',
+                            },
+                        },
+                    ],
+                }}
+                state="loading"
+                onSearchAgain={onSearchAgain}
+            />
+        </div>
+
+        <H2>2 results from 2 repositories, complete, skipped with warning</H2>
+        <div className="d-flex align-items-center my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 1500,
+                    matchCount: 2,
+                    repositoriesCount: 2,
+                    skipped: [
+                        {
+                            reason: 'excluded-fork',
+                            message: '10k forked repositories excluded',
+                            severity: 'info',
+                            title: '10k forked repositories excluded',
+                            suggested: {
+                                title: 'forked:yes',
+                                queryExpression: 'forked:yes',
+                            },
+                        },
+                        {
+                            reason: 'excluded-archive',
+                            message: '60k archived repositories excluded',
+                            severity: 'info',
+                            title: '60k archived repositories excluded',
+                            suggested: {
+                                title: 'archived:yes',
+                                queryExpression: 'archived:yes',
+                            },
+                        },
+                        {
+                            reason: 'shard-timedout',
+                            message: 'Search timed out',
+                            severity: 'warn',
+                            title: 'Search timed out',
+                            suggested: {
+                                title: 'timeout:2m',
+                                queryExpression: 'timeout:2m',
+                            },
+                        },
+                    ],
+                }}
+                state="complete"
+                onSearchAgain={onSearchAgain}
+            />
+        </div>
+
+        <H2>2 results from 2 repositories, loading, skipped with warning</H2>
+        <div className="d-flex align-items-center my-2">
+            <StreamingProgress
+                progress={{
+                    durationMs: 1500,
+                    matchCount: 2,
+                    repositoriesCount: 2,
+                    skipped: [
+                        {
+                            reason: 'excluded-fork',
+                            message: '10k forked repositories excluded',
+                            severity: 'info',
+                            title: '10k forked repositories excluded',
+                            suggested: {
+                                title: 'forked:yes',
+                                queryExpression: 'forked:yes',
+                            },
+                        },
+                        {
+                            reason: 'excluded-archive',
+                            message: '60k archived repositories excluded',
+                            severity: 'info',
+                            title: '60k archived repositories excluded',
+                            suggested: {
+                                title: 'archived:yes',
+                                queryExpression: 'archived:yes',
+                            },
+                        },
+                        {
+                            reason: 'shard-timedout',
+                            message: 'Search timed out',
+                            severity: 'warn',
+                            title: 'Search timed out',
+                            suggested: {
+                                title: 'timeout:2m',
+                                queryExpression: 'timeout:2m',
+                            },
+                        },
+                    ],
+                }}
+                state="loading"
+                onSearchAgain={onSearchAgain}
+            />
+        </div>
+    </>
+)
+
 export const StreamingProgressStory: Story = () => (
     <BrandedStory>
         {() => (
             <>
-                <H2>0 results, in progress</H2>
-                <div className="d-flex align-items-center my-2">
-                    <StreamingProgress
-                        progress={{
-                            durationMs: 0,
-                            matchCount: 0,
-                            skipped: [],
-                        }}
-                        state="loading"
-                        onSearchAgain={onSearchAgain}
-                    />
-                </div>
-
-                <H2>0 results, in progress, traced</H2>
-                <div className="d-flex align-items-center  my-2">
-                    <StreamingProgress
-                        progress={{
-                            durationMs: 0,
-                            matchCount: 0,
-                            skipped: [],
-                            trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
-                        }}
-                        state="loading"
-                        onSearchAgain={onSearchAgain}
-                        showTrace={true}
-                    />
-                </div>
-
-                <H2>1 result from 1 repository, in progress</H2>
-                <div className="d-flex align-items-center  my-2">
-                    <StreamingProgress
-                        progress={{
-                            durationMs: 500,
-                            matchCount: 1,
-                            repositoriesCount: 1,
-                            skipped: [],
-                        }}
-                        state="loading"
-                        onSearchAgain={onSearchAgain}
-                    />
-                </div>
-
-                <H2>Big numbers, done</H2>
-                <div className="d-flex align-items-center my-2">
-                    <StreamingProgress
-                        progress={{
-                            durationMs: 52500,
-                            matchCount: 1234567,
-                            repositoriesCount: 8901,
-                            skipped: [],
-                        }}
-                        state="complete"
-                        onSearchAgain={onSearchAgain}
-                    />
-                </div>
-
-                <H2>Big numbers, done, traced</H2>
-                <div className="d-flex align-items-center my-2">
-                    <StreamingProgress
-                        progress={{
-                            durationMs: 52500,
-                            matchCount: 1234567,
-                            repositoriesCount: 8901,
-                            skipped: [],
-                            trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
-                        }}
-                        state="complete"
-                        onSearchAgain={onSearchAgain}
-                        showTrace={true}
-                    />
-                </div>
-
-                <H2>2 results from 2 repositories, complete, skipped with info</H2>
-                <div className="d-flex align-items-center my-2">
-                    <StreamingProgress
-                        progress={{
-                            durationMs: 1500,
-                            matchCount: 2,
-                            repositoriesCount: 2,
-                            skipped: [
-                                {
-                                    reason: 'excluded-fork',
-                                    message: '10k forked repositories excluded',
-                                    severity: 'info',
-                                    title: '10k forked repositories excluded',
-                                    suggested: {
-                                        title: 'forked:yes',
-                                        queryExpression: 'forked:yes',
-                                    },
-                                },
-                                {
-                                    reason: 'excluded-archive',
-                                    message: '60k archived repositories excluded',
-                                    severity: 'info',
-                                    title: '60k archived repositories excluded',
-                                    suggested: {
-                                        title: 'archived:yes',
-                                        queryExpression: 'archived:yes',
-                                    },
-                                },
-                            ],
-                        }}
-                        state="complete"
-                        onSearchAgain={onSearchAgain}
-                    />
-                </div>
-
-                <H2>2 results from 2 repositories, loading, skipped with info</H2>
-                <div className="d-flex align-items-center my-2">
-                    <StreamingProgress
-                        progress={{
-                            durationMs: 1500,
-                            matchCount: 2,
-                            repositoriesCount: 2,
-                            skipped: [
-                                {
-                                    reason: 'excluded-fork',
-                                    message: '10k forked repositories excluded',
-                                    severity: 'info',
-                                    title: '10k forked repositories excluded',
-                                    suggested: {
-                                        title: 'forked:yes',
-                                        queryExpression: 'forked:yes',
-                                    },
-                                },
-                                {
-                                    reason: 'excluded-archive',
-                                    message: '60k archived repositories excluded',
-                                    severity: 'info',
-                                    title: '60k archived repositories excluded',
-                                    suggested: {
-                                        title: 'archived:yes',
-                                        queryExpression: 'archived:yes',
-                                    },
-                                },
-                            ],
-                        }}
-                        state="loading"
-                        onSearchAgain={onSearchAgain}
-                    />
-                </div>
-
-                <H2>2 results from 2 repositories, complete, skipped with warning</H2>
-                <div className="d-flex align-items-center my-2">
-                    <StreamingProgress
-                        progress={{
-                            durationMs: 1500,
-                            matchCount: 2,
-                            repositoriesCount: 2,
-                            skipped: [
-                                {
-                                    reason: 'excluded-fork',
-                                    message: '10k forked repositories excluded',
-                                    severity: 'info',
-                                    title: '10k forked repositories excluded',
-                                    suggested: {
-                                        title: 'forked:yes',
-                                        queryExpression: 'forked:yes',
-                                    },
-                                },
-                                {
-                                    reason: 'excluded-archive',
-                                    message: '60k archived repositories excluded',
-                                    severity: 'info',
-                                    title: '60k archived repositories excluded',
-                                    suggested: {
-                                        title: 'archived:yes',
-                                        queryExpression: 'archived:yes',
-                                    },
-                                },
-                                {
-                                    reason: 'shard-timedout',
-                                    message: 'Search timed out',
-                                    severity: 'warn',
-                                    title: 'Search timed out',
-                                    suggested: {
-                                        title: 'timeout:2m',
-                                        queryExpression: 'timeout:2m',
-                                    },
-                                },
-                            ],
-                        }}
-                        state="complete"
-                        onSearchAgain={onSearchAgain}
-                    />
-                </div>
-
-                <H2>2 results from 2 repositories, loading, skipped with warning</H2>
-                <div className="d-flex align-items-center my-2">
-                    <StreamingProgress
-                        progress={{
-                            durationMs: 1500,
-                            matchCount: 2,
-                            repositoriesCount: 2,
-                            skipped: [
-                                {
-                                    reason: 'excluded-fork',
-                                    message: '10k forked repositories excluded',
-                                    severity: 'info',
-                                    title: '10k forked repositories excluded',
-                                    suggested: {
-                                        title: 'forked:yes',
-                                        queryExpression: 'forked:yes',
-                                    },
-                                },
-                                {
-                                    reason: 'excluded-archive',
-                                    message: '60k archived repositories excluded',
-                                    severity: 'info',
-                                    title: '60k archived repositories excluded',
-                                    suggested: {
-                                        title: 'archived:yes',
-                                        queryExpression: 'archived:yes',
-                                    },
-                                },
-                                {
-                                    reason: 'shard-timedout',
-                                    message: 'Search timed out',
-                                    severity: 'warn',
-                                    title: 'Search timed out',
-                                    suggested: {
-                                        title: 'timeout:2m',
-                                        queryExpression: 'timeout:2m',
-                                    },
-                                },
-                            ],
-                        }}
-                        state="loading"
-                        onSearchAgain={onSearchAgain}
-                    />
-                </div>
+                {render()}
+                <MockTemporarySettings settings={{ 'coreWorkflowImprovements.enabled': true }}>
+                    <>
+                        <H1>With simple UI enabled</H1>
+                        {render()}
+                    </>
+                </MockTemporarySettings>
             </>
         )}
     </BrandedStory>

--- a/client/search-ui/src/results/progress/StreamingProgress.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgress.tsx
@@ -26,10 +26,16 @@ export const StreamingProgress: React.FunctionComponent<React.PropsWithChildren<
     onSearchAgain,
 }) => {
     const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+    const isLoading = state === 'loading'
+
     return (
         <>
-            <StreamingProgressCount progress={progress} state={state} />
-            <StreamingProgressSkippedButton progress={progress} onSearchAgain={onSearchAgain} />
+            {(!coreWorkflowImprovementsEnabled || isLoading) && (
+                <StreamingProgressCount progress={progress} state={state} hideIcon={coreWorkflowImprovementsEnabled} />
+            )}
+            {(!coreWorkflowImprovementsEnabled || !isLoading) && (
+                <StreamingProgressSkippedButton progress={progress} onSearchAgain={onSearchAgain} />
+            )}
             <TraceLink showTrace={showTrace} trace={progress.trace} />
         </>
     )

--- a/client/search-ui/src/results/progress/StreamingProgress.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgress.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react'
 
+import { mdiClipboardPulseOutline } from '@mdi/js'
+import classNames from 'classnames'
+
 import { Progress, StreamingResultsState } from '@sourcegraph/shared/src/search/stream'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
+import { Icon, Link } from '@sourcegraph/wildcard'
 
 import { StreamingProgressCount } from './StreamingProgressCount'
 import { StreamingProgressSkippedButton } from './StreamingProgressSkippedButton'
+
+import styles from './StreamingProgressCount.module.scss'
 
 export interface StreamingProgressProps {
     state: StreamingResultsState
@@ -12,9 +19,30 @@ export interface StreamingProgressProps {
     onSearchAgain: (additionalFilters: string[]) => void
 }
 
-export const StreamingProgress: React.FunctionComponent<React.PropsWithChildren<StreamingProgressProps>> = props => (
-    <>
-        <StreamingProgressCount {...props} />
-        <StreamingProgressSkippedButton {...props} />
-    </>
-)
+export const StreamingProgress: React.FunctionComponent<React.PropsWithChildren<StreamingProgressProps>> = ({
+    progress,
+    state,
+    showTrace,
+    onSearchAgain,
+}) => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+    return (
+        <>
+            <StreamingProgressCount progress={progress} state={state} />
+            <StreamingProgressSkippedButton progress={progress} onSearchAgain={onSearchAgain} />
+            <TraceLink showTrace={showTrace} trace={progress.trace} />
+        </>
+    )
+}
+
+const TraceLink: React.FunctionComponent<{ showTrace?: boolean; trace?: string }> = ({ showTrace, trace }) =>
+    showTrace && trace ? (
+        <small className={classNames('d-flex align-items-center', styles.count)}>
+            <Link to={trace}>
+                <Icon aria-hidden={true} className="mr-2" svgPath={mdiClipboardPulseOutline} />
+                View trace
+            </Link>
+        </small>
+    ) : (
+        <></>
+    )

--- a/client/search-ui/src/results/progress/StreamingProgressCount.test.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressCount.test.tsx
@@ -76,28 +76,4 @@ describe('StreamingProgressCount', () => {
 
         expect(render(<StreamingProgressCount state="complete" progress={progress} />).asFragment()).toMatchSnapshot()
     })
-
-    it('should render correctly when a trace url is provided', () => {
-        const progress: Progress = {
-            durationMs: 0,
-            matchCount: 0,
-            skipped: [],
-            trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
-        }
-
-        expect(
-            render(<StreamingProgressCount state="loading" progress={progress} showTrace={true} />).asFragment()
-        ).toMatchSnapshot()
-    })
-
-    it('should not render a trace link when not opted into with &trace=1', () => {
-        const progress: Progress = {
-            durationMs: 0,
-            matchCount: 0,
-            skipped: [],
-            trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
-        }
-
-        expect(render(<StreamingProgressCount state="loading" progress={progress} />).asFragment()).toMatchSnapshot()
-    })
 })

--- a/client/search-ui/src/results/progress/StreamingProgressCount.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressCount.tsx
@@ -25,7 +25,8 @@ const abbreviateNumber = (number: number): string => {
     return (number / 1e9).toFixed(1) + 'b'
 }
 
-const limitHit = (progress: Progress): boolean => progress.skipped.some(skipped => skipped.reason.indexOf('-limit') > 0)
+export const limitHit = (progress: Progress): boolean =>
+    progress.skipped.some(skipped => skipped.reason.indexOf('-limit') > 0)
 
 export const getProgressText = (progress: Progress): { visibleText: string; readText: string } => {
     const contentWithoutTimeUnit =

--- a/client/search-ui/src/results/progress/StreamingProgressCount.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressCount.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 
-import { mdiClipboardPulseOutline, mdiInformationOutline } from '@mdi/js'
+import { mdiInformationOutline } from '@mdi/js'
 import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
 import { Progress } from '@sourcegraph/shared/src/search/stream'
-import { Link, Icon, Tooltip } from '@sourcegraph/wildcard'
+import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { StreamingProgressProps } from './StreamingProgress'
 
@@ -28,8 +28,10 @@ const abbreviateNumber = (number: number): string => {
 const limitHit = (progress: Progress): boolean => progress.skipped.some(skipped => skipped.reason.indexOf('-limit') > 0)
 
 export const StreamingProgressCount: React.FunctionComponent<
-    React.PropsWithChildren<Pick<StreamingProgressProps, 'progress' | 'state' | 'showTrace'> & { className?: string }>
-> = ({ progress, state, showTrace, className = '' }) => {
+    React.PropsWithChildren<
+        Pick<StreamingProgressProps, 'progress' | 'state'> & { className?: string; hideIcon?: boolean }
+    >
+> = ({ progress, state, className = '', hideIcon = false }) => {
     const isLoading = state === 'loading'
     const contentWithoutTimeUnit =
         `${abbreviateNumber(progress.matchCount)}` +
@@ -58,7 +60,7 @@ export const StreamingProgressCount: React.FunctionComponent<
                     <VisuallyHidden aria-live="polite">{readingContent}</VisuallyHidden>
                 </span>
                 <span aria-hidden={true}>{content}</span>
-                {progress.repositoriesCount !== undefined && (
+                {!hideIcon && progress.repositoriesCount !== undefined && (
                     <Tooltip
                         content={`From ${abbreviateNumber(progress.repositoriesCount)} ${pluralize(
                             'repository',
@@ -79,14 +81,6 @@ export const StreamingProgressCount: React.FunctionComponent<
                     </Tooltip>
                 )}
             </small>
-            {showTrace && progress.trace && (
-                <small className={classNames('d-flex align-items-center', className, styles.count)}>
-                    <Link to={progress.trace}>
-                        <Icon aria-hidden={true} className="mr-2" svgPath={mdiClipboardPulseOutline} />
-                        View trace
-                    </Link>
-                </small>
-            )}
         </>
     )
 }

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedButton.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
-import { mdiAlertCircle, mdiChevronDown } from '@mdi/js'
+import { mdiAlertCircle, mdiChevronDown, mdiInformationOutline } from '@mdi/js'
 
 import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { Button, Popover, PopoverContent, PopoverTrigger, Position, Icon } from '@sourcegraph/wildcard'
@@ -49,6 +49,8 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
                     >
                         {skippedWithWarningOrError ? (
                             <Icon aria-hidden={true} className="mr-2" svgPath={mdiAlertCircle} />
+                        ) : coreWorkflowImprovementsEnabled ? (
+                            <Icon aria-hidden={true} className="mr-2" svgPath={mdiInformationOutline} />
                         ) : null}
                         {coreWorkflowImprovementsEnabled ? (
                             <CountContent progressText={progressText} />

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedButton.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedButton.tsx
@@ -2,9 +2,11 @@ import React, { useCallback, useMemo, useState } from 'react'
 
 import { mdiAlertCircle, mdiChevronDown } from '@mdi/js'
 
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { Button, Popover, PopoverContent, PopoverTrigger, Position, Icon } from '@sourcegraph/wildcard'
 
 import { StreamingProgressProps } from './StreamingProgress'
+import { CountContent, getProgressText } from './StreamingProgressCount'
 import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopover'
 
 import styles from './StreamingProgressSkippedButton.module.scss'
@@ -12,6 +14,8 @@ import styles from './StreamingProgressSkippedButton.module.scss'
 export const StreamingProgressSkippedButton: React.FunctionComponent<
     React.PropsWithChildren<Pick<StreamingProgressProps, 'progress' | 'onSearchAgain'>>
 > = ({ progress, onSearchAgain }) => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+
     const [isOpen, setIsOpen] = useState(false)
 
     const skippedWithWarningOrError = useMemo(
@@ -27,9 +31,11 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
         [setIsOpen, onSearchAgain]
     )
 
+    const progressText = getProgressText(progress)
+
     return (
         <>
-            {progress.skipped.length > 0 && (
+            {(coreWorkflowImprovementsEnabled || progress.skipped.length > 0) && (
                 <Popover isOpen={isOpen} onOpenChange={event => setIsOpen(event.isOpen)}>
                     <PopoverTrigger
                         className="mb-0 d-flex align-items-center text-decoration-none"
@@ -44,7 +50,11 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
                         {skippedWithWarningOrError ? (
                             <Icon aria-hidden={true} className="mr-2" svgPath={mdiAlertCircle} />
                         ) : null}
-                        Some results excluded{' '}
+                        {coreWorkflowImprovementsEnabled ? (
+                            <CountContent progressText={progressText} />
+                        ) : (
+                            <>Some results excluded </>
+                        )}
                         <Icon aria-hidden={true} data-caret={true} className="mr-0" svgPath={mdiChevronDown} />
                     </PopoverTrigger>
                     <PopoverContent

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
@@ -2,16 +2,17 @@ import React, { useCallback, useState } from 'react'
 
 import { mdiAlertCircle, mdiChevronDown, mdiChevronLeft, mdiInformationOutline, mdiMagnify } from '@mdi/js'
 import classNames from 'classnames'
-// eslint-disable-next-line no-restricted-imports
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { renderMarkdown } from '@sourcegraph/common'
+import { pluralize, renderMarkdown } from '@sourcegraph/common'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { Skipped } from '@sourcegraph/shared/src/search/stream'
-import { Button, Collapse, CollapseHeader, CollapsePanel, Icon, Checkbox, H4 } from '@sourcegraph/wildcard'
+import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
+import { Button, Collapse, CollapseHeader, CollapsePanel, Icon, Checkbox, H4, Text } from '@sourcegraph/wildcard'
 
 import { StreamingProgressProps } from './StreamingProgress'
+import { limitHit } from './StreamingProgressCount'
 
 import styles from './StreamingProgressSkippedPopover.module.scss'
 
@@ -103,6 +104,8 @@ const SkippedMessage: React.FunctionComponent<React.PropsWithChildren<{ skipped:
 export const StreamingProgressSkippedPopover: React.FunctionComponent<
     React.PropsWithChildren<Pick<StreamingProgressProps, 'progress' | 'onSearchAgain'>>
 > = ({ progress, onSearchAgain }) => {
+    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+
     const [selectedSuggestedSearches, setSelectedSuggestedSearches] = useState(new Set<string>())
     const submitHandler = useCallback(
         (event: React.FormEvent) => {
@@ -129,6 +132,21 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<
 
     return (
         <>
+            {coreWorkflowImprovementsEnabled && (
+                <Text className="m-3">
+                    Found {limitHit(progress) ? 'more than ' : ''}
+                    {progress.matchCount} {pluralize('result', progress.matchCount)}
+                    {progress.repositoriesCount !== undefined
+                        ? ` from ${progress.repositoriesCount} ${pluralize(
+                              'repository',
+                              progress.repositoriesCount,
+                              'repositories'
+                          )}`
+                        : ''}
+                    .
+                </Text>
+            )}
+
             {sortedSkippedItems.map((skipped, index) => (
                 <SkippedMessage
                     key={skipped.reason}

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
@@ -9,7 +9,7 @@ import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { Skipped } from '@sourcegraph/shared/src/search/stream'
 import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
-import { Button, Collapse, CollapseHeader, CollapsePanel, Icon, Checkbox, H4, Text } from '@sourcegraph/wildcard'
+import { Button, Collapse, CollapseHeader, CollapsePanel, Icon, Checkbox, H4, Text, H3 } from '@sourcegraph/wildcard'
 
 import { StreamingProgressProps } from './StreamingProgress'
 import { limitHit } from './StreamingProgressCount'
@@ -133,7 +133,7 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<
     return (
         <>
             {coreWorkflowImprovementsEnabled && (
-                <Text className="m-3">
+                <Text className="mx-3 mt-3">
                     Found {limitHit(progress) ? 'more than ' : ''}
                     {progress.matchCount} {pluralize('result', progress.matchCount)}
                     {progress.repositoriesCount !== undefined
@@ -147,6 +147,9 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<
                 </Text>
             )}
 
+            {coreWorkflowImprovementsEnabled && sortedSkippedItems.length > 0 && (
+                <H3 className="mx-3">Some results skipped:</H3>
+            )}
             {sortedSkippedItems.map((skipped, index) => (
                 <SkippedMessage
                     key={skipped.reason}

--- a/client/search-ui/src/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/search-ui/src/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -1,36 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StreamingProgressCount should not render a trace link when not opted into with &trace=1 1`] = `
-<DocumentFragment>
-  <span
-    aria-live="polite"
-    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
-  >
-    Searching
-  </span>
-  <small
-    class="d-flex align-items-center count countInProgress"
-    data-testid="streaming-progress-count"
-  >
-    <span
-      class="position-relative"
-    >
-      <span
-        aria-live="polite"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
-      >
-        0 results in 0.00 seconds
-      </span>
-    </span>
-    <span
-      aria-hidden="true"
-    >
-      0 results in 0.00s
-    </span>
-  </small>
-</DocumentFragment>
-`;
-
 exports[`StreamingProgressCount should render correctly for 0 items in progress 1`] = `
 <DocumentFragment>
   <span
@@ -264,60 +233,6 @@ exports[`StreamingProgressCount should render correctly for limithit 1`] = `
         d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
       />
     </svg>
-  </small>
-</DocumentFragment>
-`;
-
-exports[`StreamingProgressCount should render correctly when a trace url is provided 1`] = `
-<DocumentFragment>
-  <span
-    aria-live="polite"
-    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
-  >
-    Searching
-  </span>
-  <small
-    class="d-flex align-items-center count countInProgress"
-    data-testid="streaming-progress-count"
-  >
-    <span
-      class="position-relative"
-    >
-      <span
-        aria-live="polite"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
-      >
-        0 results in 0.00 seconds
-      </span>
-    </span>
-    <span
-      aria-hidden="true"
-    >
-      0 results in 0.00s
-    </span>
-  </small>
-  <small
-    class="d-flex align-items-center count"
-  >
-    <a
-      class=""
-      href="https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg"
-    >
-      <svg
-        aria-hidden="true"
-        class="mdi-icon iconInline mr-2"
-        fill="currentColor"
-        height="24"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-      >
-        <path
-          d="M19,3H14.82C14.4,1.84 13.3,1 12,1C10.7,1 9.6,1.84 9.18,3H5A2,2 0 0,0 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5A2,2 0 0,0 19,3M12,3A1,1 0 0,1 13,4A1,1 0 0,1 12,5A1,1 0 0,1 11,4A1,1 0 0,1 12,3M5,15H8.11L9.62,12.15L10.38,17.92L14.07,13.21L15.89,15H19V19H5V15M19,13.46H16.53L13.93,10.86L11.44,14.05L10.5,7.08L7.17,13.46H5V5H7V6H17V5H19V6L19,13.46Z"
-        />
-      </svg>
-      View trace
-    </a>
   </small>
 </DocumentFragment>
 `;

--- a/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -437,6 +437,82 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       >
         <input
           class="form-check-input"
+          data-testid="streaming-progress-skipped-suggest-check-3"
+          id="streaming-progress-skipped-suggest-check-3"
+          label="[object Object]"
+          type="checkbox"
+          value="archived:yes"
+        />
+        <label
+          class="label form-check-label label"
+          for="streaming-progress-skipped-suggest-check-3"
+        >
+          archived:yes (
+          <span
+            class="text-monospace search-query-link"
+          >
+            <span
+              class="search-filter-keyword"
+            >
+              archived
+            </span>
+            <span
+              class="search-filter-separator"
+            >
+              :
+            </span>
+            <span
+              class="search-query-text"
+            >
+              yes
+            </span>
+          </span>
+          )
+        </label>
+      </div>
+      <div
+        class="form-check mb-1 d-block"
+      >
+        <input
+          class="form-check-input"
+          data-testid="streaming-progress-skipped-suggest-check-3"
+          id="streaming-progress-skipped-suggest-check-3"
+          label="[object Object]"
+          type="checkbox"
+          value="archived:yes"
+        />
+        <label
+          class="label form-check-label label"
+          for="streaming-progress-skipped-suggest-check-3"
+        >
+          archived:yes (
+          <span
+            class="text-monospace search-query-link"
+          >
+            <span
+              class="search-filter-keyword"
+            >
+              archived
+            </span>
+            <span
+              class="search-filter-separator"
+            >
+              :
+            </span>
+            <span
+              class="search-query-text"
+            >
+              yes
+            </span>
+          </span>
+          )
+        </label>
+      </div>
+      <div
+        class="form-check mb-1 d-block"
+      >
+        <input
+          class="form-check-input"
           data-testid="streaming-progress-skipped-suggest-check-4"
           id="streaming-progress-skipped-suggest-check-4"
           label="[object Object]"


### PR DESCRIPTION
Fixes #38670

## Review notes

Please review commit by commit, I've tried to make each commit an atomic change and add good commit messages. Also review with "show whitespace" off.

## Changes

For all cases of the search progress/skipped results dropdown:
- If tracing is on (URL contains `&trace=1`), "Show trace" button is now shown after the skipped results dropdown button instead of before

When `coreWorkflowImprovementsEnabled` is on:
- Search progress count with animation is now only shown when search is in progress
- Skipped results dropdown button is now only shown when search is complete
- Skipped results dropdown button now shows the count instead of generic text
- Skipped results dropdown popover now shows details on the count

![image](https://user-images.githubusercontent.com/206864/184990667-1160512b-86c4-4674-87ec-dcc104940ab4.png)

## Test plan

Updated storybook tests for StreamingProgress to include with and without `coreWorkflowImprovementsEnabled`
- Only visual change without it on should be moving the "Show trace" button to the end

## App preview:

- [Web](https://sg-web-jp-infobarprogresssimple.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qaqnexxhsq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
