### PR TITLE
CodeMirror Blob: support fuzzy finder

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -96,6 +96,7 @@ interface Props
     isRepositoryRelatedPage?: boolean
     branding?: typeof window.context.branding
     showKeyboardShortcutsHelp: () => void
+    onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 /**

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -59,6 +59,7 @@ import { parseBrowserRepoURL } from '../util/url'
 import { GoToCodeHostAction } from './actions/GoToCodeHostAction'
 import { fetchFileExternalLinks, fetchRepository, resolveRevision } from './backend'
 import { BlameContextProvider } from './blame/useBlameVisibility'
+import { BlobProps } from './blob/Blob'
 import { RepoHeader, RepoHeaderActionButton, RepoHeaderContributionsLifecycleProps } from './RepoHeader'
 import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
 import { RepoRevisionContainer, RepoRevisionContainerRoute } from './RepoRevisionContainer'
@@ -124,6 +125,7 @@ interface RepoContainerProps
         ActivationProps,
         ThemeProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
+        Pick<BlobProps, 'onHandleFuzzyFinder'>,
         BreadcrumbSetters,
         BreadcrumbsProps,
         SearchStreamingProps,
@@ -463,6 +465,7 @@ export const RepoContainer: React.FunctionComponent<React.PropsWithChildren<Repo
                                         // must exactly match how the revision was encoded in the URL
                                         routePrefix={`${repoMatchURL}${rawRevision ? `@${rawRevision}` : ''}`}
                                         useActionItemsBar={useActionItemsBar}
+                                        onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                                     />
                                 )}
                             />

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -38,6 +38,7 @@ import { RouteDescriptor } from '../util/contributions'
 import { CopyPathAction } from './actions/CopyPathAction'
 import { GoToPermalinkAction } from './actions/GoToPermalinkAction'
 import { ResolvedRevision } from './backend'
+import { BlobProps } from './blob/Blob'
 import { RepoRevisionChevronDownIcon, RepoRevisionWrapper } from './components/RepoRevision'
 import { HoverThresholdProps, RepoContainerContext } from './RepoContainer'
 import { RepoHeaderContributionsLifecycleProps } from './RepoHeader'
@@ -61,6 +62,7 @@ export interface RepoRevisionContainerContext
         ActivationProps,
         Omit<RepoContainerContext, 'onDidUpdateExternalLinks'>,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
+        Pick<BlobProps, 'onHandleFuzzyFinder'>,
         RevisionSpec,
         BreadcrumbSetters,
         ActionItemsBarProps,
@@ -95,6 +97,7 @@ interface RepoRevisionContainerProps
         ThemeProps,
         ActivationProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
+        Pick<BlobProps, 'onHandleFuzzyFinder'>,
         RevisionSpec,
         BreadcrumbSetters,
         ActionItemsBarProps,

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -11,6 +11,7 @@ import { ActionItemsBar } from '../extensions/components/ActionItemsBar'
 import { GettingStartedTour } from '../tour/GettingStartedTour'
 import { formatHash, formatLineOrPositionOrRange } from '../util/url'
 
+import { BlobProps } from './blob/Blob'
 import { BlobPage } from './blob/BlobPage'
 import { BlobStatusBarContainer } from './blob/ui/BlobStatusBarContainer'
 import { RepoRevisionContainerContext } from './RepoRevisionContainer'
@@ -23,7 +24,8 @@ export interface RepositoryFileTreePageProps
             objectType: 'blob' | 'tree' | undefined
             filePath: string | undefined
             spec: string
-        }> {}
+        }>,
+        Pick<BlobProps, 'onHandleFuzzyFinder'> {}
 
 /** Dev feature flag to make benchmarking the file tree in isolation easier. */
 const hideRepoRevisionContent = localStorage.getItem('hideRepoRevContent')
@@ -117,6 +119,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                                     repoHeaderContributionsLifecycleProps={
                                         context.repoHeaderContributionsLifecycleProps
                                     }
+                                    onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                                 />
                             </>
                         ) : (

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -132,6 +132,7 @@ export interface BlobProps
     ariaLabel?: string
 
     blameDecorations?: TextDocumentDecoration[]
+    onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export interface BlobInfo extends AbsoluteRepoFile, ModeSpec {

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -43,7 +43,7 @@ import { ToggleLineWrap } from './actions/ToggleLineWrap'
 import { ToggleRenderedFileMode } from './actions/ToggleRenderedFileMode'
 import { getModeFromURL } from './actions/utils'
 import { fetchBlob } from './backend'
-import { Blob, BlobInfo } from './Blob'
+import { Blob, BlobInfo, BlobProps } from './Blob'
 import { Blob as CodeMirrorBlob } from './CodeMirrorBlob'
 import { GoToRawAction } from './GoToRawAction'
 import { useBlobPanelViews } from './panel/BlobPanel'
@@ -64,6 +64,7 @@ interface Props
         HoverThresholdProps,
         BreadcrumbSetters,
         SearchStreamingProps,
+        Pick<BlobProps, 'onHandleFuzzyFinder'>,
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'> {
     location: H.Location
@@ -459,6 +460,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                     role="region"
                     ariaLabel="File blob"
                     blameDecorations={blameDecorations}
+                    onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                 />
             )}
         </>

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -29,7 +29,7 @@ import { isValidLineRange, offsetToUIPosition, uiPositionToOffset } from './code
 
 const staticExtensions: Extension = [
     EditorState.readOnly.of(true),
-    EditorView.editable.of(true),
+    EditorView.editable.of(false),
     EditorView.contentAttributes.of({
         // This is required to make the blob view focusable and to make
         // triggering the in-document search (see below) work when Mod-f is

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -29,7 +29,7 @@ import { isValidLineRange, offsetToUIPosition, uiPositionToOffset } from './code
 
 const staticExtensions: Extension = [
     EditorState.readOnly.of(true),
-    EditorView.editable.of(false),
+    EditorView.editable.of(true),
     EditorView.contentAttributes.of({
         // This is required to make the blob view focusable and to make
         // triggering the in-document search (see below) work when Mod-f is
@@ -57,7 +57,7 @@ const staticExtensions: Extension = [
     keymap.of(searchKeymap),
 ]
 
-// Compartments are used to reconfigure some parts of the editor withoug
+// Compartments are used to reconfigure some parts of the editor without
 // affecting others.
 
 // Compartment to update various smaller settings
@@ -66,6 +66,28 @@ const settingsCompartment = new Compartment()
 const blameDecorationsCompartment = new Compartment()
 // Compartment for propagating component props
 const blobPropsCompartment = new Compartment()
+
+// See CodeMirrorQueryInput for a detailed comment about the pattern that's used
+// below. The CodeMirror search bar uses a similar pattern to support global
+// shortcuts (including Mod-k) while the search bar is focused.
+const [callbacksField, setCallbacks] = createUpdateableField<Pick<BlobProps, 'onHandleFuzzyFinder'>>(
+    { onHandleFuzzyFinder: () => {} },
+    callbacks => [
+        keymap.of([
+            {
+                key: 'Mod-k',
+                run: view => {
+                    const { onHandleFuzzyFinder } = view.state.field(callbacks)
+                    if (onHandleFuzzyFinder) {
+                        onHandleFuzzyFinder(true)
+                        return true
+                    }
+                    return false
+                },
+            },
+        ]),
+    ]
+)
 
 export const Blob: React.FunctionComponent<BlobProps> = props => {
     const {
@@ -83,6 +105,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // Reference panel specific props
         disableStatusBar,
         disableDecorations,
+        onHandleFuzzyFinder,
     } = props
 
     const [container, setContainer] = useState<HTMLDivElement | null>(null)
@@ -150,6 +173,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     const extensions = useMemo(
         () => [
             staticExtensions,
+            callbacksField,
             selectableLineNumbers({ onSelection, initialSelection: position.line !== undefined ? position : null }),
             syntaxHighlight.of(blobInfo),
             pinnedRangeField.init(() => (hasPin ? position : null)),
@@ -178,6 +202,12 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         updateValueOnChange: false,
         updateOnExtensionChange: false,
     })
+
+    useEffect(() => {
+        if (editor) {
+            setCallbacks(editor, { onHandleFuzzyFinder })
+        }
+    }, [editor, onHandleFuzzyFinder])
 
     // Reconfigure editor when blobInfo or core extensions changed
     useEffect(() => {

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -13,6 +13,7 @@ import type { LayoutProps } from './Layout'
 import { CreateNotebookPage } from './notebooks/createPage/CreateNotebookPage'
 import { NotebooksListPage } from './notebooks/listPage/NotebooksListPage'
 import { InstallGitHubAppSuccessPage } from './org/settings/codeHosts/InstallGitHubAppSuccessPage'
+import { BlobProps } from './repo/blob/Blob'
 import { PageRoutes } from './routes.constants'
 import { SearchPageWrapper } from './search/SearchPageWrapper'
 import { getExperimentalFeatures, useExperimentalFeatures } from './stores'
@@ -36,7 +37,8 @@ export interface LayoutRouteComponentProps<RouteParameters extends { [K in keyof
         BreadcrumbsProps,
         BreadcrumbSetters,
         CodeIntelligenceProps,
-        BatchChangesProps {
+        BatchChangesProps,
+        Pick<BlobProps, 'onHandleFuzzyFinder'> {
     isSourcegraphDotCom: boolean
     isMacPlatform: boolean
 }


### PR DESCRIPTION
Fixes #40509

Previously, the fuzzy finder was not activated when using the `Mod-k` shortcut while the CodeMirror blob view was focused. 

This PR only moves existing code around. The diff is modestly large because we had to move the fuzzy finder state to the
toplevel `Layout` component and drill it down to the search bar and the blob view (which has a long path from the layout component). 

## Test plan

See the CI go green. I manually verified the change works as expected by triggering Cmd+k while having the CodeMirror blob view focused.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-cm-fuzzy-finder.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ynbmuvlxrk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
