### PR TITLE
repos: consolidate test helpers

### DIFF
--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -449,10 +449,7 @@ func TestSetCloneStatus(t *testing.T) {
 	})
 
 	// Set cloned
-	err := db.GitserverRepos().SetCloneStatus(ctx, repo.Name, types.CloneStatusCloned, "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	setGitserverRepoCloneStatus(t, db, repo.Name, types.CloneStatusCloned)
 
 	fromDB, err := db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID)
 	if err != nil {
@@ -460,6 +457,7 @@ func TestSetCloneStatus(t *testing.T) {
 	}
 
 	gitserverRepo.CloneStatus = types.CloneStatusCloned
+	gitserverRepo.ShardID = shardID
 	if diff := cmp.Diff(gitserverRepo, fromDB, cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt")); diff != "" {
 		t.Fatal(diff)
 	}
@@ -477,9 +475,7 @@ func TestSetCloneStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := db.GitserverRepos().SetCloneStatus(ctx, repo2.Name, types.CloneStatusCloned, shardID); err != nil {
-		t.Fatal(err)
-	}
+	setGitserverRepoCloneStatus(t, db, repo2.Name, types.CloneStatusCloned)
 	fromDB, err = db.GitserverRepos().GetByID(ctx, repo2.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -494,9 +490,7 @@ func TestSetCloneStatus(t *testing.T) {
 	}
 
 	// Setting the same status again should not touch the row
-	if err := db.GitserverRepos().SetCloneStatus(ctx, repo2.Name, types.CloneStatusCloned, shardID); err != nil {
-		t.Fatal(err)
-	}
+	setGitserverRepoCloneStatus(t, db, repo2.Name, types.CloneStatusCloned)
 	after, err := db.GitserverRepos().GetByID(ctx, repo2.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -73,6 +73,31 @@ func mustCreate(ctx context.Context, t *testing.T, db DB, repo *types.Repo) *typ
 	return repo
 }
 
+func setGitserverRepoCloneStatus(t *testing.T, db DB, name api.RepoName, s types.CloneStatus) {
+	t.Helper()
+
+	if err := db.GitserverRepos().SetCloneStatus(context.Background(), name, s, shardID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setGitserverRepoLastChanged(t *testing.T, db DB, name api.RepoName, last time.Time) {
+	t.Helper()
+
+	if err := db.GitserverRepos().SetLastFetched(context.Background(), name, GitserverFetchData{LastFetched: last, LastChanged: last}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setGitserverRepoLastError(t *testing.T, db DB, name api.RepoName, msg string) {
+	t.Helper()
+
+	err := db.GitserverRepos().SetLastError(context.Background(), name, msg, shardID)
+	if err != nil {
+		t.Fatalf("failed to set last error: %s", err)
+	}
+}
+
 func repoNamesFromRepos(repos []*types.Repo) []types.MinimalRepo {
 	rnames := make([]types.MinimalRepo, 0, len(repos))
 	for _, repo := range repos {
@@ -656,22 +681,6 @@ func TestRepos_List_fork(t *testing.T) {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, append(append([]*types.Repo(nil), mine...), yours...), repos)
-	}
-}
-
-func setGitserverRepoCloneStatus(t *testing.T, db DB, name api.RepoName, s types.CloneStatus) {
-	t.Helper()
-
-	if err := db.GitserverRepos().SetCloneStatus(context.Background(), name, s, ""); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func setGitserverRepoLastChanged(t *testing.T, db DB, name api.RepoName, last time.Time) {
-	t.Helper()
-
-	if err := db.GitserverRepos().SetLastFetched(context.Background(), name, GitserverFetchData{LastFetched: last, LastChanged: last}); err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -632,23 +632,6 @@ func TestRepos_StatisticsCounts(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1, Internal: true})
 
 	// Helper functions
-	setCloneStatus := func(t *testing.T, repo *types.Repo, status types.CloneStatus) {
-		t.Helper()
-		err := db.GitserverRepos().SetCloneStatus(ctx, repo.Name, status, "shard-1")
-		if err != nil {
-			t.Fatalf("failed to set clone status: %s", err)
-		}
-	}
-
-	setError := func(t *testing.T, repo *types.Repo, msg string) {
-		t.Helper()
-
-		err := db.GitserverRepos().SetLastError(ctx, repo.Name, msg, "shard-1")
-		if err != nil {
-			t.Fatalf("failed to set last error: %s", err)
-		}
-	}
-
 	deleteRepo := func(t *testing.T, repo *types.Repo) {
 		t.Helper()
 
@@ -694,8 +677,8 @@ func TestRepos_StatisticsCounts(t *testing.T) {
 	})
 
 	// 2 repos are being cloned
-	setCloneStatus(t, repos[0], types.CloneStatusCloning)
-	setCloneStatus(t, repos[1], types.CloneStatusCloning)
+	setGitserverRepoCloneStatus(t, db, repos[0].Name, types.CloneStatusCloning)
+	setGitserverRepoCloneStatus(t, db, repos[1].Name, types.CloneStatusCloning)
 
 	assertCounts(t, StatisticsCounts{
 		Total:     3,
@@ -704,7 +687,7 @@ func TestRepos_StatisticsCounts(t *testing.T) {
 	})
 
 	// 1 of them runs into error
-	setError(t, repos[2], "connection reset by pete")
+	setGitserverRepoLastError(t, db, repos[2].Name, "connection reset by pete")
 
 	assertCounts(t, StatisticsCounts{
 		Total:       3,
@@ -714,8 +697,8 @@ func TestRepos_StatisticsCounts(t *testing.T) {
 	})
 
 	// Cloned
-	setCloneStatus(t, repos[0], types.CloneStatusCloned)
-	setCloneStatus(t, repos[1], types.CloneStatusCloned)
+	setGitserverRepoCloneStatus(t, db, repos[0].Name, types.CloneStatusCloned)
+	setGitserverRepoCloneStatus(t, db, repos[1].Name, types.CloneStatusCloned)
 	assertCounts(t, StatisticsCounts{
 		Total:       3,
 		NotCloned:   1,


### PR DESCRIPTION
This moves the helpers to the other helpers and uses them consistently.

## Test plan

- Existing tests