### PR TITLE
Call store.ListIndexableRepos in (*repos).ListIndexable

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -183,7 +183,7 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 	return s.store.List(ctx, opt)
 }
 
-// ListIndexable calls database.IndexableRepos.List, with tracing. It lists
+// ListIndexable calls database.ListMinimalRepos, with tracing. It lists
 // ALL indexable repos which could include private user added repos.
 // In addition, it only lists cloned repositories.
 //
@@ -203,9 +203,10 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.MinimalRepo, e
 		return s.cache.List(ctx)
 	}
 
-	return s.store.ListIndexableRepos(ctx, database.ListIndexableReposOptions{
-		CloneStatus:    types.CloneStatusCloned,
-		IncludePrivate: true,
+	trueP := true
+	return s.store.ListMinimalRepos(ctx, database.ReposListOptions{
+		Index:      &trueP,
+		OnlyCloned: true,
 	})
 }
 

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -203,10 +203,9 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.MinimalRepo, e
 		return s.cache.List(ctx)
 	}
 
-	trueP := true
-	return s.store.ListMinimalRepos(ctx, database.ReposListOptions{
-		Index:      &trueP,
-		OnlyCloned: true,
+	return s.store.ListIndexableRepos(ctx, database.ListIndexableReposOptions{
+		CloneStatus:    types.CloneStatusCloned,
+		IncludePrivate: true,
 	})
 }
 


### PR DESCRIPTION
The docstring for `(*repos).ListIndexable` says:

> ListIndexable calls database.IndexableRepos.List, with tracing. It lists
> ALL indexable repos which could include private user added repos.
> In addition, it only lists cloned repositories.

But it didn't call `database.IndexableRepos`.

So either the docstring was wrong or the code. This PR here makes the
code do what the docstring says, but I'm not sure whether that's
correct - looking for feedback here.

(Data point that speaks for this change: the `s.cache.List` method
called right before also calls `store.ListIndexableRepos` in case the
cache is invalid)

## Test plan

- Existing tests
