### PR TITLE
client/opentelemetry: properly create endpoint URLs

### DIFF
--- a/client/web/src/monitoring/opentelemetry/initOpenTelemetry.ts
+++ b/client/web/src/monitoring/opentelemetry/initOpenTelemetry.ts
@@ -32,11 +32,11 @@ export function initOpenTelemetry(): void {
 
         const url = isAbsoluteUrl(openTelemetry.endpoint)
             ? openTelemetry.endpoint
-            : `${externalURL}/${openTelemetry.endpoint}`
+            : new URL(openTelemetry.endpoint, externalURL).toString()
 
         // As per spec non-signal-specific configuration should have signal-specific paths appended.
         // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#endpoint-urls-for-otlphttp
-        const collectorExporter = new OTLPTraceExporter({ url: url + '/v1/traces' })
+        const collectorExporter = new OTLPTraceExporter({ url: new URL('/v1/traces', url).toString() })
 
         provider.addSpanProcessor(new BatchSpanProcessor(collectorExporter))
         provider.addSpanProcessor(new SharedSpanStoreProcessor())


### PR DESCRIPTION
This should negate the need for ` "endpoint": "-/debug/otlp"` which is a bit confusing to read 😬 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
  "observability.client": {
    "openTelemetry": {
      "endpoint": "/-/debug/otlp"
    }
  },
```

## App preview:

- [Web](https://sg-web-web-opentelemetry-url.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pukwvoyary.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
