### PR TITLE
Highlight `*.mjs` files as JavaScript

### DIFF
--- a/client/shared/src/languages.ts
+++ b/client/shared/src/languages.ts
@@ -218,6 +218,7 @@ function getModeFromExtension(extension: string): string | undefined {
         case 'jsx':
         case 'es':
         case 'es6':
+        case 'mjs':
         case 'jss':
         case 'jsm':
             return 'javascript'


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/34179

## Test plan

Ran Sourcegraph locally and verified that `*.mjs` files are correctly highlighted.

https://github.com/sourcegraph/sourcegraph/issues/34179
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-mjs.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vcrhpygdjf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
