### PR TITLE
oobmigration: Set minimum delay when registering with conf

### DIFF
--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -39,7 +39,7 @@ func RegisterEnterpriseMigrations(ctx context.Context, db database.DB, runner *o
 
 	keyring := keyring.Default()
 
-	return registerEnterpriseMigrations(runner, dependencies{
+	return registerEnterpriseMigrations(runner, false, dependencies{
 		store:          basestore.NewWithHandle(db.Handle()),
 		codeIntelStore: basestore.NewWithHandle(basestore.NewHandleWithDB(codeIntelDB, sql.TxOptions{})),
 		insightsStore:  insightsStore,
@@ -79,7 +79,7 @@ func RegisterEnterpriseMigrationsFromConfig(ctx context.Context, db database.DB,
 		keys = &keyring.Ring{}
 	}
 
-	return registerEnterpriseMigrations(runner, dependencies{
+	return registerEnterpriseMigrations(runner, true, dependencies{
 		store:          basestore.NewWithHandle(db.Handle()),
 		codeIntelStore: basestore.NewWithHandle(basestore.NewHandleWithDB(codeIntelDB, sql.TxOptions{})),
 		insightsStore:  insightsStore,
@@ -94,7 +94,7 @@ type dependencies struct {
 	keyring        *keyring.Ring
 }
 
-func registerEnterpriseMigrations(runner *oobmigration.Runner, deps dependencies) error {
+func registerEnterpriseMigrations(runner *oobmigration.Runner, noDelay bool, deps dependencies) error {
 	var insightsMigrator migrations.TaggedMigrator
 	if deps.insightsStore != nil {
 		insightsMigrator = insights.NewMigrator(deps.store, deps.insightsStore)
@@ -102,7 +102,7 @@ func registerEnterpriseMigrations(runner *oobmigration.Runner, deps dependencies
 		insightsMigrator = insights.NewMigratorNoOp()
 	}
 
-	return migrations.RegisterAll(runner, []migrations.TaggedMigrator{
+	return migrations.RegisterAll(runner, noDelay, []migrations.TaggedMigrator{
 		iam.NewSubscriptionAccountNumberMigrator(deps.store, 500),
 		iam.NewLicenseKeyFieldsMigrator(deps.store, 500),
 		batches.NewSSHMigratorWithDB(deps.store, deps.keyring.BatchChangesCredentialKey, 5),

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -40,7 +40,6 @@ func RegisterEnterpriseMigrators(ctx context.Context, db database.DB, runner *oo
 	keyring := keyring.Default()
 
 	return registerEnterpriseMigrators(runner, false, dependencies{
-	return registerEnterpriseMigrators(runner, dependencies{
 		store:          basestore.NewWithHandle(db.Handle()),
 		codeIntelStore: basestore.NewWithHandle(basestore.NewHandleWithDB(codeIntelDB, sql.TxOptions{})),
 		insightsStore:  insightsStore,

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -86,7 +86,6 @@ func RegisterEnterpriseMigratorsUsingConfAndStoreFactory(
 	}
 
 	return registerEnterpriseMigrators(runner, true, dependencies{
-	return registerEnterpriseMigrators(runner, dependencies{
 		store:          basestore.NewWithHandle(db.Handle()),
 		codeIntelStore: basestore.NewWithHandle(basestore.NewHandleWithDB(codeIntelDB, sql.TxOptions{})),
 		insightsStore:  insightsStore,


### PR DESCRIPTION
This is a refactor step towards #39578. This PR sets the interval between migration runner up/down calls to a nanosecond (pass zero uses a default of 1s). The migrator will be the only caller constructing runners with a canned config/store factory, and there's no reason to delay migration runs in this scenario as there's no active instance to disrupt.

## Test plan

Existing CI pipelines.