### PR TITLE
vsce: re-enable test

### DIFF
--- a/client/vscode/tests/vsce.test.ts
+++ b/client/vscode/tests/vsce.test.ts
@@ -140,22 +140,21 @@ describe('VS Code extension', () => {
             throw new Error('Timeout waiting for search results to render after viewing repo page')
         }
 
-        // This will be fixed and re-enabled in https://github.com/sourcegraph/sourcegraph/issues/40366
-        // // Open remote file from search results
-        // try {
-        //     await searchPanelFrame.waitForSelector('.test-search-result strong', { visible: true })
-        //     await searchPanelFrame.click('.test-search-result strong', { delay: 100 })
-        // } catch {
-        //     throw new Error('Timeout waiting for search results to render after nevigating back from repo display page')
-        // }
+        // Open remote file from search results
+        try {
+            await searchPanelFrame.waitForSelector('.test-search-result strong', { visible: true })
+            await searchPanelFrame.click('.test-search-result strong', { delay: 100 })
+        } catch {
+            throw new Error('Timeout waiting for search results to render after nevigating back from repo display page')
+        }
 
-        // await vsCodeDriver.page.waitForTimeout(10000)
+        await vsCodeDriver.page.waitForTimeout(10000)
 
-        // // Look for file title
-        // const remoteFileTitle = await vsCodeDriver.page.title()
-        // if (!remoteFileTitle.includes('bool_or_string_test.go')) {
-        //     throw new Error('Timeout waiting for remote file to render')
-        // }
+        // Look for file title
+        const remoteFileTitle = await vsCodeDriver.page.title()
+        if (!remoteFileTitle.includes('bool_or_string_test.go')) {
+            throw new Error('Timeout waiting for remote file to render')
+        }
     })
 
     // Potential future test cases:

--- a/client/vscode/tests/vsce.test.ts
+++ b/client/vscode/tests/vsce.test.ts
@@ -30,14 +30,15 @@ describe('VS Code extension', () => {
         )
     })
 
-    afterEach(async () => {
-        // Close Remote File
-        await vsCodeDriver.page.waitForSelector('.tabs-container .active .tab-actions', { visible: true })
-        await vsCodeDriver.page.click('.tabs-container .active .tab-actions', { delay: 50 })
-        // Close Search Panel
-        await vsCodeDriver.page.waitForSelector('.tabs-container .active .tab-actions', { visible: true })
-        await vsCodeDriver.page.click('.tabs-container .active .tab-actions', { delay: 50 })
-    })
+    // This will be fixed and re-enabled in https://github.com/sourcegraph/sourcegraph/issues/40366
+    // afterEach(async () => {
+    //     // Close Remote File
+    //     await vsCodeDriver.page.waitForSelector('.tabs-container .active .tab-actions', { visible: true })
+    //     await vsCodeDriver.page.click('.tabs-container .active .tab-actions', { delay: 50 })
+    //     // Close Search Panel
+    //     await vsCodeDriver.page.waitForSelector('.tabs-container .active .tab-actions', { visible: true })
+    //     await vsCodeDriver.page.click('.tabs-container .active .tab-actions', { delay: 50 })
+    // })
 
     // Debt: reset VS Code extension state between test cases in `afterEach` once we
     // have multiple tests. This will likely involve just closing the search panel.

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -319,8 +319,6 @@ func clientIntegrationTests(pipeline *bk.Pipeline) {
 
 	addBrowserExtensionIntegrationTests(chunkCount)(pipeline)
 
-	addVsceIntegrationTests(pipeline)
-
 	// Add pipeline step for each chunk of web integrations files.
 	for i, chunkTestFiles := range chunkedTestFiles {
 		stepLabel := fmt.Sprintf(":puppeteer::electric_plug: Puppeteer tests chunk #%s", fmt.Sprint(i+1))

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -319,6 +319,8 @@ func clientIntegrationTests(pipeline *bk.Pipeline) {
 
 	addBrowserExtensionIntegrationTests(chunkCount)(pipeline)
 
+	addVsceIntegrationTests(pipeline)
+
 	// Add pipeline step for each chunk of web integrations files.
 	for i, chunkTestFiles := range chunkedTestFiles {
 		stepLabel := fmt.Sprintf(":puppeteer::electric_plug: Puppeteer tests chunk #%s", fmt.Sprint(i+1))


### PR DESCRIPTION
Disables after each hook triggering test failure in CI and re-enable previously disabled test in https://github.com/sourcegraph/sourcegraph/pull/40364. 

## Test plan
Tested functionality locally. Ensure CI passes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fix-vsce-integration.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-avytyqhtbt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

