### PR TITLE
Fix TestConcurrentTransactions test by closing transaction

### DIFF
--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -93,20 +93,27 @@ func TestConcurrentTransactions(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		t.Cleanup(func() {
+			if err := tx.Done(err); err != nil {
+				t.Fatalf("closing transaction failed: %s", err)
+			}
+		})
+
 		capturingLogger, export := logtest.Captured(t)
 		tx.handle.(*txHandle).logger = capturingLogger
 
 		var g errgroup.Group
 		for i := 0; i < 2; i++ {
+			routine := i
 			g.Go(func() (err error) {
-				return tx.Exec(ctx, sqlf.Sprintf(`select pg_sleep(0.1)`))
+				return tx.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (%s, %s)`, routine, routine))
 			})
 		}
 		err = g.Wait()
 		require.NoError(t, err)
 
 		captured := export()
-		require.Greater(t, len(captured), 0)
+		require.NotEmpty(t, captured)
 		require.Equal(t, "transaction used concurrently", captured[0].Message)
 	})
 }

--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -106,7 +106,10 @@ func TestConcurrentTransactions(t *testing.T) {
 		for i := 0; i < 2; i++ {
 			routine := i
 			g.Go(func() (err error) {
-				return tx.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (%s, %s)`, routine, routine))
+				if err := tx.Exec(ctx, sqlf.Sprintf(`SELECT pg_sleep(0.1);`)); err != nil {
+					return err
+				}
+				return tx.Exec(ctx, sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (%s, %s)`, routine, routine))
 			})
 		}
 		err = g.Wait()


### PR DESCRIPTION
The test failed for me on a separate branch due to a timeout: it
panicked after 10m. See build: https://buildkite.com/sourcegraph/sourcegraph/builds/168105#0182b53e-7a71-471b-a45e-e9125de6ed1e

I'm 99% it's unrelated to my code, especially since it only shows up in
the backcompat test run and my changes are backwards compatible and
shouldn't have anything to do with transactions executing `pg_sleep`.

So, what this does:

* it closes the transaction at the end of the test (pretty sure that
  this lead to timeouts).
* it inserts something into the test table (so it does what it says in
  the description)
* uses this `NotEmpty` test helper cause I couldnt' resist

## Test plan

- Ran this locally multiple tests
- CI
