### PR TITLE
dev/build-tracker: report nth consecutive failure of build

### DIFF
--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -13,6 +13,9 @@ type Build struct {
 	buildkite.Build
 	Pipeline *Pipeline
 	Jobs     map[string]Job
+
+	// ConsecutiveFailure indicates whether this build is the nth consecutive failure.
+	ConsecutiveFailure int
 }
 
 func (b *Build) hasFailed() bool {
@@ -86,6 +89,9 @@ type Pipeline struct {
 }
 
 func (p *Pipeline) name() string {
+	if p == nil {
+		return ""
+	}
 	return strp(p.Name)
 }
 
@@ -133,15 +139,24 @@ func (b *Event) buildNumber() int {
 // in a Build and added to the map. When the event contains a Job the corresponding job is retrieved from the map and added to the Job it is for.
 type BuildStore struct {
 	logger log.Logger
+
 	builds map[int]*Build
-	m      sync.RWMutex
+	// consecutiveFailures tracks how many consecutive build failed events has been
+	// received by pipeline
+	consecutiveFailures map[string]int
+
+	// m locks all writes to BuildStore properties.
+	m sync.RWMutex
 }
 
 func NewBuildStore(logger log.Logger) *BuildStore {
 	return &BuildStore{
 		logger: logger.Scoped("store", "stores all the buildkite builds"),
-		builds: make(map[int]*Build),
-		m:      sync.RWMutex{},
+
+		builds:              make(map[int]*Build),
+		consecutiveFailures: make(map[string]int),
+
+		m: sync.RWMutex{},
 	}
 }
 
@@ -154,9 +169,19 @@ func (s *BuildStore) Add(event *Event) {
 		build = event.build()
 		s.builds[event.buildNumber()] = build
 	}
-	// if the build is finished replace the original build with the replaced one since it will be more up to date
-	build.Build = event.Build
-	build.Pipeline = event.pipeline()
+
+	// if the build is finished replace the original build with the replaced one since it
+	// will be more up to date, and tack on some finalized data
+	if event.isBuildFinished() {
+		build.Build = event.Build
+		build.Pipeline = event.pipeline()
+		if build.hasFailed() {
+			s.consecutiveFailures[build.Pipeline.name()] += 1
+			build.ConsecutiveFailure = s.consecutiveFailures[build.Pipeline.name()]
+		} else {
+			s.consecutiveFailures[build.Pipeline.name()] = 1
+		}
+	}
 
 	wrappedJob := event.job()
 	if wrappedJob.name() != "" {

--- a/dev/build-tracker/build_test.go
+++ b/dev/build-tracker/build_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildStoreAdd(t *testing.T) {
+	failed := "failed"
+	pipeline := "bobheadxi"
+	eventFailed := func(n int) *Event {
+		return &Event{Name: "build.finished", Build: buildkite.Build{State: &failed, Number: &n, Pipeline: &buildkite.Pipeline{Name: &pipeline}}}
+	}
+	eventSucceeded := func(n int) *Event {
+		// no state === not failed
+		return &Event{Name: "build.finished", Build: buildkite.Build{State: nil, Number: &n, Pipeline: &buildkite.Pipeline{Name: &pipeline}}}
+	}
+
+	store := NewBuildStore(logtest.Scoped(t))
+
+	t.Run("subsequent failures should increment ConsecutiveFailure", func(t *testing.T) {
+		store.Add(eventFailed(1))
+		build := store.GetByBuildNumber(1)
+		assert.Equal(t, build.ConsecutiveFailure, 1)
+
+		store.Add(eventFailed(2))
+		build = store.GetByBuildNumber(2)
+		assert.Equal(t, build.ConsecutiveFailure, 2)
+
+		store.Add(eventFailed(3))
+		build = store.GetByBuildNumber(3)
+		assert.Equal(t, build.ConsecutiveFailure, 3)
+	})
+
+	t.Run("a pass should reset ConsecutiveFailure", func(t *testing.T) {
+		store.Add(eventSucceeded(4))
+		build := store.GetByBuildNumber(4)
+		assert.Equal(t, build.ConsecutiveFailure, 0)
+
+		store.Add(eventSucceeded(5))
+		build = store.GetByBuildNumber(5)
+		assert.Equal(t, build.ConsecutiveFailure, 0)
+	})
+}

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -125,7 +126,7 @@ func (s *Server) handleHealthz(w http.ResponseWriter, req *http.Request) {
 func (s *Server) notifyIfFailed(build *Build) error {
 	if build.hasFailed() {
 		s.logger.Info("detected failed build - sending notification", log.Int("buildNumber", intp(build.Number)))
-		return s.notifyClient.send(build)
+		return s.notifyClient.sendFailedBuild(build)
 	}
 
 	s.logger.Info("build has not failed", log.Int("buildNumber", intp(build.Number)))


### PR DESCRIPTION
Previously, we had "still failing" from the Buildkite notifications, which we don't have with build-tracker. We can do it better this time, by including exactly how many consecutive failures has been encountered!

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Unit tests