### PR TITLE
Move save/discard for settings/config editors to bottom left

### DIFF
--- a/client/web/src/components/SaveToolbar.module.scss
+++ b/client/web/src/components/SaveToolbar.module.scss
@@ -44,4 +44,5 @@
 
 .actions {
     display: flex;
+    justify-content: flex-end;
 }

--- a/client/web/src/components/SaveToolbar.module.scss
+++ b/client/web/src/components/SaveToolbar.module.scss
@@ -21,28 +21,7 @@
     align-items: center;
 }
 
-.btn {
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-    border-bottom: none;
-    border-left: none;
-    &-first {
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-        border-top-right-radius: 0;
-        padding-left: 1rem;
-        padding-right: 1rem;
-    }
-    &-last {
-        border-bottom-right-radius: 0;
-        border-bottom-left-radius: 0;
-        border-top-left-radius: 0;
-        padding-left: 1rem;
-        padding-right: 1rem;
-    }
-}
-
 .actions {
     display: flex;
-    justify-content: flex-end;
+    justify-content: flex-start;
 }

--- a/client/web/src/components/SaveToolbar.tsx
+++ b/client/web/src/components/SaveToolbar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { mdiAlertCircle, mdiCheck, mdiClose } from '@mdi/js'
+import { mdiAlertCircle } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Button, LoadingSpinner, Icon } from '@sourcegraph/wildcard'
@@ -53,26 +53,24 @@ export const SaveToolbar: React.FunctionComponent<
                     {error.message}
                 </div>
             )}
-            <div className={styles.actions}>
+            <div className={classNames('mt-2', styles.actions)}>
                 <Button
                     disabled={disabled}
                     title={saveDiscardTitle || 'Save changes'}
-                    className={classNames('test-save-toolbar-save', styles.item, styles.btn, styles.btnFirst)}
+                    className={classNames('test-save-toolbar-save mr-2', styles.item)}
                     onClick={onSave}
-                    variant="success"
-                    size="sm"
+                    variant="primary"
                 >
-                    <Icon style={{ marginRight: '0.1em' }} aria-hidden={true} svgPath={mdiCheck} /> Save changes
+                    Save
                 </Button>
                 <Button
                     disabled={disabled}
                     title={saveDiscardTitle || 'Discard changes'}
-                    className={classNames('test-save-toolbar-discard', styles.item, styles.btn, styles.btnLast)}
+                    className={classNames('test-save-toolbar-discard', styles.item)}
                     onClick={onDiscard}
                     variant="secondary"
-                    size="sm"
                 >
-                    <Icon aria-hidden={true} svgPath={mdiClose} /> Discard
+                    Discard changes
                 </Button>
                 {children}
                 {saving && (

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -105,10 +105,14 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
                     actions={editorActions}
                     className="test-external-service-editor"
                     telemetryService={telemetryService}
+                    explanation={
+                        <Text className="form-text text-muted">
+                            <small>
+                                Use Ctrl+Space for completion, and hover over JSON properties for documentation.
+                            </small>
+                        </Text>
+                    }
                 />
-                <Text className="form-text text-muted">
-                    <small>Use Ctrl+Space for completion, and hover over JSON properties for documentation.</small>
-                </Text>
             </div>
             <Button
                 type="submit"

--- a/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
+++ b/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
@@ -36,13 +36,6 @@ exports[`ExternalServiceForm create GitHub 1`] = `
       class="form-group"
     >
       DynamicallyImportedMonacoSettingsEditor
-      <p
-        class="form-text text-muted"
-      >
-        <small>
-          Use Ctrl+Space for completion, and hover over JSON properties for documentation.
-        </small>
-      </p>
     </div>
     <button
       class="btn btnPrimary mb-3 test-add-external-service-button"
@@ -90,13 +83,6 @@ exports[`ExternalServiceForm edit GitHub 1`] = `
       class="form-group"
     >
       DynamicallyImportedMonacoSettingsEditor
-      <p
-        class="form-text text-muted"
-      >
-        <small>
-          Use Ctrl+Space for completion, and hover over JSON properties for documentation.
-        </small>
-      </p>
     </div>
     <button
       class="btn btnPrimary mb-3 test-add-external-service-button"
@@ -145,13 +131,6 @@ exports[`ExternalServiceForm edit GitHub, loading 1`] = `
       class="form-group"
     >
       DynamicallyImportedMonacoSettingsEditor
-      <p
-        class="form-text text-muted"
-      >
-        <small>
-          Use Ctrl+Space for completion, and hover over JSON properties for documentation.
-        </small>
-      </p>
     </div>
     <button
       class="btn btnPrimary mb-3 test-add-external-service-button"

--- a/client/web/src/integration/settings.test.ts
+++ b/client/web/src/integration/settings.test.ts
@@ -127,7 +127,7 @@ describe('Settings', () => {
 
             // Assert mutation is done when save button is clicked
             const overrideSettingsVariables = await testContext.waitForGraphQLRequest(async () => {
-                await driver.findElementWithText('Save changes', { action: 'click' })
+                await driver.findElementWithText('Save', { action: 'click' })
             }, 'OverwriteSettings')
 
             assert.deepStrictEqual(overrideSettingsVariables, {

--- a/client/web/src/org/settings/OrgSettingsArea.tsx
+++ b/client/web/src/org/settings/OrgSettingsArea.tsx
@@ -81,7 +81,7 @@ export const OrgSettingsArea: React.FunctionComponent<React.PropsWithChildren<Pr
     }
 
     const showOrgCode = data?.organizationFeatureFlagValue || false
-    const showOrgDeletion = true || orgDeletionFlag.data?.organizationFeatureFlagValue || false
+    const showOrgDeletion = orgDeletionFlag.data?.organizationFeatureFlagValue || false
 
     return (
         <div className="d-flex">
@@ -116,7 +116,7 @@ export const OrgSettingsArea: React.FunctionComponent<React.PropsWithChildren<Pr
                                                 </>
                                             }
                                         />
-                                        {props.org.viewerIsMember && showOrgDeletion && (
+                                        {props.isSourcegraphDotCom && props.org.viewerIsMember && showOrgDeletion && (
                                             <DeleteOrg {...routeComponentProps} {...props} />
                                         )}
                                     </div>

--- a/client/web/src/org/settings/OrgSettingsArea.tsx
+++ b/client/web/src/org/settings/OrgSettingsArea.tsx
@@ -81,7 +81,7 @@ export const OrgSettingsArea: React.FunctionComponent<React.PropsWithChildren<Pr
     }
 
     const showOrgCode = data?.organizationFeatureFlagValue || false
-    const showOrgDeletion = orgDeletionFlag.data?.organizationFeatureFlagValue || false
+    const showOrgDeletion = true || orgDeletionFlag.data?.organizationFeatureFlagValue || false
 
     return (
         <div className="d-flex">
@@ -116,7 +116,7 @@ export const OrgSettingsArea: React.FunctionComponent<React.PropsWithChildren<Pr
                                                 </>
                                             }
                                         />
-                                        {props.isSourcegraphDotCom && props.org.viewerIsMember && showOrgDeletion && (
+                                        {props.org.viewerIsMember && showOrgDeletion && (
                                             <DeleteOrg {...routeComponentProps} {...props} />
                                         )}
                                     </div>

--- a/client/web/src/regression/core.test.ts
+++ b/client/web/src/regression/core.test.ts
@@ -119,7 +119,7 @@ describe('Core functionality regression test suite', () => {
             selectMethod: 'keyboard',
             enterTextMethod: 'type',
         })
-        await driver.findElementWithText('Save changes', { action: 'click' })
+        await driver.findElementWithText('Save', { action: 'click' })
         await driver.page.waitForFunction(
             () => document.evaluate("//*[text() = ' Saving...']", document).iterateNext() === null
         )

--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -131,7 +131,6 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
 
         return (
             <div className={this.props.className || ''}>
-                {this.props.canEdit && saveToolbar}
                 {this.props.actions && (
                     <div className={adminConfigurationStyles.actionGroups}>
                         <div className={adminConfigurationStyles.actions}>
@@ -158,6 +157,7 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
                         monacoRef={this.monacoRef}
                     />
                 </React.Suspense>
+                {this.props.canEdit && saveToolbar}
             </div>
         )
     }

--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -53,6 +53,8 @@ interface Props<T extends object>
         saveToolbar: React.FunctionComponent<React.PropsWithChildren<SaveToolbarProps & T>>
     }
 
+    explanation?: JSX.Element
+
     history: H.History
 }
 
@@ -157,6 +159,7 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
                         monacoRef={this.monacoRef}
                     />
                 </React.Suspense>
+                {this.props.explanation && this.props.explanation}
                 {this.props.canEdit && saveToolbar}
             </div>
         )

--- a/client/web/src/settings/SettingsFile.tsx
+++ b/client/web/src/settings/SettingsFile.tsx
@@ -168,13 +168,6 @@ export class SettingsFile extends React.PureComponent<Props, State> {
 
         return (
             <div className={classNames('test-settings-file d-flex flex-grow-1 flex-column', styles.settingsFile)}>
-                <SaveToolbar
-                    dirty={dirty}
-                    error={this.props.commitError}
-                    saving={this.state.saving}
-                    onSave={this.save}
-                    onDiscard={this.discard}
-                />
                 <div className={adminConfigurationStyles.actionGroups}>
                     <div className={adminConfigurationStyles.actions}>
                         {settingsActions.map(({ id, label }) => (
@@ -201,6 +194,13 @@ export class SettingsFile extends React.PureComponent<Props, State> {
                         onDidSave={this.save}
                     />
                 </React.Suspense>
+                <SaveToolbar
+                    dirty={dirty}
+                    error={this.props.commitError}
+                    saving={this.state.saving}
+                    onSave={this.save}
+                    onDiscard={this.discard}
+                />
             </div>
         )
     }

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -397,14 +397,16 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                             actions={quickConfigureActions}
                             history={this.props.history}
                             telemetryService={this.props.telemetryService}
+                            explanation={
+                                <Text className="form-text text-muted">
+                                    <small>
+                                        Use Ctrl+Space for completion, and hover over JSON properties for documentation.
+                                        For more information, see the{' '}
+                                        <Link to="/help/admin/config/site_config">documentation</Link>.
+                                    </small>
+                                </Text>
+                            }
                         />
-                        <Text className="form-text text-muted">
-                            <small>
-                                Use Ctrl+Space for completion, and hover over JSON properties for documentation. For
-                                more information, see the <Link to="/help/admin/config/site_config">documentation</Link>
-                                .
-                            </small>
-                        </Text>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
This moves the "Save"/"Discard" buttons that come with all of our Monaco settings/config editors to the bottom left. Basd on [this Figma](https://www.figma.com/file/D0n7ffJA3OmLartpmg0rEB/Untitled?node-id=0%3A1866) by @quinnkeast.

Slack discussions on how confusing it is that the "Save" button is top-left above the editor and other buttons (example: "Delete organization") shows up bottom right:

- https://sourcegraph.slack.com/archives/C03CSAER9LK/p1660748393403849
- https://sourcegraph.slack.com/archives/C03CSAER9LK/p1653495469685739


## Before & After

| before | after |
|-------|-------|
| <img width="1251" alt="screenshot_2022-08-18_11 25 00@2x" src="https://user-images.githubusercontent.com/1185253/185360780-5f2cd4e6-9cc7-4a38-82f5-6c76f7920f7e.png"> |  <img width="1182" alt="screenshot_2022-08-18_12 47 11@2x" src="https://user-images.githubusercontent.com/1185253/185377283-9c0f5811-61ab-4f5e-93aa-f15b440e4030.png"> |
| <img width="1155" alt="screenshot_2022-08-18_11 24 31@2x" src="https://user-images.githubusercontent.com/1185253/185360681-0196bd80-29df-47ff-989d-e89e7ec74d5e.png"> | <img width="1142" alt="screenshot_2022-08-18_12 48 06@2x" src="https://user-images.githubusercontent.com/1185253/185377463-c5899920-8b9f-4b57-bd01-e8ffb3934950.png"> |
| <img width="1222" alt="screenshot_2022-08-18_11 25 56@2x" src="https://user-images.githubusercontent.com/1185253/185360964-79d02888-504f-4b1b-a845-b4cd2364ce58.png"> | <img width="1176" alt="screenshot_2022-08-18_12 46 33@2x" src="https://user-images.githubusercontent.com/1185253/185377158-9d5cbb2a-4463-4a1c-9606-ae745d688089.png"> |
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mrn-move-monaco-toolbar-bottom.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vzhwiyioiw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
