### PR TITLE
upgrades: Raise error when version tag is unknown

### DIFF
--- a/internal/database/migration/cliutil/upgrade_planner.go
+++ b/internal/database/migration/cliutil/upgrade_planner.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/shared"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type upgradePlan struct {
@@ -114,8 +115,7 @@ func filterStitchedMigrationsForTags(tags []string) (map[string]shared.StitchedM
 		for _, tag := range tags {
 			bounds, ok := shared.StitchedMigationsBySchemaName[schemaName].BoundsByRev[tag]
 			if !ok {
-				// TODO
-				// return nil, errors.Newf("unknown tag %q", tag)
+				return nil, errors.Newf("unknown tag %q", tag)
 			}
 
 			boundsByRev[tag] = bounds

--- a/internal/database/migration/cliutil/upgrade_planner.go
+++ b/internal/database/migration/cliutil/upgrade_planner.go
@@ -112,7 +112,13 @@ func filterStitchedMigrationsForTags(tags []string) (map[string]shared.StitchedM
 	for _, schemaName := range schemas.SchemaNames {
 		boundsByRev := make(map[string]shared.MigrationBounds, len(tags))
 		for _, tag := range tags {
-			boundsByRev[tag] = shared.StitchedMigationsBySchemaName[schemaName].BoundsByRev[tag]
+			bounds, ok := shared.StitchedMigationsBySchemaName[schemaName].BoundsByRev[tag]
+			if !ok {
+				// TODO
+				// return nil, errors.Newf("unknown tag %q", tag)
+			}
+
+			boundsByRev[tag] = bounds
 		}
 
 		filteredStitchedMigrationBySchemaName[schemaName] = shared.StitchedMigration{


### PR DESCRIPTION
Ensure we throw an error into the user's face when they try to upgrade to `v4.GOBBLEDYGOOK.2`.

## Test plan

Locally ensured an error gets thrown into THIS user's face.