### PR TITLE
batches: disable autoplay for SSBC demo video

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.tsx
@@ -49,9 +49,9 @@ export const RunServerSideModal: React.FunctionComponent<RunServerSideModalProps
                     playsInline={true}
                     controls={false}
                 >
-                    {/* TODO: Accessibility improvement - Add caption for video */}
                     <source type="video/webm" src="https://storage.googleapis.com/sourcegraph-assets/ssbc_demo.webm" />
                     <source type="video/mp4" src="https://storage.googleapis.com/sourcegraph-assets/ssbc_demo.mp4" />
+                    {/* TODO: Accessibility improvement - Add caption for video */}
                 </video>
             </div>
             <div className={styles.right}>

--- a/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.tsx
@@ -43,9 +43,9 @@ export const RunServerSideModal: React.FunctionComponent<RunServerSideModalProps
                     className="w-100 h-auto shadow percy-hide"
                     width={1280}
                     height={720}
-                    autoPlay={true}
-                    muted={true}
-                    loop={true}
+                    autoPlay={false}
+                    muted={false}
+                    loop={false}
                     playsInline={true}
                     controls={false}
                 >

--- a/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.tsx
@@ -49,6 +49,7 @@ export const RunServerSideModal: React.FunctionComponent<RunServerSideModalProps
                     playsInline={true}
                     controls={false}
                 >
+                    {/* TODO: Accessibility improvement - Add caption for video */}
                     <source type="video/webm" src="https://storage.googleapis.com/sourcegraph-assets/ssbc_demo.webm" />
                     <source type="video/mp4" src="https://storage.googleapis.com/sourcegraph-assets/ssbc_demo.mp4" />
                 </video>


### PR DESCRIPTION
This PR disables autoplay for the SSBC demo video. Autoplaying [media isn't a good approach for accessibility](https://www.boia.org/blog/why-autoplay-is-an-accessibility-no-no#:~:text=Under%20WCAG%20guidelines%2C%20any%20media,sounds%2C%20and%20other%20possible%20triggers.).

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Ensure video works as normal and does not autoplay when loaded

## App preview:

- [Web](https://sg-web-bo-make-ssbc-demo-video-not.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bktlwsclsc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
