### PR TITLE
CodeMirror Blob: add syntax highlighting to find ref blobs

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.mocks.ts
+++ b/client/web/src/codeintel/ReferencesPanel.mocks.ts
@@ -1,5 +1,6 @@
 import { MockedResponse } from '@apollo/client/testing'
 import {
+    HighlightResponseFormat,
     LocationFields,
     ReferencesPanelHighlightedBlobVariables,
     ResolveRepoAndRevisionVariables,
@@ -90,6 +91,8 @@ export function buildReferencePanelMocks(): ReferencePanelMock {
         commit,
         path,
         repository: repoName,
+        format: HighlightResponseFormat.JSON_SCIP,
+        html: false,
     }
 
     return {

--- a/client/web/src/codeintel/ReferencesPanel.mocks.ts
+++ b/client/web/src/codeintel/ReferencesPanel.mocks.ts
@@ -1,4 +1,7 @@
 import { MockedResponse } from '@apollo/client/testing'
+
+import { getDocumentNode } from '@sourcegraph/http-client'
+
 import {
     HighlightResponseFormat,
     LocationFields,
@@ -7,8 +10,6 @@ import {
     UsePreciseCodeIntelForPositionResult,
     UsePreciseCodeIntelForPositionVariables,
 } from '../graphql-operations'
-
-import { getDocumentNode } from '@sourcegraph/http-client'
 
 import {
     USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY,

--- a/client/web/src/codeintel/ReferencesPanel.mocks.ts
+++ b/client/web/src/codeintel/ReferencesPanel.mocks.ts
@@ -6,7 +6,7 @@ import {
     ResolveRepoAndRevisionVariables,
     UsePreciseCodeIntelForPositionResult,
     UsePreciseCodeIntelForPositionVariables,
-} from 'src/graphql-operations'
+} from '../graphql-operations'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 
@@ -91,8 +91,8 @@ export function buildReferencePanelMocks(): ReferencePanelMock {
         commit,
         path,
         repository: repoName,
-        format: HighlightResponseFormat.JSON_SCIP,
-        html: false,
+        format: HighlightResponseFormat.HTML_HIGHLIGHT,
+        html: true,
     }
 
     return {

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -18,6 +18,7 @@ import {
 import { useQuery } from '@sourcegraph/http-client'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
+import { HighlightResponseFormat } from '@sourcegraph/shared/src/graphql-operations'
 import { getModeFromPath } from '@sourcegraph/shared/src/languages'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
@@ -639,6 +640,7 @@ const SideBlob: React.FunctionComponent<
         [useCodeMirror, history, panelHistory]
     )
 
+    const highlightFormat = useCodeMirror ? HighlightResponseFormat.JSON_SCIP : HighlightResponseFormat.HTML_HIGHLIGHT
     const { data, error, loading } = useQuery<
         ReferencesPanelHighlightedBlobResult,
         ReferencesPanelHighlightedBlobVariables
@@ -647,6 +649,8 @@ const SideBlob: React.FunctionComponent<
             repository: props.activeLocation.repo,
             commit: props.activeLocation.commitID,
             path: props.activeLocation.file,
+            format: highlightFormat,
+            html: highlightFormat === HighlightResponseFormat.HTML_HIGHLIGHT,
         },
         // Cache this data but always re-request it in the background when we revisit
         // this page to pick up newer changes.
@@ -685,7 +689,7 @@ const SideBlob: React.FunctionComponent<
         return <>Nothing found</>
     }
 
-    const { html, aborted } = data?.repository?.commit?.blob?.highlight
+    const { html, aborted, lsif } = data?.repository?.commit?.blob?.highlight
     if (aborted) {
         return (
             <Text alignment="center" className="text-warning">
@@ -707,7 +711,8 @@ const SideBlob: React.FunctionComponent<
             wrapCode={true}
             className={styles.sideBlobCode}
             blobInfo={{
-                html,
+                html: html ?? '',
+                lsif: lsif ?? '',
                 content: props.activeLocation.content,
                 filePath: props.activeLocation.file,
                 repoName: props.activeLocation.repo,

--- a/client/web/src/codeintel/ReferencesPanelQueries.ts
+++ b/client/web/src/codeintel/ReferencesPanelQueries.ts
@@ -168,13 +168,20 @@ export const LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY = gql`
 
 export const FETCH_HIGHLIGHTED_BLOB = gql`
     fragment HighlightedGitBlobFields on GitBlob {
-        highlight(disableTimeout: false) {
+        highlight(disableTimeout: false, format: $format) {
             aborted
-            html
+            html @include(if: $html)
+            lsif
         }
     }
 
-    query ReferencesPanelHighlightedBlob($repository: String!, $commit: String!, $path: String!) {
+    query ReferencesPanelHighlightedBlob(
+        $repository: String!
+        $commit: String!
+        $path: String!
+        $format: HighlightResponseFormat!
+        $html: Boolean!
+    ) {
         repository(name: $repository) {
             id
             commit(rev: $commit) {


### PR DESCRIPTION
Fixes #40510.

Previously, the preview pane in the new reference panel didn't have
syntax highlighting when using the new CodeMirror blob view. This commit
fixes this issue by updating the GraphQL query for syntax highlighting
to mirror the query that we use to highlight regular blob views.



## Test plan

Manually ran the change locally and verified that the preview pane is now syntax highlighted.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-cm-ref-hl.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wgmtctnpzn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
