### PR TITLE
insights: change oob migration deprecation version to 4.0

### DIFF
--- a/internal/oobmigration/oobmigrations.yaml
+++ b/internal/oobmigration/oobmigrations.yaml
@@ -62,8 +62,8 @@
   is_enterprise: true
   introduced_version_major: 3
   introduced_version_minor: 35
-  deprecated_version_major: 3
-  deprecated_version_minor: 43
+  deprecated_version_major: 4
+  deprecated_version_minor: 0
 - id: 15
   team: iam
   component: frontend-db.product_subscriptions


### PR DESCRIPTION
## Description

We can't deprecate in `3.34` because the new no-op migration was also introduced in that version and won't have had a chance to run yet. This causes the upgrade to fail because the migration is marked as 0% completed. So instead we'll deprecate in 4.0.

## Test plan

This should unblock CI for the release cut. Ran it locally and confirmed:
<img width="812" alt="image" src="https://user-images.githubusercontent.com/7999356/185266411-ba3c5133-7b5a-4ae7-b8a7-4946dee554c9.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
