### PR TITLE
authz: remove unused return parameter from GetProviders

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -389,7 +389,7 @@ func listAuthzProvidersHandler() http.HandlerFunc {
 			ExternalServiceURL string `json:"external_service_url"`
 		}
 
-		_, providers := authz.GetProviders()
+		providers := authz.GetProviders()
 		infos := make([]providerInfo, len(providers))
 		for i, p := range providers {
 			_, id := extsvc.DecodeURN(p.URN())

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	gh "github.com/google/go-github/v41/github"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	eauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
@@ -197,7 +198,7 @@ func (s *PermsSyncer) scheduleRepos(ctx context.Context, repos ...scheduledRepo)
 // providersByServiceID returns a list of authz.Provider configured in the external services.
 // Keys are ServiceID, e.g. "https://github.com/".
 func (s *PermsSyncer) providersByServiceID() map[string]authz.Provider {
-	_, ps := authz.GetProviders()
+	ps := authz.GetProviders()
 	providers := make(map[string]authz.Provider, len(ps))
 	for _, p := range ps {
 		providers[p.ServiceID()] = p
@@ -208,7 +209,7 @@ func (s *PermsSyncer) providersByServiceID() map[string]authz.Provider {
 // providersByURNs returns a list of authz.Provider configured in the external services.
 // Keys are URN, e.g. "extsvc:github:1".
 func (s *PermsSyncer) providersByURNs() map[string]authz.Provider {
-	_, ps := authz.GetProviders()
+	ps := authz.GetProviders()
 	providers := make(map[string]authz.Provider, len(ps))
 	for _, p := range ps {
 		providers[p.URN()] = p

--- a/internal/authz/register.go
+++ b/internal/authz/register.go
@@ -54,7 +54,7 @@ func SetProviders(authzAllowByDefault bool, z []Provider) {
 // GetProviders returns the current authz parameters. It is concurrency-safe.
 //
 // It blocks until SetProviders has been called at least once.
-func GetProviders() (authzAllowByDefault bool, providers []Provider) {
+func GetProviders() (providers []Provider) {
 	if !isTest {
 		<-authzProvidersReady
 	}
@@ -62,11 +62,11 @@ func GetProviders() (authzAllowByDefault bool, providers []Provider) {
 	defer authzMu.Unlock()
 
 	if authzProviders == nil {
-		return allowAccessByDefault, nil
+		return nil
 	}
 	providers = make([]Provider, len(authzProviders))
 	copy(providers, authzProviders)
-	return allowAccessByDefault, providers
+	return providers
 }
 
 var isTest = (func() bool {

--- a/internal/database/repos_perm.go
+++ b/internal/database/repos_perm.go
@@ -18,11 +18,12 @@ var errPermissionsUserMappingConflict = errors.New("The permissions user mapping
 // It uses `repo` as the table name to filter out repository IDs and should be
 // used as an AND condition in a complete SQL query.
 func AuthzQueryConds(ctx context.Context, db DB) (*sqlf.Query, error) {
-	authzAllowByDefault, authzProviders := authz.GetProviders()
+	authzProviders := authz.GetProviders()
 	usePermissionsUserMapping := globals.PermissionsUserMapping().Enabled
 
 	// 🚨 SECURITY: Blocking access to all repositories if both code host authz
 	// provider(s) and permissions user mapping are configured.
+	var authzAllowByDefault bool
 	if usePermissionsUserMapping {
 		if len(authzProviders) > 0 {
 			return nil, errPermissionsUserMappingConflict


### PR DESCRIPTION
The return value `authzAllowByDefault` is never set to true.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

tests should all pass still