### PR TITLE
batches: earlier template variable feedback

### DIFF
--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
+	"github.com/sourcegraph/sourcegraph/lib/batches/template"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -653,7 +654,11 @@ func (s *Service) ReplaceBatchSpecInput(ctx context.Context, opts ReplaceBatchSp
 	}
 	
 	// placing validation
-	newSpec, err = 
+	//if we got back an error that mean its invalid so return that
+	_, err = template.ValidateBatchSpecTemplate("adeola", opts.RawSpec)
+	if err != nil {
+		return nil, err
+	}
 
 	// Make sure the user has access.
 	batchSpec, err = s.store.GetBatchSpec(ctx, store.GetBatchSpecOpts{RandID: opts.BatchSpecRandID})

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -261,6 +261,11 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 		return nil, err
 	}
 
+	_, err = template.ValidateBatchSpecTemplate("spec"+spec.Name, string(rawSpec))
+	if err != nil {
+		return nil, err
+	}
+
 	actor := actor.FromContext(ctx)
 	// Actor is guaranteed to be set here, because CheckNamespaceAccess above enforces it.
 
@@ -273,6 +278,7 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 		CreatedFromRaw:  true,
 	}
 
+
 	tx, err := s.store.Transact(ctx)
 	if err != nil {
 		return nil, err
@@ -282,6 +288,8 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 	if err := tx.CreateBatchSpec(ctx, batchSpec); err != nil {
 		return nil, err
 	}
+
+	
 
 	batchChange := &btypes.BatchChange{
 		Name:            opts.Name,
@@ -704,6 +712,11 @@ func (s *Service) UpsertBatchSpecInput(ctx context.Context, opts UpsertBatchSpec
 	spec, err = btypes.NewBatchSpecFromRaw(opts.RawSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing batch spec")
+	}
+
+_, err = template.ValidateBatchSpecTemplate("spec"+spec.Spec.Name, string(opts.RawSpec))
+	if err != nil {
+		return nil, err
 	}
 
 	// Check whether the current user has access to either one of the namespaces.

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -652,10 +652,11 @@ func (s *Service) ReplaceBatchSpecInput(ctx context.Context, opts ReplaceBatchSp
 	if err != nil {
 		return nil, err
 	}
-	
-	// placing validation
-	//if we got back an error that mean its invalid so return that
-	_, err = template.ValidateBatchSpecTemplate("adeola", opts.RawSpec)
+
+	// Also validate that the batch spec only uses known templating variables and
+	// functions. If we get an error here that it's invalid, we also want to surface that
+	// error to the UI.
+	_, err = template.ValidateBatchSpecTemplate("spec"+opts.BatchSpecRandID, opts.RawSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -651,6 +651,9 @@ func (s *Service) ReplaceBatchSpecInput(ctx context.Context, opts ReplaceBatchSp
 	if err != nil {
 		return nil, err
 	}
+	
+	// placing validation
+	newSpec, err = 
 
 	// Make sure the user has access.
 	batchSpec, err = s.store.GetBatchSpec(ctx, store.GetBatchSpecOpts{RandID: opts.BatchSpecRandID})

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -261,7 +261,7 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 		return nil, err
 	}
 
-	_, err = template.ValidateBatchSpecTemplate("spec"+spec.Name, string(rawSpec))
+	_, err = template.ValidateBatchSpecTemplate(string(rawSpec))
 	if err != nil {
 		return nil, err
 	}
@@ -661,7 +661,7 @@ func (s *Service) ReplaceBatchSpecInput(ctx context.Context, opts ReplaceBatchSp
 	// Also validate that the batch spec only uses known templating variables and
 	// functions. If we get an error here that it's invalid, we also want to surface that
 	// error to the UI.
-	_, err = template.ValidateBatchSpecTemplate("spec"+opts.BatchSpecRandID, opts.RawSpec)
+	_, err = template.ValidateBatchSpecTemplate(opts.RawSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -711,7 +711,7 @@ func (s *Service) UpsertBatchSpecInput(ctx context.Context, opts UpsertBatchSpec
 		return nil, errors.Wrap(err, "parsing batch spec")
 	}
 
-	_, err = template.ValidateBatchSpecTemplate("spec"+spec.Spec.Name, opts.RawSpec)
+	_, err = template.ValidateBatchSpecTemplate(opts.RawSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -278,7 +278,6 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 		CreatedFromRaw:  true,
 	}
 
-
 	tx, err := s.store.Transact(ctx)
 	if err != nil {
 		return nil, err
@@ -288,8 +287,6 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 	if err := tx.CreateBatchSpec(ctx, batchSpec); err != nil {
 		return nil, err
 	}
-
-	
 
 	batchChange := &btypes.BatchChange{
 		Name:            opts.Name,
@@ -714,7 +711,7 @@ func (s *Service) UpsertBatchSpecInput(ctx context.Context, opts UpsertBatchSpec
 		return nil, errors.Wrap(err, "parsing batch spec")
 	}
 
-_, err = template.ValidateBatchSpecTemplate("spec"+spec.Spec.Name, string(opts.RawSpec))
+	_, err = template.ValidateBatchSpecTemplate("spec"+spec.Spec.Name, opts.RawSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1540,6 +1540,76 @@ index e5af166..d44c3fc 100644
 			}
 		})
 
+		tests := []struct {
+			name    string
+			rawSpec string
+			wantErr error
+		}{
+			{
+				name:    "empty",
+				rawSpec: "",
+				wantErr: errors.New("Expected: object, given: null"),
+			},
+			{
+				name:    "invalid YAML",
+				rawSpec: "invalid YAML",
+				wantErr: errors.New("Expected: object, given: string"),
+			},
+			{
+				name:    "invalid name",
+				rawSpec: "name: invalid name",
+				wantErr: errors.New("The batch change name can only contain word characters, dots and dashes. No whitespace or newlines allowed."),
+			},
+			{
+				name: "requires changesetTemplate when steps are included",
+				rawSpec: `
+name: test
+on:
+  - repository: github.com/sourcegraph-testing/some-repo
+steps:
+  - run: echo "Hello world"
+    container: alpine:3`,
+				wantErr: errors.New("batch spec includes steps but no changesetTemplate"),
+			},
+			{
+				name: "unknown templating variable",
+				rawSpec: `
+name: hello
+on:
+  - repository: github.com/sourcegraph-testing/some-repo
+steps:
+  - run: echo "Hello ${{ resopitory.name }}" >> message.txt
+    container: alpine:3
+changesetTemplate:
+  title: Hello World
+  body: My first batch change!
+  branch: hello-world
+  commit:
+    message: Write a message to a text file
+`,
+				wantErr: errors.New("unknown templating variable: 'resopitory'"),
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run("batchSpec has invalid raw spec: "+tc.name, func(t *testing.T) {
+				spec := createBatchSpecWithWorkspaces(t)
+
+				_, gotErr := svc.ReplaceBatchSpecInput(ctx, ReplaceBatchSpecInputOpts{
+					BatchSpecRandID: spec.RandID,
+					RawSpec:         tc.rawSpec,
+				})
+
+				if gotErr == nil {
+					t.Fatalf("unexpected nil error.\nwant=%s\n---\ngot=nil", tc.wantErr)
+				}
+
+				if !strings.Contains(gotErr.Error(), tc.wantErr.Error()) {
+					t.Fatalf("unexpected error.\nwant=%s\n---\ngot=%s", tc.wantErr, gotErr)
+				}
+			})
+		}
+
 		t.Run("batchSpec already has changeset specs", func(t *testing.T) {
 			assertNoChangesetSpecs := func(t *testing.T, batchSpecID int64) {
 				t.Helper()

--- a/lib/batches/template/template.go
+++ b/lib/batches/template/template.go
@@ -13,7 +13,6 @@ func New(name, tmpl, option string, ctxs ...template.FuncMap) (*template.Templat
 	for _, ctx := range ctxs {
 		t = t.Funcs(ctx)
 	}
-	
+
 	return t.Parse(tmpl)
 }
-

--- a/lib/batches/template/template.go
+++ b/lib/batches/template/template.go
@@ -1,0 +1,19 @@
+package template
+
+import "text/template"
+
+func New(name, tmpl, option string, ctxs ...template.FuncMap) (*template.Template, error) {
+	t := template.New(name).Delims(startDelim, endDelim)
+	if option != "" {
+		t = t.Option(option)
+	}
+
+	t = t.Funcs(builtins)
+
+	for _, ctx := range ctxs {
+		t = t.Funcs(ctx)
+	}
+	
+	return t.Parse(tmpl)
+}
+

--- a/lib/batches/template/templating.go
+++ b/lib/batches/template/templating.go
@@ -73,7 +73,7 @@ func ValidateBatchSpecTemplate(name, spec string) (bool, error) {
 	// want to fail immediately if we encounter one. We accomplish this by setting the
 	// option "missingkey=error". See https://pkg.go.dev/text/template#Template.Option for
 	// more.
-	t, err := template.New(name).Delims(startDelim, endDelim).Option("missingkey=error").Funcs(builtins).Funcs(sfm).Funcs(cstfm).Parse(spec)
+	t, err := New(name, spec, "missingkey=error", sfm, cstfm)
 
 	if err != nil {
 		// Attempt to extract the specific template variable field that caused the error
@@ -127,7 +127,7 @@ func RenderStepTemplate(name, tmpl string, out io.Writer, stepCtx *StepContext) 
 	// user as an error during execution. Instead, we prefer to fail immediately if we
 	// encounter an unknown variable. We accomplish this by setting the option
 	// "missingkey=error". See https://pkg.go.dev/text/template#Template.Option for more.
-	t, err := template.New(name).Delims(startDelim, endDelim).Option("missingkey=error").Funcs(builtins).Funcs(stepCtx.ToFuncMap()).Parse(tmpl)
+	t, err := New(name, tmpl, "missingkey=error", stepCtx.ToFuncMap())
 	if err != nil {
 		return errors.Wrap(err, "parsing step run")
 	}
@@ -321,7 +321,7 @@ func RenderChangesetTemplateField(name, tmpl string, tmplCtx *ChangesetTemplateC
 	// user as an error during execution. Instead, we prefer to fail immediately if we
 	// encounter an unknown variable. We accomplish this by setting the option
 	// "missingkey=error". See https://pkg.go.dev/text/template#Template.Option for more.
-	t, err := template.New(name).Delims(startDelim, endDelim).Option("missingkey=error").Funcs(builtins).Funcs(tmplCtx.ToFuncMap()).Parse(tmpl)
+	t, err := New(name, tmpl, "missingkey=error", tmplCtx.ToFuncMap())
 	if err != nil {
 		return "", err
 	}

--- a/lib/batches/template/templating.go
+++ b/lib/batches/template/templating.go
@@ -45,7 +45,7 @@ var builtins = template.FuncMap{
 // spec template for any templating variables which are not dependent on execution
 // context. It returns a tuple whose first element is whether or not the batch spec is
 // valid and whose second element is an error message if the spec is found to be invalid.
-func ValidateBatchSpecTemplate(name, spec string) (bool, error) {
+func ValidateBatchSpecTemplate(spec string) (bool, error) {
 	// We use empty contexts to create "dummy" `template.FuncMap`s -- function mappings
 	// with all the right keys, but no actual values. We'll use these `FuncMap`s to do a
 	// dry run on the batch spec to determine if it's valid or not, before we actually
@@ -73,7 +73,7 @@ func ValidateBatchSpecTemplate(name, spec string) (bool, error) {
 	// want to fail immediately if we encounter one. We accomplish this by setting the
 	// option "missingkey=error". See https://pkg.go.dev/text/template#Template.Option for
 	// more.
-	t, err := New(name, spec, "missingkey=error", sfm, cstfm)
+	t, err := New("validateBatchSpecTemplate", spec, "missingkey=error", sfm, cstfm)
 
 	if err != nil {
 		// Attempt to extract the specific template variable field that caused the error

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -314,8 +314,6 @@ ${{ previous_step.deleted_files }}
 ${{ previous_step.renamed_files }}
 ${{ previous_step.stdout }}
 ${{ previous_step.stderr}}
-${{ outputs.lastLine }}
-${{ outputs.project }}
 ${{ step.modified_files }}
 ${{ step.added_files }}
 ${{ step.deleted_files }}
@@ -336,8 +334,6 @@ ${{ steps.path }}
 []
 
 
-<no value>
-<no value>
 []
 []
 []
@@ -350,13 +346,6 @@ ${{ steps.path }}
 []
 
 `,
-		},
-		// TODO: Fix me!
-		{
-			name:    "typo 1 level deep in template variable",
-			stepCtx: &StepContext{},
-			run:     `${{ repository.search_resalt_paths }}`,
-			want:    "fake",
 		},
 	}
 

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -468,17 +468,13 @@ ${{ batch_change_link }}`,
 			tmplCtx: &ChangesetTemplateContext{},
 			tmpl: `${{ repository.search_result_paths }}
 ${{ repository.name }}
-${{ outputs.lastLine }}
-${{ outputs.project }}
 ${{ steps.modified_files }}
 ${{ steps.added_files }}
 ${{ steps.deleted_files }}
 ${{ steps.renamed_files }}
 ${{ batch_change_link }}
 `,
-			want: `<no value>
-<no value>
-[]
+			want: `[]
 []
 []
 []

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -354,6 +354,7 @@ ${{ steps.path }}
 
 `,
 		},
+		// TODO: Fix me!
 		{
 			name:    "typo 1 level deep in template variable",
 			stepCtx: &StepContext{},

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -77,7 +77,8 @@ func TestValidateBatchSpecTemplate(t *testing.T) {
 				${{ join_if "---" "a" "b" "" "d" }}
 				${{ replace "a/b/c/d" "/" "-" }}
 				${{ split repository.name "/" }}
-				${{ matches repository.name "github.com/my-org/terra*" }}`,
+				${{ matches repository.name "github.com/my-org/terra*" }}
+				${{ index steps.modified_files 1 }}`,
 			wantValid: true,
 		},
 		{
@@ -110,15 +111,18 @@ func TestValidateBatchSpecTemplate(t *testing.T) {
 			wantValid: true,
 		},
 		{
-			name:      "output variables are ignored",
-			batchSpec: `${{ outputs.IDontExist }} ${{OUTPUTS.anotherOne}}`,
+			name: "output variables are ignored",
+			batchSpec: `${{ outputs.IDontExist }}
+						${{OUTPUTS.anotherOne}}
+						${{ join outputs.myArray "," }}
+						${{ index outputs.env.something 1 }}`,
 			wantValid: true,
 		},
 		{
 			name:      "output variables are ignored, but invalid step template variable still fails",
-			batchSpec: `${{ outputs.IDontExist }} ${{ repository.i_dont_exist_either }}`,
+			batchSpec: `${{ outputs.unknown }} ${{ outputz.unknown }}`,
 			wantValid: false,
-			wantErr:   errors.New("validating batch spec template: unknown templating variable: 'repository.i_dont_exist_either'"),
+			wantErr:   errors.New("validating batch spec template: unknown templating variable: 'outputz'"),
 		},
 	}
 

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -130,9 +130,6 @@ func TestValidateBatchSpecTemplate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotValid, gotErr := ValidateBatchSpecTemplate("testing", tc.batchSpec)
 
-			// TODO: Testing
-			// t.Fatal("test")
-
 			if tc.wantValid != gotValid {
 				t.Fatalf("unexpected valid status. want valid=%t, got valid=%t\nerror message: %s", tc.wantValid, gotValid, gotErr)
 			}

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -128,7 +128,7 @@ func TestValidateBatchSpecTemplate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotValid, gotErr := ValidateBatchSpecTemplate("testing", tc.batchSpec)
+			gotValid, gotErr := ValidateBatchSpecTemplate(tc.batchSpec)
 
 			if tc.wantValid != gotValid {
 				t.Fatalf("unexpected valid status. want valid=%t, got valid=%t\nerror message: %s", tc.wantValid, gotValid, gotErr)


### PR DESCRIPTION
Cloese #36183 

Added a function to our templating file that makes use of the existing templating library, text/template, by creating a function that searches a batch spec for known templating variables and returns whether or not the batch spec is valid or returns an error if the spec is found to be invalid due to an unrecognized template variable

The use of the template library is a little different from prior use due to not needing to actually replace the template variable, but to just check it, match it, and return an error if we cant

Kelli and I then decided to add this validation to the `ReplaceBatchSpecInput` service where other validation like checking the spec is valid and making sure the user has access occurs after a user previews their workspaces. Open to feedback if this was good placement

If an unknown template variable is detected, the UI will display the following error after a user attempts to preview workspaces

<img width="1090" alt="Screen Shot 2022-08-25 at 3 25 34 AM" src="https://user-images.githubusercontent.com/67931373/186601923-f9da8dc4-7222-465f-bba1-081444c8b1f3.png">

## Test plan
checked changes with a failing template variable and confirmed the correct error was surfaced in the UI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
