### PR TITLE
insights: attach aggregation logic to resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -493,6 +493,7 @@ type ExhaustiveSearchAggregationResultResolver interface {
 	SupportsPersistence() (*bool, error)
 	OtherResultCount() (*int32, error)
 	OtherGroupCount() (*int32, error)
+	Mode() (string, error)
 }
 
 type NonExhaustiveSearchAggregationResultResolver interface {
@@ -500,6 +501,7 @@ type NonExhaustiveSearchAggregationResultResolver interface {
 	SupportsPersistence() (*bool, error)
 	OtherResultCount() (*int32, error)
 	ApproximateOtherGroupCount() (*int32, error)
+	Mode() (string, error)
 }
 
 type AggregationGroup interface {
@@ -510,6 +512,7 @@ type AggregationGroup interface {
 
 type SearchAggregationNotAvailable interface {
 	Reason() string
+	Mode() string
 }
 
 type SearchAggregationResultResolver interface {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -1294,6 +1294,10 @@ type ExhaustiveSearchAggregationResult {
     A count to represent the number of aggregation groups that were not returned due to the requested LIMIT
     """
     otherGroupCount: Int
+    """
+    The SearchAggregationMode the results relate to
+    """
+    mode: SearchAggregationMode!
 }
 
 """
@@ -1317,6 +1321,10 @@ type NonExhaustiveSearchAggregationResult {
     An approximate count of the total number of aggregation groups that were not available in the values list
     """
     approximateOtherGroupCount: Int
+    """
+    The SearchAggregationMode the results relate to
+    """
+    mode: SearchAggregationMode!
 }
 
 """
@@ -1353,4 +1361,8 @@ type SearchAggregationNotAvailable {
     The reason a search aggregation is not available
     """
     reason: String!
+    """
+    The SearchAggregationMode that is unavailable
+    """
+    mode: SearchAggregationMode!
 }

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -88,7 +88,7 @@ func NewWorker(ctx context.Context, logger log.Logger, workerStore dbworkerstore
 		seriesCache:     sharedCache,
 		searchStream: func(ctx context.Context, query string) (*streaming.TabulationResult, error) {
 			decoder, streamResults := streaming.TabulationDecoder()
-			err := streaming.Search(ctx, query, decoder)
+			err := streaming.Search(ctx, query, nil, decoder)
 			if err != nil {
 				return nil, errors.Wrap(err, "streaming.Search")
 			}

--- a/enterprise/internal/insights/query/streaming/aggregation.go
+++ b/enterprise/internal/insights/query/streaming/aggregation.go
@@ -7,7 +7,7 @@ import (
 type LimitedAggregator interface {
 	Add(label string, count int32)
 	SortAggregate() []*Aggregate
-	OtherResults() OtherCount
+	OtherCounts() OtherCount
 }
 
 func NewLimitedAggregator(bufferSize int) LimitedAggregator {
@@ -110,7 +110,7 @@ func (a limitedAggregator) SortAggregate() []*Aggregate {
 	return aggregateSlice
 }
 
-func (a *limitedAggregator) OtherResults() OtherCount {
+func (a *limitedAggregator) OtherCounts() OtherCount {
 	return a.OtherCount
 }
 

--- a/enterprise/internal/insights/query/streaming/aggregation.go
+++ b/enterprise/internal/insights/query/streaming/aggregation.go
@@ -4,7 +4,20 @@ import (
 	"sort"
 )
 
-type aggregated struct {
+type LimitedAggregator interface {
+	Add(label string, count int32)
+	SortAggregate() []*Aggregate
+	OtherResults() OtherCount
+}
+
+func NewLimitedAggregator(bufferSize int) LimitedAggregator {
+	return &limitedAggregator{
+		resultBufferSize: bufferSize,
+		Results:          map[string]int32{},
+	}
+}
+
+type limitedAggregator struct {
 	resultBufferSize int
 	smallestResult   *Aggregate
 	Results          map[string]int32
@@ -22,7 +35,7 @@ type OtherCount struct {
 }
 
 // Add performs best-effort aggregation for a (label, count) search result.
-func (a *aggregated) Add(label string, count int32) {
+func (a *limitedAggregator) Add(label string, count int32) {
 	// 1. We have a match in our in-memory map. Update and update the smallest result.
 	// 2. We haven't hit the max buffer size. Add to our in-memory map and update the smallest result.
 	// 3. We don't have a match but have a better result than our smallest. Update the overflow by ejected smallest.
@@ -60,7 +73,7 @@ func (a *aggregated) Add(label string, count int32) {
 }
 
 // findSmallestAggregate finds the result with the smallest count and returns it.
-func (a *aggregated) findSmallestAggregate() *Aggregate {
+func (a *limitedAggregator) findSmallestAggregate() *Aggregate {
 	var smallestAggregate *Aggregate
 	for label, count := range a.Results {
 		tempSmallest := &Aggregate{label, count}
@@ -71,20 +84,20 @@ func (a *aggregated) findSmallestAggregate() *Aggregate {
 	return smallestAggregate
 }
 
-func (a *aggregated) updateSmallestAggregate() {
+func (a *limitedAggregator) updateSmallestAggregate() {
 	smallestResult := a.findSmallestAggregate()
 	if smallestResult != nil {
 		a.smallestResult = smallestResult
 	}
 }
 
-func (a *aggregated) updateOtherCount(resultCount, groupCount int32) {
+func (a *limitedAggregator) updateOtherCount(resultCount, groupCount int32) {
 	a.OtherCount.ResultCount += resultCount
 	a.OtherCount.GroupCount += groupCount
 }
 
 // SortAggregate sorts aggregated results into a slice of descending order.
-func (a aggregated) SortAggregate() []*Aggregate {
+func (a limitedAggregator) SortAggregate() []*Aggregate {
 	aggregateSlice := make([]*Aggregate, 0, len(a.Results))
 	for val, count := range a.Results {
 		aggregateSlice = append(aggregateSlice, &Aggregate{val, count})
@@ -95,6 +108,10 @@ func (a aggregated) SortAggregate() []*Aggregate {
 	})
 
 	return aggregateSlice
+}
+
+func (a *limitedAggregator) OtherResults() OtherCount {
+	return a.OtherCount
 }
 
 func (a *Aggregate) Less(b *Aggregate) bool {

--- a/enterprise/internal/insights/query/streaming/aggregation_decoder.go
+++ b/enterprise/internal/insights/query/streaming/aggregation_decoder.go
@@ -121,7 +121,7 @@ func newEventMatch(event streamhttp.EventMatch) *eventMatch {
 			RepoID:      match.RepositoryID,
 			Path:        match.Path,
 			Lang:        lang,
-			ResultCount: len(match.ChunkMatches),
+			ResultCount: len(match.LineMatches),
 		}
 	case *streamhttp.EventPathMatch:
 		lang, _ := enry.GetLanguageByExtension(match.Path)

--- a/enterprise/internal/insights/query/streaming/aggregation_decoder.go
+++ b/enterprise/internal/insights/query/streaming/aggregation_decoder.go
@@ -116,12 +116,16 @@ func newEventMatch(event streamhttp.EventMatch) *eventMatch {
 	switch match := event.(type) {
 	case *streamhttp.EventContentMatch:
 		lang, _ := enry.GetLanguageByExtension(match.Path)
+		resultCount := 0
+		for _, lineMatch := range match.LineMatches {
+			resultCount += len(lineMatch.OffsetAndLengths)
+		}
 		return &eventMatch{
 			Repo:        match.Repository,
 			RepoID:      match.RepositoryID,
 			Path:        match.Path,
 			Lang:        lang,
-			ResultCount: len(match.LineMatches),
+			ResultCount: resultCount,
 		}
 	case *streamhttp.EventPathMatch:
 		lang, _ := enry.GetLanguageByExtension(match.Path)

--- a/enterprise/internal/insights/query/streaming/aggregation_decoder_test.go
+++ b/enterprise/internal/insights/query/streaming/aggregation_decoder_test.go
@@ -24,6 +24,7 @@ func (r *testAggregator) AddResult(result *AggregationMatchResult, err error) {
 
 func contentMatch(repo, path string, repoID int32, chunks ...string) *streamhttp.EventContentMatch {
 	matches := make([]streamhttp.ChunkMatch, 0, len(chunks))
+	lineMatches := make([]streamhttp.EventLineMatch, 0, len(chunks))
 	for _, content := range chunks {
 		matches = append(matches, streamhttp.ChunkMatch{
 			Content:      content,
@@ -33,6 +34,9 @@ func contentMatch(repo, path string, repoID int32, chunks ...string) *streamhttp
 				End:   streamhttp.Location{Offset: len(content), Line: 1, Column: len(content)},
 			}},
 		})
+		lineMatches = append(lineMatches, streamhttp.EventLineMatch{
+			OffsetAndLengths: [][2]int32{{1, int32(len(content))}},
+		})
 	}
 
 	return &streamhttp.EventContentMatch{
@@ -41,6 +45,7 @@ func contentMatch(repo, path string, repoID int32, chunks ...string) *streamhttp
 		RepositoryID: repoID,
 		Repository:   repo,
 		ChunkMatches: matches,
+		LineMatches:  lineMatches,
 	}
 }
 

--- a/enterprise/internal/insights/query/streaming/aggregation_test.go
+++ b/enterprise/internal/insights/query/streaming/aggregation_test.go
@@ -9,32 +9,32 @@ import (
 func TestAddAggregate(t *testing.T) {
 	testCases := []struct {
 		name  string
-		have  aggregated
+		have  limitedAggregator
 		value string
 		count int32
-		want  aggregated
+		want  limitedAggregator
 	}{
 		{
 			name: "invalid buffer size does nothing",
-			have: aggregated{
+			have: limitedAggregator{
 				resultBufferSize: -1,
 			},
 			value: "B",
 			count: 9,
-			want: aggregated{
+			want: limitedAggregator{
 				resultBufferSize: -1,
 			},
 		},
 		{
 			name: "adds up other count",
-			have: aggregated{
+			have: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{"A": 12},
 				smallestResult:   &Aggregate{"A", 12},
 			},
 			value: "B",
 			count: 9,
-			want: aggregated{
+			want: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{"A": 12},
 				smallestResult:   &Aggregate{"A", 12},
@@ -43,14 +43,14 @@ func TestAddAggregate(t *testing.T) {
 		},
 		{
 			name: "adds new result",
-			have: aggregated{
+			have: limitedAggregator{
 				resultBufferSize: 2,
 				Results:          map[string]int32{"A": 24},
 				smallestResult:   &Aggregate{"A", 24},
 			},
 			value: "B",
 			count: 32,
-			want: aggregated{
+			want: limitedAggregator{
 				resultBufferSize: 2,
 				Results:          map[string]int32{"A": 24, "B": 32},
 				smallestResult:   &Aggregate{"A", 24},
@@ -58,14 +58,14 @@ func TestAddAggregate(t *testing.T) {
 		},
 		{
 			name: "updates existing results",
-			have: aggregated{
+			have: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{"C": 5},
 				smallestResult:   &Aggregate{"C", 5},
 			},
 			value: "C",
 			count: 11,
-			want: aggregated{
+			want: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{"C": 16},
 				smallestResult:   &Aggregate{"C", 16},
@@ -73,14 +73,14 @@ func TestAddAggregate(t *testing.T) {
 		},
 		{
 			name: "ejects smallest result",
-			have: aggregated{
+			have: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{"C": 5},
 				smallestResult:   &Aggregate{"C", 5},
 			},
 			value: "A",
 			count: 15,
-			want: aggregated{
+			want: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{"A": 15},
 				smallestResult:   &Aggregate{"A", 15},
@@ -89,7 +89,7 @@ func TestAddAggregate(t *testing.T) {
 		},
 		{
 			name: "adds up other group count",
-			have: aggregated{
+			have: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{"A": 12},
 				smallestResult:   &Aggregate{"A", 12},
@@ -97,7 +97,7 @@ func TestAddAggregate(t *testing.T) {
 			},
 			value: "B",
 			count: 9,
-			want: aggregated{
+			want: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{"A": 12},
 				smallestResult:   &Aggregate{"A", 12},
@@ -106,13 +106,13 @@ func TestAddAggregate(t *testing.T) {
 		},
 		{
 			name: "first result becomes smallest result",
-			have: aggregated{
+			have: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{},
 			},
 			value: "new",
 			count: 1,
-			want: aggregated{
+			want: limitedAggregator{
 				resultBufferSize: 1,
 				Results:          map[string]int32{"new": 1},
 				smallestResult:   &Aggregate{"new", 1},
@@ -130,7 +130,7 @@ func TestAddAggregate(t *testing.T) {
 func TestFindSmallestAggregate(t *testing.T) {
 	testCases := []struct {
 		name string
-		have aggregated
+		have limitedAggregator
 		want *Aggregate
 	}{
 		{
@@ -139,21 +139,21 @@ func TestFindSmallestAggregate(t *testing.T) {
 		},
 		{
 			name: "one result is smallest",
-			have: aggregated{
+			have: limitedAggregator{
 				Results: map[string]int32{"myresult": 20},
 			},
 			want: &Aggregate{"myresult", 20},
 		},
 		{
 			name: "finds smallest result by count",
-			have: aggregated{
+			have: limitedAggregator{
 				Results: map[string]int32{"high": 20, "low": 5, "mid": 10},
 			},
 			want: &Aggregate{"low", 5},
 		},
 		{
 			name: "finds smallest result by label",
-			have: aggregated{
+			have: limitedAggregator{
 				Results: map[string]int32{"outsider": 5, "abc/1": 5, "abcd": 5, "abc/2": 5},
 			},
 			want: &Aggregate{"abc/1", 5},
@@ -168,7 +168,7 @@ func TestFindSmallestAggregate(t *testing.T) {
 }
 
 func TestSortAggregate(t *testing.T) {
-	a := aggregated{
+	a := limitedAggregator{
 		Results:          make(map[string]int32),
 		resultBufferSize: 5,
 	}

--- a/enterprise/internal/insights/query/streaming/search.go
+++ b/enterprise/internal/insights/query/streaming/search.go
@@ -25,7 +25,7 @@ type Opts struct {
 
 // Search calls the streaming search endpoint and uses decoder to decode the
 // response body.
-func Search(ctx context.Context, query string, decoder streamhttp.FrontendStreamDecoder) (err error) {
+func Search(ctx context.Context, query string, patternType *string, decoder streamhttp.FrontendStreamDecoder) (err error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "InsightsStreamSearch")
 	defer func() {
 		span.LogFields(
@@ -37,6 +37,10 @@ func Search(ctx context.Context, query string, decoder streamhttp.FrontendStream
 	if err != nil {
 		return err
 	}
+	if patternType != nil {
+		req.URL.Query().Add("t", *patternType)
+	}
+
 	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "code-insights-backend")
 

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -84,7 +84,7 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 			}
 
 			decoder, tabulationResult := streaming.TabulationDecoder()
-			err = streaming.Search(ctx, modified.String(), decoder)
+			err = streaming.Search(ctx, modified.String(), nil, decoder)
 			if err != nil {
 				return nil, errors.Wrap(err, "streaming.Search")
 			}

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -2,11 +2,17 @@ package resolvers
 
 import (
 	"context"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/querybuilder"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/streaming"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+const searchTimeLimitSeconds = 2
+const aggregationBufferSize = 500
 
 type searchAggregateResolver struct {
 	baseInsightResolver
@@ -23,8 +29,140 @@ func (r *searchAggregateResolver) ModeAvailability(ctx context.Context) []graphq
 }
 
 func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphqlbackend.AggregationsArgs) (graphqlbackend.SearchAggregationResultResolver, error) {
-	// TODO(chwarwick): Replace with logic to detmine if available and return values
-	return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver()}, nil
+	// Steps:
+	// 1. - Get default mode (currently defaulted in gql to REPO)
+	// 2. - Validate mode supported
+	// 3. - Modify search query (timeout: & count:)
+	// 3. - Run Search
+	// 4. - Check search for errors/alerts
+	// 5 -  Generate correct resolver pass search results if valid
+	aggreationMode := types.SearchAggregationMode(args.Mode)
+	supported, reason := aggreagtionModeSupported(r.searchQuery, r.patternType, aggreationMode)
+	if !supported {
+		return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(reason)}, nil
+	}
+
+	// If a search includes a timeout it reports as completing succesfully with the timeout is hit
+	// This includes a timeout in the search that is a second longer than the context we will cancel as a fail safe
+	modifiedQuery, err := querybuilder.AggregationQuery(querybuilder.BasicQuery(r.searchQuery), searchTimeLimitSeconds+1)
+	if err != nil {
+		return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver("search query could not be expanded for aggregation")}, nil
+	}
+
+	cappedAggregator := streaming.NewLimitedAggregator(aggregationBufferSize)
+	tabulationErrors := []error{}
+	tabulationFunc := func(amr *streaming.AggregationMatchResult, err error) {
+		if err != nil {
+			tabulationErrors = append(tabulationErrors, err)
+			return
+		}
+		cappedAggregator.Add(amr.Key.Group, int32(amr.Count))
+	}
+	onMatchFunc, err := streaming.TabulateAggregationMatches(tabulationFunc, aggreationMode)
+	if err != nil {
+		return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(err.Error())}, nil
+	}
+	decoder, searchEvents := streaming.AggregationDecoder(onMatchFunc)
+
+	requestContext, _ := context.WithTimeout(ctx, time.Minute*searchTimeLimitSeconds)
+	err = streaming.Search(requestContext, string(modifiedQuery), &r.patternType, decoder)
+	if err != nil {
+		reason := "unable to run search"
+		if errors.Is(err, context.Canceled) {
+			reason = "search did not complete in time"
+		}
+		return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(reason)}, nil
+	}
+
+	successful, failureReason := searchSuccessful(searchEvents, tabulationErrors)
+	if !successful {
+		return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(failureReason)}, nil
+	}
+
+	results := buildResults(cappedAggregator, int(args.Limit), aggreationMode, r.searchQuery)
+
+	return &searchAggregationResultResolver{resolver: &searchAggregationModeResultResolver{
+		baseInsightResolver: r.baseInsightResolver,
+		searchQuery:         r.searchQuery,
+		patternType:         r.patternType,
+		mode:                aggreationMode,
+		results:             results,
+		isExhaustive:        cappedAggregator.OtherResults().GroupCount == 0,
+	}}, nil
+
+}
+
+// Temporary placeholder to limit mode to only REPO
+func aggreagtionModeSupported(searchQuery, patternType string, mode types.SearchAggregationMode) (bool, string) {
+	if mode == types.REPO_AGGREGATION_MODE {
+		return true, ""
+	}
+	return false, "Only aggregation by repository is currently supported."
+}
+
+func searchSuccessful(events *streaming.AggregationDecoderEvents, tabulationErrors []error) (bool, string) {
+	for _, skipped := range events.Skipped {
+		if skipped.Reason == string(streaming.ShardTimeoutSkippedReason) {
+			return false, "query was unable to complete"
+		}
+	}
+
+	if len(events.Errors) > 0 {
+		return false, "query returned with errors"
+	}
+
+	if len(tabulationErrors) > 0 {
+		return false, "query returned with errors"
+	}
+
+	return true, ""
+}
+
+type aggregationResults struct {
+	groups           []graphqlbackend.AggregationGroup
+	otherResultCount int
+	otherGroupCount  int
+}
+
+type AggregationGroup struct {
+	label string
+	count int
+	query *string
+}
+
+func (r *AggregationGroup) Label() string {
+	return r.label
+}
+func (r *AggregationGroup) Count() int32 {
+	return int32(r.count)
+}
+func (r *AggregationGroup) Query() (*string, error) {
+	return r.query, nil
+}
+
+func buildResults(aggregator streaming.LimitedAggregator, limit int, mode types.SearchAggregationMode, originalQuery string) aggregationResults {
+	sorted := aggregator.SortAggregate()
+	groups := make([]graphqlbackend.AggregationGroup, 0, limit)
+	var otherResults, otherGroups int
+
+	for i := 0; i < len(sorted); i++ {
+		if i < limit {
+			groups = append(groups, &AggregationGroup{
+				label: sorted[i].Label,
+				count: int(sorted[i].Count),
+				query: nil,
+			})
+		} else {
+			otherGroups++
+			otherResults += int(sorted[i].Count)
+		}
+	}
+
+	return aggregationResults{
+		groups:           groups,
+		otherResultCount: otherResults,
+		otherGroupCount:  otherGroups,
+	}
 }
 
 func newAggregationModeAvailabilityResolver(searchQuery string, patternType string, mode types.SearchAggregationMode) graphqlbackend.AggregationModeAvailabilityResolver {
@@ -79,15 +217,16 @@ func (r *searchAggregationResultResolver) ToSearchAggregationNotAvailable() (gra
 	return res, ok
 }
 
-func newSearchAggregationNotAvailableResolver() graphqlbackend.SearchAggregationNotAvailable {
+func newSearchAggregationNotAvailableResolver(reason string) graphqlbackend.SearchAggregationNotAvailable {
 	return &searchAggregationNotAvailableResolver{}
 }
 
 type searchAggregationNotAvailableResolver struct {
+	reason string
 }
 
 func (r *searchAggregationNotAvailableResolver) Reason() string {
-	return "not implemented"
+	return r.reason
 }
 
 // Resolver to calculate aggregations for a combination of search query, pattern type, aggregation mode
@@ -96,25 +235,29 @@ type searchAggregationModeResultResolver struct {
 	searchQuery  string
 	patternType  string
 	mode         types.SearchAggregationMode
+	results      aggregationResults
 	isExhaustive bool
 }
 
 func (r *searchAggregationModeResultResolver) Groups() ([]graphqlbackend.AggregationGroup, error) {
-	return nil, errors.New("not implemented")
+	return r.results.groups, nil
 }
 
 func (r *searchAggregationModeResultResolver) OtherResultCount() (*int32, error) {
-	return nil, errors.New("not implemented")
+	var count int32 = int32(r.results.otherResultCount)
+	return &count, nil
 }
 
 // OtherGroupCount - used for exhaustive aggregations to indicate count of additional groups
 func (r *searchAggregationModeResultResolver) OtherGroupCount() (*int32, error) {
-	return nil, errors.New("not implemented")
+	var count int32 = int32(r.results.otherGroupCount)
+	return &count, nil
 }
 
 // ApproximateOtherGroupCount - used for nonexhaustive aggregations to indicate approx count of additional groups
 func (r *searchAggregationModeResultResolver) ApproximateOtherGroupCount() (*int32, error) {
-	return nil, errors.New("not implemented")
+	var count int32 = int32(r.results.otherGroupCount)
+	return &count, nil
 }
 
 func (r *searchAggregationModeResultResolver) SupportsPersistence() (*bool, error) {

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -12,7 +12,7 @@ import (
 )
 
 const searchTimeLimitSeconds = 2
-const aggregationBufferSize = 2
+const aggregationBufferSize = 500
 
 type searchAggregateResolver struct {
 	baseInsightResolver

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -12,7 +12,7 @@ import (
 )
 
 const searchTimeLimitSeconds = 2
-const aggregationBufferSize = 500
+const aggregationBufferSize = 2
 
 type searchAggregateResolver struct {
 	baseInsightResolver
@@ -145,7 +145,8 @@ func (r *AggregationGroup) Query() (*string, error) {
 func buildResults(aggregator streaming.LimitedAggregator, limit int, mode types.SearchAggregationMode, originalQuery string) aggregationResults {
 	sorted := aggregator.SortAggregate()
 	groups := make([]graphqlbackend.AggregationGroup, 0, limit)
-	var otherResults, otherGroups int
+	otherResults := aggregator.OtherResults().ResultCount
+	otherGroups := aggregator.OtherResults().GroupCount
 
 	for i := 0; i < len(sorted); i++ {
 		if i < limit {
@@ -156,14 +157,14 @@ func buildResults(aggregator streaming.LimitedAggregator, limit int, mode types.
 			})
 		} else {
 			otherGroups++
-			otherResults += int(sorted[i].Count)
+			otherResults += sorted[i].Count
 		}
 	}
 
 	return aggregationResults{
 		groups:           groups,
-		otherResultCount: otherResults,
-		otherGroupCount:  otherGroups,
+		otherResultCount: int(otherResults),
+		otherGroupCount:  int(otherGroups),
 	}
 }
 


### PR DESCRIPTION
Attaches the aggregation logic to the resolver
Adds an additional `mode` to the results because clients need to know what mode is returned if they pass a null to get the default back.

## Test plan
execute manual gql request and validate results
```graphql
{
  searchQueryAggregate(query: "context:global worker", patternType: standard) {
    aggregations(mode: REPO, limit: 10) {
      __typename
      ... on ExhaustiveSearchAggregationResult {
        groups {
          label
          count
          query
        }
        otherResultCount
        otherGroupCount
      }
      ... on SearchAggregationNotAvailable {
        reason
      }
    }
  }
}
```
```json
{
  "data": {
    "searchQueryAggregate": {
      "aggregations": {
        "__typename": "ExhaustiveSearchAggregationResult",
        "groups": [
          {
            "label": "github.com/sgtest/megarepo",
            "count": 38490,
            "query": null
          },
          {
            "label": "github.com/sourcegraph/sourcegraph",
            "count": 6601,
            "query": null
          },
          {
            "label": "github.com/sourcegraph-testing/etcd",
            "count": 13,
            "query": null
          }
        ],
        "otherResultCount": 0,
        "otherGroupCount": 0
      }
    }
  }
}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
