### PR TITLE
encryption: Fix bytea payload writes

### DIFF
--- a/enterprise/internal/batches/store/site_credentials.go
+++ b/enterprise/internal/batches/store/site_credentials.go
@@ -65,7 +65,7 @@ func createSiteCredentialQuery(ctx context.Context, c *btypes.SiteCredential, ke
 		createSiteCredentialQueryFmtstr,
 		c.ExternalServiceType,
 		c.ExternalServiceID,
-		encryptedCredential,
+		[]byte(encryptedCredential),
 		keyID,
 		c.CreatedAt,
 		c.UpdatedAt,
@@ -270,7 +270,7 @@ func (s *Store) updateSiteCredentialQuery(ctx context.Context, c *btypes.SiteCre
 		updateSiteCredentialQueryFmtstr,
 		c.ExternalServiceType,
 		c.ExternalServiceID,
-		encryptedCredential,
+		[]byte(encryptedCredential),
 		keyID,
 		c.CreatedAt,
 		c.UpdatedAt,
@@ -290,7 +290,10 @@ var siteCredentialColumns = []*sqlf.Query{
 }
 
 func scanSiteCredential(c *btypes.SiteCredential, key encryption.Key, sc dbutil.Scanner) error {
-	var encryptedCredential, keyID string
+	var (
+		encryptedCredential []byte
+		keyID               string
+	)
 	if err := sc.Scan(
 		&c.ID,
 		&c.ExternalServiceType,
@@ -303,6 +306,6 @@ func scanSiteCredential(c *btypes.SiteCredential, key encryption.Key, sc dbutil.
 		return err
 	}
 
-	c.Credential = database.NewEncryptedCredential(encryptedCredential, keyID, key)
+	c.Credential = database.NewEncryptedCredential(string(encryptedCredential), keyID, key)
 	return nil
 }

--- a/internal/database/webhook_logs.go
+++ b/internal/database/webhook_logs.go
@@ -60,8 +60,8 @@ func (s *webhookLogStore) Create(ctx context.Context, log *types.WebhookLog) err
 		receivedAt,
 		dbutil.NullInt64{N: log.ExternalServiceID},
 		log.StatusCode,
-		rawRequest,
-		rawResponse,
+		[]byte(rawRequest),
+		[]byte(rawResponse),
 		keyID,
 		sqlf.Join(webhookLogColumns, ", "),
 	)
@@ -278,8 +278,9 @@ WHERE
 
 func (s *webhookLogStore) scanWebhookLog(ctx context.Context, log *types.WebhookLog, sc dbutil.Scanner) error {
 	var (
-		externalServiceID        int64 = -1
-		request, response, keyID string
+		externalServiceID int64 = -1
+		request, response []byte
+		keyID             string
 	)
 
 	if err := sc.Scan(
@@ -298,7 +299,7 @@ func (s *webhookLogStore) scanWebhookLog(ctx context.Context, log *types.Webhook
 		log.ExternalServiceID = &externalServiceID
 	}
 
-	log.Request = types.NewEncryptedWebhookLogMessage(request, keyID, s.key)
-	log.Response = types.NewEncryptedWebhookLogMessage(response, keyID, s.key)
+	log.Request = types.NewEncryptedWebhookLogMessage(string(request), keyID, s.key)
+	log.Response = types.NewEncryptedWebhookLogMessage(string(response), keyID, s.key)
 	return nil
 }

--- a/internal/database/webhook_logs_test.go
+++ b/internal/database/webhook_logs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	keytesting "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
+	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -71,7 +71,7 @@ func TestWebhookLogStore(t *testing.T) {
 			assert.Nil(t, err)
 			defer func() { _ = tx.Done(errors.New("rollback")) }()
 
-			store := tx.WebhookLogs(keytesting.TestKey{})
+			store := tx.WebhookLogs(et.ByteaTestKey{})
 
 			// Weirdly, Go doesn't have a HTTP constant for "418 I'm a Teapot".
 			log := createWebhookLog(0, 418, time.Now())
@@ -108,7 +108,7 @@ func TestWebhookLogStore(t *testing.T) {
 			assert.Nil(t, err)
 			defer func() { _ = tx.Done(errors.New("rollback")) }()
 
-			store := tx.WebhookLogs(&keytesting.BadKey{Err: errors.New("uh-oh")})
+			store := tx.WebhookLogs(&et.BadKey{Err: errors.New("uh-oh")})
 
 			log := createWebhookLog(0, http.StatusExpectationFailed, time.Now())
 			err = store.Create(ctx, log)
@@ -123,7 +123,7 @@ func TestWebhookLogStore(t *testing.T) {
 		assert.Nil(t, err)
 		defer func() { _ = tx.Done(errors.New("rollback")) }()
 
-		store := tx.WebhookLogs(keytesting.TestKey{})
+		store := tx.WebhookLogs(et.TestKey{})
 
 		log := createWebhookLog(0, http.StatusInternalServerError, time.Now())
 		err = store.Create(ctx, log)
@@ -141,7 +141,7 @@ func TestWebhookLogStore(t *testing.T) {
 		})
 
 		t.Run("different key", func(t *testing.T) {
-			store := tx.WebhookLogs(&keytesting.TransparentKey{})
+			store := tx.WebhookLogs(&et.TransparentKey{})
 			v, err := store.GetByID(ctx, log.ID)
 			assert.Nil(t, err)
 
@@ -166,7 +166,7 @@ func TestWebhookLogStore(t *testing.T) {
 		}
 		assert.Nil(t, esStore.Upsert(ctx, es))
 
-		store := tx.WebhookLogs(keytesting.TestKey{})
+		store := tx.WebhookLogs(et.TestKey{})
 
 		okTime := time.Date(2021, 10, 29, 18, 46, 0, 0, time.UTC)
 		okLog := createWebhookLog(es.ID, http.StatusOK, okTime)
@@ -282,7 +282,7 @@ func TestWebhookLogStore(t *testing.T) {
 		}
 		assert.Nil(t, esStore.Upsert(ctx, es))
 
-		store := tx.WebhookLogs(keytesting.TestKey{})
+		store := tx.WebhookLogs(et.TestKey{})
 		retention, err := time.ParseDuration("24h")
 		assert.Nil(t, err)
 

--- a/internal/encryption/testing/key.go
+++ b/internal/encryption/testing/key.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
@@ -41,7 +42,11 @@ func (k ByteaTestKey) Encrypt(ctx context.Context, plaintext []byte) ([]byte, er
 }
 
 func (k ByteaTestKey) Decrypt(ctx context.Context, ciphertext []byte) (*encryption.Secret, error) {
-	decoded, err := base64.StdEncoding.DecodeString(string(ciphertext[1:]))
+	if len(ciphertext) < 4 || string(ciphertext[:4]) != "\\x20" {
+		return nil, errors.New("incorrect prefix")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(string(ciphertext[4:]))
 	s := encryption.NewSecret(string(decoded))
 	return &s, err
 }

--- a/internal/encryption/testing/key.go
+++ b/internal/encryption/testing/key.go
@@ -29,6 +29,27 @@ func (k TestKey) Version(ctx context.Context) (encryption.KeyVersion, error) {
 	return encryption.KeyVersion{Type: "testkey"}, nil
 }
 
+// ByteaTestKey is an encryption.Key that wraps TestKey in a way that adds arbitrary
+// non-ascii characters. This ensures that we do not try to insert illegal text into
+// encrypted bytea columns.
+type ByteaTestKey struct{}
+
+var _ encryption.Key = TestKey{}
+
+func (k ByteaTestKey) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	return []byte("\\x20" + base64.StdEncoding.EncodeToString(plaintext)), nil
+}
+
+func (k ByteaTestKey) Decrypt(ctx context.Context, ciphertext []byte) (*encryption.Secret, error) {
+	decoded, err := base64.StdEncoding.DecodeString(string(ciphertext[1:]))
+	s := encryption.NewSecret(string(decoded))
+	return &s, err
+}
+
+func (k ByteaTestKey) Version(ctx context.Context) (encryption.KeyVersion, error) {
+	return encryption.KeyVersion{Type: "byteatestkey"}, nil
+}
+
 // BadKey is an encryption.Key that always returns an error when any of its
 // methods are invoked.
 type BadKey struct{ Err error }


### PR DESCRIPTION
Noticed that writes were failing in k8s postgres pod logs and investigated. Found that non-ascii characters can cause the bytea format to fail insertion.

## Test plan

New unit tests.
