### PR TITLE
Add enableLegacyExtension flag to frontend config to make sg start web-standalone work again

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -67,6 +67,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         openTelemetry: {
             endpoint: ENVIRONMENT_CONFIG.CLIENT_OTEL_EXPORTER_OTLP_ENDPOINT,
         },
+        enableLegacyExtensions: true,
         // Site-config overrides default JS context
         ...siteConfig,
     }


### PR DESCRIPTION
We broke extensions when the dev server is started via `sg start web-standalone` since we don't properly initialize the config for this env (and default value for experimentalFeatures is an empty flag).

This needs to be updated when we change the default (I'll make an issue to clean up)

## Test plan

![Screenshot 2022-08-17 at 12 45 05](https://user-images.githubusercontent.com/458591/185100299-3254df90-9609-4388-9713-eb058741d3e3.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-standalone-mode.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-aqiitehtft.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
