### PR TITLE
user-management: exclude non-billable events from events count calculation

### DIFF
--- a/internal/users/update_aggregated_stats_job.go
+++ b/internal/users/update_aggregated_stats_job.go
@@ -23,7 +23,8 @@ var (
 			SELECT
 				user_id,
 				MAX(timestamp) AS last_active_at,
-				COUNT(*) AS events_count
+				-- count billable only events for each user
+				COUNT(*) FILTER (WHERE name NOT IN ('ViewSignIn', 'ViewResetPassword')) AS events_count
 			FROM
 				event_logs
 			GROUP BY


### PR DESCRIPTION
This PR excludes some non-billable events (`'ViewSignIn', 'ViewResetPassword'`) from being counted in the events column for the new user management page.

## Test plan
- Check the diff
- or also `sg start`
  - Wait ~10 mins for the aggregation/recalculation job to finish (it doesn't start immediately but there is a 5-10 minutes wait from start of the app)
  - Open http://localhost:3080/site-admin/users
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
