### PR TITLE
VSCE: fix release script

### DIFF
--- a/client/vscode/scripts/publish.ts
+++ b/client/vscode/scripts/publish.ts
@@ -39,7 +39,16 @@ const commands = {
 try {
     // Get the latest release version nubmer of the last release from VS Code Marketplace using the vsce cli tool
     const response = childProcess.execSync(commands.vscode_info).toString()
-    const latestVersion: string = JSON.parse(response).versions[0].version
+    /*
+        `vscode_info` command output is extension info prepended by command name and arguments, e.g.
+        $ /Users/taras/projects/sourcegraph/node_modules/.bin/vsce show sourcegraph.sourcegraph --json
+        {
+            ...json
+        }
+        We cut everything before the json object so that we can parse it as json.
+    */
+    const trimmedResponse = response.substring(response.indexOf('{'))
+    const latestVersion: string = JSON.parse(trimmedResponse).versions[0].version
     if (hasTokens && (version === latestVersion || !semver.valid(latestVersion) || !semver.valid(version))) {
         throw new Error(
             version === latestVersion


### PR DESCRIPTION
The latest VSCE release [failed with error](https://buildkite.com/sourcegraph/sourcegraph/builds/167584#0182ab8b-5205-4efd-86d8-5cab11309a77/152-385). 
The error was caused by the release script trying to parse as JSON the `yarn vsce show sourcegraph.sourcegraph --json` which appeared to be not a valid JSON string. The output is prepended by the command name and arguments; thus, it couldn't be parsed as JSON, causing failure.
Example output:
```
$ /Users/taras/projects/sourcegraph/node_modules/.bin/vsce show sourcegraph.sourcegraph --json
{
    "extensionName": "sourcegraph",
    ...other
}
```
Suggested fix: trim everything before the JSON string.

## Test plan
VSCE release script runs successfully.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
