### PR TITLE
sg: Remove `migration upgrade` subcommand

### DIFF
--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -118,7 +118,6 @@ var (
 	describeCommand = cliutil.Describe("sg migration", makeRunner, outputFactory)
 	driftCommand    = cliutil.Drift("sg migration", makeRunner, outputFactory, cliutil.GCSExpectedSchemaFactory, localGitExpectedSchemaFactory)
 	addLogCommand   = cliutil.AddLog(logger, "sg migration", makeRunner, outputFactory)
-	upgradeCommand  = cliutil.Upgrade(logger, "sg migration", makeRunnerWithSchemas, outputFactory)
 
 	leavesCommand = &cli.Command{
 		Name:        "leaves",

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -191,7 +191,6 @@ sg migration squash
 			describeCommand,
 			driftCommand,
 			addLogCommand,
-			upgradeCommand,
 			leavesCommand,
 			squashCommand,
 			squashAllCommand,

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -713,18 +713,6 @@ Flags:
 * `--up`: The migration direction.
 * `--version="<value>"`: The migration `version` to log. (default: 0)
 
-### sg migration upgrade
-
-Upgrade Sourcegraph instance databases to a target version.
-
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a Github discussion
-* `--from="<value>"`: The source (current) instance version. Must be of the form `v{Major}.{Minor}`.
-* `--skip-version-check`: Skip validation of the instance's current version.
-* `--to="<value>"`: The target instance version. Must be of the form `v{Major}.{Minor}`.
-
 ### sg migration leaves
 
 Identify the migration leaves for the given commit.


### PR DESCRIPTION
Remove this subcommand from `sg` as it only makes sense from `migrator` at the moment.

## Test plan

N/A.