### PR TITLE
executors: Make use of ignite runlock configurable

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	KeepWorkspaces                bool
 	DockerHostMountPath           string
 	UseFirecracker                bool
+	UseFirecrackerRunlock         bool
 	JobNumCPUs                    int
 	JobMemory                     string
 	FirecrackerDiskSpace          string
@@ -49,6 +50,7 @@ func (c *Config) Load() {
 	c.QueuePollInterval = c.GetInterval("EXECUTOR_QUEUE_POLL_INTERVAL", "1s", "Interval between dequeue requests.")
 	c.MaximumNumJobs = c.GetInt("EXECUTOR_MAXIMUM_NUM_JOBS", "1", "Number of virtual machines or containers that can be running at once.")
 	c.UseFirecracker = c.GetBool("EXECUTOR_USE_FIRECRACKER", "true", "Whether to isolate commands in virtual machines.")
+	c.UseFirecrackerRunlock = c.GetBool("EXECUTOR_USE_FIRECRACKER_RUNLOCK", "true", "Whether to limit concurrency on VM spawns to 1.")
 	c.FirecrackerImage = c.Get("EXECUTOR_FIRECRACKER_IMAGE", "sourcegraph/ignite-ubuntu:insiders", "The base image to use for virtual machines.")
 	c.FirecrackerKernelImage = c.Get("EXECUTOR_FIRECRACKER_KERNEL_IMAGE", "sourcegraph/ignite-kernel:5.10.135-amd64", "The base image containing the kernel binary to use for virtual machines.")
 	c.VMStartupScriptPath = c.GetOptional("EXECUTOR_VM_STARTUP_SCRIPT_PATH", "A path to a file on the host that is loaded into a fresh virtual machine and executed on startup.")
@@ -121,6 +123,7 @@ func (c *Config) FirecrackerOptions() command.FirecrackerOptions {
 		Image:               c.FirecrackerImage,
 		KernelImage:         c.FirecrackerKernelImage,
 		VMStartupScriptPath: c.VMStartupScriptPath,
+		UseRunlock:          c.UseFirecrackerRunlock,
 	}
 }
 

--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -73,7 +73,11 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger Logger, 
 		Operation: operations.SetupFirecrackerStart,
 	}
 
-	if err := callWithInstrumentedLock(operations, logger, func() error { return runner.RunCommand(ctx, startCommand, logger) }); err != nil {
+	if options.FirecrackerOptions.UseRunlock {
+		if err := callWithInstrumentedLock(operations, logger, func() error { return runner.RunCommand(ctx, startCommand, logger) }); err != nil {
+			return errors.Wrap(err, "failed to start firecracker vm")
+		}
+	} else if err := runner.RunCommand(ctx, startCommand, logger); err != nil {
 		return errors.Wrap(err, "failed to start firecracker vm")
 	}
 

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -117,6 +117,7 @@ func TestSetupFirecracker(t *testing.T) {
 			Image:               "ignite-ubuntu",
 			KernelImage:         "ignite-kernel:5.10.135",
 			VMStartupScriptPath: "/vm-startup.sh",
+			UseRunlock:          true,
 		},
 		ResourceOptions: ResourceOptions{
 			NumCPUs:   4,

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -60,6 +60,10 @@ type FirecrackerOptions struct {
 	// VMStartupScriptPath is a path to a file on the host that is loaded into a fresh
 	// virtual machine and executed on startup.
 	VMStartupScriptPath string
+
+	// UseRunlock determines if the self-imposed 1-concurrency limit on `ignite run`
+	// invocations should be enforced.
+	UseRunlock bool
 }
 
 type ResourceOptions struct {


### PR DESCRIPTION
This is meant for debugging and I hope to eventually remove the run lock altogether.

## Test plan

Will use it on k8s for testing.