### PR TITLE
codeintel: dont attempt syncing non-package-repo dependencies outside of dotcom

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
@@ -50,6 +50,10 @@ type RepoUpdaterClient interface {
 	RepoLookup(ctx context.Context, name api.RepoName) (info *protocol.RepoInfo, err error)
 }
 
+type ReposStore interface {
+	ListMinimalRepos(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error)
+}
+
 type ExternalServiceStore interface {
 	List(ctx context.Context, opt database.ExternalServicesListOptions) ([]*types.ExternalService, error)
 	Upsert(ctx context.Context, svcs ...*types.ExternalService) (err error)

--- a/enterprise/cmd/worker/internal/codeintel/indexing_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing_job.go
@@ -73,6 +73,7 @@ func (j *indexingJob) Routines(ctx context.Context, logger log.Logger) ([]gorout
 
 	repoUpdaterClient := codeintel.InitRepoUpdaterClient()
 	databaseDB := database.NewDB(logger, db)
+	repoStore := database.ReposWith(logger, databaseDB)
 	extSvcStore := databaseDB.ExternalServices()
 	gitserverRepoStore := databaseDB.GitserverRepos()
 	dbStoreShim := &indexing.DBStoreShim{Store: dbStore}
@@ -83,7 +84,7 @@ func (j *indexingJob) Routines(ctx context.Context, logger log.Logger) ([]gorout
 
 	routines := []goroutine.BackgroundRoutine{
 		indexing.NewDependencySyncScheduler(dbStoreShim, dependencySyncStore, extSvcStore, syncMetrics, observationContext),
-		indexing.NewDependencyIndexingScheduler(dbStoreShim, dependencyIndexingStore, extSvcStore, gitserverRepoStore, repoUpdaterClient, indexEnqueuer, indexingConfigInst.DependencyIndexerSchedulerPollInterval, indexingConfigInst.DependencyIndexerSchedulerConcurrency, queueingMetrics),
+		indexing.NewDependencyIndexingScheduler(dbStoreShim, repoStore, dependencyIndexingStore, extSvcStore, gitserverRepoStore, repoUpdaterClient, indexEnqueuer, indexingConfigInst.DependencyIndexerSchedulerPollInterval, indexingConfigInst.DependencyIndexerSchedulerConcurrency, queueingMetrics),
 	}
 
 	return routines, nil

--- a/mockgen.test.yaml
+++ b/mockgen.test.yaml
@@ -63,6 +63,7 @@
     - path: github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel/indexing
       interfaces:
         - DBStore
+        - ReposStore
         - ExternalServiceStore
         - GitserverRepoStore
         - GitserverClient


### PR DESCRIPTION
**Existing behaviour**: originally designed for dotcom, where repos from github n co (aka cloud_default external services) are lazily fetched, we would make repo-updater sync a potentially new repo by performing a RepoLookup for package references that didnt denote a package repo external services (aka for Go package references, as theyre git-hosted). 

This is undesirable outside of dotcom (where there are no cloud_default external services), as it results in alerts and logs on repos failing to sync.

**New behaviour:** we now specifically check if we're in dotcom mode and only lookup repos via repo-updater when 1) we're in dotcom mode and 2) the repo does not already exist in the `repo table`

Closes #40517 

## Test plan

Created new and updated existing unit tests to check for specific repo-updater function calls