### PR TITLE
Fix external account deletion through graphQL if no GitHub App accounts exist

### DIFF
--- a/cmd/frontend/graphqlbackend/external_accounts.go
+++ b/cmd/frontend/graphqlbackend/external_accounts.go
@@ -142,13 +142,15 @@ func (r *schemaResolver) DeleteExternalAccount(ctx context.Context, args *struct
 			return nil, err
 		}
 
-		acctList := []int32{}
-		for _, acct := range accts {
-			acctList = append(acctList, acct.ID)
-		}
+		if len(accts) > 0 {
+			acctList := []int32{}
+			for _, acct := range accts {
+				acctList = append(acctList, acct.ID)
+			}
 
-		if err := r.db.UserExternalAccounts().Delete(ctx, acctList...); err != nil {
-			return nil, err
+			if err := r.db.UserExternalAccounts().Delete(ctx, acctList...); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/external_accounts_test.go
+++ b/cmd/frontend/graphqlbackend/external_accounts_test.go
@@ -1,0 +1,88 @@
+package graphqlbackend
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+)
+
+func TestExternalAccounts_DeleteExternalAccount(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	t.Run("has github and github app accounts", func(t *testing.T) {
+		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		act := actor.Actor{UID: 1}
+		ctx := actor.WithActor(context.Background(), &act)
+		sr := newSchemaResolver(db)
+
+		spec := extsvc.AccountSpec{
+			ServiceType: extsvc.TypeGitHub,
+			ServiceID:   "xb",
+			ClientID:    "xc",
+			AccountID:   "xd",
+		}
+
+		userID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, database.NewUser{Username: "u"}, spec, extsvc.AccountData{})
+		require.NoError(t, err)
+		spec.ServiceType = extsvc.TypeGitHubApp
+		spec.AccountID = "abc/xd"
+		err = db.UserExternalAccounts().Insert(ctx, userID, spec, extsvc.AccountData{})
+		require.NoError(t, err)
+
+		graphqlArgs := struct {
+			ExternalAccount graphql.ID
+		}{
+			ExternalAccount: graphql.ID(base64.URLEncoding.EncodeToString([]byte("ExternalAccount:1"))),
+		}
+		_, err = sr.DeleteExternalAccount(ctx, &graphqlArgs)
+		require.NoError(t, err)
+
+		accts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{UserID: 1})
+		require.NoError(t, err)
+		require.Equal(t, 0, len(accts))
+	})
+
+	t.Run("has github account but no github app accounts", func(t *testing.T) {
+		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		act := actor.Actor{UID: 1}
+		ctx := actor.WithActor(context.Background(), &act)
+		sr := newSchemaResolver(db)
+
+		spec := extsvc.AccountSpec{
+			ServiceType: extsvc.TypeGitHub,
+			ServiceID:   "xb",
+			ClientID:    "xc",
+			AccountID:   "xd",
+		}
+
+		_, err := db.UserExternalAccounts().CreateUserAndSave(ctx, database.NewUser{Username: "u"}, spec, extsvc.AccountData{})
+		require.NoError(t, err)
+
+		graphqlArgs := struct {
+			ExternalAccount graphql.ID
+		}{
+			ExternalAccount: graphql.ID(base64.URLEncoding.EncodeToString([]byte("ExternalAccount:1"))),
+		}
+		_, err = sr.DeleteExternalAccount(ctx, &graphqlArgs)
+		require.NoError(t, err)
+
+		accts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{UserID: 1})
+		require.NoError(t, err)
+		require.Equal(t, 0, len(accts))
+	})
+
+}


### PR DESCRIPTION
When a GitHub external account is deleted, but there are no corresponding GitHub App external accounts, the account list is empty, which causes a SQL error.

What this means is that you're unable to delete your normal GitHub external accounts.

This fixes that.

## Test plan
Added test confirming the bug, then fixed it.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
