### PR TITLE
executors: Get rid of ignite runlock

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -17734,50 +17734,6 @@ Query: `sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}"
 
 <br />
 
-### Executor: Run lock contention
-
-#### executor: executor_run_lock_wait_total
-
-<p class="subtitle">Milliseconds wait every 5m</p>
-
-Number of milliseconds spent waiting for the run lock every 5m
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100200` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_executor_run_lock_wait_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
-
-</details>
-
-<br />
-
-#### executor: executor_run_lock_held_total
-
-<p class="subtitle">Milliseconds held every 5m</p>
-
-Number of milliseconds spent holding for the run lock every 5m
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100201` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_executor_run_lock_held_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
-
-</details>
-
-<br />
-
 ### Executor: Executor: Queue API client
 
 #### executor: apiworker_apiclient_total
@@ -17786,7 +17742,7 @@ Query: `sum(increase(src_executor_run_lock_held_total{sg_job=~"^sourcegraph-exec
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100300` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100200` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17805,7 +17761,7 @@ Query: `sum(increase(src_apiworker_apiclient_total{sg_job=~"^sourcegraph-executo
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100301` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100201` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17824,7 +17780,7 @@ Query: `sum  by (le)(rate(src_apiworker_apiclient_duration_seconds_bucket{sg_job
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100302` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100202` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17843,7 +17799,7 @@ Query: `sum(increase(src_apiworker_apiclient_errors_total{sg_job=~"^sourcegraph-
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100303` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100203` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17862,7 +17818,7 @@ Query: `sum(increase(src_apiworker_apiclient_errors_total{sg_job=~"^sourcegraph-
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100310` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100210` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17881,7 +17837,7 @@ Query: `sum by (op)(increase(src_apiworker_apiclient_total{sg_job=~"^sourcegraph
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100311` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100211` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17900,7 +17856,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_apiclient_du
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100312` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100212` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17919,7 +17875,7 @@ Query: `sum by (op)(increase(src_apiworker_apiclient_errors_total{sg_job=~"^sour
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100313` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100213` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17940,7 +17896,7 @@ Query: `sum by (op)(increase(src_apiworker_apiclient_errors_total{sg_job=~"^sour
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100400` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100300` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17959,7 +17915,7 @@ Query: `sum(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"^sourceg
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100401` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100301` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17978,7 +17934,7 @@ Query: `sum  by (le)(rate(src_apiworker_command_duration_seconds_bucket{op=~"set
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100402` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100302` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -17997,7 +17953,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100403` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100303` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18016,7 +17972,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100410` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100310` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18035,7 +17991,7 @@ Query: `sum by (op)(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100411` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100311` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18054,7 +18010,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_dura
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100412` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100312` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18073,7 +18029,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",sg
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100413` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100313` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18094,7 +18050,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",sg
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100500` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100400` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18113,7 +18069,7 @@ Query: `sum(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^sourcegr
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100501` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100401` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18132,7 +18088,7 @@ Query: `sum  by (le)(rate(src_apiworker_command_duration_seconds_bucket{op=~"exe
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100502` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100402` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18151,7 +18107,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^s
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100503` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100403` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18170,7 +18126,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^s
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100510` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100410` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18189,7 +18145,7 @@ Query: `sum by (op)(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100511` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100411` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18208,7 +18164,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_dura
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100512` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100412` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18227,7 +18183,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100513` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100413` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18248,7 +18204,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100600` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100500` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18267,7 +18223,7 @@ Query: `sum(increase(src_apiworker_command_total{op=~"teardown.*",sg_job=~"^sour
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100601` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100501` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18286,7 +18242,7 @@ Query: `sum  by (le)(rate(src_apiworker_command_duration_seconds_bucket{op=~"tea
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100602` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100502` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18305,7 +18261,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100603` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100503` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18324,7 +18280,7 @@ Query: `sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100610` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100510` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18343,7 +18299,7 @@ Query: `sum by (op)(increase(src_apiworker_command_total{op=~"teardown.*",sg_job
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100611` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100511` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18362,7 +18318,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_dura
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100612` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100512` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18381,7 +18337,7 @@ Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"teardown.*"
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100613` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100513` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18404,7 +18360,7 @@ Indicates the amount of CPU time excluding idle and iowait time, divided by the 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100700` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100600` on your Sourcegraph instance.
 
 
 <details>
@@ -18424,7 +18380,7 @@ Indicates the average summed time a number of (but strictly not all) non-idle pr
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100701` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100601` on your Sourcegraph instance.
 
 
 <details>
@@ -18444,7 +18400,7 @@ Indicates the amount of available memory (including cache and buffers) as a perc
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100710` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100610` on your Sourcegraph instance.
 
 
 <details>
@@ -18464,7 +18420,7 @@ Indicates the efficiency of page reclaim, calculated as pgsteal/pgscan. Optimal 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100711` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100611` on your Sourcegraph instance.
 
 
 <details>
@@ -18484,7 +18440,7 @@ Indicates the amount of time all non-idle processes were stalled waiting on memo
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100712` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100612` on your Sourcegraph instance.
 
 
 <details>
@@ -18504,7 +18460,7 @@ Indicates the percentage of time a disk was busy. If this is less than 100%, the
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100720` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100620` on your Sourcegraph instance.
 
 
 <details>
@@ -18524,7 +18480,7 @@ Indicates the number of outstanding/queued IO requests. High but short-lived que
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100721` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100621` on your Sourcegraph instance.
 
 
 <details>
@@ -18544,7 +18500,7 @@ Indicates the averaged amount of time for which all non-idle processes were stal
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100722` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100622` on your Sourcegraph instance.
 
 
 <details>
@@ -18564,7 +18520,7 @@ Indicates the average summed receiving throughput of all network interfaces. Thi
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100730` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100630` on your Sourcegraph instance.
 
 
 <details>
@@ -18584,7 +18540,7 @@ Number of dropped received packets. This can happen if the receive queues/buffer
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100731` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100631` on your Sourcegraph instance.
 
 
 <details>
@@ -18604,7 +18560,7 @@ Number of bad/malformed packets received. https://www.kernel.org/doc/html/latest
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100732` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100632` on your Sourcegraph instance.
 
 
 <details>
@@ -18624,7 +18580,7 @@ Indicates the average summed transmitted throughput of all network interfaces. T
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100740` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100640` on your Sourcegraph instance.
 
 
 <details>
@@ -18644,7 +18600,7 @@ Number of dropped transmitted packets. This can happen if the receiving side`s r
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100741` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100641` on your Sourcegraph instance.
 
 
 <details>
@@ -18664,7 +18620,7 @@ Number of packet transmission errors. This is distinct from tx packet dropping, 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100742` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100642` on your Sourcegraph instance.
 
 
 <details>
@@ -18686,7 +18642,7 @@ Indicates the amount of CPU time excluding idle and iowait time, divided by the 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100800` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100700` on your Sourcegraph instance.
 
 
 <details>
@@ -18706,7 +18662,7 @@ Indicates the average summed time a number of (but strictly not all) non-idle pr
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100801` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100701` on your Sourcegraph instance.
 
 
 <details>
@@ -18726,7 +18682,7 @@ Indicates the amount of available memory (including cache and buffers) as a perc
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100810` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100710` on your Sourcegraph instance.
 
 
 <details>
@@ -18746,7 +18702,7 @@ Indicates the efficiency of page reclaim, calculated as pgsteal/pgscan. Optimal 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100811` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100711` on your Sourcegraph instance.
 
 
 <details>
@@ -18766,7 +18722,7 @@ Indicates the amount of time all non-idle processes were stalled waiting on memo
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100812` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100712` on your Sourcegraph instance.
 
 
 <details>
@@ -18786,7 +18742,7 @@ Indicates the percentage of time a disk was busy. If this is less than 100%, the
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100820` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100720` on your Sourcegraph instance.
 
 
 <details>
@@ -18806,7 +18762,7 @@ Indicates the number of outstanding/queued IO requests. High but short-lived que
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100821` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100721` on your Sourcegraph instance.
 
 
 <details>
@@ -18826,7 +18782,7 @@ Indicates the averaged amount of time for which all non-idle processes were stal
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100822` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100722` on your Sourcegraph instance.
 
 
 <details>
@@ -18846,7 +18802,7 @@ Indicates the average summed receiving throughput of all network interfaces. Thi
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100830` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100730` on your Sourcegraph instance.
 
 
 <details>
@@ -18866,7 +18822,7 @@ Number of dropped received packets. This can happen if the receive queues/buffer
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100831` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100731` on your Sourcegraph instance.
 
 
 <details>
@@ -18886,7 +18842,7 @@ Number of bad/malformed packets received. https://www.kernel.org/doc/html/latest
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100832` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100732` on your Sourcegraph instance.
 
 
 <details>
@@ -18906,7 +18862,7 @@ Indicates the average summed transmitted throughput of all network interfaces. T
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100840` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100740` on your Sourcegraph instance.
 
 
 <details>
@@ -18926,7 +18882,7 @@ Number of dropped transmitted packets. This can happen if the receiving side`s r
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100841` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100741` on your Sourcegraph instance.
 
 
 <details>
@@ -18946,7 +18902,7 @@ Number of packet transmission errors. This is distinct from tx packet dropping, 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100842` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100742` on your Sourcegraph instance.
 
 
 <details>
@@ -18968,7 +18924,7 @@ A high value here indicates a possible goroutine leak.
 
 Refer to the [alerts reference](./alerts.md#executor-go-goroutines) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100900` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100800` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -18987,7 +18943,7 @@ Query: `max by(sg_instance) (go_goroutines{sg_job=~".*sourcegraph-executors"})`
 
 Refer to the [alerts reference](./alerts.md#executor-go-gc-duration-seconds) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100901` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100801` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 

--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -30,7 +30,6 @@ type Config struct {
 	KeepWorkspaces                bool
 	DockerHostMountPath           string
 	UseFirecracker                bool
-	UseFirecrackerRunlock         bool
 	JobNumCPUs                    int
 	JobMemory                     string
 	FirecrackerDiskSpace          string
@@ -50,7 +49,6 @@ func (c *Config) Load() {
 	c.QueuePollInterval = c.GetInterval("EXECUTOR_QUEUE_POLL_INTERVAL", "1s", "Interval between dequeue requests.")
 	c.MaximumNumJobs = c.GetInt("EXECUTOR_MAXIMUM_NUM_JOBS", "1", "Number of virtual machines or containers that can be running at once.")
 	c.UseFirecracker = c.GetBool("EXECUTOR_USE_FIRECRACKER", "true", "Whether to isolate commands in virtual machines.")
-	c.UseFirecrackerRunlock = c.GetBool("EXECUTOR_USE_FIRECRACKER_RUNLOCK", "true", "Whether to limit concurrency on VM spawns to 1.")
 	c.FirecrackerImage = c.Get("EXECUTOR_FIRECRACKER_IMAGE", "sourcegraph/ignite-ubuntu:insiders", "The base image to use for virtual machines.")
 	c.FirecrackerKernelImage = c.Get("EXECUTOR_FIRECRACKER_KERNEL_IMAGE", "sourcegraph/ignite-kernel:5.10.135-amd64", "The base image containing the kernel binary to use for virtual machines.")
 	c.VMStartupScriptPath = c.GetOptional("EXECUTOR_VM_STARTUP_SCRIPT_PATH", "A path to a file on the host that is loaded into a fresh virtual machine and executed on startup.")
@@ -123,7 +121,6 @@ func (c *Config) FirecrackerOptions() command.FirecrackerOptions {
 		Image:               c.FirecrackerImage,
 		KernelImage:         c.FirecrackerKernelImage,
 		VMStartupScriptPath: c.VMStartupScriptPath,
-		UseRunlock:          c.UseFirecrackerRunlock,
 	}
 }
 

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -117,7 +117,6 @@ func TestSetupFirecracker(t *testing.T) {
 			Image:               "ignite-ubuntu",
 			KernelImage:         "ignite-kernel:5.10.135",
 			VMStartupScriptPath: "/vm-startup.sh",
-			UseRunlock:          true,
 		},
 		ResourceOptions: ResourceOptions{
 			NumCPUs:   4,
@@ -128,18 +127,8 @@ func TestSetupFirecracker(t *testing.T) {
 	operations := NewOperations(&observation.TestContext)
 
 	logger := NewMockLogger()
-	logEntry := NewMockLogEntry()
-	logger.LogFunc.SetDefaultHook(func(_ string, _ []string) LogEntry { return logEntry })
 	if err := setupFirecracker(context.Background(), runner, logger, "deadbeef", "/proj", options, operations); err != nil {
 		t.Fatalf("unexpected error tearing down virtual machine: %s", err)
-	}
-
-	if len(logger.LogFunc.History()) != 1 {
-		t.Error("logger not called")
-	}
-
-	if len(logEntry.CloseFunc.History()) != 1 {
-		t.Error("log handle not closed")
 	}
 
 	var actual []string

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -60,10 +60,6 @@ type FirecrackerOptions struct {
 	// VMStartupScriptPath is a path to a file on the host that is loaded into a fresh
 	// virtual machine and executed on startup.
 	VMStartupScriptPath string
-
-	// UseRunlock determines if the self-imposed 1-concurrency limit on `ignite run`
-	// invocations should be enforced.
-	UseRunlock bool
 }
 
 type ResourceOptions struct {

--- a/monitoring/definitions/executor.go
+++ b/monitoring/definitions/executor.go
@@ -41,7 +41,6 @@ func Executor() *monitoring.Dashboard {
 		Groups: []monitoring.Group{
 			shared.CodeIntelligence.NewExecutorQueueGroup(queueContainerName),
 			shared.CodeIntelligence.NewExecutorProcessorGroup(executorsJobName),
-			shared.CodeIntelligence.NewExecutorExecutionRunLockContentionGroup(executorsJobName),
 			shared.CodeIntelligence.NewExecutorAPIClientGroup(executorsJobName),
 			shared.CodeIntelligence.NewExecutorSetupCommandGroup(executorsJobName),
 			shared.CodeIntelligence.NewExecutorExecutionCommandGroup(executorsJobName),

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -332,36 +332,6 @@ func (codeIntelligence) NewExecutorProcessorGroup(containerName string) monitori
 	})
 }
 
-// src_executor_run_lock_wait_total
-// src_executor_run_lock_held_total
-func (codeIntelligence) NewExecutorExecutionRunLockContentionGroup(containerName string) monitoring.Group {
-	constructor := func(metricNameRoot, legend string) Observable {
-		filters := makeFilters("sg_job", containerName)
-		return Observable{
-			Name:        metricNameRoot + "_total",
-			Description: fmt.Sprintf("milliseconds %s every 5m", legend),
-			Owner:       monitoring.ObservableOwnerCodeIntel,
-			Query:       fmt.Sprintf(`sum(increase(src_%s_total{%s}[5m]))`, metricNameRoot, filters),
-			Panel:       monitoring.Panel().LegendFormat(legend).Unit(monitoring.Milliseconds),
-		}
-	}
-
-	return monitoring.Group{
-		Title:  "Run lock contention",
-		Hidden: true,
-		Rows: []monitoring.Row{
-			{
-				constructor("executor_run_lock_wait", "wait").WithNoAlerts(`
-					Number of milliseconds spent waiting for the run lock every 5m
-				`).Observable(),
-				constructor("executor_run_lock_held", "held").WithNoAlerts(`
-					Number of milliseconds spent holding for the run lock every 5m
-				`).Observable(),
-			},
-		},
-	}
-}
-
 // src_apiworker_command_total
 // src_apiworker_command_duration_seconds_bucket
 // src_apiworker_command_errors_total


### PR DESCRIPTION
The original reason doesn't hold anymore, we don't pull images at VM start anymore.
There was another potential race condition in ignite that could've lead to device busy errors so it had an internal run lock as well, I was able to defeat that here: https://github.com/sourcegraph/ignite/pull/1 and it works reliably across large workloads on k8s.

## Why is this exciting:

This makes large instances finally usable for executors! The more VMs a system can handle, the longer the overlap of ignite VM startup would be and hence big instances like AWS's metal ones which we usually use with 36x concurrency didn't really have any more throughput than a 4x instance, because 90% of time was spent in that concurrency gate.
This unleashes the full power of these machines.
On a 4x parallelism, 8 replica executors cluster against k8s, this reduced the run time of our example spec against 1000 workspaces from 20 minutes to 10:30 minutes. Bigger machines will benefit even more from this.
In addition, the lock meant that larger workspaces (big repos) would let other repos starve for even longer. Now there is no direct impact between runtime and repo size anymore.

## Test plan

Tested thoroughly on k8s.