### PR TITLE
Allow users to list repositories currently being cloned

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -93,13 +93,19 @@ const FILTERS: FilteredConnectionFilter[] = [
                 label: 'Cloned',
                 value: 'cloned',
                 tooltip: 'Show cloned repositories only',
-                args: { cloned: true, notCloned: false },
+                args: { cloneStatus: 'CLONED' },
+            },
+            {
+                label: 'Cloning',
+                value: 'cloning',
+                tooltip: 'Show repositories currently being cloned only',
+                args: { cloneStatus: 'CLONING' },
             },
             {
                 label: 'Not cloned',
                 value: 'not-cloned',
                 tooltip: 'Show only repositories that have not been cloned yet',
-                args: { cloned: false, notCloned: true },
+                args: { cloneStatus: 'NOT_CLONED' },
             },
             {
                 label: 'Needs index',

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -429,20 +429,18 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
             query Repositories(
                 $first: Int
                 $query: String
-                $cloned: Boolean
-                $notCloned: Boolean
                 $indexed: Boolean
                 $notIndexed: Boolean
                 $failedFetch: Boolean
+                $cloneStatus: CloneStatus
             ) {
                 repositories(
                     first: $first
                     query: $query
-                    cloned: $cloned
-                    notCloned: $notCloned
                     indexed: $indexed
                     notIndexed: $notIndexed
                     failedFetch: $failedFetch
+                    cloneStatus: $cloneStatus
                 ) {
                     nodes {
                         ...SiteAdminRepositoryFields
@@ -457,13 +455,12 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
             ${siteAdminRepositoryFieldsFragment}
         `,
         {
-            cloned: args.cloned ?? true,
-            notCloned: args.notCloned ?? true,
             indexed: args.indexed ?? true,
             notIndexed: args.notIndexed ?? true,
             failedFetch: args.failedFetch ?? false,
             first: args.first ?? null,
             query: args.query ?? null,
+            cloneStatus: args.cloneStatus ?? null,
         }
     ).pipe(
         map(dataOrThrowErrors),

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -457,6 +457,7 @@ type ListOrgRepositoriesArgs struct {
 	First              *int32
 	Query              *string
 	After              *string
+	CloneStatus        *string
 	Cloned             bool
 	NotCloned          bool
 	Indexed            bool

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -20,9 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-type RepositoriesQueryBaseArgs struct {
-}
-
 type repositoryArgs struct {
 	graphqlutil.ConnectionArgs
 	Query       *string

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1239,6 +1239,10 @@ type Query {
         """
         cloned: Boolean = true
         """
+        Include only repositories of the given clone status.
+        """
+        cloneStatus: CloneStatus
+        """
         Include repositories that are not yet cloned and for which cloning is not in progress.
         """
         notCloned: Boolean = true
@@ -7468,4 +7472,13 @@ type WebhookLogHeader {
     The header values.
     """
     values: [String!]!
+}
+
+"""
+The clone status of a repository.
+"""
+enum CloneStatus {
+    NOT_CLONED
+    CLONING
+    CLONED
 }

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -717,6 +717,9 @@ type ReposListOptions struct {
 	// OnlyCloned excludes non-cloned repositories from the list.
 	OnlyCloned bool
 
+	// CloneStatus if set will only return repos of that clone status.
+	CloneStatus types.CloneStatus
+
 	// NoPrivate excludes private repositories from the list.
 	NoPrivate bool
 
@@ -1059,6 +1062,10 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 	if opt.OnlyCloned {
 		where = append(where, sqlf.Sprintf("gr.clone_status = 'cloned'"))
 	}
+	if opt.CloneStatus != types.CloneStatusUnknown {
+		where = append(where, sqlf.Sprintf("gr.clone_status = %s", opt.CloneStatus))
+	}
+
 	if opt.FailedFetch {
 		where = append(where, sqlf.Sprintf("gr.last_error IS NOT NULL"))
 	}
@@ -1138,7 +1145,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 		where = append(where, sqlf.Sprintf("external_service_repos.org_id = %d", opt.OrgID))
 	}
 
-	if opt.NoCloned || opt.OnlyCloned || opt.FailedFetch || !opt.MinLastChanged.IsZero() || opt.joinGitserverRepos {
+	if opt.NoCloned || opt.OnlyCloned || opt.FailedFetch || !opt.MinLastChanged.IsZero() || opt.joinGitserverRepos || opt.CloneStatus != types.CloneStatusUnknown {
 		joins = append(joins, sqlf.Sprintf("JOIN gitserver_repos gr ON gr.repo_id = repo.id"))
 	}
 

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -717,19 +717,35 @@ func TestRepos_List_cloned(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	ctx := actor.WithInternalActor(context.Background())
 
-	mine := mustCreate(ctx, t, db, &types.Repo{Name: "a/r"})
-	yours := mustCreate(ctx, t, db, &types.Repo{Name: "b/r"})
-	setGitserverRepoCloneStatus(t, db, yours.Name, types.CloneStatusCloned)
+	var repos []*types.Repo
+	for _, data := range []struct {
+		repo        *types.Repo
+		cloneStatus types.CloneStatus
+	}{
+		{repo: &types.Repo{Name: "repo-0"}, cloneStatus: types.CloneStatusNotCloned},
+		{repo: &types.Repo{Name: "repo-1"}, cloneStatus: types.CloneStatusCloned},
+		{repo: &types.Repo{Name: "repo-2"}, cloneStatus: types.CloneStatusCloning},
+	} {
+		repo := mustCreate(ctx, t, db, data.repo)
+		setGitserverRepoCloneStatus(t, db, repo.Name, data.cloneStatus)
+		repos = append(repos, repo)
+	}
 
 	tests := []struct {
 		name string
 		opt  ReposListOptions
 		want []*types.Repo
 	}{
-		{"OnlyCloned", ReposListOptions{OnlyCloned: true}, []*types.Repo{yours}},
-		{"NoCloned", ReposListOptions{NoCloned: true}, []*types.Repo{mine}},
+		{"OnlyCloned", ReposListOptions{OnlyCloned: true}, []*types.Repo{repos[1]}},
+		{"NoCloned", ReposListOptions{NoCloned: true}, []*types.Repo{repos[0], repos[2]}},
 		{"NoCloned && OnlyCloned", ReposListOptions{NoCloned: true, OnlyCloned: true}, nil},
-		{"Default", ReposListOptions{}, append(append([]*types.Repo(nil), mine), yours)},
+		{"Default", ReposListOptions{}, repos},
+		{"CloneStatus=Cloned", ReposListOptions{CloneStatus: types.CloneStatusCloned}, []*types.Repo{repos[1]}},
+		{"CloneStatus=NotCloned", ReposListOptions{CloneStatus: types.CloneStatusNotCloned}, []*types.Repo{repos[0]}},
+		{"CloneStatus=Cloning", ReposListOptions{CloneStatus: types.CloneStatusCloning}, []*types.Repo{repos[2]}},
+		// These don't make sense, but we test that both conditions are used
+		{"OnlyCloned && CloneStatus=Cloning", ReposListOptions{OnlyCloned: true, CloneStatus: types.CloneStatusCloning}, nil},
+		{"NoCloned && CloneStatus=Cloned", ReposListOptions{NoCloned: true, CloneStatus: types.CloneStatusCloned}, nil},
 	}
 
 	for _, test := range tests {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -533,6 +533,13 @@ func ParseCloneStatus(s string) CloneStatus {
 	}
 }
 
+// ParseCloneStatusFromGraphQL converts the raw value of the GraphQL enum
+// CloneStatus into the corresponding CloneStatus defined here. If the GraphQL
+// value can't be matched to a CloneStatus, CloneStatusUnknown is returned.
+func ParseCloneStatusFromGraphQL(s string) CloneStatus {
+	return ParseCloneStatus(strings.ToLower(s))
+}
+
 // GitserverRepo  represents the data gitserver knows about a repo
 type GitserverRepo struct {
 	RepoID api.RepoID


### PR DESCRIPTION
This introduced a new filter to the GraphQL: `cloneStatus`. If set, it
returns only repositories that have the given clone status.

With that we can reduce the number of booleans we use when interacting
with the API: instead of querying for `{cloned: true, notCloned: false}`
(which we did even though the `notCloned` was useless) we can query for
`{cloneStatus: "CLONED"}`.

And now we can also query for `{cloneStatus: "CLONING"}`.

This also changes how the site-admin UI works:
* previously: listing "not cloned" would include "cloning" repositories
* now: listing "not cloned" only lists repositories that are "not cloned".

Subpart of this ticket: https://github.com/sourcegraph/sourcegraph/issues/39328

## Test plan

- unit tests
- manual testing
