### PR TITLE
CodeMirror Blob: fix syntax highlighting error

### DIFF
--- a/client/web/src/lsif/lsif-typed.ts
+++ b/client/web/src/lsif/lsif-typed.ts
@@ -12,10 +12,27 @@ export interface JsonOccurrence {
 
 export class Position {
     constructor(public readonly line: number, public readonly character: number) {}
+
+    public compare(other: Position): number {
+        if (this.line !== other.line) {
+            return this.line - other.line
+        }
+        return this.character - other.character
+    }
 }
 
 export class Range {
     constructor(public readonly start: Position, public readonly end: Position) {}
+    public isSingleLine(): boolean {
+        return this.start.line === this.end.line
+    }
+    public compare(other: Range): number {
+        const byStart = this.start.compare(other.start)
+        if (byStart !== 0) {
+            return byStart
+        }
+        return this.end.compare(other.end)
+    }
 }
 
 export class Occurrence {
@@ -34,6 +51,11 @@ export class Occurrence {
         )
 
         this.kind = occ.syntaxKind
+    }
+    public static fromJson(json: string): Occurrence[] {
+        const jsonOccurrences = (JSON.parse(json) as JsonDocument).occurrences ?? []
+        const occurrences = jsonOccurrences.map(occ => new Occurrence(occ))
+        return occurrences.sort((a, b) => a.range.compare(b.range))
     }
 }
 

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -47,8 +47,8 @@ function createHighlightTable(json: string | undefined): HighlightIndex {
         }
 
         return { occurrences, lineIndex }
-    } catch (e) {
-        console.error(`Unable to process SCIP highlight data: ${json}`, e)
+    } catch (error) {
+        console.error(`Unable to process SCIP highlight data: ${json}`, error)
         return { occurrences: [], lineIndex }
     }
 }
@@ -121,8 +121,8 @@ class SyntaxHighlightManager implements PluginValue {
                     builder.add(from, to, decoration)
                 }
             }
-        } catch (e) {
-            console.error('Failed to compute decorations from SCIP occurrences', e)
+        } catch (error) {
+            console.error('Failed to compute decorations from SCIP occurrences', error)
         }
         return builder.finish()
     }

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -1,7 +1,7 @@
 import { Facet, RangeSetBuilder } from '@codemirror/state'
 import { Decoration, DecorationSet, EditorView, PluginValue, ViewPlugin, ViewUpdate } from '@codemirror/view'
 
-import { JsonDocument, JsonOccurrence, SyntaxKind } from '../../../lsif/lsif-typed'
+import { Occurrence, SyntaxKind } from '../../../lsif/lsif-typed'
 import { BlobInfo } from '../Blob'
 
 /**
@@ -10,7 +10,7 @@ import { BlobInfo } from '../Blob'
  * number, with minimal additional impact on memory (e.g. garbage collection).
  */
 interface HighlightIndex {
-    occurrences: JsonOccurrence[]
+    occurrences: Occurrence[]
     lineIndex: (number | undefined)[]
 }
 
@@ -27,30 +27,28 @@ function createHighlightTable(json: string | undefined): HighlightIndex {
     }
 
     try {
-        const occurrences = (JSON.parse(json) as JsonDocument).occurrences ?? []
+        const occurrences = Occurrence.fromJson(json)
         let previousEndline: number | undefined
 
         for (let index = 0; index < occurrences.length; index++) {
             const current = occurrences[index]
-            const startLine = current.range[0]
-            const endLine = current.range.length === 3 ? startLine : current.range[2]
 
-            if (previousEndline !== startLine) {
+            if (previousEndline !== current.range.start.line) {
                 // Only use the current index if there isn't already an occurence on
                 // the current line.
-                lineIndex[startLine] = index
+                lineIndex[current.range.start.line] = index
             }
 
-            if (startLine !== endLine) {
-                lineIndex[endLine] = index
+            if (!current.range.isSingleLine()) {
+                lineIndex[current.range.end.line] = index
             }
 
-            previousEndline = endLine
+            previousEndline = current.range.end.line
         }
 
         return { occurrences, lineIndex }
-    } catch {
-        console.error(`Unable to process SCIP highlight data: ${json}`)
+    } catch (e) {
+        console.error(`Unable to process SCIP highlight data: ${json}`, e)
         return { occurrences: [], lineIndex }
     }
 }
@@ -70,60 +68,62 @@ class SyntaxHighlightManager implements PluginValue {
     }
 
     private computeDecorations(view: EditorView): DecorationSet {
-        const { from, to } = view.viewport
-
-        // Determine the start and end lines of the current viewport
-        const fromLine = view.state.doc.lineAt(from)
-        const toLine = view.state.doc.lineAt(to)
-
-        const { occurrences, lineIndex } = view.state.facet(syntaxHighlight)
-
-        // Find index of first relevant token
-        let startIndex: number | undefined
-        {
-            let line = fromLine.number - 1
-            do {
-                startIndex = lineIndex[line++]
-            } while (startIndex === undefined && line < lineIndex.length)
-        }
-
         const builder = new RangeSetBuilder<Decoration>()
+        try {
+            const { from, to } = view.viewport
 
-        // Cache current line object
-        let line = fromLine
+            // Determine the start and end lines of the current viewport
+            const fromLine = view.state.doc.lineAt(from)
+            const toLine = view.state.doc.lineAt(to)
 
-        if (startIndex !== undefined) {
-            // Iterate over the rendered line (numbers) and get the
-            // corresponding occurrences from the highlighting table.
-            for (let index = startIndex; index < occurrences.length; index++) {
-                const occurrence = occurrences[index]
+            const { occurrences, lineIndex } = view.state.facet(syntaxHighlight)
 
-                if (occurrence.range[0] > toLine.number) {
-                    break
-                }
-
-                if (occurrence.syntaxKind === undefined) {
-                    continue
-                }
-
-                // Fetch new line information if necessary
-                if (line.number !== occurrence.range[0] + 1) {
-                    line = view.state.doc.line(occurrence.range[0] + 1)
-                }
-
-                builder.add(
-                    line.from + occurrence.range[1],
-                    occurrence.range.length === 3
-                        ? line.from + occurrence.range[2]
-                        : view.state.doc.line(occurrence.range[2] + 1).from + occurrence.range[3],
-                    this.decorationCache[occurrence.syntaxKind] ||
-                        (this.decorationCache[occurrence.syntaxKind] = Decoration.mark({
-                            class: `hl-typed-${SyntaxKind[occurrence.syntaxKind]}`,
-                        }))
-                )
+            // Find index of first relevant token
+            let startIndex: number | undefined
+            {
+                let line = fromLine.number - 1
+                do {
+                    startIndex = lineIndex[line++]
+                } while (startIndex === undefined && line < lineIndex.length)
             }
-        }
 
+            // Cache current line object
+            let line = fromLine
+
+            if (startIndex !== undefined) {
+                // Iterate over the rendered line (numbers) and get the
+                // corresponding occurrences from the highlighting table.
+                for (let index = startIndex; index < occurrences.length; index++) {
+                    const occurrence = occurrences[index]
+
+                    if (occurrence.range.start.line > toLine.number) {
+                        break
+                    }
+
+                    if (occurrence.kind === undefined) {
+                        continue
+                    }
+
+                    // Fetch new line information if necessary
+                    if (line.number !== occurrence.range.start.line + 1) {
+                        line = view.state.doc.line(occurrence.range.start.line + 1)
+                    }
+
+                    const from = line.from + occurrence.range.start.character
+                    const to = occurrence.range.isSingleLine()
+                        ? line.from + occurrence.range.end.character
+                        : view.state.doc.line(occurrence.range.end.line + 1).from + occurrence.range.end.character
+                    const decoration =
+                        this.decorationCache[occurrence.kind] ||
+                        (this.decorationCache[occurrence.kind] = Decoration.mark({
+                            class: `hl-typed-${SyntaxKind[occurrence.kind]}`,
+                        }))
+                    builder.add(from, to, decoration)
+                }
+            }
+        } catch (e) {
+            console.error('Failed to compute decorations from SCIP occurrences', e)
+        }
         return builder.finish()
     }
 }


### PR DESCRIPTION
Previously, syntax highlighting occasionally failed because the
occurrences were not correctly ordered when we computed CodeMirror
"decorations", causing `RangeSetBuilder.finish()` to crash with an
uncaught exception. This commit addresses the issue with several fixes:

- Sort occurrences on the client-side so that it's OK if the server
  returns unordered occurrences
- Use the higher-level `Occurrences` class to minimize the risk of
  making mistakes when working with the low-level `range: number[]`
  encoding.
- Catch exceptions and log a helpful error message if an error gets
  thrown again while computing decorations, making it easier to
  troubleshoot similar issues in the future.

Fixes #40352
Fixes #40355

## Test plan

Run `sg start` and browse Java and TypeScript files. All files should render
correct highlighting, including `backend.ts` and `client/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java` (which don't render correctly currently on sourcegraph.com)

![CleanShot 2022-08-17 at 17 54 55](https://user-images.githubusercontent.com/1408093/185186276-7e0b3541-d50e-4dd1-bd3c-fe230c13b563.png)
![CleanShot 2022-08-17 at 17 56 06](https://user-images.githubusercontent.com/1408093/185186514-1001514e-5ecf-4803-910b-99463780d4ca.png)




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-cm-hl.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lovgnmhkdv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
