### PR TITLE
executors: Switch to sourcegraph ignite releases

### DIFF
--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -ex -o nounset -o pipefail
 
-export IGNITE_VERSION=v0.10.0
+export IGNITE_VERSION=v0.10.1
 export CNI_VERSION=v0.9.1
-export RUNTIME_IMAGE="weaveworks/ignite:${IGNITE_VERSION}"
+export RUNTIME_IMAGE="sourcegraph/ignite:${IGNITE_VERSION}"
 export KERNEL_IMAGE="sourcegraph/ignite-kernel:5.10.135-amd64"
 export EXECUTOR_FIRECRACKER_IMAGE="sourcegraph/ignite-ubuntu:insiders"
 export NODE_EXPORTER_VERSION=1.2.2
@@ -81,7 +81,7 @@ function install_ignite() {
   apt-get install -y mount tar binutils e2fsprogs openssh-client dmsetup
 
   # Download and install ignite binary.
-  curl -sfLo ignite https://github.com/weaveworks/ignite/releases/download/${IGNITE_VERSION}/ignite-amd64
+  curl -sfLo ignite https://github.com/sourcegraph/ignite/releases/download/${IGNITE_VERSION}/ignite-amd64
   chmod +x ignite
   mv ignite /usr/local/bin
 }


### PR DESCRIPTION
Let's see if they work, I've tried to adjust the release pipeline to our fork. This is meant to be a way for us to quickly iterate on ignite, since the last release was around 1 year ago it doesn't seem feasible to run every test patch by the upstream repo for now. We can try to upstream some of the changes later if they prove to be good.



## Test plan

Will test this version on k8s.