### PR TITLE
gitserver servermetrics: use faster statistics tables

### DIFF
--- a/cmd/worker/internal/gitserver/servermetrics.go
+++ b/cmd/worker/internal/gitserver/servermetrics.go
@@ -45,15 +45,7 @@ func (j *metricsJob) Routines(ctx context.Context, logger log.Logger) ([]gorouti
 		defer cancel()
 
 		var count int64
-		err := db.QueryRowContext(ctx, `
-SELECT COUNT(*)
-FROM gitserver_repos AS gr
-JOIN repo AS r ON gr.repo_id = r.id
-WHERE
-	gr.last_error IS NOT NULL
-	AND r.deleted_at IS NULL
-	AND r.blocked IS NULL
-		`).Scan(&count)
+		err := db.QueryRowContext(ctx, `SELECT SUM(failed_fetch) FROM gitserver_repos_statistics`).Scan(&count)
 		if err != nil {
 			j.Logger.Error("failed to count repository errors", log.Error(err))
 			return 0
@@ -70,13 +62,7 @@ WHERE
 		defer cancel()
 
 		var count int64
-		err := db.QueryRowContext(ctx, `
-SELECT COUNT(*)
-FROM repo AS r
-WHERE
-	r.deleted_at IS NULL
-	AND r.blocked IS NULL
-		`).Scan(&count)
+		err := db.QueryRowContext(ctx, `SELECT SUM(total) FROM repo_statistics`).Scan(&count)
 		if err != nil {
 			j.Logger.Error("failed to count repositories", log.Error(err))
 			return 0


### PR DESCRIPTION
This makes use of the statistics tables introduced in #40577 to make
these queries faster and reduce load on big systems. See [this Slack
thread](https://sourcegraph.slack.com/archives/C018CJQ5YBB/p1657276718654509)
for more context on how heavy these queries can become.

## Test plan

- Existing tests
