### PR TITLE
upgrade: Calculate correct upgrade interrupt versions

### DIFF
--- a/internal/database/migration/cliutil/upgrade_runner.go
+++ b/internal/database/migration/cliutil/upgrade_runner.go
@@ -70,19 +70,6 @@ func runUpgrade(
 			})
 		}
 
-		if len(step.outOfBandMigrationIDs) > 0 {
-			if err := runOutOfBandMigrations(
-				ctx,
-				db,
-				dryRun,
-				registerMigrators,
-				out,
-				step.outOfBandMigrationIDs,
-			); err != nil {
-				return err
-			}
-		}
-
 		out.WriteLine(output.Line(output.EmojiFingerPointRight, output.StyleReset, "Running schema migrations"))
 
 		if !dryRun {
@@ -94,8 +81,21 @@ func runUpgrade(
 			}); err != nil {
 				return err
 			}
+		}
 
-			out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Schema migrations complete"))
+		out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Schema migrations complete"))
+
+		if len(step.outOfBandMigrationIDs) > 0 {
+			if err := runOutOfBandMigrations(
+				ctx,
+				db,
+				dryRun,
+				registerMigrators,
+				out,
+				step.outOfBandMigrationIDs,
+			); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/oobmigration/upgrade_test.go
+++ b/internal/oobmigration/upgrade_test.go
@@ -33,12 +33,12 @@ func TestScheduleMigrationInterrupts(t *testing.T) {
 			from: NewVersion(3, 32),
 			to:   NewVersion(3, 44),
 			migrations: []yamlMigration{
-				// 1: [------]
-				// 2: .      . [------]
-				// 3: .      . .      . [------]
-				// 4: .      . .      . .      . [------]
+				// 1: [------)
+				// 2: .      . [------)
+				// 3: .      . .      . [------)
+				// 4: .      . .      . .      . [------)
 				//    32 33 34 35 36 37 38 39 40 41 42 43
-				//          **       **       **       **
+				//       **       **       **       **
 
 				migration(1 /* introduced = */, 3, 32 /* deprecated = */, 3, 34),
 				migration(2 /* introduced = */, 3, 35 /* deprecated = */, 3, 37),
@@ -46,10 +46,10 @@ func TestScheduleMigrationInterrupts(t *testing.T) {
 				migration(4 /* introduced = */, 3, 41 /* deprecated = */, 3, 43),
 			},
 			interrupts: []MigrationInterrupt{
-				{Version: Version{3, 34}, MigrationIDs: []int{1}},
-				{Version: Version{3, 37}, MigrationIDs: []int{2}},
-				{Version: Version{3, 40}, MigrationIDs: []int{3}},
-				{Version: Version{3, 43}, MigrationIDs: []int{4}},
+				{Version: Version{3, 33}, MigrationIDs: []int{1}},
+				{Version: Version{3, 36}, MigrationIDs: []int{2}},
+				{Version: Version{3, 39}, MigrationIDs: []int{3}},
+				{Version: Version{3, 42}, MigrationIDs: []int{4}},
 			},
 		},
 		{
@@ -57,15 +57,15 @@ func TestScheduleMigrationInterrupts(t *testing.T) {
 			from: NewVersion(3, 32),
 			to:   NewVersion(3, 44),
 			migrations: []yamlMigration{
-				// 1: [------]
-				// 2: .  [------]
-				// 3: .  .   .  . [---------------]
-				// 4: .  .   .  . .  [---]        .
-				// 5: .  .   .  . .  .   . [---]  .
-				// 6: .  .   .  . .  .   . .   .  . [---]
+				// 1: [------)
+				// 2: .  [------)
+				// 3: .  .   .  . [---------------)
+				// 4: .  .   .  . .  [---)        .
+				// 5: .  .   .  . .  .   . [---)  .
+				// 6: .  .   .  . .  .   . .   .  . [---)
 				//    .  .   .  . .  .   . .   .  . .   .
 				//    32 33 34 35 36 37 38 39 40 41 42 43
-				//          **          **    **       **
+				//       **          **    **       **
 
 				migration(1 /* introduced = */, 3, 32 /* deprecated = */, 3, 34),
 				migration(2 /* introduced = */, 3, 33 /* deprecated = */, 3, 35),
@@ -75,10 +75,10 @@ func TestScheduleMigrationInterrupts(t *testing.T) {
 				migration(6 /* introduced = */, 3, 42 /* deprecated = */, 3, 43),
 			},
 			interrupts: []MigrationInterrupt{
-				{Version: Version{3, 34}, MigrationIDs: []int{1, 2}},
-				{Version: Version{3, 38}, MigrationIDs: []int{4}},
-				{Version: Version{3, 40}, MigrationIDs: []int{3, 5}},
-				{Version: Version{3, 43}, MigrationIDs: []int{6}},
+				{Version: Version{3, 33}, MigrationIDs: []int{1, 2}},
+				{Version: Version{3, 37}, MigrationIDs: []int{4}},
+				{Version: Version{3, 39}, MigrationIDs: []int{3, 5}},
+				{Version: Version{3, 42}, MigrationIDs: []int{6}},
 			},
 		},
 		{
@@ -86,15 +86,15 @@ func TestScheduleMigrationInterrupts(t *testing.T) {
 			from: NewVersion(3, 34),
 			to:   NewVersion(3, 41),
 			migrations: []yamlMigration{
-				// 1: [... --] |
-				// 2: [... ----|--]
-				// 3:        . |  . [---------------]
-				// 4:        . |  . .  [---]        .
-				// 5:        . |  . .  .   . [---]  .
-				// 6:        . |  . .  .   . .   .  .
-				//           . |  . .  .   . .   .  .
-				//          34 | 35 36 37 38 39 40 41
-				//             |          **    **
+				// 1: [... --)
+				// 2: [... -----)
+				// 3:        .  . [---------------)
+				// 4:        .  . .  [---)        .
+				// 5:        .  . .  .   . [---)  .
+				// 6:        .  . .  .   . .   .  .
+				//           .  . .  .   . .   .  .
+				//          34 35 36 37 38 39 40 41
+				//          **       **    **
 
 				migration(1 /* introduced = */, 3, 32 /* deprecated = */, 3, 34),
 				migration(2 /* introduced = */, 3, 33 /* deprecated = */, 3, 35),
@@ -103,9 +103,9 @@ func TestScheduleMigrationInterrupts(t *testing.T) {
 				migration(5 /* introduced = */, 3, 39 /* deprecated = */, 3, 40),
 			},
 			interrupts: []MigrationInterrupt{
-				{Version: Version{3, 35}, MigrationIDs: []int{2}},
-				{Version: Version{3, 38}, MigrationIDs: []int{4}},
-				{Version: Version{3, 40}, MigrationIDs: []int{5}},
+				{Version: Version{3, 34}, MigrationIDs: []int{2}},
+				{Version: Version{3, 37}, MigrationIDs: []int{4}},
+				{Version: Version{3, 39}, MigrationIDs: []int{5}},
 			},
 		},
 	} {


### PR DESCRIPTION
The previous version of this method returned interrupts _at_ the version at which the oobmigration is deprecated. This is actually an off-by-one error. The deprecated version is the first version at which the migration does NOT run, so we should actually be breaking the upgrades one version earlier.

This PR adjusts the selected interrupt points and associated tests. We also flip the oobmigration/schema migrations ordering in the upgrade command to perform operations in the correct order as well.

## Test plan

Tested locally, updated unit tests.