### PR TITLE
migrator: Add -dry-run flag to upgrade command

### DIFF
--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -107,6 +107,9 @@ func runOutOfBandMigrations(
 	}
 	defer runner.Stop()
 
+	// TODO - need to query ids first
+	out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleReset, "Running out of band migrations %v", ids))
+
 	for range time.NewTicker(time.Second).C {
 		migrations, err := getMigrations()
 		if err != nil {

--- a/internal/database/migration/cliutil/upgrade.go
+++ b/internal/database/migration/cliutil/upgrade.go
@@ -64,36 +64,17 @@ func Upgrade(
 		if err != nil {
 			return err
 		}
-		if len(plan.steps) == 0 {
-			return errors.New("upgrade plan contains no steps")
-		}
 
-		if dryRunFlag.Get(cmd) {
-			for i, step := range plan.steps {
-				out.WriteLine(output.Linef(
-					output.EmojiFingerPointRight,
-					output.StyleReset,
-					"Migrating to v%s (step %d of %d)",
-					step.instanceVersion,
-					i+1,
-					len(plan.steps),
-				))
-
-				out.WriteLine(output.Line(output.EmojiFingerPointRight, output.StyleReset, "Running schema migrations"))
-
-				for schemaName, leafIDs := range step.schemaMigrationLeafIDsBySchemaName {
-					out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleReset, "%s -> %v", schemaName, leafIDs))
-				}
-
-				if len(step.outOfBandMigrationIDs) > 0 {
-					out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleReset, "Running out of band migrations %v", step.outOfBandMigrationIDs))
-				}
-
-			}
-		} else {
-			if err := runUpgrade(ctx, runnerFactory, plan, skipVersionCheckFlag.Get(cmd), registerMigrators, out); err != nil {
-				return err
-			}
+		if err := runUpgrade(
+			ctx,
+			runnerFactory,
+			plan,
+			skipVersionCheckFlag.Get(cmd),
+			dryRunFlag.Get(cmd),
+			registerMigrators,
+			out,
+		); err != nil {
+			return err
 		}
 
 		return nil

--- a/internal/database/migration/cliutil/upgrade_runner.go
+++ b/internal/database/migration/cliutil/upgrade_runner.go
@@ -18,9 +18,14 @@ func runUpgrade(
 	runnerFactory RunnerFactoryWithSchemas,
 	plan upgradePlan,
 	skipVersionCheck bool,
+	dryRun bool,
 	registerMigratorsWithStore func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc,
 	out *output.Output,
 ) error {
+	if len(plan.steps) == 0 {
+		return errors.New("upgrade plan contains no steps")
+	}
+
 	var runnerSchemas []*schemas.Schema
 	for _, schemaName := range schemas.SchemaNames {
 		runnerSchemas = append(runnerSchemas, &schemas.Schema{
@@ -66,23 +71,32 @@ func runUpgrade(
 		}
 
 		if len(step.outOfBandMigrationIDs) > 0 {
-			if err := runOutOfBandMigrations(ctx, db, registerMigrators, out, step.outOfBandMigrationIDs); err != nil {
+			if err := runOutOfBandMigrations(
+				ctx,
+				db,
+				dryRun,
+				registerMigrators,
+				out,
+				step.outOfBandMigrationIDs,
+			); err != nil {
 				return err
 			}
 		}
 
 		out.WriteLine(output.Line(output.EmojiFingerPointRight, output.StyleReset, "Running schema migrations"))
 
-		if err := r.Run(ctx, runner.Options{
-			Operations:           operations,
-			PrivilegedMode:       runner.ApplyPrivilegedMigrations,
-			PrivilegedHash:       "",
-			IgnoreSingleDirtyLog: false,
-		}); err != nil {
-			return err
-		}
+		if !dryRun {
+			if err := r.Run(ctx, runner.Options{
+				Operations:           operations,
+				PrivilegedMode:       runner.ApplyPrivilegedMigrations,
+				PrivilegedHash:       "",
+				IgnoreSingleDirtyLog: false,
+			}); err != nil {
+				return err
+			}
 
-		out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Schema migrations complete"))
+			out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Schema migrations complete"))
+		}
 	}
 
 	return nil

--- a/internal/database/migration/cliutil/upgrade_runner.go
+++ b/internal/database/migration/cliutil/upgrade_runner.go
@@ -21,10 +21,6 @@ func runUpgrade(
 	registerMigratorsWithStore func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc,
 	out *output.Output,
 ) error {
-	if len(plan.steps) == 0 {
-		return errors.New("upgrade plan contains no steps")
-	}
-
 	var runnerSchemas []*schemas.Schema
 	for _, schemaName := range schemas.SchemaNames {
 		runnerSchemas = append(runnerSchemas, &schemas.Schema{


### PR DESCRIPTION
This PR adds a `-dry-run` flag to the migrator upgrade command, which runs through the upgrade sequence to print steps but no-ops each step that affects the database.

## Test plan

Tested locally.