### PR TITLE
panic: Fix worker panic on startup

### DIFF
--- a/enterprise/internal/oobmigration/migrations/insights/migration_no_op.go
+++ b/enterprise/internal/oobmigration/migrations/insights/migration_no_op.go
@@ -2,26 +2,18 @@ package insights
 
 import (
 	"context"
-
-	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"time"
 )
 
-type migratorNoOp struct {
-}
+type migratorNoOp struct{}
 
-func NewMigratorNoOp() oobmigration.Migrator {
+func NewMigratorNoOp() *migratorNoOp {
 	return &migratorNoOp{}
 }
 
-func (m *migratorNoOp) Progress(ctx context.Context) (float64, error) {
-	return 1, nil
-}
+func (m *migratorNoOp) ID() int                 { return 14 }
+func (m *migratorNoOp) Interval() time.Duration { return time.Second * 10 }
 
-func (m *migratorNoOp) Up(ctx context.Context) (err error) {
-
-	return nil
-}
-
-func (m *migratorNoOp) Down(ctx context.Context) (err error) {
-	return nil
-}
+func (m *migratorNoOp) Progress(ctx context.Context) (float64, error) { return 1, nil }
+func (m *migratorNoOp) Up(ctx context.Context) (err error)            { return nil }
+func (m *migratorNoOp) Down(ctx context.Context) (err error)          { return nil }

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -32,6 +32,13 @@ func RegisterEnterpriseMigrations(db database.DB, outOfBandMigrationRunner *oobm
 
 	batchesCredentialKey := keyring.Default().BatchChangesCredentialKey
 
+	var insightsMigrator migrations.TaggedMigrator
+	if internalInsights.IsEnabled() {
+		insightsMigrator = insights.NewMigrator(frontendStore, insightsStore)
+	} else {
+		insightsMigrator = insights.NewMigratorNoOp()
+	}
+
 	return migrations.RegisterAll(outOfBandMigrationRunner, []migrations.TaggedMigrator{
 		iam.NewSubscriptionAccountNumberMigrator(frontendStore, 500),
 		iam.NewLicenseKeyFieldsMigrator(frontendStore, 500),
@@ -41,7 +48,7 @@ func RegisterEnterpriseMigrations(db database.DB, outOfBandMigrationRunner *oobm
 		codeintel.NewReferencesLocationsCountMigrator(codeIntelStore, 1000),
 		codeintel.NewDocumentColumnSplitMigrator(codeIntelStore, 100),
 		codeintel.NewAPIDocsSearchMigrator(),
-		insights.NewMigrator(frontendStore, insightsStore),
+		insightsMigrator,
 	})
 }
 


### PR DESCRIPTION
In a recent refactor I ignored the insights no-op migrator. Broken by #40580.

## Test plan

Tested locally.