### PR TITLE
Remove too much margin from privacy page

### DIFF
--- a/client/web/src/user/settings/privacy/UserSettingsPrivacyPage.tsx
+++ b/client/web/src/user/settings/privacy/UserSettingsPrivacyPage.tsx
@@ -87,7 +87,7 @@ export const UserSettingsPrivacyPage: React.FunctionComponent<React.PropsWithChi
                         Save
                     </Button>
                 </div>
-                <div className="d-flex justify-content-start mb-3">
+                <div className="d-flex justify-content-start">
                     <Text>
                         Learn more about{' '}
                         <Link to="https://docs.sourcegraph.com/code_search/explanations/sourcegraph_cloud#how-secure-is-sourcegraph-cloud-can-sourcegraph-see-my-code">


### PR DESCRIPTION
Critical stuff.

## Test plan

- Tested locally

## App preview:

- [Web](https://sg-web-mrn-profile-privacy-margin.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gipzjgxefs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
