### PR TITLE
executors: alert when no jobs processed but queue > 0

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -5942,6 +5942,8 @@ Custom alert query: `
 **Next steps**
 
 - Check to see the state of any compute VMs, they may be taking longer than expected to boot.
+- Make sure the executors appear under Site Admin > Executors.
+- Check the Grafana dashboard section for APIClient, it should do frequent requests to Dequeue and Heartbeat and those must not fail.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#executor-executor-processor-total).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -5926,17 +5926,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> executor: less than 0 handler operations every 5m for 5m0s
+- <span class="badge badge-critical">critical</span> executor: less than 0 handler operations every 5m for 15m0s
 
 <details>
 <summary>Technical details</summary>
 
 Custom alert query: `
-		(
-			sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))
-			+ (sum(increase(src_executor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m])))
-			OR vector(0)
-		) == 0
+		(sum(src_executor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}) OR vector(0)) == 0
 			AND
 		(sum by (queue)(src_executor_total{job=~"^sourcegraph-executors.*"})) > 0
 	`
@@ -5945,7 +5941,9 @@ Custom alert query: `
 
 **Next steps**
 
-- possibleSolution string
+- Check to see the state of any compute VMs, they may be taking longer than expected to boot.
+- If the VMs are booted, are they processing anything? We don`t track number of in-progress active jobs today,
+so the alert would only subside once a completed (successful or failed) job is reported.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#executor-executor-processor-total).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5970,7 +5968,7 @@ Custom alert query: `
 <details>
 <summary>Technical details</summary>
 
-Custom alert query: `last_over_time(sum(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"})[5h:]) / (last_over_time(sum(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"})[5h:]) + last_over_time(sum(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"})[5h:])) * 100`
+Custom alert query: `last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) / (last_over_time(sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) + last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:])) * 100`
 
 </details>
 

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -5926,7 +5926,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> executor: less than 0 handler operations every 5m for 15m0s
+- <span class="badge badge-critical">critical</span> executor: less than 0 handler operations every 5m for 5m0s
 
 <details>
 <summary>Technical details</summary>
@@ -5942,8 +5942,6 @@ Custom alert query: `
 **Next steps**
 
 - Check to see the state of any compute VMs, they may be taking longer than expected to boot.
-- If the VMs are booted, are they processing anything? We don`t track number of in-progress active jobs today,
-so the alert would only subside once a completed (successful or failed) job is reported.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#executor-executor-processor-total).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -5920,6 +5920,45 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
+## executor: executor_processor_total
+
+<p class="subtitle">handler operations every 5m</p>
+
+**Descriptions**
+
+- <span class="badge badge-critical">critical</span> executor: less than 0 handler operations every 5m for 5m0s
+
+<details>
+<summary>Technical details</summary>
+
+Custom alert query: `
+		(
+			sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))
+			+ (sum(increase(src_executor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m])))
+			OR vector(0)
+		) == 0
+			AND
+		(sum by (queue)(src_executor_total{job=~"^sourcegraph-executors.*"})) > 0
+	`
+
+</details>
+
+**Next steps**
+
+- possibleSolution string
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#executor-executor-processor-total).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "critical_executor_executor_processor_total"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<br />
+
 ## executor: executor_processor_error_rate
 
 <p class="subtitle">handler operation error rate over 5m</p>
@@ -5931,7 +5970,7 @@ with your code hosts connections or networking issues affecting communication wi
 <details>
 <summary>Technical details</summary>
 
-Custom alert query: `last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) / (last_over_time(sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) + last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:])) * 100`
+Custom alert query: `last_over_time(sum(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"})[5h:]) / (last_over_time(sum(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"})[5h:]) + last_over_time(sum(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"})[5h:])) * 100`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -17662,7 +17662,7 @@ Query: `sum(src_executor_processor_handlers{queue=~"${queue:regex}",sg_job=~"^so
 
 <p class="subtitle">Handler operations every 5m</p>
 
-This panel has no related alerts.
+Refer to the [alerts reference](./alerts.md#executor-executor-processor-total) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100110` on your Sourcegraph instance.
 

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -324,13 +324,11 @@ func (codeIntelligence) NewExecutorProcessorGroup(containerName string) monitori
 				monitoring.Alert().
 					CustomQuery(Workerutil.QueueForwardProgress(containerName, constructorOptions, queueConstructorOptions)).
 					LessOrEqual(0).
-					// ~5min for scale-from-zero + processing time as we dont have figures for in-flight jobs, only completed
-					For(time.Minute*15),
+					// ~5min for scale-from-zero
+					For(time.Minute*5),
 				`
 				- Check to see the state of any compute VMs, they may be taking longer than expected to boot.
-				- If the VMs are booted, are they processing anything? We don't track number of in-progress active jobs today,
-				so the alert would only subside once a completed (successful or failed) job is reported.
-				`),
+			`),
 			Duration: NoAlertsOption("none"),
 			Errors:   NoAlertsOption("none"),
 			ErrorRate: CriticalOption(

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -328,6 +328,8 @@ func (codeIntelligence) NewExecutorProcessorGroup(containerName string) monitori
 					For(time.Minute*5),
 				`
 				- Check to see the state of any compute VMs, they may be taking longer than expected to boot.
+				- Make sure the executors appear under Site Admin > Executors.
+				- Check the Grafana dashboard section for APIClient, it should do frequent requests to Dequeue and Heartbeat and those must not fail.
 			`),
 			Duration: NoAlertsOption("none"),
 			Errors:   NoAlertsOption("none"),

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -324,11 +324,13 @@ func (codeIntelligence) NewExecutorProcessorGroup(containerName string) monitori
 				monitoring.Alert().
 					CustomQuery(Workerutil.QueueForwardProgress(containerName, constructorOptions, queueConstructorOptions)).
 					LessOrEqual(0).
-					// ~5min for scale-from-zero + processing time
-					// as we dont have figures for in-flight jobs,
-					// only completed
+					// ~5min for scale-from-zero + processing time as we dont have figures for in-flight jobs, only completed
 					For(time.Minute*15),
-				`possibleSolution string`),
+				`
+				- Check to see the state of any compute VMs, they may be taking longer than expected to boot.
+				- If the VMs are booted, are they processing anything? We don't track number of in-progress active jobs today,
+				so the alert would only subside once a completed (successful or failed) job is reported.
+				`),
 			Duration: NoAlertsOption("none"),
 			Errors:   NoAlertsOption("none"),
 			ErrorRate: CriticalOption(

--- a/monitoring/definitions/shared/workerutil.go
+++ b/monitoring/definitions/shared/workerutil.go
@@ -88,11 +88,7 @@ func (workerutilConstructor) QueueForwardProgress(containerName string, handlerO
 	queueBy, _ := makeBy(queueOptions.By...)
 
 	return fmt.Sprintf(`
-		(
-			sum%[1]s(increase(src_%[2]s_processor_total{%[3]s}[5m]))
-			+ (sum%[1]s(increase(src_%[2]s_errors_total{%[3]s}[5m])))
-			OR vector(0)
-		) == 0
+		(sum%[1]s(src_%[2]s_total{%[3]s}) OR vector(0)) == 0
 			AND
 		(sum%[4]s(src_%[5]s_total{%[6]s})) > 0
 	`, handlerBy, handlerOptions.MetricNameRoot, handlerFilters, queueBy, queueOptions.MetricNameRoot, queueFilters)

--- a/monitoring/definitions/shared/workerutil.go
+++ b/monitoring/definitions/shared/workerutil.go
@@ -80,8 +80,6 @@ func (workerutilConstructor) LastOverTimeErrorRate(containerName string, lookbac
 
 // QueueForwardProgress creates a queue-based workerutil-specific query that yields 0 when the queue is non-empty but the
 // number of processed records is zero.
-// This should be combined with a reasonable time threshold to account for cloud VM startup time + job processing time, as
-// we don't track in-flight jobs today, only 'completed'.
 func (workerutilConstructor) QueueForwardProgress(containerName string, handlerOptions, queueOptions ObservableConstructorOptions) string {
 	handlerFilters := makeFilters(handlerOptions.JobLabel, containerName, handlerOptions.Filters...)
 	handlerBy, _ := makeBy(handlerOptions.By...)


### PR DESCRIPTION
Adds an alert for, after a certain time period, when the executor queue size is greater than 0 and the number of completed or errored job attempts is not increasing, then we likely have some issue causing executors to stall. 
This is complementary to https://github.com/sourcegraph/sourcegraph/pull/38767 (which needs to be improved to handle gaps as per https://sourcegraph.slack.com/archives/C07KZF47K/p1660661668690719)

Closes https://github.com/sourcegraph/sourcegraph/issues/40409

The orange line below represents the alert case (before alert duration threshold is applied), yellow is the queue size, blue is the in-flight jobs.

![image](https://user-images.githubusercontent.com/18282288/185642490-e8cc23e3-e49c-41d1-a46f-409cc638f6ca.png)

## Test plan

Ran the queries against dotcom metrics data as per above
