### PR TITLE
Site Admin: Fix User management styles

### DIFF
--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/Table.module.scss
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/Table.module.scss
@@ -12,8 +12,7 @@
 
 .header {
     display: flex;
-    align-items: start;
-    justify-content: start;
+    align-items: flex-start;
     padding: 0 0.5rem;
 
     &.align-right {


### PR DESCRIPTION
Fix user management styles (there is no value for flex box rules as `start` but `flex-start`). This also removes post-CSS warnings from the browser and CLI logs. 

## Test plan
- Make sure that User Management table doesn't have any visual regressions 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-post-css-warnings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-klcoiualvj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
