### PR TITLE
migrator: Fix nil reference in non-enterprise migrator

### DIFF
--- a/cmd/migrator/shared/registration.go
+++ b/cmd/migrator/shared/registration.go
@@ -28,6 +28,9 @@ func composeRegisterMigratorsFuncs(fnsFromConfAndStoreFactory ...registerMigrato
 			fns := make([]oobmigration.RegisterMigratorsFunc, 0, len(fnsFromConfAndStoreFactory))
 			for _, f := range fnsFromConfAndStoreFactory {
 				f := f // avoid loop capture
+				if f == nil {
+					continue
+				}
 
 				fns = append(fns, func(ctx context.Context, db database.DB, runner *oobmigration.Runner) error {
 					return f(ctx, db, runner, conf, storeFactory)


### PR DESCRIPTION
The function `oobmigration.ComposeRegisterMigratorsFuncs` (called below) checks this condition, but our wrapper here doesn't.

## Test plan

Tested locally.