### PR TITLE
admin-analytics: fix headings

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
@@ -109,7 +109,7 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
 
     return (
         <>
-            <AnalyticsPageTitle>Analytics / Batch Changes</AnalyticsPageTitle>
+            <AnalyticsPageTitle>Batch Changes</AnalyticsPageTitle>
 
             <Card className="p-3 position-relative">
                 <div className="d-flex justify-content-end align-items-stretch mb-2 text-nowrap">

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -174,7 +174,7 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
 
     return (
         <>
-            <AnalyticsPageTitle>Analytics / Code intel</AnalyticsPageTitle>
+            <AnalyticsPageTitle>Code intel</AnalyticsPageTitle>
 
             <Card className="p-3 position-relative">
                 <div className="d-flex justify-content-end align-items-stretch mb-2 text-nowrap">

--- a/client/web/src/site-admin/analytics/AnalyticsComingSoonPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsComingSoonPage/index.tsx
@@ -18,7 +18,7 @@ export const AnalyticsComingSoonPage: React.FunctionComponent<RouteComponentProp
     }, [props.match.path])
     return (
         <>
-            <AnalyticsPageTitle>Analytics / {title}</AnalyticsPageTitle>
+            <AnalyticsPageTitle>{title}</AnalyticsPageTitle>
 
             <div className="d-flex flex-column justify-content-center align-items-center p-5">
                 <Icon

--- a/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
@@ -128,7 +128,7 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
 
     return (
         <>
-            <AnalyticsPageTitle>Analytics / Notebooks</AnalyticsPageTitle>
+            <AnalyticsPageTitle>Notebooks</AnalyticsPageTitle>
 
             <Card className="p-3 position-relative">
                 <div className="d-flex justify-content-end align-items-stretch mb-2 text-nowrap">

--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
@@ -173,7 +173,7 @@ export const AnalyticsSearchPage: React.FunctionComponent<RouteComponentProps<{}
 
     return (
         <>
-            <AnalyticsPageTitle>Analytics / Search</AnalyticsPageTitle>
+            <AnalyticsPageTitle>Search</AnalyticsPageTitle>
 
             <Card className="p-3">
                 <div className="d-flex justify-content-end align-items-stretch mb-2 text-nowrap">

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -125,7 +125,7 @@ export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>
 
     return (
         <>
-            <AnalyticsPageTitle>Analytics / Users</AnalyticsPageTitle>
+            <AnalyticsPageTitle>Users</AnalyticsPageTitle>
             <Card className="p-3">
                 <div className="d-flex justify-content-end align-items-stretch mb-2 text-nowrap">
                     <HorizontalSelect<typeof dateRange.value> {...dateRange} />

--- a/client/web/src/site-admin/analytics/components/AnalyticsPageTitle.module.scss
+++ b/client/web/src/site-admin/analytics/components/AnalyticsPageTitle.module.scss
@@ -1,0 +1,3 @@
+.icon-color {
+    color: var(--icon-color);
+}

--- a/client/web/src/site-admin/analytics/components/AnalyticsPageTitle.tsx
+++ b/client/web/src/site-admin/analytics/components/AnalyticsPageTitle.tsx
@@ -1,14 +1,17 @@
 import React from 'react'
 
 import { mdiChartLineVariant } from '@mdi/js'
+import classNames from 'classnames'
 
-import { Badge, H1, Icon } from '@sourcegraph/wildcard'
+import { Badge, H2, Icon } from '@sourcegraph/wildcard'
+
+import styles from './AnalyticsPageTitle.module.scss'
 
 export const AnalyticsPageTitle: React.FunctionComponent<React.PropsWithChildren<{}>> = ({ children }) => (
     <div className="d-flex flex-column justify-content-between align-items-start">
         <Badge variant="merged">Experimental</Badge>
 
-        <H1 className="mb-4 mt-2 d-flex align-items-center">
+        <H2 className="mb-4 mt-2 d-flex align-items-center">
             <Icon
                 className="mr-1"
                 color="var(--link-color)"
@@ -16,7 +19,9 @@ export const AnalyticsPageTitle: React.FunctionComponent<React.PropsWithChildren
                 size="sm"
                 aria-label="Analytics icon"
             />
+            Analytics
+            <span className={classNames(styles.iconColor, 'mx-2')}>/</span>
             {children}
-        </H1>
+        </H2>
     </div>
 )


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39939.
This PR:
- Changes headers to be H2 instead of H1
- Updates heading dividers to be icon-color

## Test plan
- `sg start`
- Open http://localhost:3080/site-admin/analytics
- Check that all analytics features page headings follow the same styling

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
