### PR TITLE
batches: hide scrollbar on tab bar

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/TabBar.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.module.scss
@@ -6,7 +6,7 @@
     margin-bottom: 0;
     list-style: none;
     max-width: 100%;
-    overflow-x: scroll;
+    overflow-x: auto;
     // This prevents the active item border from being cut off, since .nav-item applies margin-bottom: -1px;
     // stylelint-disable-next-line declaration-property-unit-allowed-list
     padding-bottom: 1px;


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39808.

Gets rid of the weird border line underneath the 4 steps tab bar on the Batch Change "create" page and SSBC workflow pages, which turned out to be a disabled scrollbar.

Before | After
:-------:|:-----:
<img width="632" alt="Screen Shot 2022-08-19 at 6 42 39 PM" src="https://user-images.githubusercontent.com/8942601/185724524-c83359da-cc55-4a25-805f-da6a0b286948.png"> | <img width="626" alt="Screen Shot 2022-08-19 at 6 43 11 PM" src="https://user-images.githubusercontent.com/8942601/185724526-e09417bb-777f-439d-9977-8e6a0c1477d6.png">


To answer your inevitable questions about this change:

- No, I don't know why we had this set to `scroll` originally. There's no good reason to ever set `overflow: scroll.`
- No, I don't know why Randell/Daniel saw the scrollbar in any browser, at any window size but Erik and myself didn't see it in any browser, at any window size. Best guess is that it's a manifestation of a MacOS "automatic" scrollbar setting behaving differently on different machines.

In short, 🤷‍♀️

## Test plan

1. Be Randell/Daniel. Or if you're not so blessed, on MacOS, go to System Preferences > General and set scrollbar visibility to "Always"
2. Visit /batch-changes/create
3. Observe lack of scrollbar 👍
4. Resize window width until the tabs no longer fit
5. Observe scrollbar 👍

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-no-scrollbar-pls.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fdfnjaqhcx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
