### PR TITLE
dev/sg: disable svg lint

### DIFF
--- a/dev/sg/internal/check/runner.go
+++ b/dev/sg/internal/check/runner.go
@@ -370,8 +370,8 @@ func (r *Runner[Args]) runAllCategoryChecks(ctx context.Context, args Args) *run
 		}
 
 		if _, ok := categoriesSkipped[i]; ok {
-			r.Output.WriteSkippedf("%s %s[SKIPPED. Reason: %s]%s", summaryStr,
-				output.StyleBold, categoriesSkipped[i], output.StyleReset)
+			r.Output.WriteSkippedf("%s %s[SKIPPED]%s",
+				summaryStr, output.StyleBold, output.StyleReset)
 			results.skipped = append(results.skipped, i)
 			continue
 		}

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type Target = check.Category[*repo.State]
@@ -75,6 +76,7 @@ var Targets = []Target{
 	{
 		Name:        "svg",
 		Description: "Check svg assets",
+		Enabled:     disabled("reported as unreliable"),
 		Checks: []*linter{
 			checkSVGCompression(),
 		},
@@ -128,5 +130,12 @@ func yarnInstallFilter() run.LineMap {
 			return 0, nil
 		}
 		return dst.Write(line)
+	}
+}
+
+// disabled can be used to mark a category or check as disabled.
+func disabled(reason string) check.EnableFunc[*repo.State] {
+	return func(context.Context, *repo.State) error {
+		return errors.Newf("disabled: %s", reason)
 	}
 }


### PR DESCRIPTION
TODO link to issue

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go run ./dev/sg lint svg`