### PR TITLE
feat(vscode): Prompt to get an access token when authentication fails

### DIFF
--- a/client/vscode/src/backend/instanceVersion.ts
+++ b/client/vscode/src/backend/instanceVersion.ts
@@ -9,6 +9,25 @@ import { requestGraphQLFromVSCode } from './requestGraphQl'
 /**
  * Regular instance version format: ex 3.38.2
  * Insider version format: ex 134683_2022-03-02_5188fes0101
+ */
+export async function getInstanceVersionNumber(): Promise<string | undefined> {
+    try {
+        const siteVersionResult = await requestGraphQLFromVSCode<SiteVersionResult>(siteVersionQuery, {})
+        if (siteVersionResult.data) {
+            // assume instance version longer than 8 is using insider version
+            const flattenVersion =
+                siteVersionResult.data.site.productVersion.length > 8
+                    ? '999999'
+                    : siteVersionResult.data.site.productVersion.split('.').join('')
+            return flattenVersion
+        }
+    } catch (error) {
+        console.error('Failed to get instance version from host:', error)
+    }
+    return
+}
+
+/**
  * This function will return the EventSource Type based
  * on the instance version
  */
@@ -19,14 +38,9 @@ export function initializeInstanceVersionNumber(
 ): EventSource {
     // Check only if a user is trying to connect to a private instance with a valid access token provided
     if (instanceURL !== 'https://sourcegraph.com' && accessToken) {
-        requestGraphQLFromVSCode<SiteVersionResult>(siteVersionQuery, {})
-            .then(async siteVersionResult => {
-                if (siteVersionResult.data) {
-                    // assume instance version longer than 8 is using insider version
-                    const flattenVersion =
-                        siteVersionResult.data.site.productVersion.length > 8
-                            ? '999999'
-                            : siteVersionResult.data.site.productVersion.split('.').join('')
+        getInstanceVersionNumber()
+            .then(async flattenVersion => {
+                if (flattenVersion) {
                     if (flattenVersion < '3320') {
                         displayWarning(
                             'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
@@ -34,9 +48,6 @@ export function initializeInstanceVersionNumber(
                     }
                     await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
                 }
-            })
-            .catch(error => {
-                console.error('Failed to get instance version from host:', error)
             })
         const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
         // instances below 3.38.0 does not support EventSource.IDEEXTENSION and should fallback to BACKEND source

--- a/client/vscode/src/backend/instanceVersion.ts
+++ b/client/vscode/src/backend/instanceVersion.ts
@@ -38,17 +38,16 @@ export function initializeInstanceVersionNumber(
 ): EventSource {
     // Check only if a user is trying to connect to a private instance with a valid access token provided
     if (instanceURL !== 'https://sourcegraph.com' && accessToken) {
-        getInstanceVersionNumber()
-            .then(async flattenVersion => {
-                if (flattenVersion) {
-                    if (flattenVersion < '3320') {
-                        displayWarning(
-                            'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
-                        ).catch(() => {})
-                    }
-                    await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
+        getInstanceVersionNumber().then(async flattenVersion => {
+            if (flattenVersion) {
+                if (flattenVersion < '3320') {
+                    displayWarning(
+                        'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
+                    ).catch(() => {})
                 }
-            })
+                await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
+            }
+        })
         const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
         // instances below 3.38.0 does not support EventSource.IDEEXTENSION and should fallback to BACKEND source
         return versionNumber >= '3380' ? EventSource.IDEEXTENSION : EventSource.BACKEND

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode'
 
 import { readConfiguration } from './readConfiguration'
+import { endpointHostnameSetting, endpointProtocolSetting } from './endpointSetting'
+import { getInstanceVersionNumber } from '../backend/instanceVersion'
 
 export function accessTokenSetting(): string | undefined {
     return readConfiguration().get<string>('accessToken')
@@ -19,7 +21,18 @@ export async function handleAccessTokenError(badToken?: string, endpointURL?: st
             ? `A valid access token is required to connect to ${endpointURL}`
             : `Connection to ${endpointURL} failed because the token is invalid. Please reload VS Code if your Sourcegraph instance URL has changed.`
 
-        await vscode.window.showErrorMessage(message)
+        const instanceVersion = await getInstanceVersionNumber()
+        const supportsTokenCallback = instanceVersion && instanceVersion < '3410'
+        const action = await vscode.window.showErrorMessage(message, "Get Token", "Open Settings")
+
+        if (action === "Open Settings") {
+            vscode.commands.executeCommand('workbench.action.openSettings', 'sourcegraph.accessToken')
+        } else if (action === "Get Token") {
+            const path = supportsTokenCallback ? '/user/settings/tokens/new/callback' : '/user/settings/'
+            const query = supportsTokenCallback ? 'requestFrom=VSCEAUTH' : ''
+
+            vscode.env.openExternal(vscode.Uri.from({ scheme: endpointProtocolSetting().slice(0, -1), authority: endpointHostnameSetting(), path, query }))
+        }
         showingAccessTokenErrorMessage = false
     }
 }

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -23,15 +23,22 @@ export async function handleAccessTokenError(badToken?: string, endpointURL?: st
 
         const instanceVersion = await getInstanceVersionNumber()
         const supportsTokenCallback = instanceVersion && instanceVersion < '3410'
-        const action = await vscode.window.showErrorMessage(message, "Get Token", "Open Settings")
+        const action = await vscode.window.showErrorMessage(message, 'Get Token', 'Open Settings')
 
-        if (action === "Open Settings") {
+        if (action === 'Open Settings') {
             vscode.commands.executeCommand('workbench.action.openSettings', 'sourcegraph.accessToken')
-        } else if (action === "Get Token") {
+        } else if (action === 'Get Token') {
             const path = supportsTokenCallback ? '/user/settings/tokens/new/callback' : '/user/settings/'
             const query = supportsTokenCallback ? 'requestFrom=VSCEAUTH' : ''
 
-            vscode.env.openExternal(vscode.Uri.from({ scheme: endpointProtocolSetting().slice(0, -1), authority: endpointHostnameSetting(), path, query }))
+            vscode.env.openExternal(
+                vscode.Uri.from({
+                    scheme: endpointProtocolSetting().slice(0, -1),
+                    authority: endpointHostnameSetting(),
+                    path,
+                    query,
+                })
+            )
         }
         showingAccessTokenErrorMessage = false
     }

--- a/client/vscode/src/settings/endpointSetting.ts
+++ b/client/vscode/src/settings/endpointSetting.ts
@@ -18,6 +18,10 @@ export function endpointPortSetting(): number {
     return port ? parseInt(port, 10) : 443
 }
 
+export function endpointProtocolSetting(): string {
+    return new URL(endpointSetting()).protocol
+}
+
 export function endpointAccessTokenSetting(): boolean {
     if (readConfiguration().get<string>('accessToken')) {
         return true


### PR DESCRIPTION
If connecting to the sourcegraph instance returns a 401, give the user two actions to take. The first will take the user to sourcegraph to create a new token, using the token callback flow added in #35826 if available. The second will open the workbench settings to allow the user to paste in a token.

This is particularly useful when distributing a `sourcegraph.url` setting as part of the workspace/repository to point to a private instance. Since the URL is already set, the user does not get the first-time setup view when activating the sourcegraph extension. Instead, they will get this error dialog:

<img width="472" alt="Access Token Error" src="https://user-images.githubusercontent.com/1423851/185488219-a2c2af5e-4225-44f9-be45-a43a98413650.png">


## Test plan

- [x] Ran existing unit tests with `yarn test`
- [x] Ran existing integration tests with `yarn test-integration`
- [x] Walked through the flow of installing the vscode extension in a fresh instance with no settings, with a URL and token already set, with only a URL set, against both sourcegraph.com and a private instance
