### PR TITLE
dev/build-tracker: tweak messages

### DIFF
--- a/dev/build-tracker/README.md
+++ b/dev/build-tracker/README.md
@@ -23,4 +23,11 @@ To run the tests execute `go test .`
 
 ### Notification testing
 
-To test the notifications that get sent over slack you can pass the flag `-RunIntegrationTest` as part of your test invocation i.e. `SLACK_TOKEN='my valid token' go test . -RunIntegrationTest`. In addition to the flag, you also need a valid slack token defined in your environment variables as `SLACK_TOKEN`.
+To test the notifications that get sent over slack you can pass the flag `-RunIntegrationTest` as part of your test invocation, with some required configuration:
+
+```sh
+export SLACK_TOKEN='my valid token'
+export BUILDKITE_WEBHOOK_TOKEN='optional'
+export GITHUB_TOKEN='optional'
+go test . -RunIntegrationTest
+````

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-github/v41/github"
 	"github.com/slack-go/slack"
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/dev/team"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -186,31 +187,25 @@ func createMessageBlocks(logger log.Logger, teammate *team.Teammate, build *Buil
 		slack.NewHeaderBlock(
 			slack.NewTextBlockObject(slack.PlainTextType, fmt.Sprintf(":red_circle: Build %d failed", build.number()), true, false),
 		),
+		slack.NewSectionBlock(&slack.TextBlockObject{Type: slack.MarkdownType, Text: failedSection}, nil, nil),
+		slack.NewSectionBlock(
+			&slack.TextBlockObject{
+				Type: slack.MarkdownType,
+				Text: `:books: *More information on flakes*
+• <https://docs.sourcegraph.com/dev/background-information/ci#flakes|How to disable flakey tests>
+• <https://docs.sourcegraph.com/dev/how-to/testing#assessing-flaky-client-steps|Recognizing flakey client steps and how to fix them>
+
+_:sourcegraph: Disable flakes on sight and save your fellow teammate some time!_`,
+			},
+			nil,
+			nil,
+		),
 		slack.NewSectionBlock(
 			nil,
 			[]*slack.TextBlockObject{
 				{Type: slack.MarkdownType, Text: fmt.Sprintf("*Author:* %s", author)},
 				{Type: slack.MarkdownType, Text: fmt.Sprintf("*Pipeline:* %s", build.Pipeline.name())},
 			},
-			nil,
-		),
-		&slack.DividerBlock{
-			Type: slack.MBTDivider,
-		},
-		slack.NewSectionBlock(&slack.TextBlockObject{Type: slack.MarkdownType, Text: failedSection}, nil, nil),
-		&slack.DividerBlock{
-			Type: slack.MBTDivider,
-		},
-		slack.NewSectionBlock(
-			&slack.TextBlockObject{
-				Type: slack.MarkdownType,
-				Text: `:books: *More information on flakes*
-• *<https://docs.sourcegraph.com/dev/background-information/ci#flakes|How to disable flakey tests>*
-• *<https://docs.sourcegraph.com/dev/how-to/testing#assessing-flaky-client-steps|Recognizing flakey client steps and how to fix them>*
-
-_:sourcegraph: disable flakes on sight and save your fellow teammate some time!_`,
-			},
-			nil,
 			nil,
 		),
 		&slack.DividerBlock{
@@ -233,7 +228,7 @@ _:sourcegraph: disable flakes on sight and save your fellow teammate some time!_
 				&slack.ButtonBlockElement{
 					Type: slack.METButton,
 					URL:  "https://www.loom.com/share/58cedf44d44c45a292f650ddd3547337",
-					Text: &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Is this a flake ?"},
+					Text: &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Is this a flake?"},
 				},
 			}...,
 		),

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -165,8 +165,8 @@ func slackMention(teammate *team.Teammate, build *Build) string {
 func createMessageBlocks(logger log.Logger, teammate *team.Teammate, build *Build) ([]slack.Block, error) {
 	msg, _, _ := strings.Cut(build.message(), "\n")
 	msg += fmt.Sprintf(" (%s)", build.commit()[:7])
-	failedSection := fmt.Sprintf("%s\n\n", commitLink(msg, build.commit()))
-	failedSection += "*Failed jobs*\n\n"
+	failedSection := fmt.Sprintf("> %s\n\n", commitLink(msg, build.commit()))
+	failedSection += "*Failed jobs:*\n\n"
 	for _, j := range build.Jobs {
 		if j.ExitStatus != nil && *j.ExitStatus != 0 && !j.SoftFailed {
 			failedSection += fmt.Sprintf("• %s", *j.Name)
@@ -189,18 +189,6 @@ func createMessageBlocks(logger log.Logger, teammate *team.Teammate, build *Buil
 		),
 		slack.NewSectionBlock(&slack.TextBlockObject{Type: slack.MarkdownType, Text: failedSection}, nil, nil),
 		slack.NewSectionBlock(
-			&slack.TextBlockObject{
-				Type: slack.MarkdownType,
-				Text: `:books: *More information on flakes*
-• <https://docs.sourcegraph.com/dev/background-information/ci#flakes|How to disable flakey tests>
-• <https://docs.sourcegraph.com/dev/how-to/testing#assessing-flaky-client-steps|Recognizing flakey client steps and how to fix them>
-
-_:sourcegraph: Disable flakes on sight and save your fellow teammate some time!_`,
-			},
-			nil,
-			nil,
-		),
-		slack.NewSectionBlock(
 			nil,
 			[]*slack.TextBlockObject{
 				{Type: slack.MarkdownType, Text: fmt.Sprintf("*Author:* %s", author)},
@@ -208,9 +196,6 @@ _:sourcegraph: Disable flakes on sight and save your fellow teammate some time!_
 			},
 			nil,
 		),
-		&slack.DividerBlock{
-			Type: slack.MBTDivider,
-		},
 		slack.NewActionBlock(
 			"",
 			[]slack.BlockElement{
@@ -231,6 +216,21 @@ _:sourcegraph: Disable flakes on sight and save your fellow teammate some time!_
 					Text: &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Is this a flake?"},
 				},
 			}...,
+		),
+
+		&slack.DividerBlock{Type: slack.MBTDivider},
+
+		slack.NewSectionBlock(
+			&slack.TextBlockObject{
+				Type: slack.MarkdownType,
+				Text: `:books: *More information on flakes*
+• <https://docs.sourcegraph.com/dev/background-information/ci#flakes|How to disable flakey tests>
+• <https://docs.sourcegraph.com/dev/how-to/testing#assessing-flaky-client-steps|Recognizing flakey client steps and how to fix them>
+
+_Disable flakes on sight and save your fellow teammate some time!_`,
+			},
+			nil,
+			nil,
 		),
 	}
 


### PR DESCRIPTION
Tries to improve the readabilty of the messages a bit, so that we have the following info in the following structure:

1. Build number
2. What changed in the build (commit message)
3. What went wrong

With the important business out of the way, _then_ we have:

5. Additional context (author, pipeline)
6. Actions (buttons)

Afterwards we have miscellaneous content - this is where the need for dividers comes in, I think the above doesn't really need dividers yet:

7. Divider
8. Info on flakes

Also updates the test instructions

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
go test . -RunIntegrationTest
```

<img width="661" alt="Screenshot 2022-08-17 at 4 21 15 PM" src="https://user-images.githubusercontent.com/23356519/185260323-521ca298-c07c-47b2-a4ff-f54575257b62.png">
