### PR TITLE
CodeMirror Blob: make syntax highlighting more usable

### DIFF
--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -585,7 +585,7 @@
         color: var(--hl-purple);
     }
 
-        // color: var(--hl-gray-3);
+    // color: var(--hl-gray-3);
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
     // .hl-typed-Tag {
     // }

--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -486,7 +486,7 @@
     // .hl-typed-$SYNTAX_KIND
 
     .hl-typed-Comment {
-        color: var(--hl-dark-green);
+        color: var(--hl-gray-0);
     }
     .hl-typed-PunctuationDelimiter {
         color: var(--hl-orange);
@@ -495,17 +495,20 @@
         color: var(--hl-orange);
     }
     .hl-typed-IdentifierKeyword {
-        color: var(--hl-dark-blue-3);
+        color: var(--hl-green);
     }
     .hl-typed-IdentifierOperator {
-        color: var(--hl-dark-blue-1);
+        color: var(--hl-gray-3);
     }
     .hl-typed-Identifier {
         color: var(--hl-blue);
     }
     .hl-typed-IdentifierBuiltin {
-        color: var(--hl-blue);
+        color: var(--hl-yellow);
         // filter: brightness(105%);
+    }
+    .hl-typed-IdentifierBuiltinType {
+        color: var(--hl-green);
     }
     .hl-typed-IdentifierNull {
         color: var(--hl-orange);
@@ -515,7 +518,7 @@
         color: var(--hl-orange);
     }
     .hl-typed-IdentifierConstant {
-        color: var(--hl-dark-blue-1);
+        color: var(--hl-yellow);
     }
     .hl-typed-IdentifierMutableGlobal {
         color: var(--hl-dark-blue-1);
@@ -545,9 +548,6 @@
         color: var(--hl-yellow);
     }
     .hl-typed-IdentifierType {
-        color: var(--hl-blue);
-    }
-    .hl-typed-IdentifierBuiltinType {
         color: var(--hl-blue);
     }
     .hl-typed-IdentifierAttribute {

--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -489,10 +489,10 @@
         color: var(--hl-gray-0);
     }
     .hl-typed-PunctuationDelimiter {
-        color: var(--hl-orange);
+        color: var(--hl-gray-0);
     }
     .hl-typed-PunctuationBracket {
-        color: var(--hl-orange);
+        color: var(--hl-gray-0);
     }
     .hl-typed-IdentifierKeyword {
         color: var(--hl-green);
@@ -548,10 +548,10 @@
         color: var(--hl-yellow);
     }
     .hl-typed-IdentifierType {
-        color: var(--hl-blue);
+        color: var(--hl-orange);
     }
     .hl-typed-IdentifierAttribute {
-        color: var(--hl-purple);
+        color: var(--hl-property);
     }
 
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
@@ -567,7 +567,7 @@
     // }
 
     .hl-typed-StringLiteral {
-        color: var(--hl-red);
+        color: var(--hl-cyan);
     }
     .hl-typed-StringLiteralEscape {
         color: var(--hl-red);
@@ -582,9 +582,10 @@
         color: var(--hl-red);
     }
     .hl-typed-NumericLiteral {
-        color: var(--hl-green-1);
+        color: var(--hl-purple);
     }
 
+        // color: var(--hl-gray-3);
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
     // .hl-typed-Tag {
     // }
@@ -901,24 +902,31 @@
     //
     // Each group should exactly match the name of the spec.
     // .hl-typed-$SYNTAX_KIND
+    --hl-scip-identifier: #859900;
 
     .hl-typed-Comment {
         color: var(--hl-dark-green);
     }
     .hl-typed-PunctuationDelimiter {
-        color: var(--hl-orange);
+        color: var(--hl-gray-2);
     }
     .hl-typed-PunctuationBracket {
-        color: var(--hl-orange);
+        color: var(--hl-gray-2);
     }
     .hl-typed-IdentifierKeyword {
-        color: var(--hl-dark-blue-3);
+        color: var(--hl-dark-blue-2);
     }
     .hl-typed-IdentifierOperator {
-        color: var(--hl-dark-blue-1);
+        color: var(--hl-gray-0);
     }
     .hl-typed-Identifier {
         color: var(--hl-blue);
+    }
+    .hl-typed-IdentifierFunction {
+        color: var(--hl-dark-yellow);
+    }
+    .hl-typed-IdentifierType {
+        color: var(--hl-gray-1);
     }
     .hl-typed-IdentifierBuiltin {
         color: var(--hl-blue);
@@ -932,10 +940,10 @@
         color: var(--hl-orange);
     }
     .hl-typed-IdentifierConstant {
-        color: var(--hl-dark-blue-1);
+        color: var(--hl-orange);
     }
     .hl-typed-IdentifierMutableGlobal {
-        color: var(--hl-dark-blue-1);
+        color: var(--hl-blue);
     }
     .hl-typed-IdentifierParameter {
         color: var(--hl-blue);
@@ -949,9 +957,6 @@
     .hl-typed-IdentifierModule {
         color: var(--hl-blue);
     }
-    .hl-typed-IdentifierFunction {
-        color: var(--hl-yellow);
-    }
     .hl-typed-IdentifierFunctionDefinition {
         color: var(--hl-yellow);
     }
@@ -961,11 +966,8 @@
     .hl-typed-IdentifierMacroDefinition {
         color: var(--hl-yellow);
     }
-    .hl-typed-IdentifierType {
-        color: var(--hl-blue);
-    }
     .hl-typed-IdentifierBuiltinType {
-        color: var(--hl-blue);
+        color: var(--hl-orange);
     }
     .hl-typed-IdentifierAttribute {
         color: var(--hl-purple);
@@ -999,7 +1001,7 @@
         color: var(--hl-red);
     }
     .hl-typed-NumericLiteral {
-        color: var(--hl-green-1);
+        color: var(--hl-green);
     }
 
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995

--- a/client/web/src/lsif/html.ts
+++ b/client/web/src/lsif/html.ts
@@ -1,6 +1,6 @@
 import escape from 'escape-html'
 
-import { JsonDocument, Occurrence, SyntaxKind } from './lsif-typed'
+import { DocumentInfo, Occurrence, SyntaxKind } from './lsif-typed'
 
 class HtmlBuilder {
     public readonly buffer: string[] = []
@@ -69,12 +69,8 @@ function highlightSlice(html: HtmlBuilder, kind: SyntaxKind | undefined, slice: 
 }
 
 // Currently assumes that no ranges overlap in the occurrences.
-export function render(lsif_json: string, content: string): string {
-    if (!lsif_json.trim()) {
-        return ''
-    }
-
-    const occurrences = (JSON.parse(lsif_json) as JsonDocument).occurrences?.map(occ => new Occurrence(occ))
+export function render(info: DocumentInfo): string {
+    const occurrences = Occurrence.fromInfo(info)
     if (!occurrences) {
         return ''
     }
@@ -88,7 +84,7 @@ export function render(lsif_json: string, content: string): string {
         return a.range.start.character - b.range.start.character
     })
 
-    const lines = content.replaceAll('\r\n', '\n').split('\n')
+    const lines = info.content.replaceAll('\r\n', '\n').split('\n')
     const html = new HtmlBuilder()
 
     let occIndex = 0

--- a/client/web/src/lsif/lsif-typed.ts
+++ b/client/web/src/lsif/lsif-typed.ts
@@ -51,7 +51,11 @@ export class Range {
         if (byStart !== 0) {
             return byStart
         }
-        return this.end.compare(other.end)
+        // Both ranges have the same start position, sort by inverse end
+        // position so that the longer range appears first. The motivation for
+        // using inverse order is so that we handle the larger range first when
+        // dealing with overlapping ranges.
+        return -this.end.compare(other.end)
     }
 }
 
@@ -114,7 +118,7 @@ function nonOverlappingOccurrences(occurrences: Occurrence[]): Occurrence[] {
             result.push(current)
         }
     }
-    return result
+    return result.sort((a, b) => a.range.compare(b.range))
 }
 
 // Returns a list of occurrences that are guaranteed to only consiste of

--- a/client/web/src/lsif/lsif-typed.ts
+++ b/client/web/src/lsif/lsif-typed.ts
@@ -1,10 +1,13 @@
 // TODO: Eventually we'll import the actual lsif-typed protobuf file in this project,
 // but it doesn't make sense to do so right now.
 
-import { BlobInfo } from '../repo/blob/Blob'
-
 export interface JsonDocument {
     occurrences?: JsonOccurrence[]
+}
+
+export interface DocumentInfo {
+    content: string
+    lsif?: string
 }
 
 export interface JsonOccurrence {
@@ -78,7 +81,7 @@ export class Occurrence {
 
         return new Occurrence(range, occ.syntaxKind)
     }
-    public static fromInfo(info: BlobInfo): Occurrence[] {
+    public static fromInfo(info: DocumentInfo): Occurrence[] {
         const sortedSingleLineOccurrences = parseJsonOccurrencesIntoSingleLineOccurrences(info)
         return nonOverlappingOccurrences(sortedSingleLineOccurrences)
     }
@@ -117,7 +120,7 @@ function nonOverlappingOccurrences(occurrences: Occurrence[]): Occurrence[] {
 // Returns a list of occurrences that are guaranteed to only consiste of
 // single-line ranges.  A multiline occurrence gets split into multiple
 // occurrences where each range encloses a single line.
-function parseJsonOccurrencesIntoSingleLineOccurrences(info: BlobInfo): Occurrence[] {
+function parseJsonOccurrencesIntoSingleLineOccurrences(info: DocumentInfo): Occurrence[] {
     if (!info.lsif) {
         return []
     }

--- a/client/web/src/lsif/lsif-typed.ts
+++ b/client/web/src/lsif/lsif-typed.ts
@@ -68,7 +68,7 @@ export class Occurrence {
         return new Occurrence(newRange, this.kind)
     }
 
-    public static fromJson(occ: JsonOccurrence) {
+    public static fromJson(occ: JsonOccurrence): Occurrence {
         const range = new Range(
             new Position(occ.range[0], occ.range[1]),
             // Handle 3 vs 4 length meaning different things

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -215,7 +215,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
 
                         // Replace html with lsif generated HTML, if available
                         if (!enableCodeMirror && blob.highlight.lsif) {
-                            const html = renderLsifHtml(blob.highlight.lsif, blob.content)
+                            const html = renderLsifHtml({ lsif: blob.highlight.lsif, content: blob.content })
                             if (html) {
                                 blob.highlight.html = html
                             }

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -28,6 +28,16 @@ function createHighlightTable(info: BlobInfo): HighlightIndex {
 
     try {
         const occurrences = Occurrence.fromInfo(info)
+        for (const occ of occurrences) {
+            if (occ.range.start.line === 336 && occ.kind) {
+                // regexp = new RegExp(`^${regexp.source}`, regexp.flags)
+                console.log({
+                    kind: SyntaxKind[occ.kind],
+                    start: occ.range.start.character,
+                    end: occ.range.end.character,
+                })
+            }
+        }
         let previousEndline: number | undefined
 
         for (let index = 0; index < occurrences.length; index++) {

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -19,15 +19,15 @@ interface HighlightIndex {
  * NOTE: This assumes that the data is sorted and does not contain overlapping
  * ranges.
  */
-function createHighlightTable(json: string | undefined): HighlightIndex {
+function createHighlightTable(info: BlobInfo): HighlightIndex {
     const lineIndex: (number | undefined)[] = []
 
-    if (!json) {
+    if (!info.lsif) {
         return { occurrences: [], lineIndex }
     }
 
     try {
-        const occurrences = Occurrence.fromJson(json)
+        const occurrences = Occurrence.fromInfo(info)
         let previousEndline: number | undefined
 
         for (let index = 0; index < occurrences.length; index++) {
@@ -48,7 +48,7 @@ function createHighlightTable(json: string | undefined): HighlightIndex {
 
         return { occurrences, lineIndex }
     } catch (error) {
-        console.error(`Unable to process SCIP highlight data: ${json}`, error)
+        console.error(`Unable to process SCIP highlight data: ${info.lsif}`, error)
         return { occurrences: [], lineIndex }
     }
 }
@@ -136,6 +136,6 @@ export const syntaxHighlight = Facet.define<BlobInfo, HighlightIndex>({
     static: true,
     compareInput: (blobInfoA, blobInfoB) => blobInfoA.lsif === blobInfoB.lsif,
     combine: blobInfos =>
-        blobInfos[0]?.lsif ? createHighlightTable(blobInfos[0].lsif) : { occurrences: [], lineIndex: [] },
+        blobInfos[0]?.lsif ? createHighlightTable(blobInfos[0]) : { occurrences: [], lineIndex: [] },
     enables: ViewPlugin.fromClass(SyntaxHighlightManager, { decorations: plugin => plugin.decorations }),
 })

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
@@ -55,6 +55,7 @@ fn match_scope_to_kind(scope: &Scope) -> Option<SyntaxKind> {
             (scope("entity.name.function"), IdentifierFunction),
             (scope("keyword.operator"), IdentifierOperator),
             (scope("keyword"), IdentifierKeyword),
+            (scope("variable.function"), IdentifierFunction),
             (scope("variable"), Identifier),
             (scope("constant.character.escape"), StringLiteralEscape),
             (scope("string"), StringLiteral),
@@ -64,7 +65,7 @@ fn match_scope_to_kind(scope: &Scope) -> Option<SyntaxKind> {
             (scope("storage.modifier.array"), PunctuationBracket),
             (scope("storage.modifier"), IdentifierKeyword),
             (scope("storage.type.namespace"), IdentifierNamespace),
-            (scope("storage.type"), IdentifierType),
+            (scope("storage.type"), IdentifierKeyword),
             (scope("support.type.builtin"), IdentifierBuiltinType),
             (scope("meta.path"), IdentifierNamespace),
             //
@@ -272,6 +273,8 @@ impl<'a> DocumentGenerator<'a> {
 
                             match match_scope_to_kind(&scope) {
                                 Some(kind) => {
+                                    // println!("SCOPE {row:>3}:{character:<2} {:<50} {kind:?}", format!("{scope}"));
+                                    // println!("KIND {:<30} {kind:?}", format!("{scope}"));
                                     let partial_hl = HighlightStart::some(row, character, kind);
                                     if let Some(partial_hl) = highlight_manager.push_hl(partial_hl)
                                     {

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
@@ -53,9 +53,23 @@ fn match_scope_to_kind(scope: &Scope) -> Option<SyntaxKind> {
             (scope("meta.preprocessor.include"), IdentifierNamespace),
             (scope("storage.type.keyword"), IdentifierKeyword),
             (scope("entity.name.function"), IdentifierFunction),
+            (scope("entity.name.type"), IdentifierType),
+
+            // TODO: optimization opportunity, skip testing language-specific scopes.
+            (scope("storage.type.namespace.ts"), IdentifierKeyword),
+            (scope("storage.type.module.ts"), IdentifierKeyword),
+            (scope("storage.type.interface.ts"), IdentifierKeyword),
+            (scope("storage.type.class.ts"), IdentifierKeyword),
+            (scope("storage.type.function.ts"), IdentifierKeyword),
+            (scope("keyword.operator.logical.sql"), IdentifierKeyword),
+            (scope("keyword.operator.assignment.alias.sql"), IdentifierKeyword),
+            (scope("meta.mapping.key.json"), StringLiteralKey),
+            (scope("entity.name.tag.yaml"), StringLiteralKey),
+
             (scope("keyword.operator"), IdentifierOperator),
             (scope("keyword"), IdentifierKeyword),
             (scope("variable.function"), IdentifierFunction),
+            (scope("meta.definition.property"), IdentifierAttribute),
             (scope("variable"), Identifier),
             (scope("constant.character.escape"), StringLiteralEscape),
             (scope("string"), StringLiteral),
@@ -65,16 +79,27 @@ fn match_scope_to_kind(scope: &Scope) -> Option<SyntaxKind> {
             (scope("storage.modifier.array"), PunctuationBracket),
             (scope("storage.modifier"), IdentifierKeyword),
             (scope("storage.type.namespace"), IdentifierNamespace),
-            (scope("storage.type"), IdentifierKeyword),
+            (scope("storage.type.ts"), IdentifierKeyword),
+            (scope("storage.type"), IdentifierType),
             (scope("support.type.builtin"), IdentifierBuiltinType),
+            (scope("meta.object-literal.key"), IdentifierAttribute),
             (scope("meta.path"), IdentifierNamespace),
+            // (scope("meta.type"), IdentifierType), Intentionally disabled in favor of more precise classes
+            (scope("meta.return.type"), IdentifierType),
+            (scope("support.type"), IdentifierType),
+            (scope("support.class"), IdentifierType),
+            (scope("support.function"), IdentifierFunction),
+            (scope("support.variable"), Identifier),
             //
-            // Punctuation Types
+            // Punctuation Types: while these may appear noisy, they're
+            // intentionally included so that punctutation characters get
+            // correctly highlighted when nested inside other occurrences like
+            // interpolated string literals. Example: the braces in `a${b}`.
             (scope("punctuation.section.mapping"), PunctuationBracket),
             (scope("punctuation.section.sequence"), PunctuationBracket),
             (scope("punctuation.terminator"), PunctuationDelimiter),
-            // TODO: Consider what to do w/ this
-            // (scope("punctuation"), PunctuationBracket),
+            (scope("meta.brace"), PunctuationBracket),
+            (scope("punctuation"), PunctuationBracket),
         ]
     });
 
@@ -163,6 +188,10 @@ impl HighlightManager {
         //
         // (see the documentation above for HighlightManager)
         if let Some(last_hl) = self.highlights.last_mut() {
+            // TODO: Avoid this hack to get string literal keys to take priority over strings for JSON.
+            if last_hl.kind == Some(SyntaxKind::StringLiteralKey) && hl.kind == Some(SyntaxKind::StringLiteral) {
+                return Some(last_hl.clone());
+            }
             if let Some(_kind) = last_hl.kind {
                 existing_hl = Some(last_hl.clone());
                 last_hl.row = hl.row;
@@ -273,8 +302,7 @@ impl<'a> DocumentGenerator<'a> {
 
                             match match_scope_to_kind(&scope) {
                                 Some(kind) => {
-                                    // println!("SCOPE {row:>3}:{character:<2} {:<50} {kind:?}", format!("{scope}"));
-                                    // println!("KIND {:<30} {kind:?}", format!("{scope}"));
+                                    println!("SCOPE {row:>3}:{character:<3} {} {kind:?}", format!("{}", scope));
                                     let partial_hl = HighlightStart::some(row, character, kind);
                                     if let Some(partial_hl) = highlight_manager.push_hl(partial_hl)
                                     {
@@ -366,6 +394,7 @@ fn push_document_occurence(
     }
 }
 
+
 fn new_occurence(range: Vec<i32>, syntax_kind: SyntaxKind) -> Occurrence {
     let syntax_kind = EnumOrUnknown::new(syntax_kind);
     let range = match range.len() {
@@ -393,6 +422,7 @@ fn new_occurence(range: Vec<i32>, syntax_kind: SyntaxKind) -> Occurrence {
 #[cfg(test)]
 mod test {
     use std::{
+        env,
         fs::{read_dir, File},
         io::Read,
     };
@@ -490,49 +520,23 @@ int x = 1;
     }
 
     #[test]
-    fn test_generates_c_with_comment() {
-        let syntax_set = SyntaxSet::load_defaults_newlines();
-        let mut q = crate::SourcegraphQuery::default();
-        // q.filetype = Some("csharp".to_string());
-        q.filepath = "c_with_comment.c".to_string();
-        q.code = r#"
-int main() {
-  // Single line comment
-  return x;
-}
-"#
-        .to_string();
-
-        let syntax_def = determine_language(&q, &syntax_set).unwrap();
-        let output = DocumentGenerator::new(&syntax_set, syntax_def, &q.code, q.line_length_limit)
-            .generate();
-
-        let dumped = dump_document(&output, &q.code);
-        assert_eq!(
-            dumped.trim(),
-            r#"
-  int main() {
-//^^^ IdentifierType
-//    ^^^^ IdentifierFunction
-    // Single line comment
-//  ^^^^^^^^^^^^^^^^^^^^^^ Comment
-    return x;
-//  ^^^^^^ IdentifierKeyword
-//          ^ PunctuationDelimiter
-  }
-"#
-            .trim()
-        );
-    }
-
-    #[test]
     fn test_all_files() -> Result<(), std::io::Error> {
         let ss = SyntaxSet::load_defaults_newlines();
         let mut failed = vec![];
 
         let dir = read_dir("./src/snapshots/syntect_files/")?;
+
+        let filter = env::args()
+            .last()
+            .and_then(|x| x.strip_prefix("only=").map(|x| x.to_owned()))
+            .unwrap_or("".to_owned()); // run everything
+
         for entry in dir {
             let entry = entry?;
+
+            if !entry.file_name().to_str().unwrap().contains(&filter) {
+                continue;
+            }
             let filepath = entry.path();
             let mut file = File::open(&filepath)?;
             let mut contents = String::new();

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
@@ -302,7 +302,8 @@ impl<'a> DocumentGenerator<'a> {
 
                             match match_scope_to_kind(&scope) {
                                 Some(kind) => {
-                                    println!("SCOPE {row:>3}:{character:<3} {} {kind:?}", format!("{}", scope));
+                                    // Uncomment to debug what scopes are picked up
+                                    // println!("SCOPE {row:>3}:{character:<3} {} {kind:?}", format!("{}", scope));
                                     let partial_hl = HighlightStart::some(row, character, kind);
                                     if let Some(partial_hl) = highlight_manager.push_hl(partial_hl)
                                     {

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
@@ -56,6 +56,8 @@ fn match_scope_to_kind(scope: &Scope) -> Option<SyntaxKind> {
             (scope("entity.name.type"), IdentifierType),
 
             // TODO: optimization opportunity, skip testing language-specific scopes.
+            (scope("keyword.operator.expression.keyof.ts"), IdentifierKeyword),
+            (scope("keyword.operator.expression.typeof.ts"), IdentifierKeyword),
             (scope("storage.type.namespace.ts"), IdentifierKeyword),
             (scope("storage.type.module.ts"), IdentifierKeyword),
             (scope("storage.type.interface.ts"), IdentifierKeyword),

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__3billiondevices.java.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__3billiondevices.java.snap
@@ -3,72 +3,120 @@ source: crates/sg-syntax/src/sg_sciptect.rs
 expression: "dump_document(&document, &contents)"
 ---
   interface MyInterface
-//^^^^^^^^^ IdentifierKeyword
+//^^^^^^^^^ IdentifierType
   {
+//^ PunctuationBracket
        void abstract_func(int x,int y);
-//     ^^^^ IdentifierKeyword
+//     ^^^^ IdentifierType
 //          ^^^^^^^^^^^^^ IdentifierFunction
-//                        ^^^ IdentifierKeyword
+//                       ^ PunctuationBracket
+//                        ^^^ IdentifierType
 //                            ^ Identifier
-//                              ^^^ IdentifierKeyword
+//                             ^ PunctuationBracket
+//                              ^^^ IdentifierType
 //                                  ^ Identifier
+//                                   ^ PunctuationBracket
 //                                    ^ PunctuationDelimiter
   
        default void default_Fun()
 //     ^^^^^^^ IdentifierKeyword
-//             ^^^^ IdentifierKeyword
+//             ^^^^ IdentifierType
 //                  ^^^^^^^^^^^ IdentifierFunction
+//                             ^ PunctuationBracket
+//                              ^ PunctuationBracket
       {
+//    ^ PunctuationBracket
            System.out.println("This is default method");
+//         ^^^^^^ IdentifierType
+//               ^ PunctuationBracket
+//                   ^ PunctuationBracket
 //                    ^^^^^^^ IdentifierFunction
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//                                                    ^ PunctuationBracket
 //                                                     ^ PunctuationDelimiter
       }
+//    ^ PunctuationBracket
   }
+//^ PunctuationBracket
   
   class Main
-//^^^^^ IdentifierKeyword
+//^^^^^ IdentifierType
   {
+//^ PunctuationBracket
        public static void main(String args[])
 //     ^^^^^^ IdentifierKeyword
 //            ^^^^^^ IdentifierKeyword
-//                   ^^^^ IdentifierKeyword
+//                   ^^^^ IdentifierType
 //                        ^^^^ IdentifierFunction
+//                            ^ PunctuationBracket
+//                             ^^^^^^ IdentifierType
 //                                    ^^^^ Identifier
 //                                        ^^ PunctuationBracket
+//                                          ^ PunctuationBracket
       {
+//    ^ PunctuationBracket
           //lambda expression
 //        ^^^^^^^^^^^^^^^^^^^ Comment
           MyInterface fobj = (int x, int y)->System.out.println(x+y);
+//        ^^^^^^^^^^^ IdentifierType
 //                         ^ IdentifierOperator
-//                            ^^^ IdentifierKeyword
+//                           ^ PunctuationBracket
+//                            ^^^ IdentifierType
 //                                ^ Identifier
-//                                   ^^^ IdentifierKeyword
+//                                 ^ PunctuationBracket
+//                                   ^^^ IdentifierType
 //                                       ^ Identifier
-//                                         ^^ IdentifierKeyword
+//                                        ^ PunctuationBracket
+//                                         ^^ IdentifierType
+//                                           ^^^^^^ IdentifierType
+//                                                 ^ PunctuationBracket
+//                                                     ^ PunctuationBracket
 //                                                      ^^^^^^^ IdentifierFunction
+//                                                             ^ PunctuationBracket
 //                                                               ^ IdentifierOperator
+//                                                                 ^ PunctuationBracket
 //                                                                  ^ PunctuationDelimiter
   
           System.out.print("The result = ");
+//        ^^^^^^ IdentifierType
+//              ^ PunctuationBracket
+//                  ^ PunctuationBracket
 //                   ^^^^^ IdentifierFunction
+//                        ^ PunctuationBracket
 //                         ^^^^^^^^^^^^^^^ StringLiteral
+//                                        ^ PunctuationBracket
 //                                         ^ PunctuationDelimiter
           fobj.abstract_func(5,5);
+//            ^ PunctuationBracket
 //             ^^^^^^^^^^^^^ IdentifierFunction
+//                          ^ PunctuationBracket
 //                           ^ NumericLiteral
+//                            ^ PunctuationBracket
 //                             ^ NumericLiteral
+//                              ^ PunctuationBracket
 //                               ^ PunctuationDelimiter
           fobj.default_Fun();
+//            ^ PunctuationBracket
 //             ^^^^^^^^^^^ IdentifierFunction
+//                        ^ PunctuationBracket
+//                         ^ PunctuationBracket
 //                          ^ PunctuationDelimiter
       }
+//    ^ PunctuationBracket
       String format(String x) {
+//    ^^^^^^ IdentifierType
 //           ^^^^^^ IdentifierFunction
+//                 ^ PunctuationBracket
+//                  ^^^^^^ IdentifierType
 //                         ^ Identifier
+//                          ^ PunctuationBracket
+//                            ^ PunctuationBracket
           return x;
 //        ^^^^^^ IdentifierKeyword
 //                ^ PunctuationDelimiter
       }
+//    ^ PunctuationBracket
   }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__3billiondevices.java.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__3billiondevices.java.snap
@@ -1,68 +1,74 @@
 ---
 source: crates/sg-syntax/src/sg_sciptect.rs
-assertion_line: 539
 expression: "dump_document(&document, &contents)"
 ---
-  interface MyInterface 
-//^^^^^^^^^ IdentifierType
-  { 
-       void abstract_func(int x,int y); 
-//     ^^^^ IdentifierType
+  interface MyInterface
+//^^^^^^^^^ IdentifierKeyword
+  {
+       void abstract_func(int x,int y);
+//     ^^^^ IdentifierKeyword
 //          ^^^^^^^^^^^^^ IdentifierFunction
-//                        ^^^ IdentifierType
+//                        ^^^ IdentifierKeyword
 //                            ^ Identifier
-//                              ^^^ IdentifierType
+//                              ^^^ IdentifierKeyword
 //                                  ^ Identifier
 //                                    ^ PunctuationDelimiter
-   
-       default void default_Fun() 
+  
+       default void default_Fun()
 //     ^^^^^^^ IdentifierKeyword
-//             ^^^^ IdentifierType
+//             ^^^^ IdentifierKeyword
 //                  ^^^^^^^^^^^ IdentifierFunction
-      { 
-           System.out.println("This is default method"); 
-//                    ^^^^^^^ Identifier
+      {
+           System.out.println("This is default method");
+//                    ^^^^^^^ IdentifierFunction
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
 //                                                     ^ PunctuationDelimiter
-      } 
-  } 
-   
-  class Main 
-//^^^^^ IdentifierType
-  { 
-       public static void main(String args[]) 
+      }
+  }
+  
+  class Main
+//^^^^^ IdentifierKeyword
+  {
+       public static void main(String args[])
 //     ^^^^^^ IdentifierKeyword
 //            ^^^^^^ IdentifierKeyword
-//                   ^^^^ IdentifierType
+//                   ^^^^ IdentifierKeyword
 //                        ^^^^ IdentifierFunction
 //                                    ^^^^ Identifier
 //                                        ^^ PunctuationBracket
-      { 
+      {
           //lambda expression
 //        ^^^^^^^^^^^^^^^^^^^ Comment
-          MyInterface fobj = (int x, int y)->System.out.println(x+y); 
+          MyInterface fobj = (int x, int y)->System.out.println(x+y);
 //                         ^ IdentifierOperator
-//                            ^^^ IdentifierType
+//                            ^^^ IdentifierKeyword
 //                                ^ Identifier
-//                                   ^^^ IdentifierType
+//                                   ^^^ IdentifierKeyword
 //                                       ^ Identifier
-//                                         ^^ IdentifierType
-//                                                      ^^^^^^^ Identifier
+//                                         ^^ IdentifierKeyword
+//                                                      ^^^^^^^ IdentifierFunction
 //                                                               ^ IdentifierOperator
 //                                                                  ^ PunctuationDelimiter
-   
+  
           System.out.print("The result = ");
-//                   ^^^^^ Identifier
+//                   ^^^^^ IdentifierFunction
 //                         ^^^^^^^^^^^^^^^ StringLiteral
 //                                         ^ PunctuationDelimiter
-          fobj.abstract_func(5,5); 
-//             ^^^^^^^^^^^^^ Identifier
+          fobj.abstract_func(5,5);
+//             ^^^^^^^^^^^^^ IdentifierFunction
 //                           ^ NumericLiteral
 //                             ^ NumericLiteral
 //                               ^ PunctuationDelimiter
           fobj.default_Fun();
-//             ^^^^^^^^^^^ Identifier
+//             ^^^^^^^^^^^ IdentifierFunction
 //                          ^ PunctuationDelimiter
-      } 
+      }
+      String format(String x) {
+//           ^^^^^^ IdentifierFunction
+//                         ^ Identifier
+          return x;
+//        ^^^^^^ IdentifierKeyword
+//                ^ PunctuationDelimiter
+      }
   }
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__bash-interpolation.sh.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__bash-interpolation.sh.snap
@@ -10,5 +10,8 @@ expression: "dump_document(&document, &contents)"
 //       ^^^^^^^^^^^^^ Identifier
 //                    ^ IdentifierOperator
 //                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//                                         ^ PunctuationBracket
+//                                          ^ PunctuationBracket
 //                                           ^^^^^^^^^^^^^^ Identifier
+//                                                         ^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__bash.sh.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__bash.sh.snap
@@ -11,7 +11,7 @@ expression: "dump_document(&document, &contents)"
 //^^^ Identifier
 //   ^ IdentifierOperator
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^ Identifier
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^ IdentifierFunction
 //                                ^ NumericLiteral
 //                                 ^^ IdentifierOperator
 //                                   ^ NumericLiteral
@@ -20,20 +20,20 @@ expression: "dump_document(&document, &contents)"
 //         ^ IdentifierOperator
 //          ^^ StringLiteral 4:10..9:19
    git diff origin/main -- foobar.md |
-// ^^^ Identifier
+// ^^^ IdentifierFunction
 //                     ^^^ IdentifierOperator
 //                                   ^ IdentifierOperator
    # some comment
 // ^ Comment
 //  ^^^^^^^^^^^^^ Comment
    grep ^+ |
-// ^^^^ Identifier
+// ^^^^ IdentifierFunction
 //         ^ IdentifierOperator
    # more sed
 // ^ Comment
 //  ^^^^^^^^^ Comment
    sed 's/#readme//')
-// ^^^ Identifier
+// ^^^ IdentifierFunction
 //     ^^^^^^^^^^^^^ StringLiteral
   echo "$OUT"
 //     ^^^^^^ StringLiteral
@@ -45,7 +45,7 @@ expression: "dump_document(&document, &contents)"
 //     ^^^^^^ StringLiteral
 //       ^^^ Identifier
 //            ^ IdentifierOperator
-//              ^^^^ Identifier
+//              ^^^^ IdentifierFunction
 //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
   if [ "$OUT" != '0' ]; then
 //^^ IdentifierKeyword

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__bash.sh.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__bash.sh.snap
@@ -5,19 +5,26 @@ expression: "dump_document(&document, &contents)"
   #!/bin/sh
 // ^^^^^^^^ Comment
   set -eux
-//    ^^^^ Identifier
+//^^^ IdentifierFunction
+//    ^ PunctuationBracket
+//     ^^^ Identifier
   
   OUT=$(test/backtrace-test-raise 2>&1)
 //^^^ Identifier
 //   ^ IdentifierOperator
+//    ^ PunctuationBracket
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//     ^ PunctuationBracket
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^ IdentifierFunction
 //                                ^ NumericLiteral
 //                                 ^^ IdentifierOperator
 //                                   ^ NumericLiteral
+//                                    ^ PunctuationBracket
   REPO_LINT=$(
 //^^^^^^^^^ Identifier
 //         ^ IdentifierOperator
+//          ^ PunctuationBracket
+//           ^ PunctuationBracket
 //          ^^ StringLiteral 4:10..9:19
    git diff origin/main -- foobar.md |
 // ^^^ IdentifierFunction
@@ -35,27 +42,38 @@ expression: "dump_document(&document, &contents)"
    sed 's/#readme//')
 // ^^^ IdentifierFunction
 //     ^^^^^^^^^^^^^ StringLiteral
+//                  ^ PunctuationBracket
   echo "$OUT"
+//^^^^ IdentifierFunction
 //     ^^^^^^ StringLiteral
+//      ^ PunctuationBracket
 //       ^^^ Identifier
   echo "$REPO_LINT"
+//^^^^ IdentifierFunction
 //     ^^^^^^^^^^^^ StringLiteral
+//      ^ PunctuationBracket
 //       ^^^^^^^^^ Identifier
   echo "$OUT" | grep 'in main backtrace-test-raise.cc:4'
+//^^^^ IdentifierFunction
 //     ^^^^^^ StringLiteral
+//      ^ PunctuationBracket
 //       ^^^ Identifier
 //            ^ IdentifierOperator
 //              ^^^^ IdentifierFunction
 //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
   if [ "$OUT" != '0' ]; then
 //^^ IdentifierKeyword
+//   ^ IdentifierFunction
 //     ^^^^^^ StringLiteral
+//      ^ PunctuationBracket
 //       ^^^ Identifier
 //            ^^ IdentifierOperator
 //               ^^^ StringLiteral
+//                   ^ IdentifierFunction
 //                    ^ IdentifierOperator
 //                      ^^^^ IdentifierKeyword
   echo 'foo'
+//^^^^ IdentifierFunction
 //     ^^^^^ StringLiteral
   fi
 //^^ IdentifierKeyword

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__cc.cc.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__cc.cc.snap
@@ -12,7 +12,7 @@ expression: "dump_document(&document, &contents)"
 //         ^^^^^^^^^ StringLiteral
   
   int main() {
-//^^^ IdentifierType
+//^^^ IdentifierKeyword
 //    ^^^^ IdentifierFunction
       syntect::Exception::raise("oops");
 //                              ^^^^^^ StringLiteral

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__cc.cc.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__cc.cc.snap
@@ -12,10 +12,19 @@ expression: "dump_document(&document, &contents)"
 //         ^^^^^^^^^ StringLiteral
   
   int main() {
-//^^^ IdentifierKeyword
+//^^^ IdentifierType
 //    ^^^^ IdentifierFunction
+//        ^ PunctuationBracket
+//         ^ PunctuationBracket
+//           ^ PunctuationBracket
       syntect::Exception::raise("oops");
+//           ^^ PunctuationBracket
+//                      ^^ PunctuationBracket
+//                        ^^^^^ IdentifierFunction
+//                             ^ PunctuationBracket
 //                              ^^^^^^ StringLiteral
+//                                    ^ PunctuationBracket
 //                                     ^ PunctuationDelimiter
   }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__func.go.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__func.go.snap
@@ -10,9 +10,46 @@ expression: "dump_document(&document, &contents)"
 //^^^^^^ IdentifierKeyword
 //       ^^^^^ StringLiteral
   
+  type Bar struct {
+//^^^^ IdentifierKeyword
+//     ^^^ IdentifierType
+//         ^^^^^^ IdentifierKeyword
+//                ^ PunctuationBracket
+   z int
+// ^ Identifier
+//   ^^^ IdentifierBuiltinType
+  }
+//^ PunctuationBracket
+  
+  type Foo struct {
+//^^^^ IdentifierKeyword
+//     ^^^ IdentifierType
+//         ^^^^^^ IdentifierKeyword
+//                ^ PunctuationBracket
+   x *int
+// ^ Identifier
+//   ^ IdentifierOperator
+//    ^^^ IdentifierBuiltinType
+   Y string
+// ^ Identifier
+//   ^^^^^^ IdentifierBuiltinType
+   Bar
+   Bar2 Bar
+// ^^^^ Identifier
+//      ^^^ IdentifierType
+   Bar3 *Bar
+// ^^^^ Identifier
+//      ^ IdentifierOperator
+//       ^^^ IdentifierType
+  }
+//^ PunctuationBracket
+  
   func main() {
 //^^^^ IdentifierKeyword
 //     ^^^^ IdentifierFunction
+//         ^ PunctuationBracket
+//          ^ PunctuationBracket
+//            ^ PunctuationBracket
    // this is comment
 // ^^^^^^^^^^^^^^^^^^ Comment
   
@@ -37,7 +74,7 @@ expression: "dump_document(&document, &contents)"
    multilineString := `hello
 // ^^^^^^^^^^^^^^^ Identifier
 //                 ^^ IdentifierOperator
-//                    ^^^^^^ StringLiteral 11:20..13:16
+//                    ^^^^^^ StringLiteral 23:20..25:16
    world
   this is my poem` + aString
 //                 ^ IdentifierOperator
@@ -53,13 +90,45 @@ expression: "dump_document(&document, &contents)"
 //                    ^ IdentifierOperator
 //                      ^^^ IdentifierBuiltin
   
+   foo := &Foo {
+// ^^^ Identifier
+//     ^^ IdentifierOperator
+//        ^ IdentifierOperator
+//         ^^^ Identifier
+//             ^ PunctuationBracket
+    x: 42
+//  ^ Identifier
+//   ^ PunctuationBracket
+//     ^^ NumericLiteral
+    Bar: Bar {
+//  ^^^ Identifier
+//     ^ PunctuationBracket
+//       ^^^ Identifier
+//           ^ PunctuationBracket
+     z: 43
+//   ^ Identifier
+//    ^ PunctuationBracket
+//      ^^ NumericLiteral
+    }
+//  ^ PunctuationBracket
+   }
+// ^ PunctuationBracket
+  
    fmt.Println(x, char, string, bool, null_was_a_mistake)
 // ^^^ Identifier
+//    ^ PunctuationBracket
 //     ^^^^^^^ IdentifierFunction
+//            ^ PunctuationBracket
 //             ^ Identifier
+//              ^ PunctuationBracket
 //                ^^^^ Identifier
+//                    ^ PunctuationBracket
 //                      ^^^^^^ Identifier
+//                            ^ PunctuationBracket
 //                              ^^^^ Identifier
+//                                  ^ PunctuationBracket
 //                                    ^^^^^^^^^^^^^^^^^^ Identifier
+//                                                      ^ PunctuationBracket
   }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__func.go.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__func.go.snap
@@ -96,21 +96,24 @@ expression: "dump_document(&document, &contents)"
 //        ^ IdentifierOperator
 //         ^^^ Identifier
 //             ^ PunctuationBracket
-    x: 42
+    x: 42,
 //  ^ Identifier
 //   ^ PunctuationBracket
 //     ^^ NumericLiteral
+//       ^ PunctuationBracket
     Bar: Bar {
 //  ^^^ Identifier
 //     ^ PunctuationBracket
 //       ^^^ Identifier
 //           ^ PunctuationBracket
-     z: 43
+     z: 43,
 //   ^ Identifier
 //    ^ PunctuationBracket
 //      ^^ NumericLiteral
-    }
+//        ^ PunctuationBracket
+    },
 //  ^ PunctuationBracket
+//   ^ PunctuationBracket
    }
 // ^ PunctuationBracket
   

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__func.go.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__func.go.snap
@@ -55,7 +55,7 @@ expression: "dump_document(&document, &contents)"
   
    fmt.Println(x, char, string, bool, null_was_a_mistake)
 // ^^^ Identifier
-//     ^^^^^^^ Identifier
+//     ^^^^^^^ IdentifierFunction
 //             ^ Identifier
 //                ^^^^ Identifier
 //                      ^^^^^^ Identifier

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__func.go.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__func.go.snap
@@ -90,22 +90,23 @@ expression: "dump_document(&document, &contents)"
 //                    ^ IdentifierOperator
 //                      ^^^ IdentifierBuiltin
   
-   foo := &Foo {
+   foo := &Foo{
 // ^^^ Identifier
 //     ^^ IdentifierOperator
 //        ^ IdentifierOperator
 //         ^^^ Identifier
-//             ^ PunctuationBracket
-    x: 42,
+//            ^ PunctuationBracket
+    x: &x,
 //  ^ Identifier
 //   ^ PunctuationBracket
-//     ^^ NumericLiteral
+//     ^ IdentifierOperator
+//      ^ Identifier
 //       ^ PunctuationBracket
-    Bar: Bar {
+    Bar: Bar{
 //  ^^^ Identifier
 //     ^ PunctuationBracket
 //       ^^^ Identifier
-//           ^ PunctuationBracket
+//          ^ PunctuationBracket
      z: 43,
 //   ^ Identifier
 //    ^ PunctuationBracket
@@ -117,7 +118,7 @@ expression: "dump_document(&document, &contents)"
    }
 // ^ PunctuationBracket
   
-   fmt.Println(x, char, string, bool, null_was_a_mistake)
+   fmt.Println(x, char, aString, bool, null_was_a_mistake, foo, multilineString)
 // ^^^ Identifier
 //    ^ PunctuationBracket
 //     ^^^^^^^ IdentifierFunction
@@ -126,12 +127,16 @@ expression: "dump_document(&document, &contents)"
 //              ^ PunctuationBracket
 //                ^^^^ Identifier
 //                    ^ PunctuationBracket
-//                      ^^^^^^ Identifier
-//                            ^ PunctuationBracket
-//                              ^^^^ Identifier
-//                                  ^ PunctuationBracket
-//                                    ^^^^^^^^^^^^^^^^^^ Identifier
-//                                                      ^ PunctuationBracket
+//                      ^^^^^^^ Identifier
+//                             ^ PunctuationBracket
+//                               ^^^^ Identifier
+//                                   ^ PunctuationBracket
+//                                     ^^^^^^^^^^^^^^^^^^ Identifier
+//                                                       ^ PunctuationBracket
+//                                                         ^^^ Identifier
+//                                                            ^ PunctuationBracket
+//                                                              ^^^^^^^^^^^^^^^ Identifier
+//                                                                             ^ PunctuationBracket
   }
 //^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__jason.json.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__jason.json.snap
@@ -1,20 +1,28 @@
 ---
 source: crates/sg-syntax/src/sg_sciptect.rs
-assertion_line: 540
 expression: "dump_document(&document, &contents)"
 ---
   {
 //^ PunctuationBracket
       "hello": "world",
-//    ^^^^^^^ StringLiteral
+//    ^^^^^^^ StringLiteralKey
+//           ^ PunctuationBracket
 //             ^^^^^^^ StringLiteral
+//                    ^ PunctuationBracket
       "list": [null, 1, 2.0, true, false]
-//    ^^^^^^ StringLiteral
+//    ^^^^^^ StringLiteralKey
+//          ^ PunctuationBracket
 //            ^ PunctuationBracket
 //             ^^^^ IdentifierBuiltin
+//                 ^ PunctuationBracket
 //                   ^ NumericLiteral
-//                      ^^^ NumericLiteral
+//                    ^ PunctuationBracket
+//                      ^ NumericLiteral
+//                       ^ PunctuationBracket
+//                        ^ NumericLiteral
+//                         ^ PunctuationBracket
 //                           ^^^^ IdentifierBuiltin
+//                               ^ PunctuationBracket
 //                                 ^^^^^ IdentifierBuiltin
 //                                      ^ PunctuationBracket
   }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__javascript.js.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__javascript.js.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/sg-syntax/src/sg_sciptect.rs
-assertion_line: 541
 expression: "dump_document(&document, &contents)"
 ---
   function $initHighlight(block, cls) {
-//^^^^^^^^ IdentifierType
+//^^^^^^^^ IdentifierKeyword
 //         ^^^^^^^^^^^^^^ IdentifierFunction
 //                        ^^^^^ Identifier
 //                               ^^^ Identifier
@@ -13,7 +12,7 @@ expression: "dump_document(&document, &contents)"
       if (cls.search(/\bno\-highlight\b/) != -1)
 //    ^^ IdentifierKeyword
 //        ^^^ Identifier
-//            ^^^^^^ Identifier
+//            ^^^^^^ IdentifierFunction
 //                   ^ StringLiteral
 //                    ^^ IdentifierKeyword
 //                      ^^ StringLiteral
@@ -43,7 +42,7 @@ expression: "dump_document(&document, &contents)"
     }
     for (var i = 0 / 2; i < classes.length; i++) {
 //  ^^^ IdentifierKeyword
-//       ^^^ IdentifierType
+//       ^^^ IdentifierKeyword
 //           ^ Identifier
 //             ^ IdentifierOperator
 //               ^ NumericLiteral
@@ -56,7 +55,7 @@ expression: "dump_document(&document, &contents)"
 //                                           ^^ IdentifierOperator
       if (checkCondition(classes[i]) === undefined)
 //    ^^ IdentifierKeyword
-//        ^^^^^^^^^^^^^^ Identifier
+//        ^^^^^^^^^^^^^^ IdentifierFunction
 //                       ^^^^^^^ Identifier
 //                               ^ Identifier
 //                                   ^^^ IdentifierOperator

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__javascript.js.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__javascript.js.snap
@@ -3,16 +3,24 @@ source: crates/sg-syntax/src/sg_sciptect.rs
 expression: "dump_document(&document, &contents)"
 ---
   function $initHighlight(block, cls) {
-//^^^^^^^^ IdentifierKeyword
+//^^^^^^^^ IdentifierType
 //         ^^^^^^^^^^^^^^ IdentifierFunction
+//                       ^ PunctuationBracket
 //                        ^^^^^ Identifier
+//                             ^ PunctuationBracket
 //                               ^^^ Identifier
+//                                  ^ PunctuationBracket
+//                                    ^ PunctuationBracket
     try {
 //  ^^^ IdentifierKeyword
+//      ^ PunctuationBracket
       if (cls.search(/\bno\-highlight\b/) != -1)
 //    ^^ IdentifierKeyword
+//       ^ PunctuationBracket
 //        ^^^ Identifier
+//           ^ PunctuationBracket
 //            ^^^^^^ IdentifierFunction
+//                  ^ PunctuationBracket
 //                   ^ StringLiteral
 //                    ^^ IdentifierKeyword
 //                      ^^ StringLiteral
@@ -20,59 +28,106 @@ expression: "dump_document(&document, &contents)"
 //                          ^^^^^^^^^ StringLiteral
 //                                   ^^ IdentifierKeyword
 //                                     ^ StringLiteral
+//                                      ^ PunctuationBracket
 //                                        ^^ IdentifierOperator
 //                                           ^ IdentifierOperator
 //                                            ^ NumericLiteral
+//                                             ^ PunctuationBracket
         return process(block, true, 0x0F) +
 //      ^^^^^^ IdentifierKeyword
+//                    ^ PunctuationBracket
 //                     ^^^^^ Identifier
+//                          ^ PunctuationBracket
 //                            ^^^^ IdentifierBuiltin
-//                                  ^^^^ NumericLiteral
+//                                ^ PunctuationBracket
+//                                  ^^ PunctuationBracket
+//                                    ^^ NumericLiteral
+//                                      ^ PunctuationBracket
 //                                        ^ IdentifierOperator
                ` class="${cls}"`;
 //             ^^^^^^^^^ StringLiteral
+//                      ^^ PunctuationBracket
 //                        ^^^ Identifier
+//                           ^ PunctuationBracket
 //                            ^^ StringLiteral
 //                              ^ PunctuationDelimiter
     } catch (e) {
+//  ^ PunctuationBracket
 //    ^^^^^ IdentifierKeyword
+//          ^ PunctuationBracket
 //           ^ Identifier
+//            ^ PunctuationBracket
+//              ^ PunctuationBracket
       /* handle exception */
 //    ^^^^^^^^^^^^^^^^^^^^^^ Comment
     }
+//  ^ PunctuationBracket
     for (var i = 0 / 2; i < classes.length; i++) {
 //  ^^^ IdentifierKeyword
-//       ^^^ IdentifierKeyword
+//      ^ PunctuationBracket
+//       ^^^ IdentifierType
 //           ^ Identifier
 //             ^ IdentifierOperator
 //               ^ NumericLiteral
 //                 ^ IdentifierOperator
 //                   ^ NumericLiteral
+//                    ^ PunctuationBracket
 //                      ^ Identifier
 //                        ^ IdentifierOperator
 //                          ^^^^^^^ Identifier
+//                                 ^ PunctuationBracket
+//                                        ^ PunctuationBracket
 //                                          ^ Identifier
 //                                           ^^ IdentifierOperator
+//                                             ^ PunctuationBracket
+//                                               ^ PunctuationBracket
       if (checkCondition(classes[i]) === undefined)
 //    ^^ IdentifierKeyword
+//       ^ PunctuationBracket
 //        ^^^^^^^^^^^^^^ IdentifierFunction
+//                      ^ PunctuationBracket
 //                       ^^^^^^^ Identifier
+//                              ^ PunctuationBracket
 //                               ^ Identifier
+//                                ^ PunctuationBracket
+//                                 ^ PunctuationBracket
 //                                   ^^^ IdentifierOperator
 //                                       ^^^^^^^^^ IdentifierBuiltin
+//                                                ^ PunctuationBracket
         console.log('undefined');
+//      ^^^^^^^ IdentifierType
+//             ^ PunctuationBracket
+//              ^^^ IdentifierFunction
+//                 ^ PunctuationBracket
 //                  ^^^^^^^^^^^ StringLiteral
+//                             ^ PunctuationBracket
 //                              ^ PunctuationDelimiter
     }
+//  ^ PunctuationBracket
   
     return (
 //  ^^^^^^ IdentifierKeyword
+//         ^ PunctuationBracket
       <div>
+//    ^ PunctuationBracket
+//        ^ PunctuationBracket
         <web-component>{block}</web-component>
+//      ^ PunctuationBracket
+//                    ^ PunctuationBracket
+//                     ^ PunctuationBracket
 //                      ^^^^^ Identifier
+//                           ^ PunctuationBracket
+//                            ^ PunctuationBracket
+//                             ^ PunctuationBracket
+//                                           ^ PunctuationBracket
       </div>
+//    ^ PunctuationBracket
+//     ^ PunctuationBracket
+//         ^ PunctuationBracket
     )
+//  ^ PunctuationBracket
   }
+//^ PunctuationBracket
   
   export  $initHighlight;
 //^^^^^^ IdentifierKeyword

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__kotlin.kt.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__kotlin.kt.snap
@@ -13,7 +13,7 @@ expression: "dump_document(&document, &contents)"
 //        ^^^ IdentifierFunction
 //            ^^^^^^^ Identifier
 //                   ^ IdentifierOperator
-//                     ^^^^^^^^ IdentifierKeyword
+//                     ^^^^^^^^ IdentifierType
 //                               ^^^^ IdentifierKeyword
 //                                   ^ IdentifierOperator
 //                                                   ^ IdentifierOperator
@@ -36,14 +36,14 @@ expression: "dump_document(&document, &contents)"
 //^^^^^^ IdentifierKeyword
 //       ^^^ IdentifierKeyword
 //            ^^^^^^^ IdentifierKeyword
-//                    ^ IdentifierKeyword
+//                    ^ IdentifierType
 //                           ^^ IdentifierFunction
 //                              ^^^ Identifier
 //                                 ^ IdentifierOperator
-//                                   ^^^ IdentifierKeyword
+//                                   ^^^ IdentifierType
 //                                        ^^^ Identifier
 //                                           ^ IdentifierOperator
-//                                             ^^^ IdentifierKeyword
+//                                             ^^^ IdentifierType
 //                                                  ^ IdentifierOperator
 //                                                              ^ IdentifierOperator
       when (T::class) {
@@ -73,11 +73,12 @@ expression: "dump_document(&document, &contents)"
   internal class MediaStoreData(context: Context, filePath: String, accessFlag: FileAccessFlags) :
 //^^^^^^^^ IdentifierKeyword
 //         ^^^^^ IdentifierKeyword
+//               ^^^^^^^^^^^^^^ IdentifierType
 //                              ^^^^^^^ Identifier
 //                                     ^ IdentifierOperator
 //                                                ^^^^^^^^ Identifier
 //                                                        ^ IdentifierOperator
-//                                                          ^^^^^^ IdentifierKeyword
+//                                                          ^^^^^^ IdentifierType
 //                                                                  ^^^^^^^^^^ Identifier
 //                                                                            ^ IdentifierOperator
 //                                                                                               ^ IdentifierOperator
@@ -87,16 +88,17 @@ expression: "dump_document(&document, &contents)"
 // ^^^^^^^ IdentifierKeyword
 //         ^^^^ IdentifierKeyword
 //              ^^^^^ IdentifierKeyword
+//                    ^^^^^^^^ IdentifierType
     val id: Long,
 //  ^^^ IdentifierKeyword
 //      ^^ Identifier
 //        ^ IdentifierOperator
-//          ^^^^ IdentifierKeyword
+//          ^^^^ IdentifierType
     val mediaType: String
 //  ^^^ IdentifierKeyword
 //      ^^^^^^^^^ Identifier
 //               ^ IdentifierOperator
-//                 ^^^^^^ IdentifierKeyword
+//                 ^^^^^^ IdentifierType
    )
   
    companion object {
@@ -133,10 +135,10 @@ expression: "dump_document(&document, &contents)"
 //              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentifierFunction
 //                                          ^^^^ Identifier
 //                                              ^ IdentifierOperator
-//                                                ^^^^^^ IdentifierKeyword
+//                                                ^^^^^^ IdentifierType
 //                                                       ^ IdentifierOperator
-//                                                         ^^^^^ IdentifierKeyword
-//                                                               ^^^^^^ IdentifierKeyword
+//                                                         ^^^^^ IdentifierType
+//                                                               ^^^^^^ IdentifierType
      return arrayOf(getMediaStoreDisplayName(path), getMediaStoreRelativePath(path))
 //   ^^^^^^ IdentifierKeyword
     }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__kotlin.kt.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__kotlin.kt.snap
@@ -13,7 +13,7 @@ expression: "dump_document(&document, &contents)"
 //        ^^^ IdentifierFunction
 //            ^^^^^^^ Identifier
 //                   ^ IdentifierOperator
-//                     ^^^^^^^^ IdentifierType
+//                     ^^^^^^^^ IdentifierKeyword
 //                               ^^^^ IdentifierKeyword
 //                                   ^ IdentifierOperator
 //                                                   ^ IdentifierOperator
@@ -36,14 +36,14 @@ expression: "dump_document(&document, &contents)"
 //^^^^^^ IdentifierKeyword
 //       ^^^ IdentifierKeyword
 //            ^^^^^^^ IdentifierKeyword
-//                    ^ IdentifierType
+//                    ^ IdentifierKeyword
 //                           ^^ IdentifierFunction
 //                              ^^^ Identifier
 //                                 ^ IdentifierOperator
-//                                   ^^^ IdentifierType
+//                                   ^^^ IdentifierKeyword
 //                                        ^^^ Identifier
 //                                           ^ IdentifierOperator
-//                                             ^^^ IdentifierType
+//                                             ^^^ IdentifierKeyword
 //                                                  ^ IdentifierOperator
 //                                                              ^ IdentifierOperator
       when (T::class) {
@@ -77,7 +77,7 @@ expression: "dump_document(&document, &contents)"
 //                                     ^ IdentifierOperator
 //                                                ^^^^^^^^ Identifier
 //                                                        ^ IdentifierOperator
-//                                                          ^^^^^^ IdentifierType
+//                                                          ^^^^^^ IdentifierKeyword
 //                                                                  ^^^^^^^^^^ Identifier
 //                                                                            ^ IdentifierOperator
 //                                                                                               ^ IdentifierOperator
@@ -91,12 +91,12 @@ expression: "dump_document(&document, &contents)"
 //  ^^^ IdentifierKeyword
 //      ^^ Identifier
 //        ^ IdentifierOperator
-//          ^^^^ IdentifierType
+//          ^^^^ IdentifierKeyword
     val mediaType: String
 //  ^^^ IdentifierKeyword
 //      ^^^^^^^^^ Identifier
 //               ^ IdentifierOperator
-//                 ^^^^^^ IdentifierType
+//                 ^^^^^^ IdentifierKeyword
    )
   
    companion object {
@@ -133,10 +133,10 @@ expression: "dump_document(&document, &contents)"
 //              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentifierFunction
 //                                          ^^^^ Identifier
 //                                              ^ IdentifierOperator
-//                                                ^^^^^^ IdentifierType
+//                                                ^^^^^^ IdentifierKeyword
 //                                                       ^ IdentifierOperator
-//                                                         ^^^^^ IdentifierType
-//                                                               ^^^^^^ IdentifierType
+//                                                         ^^^^^ IdentifierKeyword
+//                                                               ^^^^^^ IdentifierKeyword
      return arrayOf(getMediaStoreDisplayName(path), getMediaStoreRelativePath(path))
 //   ^^^^^^ IdentifierKeyword
     }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__larger.cs.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__larger.cs.snap
@@ -59,7 +59,7 @@ expression: "dump_document(&document, &contents)"
   {
       public class DataGridTests
 //    ^^^^^^ IdentifierKeyword
-//           ^^^^^ IdentifierType
+//           ^^^^^ IdentifierKeyword
       {
           // Css classes tests
 //        ^^^^^^^^^^^^^^^^^^^^ Comment
@@ -67,7 +67,7 @@ expression: "dump_document(&document, &contents)"
 //         ^^^^ Identifier
           public void DataGrid_Renders_CssClass()
 //        ^^^^^^ IdentifierKeyword
-//               ^^^^ IdentifierType
+//               ^^^^ IdentifierKeyword
 //                    ^^^^^^^^^^^^^^^^^^^^^^^^^ IdentifierFunction
           {
               using var ctx = new TestContext();
@@ -87,23 +87,23 @@ expression: "dump_document(&document, &contents)"
               ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
 //            ^^^ Identifier
 //                ^^^^^^^^^ Identifier
-//                          ^^^^^^^^^^^ Identifier
+//                          ^^^^^^^^^^^ IdentifierFunction
 //                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
 //                                                                                ^ PunctuationDelimiter
               var component = ctx.RenderComponent<RadzenGrid<dynamic>>(parameterBuilder =>
-//            ^^^ IdentifierType
+//            ^^^ IdentifierKeyword
 //                ^^^^^^^^^ Identifier
 //                          ^ IdentifierOperator
 //                            ^^^ Identifier
-//                                ^^^^^^^^^^^^^^^ Identifier
+//                                ^^^^^^^^^^^^^^^ IdentifierFunction
 //                                                                     ^^^^^^^^^^^^^^^^ Identifier
-//                                                                                      ^^ IdentifierType
+//                                                                                      ^^ IdentifierKeyword
               {
                   parameterBuilder.Add<IEnumerable<dynamic>>(p => p.Data, new[] { new { Id = 1 }, new { Id = 2 }, new { Id = 3 } });
 //                ^^^^^^^^^^^^^^^^ Identifier
-//                                 ^^^ Identifier
+//                                 ^^^ IdentifierFunction
 //                                                           ^ Identifier
-//                                                             ^^ IdentifierType
+//                                                             ^^ IdentifierKeyword
 //                                                                ^ Identifier
 //                                                                  ^^^^ Identifier
 //                                                                        ^^^ IdentifierOperator
@@ -122,30 +122,30 @@ expression: "dump_document(&document, &contents)"
 //                                                                                                                                 ^ PunctuationDelimiter
                   parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
 //                ^^^^^^^^^^^^^^^^ Identifier
-//                                 ^^^ Identifier
+//                                 ^^^ IdentifierFunction
 //                                                     ^ Identifier
-//                                                       ^^ IdentifierType
+//                                                       ^^ IdentifierKeyword
 //                                                          ^ Identifier
 //                                                            ^^^^^^^ Identifier
 //                                                                     ^^^^^^^ Identifier
-//                                                                             ^^ IdentifierType
+//                                                                             ^^ IdentifierKeyword
                   {
                       builder.OpenComponent(0, typeof(RadzenGridColumn<dynamic>));
 //                    ^^^^^^^ Identifier
-//                            ^^^^^^^^^^^^^ Identifier
+//                            ^^^^^^^^^^^^^ IdentifierFunction
 //                                          ^ NumericLiteral
 //                                             ^^^^^^ IdentifierOperator
 //                                                                               ^ PunctuationDelimiter
                       builder.AddAttribute(1, "Property", "Id");
 //                    ^^^^^^^ Identifier
-//                            ^^^^^^^^^^^^ Identifier
+//                            ^^^^^^^^^^^^ IdentifierFunction
 //                                         ^ NumericLiteral
 //                                            ^^^^^^^^^^ StringLiteral
 //                                                        ^^^^ StringLiteral
 //                                                             ^ PunctuationDelimiter
                       builder.CloseComponent();
 //                    ^^^^^^^ Identifier
-//                            ^^^^^^^^^^^^^^ Identifier
+//                            ^^^^^^^^^^^^^^ IdentifierFunction
 //                                            ^ PunctuationDelimiter
                   });
 //                  ^ PunctuationDelimiter
@@ -156,33 +156,33 @@ expression: "dump_document(&document, &contents)"
 //            ^^^^^^^ Comment
               Assert.Contains(@$"rz-datatable-scrollable-wrapper", component.Markup);
 //            ^^^^^^ Identifier
-//                   ^^^^^^^^ Identifier
+//                   ^^^^^^^^ IdentifierFunction
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
 //                                                                 ^^^^^^^^^ Identifier
 //                                                                           ^^^^^^ Identifier
 //                                                                                  ^ PunctuationDelimiter
               Assert.Contains(@$"rz-datatable-scrollable-view", component.Markup);
 //            ^^^^^^ Identifier
-//                   ^^^^^^^^ Identifier
+//                   ^^^^^^^^ IdentifierFunction
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
 //                                                              ^^^^^^^^^ Identifier
 //                                                                        ^^^^^^ Identifier
 //                                                                               ^ PunctuationDelimiter
   
               var component = ctx.RenderComponent<RadzenGrid<dynamic>>(parameterBuilder =>
-//            ^^^ IdentifierType
+//            ^^^ IdentifierKeyword
 //                ^^^^^^^^^ Identifier
 //                          ^ IdentifierOperator
 //                            ^^^ Identifier
-//                                ^^^^^^^^^^^^^^^ Identifier
+//                                ^^^^^^^^^^^^^^^ IdentifierFunction
 //                                                                     ^^^^^^^^^^^^^^^^ Identifier
-//                                                                                      ^^ IdentifierType
+//                                                                                      ^^ IdentifierKeyword
               {
                   parameterBuilder.Add<IEnumerable<dynamic>>(p => p.Data, new[] { new { Id = 1 }, new { Id = 2 }, new { Id = 3 } });
 //                ^^^^^^^^^^^^^^^^ Identifier
-//                                 ^^^ Identifier
+//                                 ^^^ IdentifierFunction
 //                                                           ^ Identifier
-//                                                             ^^ IdentifierType
+//                                                             ^^ IdentifierKeyword
 //                                                                ^ Identifier
 //                                                                  ^^^^ Identifier
 //                                                                        ^^^ IdentifierOperator
@@ -201,30 +201,30 @@ expression: "dump_document(&document, &contents)"
 //                                                                                                                                 ^ PunctuationDelimiter
                   parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
 //                ^^^^^^^^^^^^^^^^ Identifier
-//                                 ^^^ Identifier
+//                                 ^^^ IdentifierFunction
 //                                                     ^ Identifier
-//                                                       ^^ IdentifierType
+//                                                       ^^ IdentifierKeyword
 //                                                          ^ Identifier
 //                                                            ^^^^^^^ Identifier
 //                                                                     ^^^^^^^ Identifier
-//                                                                             ^^ IdentifierType
+//                                                                             ^^ IdentifierKeyword
                   {
                       builder.OpenComponent(0, typeof(RadzenGridColumn<dynamic>));
 //                    ^^^^^^^ Identifier
-//                            ^^^^^^^^^^^^^ Identifier
+//                            ^^^^^^^^^^^^^ IdentifierFunction
 //                                          ^ NumericLiteral
 //                                             ^^^^^^ IdentifierOperator
 //                                                                               ^ PunctuationDelimiter
                       builder.AddAttribute(1, "Property", "Id");
 //                    ^^^^^^^ Identifier
-//                            ^^^^^^^^^^^^ Identifier
+//                            ^^^^^^^^^^^^ IdentifierFunction
 //                                         ^ NumericLiteral
 //                                            ^^^^^^^^^^ StringLiteral
 //                                                        ^^^^ StringLiteral
 //                                                             ^ PunctuationDelimiter
                       builder.CloseComponent();
 //                    ^^^^^^^ Identifier
-//                            ^^^^^^^^^^^^^^ Identifier
+//                            ^^^^^^^^^^^^^^ IdentifierFunction
 //                                            ^ PunctuationDelimiter
                   });
 //                  ^ PunctuationDelimiter
@@ -232,20 +232,20 @@ expression: "dump_document(&document, &contents)"
 //              ^ PunctuationDelimiter
   
               var markup = new Regex(@"\s\s+").Replace(component.Markup, "").Trim();
-//            ^^^ IdentifierType
+//            ^^^ IdentifierKeyword
 //                ^^^^^^ Identifier
 //                       ^ IdentifierOperator
 //                         ^^^ IdentifierOperator
 //                                   ^^^^^^^^ StringLiteral
-//                                             ^^^^^^^ Identifier
+//                                             ^^^^^^^ IdentifierFunction
 //                                                     ^^^^^^^^^ Identifier
 //                                                               ^^^^^^ Identifier
 //                                                                       ^^ StringLiteral
-//                                                                           ^^^^ Identifier
+//                                                                           ^^^^ IdentifierFunction
 //                                                                                 ^ PunctuationDelimiter
               Assert.Contains(@$"""rz-cell-data"">1", markup);
 //            ^^^^^^ Identifier
-//                   ^^^^^^^^ Identifier
+//                   ^^^^^^^^ IdentifierFunction
 //                            ^^^ StringLiteral
 //                               ^^ StringLiteralEscape
 //                                 ^^^^^^^^^^^^ StringLiteral
@@ -255,7 +255,7 @@ expression: "dump_document(&document, &contents)"
 //                                                           ^ PunctuationDelimiter
               Assert.Contains(@$"""rz-cell-data"">2", markup);
 //            ^^^^^^ Identifier
-//                   ^^^^^^^^ Identifier
+//                   ^^^^^^^^ IdentifierFunction
 //                            ^^^ StringLiteral
 //                               ^^ StringLiteralEscape
 //                                 ^^^^^^^^^^^^ StringLiteral
@@ -265,7 +265,7 @@ expression: "dump_document(&document, &contents)"
 //                                                           ^ PunctuationDelimiter
               Assert.Contains(@$"""rz-cell-data"">3", markup);
 //            ^^^^^^ Identifier
-//                   ^^^^^^^^ Identifier
+//                   ^^^^^^^^ IdentifierFunction
 //                            ^^^ StringLiteral
 //                               ^^ StringLiteralEscape
 //                                 ^^^^^^^^^^^^ StringLiteral
@@ -275,7 +275,7 @@ expression: "dump_document(&document, &contents)"
 //                                                           ^ PunctuationDelimiter
               Assert.Contains(@"
 //            ^^^^^^ Identifier
-//                   ^^^^^^^^ Identifier
+//                   ^^^^^^^^ IdentifierFunction
 //                            ^^ StringLiteral 53:28..55:1
   Lorem Ipsum
   ", component.Markup);

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__larger.cs.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__larger.cs.snap
@@ -10,6 +10,7 @@ expression: "dump_document(&document, &contents)"
   using AngleSharp.Dom;
 //^^^^^ IdentifierKeyword
 //      ^^^^^^^^^^ IdentifierNamespace
+//                ^ PunctuationBracket
 //                 ^^^ IdentifierNamespace
 //                    ^ PunctuationDelimiter
   using Bunit;
@@ -19,14 +20,19 @@ expression: "dump_document(&document, &contents)"
   using Microsoft.AspNetCore.Components;
 //^^^^^ IdentifierKeyword
 //      ^^^^^^^^^ IdentifierNamespace
+//               ^ PunctuationBracket
 //                ^^^^^^^^^^ IdentifierNamespace
+//                          ^ PunctuationBracket
 //                           ^^^^^^^^^^ IdentifierNamespace
 //                                     ^ PunctuationDelimiter
   using Microsoft.AspNetCore.Components.Rendering;
 //^^^^^ IdentifierKeyword
 //      ^^^^^^^^^ IdentifierNamespace
+//               ^ PunctuationBracket
 //                ^^^^^^^^^^ IdentifierNamespace
+//                          ^ PunctuationBracket
 //                           ^^^^^^^^^^ IdentifierNamespace
+//                                     ^ PunctuationBracket
 //                                      ^^^^^^^^^ IdentifierNamespace
 //                                               ^ PunctuationDelimiter
   using System;
@@ -36,18 +42,23 @@ expression: "dump_document(&document, &contents)"
   using System.Collections.Generic;
 //^^^^^ IdentifierKeyword
 //      ^^^^^^ IdentifierNamespace
+//            ^ PunctuationBracket
 //             ^^^^^^^^^^^ IdentifierNamespace
+//                        ^ PunctuationBracket
 //                         ^^^^^^^ IdentifierNamespace
 //                                ^ PunctuationDelimiter
   using System.Linq;
 //^^^^^ IdentifierKeyword
 //      ^^^^^^ IdentifierNamespace
+//            ^ PunctuationBracket
 //             ^^^^ IdentifierNamespace
 //                 ^ PunctuationDelimiter
   using System.Text.RegularExpressions;
 //^^^^^ IdentifierKeyword
 //      ^^^^^^ IdentifierNamespace
+//            ^ PunctuationBracket
 //             ^^^^ IdentifierNamespace
+//                 ^ PunctuationBracket
 //                  ^^^^^^^^^^^^^^^^^^ IdentifierNamespace
 //                                    ^ PunctuationDelimiter
   using Xunit;
@@ -56,233 +67,418 @@ expression: "dump_document(&document, &contents)"
 //           ^ PunctuationDelimiter
   namespace Radzen.Blazor.
 //^^^^^^^^^ IdentifierNamespace
+//                ^ PunctuationBracket
+//                       ^ PunctuationBracket
   {
+//^ PunctuationBracket
       public class DataGridTests
 //    ^^^^^^ IdentifierKeyword
-//           ^^^^^ IdentifierKeyword
+//           ^^^^^ IdentifierType
       {
+//    ^ PunctuationBracket
           // Css classes tests
 //        ^^^^^^^^^^^^^^^^^^^^ Comment
           [Fact]
+//        ^ PunctuationBracket
 //         ^^^^ Identifier
+//             ^ PunctuationBracket
           public void DataGrid_Renders_CssClass()
 //        ^^^^^^ IdentifierKeyword
-//               ^^^^ IdentifierKeyword
+//               ^^^^ IdentifierType
 //                    ^^^^^^^^^^^^^^^^^^^^^^^^^ IdentifierFunction
+//                                             ^ PunctuationBracket
+//                                              ^ PunctuationBracket
           {
+//        ^ PunctuationBracket
               using var ctx = new TestContext();
+//            ^^^^^ IdentifierType
 //                  ^^^ Identifier
 //                      ^^^ Identifier
 //                          ^ IdentifierOperator
 //                            ^^^ IdentifierOperator
+//                                ^^^^^^^^^^^ IdentifierType
+//                                           ^ PunctuationBracket
+//                                            ^ PunctuationBracket
 //                                             ^ PunctuationDelimiter
               ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 //            ^^^ Identifier
+//               ^ PunctuationBracket
 //                ^^^^^^^^^ Identifier
+//                         ^ PunctuationBracket
 //                          ^^^^ Identifier
 //                               ^ IdentifierOperator
 //                                 ^^^^^^^^^^^^^ Identifier
+//                                              ^ PunctuationBracket
 //                                               ^^^^^ Identifier
 //                                                    ^ PunctuationDelimiter
               ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
 //            ^^^ Identifier
+//               ^ PunctuationBracket
 //                ^^^^^^^^^ Identifier
+//                         ^ PunctuationBracket
 //                          ^^^^^^^^^^^ IdentifierFunction
+//                                     ^ PunctuationBracket
 //                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//                                                                               ^ PunctuationBracket
 //                                                                                ^ PunctuationDelimiter
               var component = ctx.RenderComponent<RadzenGrid<dynamic>>(parameterBuilder =>
-//            ^^^ IdentifierKeyword
+//            ^^^ IdentifierType
 //                ^^^^^^^^^ Identifier
 //                          ^ IdentifierOperator
 //                            ^^^ Identifier
+//                               ^ PunctuationBracket
 //                                ^^^^^^^^^^^^^^^ IdentifierFunction
+//                                               ^ PunctuationBracket
+//                                                ^^^^^^^^^^ IdentifierType
+//                                                          ^ PunctuationBracket
+//                                                           ^^^^^^^ IdentifierType
+//                                                                  ^ PunctuationBracket
+//                                                                   ^ PunctuationBracket
+//                                                                    ^ PunctuationBracket
 //                                                                     ^^^^^^^^^^^^^^^^ Identifier
-//                                                                                      ^^ IdentifierKeyword
+//                                                                                      ^^ IdentifierType
               {
+//            ^ PunctuationBracket
                   parameterBuilder.Add<IEnumerable<dynamic>>(p => p.Data, new[] { new { Id = 1 }, new { Id = 2 }, new { Id = 3 } });
 //                ^^^^^^^^^^^^^^^^ Identifier
+//                                ^ PunctuationBracket
 //                                 ^^^ IdentifierFunction
+//                                    ^ PunctuationBracket
+//                                     ^^^^^^^^^^^ IdentifierType
+//                                                ^ PunctuationBracket
+//                                                 ^^^^^^^ IdentifierType
+//                                                        ^ PunctuationBracket
+//                                                         ^ PunctuationBracket
+//                                                          ^ PunctuationBracket
 //                                                           ^ Identifier
-//                                                             ^^ IdentifierKeyword
+//                                                             ^^ IdentifierType
 //                                                                ^ Identifier
+//                                                                 ^ PunctuationBracket
 //                                                                  ^^^^ Identifier
+//                                                                      ^ PunctuationBracket
 //                                                                        ^^^ IdentifierOperator
+//                                                                           ^ PunctuationBracket
+//                                                                            ^ PunctuationBracket
+//                                                                              ^ PunctuationBracket
 //                                                                                ^^^ IdentifierOperator
+//                                                                                    ^ PunctuationBracket
 //                                                                                      ^^ Identifier
 //                                                                                         ^ IdentifierOperator
 //                                                                                           ^ NumericLiteral
+//                                                                                             ^ PunctuationBracket
+//                                                                                              ^ PunctuationBracket
 //                                                                                                ^^^ IdentifierOperator
+//                                                                                                    ^ PunctuationBracket
 //                                                                                                      ^^ Identifier
 //                                                                                                         ^ IdentifierOperator
 //                                                                                                           ^ NumericLiteral
+//                                                                                                             ^ PunctuationBracket
+//                                                                                                              ^ PunctuationBracket
 //                                                                                                                ^^^ IdentifierOperator
+//                                                                                                                    ^ PunctuationBracket
 //                                                                                                                      ^^ Identifier
 //                                                                                                                         ^ IdentifierOperator
 //                                                                                                                           ^ NumericLiteral
+//                                                                                                                             ^ PunctuationBracket
+//                                                                                                                               ^ PunctuationBracket
+//                                                                                                                                ^ PunctuationBracket
 //                                                                                                                                 ^ PunctuationDelimiter
                   parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
 //                ^^^^^^^^^^^^^^^^ Identifier
+//                                ^ PunctuationBracket
 //                                 ^^^ IdentifierFunction
+//                                    ^ PunctuationBracket
+//                                     ^^^^^^^^^^^^^^ IdentifierType
+//                                                   ^ PunctuationBracket
+//                                                    ^ PunctuationBracket
 //                                                     ^ Identifier
-//                                                       ^^ IdentifierKeyword
+//                                                       ^^ IdentifierType
 //                                                          ^ Identifier
+//                                                           ^ PunctuationBracket
 //                                                            ^^^^^^^ Identifier
+//                                                                   ^ PunctuationBracket
 //                                                                     ^^^^^^^ Identifier
-//                                                                             ^^ IdentifierKeyword
+//                                                                             ^^ IdentifierType
                   {
+//                ^ PunctuationBracket
                       builder.OpenComponent(0, typeof(RadzenGridColumn<dynamic>));
 //                    ^^^^^^^ Identifier
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^^ IdentifierFunction
+//                                         ^ PunctuationBracket
 //                                          ^ NumericLiteral
+//                                           ^ PunctuationBracket
 //                                             ^^^^^^ IdentifierOperator
+//                                                   ^ PunctuationBracket
+//                                                    ^^^^^^^^^^^^^^^^ IdentifierType
+//                                                                    ^ PunctuationBracket
+//                                                                     ^^^^^^^ IdentifierType
+//                                                                            ^ PunctuationBracket
+//                                                                             ^ PunctuationBracket
+//                                                                              ^ PunctuationBracket
 //                                                                               ^ PunctuationDelimiter
                       builder.AddAttribute(1, "Property", "Id");
 //                    ^^^^^^^ Identifier
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^ IdentifierFunction
+//                                        ^ PunctuationBracket
 //                                         ^ NumericLiteral
+//                                          ^ PunctuationBracket
 //                                            ^^^^^^^^^^ StringLiteral
+//                                                      ^ PunctuationBracket
 //                                                        ^^^^ StringLiteral
+//                                                            ^ PunctuationBracket
 //                                                             ^ PunctuationDelimiter
                       builder.CloseComponent();
 //                    ^^^^^^^ Identifier
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^^^ IdentifierFunction
+//                                          ^ PunctuationBracket
+//                                           ^ PunctuationBracket
 //                                            ^ PunctuationDelimiter
                   });
+//                ^ PunctuationBracket
+//                 ^ PunctuationBracket
 //                  ^ PunctuationDelimiter
               });
+//            ^ PunctuationBracket
+//             ^ PunctuationBracket
 //              ^ PunctuationDelimiter
   
               // Main
 //            ^^^^^^^ Comment
               Assert.Contains(@$"rz-datatable-scrollable-wrapper", component.Markup);
 //            ^^^^^^ Identifier
+//                  ^ PunctuationBracket
 //                   ^^^^^^^^ IdentifierFunction
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//                                                               ^ PunctuationBracket
 //                                                                 ^^^^^^^^^ Identifier
+//                                                                          ^ PunctuationBracket
 //                                                                           ^^^^^^ Identifier
+//                                                                                 ^ PunctuationBracket
 //                                                                                  ^ PunctuationDelimiter
               Assert.Contains(@$"rz-datatable-scrollable-view", component.Markup);
 //            ^^^^^^ Identifier
+//                  ^ PunctuationBracket
 //                   ^^^^^^^^ IdentifierFunction
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//                                                            ^ PunctuationBracket
 //                                                              ^^^^^^^^^ Identifier
+//                                                                       ^ PunctuationBracket
 //                                                                        ^^^^^^ Identifier
+//                                                                              ^ PunctuationBracket
 //                                                                               ^ PunctuationDelimiter
   
               var component = ctx.RenderComponent<RadzenGrid<dynamic>>(parameterBuilder =>
-//            ^^^ IdentifierKeyword
+//            ^^^ IdentifierType
 //                ^^^^^^^^^ Identifier
 //                          ^ IdentifierOperator
 //                            ^^^ Identifier
+//                               ^ PunctuationBracket
 //                                ^^^^^^^^^^^^^^^ IdentifierFunction
+//                                               ^ PunctuationBracket
+//                                                ^^^^^^^^^^ IdentifierType
+//                                                          ^ PunctuationBracket
+//                                                           ^^^^^^^ IdentifierType
+//                                                                  ^ PunctuationBracket
+//                                                                   ^ PunctuationBracket
+//                                                                    ^ PunctuationBracket
 //                                                                     ^^^^^^^^^^^^^^^^ Identifier
-//                                                                                      ^^ IdentifierKeyword
+//                                                                                      ^^ IdentifierType
               {
+//            ^ PunctuationBracket
                   parameterBuilder.Add<IEnumerable<dynamic>>(p => p.Data, new[] { new { Id = 1 }, new { Id = 2 }, new { Id = 3 } });
 //                ^^^^^^^^^^^^^^^^ Identifier
+//                                ^ PunctuationBracket
 //                                 ^^^ IdentifierFunction
+//                                    ^ PunctuationBracket
+//                                     ^^^^^^^^^^^ IdentifierType
+//                                                ^ PunctuationBracket
+//                                                 ^^^^^^^ IdentifierType
+//                                                        ^ PunctuationBracket
+//                                                         ^ PunctuationBracket
+//                                                          ^ PunctuationBracket
 //                                                           ^ Identifier
-//                                                             ^^ IdentifierKeyword
+//                                                             ^^ IdentifierType
 //                                                                ^ Identifier
+//                                                                 ^ PunctuationBracket
 //                                                                  ^^^^ Identifier
+//                                                                      ^ PunctuationBracket
 //                                                                        ^^^ IdentifierOperator
+//                                                                           ^ PunctuationBracket
+//                                                                            ^ PunctuationBracket
+//                                                                              ^ PunctuationBracket
 //                                                                                ^^^ IdentifierOperator
+//                                                                                    ^ PunctuationBracket
 //                                                                                      ^^ Identifier
 //                                                                                         ^ IdentifierOperator
 //                                                                                           ^ NumericLiteral
+//                                                                                             ^ PunctuationBracket
+//                                                                                              ^ PunctuationBracket
 //                                                                                                ^^^ IdentifierOperator
+//                                                                                                    ^ PunctuationBracket
 //                                                                                                      ^^ Identifier
 //                                                                                                         ^ IdentifierOperator
 //                                                                                                           ^ NumericLiteral
+//                                                                                                             ^ PunctuationBracket
+//                                                                                                              ^ PunctuationBracket
 //                                                                                                                ^^^ IdentifierOperator
+//                                                                                                                    ^ PunctuationBracket
 //                                                                                                                      ^^ Identifier
 //                                                                                                                         ^ IdentifierOperator
 //                                                                                                                           ^ NumericLiteral
+//                                                                                                                             ^ PunctuationBracket
+//                                                                                                                               ^ PunctuationBracket
+//                                                                                                                                ^ PunctuationBracket
 //                                                                                                                                 ^ PunctuationDelimiter
                   parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
 //                ^^^^^^^^^^^^^^^^ Identifier
+//                                ^ PunctuationBracket
 //                                 ^^^ IdentifierFunction
+//                                    ^ PunctuationBracket
+//                                     ^^^^^^^^^^^^^^ IdentifierType
+//                                                   ^ PunctuationBracket
+//                                                    ^ PunctuationBracket
 //                                                     ^ Identifier
-//                                                       ^^ IdentifierKeyword
+//                                                       ^^ IdentifierType
 //                                                          ^ Identifier
+//                                                           ^ PunctuationBracket
 //                                                            ^^^^^^^ Identifier
+//                                                                   ^ PunctuationBracket
 //                                                                     ^^^^^^^ Identifier
-//                                                                             ^^ IdentifierKeyword
+//                                                                             ^^ IdentifierType
                   {
+//                ^ PunctuationBracket
                       builder.OpenComponent(0, typeof(RadzenGridColumn<dynamic>));
 //                    ^^^^^^^ Identifier
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^^ IdentifierFunction
+//                                         ^ PunctuationBracket
 //                                          ^ NumericLiteral
+//                                           ^ PunctuationBracket
 //                                             ^^^^^^ IdentifierOperator
+//                                                   ^ PunctuationBracket
+//                                                    ^^^^^^^^^^^^^^^^ IdentifierType
+//                                                                    ^ PunctuationBracket
+//                                                                     ^^^^^^^ IdentifierType
+//                                                                            ^ PunctuationBracket
+//                                                                             ^ PunctuationBracket
+//                                                                              ^ PunctuationBracket
 //                                                                               ^ PunctuationDelimiter
                       builder.AddAttribute(1, "Property", "Id");
 //                    ^^^^^^^ Identifier
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^ IdentifierFunction
+//                                        ^ PunctuationBracket
 //                                         ^ NumericLiteral
+//                                          ^ PunctuationBracket
 //                                            ^^^^^^^^^^ StringLiteral
+//                                                      ^ PunctuationBracket
 //                                                        ^^^^ StringLiteral
+//                                                            ^ PunctuationBracket
 //                                                             ^ PunctuationDelimiter
                       builder.CloseComponent();
 //                    ^^^^^^^ Identifier
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^^^ IdentifierFunction
+//                                          ^ PunctuationBracket
+//                                           ^ PunctuationBracket
 //                                            ^ PunctuationDelimiter
                   });
+//                ^ PunctuationBracket
+//                 ^ PunctuationBracket
 //                  ^ PunctuationDelimiter
               });
+//            ^ PunctuationBracket
+//             ^ PunctuationBracket
 //              ^ PunctuationDelimiter
   
               var markup = new Regex(@"\s\s+").Replace(component.Markup, "").Trim();
-//            ^^^ IdentifierKeyword
+//            ^^^ IdentifierType
 //                ^^^^^^ Identifier
 //                       ^ IdentifierOperator
 //                         ^^^ IdentifierOperator
+//                             ^^^^^ IdentifierType
+//                                  ^ PunctuationBracket
 //                                   ^^^^^^^^ StringLiteral
+//                                           ^ PunctuationBracket
+//                                            ^ PunctuationBracket
 //                                             ^^^^^^^ IdentifierFunction
+//                                                    ^ PunctuationBracket
 //                                                     ^^^^^^^^^ Identifier
+//                                                              ^ PunctuationBracket
 //                                                               ^^^^^^ Identifier
+//                                                                     ^ PunctuationBracket
 //                                                                       ^^ StringLiteral
+//                                                                         ^ PunctuationBracket
+//                                                                          ^ PunctuationBracket
 //                                                                           ^^^^ IdentifierFunction
+//                                                                               ^ PunctuationBracket
+//                                                                                ^ PunctuationBracket
 //                                                                                 ^ PunctuationDelimiter
               Assert.Contains(@$"""rz-cell-data"">1", markup);
 //            ^^^^^^ Identifier
+//                  ^ PunctuationBracket
 //                   ^^^^^^^^ IdentifierFunction
+//                           ^ PunctuationBracket
 //                            ^^^ StringLiteral
 //                               ^^ StringLiteralEscape
 //                                 ^^^^^^^^^^^^ StringLiteral
 //                                             ^^ StringLiteralEscape
 //                                               ^^^ StringLiteral
+//                                                  ^ PunctuationBracket
 //                                                    ^^^^^^ Identifier
+//                                                          ^ PunctuationBracket
 //                                                           ^ PunctuationDelimiter
               Assert.Contains(@$"""rz-cell-data"">2", markup);
 //            ^^^^^^ Identifier
+//                  ^ PunctuationBracket
 //                   ^^^^^^^^ IdentifierFunction
+//                           ^ PunctuationBracket
 //                            ^^^ StringLiteral
 //                               ^^ StringLiteralEscape
 //                                 ^^^^^^^^^^^^ StringLiteral
 //                                             ^^ StringLiteralEscape
 //                                               ^^^ StringLiteral
+//                                                  ^ PunctuationBracket
 //                                                    ^^^^^^ Identifier
+//                                                          ^ PunctuationBracket
 //                                                           ^ PunctuationDelimiter
               Assert.Contains(@$"""rz-cell-data"">3", markup);
 //            ^^^^^^ Identifier
+//                  ^ PunctuationBracket
 //                   ^^^^^^^^ IdentifierFunction
+//                           ^ PunctuationBracket
 //                            ^^^ StringLiteral
 //                               ^^ StringLiteralEscape
 //                                 ^^^^^^^^^^^^ StringLiteral
 //                                             ^^ StringLiteralEscape
 //                                               ^^^ StringLiteral
+//                                                  ^ PunctuationBracket
 //                                                    ^^^^^^ Identifier
+//                                                          ^ PunctuationBracket
 //                                                           ^ PunctuationDelimiter
               Assert.Contains(@"
 //            ^^^^^^ Identifier
+//                  ^ PunctuationBracket
 //                   ^^^^^^^^ IdentifierFunction
+//                           ^ PunctuationBracket
 //                            ^^ StringLiteral 53:28..55:1
   Lorem Ipsum
   ", component.Markup);
+// ^ PunctuationBracket
 //   ^^^^^^^^^ Identifier
+//            ^ PunctuationBracket
 //             ^^^^^^ Identifier
+//                   ^ PunctuationBracket
 //                    ^ PunctuationDelimiter
           }
+//        ^ PunctuationBracket
       }
+//    ^ PunctuationBracket
   }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__markdown.md.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__markdown.md.snap
@@ -3,12 +3,27 @@ source: crates/sg-syntax/src/sg_sciptect.rs
 expression: "dump_document(&document, &contents)"
 ---
   # Media
+//^ PunctuationBracket
   
   ## Logo
+//^^ PunctuationBracket
   
   - Primary color: `#fc60a8`
+//^ PunctuationBracket
+//                 ^ PunctuationBracket
+//                         ^ PunctuationBracket
   - Secondary color: `#494368`
+//^ PunctuationBracket
+//                   ^ PunctuationBracket
+//                           ^ PunctuationBracket
   - Font: [`Orbitron`](https://fonts.google.com/specimen/Orbitron)
+//^ PunctuationBracket
+//        ^ PunctuationBracket
+//         ^ PunctuationBracket
+//                  ^ PunctuationBracket
+//                   ^ PunctuationBracket
+//                    ^ PunctuationBracket
+//                                                               ^ PunctuationBracket
   
   You are free to use and modify the logo for your Awesome list or other usage.
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__multibyte.cs.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__multibyte.cs.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sg-syntax/src/sg_sciptect.rs
-assertion_line: 538
 expression: "dump_document(&document, &contents)"
 ---
   using System;
@@ -13,24 +12,24 @@ expression: "dump_document(&document, &contents)"
   {
       public void Something()
 //    ^^^^^^ IdentifierKeyword
-//           ^^^^ IdentifierType
+//           ^^^^ IdentifierKeyword
 //                ^^^^^^^^^ IdentifierFunction
       {
           var x = "世界";
-//        ^^^ IdentifierType
+//        ^^^ IdentifierKeyword
 //            ^ Identifier
 //              ^ IdentifierOperator
 //                ^^^^ StringLiteral
 //                    ^ PunctuationDelimiter
           var y = "世界 Hello, 世界";
-//        ^^^ IdentifierType
+//        ^^^ IdentifierKeyword
 //            ^ Identifier
 //              ^ IdentifierOperator
 //                ^^^^^^^^^^^^^^ StringLiteral
 //                              ^ PunctuationDelimiter
   
           var emoji = "🥳";
-//        ^^^ IdentifierType
+//        ^^^ IdentifierKeyword
 //            ^^^^^ Identifier
 //                  ^ IdentifierOperator
 //                    ^^^ StringLiteral

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__multibyte.cs.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__multibyte.cs.snap
@@ -10,30 +10,36 @@ expression: "dump_document(&document, &contents)"
   namespace Example
 //^^^^^^^^^ IdentifierNamespace
   {
+//^ PunctuationBracket
       public void Something()
 //    ^^^^^^ IdentifierKeyword
-//           ^^^^ IdentifierKeyword
+//           ^^^^ IdentifierType
 //                ^^^^^^^^^ IdentifierFunction
+//                         ^ PunctuationBracket
+//                          ^ PunctuationBracket
       {
+//    ^ PunctuationBracket
           var x = "世界";
-//        ^^^ IdentifierKeyword
+//        ^^^ IdentifierType
 //            ^ Identifier
 //              ^ IdentifierOperator
 //                ^^^^ StringLiteral
 //                    ^ PunctuationDelimiter
           var y = "世界 Hello, 世界";
-//        ^^^ IdentifierKeyword
+//        ^^^ IdentifierType
 //            ^ Identifier
 //              ^ IdentifierOperator
 //                ^^^^^^^^^^^^^^ StringLiteral
 //                              ^ PunctuationDelimiter
   
           var emoji = "🥳";
-//        ^^^ IdentifierKeyword
+//        ^^^ IdentifierType
 //            ^^^^^ Identifier
 //                  ^ IdentifierOperator
 //                    ^^^ StringLiteral
 //                       ^ PunctuationDelimiter
       }
+//    ^ PunctuationBracket
   }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__not_rust.c.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__not_rust.c.snap
@@ -8,12 +8,12 @@ expression: "dump_document(&document, &contents)"
 //         ^^^^^^^^^^^ StringLiteral
   
   int main() {
-//^^^ IdentifierType
+//^^^ IdentifierKeyword
 //    ^^^^ IdentifierFunction
     // Single line comment
 //  ^^^^^^^^^^^^^^^^^^^^^^ Comment
     int x = 1;
-//  ^^^ IdentifierType
+//  ^^^ IdentifierKeyword
 //        ^ IdentifierOperator
 //          ^ NumericLiteral
 //           ^ PunctuationDelimiter

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__not_rust.c.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__not_rust.c.snap
@@ -8,12 +8,15 @@ expression: "dump_document(&document, &contents)"
 //         ^^^^^^^^^^^ StringLiteral
   
   int main() {
-//^^^ IdentifierKeyword
+//^^^ IdentifierType
 //    ^^^^ IdentifierFunction
+//        ^ PunctuationBracket
+//         ^ PunctuationBracket
+//           ^ PunctuationBracket
     // Single line comment
 //  ^^^^^^^^^^^^^^^^^^^^^^ Comment
     int x = 1;
-//  ^^^ IdentifierKeyword
+//  ^^^ IdentifierType
 //        ^ IdentifierOperator
 //          ^ NumericLiteral
 //           ^ PunctuationDelimiter
@@ -27,4 +30,5 @@ expression: "dump_document(&document, &contents)"
 //  ^^^^^^ IdentifierKeyword
 //          ^ PunctuationDelimiter
   }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__python.py.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__python.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sg-syntax/src/sg_sciptect.rs
-assertion_line: 539
 expression: "dump_document(&document, &contents)"
 ---
   @requires_authorization(roles=["ADMIN"])
@@ -22,7 +21,7 @@ expression: "dump_document(&document, &contents)"
 //                              ^ IdentifierOperator
 //                               ^ NumericLiteral
       r'''A docstring'''
-//    ^ IdentifierType
+//    ^ IdentifierKeyword
 //     ^^^^^^^^^^^^^^^^^ Comment
       if param1 > param2: # interesting
 //    ^^ IdentifierKeyword
@@ -41,7 +40,7 @@ expression: "dump_document(&document, &contents)"
 //                              ^ NumericLiteral
 //                                ^ IdentifierOperator
 //                                  ^^^^ NumericLiteral
-//                                      ^ IdentifierType
+//                                      ^ IdentifierKeyword
 //                                         ^^ IdentifierOperator
 //                                            ^^^^ IdentifierBuiltin
   

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__python.py.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__python.py.snap
@@ -3,29 +3,37 @@ source: crates/sg-syntax/src/sg_sciptect.rs
 expression: "dump_document(&document, &contents)"
 ---
   @requires_authorization(roles=["ADMIN"])
+//^ PunctuationBracket
 // ^^^^^^^^^^^^^^^^^^^^^^ Identifier
+//                       ^ PunctuationBracket
 //                        ^^^^^ Identifier
 //                             ^ IdentifierOperator
 //                              ^ PunctuationBracket
 //                               ^ StringLiteral
 //                                ^^^^^^ StringLiteral
 //                                      ^ PunctuationBracket
+//                                       ^ PunctuationBracket
   def somefunc(param1='', param2=0):
 //^^^ IdentifierKeyword
 //    ^^^^^^^^ IdentifierFunction
+//            ^ PunctuationBracket
 //             ^^^^^^ Identifier
 //                   ^ IdentifierOperator
 //                    ^ StringLiteral
 //                     ^ StringLiteral
+//                      ^ PunctuationBracket
 //                        ^^^^^^ Identifier
 //                              ^ IdentifierOperator
 //                               ^ NumericLiteral
+//                                ^ PunctuationBracket
+//                                 ^ PunctuationBracket
       r'''A docstring'''
-//    ^ IdentifierKeyword
+//    ^ IdentifierType
 //     ^^^^^^^^^^^^^^^^^ Comment
       if param1 > param2: # interesting
 //    ^^ IdentifierKeyword
 //              ^ IdentifierOperator
+//                      ^ PunctuationBracket
 //                        ^^^^^^^^^^^^^ Comment
           print 'Gre\'ater'
 //        ^^^^^ IdentifierKeyword
@@ -35,17 +43,21 @@ expression: "dump_document(&document, &contents)"
 //                    ^^^^^ StringLiteral
       return (param2 - param1 + 1 + 0b10l) or None
 //    ^^^^^^ IdentifierKeyword
+//           ^ PunctuationBracket
 //                   ^ IdentifierOperator
 //                            ^ IdentifierOperator
 //                              ^ NumericLiteral
 //                                ^ IdentifierOperator
-//                                  ^^^^ NumericLiteral
-//                                      ^ IdentifierKeyword
+//                                  ^^ PunctuationBracket
+//                                    ^^ NumericLiteral
+//                                      ^ IdentifierType
+//                                       ^ PunctuationBracket
 //                                         ^^ IdentifierOperator
 //                                            ^^^^ IdentifierBuiltin
   
   class SomeClass:
 //^^^^^ IdentifierKeyword
+//               ^ PunctuationBracket
       pass
 //    ^^^^ IdentifierKeyword
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__sass.scss.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__sass.scss.snap
@@ -8,12 +8,15 @@ expression: "dump_document(&document, &contents)"
   
   :root {
       --modal-body-padding: 1.5rem;
+//    ^^^^^^^^^^^^^^^^^^^^ IdentifierType
 //                         ^^^^ NumericLiteral
 //                             ^^^ IdentifierKeyword
   }
   
   [data-reach-dialog-overlay] {
+//^ PunctuationBracket
       background-color: var(--modal-bg);
+//    ^^^^^^^^^^^^^^^^ IdentifierType
 //                      ^^^ IdentifierKeyword
   }
   
@@ -25,13 +28,21 @@ expression: "dump_document(&document, &contents)"
   .center,
   .top-third {
       transform: translate(-50%, -50%);
+//    ^^^^^^^^^ IdentifierType
+//                       ^ IdentifierFunction
+//                        ^ PunctuationBracket
+//                                   ^ PunctuationBracket
       position: absolute;
+//    ^^^^^^^^ IdentifierType
       top: 50%;
+//    ^^^ IdentifierType
 //        ^^^ NumericLiteral
 //           ^ IdentifierKeyword
       margin: 0;
+//    ^^^^^^ IdentifierType
 //           ^^ NumericLiteral
       left: 50%;
+//    ^^^^ IdentifierType
 //         ^^^ NumericLiteral
 //            ^ IdentifierKeyword
   }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__scala.scala.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__scala.scala.snap
@@ -6,25 +6,25 @@ expression: "dump_document(&document, &contents)"
 //^^^^^^^ IdentifierKeyword
   
   case class Foo(x: Int) extends AnyVal
-//^^^^^ IdentifierType
-//     ^^^^^ IdentifierType
+//^^^^^ IdentifierKeyword
+//     ^^^^^ IdentifierKeyword
 //               ^ Identifier
-//                  ^^^ IdentifierType
+//                  ^^^ IdentifierKeyword
 //                       ^^^^^^^ IdentifierKeyword
   object Foo {
-//^^^^^^ IdentifierType
+//^^^^^^ IdentifierKeyword
     val x = 42
-//  ^^^ IdentifierType
+//  ^^^ IdentifierKeyword
 //      ^ Identifier
 //        ^ IdentifierOperator
 //          ^^ NumericLiteral
     val y = 42.0
-//  ^^^ IdentifierType
+//  ^^^ IdentifierKeyword
 //      ^ Identifier
 //        ^ IdentifierOperator
 //          ^^^^ NumericLiteral
     val z = s"hello $x" + "hello world"
-//  ^^^ IdentifierType
+//  ^^^ IdentifierKeyword
 //      ^ Identifier
 //        ^ IdentifierOperator
 //          ^^^^^^^^ StringLiteral
@@ -33,10 +33,10 @@ expression: "dump_document(&document, &contents)"
 //                    ^ StringLiteral
 //                        ^^^^^^^^^^^^^ StringLiteral
     def main(args: Array[String]): Unit = {
-//  ^^^ IdentifierType
+//  ^^^ IdentifierKeyword
 //      ^^^^ IdentifierFunction
 //           ^^^^ Identifier
-//                                 ^^^^ IdentifierType
+//                                 ^^^^ IdentifierKeyword
 //                                      ^ IdentifierOperator
       println(args.toList)
     }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__scala.scala.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__scala.scala.snap
@@ -6,39 +6,60 @@ expression: "dump_document(&document, &contents)"
 //^^^^^^^ IdentifierKeyword
   
   case class Foo(x: Int) extends AnyVal
-//^^^^^ IdentifierKeyword
-//     ^^^^^ IdentifierKeyword
+//^^^^^ IdentifierType
+//     ^^^^^ IdentifierType
+//              ^ PunctuationBracket
 //               ^ Identifier
-//                  ^^^ IdentifierKeyword
+//                ^ PunctuationBracket
+//                  ^^^ IdentifierType
+//                     ^ PunctuationBracket
 //                       ^^^^^^^ IdentifierKeyword
   object Foo {
-//^^^^^^ IdentifierKeyword
+//^^^^^^ IdentifierType
+//           ^ PunctuationBracket
     val x = 42
-//  ^^^ IdentifierKeyword
+//  ^^^ IdentifierType
 //      ^ Identifier
 //        ^ IdentifierOperator
 //          ^^ NumericLiteral
     val y = 42.0
-//  ^^^ IdentifierKeyword
+//  ^^^ IdentifierType
 //      ^ Identifier
 //        ^ IdentifierOperator
-//          ^^^^ NumericLiteral
+//          ^^ NumericLiteral
+//            ^ PunctuationBracket
+//             ^ NumericLiteral
     val z = s"hello $x" + "hello world"
-//  ^^^ IdentifierKeyword
+//  ^^^ IdentifierType
 //      ^ Identifier
 //        ^ IdentifierOperator
-//          ^^^^^^^^ StringLiteral
+//          ^ IdentifierFunction
+//           ^^^^^^^ StringLiteral
 //                  ^ Identifier
 //                   ^ Identifier
 //                    ^ StringLiteral
 //                        ^^^^^^^^^^^^^ StringLiteral
     def main(args: Array[String]): Unit = {
-//  ^^^ IdentifierKeyword
+//  ^^^ IdentifierType
 //      ^^^^ IdentifierFunction
+//          ^ PunctuationBracket
 //           ^^^^ Identifier
-//                                 ^^^^ IdentifierKeyword
+//               ^ PunctuationBracket
+//                 ^^^^^ IdentifierType
+//                      ^ PunctuationBracket
+//                       ^^^^^^ IdentifierType
+//                             ^ PunctuationBracket
+//                              ^ PunctuationBracket
+//                               ^ PunctuationBracket
+//                                 ^^^^ IdentifierType
 //                                      ^ IdentifierOperator
+//                                        ^ PunctuationBracket
       println(args.toList)
+//           ^ PunctuationBracket
+//                ^ PunctuationBracket
+//                       ^ PunctuationBracket
     }
+//  ^ PunctuationBracket
   }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__small.c.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__small.c.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/sg-syntax/src/sg_sciptect.rs
-assertion_line: 541
 expression: "dump_document(&document, &contents)"
 ---
   int main() {
-//^^^ IdentifierType
+//^^^ IdentifierKeyword
 //    ^^^^ IdentifierFunction
     return 0;
 //  ^^^^^^ IdentifierKeyword

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__small.c.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__small.c.snap
@@ -3,11 +3,15 @@ source: crates/sg-syntax/src/sg_sciptect.rs
 expression: "dump_document(&document, &contents)"
 ---
   int main() {
-//^^^ IdentifierKeyword
+//^^^ IdentifierType
 //    ^^^^ IdentifierFunction
+//        ^ PunctuationBracket
+//         ^ PunctuationBracket
+//           ^ PunctuationBracket
     return 0;
 //  ^^^^^^ IdentifierKeyword
 //         ^ NumericLiteral
 //          ^ PunctuationDelimiter
   }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__sql.sql.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__sql.sql.snap
@@ -1,0 +1,46 @@
+---
+source: crates/sg-syntax/src/sg_sciptect.rs
+expression: "dump_document(&document, &contents)"
+---
+  WITH event_log_stats AS (
+//^^^^ IdentifierKeyword
+//                     ^^ IdentifierKeyword
+      SELECT
+//    ^^^^^^ IdentifierKeyword
+          NULLIF(COUNT(*) FILTER (WHERE name IN ('ViewCodeMonitoringPage', 'CodeMonitoringPageViewed')), 0) :: INT AS code_monitoring_page_views,
+//               ^^^^^ IdentifierFunction
+//                     ^ Identifier
+//                                ^^^^^ IdentifierKeyword
+//                                           ^^ IdentifierKeyword
+//                                               ^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//                                                                                                       ^ NumericLiteral
+//                                                                                                             ^^^ IdentifierType
+//                                                                                                                 ^^ IdentifierKeyword
+      FROM event_logs
+//    ^^^^ IdentifierKeyword
+      WHERE
+//    ^^^^^ IdentifierKeyword
+          name IN (
+//             ^^ IdentifierKeyword
+              -- The events that share a line are events that changed names and are aliases of each other
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Comment
+              'CodeMonitoringLogsPageViewed'
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+          )
+  )
+  SELECT
+//^^^^^^ IdentifierKeyword
+      event_log_stats.code_monitoring_page_views,
+      event_log_stats.create_code_monitor_page_views,
+      trigger_jobs.p90_trigger_run_time
+  FROM
+//^^^^ IdentifierKeyword
+      event_log_stats,
+      email_actions,
+      slack_actions,
+      webhook_actions,
+      action_jobs,
+      trigger_jobs
+  ;
+

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__styles.css.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__styles.css.snap
@@ -3,16 +3,35 @@ source: crates/sg-syntax/src/sg_sciptect.rs
 expression: "dump_document(&document, &contents)"
 ---
   :root {
+//^ PunctuationBracket
+//      ^ PunctuationBracket
       --modal-body-padding: 1.5rem;
-//                          ^^^ NumericLiteral
+//    ^^ PunctuationBracket
+//      ^^^^^^^^^^^^^^^^^^ IdentifierType
+//                        ^ PunctuationBracket
+//                          ^ NumericLiteral
+//                           ^ PunctuationBracket
+//                            ^ NumericLiteral
 //                             ^^^ IdentifierKeyword
 //                                ^ PunctuationDelimiter
   }
+//^ PunctuationBracket
   
   [data-reach-dialog-overlay] {
+//^ PunctuationBracket
+//                          ^ PunctuationBracket
+//                            ^ PunctuationBracket
       background-color: var(--modal-bg);
+//    ^^^^^^^^^^^^^^^^ IdentifierType
+//                    ^ PunctuationBracket
+//                      ^^^ IdentifierFunction
+//                         ^ PunctuationBracket
+//                          ^^ PunctuationBracket
+//                            ^^^^^^^^ IdentifierType
+//                                    ^ PunctuationBracket
 //                                     ^ PunctuationDelimiter
   }
+//^ PunctuationBracket
   
   
   /*
@@ -20,25 +39,44 @@ expression: "dump_document(&document, &contents)"
    * Positions
    */
   .center,
+//^ PunctuationBracket
+//       ^ PunctuationBracket
   .top-third {
+//^ PunctuationBracket
+//           ^ PunctuationBracket
       transform: translate(-50%, -50%);
+//    ^^^^^^^^^ IdentifierType
+//             ^ PunctuationBracket
+//               ^^^^^^^^^ IdentifierFunction
+//                        ^ PunctuationBracket
 //                         ^^^ NumericLiteral
 //                            ^ IdentifierKeyword
+//                             ^ PunctuationBracket
 //                               ^^^ NumericLiteral
 //                                  ^ IdentifierKeyword
+//                                   ^ PunctuationBracket
 //                                    ^ PunctuationDelimiter
       position: absolute;
+//    ^^^^^^^^ IdentifierType
+//            ^ PunctuationBracket
 //                      ^ PunctuationDelimiter
       top: 50%;
+//    ^^^ IdentifierType
+//       ^ PunctuationBracket
 //         ^^ NumericLiteral
 //           ^ IdentifierKeyword
 //            ^ PunctuationDelimiter
       margin: 0;
+//    ^^^^^^ IdentifierType
+//          ^ PunctuationBracket
 //            ^ NumericLiteral
 //             ^ PunctuationDelimiter
       left: 50%;
+//    ^^^^ IdentifierType
+//        ^ PunctuationBracket
 //          ^^ NumericLiteral
 //            ^ IdentifierKeyword
 //             ^ PunctuationDelimiter
   }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__typescript.ts.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__typescript.ts.snap
@@ -2,45 +2,66 @@
 source: crates/sg-syntax/src/sg_sciptect.rs
 expression: "dump_document(&document, &contents)"
 ---
-  class MyClass {
-//^^^^^ IdentifierKeyword
+  export class MyClass {
+//^^^^^^ IdentifierKeyword
+//       ^^^^^ IdentifierKeyword
+//             ^^^^^^^ IdentifierType
+//                     ^ PunctuationBracket
     public static myValue: string;
 //  ^^^^^^ IdentifierKeyword
 //         ^^^^^^ IdentifierKeyword
 //                ^^^^^^^ Identifier
 //                       ^ IdentifierOperator
+//                         ^^^^^^ IdentifierType
 //                               ^ PunctuationDelimiter
     constructor(init: string) {
 //  ^^^^^^^^^^^ IdentifierKeyword
+//             ^ PunctuationBracket
 //              ^^^^ Identifier
 //                  ^ IdentifierOperator
+//                    ^^^^^^ IdentifierType
+//                          ^ PunctuationBracket
+//                            ^ PunctuationBracket
       this.myValue = init;
 //    ^^^^ Identifier
+//        ^ PunctuationBracket
 //         ^^^^^^^ Identifier
 //                 ^ IdentifierOperator
 //                   ^^^^ Identifier
 //                       ^ PunctuationDelimiter
     }
+//  ^ PunctuationBracket
   }
+//^ PunctuationBracket
   import fs = require("fs");
 //^^^^^^ IdentifierKeyword
 //       ^^ Identifier
 //          ^ IdentifierOperator
 //            ^^^^^^^ IdentifierKeyword
+//                   ^ PunctuationBracket
 //                    ^^^^ StringLiteral
+//                        ^ PunctuationBracket
 //                         ^ PunctuationDelimiter
-  module MyModule {
-//^^^^^^ IdentifierNamespace
+  declare module MyModule {
+//^^^^^^^ IdentifierKeyword
+//        ^^^^^^ IdentifierKeyword
+//               ^^^^^^^^ IdentifierType
+//                        ^ PunctuationBracket
     export interface MyInterface extends Other {
 //  ^^^^^^ IdentifierKeyword
 //         ^^^^^^^^^ IdentifierKeyword
+//                   ^^^^^^^^^^^ IdentifierType
 //                               ^^^^^^^ IdentifierKeyword
+//                                             ^ PunctuationBracket
       myProperty: any;
 //    ^^^^^^^^^^ Identifier
 //              ^ IdentifierOperator
+//                ^^^ IdentifierType
 //                   ^ PunctuationDelimiter
     }
+//  ^ PunctuationBracket
   }
+//^ PunctuationBracket
   declare magicNumber number;
 //^^^^^^^ IdentifierKeyword
 //        ^^^^^^^^^^^ Identifier
@@ -48,7 +69,15 @@ expression: "dump_document(&document, &contents)"
 //                          ^ PunctuationDelimiter
   myArray.forEach(() => { }); // fat arrow syntax
 //^^^^^^^ Identifier
-//                   ^^ IdentifierKeyword
+//       ^ PunctuationBracket
+//        ^^^^^^^ IdentifierFunction
+//               ^ PunctuationBracket
+//                ^ PunctuationBracket
+//                 ^ PunctuationBracket
+//                   ^^ IdentifierType
+//                      ^ PunctuationBracket
+//                        ^ PunctuationBracket
+//                         ^ PunctuationBracket
 //                          ^ PunctuationDelimiter
 //                            ^^ Comment
 //                              ^^^^^^^^^^^^^^^^^ Comment
@@ -56,29 +85,205 @@ expression: "dump_document(&document, &contents)"
 //^^^^^ IdentifierKeyword
 //      ^^^^^ IdentifierFunction
 //            ^ IdentifierOperator
+//              ^ PunctuationBracket
 //               ^ Identifier
 //                ^ IdentifierOperator
+//                 ^^^^^^ IdentifierType
+//                       ^ PunctuationBracket
 //                        ^ IdentifierOperator
-//                                 ^^ IdentifierKeyword
+//                         ^ IdentifierType
+//                          ^^^^^^ IdentifierType
+//                                ^ IdentifierType
+//                                 ^^ IdentifierType
 //                                    ^ Identifier
 //                                      ^ IdentifierOperator
 //                                        ^ NumericLiteral
-  export const x = 42
+  export const a = 42
 //^^^^^^ IdentifierKeyword
 //       ^^^^^ IdentifierKeyword
 //             ^ Identifier
 //               ^ IdentifierOperator
 //                 ^^ NumericLiteral
-  export let y = 42
+  export let b = 42
 //^^^^^^ IdentifierKeyword
 //       ^^^ IdentifierKeyword
 //           ^ Identifier
 //             ^ IdentifierOperator
 //               ^^ NumericLiteral
-  export var z = 42
+  export var c = 42
 //^^^^^^ IdentifierKeyword
 //       ^^^ IdentifierKeyword
 //           ^ Identifier
 //             ^ IdentifierOperator
 //               ^^ NumericLiteral
+  export var d1 = {e2:41}
+//^^^^^^ IdentifierKeyword
+//       ^^^ IdentifierKeyword
+//           ^^ Identifier
+//              ^ IdentifierOperator
+//                ^ PunctuationBracket
+//                 ^^ IdentifierAttribute
+//                   ^ PunctuationBracket
+//                    ^^ NumericLiteral
+//                      ^ PunctuationBracket
+  export var d = {
+//^^^^^^ IdentifierKeyword
+//       ^^^ IdentifierKeyword
+//           ^ Identifier
+//             ^ IdentifierOperator
+//               ^ PunctuationBracket
+      key1: 1,
+//    ^^^^ IdentifierAttribute
+//        ^ PunctuationBracket
+//          ^ NumericLiteral
+//           ^ PunctuationBracket
+      key2: null,
+//    ^^^^ IdentifierAttribute
+//        ^ PunctuationBracket
+//          ^^^^ IdentifierBuiltin
+//              ^ PunctuationBracket
+      key3: `abc${d1.e2}`,
+//    ^^^^ IdentifierAttribute
+//        ^ PunctuationBracket
+//          ^ PunctuationBracket
+//           ^^^^^^^^^^^ StringLiteral
+//              ^^ PunctuationBracket
+//                ^^ Identifier
+//                  ^ PunctuationBracket
+//                   ^^ Identifier
+//                     ^ PunctuationBracket
+//                      ^ PunctuationBracket
+//                       ^ PunctuationBracket
+  }
+//^ PunctuationBracket
+  export var e = Object.keys(d) as MyClass
+//^^^^^^ IdentifierKeyword
+//       ^^^ IdentifierKeyword
+//           ^ Identifier
+//             ^ IdentifierOperator
+//               ^^^^^^ IdentifierType
+//                     ^ PunctuationBracket
+//                      ^^^^ IdentifierFunction
+//                          ^ PunctuationBracket
+//                           ^ Identifier
+//                            ^ PunctuationBracket
+//                              ^^ IdentifierKeyword
+//                                 ^^^^^^^ IdentifierType
+  export function f() {}
+//^^^^^^ IdentifierKeyword
+//       ^^^^^^^^ IdentifierKeyword
+//                ^ IdentifierFunction
+//                 ^ PunctuationBracket
+//                  ^ PunctuationBracket
+//                    ^ PunctuationBracket
+//                     ^ PunctuationBracket
+  
+  const negatedFilterToNegatableFilter: { [key: string]: MyClass } = null as any
+//^^^^^ IdentifierKeyword
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Identifier
+//                                    ^ IdentifierOperator
+//                                      ^ PunctuationBracket
+//                                        ^ PunctuationBracket
+//                                         ^^^ Identifier
+//                                            ^ IdentifierOperator
+//                                              ^^^^^^ IdentifierType
+//                                                    ^ PunctuationBracket
+//                                                     ^ IdentifierOperator
+//                                                       ^^^^^^^ IdentifierType
+//                                                               ^ PunctuationBracket
+//                                                                 ^ IdentifierOperator
+//                                                                   ^^^^ IdentifierBuiltin
+//                                                                        ^^ IdentifierKeyword
+//                                                                           ^^^ IdentifierType
+  
+  const scanToken = <T extends Term = Literal>(
+//^^^^^ IdentifierKeyword
+//      ^^^^^^^^^ IdentifierFunction
+//                ^ IdentifierOperator
+//                  ^ PunctuationBracket
+//                   ^ IdentifierType
+//                     ^^^^^^^ IdentifierKeyword
+//                             ^^^^ IdentifierType
+//                                  ^ IdentifierOperator
+//                                    ^^^^^^^ IdentifierType
+//                                           ^ PunctuationBracket
+//                                            ^ PunctuationBracket
+      regexp: RegExp,
+//    ^^^^^^ Identifier
+//          ^ IdentifierOperator
+//            ^^^^^^ IdentifierType
+//                  ^ PunctuationBracket
+      output?: T | ((input: string, range: CharacterRange) => T),
+//    ^^^^^^ Identifier
+//          ^ IdentifierOperator
+//           ^ IdentifierOperator
+//             ^ IdentifierType
+//               ^ IdentifierOperator
+//                 ^ PunctuationBracket
+//                  ^ PunctuationBracket
+//                   ^^^^^ Identifier
+//                        ^ IdentifierOperator
+//                          ^^^^^^ IdentifierType
+//                                ^ PunctuationBracket
+//                                  ^^^^^ Identifier
+//                                       ^ IdentifierOperator
+//                                         ^^^^^^^^^^^^^^ IdentifierType
+//                                                       ^ PunctuationBracket
+//                                                         ^^ IdentifierType
+//                                                            ^ IdentifierType
+//                                                             ^ PunctuationBracket
+//                                                              ^ PunctuationBracket
+      expected?: string
+//    ^^^^^^^^ Identifier
+//            ^ IdentifierOperator
+//             ^ IdentifierOperator
+//               ^^^^^^ IdentifierType
+  ): Parser<T> => {
+//^ PunctuationBracket
+// ^ IdentifierOperator
+//  ^ IdentifierType
+//   ^^^^^^ IdentifierType
+//         ^ PunctuationBracket
+//         ^^^^ IdentifierType
+//          ^ IdentifierType
+//           ^ PunctuationBracket
+//             ^^ IdentifierType
+//                ^ PunctuationBracket
+      if (!regexp.source.startsWith('^')) {
+//    ^^ IdentifierKeyword
+//       ^ PunctuationBracket
+//        ^ IdentifierOperator
+//         ^^^^^^ Identifier
+//               ^ PunctuationBracket
+//                ^^^^^^ Identifier
+//                      ^ PunctuationBracket
+//                       ^^^^^^^^^^ IdentifierFunction
+//                                 ^ PunctuationBracket
+//                                  ^^^ StringLiteral
+//                                     ^ PunctuationBracket
+//                                      ^ PunctuationBracket
+//                                        ^ PunctuationBracket
+          regexp = new RegExp(`^${regexp.source}`, regexp.flags)
+//        ^^^^^^ Identifier
+//               ^ IdentifierOperator
+//                 ^^^ IdentifierOperator
+//                     ^^^^^^ IdentifierType
+//                           ^ PunctuationBracket
+//                            ^ PunctuationBracket
+//                             ^^^^^^^^^^^^^^^^^ StringLiteral
+//                              ^^ PunctuationBracket
+//                                ^^^^^^ Identifier
+//                                      ^ PunctuationBracket
+//                                       ^^^^^^ Identifier
+//                                             ^ PunctuationBracket
+//                                              ^ PunctuationBracket
+//                                               ^ PunctuationBracket
+//                                                 ^^^^^^ Identifier
+//                                                       ^ PunctuationBracket
+//                                                        ^^^^^ Identifier
+//                                                             ^ PunctuationBracket
+      }
+//    ^ PunctuationBracket
+  }
+//^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__typescript.ts.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__typescript.ts.snap
@@ -58,6 +58,12 @@ expression: "dump_document(&document, &contents)"
 //              ^ IdentifierOperator
 //                ^^^ IdentifierType
 //                   ^ PunctuationDelimiter
+      myKeyoff: keyof MyClass;
+//    ^^^^^^^^ Identifier
+//            ^ IdentifierOperator
+//              ^^^^^ IdentifierKeyword
+//                    ^^^^^^^ IdentifierType
+//                           ^ PunctuationDelimiter
     }
 //  ^ PunctuationBracket
   }
@@ -286,4 +292,12 @@ expression: "dump_document(&document, &contents)"
 //    ^ PunctuationBracket
   }
 //^ PunctuationBracket
+  
+  export const URI: typeof URL
+//^^^^^^ IdentifierKeyword
+//       ^^^^^ IdentifierKeyword
+//             ^^^ Identifier
+//                ^ IdentifierOperator
+//                  ^^^^^^ IdentifierKeyword
+//                         ^^^ IdentifierType
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__typescript.ts.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__typescript.ts.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/sg-syntax/src/sg_sciptect.rs
-assertion_line: 538
 expression: "dump_document(&document, &contents)"
 ---
   class MyClass {
-//^^^^^ IdentifierType
+//^^^^^ IdentifierKeyword
     public static myValue: string;
 //  ^^^^^^ IdentifierKeyword
 //         ^^^^^^ IdentifierKeyword
@@ -12,7 +11,7 @@ expression: "dump_document(&document, &contents)"
 //                       ^ IdentifierOperator
 //                               ^ PunctuationDelimiter
     constructor(init: string) {
-//  ^^^^^^^^^^^ IdentifierType
+//  ^^^^^^^^^^^ IdentifierKeyword
 //              ^^^^ Identifier
 //                  ^ IdentifierOperator
       this.myValue = init;
@@ -34,7 +33,7 @@ expression: "dump_document(&document, &contents)"
 //^^^^^^ IdentifierNamespace
     export interface MyInterface extends Other {
 //  ^^^^^^ IdentifierKeyword
-//         ^^^^^^^^^ IdentifierType
+//         ^^^^^^^^^ IdentifierKeyword
 //                               ^^^^^^^ IdentifierKeyword
       myProperty: any;
 //    ^^^^^^^^^^ Identifier
@@ -49,8 +48,37 @@ expression: "dump_document(&document, &contents)"
 //                          ^ PunctuationDelimiter
   myArray.forEach(() => { }); // fat arrow syntax
 //^^^^^^^ Identifier
-//                   ^^ IdentifierType
+//                   ^^ IdentifierKeyword
 //                          ^ PunctuationDelimiter
 //                            ^^ Comment
 //                              ^^^^^^^^^^^^^^^^^ Comment
+  const oneOf = (a:number): number => a + 1
+//^^^^^ IdentifierKeyword
+//      ^^^^^ IdentifierFunction
+//            ^ IdentifierOperator
+//               ^ Identifier
+//                ^ IdentifierOperator
+//                        ^ IdentifierOperator
+//                                 ^^ IdentifierKeyword
+//                                    ^ Identifier
+//                                      ^ IdentifierOperator
+//                                        ^ NumericLiteral
+  export const x = 42
+//^^^^^^ IdentifierKeyword
+//       ^^^^^ IdentifierKeyword
+//             ^ Identifier
+//               ^ IdentifierOperator
+//                 ^^ NumericLiteral
+  export let y = 42
+//^^^^^^ IdentifierKeyword
+//       ^^^ IdentifierKeyword
+//           ^ Identifier
+//             ^ IdentifierOperator
+//               ^^ NumericLiteral
+  export var z = 42
+//^^^^^^ IdentifierKeyword
+//       ^^^ IdentifierKeyword
+//           ^ Identifier
+//             ^ IdentifierOperator
+//               ^^ NumericLiteral
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__xml.xml.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__xml.xml.snap
@@ -3,22 +3,63 @@ source: crates/sg-syntax/src/sg_sciptect.rs
 expression: "dump_document(&document, &contents)"
 ---
   <?xml version="1.0" encoding="UTF-8"?>
+//^^ PunctuationBracket
+//             ^ PunctuationBracket
 //              ^^^^^ StringLiteral
+//                            ^ PunctuationBracket
 //                             ^^^^^^^ StringLiteral
+//                                    ^^ PunctuationBracket
   <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+//^ PunctuationBracket
+//              ^ PunctuationBracket
 //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//                                                        ^ PunctuationBracket
+//                                                            ^ PunctuationBracket
 //                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
            xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+//            ^ PunctuationBracket
+//                           ^ PunctuationBracket
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
+//                                                                                                           ^ PunctuationBracket
       <modelVersion>4.0.0</modelVersion>
+//    ^ PunctuationBracket
+//                 ^ PunctuationBracket
+//                       ^^ PunctuationBracket
+//                                     ^ PunctuationBracket
       <groupId>com.macro.mall</groupId>
+//    ^ PunctuationBracket
+//            ^ PunctuationBracket
+//                           ^^ PunctuationBracket
+//                                    ^ PunctuationBracket
       <build>
+//    ^ PunctuationBracket
+//          ^ PunctuationBracket
           <plugins>
+//        ^ PunctuationBracket
+//                ^ PunctuationBracket
               <plugin>
+//            ^ PunctuationBracket
+//                   ^ PunctuationBracket
                   <groupId>org.springframework.boot</groupId>
+//                ^ PunctuationBracket
+//                        ^ PunctuationBracket
+//                                                 ^^ PunctuationBracket
+//                                                          ^ PunctuationBracket
                   <artifactId>spring-boot-maven-plugin</artifactId>
+//                ^ PunctuationBracket
+//                           ^ PunctuationBracket
+//                                                    ^^ PunctuationBracket
+//                                                                ^ PunctuationBracket
               </plugin>
+//            ^^ PunctuationBracket
+//                    ^ PunctuationBracket
           </plugins>
+//        ^^ PunctuationBracket
+//                 ^ PunctuationBracket
       </build>
+//    ^^ PunctuationBracket
+//           ^ PunctuationBracket
   </project>
+//^^ PunctuationBracket
+//         ^ PunctuationBracket
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__yaml.yaml.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_sciptect__test__.__yaml.yaml.snap
@@ -3,62 +3,108 @@ source: crates/sg-syntax/src/sg_sciptect.rs
 expression: "dump_document(&document, &contents)"
 ---
   ---
+  name: hello
+//^^^^ StringLiteralKey
+//    ^ PunctuationBracket
+//      ^^^^^ StringLiteral
   json:
-//^^^^ StringLiteral
+//^^^^ StringLiteralKey
+//    ^ PunctuationBracket
   - rigid
+//^ PunctuationBracket
 //  ^^^^^ StringLiteral
   - better for data interchange
+//^ PunctuationBracket
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
   yaml:
-//^^^^ StringLiteral
+//^^^^ StringLiteralKey
+//    ^ PunctuationBracket
   - slim and flexible
+//^ PunctuationBracket
 //  ^^^^^^^^^^^^^^^^^ StringLiteral
   - better for configuration
+//^ PunctuationBracket
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
   object:
-//^^^^^^ StringLiteral
+//^^^^^^ StringLiteralKey
+//      ^ PunctuationBracket
     key: value
-//  ^^^ StringLiteral
+//  ^^^ StringLiteralKey
+//     ^ PunctuationBracket
 //       ^^^^^ StringLiteral
     array:
-//  ^^^^^ StringLiteral
+//  ^^^^^ StringLiteralKey
+//       ^ PunctuationBracket
+    - array_value: [1,2,3]
+//  ^ PunctuationBracket
+//    ^^^^^^^^^^^ StringLiteralKey
+//               ^ PunctuationBracket
+//                 ^ PunctuationBracket
+//                  ^ NumericLiteral
+//                   ^ PunctuationBracket
+//                    ^ NumericLiteral
+//                     ^ PunctuationBracket
+//                      ^ NumericLiteral
+//                       ^ PunctuationBracket
     - null_value:
-//    ^^^^^^^^^^ StringLiteral
+//  ^ PunctuationBracket
+//    ^^^^^^^^^^ StringLiteralKey
+//              ^ PunctuationBracket
     - boolean: true
-//    ^^^^^^^ StringLiteral
+//  ^ PunctuationBracket
+//    ^^^^^^^ StringLiteralKey
+//           ^ PunctuationBracket
 //             ^^^^ IdentifierBuiltin
     - integer: 1
-//    ^^^^^^^ StringLiteral
+//  ^ PunctuationBracket
+//    ^^^^^^^ StringLiteralKey
+//           ^ PunctuationBracket
 //             ^ NumericLiteral
     - alias: aliases are like variables
-//    ^^^^^ StringLiteral
+//  ^ PunctuationBracket
+//    ^^^^^ StringLiteralKey
+//         ^ PunctuationBracket
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
     - alias: aliases are like variables
-//    ^^^^^ StringLiteral
+//  ^ PunctuationBracket
+//    ^^^^^ StringLiteralKey
+//         ^ PunctuationBracket
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^ StringLiteral
   paragraph: |
-//^^^^^^^^^ StringLiteral
+//^^^^^^^^^ StringLiteralKey
+//         ^ PunctuationBracket
 //           ^ IdentifierKeyword
     Blank lines denote
-//^^^^^^^^^^^^^^^^^^^^ StringLiteral 16:0..18:0
+//^^^^^^^^^^^^^^^^^^^^ StringLiteral 18:0..20:0
     paragraph breaks
   content: |-
-//^^^^^^^ StringLiteral
+//^^^^^^^ StringLiteralKey
+//       ^ PunctuationBracket
 //         ^ IdentifierKeyword
 //          ^ IdentifierKeyword
     Or we
-//^^^^^^^ StringLiteral 19:0..23:0
+//^^^^^^^ StringLiteral 21:0..25:0
     can auto
     convert line breaks
     to save space
   alias:
-//^^^^^ StringLiteral
-    bar: baz
-//  ^^^ StringLiteral
-//       ^^^ StringLiteral
+//^^^^^ StringLiteralKey
+//     ^ PunctuationBracket
+    - "media/**"
+//  ^ PunctuationBracket
+//    ^^^^^^^^^^ StringLiteral
+  jobs:
+//^^^^ StringLiteralKey
+//    ^ PunctuationBracket
+  bar: baz
+//^^^ StringLiteralKey
+//   ^ PunctuationBracket
+//     ^^^ StringLiteral
   alias_reuse:
-//^^^^^^^^^^^ StringLiteral
+//^^^^^^^^^^^ StringLiteralKey
+//           ^ PunctuationBracket
     bar: baz
-//  ^^^ StringLiteral
+//  ^^^ StringLiteralKey
+//     ^ PunctuationBracket
 //       ^^^ StringLiteral
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/3billiondevices.java
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/3billiondevices.java
@@ -1,22 +1,25 @@
-interface MyInterface 
-{ 
-     void abstract_func(int x,int y); 
- 
-     default void default_Fun() 
-    { 
-         System.out.println("This is default method"); 
-    } 
-} 
- 
-class Main 
-{ 
-     public static void main(String args[]) 
-    { 
+interface MyInterface
+{
+     void abstract_func(int x,int y);
+
+     default void default_Fun()
+    {
+         System.out.println("This is default method");
+    }
+}
+
+class Main
+{
+     public static void main(String args[])
+    {
         //lambda expression
-        MyInterface fobj = (int x, int y)->System.out.println(x+y); 
- 
+        MyInterface fobj = (int x, int y)->System.out.println(x+y);
+
         System.out.print("The result = ");
-        fobj.abstract_func(5,5); 
+        fobj.abstract_func(5,5);
         fobj.default_Fun();
-    } 
+    }
+    String format(String x) {
+        return x;
+    }
 }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/func.go
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/func.go
@@ -28,12 +28,12 @@ this is my poem` + aString
 	var null_was_a_mistake *int
 	null_was_a_mistake = nil
 
-	foo := &Foo {
-		x: 42,
-		Bar: Bar {
+	foo := &Foo{
+		x: &x,
+		Bar: Bar{
 			z: 43,
 		},
 	}
 
-	fmt.Println(x, char, string, bool, null_was_a_mistake)
+	fmt.Println(x, char, aString, bool, null_was_a_mistake, foo, multilineString)
 }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/func.go
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/func.go
@@ -2,6 +2,18 @@ package main
 
 import "fmt"
 
+type Bar struct {
+	z int
+}
+
+type Foo struct {
+	x *int
+	Y string
+	Bar
+	Bar2 Bar
+	Bar3 *Bar
+}
+
 func main() {
 	// this is comment
 
@@ -15,6 +27,13 @@ this is my poem` + aString
 
 	var null_was_a_mistake *int
 	null_was_a_mistake = nil
+
+	foo := &Foo {
+		x: 42
+		Bar: Bar {
+			z: 43
+		}
+	}
 
 	fmt.Println(x, char, string, bool, null_was_a_mistake)
 }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/func.go
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/func.go
@@ -29,10 +29,10 @@ this is my poem` + aString
 	null_was_a_mistake = nil
 
 	foo := &Foo {
-		x: 42
+		x: 42,
 		Bar: Bar {
-			z: 43
-		}
+			z: 43,
+		},
 	}
 
 	fmt.Println(x, char, string, bool, null_was_a_mistake)

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/sql.sql
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/sql.sql
@@ -1,0 +1,22 @@
+WITH event_log_stats AS (
+    SELECT
+        NULLIF(COUNT(*) FILTER (WHERE name IN ('ViewCodeMonitoringPage', 'CodeMonitoringPageViewed')), 0) :: INT AS code_monitoring_page_views,
+    FROM event_logs
+    WHERE
+        name IN (
+            -- The events that share a line are events that changed names and are aliases of each other
+            'CodeMonitoringLogsPageViewed'
+        )
+)
+SELECT
+    event_log_stats.code_monitoring_page_views,
+    event_log_stats.create_code_monitor_page_views,
+    trigger_jobs.p90_trigger_run_time
+FROM
+    event_log_stats,
+    email_actions,
+    slack_actions,
+    webhook_actions,
+    action_jobs,
+    trigger_jobs
+;

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/typescript.ts
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/typescript.ts
@@ -1,11 +1,11 @@
-class MyClass {
+export class MyClass {
   public static myValue: string;
   constructor(init: string) {
     this.myValue = init;
   }
 }
 import fs = require("fs");
-module MyModule {
+declare module MyModule {
   export interface MyInterface extends Other {
     myProperty: any;
   }
@@ -13,6 +13,26 @@ module MyModule {
 declare magicNumber number;
 myArray.forEach(() => { }); // fat arrow syntax
 const oneOf = (a:number): number => a + 1
-export const x = 42
-export let y = 42
-export var z = 42
+export const a = 42
+export let b = 42
+export var c = 42
+export var d1 = {e2:41}
+export var d = {
+    key1: 1,
+    key2: null,
+    key3: `abc${d1.e2}`,
+}
+export var e = Object.keys(d) as MyClass
+export function f() {}
+
+const negatedFilterToNegatableFilter: { [key: string]: MyClass } = null as any
+
+const scanToken = <T extends Term = Literal>(
+    regexp: RegExp,
+    output?: T | ((input: string, range: CharacterRange) => T),
+    expected?: string
+): Parser<T> => {
+    if (!regexp.source.startsWith('^')) {
+        regexp = new RegExp(`^${regexp.source}`, regexp.flags)
+    }
+}

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/typescript.ts
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/typescript.ts
@@ -12,3 +12,7 @@ module MyModule {
 }
 declare magicNumber number;
 myArray.forEach(() => { }); // fat arrow syntax
+const oneOf = (a:number): number => a + 1
+export const x = 42
+export let y = 42
+export var z = 42

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/typescript.ts
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/typescript.ts
@@ -8,6 +8,7 @@ import fs = require("fs");
 declare module MyModule {
   export interface MyInterface extends Other {
     myProperty: any;
+    myKeyoff: keyof MyClass;
   }
 }
 declare magicNumber number;
@@ -36,3 +37,5 @@ const scanToken = <T extends Term = Literal>(
         regexp = new RegExp(`^${regexp.source}`, regexp.flags)
     }
 }
+
+export const URI: typeof URL

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/yaml.yaml
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/syntect_files/yaml.yaml
@@ -1,4 +1,5 @@
 ---
+name: hello
 json:
 - rigid
 - better for data interchange
@@ -8,6 +9,7 @@ yaml:
 object:
   key: value
   array:
+  - array_value: [1,2,3]
   - null_value:
   - boolean: true
   - integer: 1
@@ -22,6 +24,8 @@ content: |-
   convert line breaks
   to save space
 alias:
-  bar: baz
+  - "media/**"
+jobs:
+bar: baz
 alias_reuse:
   bar: baz


### PR DESCRIPTION
Towards https://github.com/sourcegraph/sourcegraph/issues/40551.

This is the first conscious effort to close the gap on syntax highlighting colors between the old and new blob view. This
commit only addressed the most obvious differences for Go, TypeScript, JSON and YAML. There are other differences that will need to be addressed separately.

## Test plan
Open a Go, TypeScript, YAML, and JSON file and manually verify that the colors are improved by this PR.

## App preview:

- [Web](https://sg-web-olafurpg-cm-pretty.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vugtgztzxa.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

