### PR TITLE
oobmigrations: Feed store factory through register functions

### DIFF
--- a/cmd/migrator/shared/main.go
+++ b/cmd/migrator/shared/main.go
@@ -30,7 +30,7 @@ var out = output.NewOutput(os.Stdout, output.OutputOpts{
 	ForceTTY:   true,
 })
 
-func Start(logger log.Logger, registerEnterpriseMigrators registerMigratorsFromConfAndStoreFactoryFunc) error {
+func Start(logger log.Logger, registerEnterpriseMigrators registerMigratorsUsingConfAndStoreFactoryFunc) error {
 	observationContext := &observation.Context{
 		Logger:     logger,
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},

--- a/cmd/migrator/shared/main.go
+++ b/cmd/migrator/shared/main.go
@@ -30,7 +30,7 @@ var out = output.NewOutput(os.Stdout, output.OutputOpts{
 	ForceTTY:   true,
 })
 
-func Start(logger log.Logger, registerEnterpriseMigrations registerMigratorsFromConfFunc) error {
+func Start(logger log.Logger, registerEnterpriseMigrators registerMigratorsFromConfAndStoreFactoryFunc) error {
 	observationContext := &observation.Context{
 		Logger:     logger,
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
@@ -73,8 +73,8 @@ func Start(logger log.Logger, registerEnterpriseMigrations registerMigratorsFrom
 			cliutil.AddLog(logger, appName, newRunner, outputFactory),
 			cliutil.Upgrade(logger, appName, newRunnerWithSchemas, outputFactory),
 			cliutil.RunOutOfBandMigrations(logger, appName, newRunner, outputFactory, composeRegisterMigratorsFuncs(
-				ossmigrations.RegisterOSSMigrationsFromConfig,
-				registerEnterpriseMigrations,
+				ossmigrations.RegisterOSSMigratorsUsingConfAndStoreFactory,
+				registerEnterpriseMigrators,
 			)),
 		},
 	}

--- a/cmd/migrator/shared/registration.go
+++ b/cmd/migrator/shared/registration.go
@@ -6,31 +6,35 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration/migrations"
 )
 
-type registerMigratorsFromConfFunc func(
+type registerMigratorsFromConfAndStoreFactoryFunc func(
 	ctx context.Context,
 	db database.DB,
 	runner *oobmigration.Runner,
 	conf conftypes.UnifiedQuerier,
+	storeFactory migrations.StoreFactory,
 ) error
 
-func composeRegisterMigratorsFuncs(fnsFromConfig ...registerMigratorsFromConfFunc) oobmigration.RegisterMigratorsFunc {
-	return func(ctx context.Context, db database.DB, runner *oobmigration.Runner) error {
-		conf, err := newStaticConf(ctx, db)
-		if err != nil {
-			return err
+func composeRegisterMigratorsFuncs(fnsFromConfAndStoreFactory ...registerMigratorsFromConfAndStoreFactoryFunc) func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc {
+	return func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc {
+		return func(ctx context.Context, db database.DB, runner *oobmigration.Runner) error {
+			conf, err := newStaticConf(ctx, db)
+			if err != nil {
+				return err
+			}
+
+			fns := make([]oobmigration.RegisterMigratorsFunc, 0, len(fnsFromConfAndStoreFactory))
+			for _, f := range fnsFromConfAndStoreFactory {
+				f := f // avoid loop capture
+
+				fns = append(fns, func(ctx context.Context, db database.DB, runner *oobmigration.Runner) error {
+					return f(ctx, db, runner, conf, storeFactory)
+				})
+			}
+
+			return oobmigration.ComposeRegisterMigratorsFuncs(fns...)(ctx, db, runner)
 		}
-
-		fns := make([]oobmigration.RegisterMigratorsFunc, 0, len(fnsFromConfig))
-		for _, f := range fnsFromConfig {
-			f := f // avoid loop capture
-
-			fns = append(fns, func(ctx context.Context, db database.DB, runner *oobmigration.Runner) error {
-				return f(ctx, db, runner, conf)
-			})
-		}
-
-		return oobmigration.ComposeRegisterMigratorsFuncs(fns...)(ctx, db, runner)
 	}
 }

--- a/cmd/migrator/shared/registration.go
+++ b/cmd/migrator/shared/registration.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration/migrations"
 )
 
-type registerMigratorsFromConfAndStoreFactoryFunc func(
+type registerMigratorsUsingConfAndStoreFactoryFunc func(
 	ctx context.Context,
 	db database.DB,
 	runner *oobmigration.Runner,
@@ -17,7 +17,7 @@ type registerMigratorsFromConfAndStoreFactoryFunc func(
 	storeFactory migrations.StoreFactory,
 ) error
 
-func composeRegisterMigratorsFuncs(fnsFromConfAndStoreFactory ...registerMigratorsFromConfAndStoreFactoryFunc) func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc {
+func composeRegisterMigratorsFuncs(fnsFromConfAndStoreFactory ...registerMigratorsUsingConfAndStoreFactoryFunc) func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc {
 	return func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc {
 		return func(ctx context.Context, db database.DB, runner *oobmigration.Runner) error {
 			conf, err := newStaticConf(ctx, db)

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -38,11 +38,11 @@ const addr = ":3189"
 
 // Start runs the worker.
 func Start(logger log.Logger, additionalJobs map[string]job.Job, registerEnterpriseMigrators oobmigration.RegisterMigratorsFunc) error {
-	registerMigratiors := oobmigration.ComposeRegisterMigratorsFuncs(migrations.RegisterOSSMigrators, registerEnterpriseMigrators)
+	registerMigrators := oobmigration.ComposeRegisterMigratorsFuncs(migrations.RegisterOSSMigrators, registerEnterpriseMigrators)
 
 	builtins := map[string]job.Job{
 		"webhook-log-janitor":                   webhooks.NewJanitor(),
-		"out-of-band-migrations":                workermigrations.NewMigrator(registerMigratiors),
+		"out-of-band-migrations":                workermigrations.NewMigrator(registerMigrators),
 		"codeintel-documents-indexer":           codeintel.NewDocumentsIndexerJob(),
 		"codeintel-policies-repository-matcher": codeintel.NewPoliciesRepositoryMatcherJob(),
 		"gitserver-metrics":                     gitserver.NewMetricsJob(),

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -37,12 +37,12 @@ import (
 const addr = ":3189"
 
 // Start runs the worker.
-func Start(logger log.Logger, additionalJobs map[string]job.Job, registerEnterpriseMigrations oobmigration.RegisterMigratorsFunc) error {
-	registerMigrations := oobmigration.ComposeRegisterMigratorsFuncs(migrations.RegisterOSSMigrations, registerEnterpriseMigrations)
+func Start(logger log.Logger, additionalJobs map[string]job.Job, registerEnterpriseMigrators oobmigration.RegisterMigratorsFunc) error {
+	registerMigratiors := oobmigration.ComposeRegisterMigratorsFuncs(migrations.RegisterOSSMigrators, registerEnterpriseMigrators)
 
 	builtins := map[string]job.Job{
 		"webhook-log-janitor":                   webhooks.NewJanitor(),
-		"out-of-band-migrations":                workermigrations.NewMigrator(registerMigrations),
+		"out-of-band-migrations":                workermigrations.NewMigrator(registerMigratiors),
 		"codeintel-documents-indexer":           codeintel.NewDocumentsIndexerJob(),
 		"codeintel-policies-repository-matcher": codeintel.NewPoliciesRepositoryMatcherJob(),
 		"gitserver-metrics":                     gitserver.NewMetricsJob(),

--- a/enterprise/cmd/migrator/main.go
+++ b/enterprise/cmd/migrator/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	logger := log.Scoped("migrator", "migrator enterprise edition")
 
-	if err := shared.Start(logger, migrations.RegisterEnterpriseMigrationsFromConfig); err != nil {
+	if err := shared.Start(logger, migrations.RegisterEnterpriseMigratorsUsingConfAndStoreFactory); err != nil {
 		logger.Fatal(err.Error())
 	}
 }

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -70,7 +70,7 @@ func main() {
 		"codeintel-auto-indexing": codeintel.NewIndexingJob(),
 	}
 
-	if err := shared.Start(logger, additionalJobs, migrations.RegisterEnterpriseMigrations); err != nil {
+	if err := shared.Start(logger, additionalJobs, migrations.RegisterEnterpriseMigrators); err != nil {
 		logger.Fatal(err.Error())
 	}
 }

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration/migrations"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -19,7 +20,7 @@ func RunOutOfBandMigrations(
 	commandName string,
 	runnerFactory RunnerFactory,
 	outFactory OutputFactory,
-	register oobmigration.RegisterMigratorsFunc,
+	register func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc,
 ) *cli.Command {
 	idFlag := &cli.IntFlag{
 		Name:     "id",
@@ -41,7 +42,7 @@ func RunOutOfBandMigrations(
 		if err := runner.SynchronizeMetadata(ctx); err != nil {
 			return err
 		}
-		if err := register(ctx, db, runner); err != nil {
+		if err := register(nil)(ctx, db, runner); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This is a refactor step towards #39578. This PR adds a currently un-utilized parameter to the oob migration runner registration functions used by the worker/migrator init sequence.

## Test plan

Existing CI pipelines.