### PR TITLE
Gate extensions registry (GraphQL and download APIs)

### DIFF
--- a/cmd/frontend/registry/api/extension_connection_graphql.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql.go
@@ -70,6 +70,11 @@ func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]gr
 			query = *args2.Query
 		}
 
+		// Verify that the instance has extensions enabled
+		if r.err = ExtensionRegistryReadEnabled(); r.err != nil {
+			return
+		}
+
 		// Query local registry extensions.
 		var local []graphqlbackend.RegistryExtension
 		if r.args.Local && ListLocalRegistryExtensions != nil {

--- a/cmd/frontend/registry/api/extensions.go
+++ b/cmd/frontend/registry/api/extensions.go
@@ -89,6 +89,11 @@ func GetExtensionByExtensionID(ctx context.Context, db database.DB, extensionID 
 		return nil, nil, err
 	}
 
+	err = ExtensionRegistryReadEnabled()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if isLocal {
 		if GetLocalExtensionByExtensionID != nil {
 			x, err := GetLocalExtensionByExtensionID(ctx, db, extensionIDWithoutPrefix)

--- a/cmd/frontend/registry/api/gating.go
+++ b/cmd/frontend/registry/api/gating.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+)
+
+func ExtensionRegistryReadEnabled() error {
+	// We need to allow read access to the extension registry of sourcegraph.com to allow instances
+	// on older versions to fetch extensions.
+	if envvar.SourcegraphDotComMode() {
+		return nil
+	}
+
+	return ExtensionRegistryWriteEnabled()
+}
+
+func ExtensionRegistryWriteEnabled() error {
+	// @TODO(@philipp-spiess): Enable this once we shipped a fix for #40085 and make the flag dynamic
+	// cfg := conf.Get()
+	// if cfg.ExperimentalFeatures != nil && cfg.ExperimentalFeatures.EnableLegacyExtensions == false {
+	// 	return errors.Errorf("Extensions are disabled. See https://docs.sourcegraph.com/extensions/deprecation")
+	// }
+
+	// @TODO(@philipp-spiess): Change the default when we roll out 4.0
+	return nil
+}

--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	frontendregistry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -36,10 +37,17 @@ func handleRegistryExtensionBundle(db database.DB) http.HandlerFunc {
 			return
 		}
 
+		err := api.ExtensionRegistryReadEnabled()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+
 		filename := mux.Vars(r)["RegistryExtensionReleaseFilename"]
 		wantSourceMap := filepath.Ext(filename) == ".map"
 
-		releaseID, err := parseExtensionBundleFilename(filename)
+		var releaseID int64
+		releaseID, err = parseExtensionBundleFilename(filename)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/enterprise/cmd/frontend/internal/registry/registry_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/registry_graphql.go
@@ -26,6 +26,9 @@ func registryExtensionByIDInt32(ctx context.Context, db database.DB, id int32) (
 	if conf.Extensions() == nil {
 		return nil, graphqlbackend.ErrExtensionsDisabled
 	}
+	if err := frontendregistry.ExtensionRegistryReadEnabled(); err != nil {
+		return nil, err
+	}
 	x, err := stores.Extensions(db).GetByID(ctx, id)
 	if err != nil {
 		return nil, err
@@ -36,6 +39,9 @@ func registryExtensionByIDInt32(ctx context.Context, db database.DB, id int32) (
 
 func extensionRegistryCreateExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryCreateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
 	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
+		return nil, err
+	}
+	if err := frontendregistry.ExtensionRegistryWriteEnabled(); err != nil {
 		return nil, err
 	}
 
@@ -68,6 +74,9 @@ func viewerCanAdministerExtension(ctx context.Context, db database.DB, id fronte
 }
 
 func extensionRegistryUpdateExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryUpdateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
+	if err := frontendregistry.ExtensionRegistryWriteEnabled(); err != nil {
+		return nil, err
+	}
 	id, err := frontendregistry.UnmarshalRegistryExtensionID(args.Extension)
 	if err != nil {
 		return nil, err
@@ -85,6 +94,9 @@ func extensionRegistryUpdateExtension(ctx context.Context, db database.DB, args 
 }
 
 func extensionRegistryDeleteExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryDeleteExtensionArgs) (*graphqlbackend.EmptyResponse, error) {
+	if err := frontendregistry.ExtensionRegistryWriteEnabled(); err != nil {
+		return nil, err
+	}
 	id, err := frontendregistry.UnmarshalRegistryExtensionID(args.Extension)
 	if err != nil {
 		return nil, err
@@ -103,6 +115,9 @@ func extensionRegistryDeleteExtension(ctx context.Context, db database.DB, args 
 
 func extensionRegistryPublishExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryPublishExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
 	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
+		return nil, err
+	}
+	if err := frontendregistry.ExtensionRegistryWriteEnabled(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #40434
Fixes #39044
Fixes #39043

This is an audit of the extension registry (GraphQL and content download) APIs. Here's a list of all commands that have been audited:

- CLI:
  - `copy` (This uses the same GQL API as `publish`)
  - `list`
  - `get`
  - `delete`
- Web:
  -  Download URL e.g. `https://sourcegraph.test:3443/-/static/extension/1-sourcegraph-test-3443-philippspiess-lisp.js`
- GraphQL:
  - `query extension`
  - `query extensions`
  - `mutation createExtension`
  - `mutation updateExtension`
  - `mutation publishExtension`
  - `mutation deleteExtension`

GraphQL APIs that were not changed (these seemed relatively harmless):

- `query viewerPublishers`
- `query publishers`
- `query featuredExtensions`

The new gating that was added has a special case for dotcom which needs to be stay in read-only mode even after 4.0 and the `enableLegacyExtensions` flag is set to false.

Note: We can't make the gating dynamic yet because we're still waiting for #40085. The change after we have a fix for #40085 is trivial though, I'll create a follow-up issue for that.

## Test plan

Here's a bunch of screenshots that show that the error is properly propagated:

![Screenshot 2022-08-17 at 13 10 30](https://user-images.githubusercontent.com/458591/185106110-f34cc52b-247c-4bdc-9180-eff30d778aef.png)
![Screenshot 2022-08-17 at 12 22 34](https://user-images.githubusercontent.com/458591/185106115-73e53681-5756-4f90-b92e-a879dcd2434b.png)
![Screenshot 2022-08-17 at 12 22 05](https://user-images.githubusercontent.com/458591/185106118-3bbe86f9-6107-44f5-85a1-d205957dc255.png)
![Screenshot 2022-08-17 at 12 13 47](https://user-images.githubusercontent.com/458591/185106120-115b8fb2-7857-4852-a0a3-1d212c00d1b7.png)
![Screenshot 2022-08-17 at 11 45 39](https://user-images.githubusercontent.com/458591/185106122-b0b5888d-7377-4ebd-a110-7f53fc77777b.png)
![Screenshot 2022-08-17 at 11 45 27](https://user-images.githubusercontent.com/458591/185106123-59cc5514-fc30-4ab5-a30f-51b00442b010.png)
![Screenshot 2022-08-17 at 13 28 25](https://user-images.githubusercontent.com/458591/185107632-c20feacd-247b-45fa-9b6d-76352d7fe9cc.png)
![Screenshot 2022-08-17 at 13 27 16](https://user-images.githubusercontent.com/458591/185107638-b7dd7f8e-c870-441e-94ac-9ae8824455ee.png)



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
