### PR TITLE
esbuild: print success banner with URL

### DIFF
--- a/client/web/dev/esbuild/server.ts
+++ b/client/web/dev/esbuild/server.ts
@@ -7,6 +7,8 @@ import signale from 'signale'
 
 import { STATIC_ASSETS_PATH, buildMonaco } from '@sourcegraph/build-config'
 
+import { HTTPS_WEB_SERVER_URL, printSuccessBanner } from '../utils'
+
 import { BUILD_OPTIONS } from './build'
 import { assetPathPrefix } from './manifestPlugin'
 
@@ -47,6 +49,7 @@ export const esbuildDevelopmentServer = async (
     return await new Promise<void>((resolve, reject) => {
         proxyServer.once('listening', () => {
             signale.success('esbuild server is ready')
+            printSuccessBanner(['✱ Sourcegraph is really ready now!', `Click here: ${HTTPS_WEB_SERVER_URL}`])
             esbuildStopped.finally(() => proxyServer.close(error => (error ? reject(error) : resolve())))
         })
         proxyServer.once('error', error => reject(error))


### PR DESCRIPTION
This adds the success banner we have for non-esbuild that prints 

<img width="628" alt="screenshot_2022-08-18_11 51 36@2x" src="https://user-images.githubusercontent.com/1185253/185366609-2a0790fb-0779-40cb-8c75-253033b52f77.png">

## Test plan

- Tested locally

## App preview:

- [Web](https://sg-web-mrn-esbuild-print-success-banner.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vxhjngzddy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
