### PR TITLE
buildchecker: do not fail when checking org membership

### DIFF
--- a/dev/buildchecker/branch.go
+++ b/dev/buildchecker/branch.go
@@ -58,7 +58,8 @@ func (b *repoBranchLocker) Lock(ctx context.Context, commits []CommitInfo, fallb
 	for _, u := range failureAuthors {
 		membership, _, err := b.ghc.Organizations.GetOrgMembership(ctx, *u.Login, b.owner)
 		if err != nil {
-			return nil, errors.Newf("getOrgMembership: %w", err)
+			fmt.Printf("getOrgMembership error: %s\n", err)
+			continue // we don't want this user
 		}
 		if membership == nil || *membership.State != "active" {
 			continue // we don't want this user


### PR DESCRIPTION
Buildchecker is currently stuck on this API call: https://github.com/sourcegraph/sourcegraph/runs/7885574019?check_suite_focus=true#step:4:54

It seems we get a 404 which is strange, instead of just a nil membership like before - maybe new behaviour from GitHub?

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

recorded tests continue to pass