### PR TITLE
Tweak Reference panel UI

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -1,4 +1,5 @@
 $filter-input-height: 2.5rem;
+
 .filter {
     height: $filter-input-height;
     padding-left: 1rem;
@@ -17,7 +18,7 @@ $filter-input-height: 2.5rem;
     }
 
     input::placeholder {
-        font-size: 0.6875rem;
+        font-size: 0.75rem;
         color: var(--gray-07);
     }
 
@@ -32,7 +33,7 @@ $filter-input-height: 2.5rem;
     }
 }
 
-$group-header-font-size: 0.75rem;
+$group-header-font-size: 0.875rem;
 $group-divider-height: 0.25rem;
 
 .repo-location-group {
@@ -161,12 +162,14 @@ $group-divider-height: 0.25rem;
         overflow: scroll;
         -ms-overflow-style: none;
     }
+
     ul::-webkit-scrollbar {
         display: none;
     }
 }
 
 $card-header-height: 1.5rem;
+
 .card-header {
     padding-top: 0.1rem;
     padding-bottom: 0.1rem;

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -403,7 +403,7 @@ export const ReferencesList: React.FunctionComponent<
                             aria-hidden={true}
                             as={canShowSpinner ? LoadingSpinner : undefined}
                             svgPath={!canShowSpinner ? mdiFilterOutline : undefined}
-                            size="sm"
+                            size="md"
                             className={styles.filterIcon}
                         />
                     </small>

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -72,11 +72,11 @@ type Token = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisio
 
 interface ReferencesPanelProps
     extends SettingsCascadeProps,
-    PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'>,
-    TelemetryProps,
-    HoverThresholdProps,
-    ExtensionsControllerProps,
-    ThemeProps {
+        PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'>,
+        TelemetryProps,
+        HoverThresholdProps,
+        ExtensionsControllerProps,
+        ThemeProps {
     /** Whether to show the first loaded reference in mini code view */
     jumpToFirst?: boolean
 
@@ -761,13 +761,13 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
 const CollapsibleRepoLocationGroup: React.FunctionComponent<
     React.PropsWithChildren<
         ActiveLocationProps &
-        CollapseProps &
-        SearchTokenProps & {
-            filter: string | undefined
-            navigateToUrl: (url: string) => void
-            repoLocationGroup: RepoLocationGroup
-            openByDefault: boolean
-        }
+            CollapseProps &
+            SearchTokenProps & {
+                filter: string | undefined
+                navigateToUrl: (url: string) => void
+                repoLocationGroup: RepoLocationGroup
+                openByDefault: boolean
+            }
     >
 > = ({
     repoLocationGroup,
@@ -780,63 +780,63 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     handleOpenChange,
     searchToken,
 }) => {
-        const repoUrl = `/${repoLocationGroup.repoName}`
-        const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
+    const repoUrl = `/${repoLocationGroup.repoName}`
+    const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
 
-        return (
-            <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(repoLocationGroup.repoName, isOpen)}>
-                <div className={styles.repoLocationGroup}>
-                    <CollapseHeader
-                        as={Button}
-                        aria-expanded={open}
-                        aria-label={`Repository ${repoLocationGroup.repoName}`}
-                        type="button"
-                        className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroupHeader)}
-                    >
-                        <Icon aria-hidden="true" svgPath={open ? mdiChevronDown : mdiChevronRight} />
-                        <small>
-                            <Link
-                                to={repoUrl}
-                                onClick={event => {
-                                    event.preventDefault()
-                                    navigateToUrl(repoUrl)
-                                }}
-                                className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}
-                            >
-                                {displayRepoName(repoLocationGroup.repoName)}
-                            </Link>
-                        </small>
-                    </CollapseHeader>
+    return (
+        <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(repoLocationGroup.repoName, isOpen)}>
+            <div className={styles.repoLocationGroup}>
+                <CollapseHeader
+                    as={Button}
+                    aria-expanded={open}
+                    aria-label={`Repository ${repoLocationGroup.repoName}`}
+                    type="button"
+                    className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroupHeader)}
+                >
+                    <Icon aria-hidden="true" svgPath={open ? mdiChevronDown : mdiChevronRight} />
+                    <small>
+                        <Link
+                            to={repoUrl}
+                            onClick={event => {
+                                event.preventDefault()
+                                navigateToUrl(repoUrl)
+                            }}
+                            className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}
+                        >
+                            {displayRepoName(repoLocationGroup.repoName)}
+                        </Link>
+                    </small>
+                </CollapseHeader>
 
-                    <CollapsePanel id={repoLocationGroup.repoName}>
-                        {repoLocationGroup.referenceGroups.map(group => (
-                            <CollapsibleLocationGroup
-                                key={group.path + group.repoName}
-                                searchToken={searchToken}
-                                group={group}
-                                isActiveLocation={isActiveLocation}
-                                setActiveLocation={setActiveLocation}
-                                filter={filter}
-                                handleOpenChange={(id, isOpen) => handleOpenChange(repoLocationGroup.repoName + id, isOpen)}
-                                isOpen={id => isOpen(repoLocationGroup.repoName + id)}
-                                navigateToUrl={navigateToUrl}
-                            />
-                        ))}
-                    </CollapsePanel>
-                </div>
-            </Collapse>
-        )
-    }
+                <CollapsePanel id={repoLocationGroup.repoName}>
+                    {repoLocationGroup.referenceGroups.map(group => (
+                        <CollapsibleLocationGroup
+                            key={group.path + group.repoName}
+                            searchToken={searchToken}
+                            group={group}
+                            isActiveLocation={isActiveLocation}
+                            setActiveLocation={setActiveLocation}
+                            filter={filter}
+                            handleOpenChange={(id, isOpen) => handleOpenChange(repoLocationGroup.repoName + id, isOpen)}
+                            isOpen={id => isOpen(repoLocationGroup.repoName + id)}
+                            navigateToUrl={navigateToUrl}
+                        />
+                    ))}
+                </CollapsePanel>
+            </div>
+        </Collapse>
+    )
+}
 
 const CollapsibleLocationGroup: React.FunctionComponent<
     React.PropsWithChildren<
         ActiveLocationProps &
-        CollapseProps &
-        SearchTokenProps & {
-            group: LocationGroup
-            filter: string | undefined
-            navigateToUrl: (url: string) => void
-        }
+            CollapseProps &
+            SearchTokenProps & {
+                group: LocationGroup
+                filter: string | undefined
+                navigateToUrl: (url: string) => void
+            }
     >
 > = ({ group, setActiveLocation, isActiveLocation, filter, isOpen, handleOpenChange, navigateToUrl }) => {
     let highlighted = [group.path]

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -72,11 +72,11 @@ type Token = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisio
 
 interface ReferencesPanelProps
     extends SettingsCascadeProps,
-        PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'>,
-        TelemetryProps,
-        HoverThresholdProps,
-        ExtensionsControllerProps,
-        ThemeProps {
+    PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'>,
+    TelemetryProps,
+    HoverThresholdProps,
+    ExtensionsControllerProps,
+    ThemeProps {
     /** Whether to show the first loaded reference in mini code view */
     jumpToFirst?: boolean
 
@@ -761,13 +761,13 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
 const CollapsibleRepoLocationGroup: React.FunctionComponent<
     React.PropsWithChildren<
         ActiveLocationProps &
-            CollapseProps &
-            SearchTokenProps & {
-                filter: string | undefined
-                navigateToUrl: (url: string) => void
-                repoLocationGroup: RepoLocationGroup
-                openByDefault: boolean
-            }
+        CollapseProps &
+        SearchTokenProps & {
+            filter: string | undefined
+            navigateToUrl: (url: string) => void
+            repoLocationGroup: RepoLocationGroup
+            openByDefault: boolean
+        }
     >
 > = ({
     repoLocationGroup,
@@ -780,63 +780,63 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     handleOpenChange,
     searchToken,
 }) => {
-    const repoUrl = `/${repoLocationGroup.repoName}`
-    const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
+        const repoUrl = `/${repoLocationGroup.repoName}`
+        const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
 
-    return (
-        <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(repoLocationGroup.repoName, isOpen)}>
-            <div className={styles.repoLocationGroup}>
-                <CollapseHeader
-                    as={Button}
-                    aria-expanded={open}
-                    aria-label={`Repository ${repoLocationGroup.repoName}`}
-                    type="button"
-                    className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroupHeader)}
-                >
-                    <Icon aria-hidden="true" svgPath={open ? mdiChevronDown : mdiChevronRight} />
-                    <small>
-                        <Link
-                            to={repoUrl}
-                            onClick={event => {
-                                event.preventDefault()
-                                navigateToUrl(repoUrl)
-                            }}
-                            className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}
-                        >
-                            {displayRepoName(repoLocationGroup.repoName)}
-                        </Link>
-                    </small>
-                </CollapseHeader>
+        return (
+            <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(repoLocationGroup.repoName, isOpen)}>
+                <div className={styles.repoLocationGroup}>
+                    <CollapseHeader
+                        as={Button}
+                        aria-expanded={open}
+                        aria-label={`Repository ${repoLocationGroup.repoName}`}
+                        type="button"
+                        className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroupHeader)}
+                    >
+                        <Icon aria-hidden="true" svgPath={open ? mdiChevronDown : mdiChevronRight} />
+                        <small>
+                            <Link
+                                to={repoUrl}
+                                onClick={event => {
+                                    event.preventDefault()
+                                    navigateToUrl(repoUrl)
+                                }}
+                                className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}
+                            >
+                                {displayRepoName(repoLocationGroup.repoName)}
+                            </Link>
+                        </small>
+                    </CollapseHeader>
 
-                <CollapsePanel id={repoLocationGroup.repoName}>
-                    {repoLocationGroup.referenceGroups.map(group => (
-                        <CollapsibleLocationGroup
-                            key={group.path + group.repoName}
-                            searchToken={searchToken}
-                            group={group}
-                            isActiveLocation={isActiveLocation}
-                            setActiveLocation={setActiveLocation}
-                            filter={filter}
-                            handleOpenChange={(id, isOpen) => handleOpenChange(repoLocationGroup.repoName + id, isOpen)}
-                            isOpen={id => isOpen(repoLocationGroup.repoName + id)}
-                            navigateToUrl={navigateToUrl}
-                        />
-                    ))}
-                </CollapsePanel>
-            </div>
-        </Collapse>
-    )
-}
+                    <CollapsePanel id={repoLocationGroup.repoName}>
+                        {repoLocationGroup.referenceGroups.map(group => (
+                            <CollapsibleLocationGroup
+                                key={group.path + group.repoName}
+                                searchToken={searchToken}
+                                group={group}
+                                isActiveLocation={isActiveLocation}
+                                setActiveLocation={setActiveLocation}
+                                filter={filter}
+                                handleOpenChange={(id, isOpen) => handleOpenChange(repoLocationGroup.repoName + id, isOpen)}
+                                isOpen={id => isOpen(repoLocationGroup.repoName + id)}
+                                navigateToUrl={navigateToUrl}
+                            />
+                        ))}
+                    </CollapsePanel>
+                </div>
+            </Collapse>
+        )
+    }
 
 const CollapsibleLocationGroup: React.FunctionComponent<
     React.PropsWithChildren<
         ActiveLocationProps &
-            CollapseProps &
-            SearchTokenProps & {
-                group: LocationGroup
-                filter: string | undefined
-                navigateToUrl: (url: string) => void
-            }
+        CollapseProps &
+        SearchTokenProps & {
+            group: LocationGroup
+            filter: string | undefined
+            navigateToUrl: (url: string) => void
+        }
     >
 > = ({ group, setActiveLocation, isActiveLocation, filter, isOpen, handleOpenChange, navigateToUrl }) => {
     let highlighted = [group.path]
@@ -885,7 +885,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                     group.path
                                 )}{' '}
                             </Link>
-                            <span className={classNames('ml-2 text-muted small', styles.cardHeaderSmallText)}>
+                            <span className={classNames('ml-2 text-muted', styles.cardHeaderSmallText)}>
                                 ({group.locations.length}{' '}
                                 {pluralize('occurrence', group.locations.length, 'occurrences')})
                             </span>


### PR DESCRIPTION
## Description
As per @jjinnii's [recommendations](https://github.com/sourcegraph/sourcegraph/issues/34023#issuecomment-1193973335), this PR makes the ref panel UI a bit better:

- increased font size for repo title / num of occurrences
- increased search input placeholder font size
- larger filter icon 

I couldn't make the icon `16x16px` exactly as we've got two pre-defined sizes, `sm` and `md`. It's now `~17px` large.

<img width="1175" alt="Screenshot 2022-08-18 at 13 09 36" src="https://user-images.githubusercontent.com/2196347/185391413-4484f5bb-d88d-4d66-8cd3-781774a6c4e5.png">


## Test plan

1. Pull the branch
2. Open the app
3. Check that the ref panel looks good

## App preview:

- [Web](https://sg-web-og-ref-panel-ui-tweaks.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mcjddmifzf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
