### PR TITLE
Reclone repo after 3 failed sgm runs by default

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -103,11 +103,12 @@ var sgmLogExpire = env.MustGetDuration("SRC_GIT_LOG_FILE_EXPIRY", 24*time.Hour, 
 
 // Each failed sg maintenance run increments a counter in the sgmLog file.
 // We reclone the repository if the number of retries exceeds sgmRetries.
-// Setting SRC_SGM_RETRIES to -1 (default) disables the limit.
+// Setting SRC_SGM_RETRIES to -1 disables recloning due to sgm failures.
+// Default value is 3 (reclone after 3 failed sgm runs).
 //
 // We mention this ENV variable in the header message of the sgmLog files. Make
 // sure that changes here are reflected in sgmLogHeader, too.
-var sgmRetries, _ = strconv.Atoi(env.Get("SRC_SGM_RETRIES", "-1", "the maximum number of times we retry sg maintenance before triggering a reclone."))
+var sgmRetries, _ = strconv.Atoi(env.Get("SRC_SGM_RETRIES", "3", "the maximum number of times we retry sg maintenance before triggering a reclone."))
 
 // The limit of repos cloned on the wrong shard to delete in one janitor run - value <=0 disables delete.
 var wrongShardReposDeleteLimit, _ = strconv.Atoi(env.Get("SRC_WRONG_SHARD_DELETE_LIMIT", "10", "the maximum number of repos not assigned to this shard we delete in one run"))


### PR DESCRIPTION
Currently, recloning after sgm failures is disabled y default, and can be modified by setting the `SRC_SGM_RETRIES` env variable. This leads to situations by default where sgm will not reclone a repo even after several failed sgm runs, leaving repos in potentially corrupted states forever. I've set the default to 3 failed sgm runs before reclone, and the reclones can still be disabled by setting `SRC_SGM_RETRIES` to -1 if desired.


## Test plan
Just a default value change, N/A.