### PR TITLE
Disable in-app changelog for 3.43 release

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -6,8 +6,6 @@ import { CardBody, Card, Link, H4, Text } from '@sourcegraph/wildcard'
 
 import { SourcegraphIcon } from '../../../auth/icons'
 
-import { BatchChangesChangelogAlert } from './BatchChangesChangelogAlert'
-
 import styles from './BatchChangesListIntro.module.scss'
 
 export interface BatchChangesListIntroProps {
@@ -17,26 +15,15 @@ export interface BatchChangesListIntroProps {
 export const BatchChangesListIntro: React.FunctionComponent<React.PropsWithChildren<BatchChangesListIntroProps>> = ({
     isLicensed,
 }) => {
-    if (isLicensed === undefined) {
+    if (isLicensed === undefined || isLicensed === true) {
         return null
     }
 
     return (
         <div className="row">
-            {isLicensed === true ? (
-                <div className="col-12">
-                    <BatchChangesChangelogAlert />
-                </div>
-            ) : (
-                <>
-                    <div className="col-12 col-md-6 mb-3">
-                        <BatchChangesUnlicensedAlert />
-                    </div>
-                    <div className="col-12 col-md-6 mb-3">
-                        <BatchChangesChangelogAlert />
-                    </div>
-                </>
-            )}
+            <div className="col-12 mb-3">
+                <BatchChangesUnlicensedAlert />
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
No noteworthy items this time.

## Test plan

Chromatic.

## App preview:

- [Web](https://sg-web-es-in-app-343.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-holjwnswyf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
