### PR TITLE
syntax-highlighter: Bump tag for http-server-stabilizer.

### DIFF
--- a/docker-images/syntax-highlighter/Dockerfile
+++ b/docker-images/syntax-highlighter/Dockerfile
@@ -14,12 +14,12 @@ RUN cp ./target/release/syntect_server /syntect_server
 ################################
 # Build http-server-stabilizer #
 ################################
-FROM golang:1.15.2-alpine@sha256:fc801399d044a8e01f125eeb5aa3f160a0d12d6e03ba17a1d0b22ce50dfede81 as hss
+FROM golang:1.19-alpine@sha256:70df3b8f9f099da7f60f0b32480015165e3d0b51bfacf9e255b59f3dd6bd2828 as hss
 
 RUN apk add --no-cache git>=2.26.3
-RUN git clone https://github.com/sourcegraph/http-server-stabilizer /repo
+RUN git clone --branch v1.0.5 --single-branch https://github.com/sourcegraph/http-server-stabilizer /repo
 WORKDIR /repo
-RUN git checkout v1.0.4 && go build -o /http-server-stabilizer .
+RUN go build -o /http-server-stabilizer .
 
 #######################
 # Compile final image #


### PR DESCRIPTION
Forgot to do this earlier. This tag contains the bumped dependency.

## Test plan

Manually test with `trivy`.