### PR TITLE
    CodeMirror Blob: ensure occurrences are single lines and non-overlapping

### DIFF
--- a/client/web/src/lsif/html.ts
+++ b/client/web/src/lsif/html.ts
@@ -1,6 +1,6 @@
 import escape from 'escape-html'
 
-import { JsonDocument, Occurrence, SyntaxKind } from './lsif-typed'
+import { DocumentInfo, Occurrence, SyntaxKind } from './lsif-typed'
 
 class HtmlBuilder {
     public readonly buffer: string[] = []
@@ -69,12 +69,8 @@ function highlightSlice(html: HtmlBuilder, kind: SyntaxKind | undefined, slice: 
 }
 
 // Currently assumes that no ranges overlap in the occurrences.
-export function render(lsif_json: string, content: string): string {
-    if (!lsif_json.trim()) {
-        return ''
-    }
-
-    const occurrences = (JSON.parse(lsif_json) as JsonDocument).occurrences?.map(occ => new Occurrence(occ))
+export function render(info: DocumentInfo): string {
+    const occurrences = Occurrence.fromInfo(info)
     if (!occurrences) {
         return ''
     }
@@ -88,7 +84,7 @@ export function render(lsif_json: string, content: string): string {
         return a.range.start.character - b.range.start.character
     })
 
-    const lines = content.replaceAll('\r\n', '\n').split('\n')
+    const lines = info.content.replaceAll('\r\n', '\n').split('\n')
     const html = new HtmlBuilder()
 
     let occIndex = 0

--- a/client/web/src/lsif/lsif-typed.ts
+++ b/client/web/src/lsif/lsif-typed.ts
@@ -1,10 +1,13 @@
 // TODO: Eventually we'll import the actual lsif-typed protobuf file in this project,
 // but it doesn't make sense to do so right now.
 
-import { BlobInfo } from '../repo/blob/Blob'
-
 export interface JsonDocument {
     occurrences?: JsonOccurrence[]
+}
+
+export interface DocumentInfo {
+    content: string
+    lsif?: string
 }
 
 export interface JsonOccurrence {
@@ -78,7 +81,7 @@ export class Occurrence {
 
         return new Occurrence(range, occ.syntaxKind)
     }
-    public static fromInfo(info: BlobInfo): Occurrence[] {
+    public static fromInfo(info: DocumentInfo): Occurrence[] {
         const sortedSingleLineOccurrences = parseJsonOccurrencesIntoSingleLineOccurrences(info)
         return nonOverlappingOccurrences(sortedSingleLineOccurrences)
     }
@@ -117,7 +120,7 @@ function nonOverlappingOccurrences(occurrences: Occurrence[]): Occurrence[] {
 // Returns a list of occurrences that are guaranteed to only consiste of
 // single-line ranges.  A multiline occurrence gets split into multiple
 // occurrences where each range encloses a single line.
-function parseJsonOccurrencesIntoSingleLineOccurrences(info: BlobInfo): Occurrence[] {
+function parseJsonOccurrencesIntoSingleLineOccurrences(info: DocumentInfo): Occurrence[] {
     if (!info.lsif) {
         return []
     }

--- a/client/web/src/lsif/lsif-typed.ts
+++ b/client/web/src/lsif/lsif-typed.ts
@@ -68,7 +68,7 @@ export class Occurrence {
         return new Occurrence(newRange, this.kind)
     }
 
-    public static fromJson(occ: JsonOccurrence) {
+    public static fromJson(occ: JsonOccurrence): Occurrence {
         const range = new Range(
             new Position(occ.range[0], occ.range[1]),
             // Handle 3 vs 4 length meaning different things

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -215,7 +215,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
 
                         // Replace html with lsif generated HTML, if available
                         if (!enableCodeMirror && blob.highlight.lsif) {
-                            const html = renderLsifHtml(blob.highlight.lsif, blob.content)
+                            const html = renderLsifHtml({ lsif: blob.highlight.lsif, content: blob.content })
                             if (html) {
                                 blob.highlight.html = html
                             }

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -19,15 +19,15 @@ interface HighlightIndex {
  * NOTE: This assumes that the data is sorted and does not contain overlapping
  * ranges.
  */
-function createHighlightTable(json: string | undefined): HighlightIndex {
+function createHighlightTable(info: BlobInfo): HighlightIndex {
     const lineIndex: (number | undefined)[] = []
 
-    if (!json) {
+    if (!info.lsif) {
         return { occurrences: [], lineIndex }
     }
 
     try {
-        const occurrences = Occurrence.fromJson(json)
+        const occurrences = Occurrence.fromInfo(info)
         let previousEndline: number | undefined
 
         for (let index = 0; index < occurrences.length; index++) {
@@ -48,7 +48,7 @@ function createHighlightTable(json: string | undefined): HighlightIndex {
 
         return { occurrences, lineIndex }
     } catch (error) {
-        console.error(`Unable to process SCIP highlight data: ${json}`, error)
+        console.error(`Unable to process SCIP highlight data: ${info.lsif}`, error)
         return { occurrences: [], lineIndex }
     }
 }
@@ -136,6 +136,6 @@ export const syntaxHighlight = Facet.define<BlobInfo, HighlightIndex>({
     static: true,
     compareInput: (blobInfoA, blobInfoB) => blobInfoA.lsif === blobInfoB.lsif,
     combine: blobInfos =>
-        blobInfos[0]?.lsif ? createHighlightTable(blobInfos[0].lsif) : { occurrences: [], lineIndex: [] },
+        blobInfos[0]?.lsif ? createHighlightTable(blobInfos[0]) : { occurrences: [], lineIndex: [] },
     enables: ViewPlugin.fromClass(SyntaxHighlightManager, { decorations: plugin => plugin.decorations }),
 })


### PR DESCRIPTION

    Towards #40551

    Our old CodeMirror Blob logic assumed that all highlighting
    occurrences enclosed a single line and had no overlaps between them,
    while the syntect server regularly returned multiline
    occurrences with potential overlaps. This commit updates the
    logic to split multiline and overlapping occurrences the
    assumption is correct resulting in improved highlighting.

    This commit does not fix all highlighting issues with the new blob view,
    we still need to support more "scopes" from syntect, and we need to
    refine the actual CSS colors for the SCIP syntax kind classes.

## Test plan

Ran the server locally and manually verified that the syntax highlighting has improved for the CodeMirror blob view

**Before**

![CleanShot 2022-08-19 at 13 18 05](https://user-images.githubusercontent.com/1408093/185620949-b2ba6fdb-5d17-4fdd-be04-b3eda33c810a.png)

**After**
![CleanShot 2022-08-19 at 14 42 56](https://user-images.githubusercontent.com/1408093/185620983-a632a9c1-bf49-4f9a-b2d6-deaa645603fd.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-cm-overlaps.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bqkvmphsqn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
