### PR TITLE
upgrade: Feed oobmigration register function to upgrade command

### DIFF
--- a/cmd/migrator/shared/main.go
+++ b/cmd/migrator/shared/main.go
@@ -61,7 +61,7 @@ func Start(logger log.Logger, registerEnterpriseMigrators registerMigratorsUsing
 
 	registerMigrators := composeRegisterMigratorsFuncs(
 		ossmigrations.RegisterOSSMigratorsUsingConfAndStoreFactory,
-		registerEnterpriseMigrations,
+		registerEnterpriseMigrators,
 	)
 
 	command := &cli.App{

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -118,7 +118,7 @@ var (
 	describeCommand = cliutil.Describe("sg migration", makeRunner, outputFactory)
 	driftCommand    = cliutil.Drift("sg migration", makeRunner, outputFactory, cliutil.GCSExpectedSchemaFactory, localGitExpectedSchemaFactory)
 	addLogCommand   = cliutil.AddLog(logger, "sg migration", makeRunner, outputFactory)
-	upgradeCommand  = cliutil.Upgrade(logger, "sg migration", makeRunnerWithSchemas, outputFactory)
+	upgradeCommand  = cliutil.Upgrade(logger, "sg migration", makeRunnerWithSchemas, outputFactory, nil)
 
 	leavesCommand = &cli.Command{
 		Name:        "leaves",

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -19,7 +19,7 @@ func RunOutOfBandMigrations(
 	commandName string,
 	runnerFactory RunnerFactory,
 	outFactory OutputFactory,
-	register oobmigration.RegisterMigratorsFunc,
+	registerMigrators oobmigration.RegisterMigratorsFunc,
 ) *cli.Command {
 	idFlag := &cli.IntFlag{
 		Name:     "id",
@@ -41,7 +41,7 @@ func RunOutOfBandMigrations(
 		if err := runner.SynchronizeMetadata(ctx); err != nil {
 			return err
 		}
-		if err := register(ctx, db, runner); err != nil {
+		if err := registerMigrators(ctx, db, runner); err != nil {
 			return err
 		}
 

--- a/internal/database/migration/cliutil/upgrade.go
+++ b/internal/database/migration/cliutil/upgrade.go
@@ -11,7 +11,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func Upgrade(logger log.Logger, commandName string, runnerFactory RunnerFactoryWithSchemas, outFactory OutputFactory) *cli.Command {
+func Upgrade(
+	logger log.Logger,
+	commandName string,
+	runnerFactory RunnerFactoryWithSchemas,
+	outFactory OutputFactory,
+	registerMigrators oobmigration.RegisterMigratorsFunc,
+) *cli.Command {
 	fromFlag := &cli.StringFlag{
 		Name:     "from",
 		Usage:    "The source (current) instance version. Must be of the form `v{Major}.{Minor}`.",

--- a/internal/database/migration/cliutil/upgrade.go
+++ b/internal/database/migration/cliutil/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration/migrations"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -16,7 +17,7 @@ func Upgrade(
 	commandName string,
 	runnerFactory RunnerFactoryWithSchemas,
 	outFactory OutputFactory,
-	registerMigrators oobmigration.RegisterMigratorsFunc,
+	registerMigrators func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc,
 ) *cli.Command {
 	fromFlag := &cli.StringFlag{
 		Name:     "from",


### PR DESCRIPTION
This is a refactor step towards #39578. This PR adds a currently un-utilized parameter to the upgrade subcommand that will be used to initialize the oobmigration runner.

## Test plan

Existing CI pipelines.