### PR TITLE
oobmigration: Add `Version.Previous` method

### DIFF
--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -43,12 +43,12 @@ func (v Version) GitTag() string {
 	return fmt.Sprintf("v%d.%d.0", v.Major, v.Minor)
 }
 
+var lastMinorVersionInMajorRelease = map[int]int{
+	3: 43, // 3.43.0 -> 4.0.0
+}
+
 // Next returns the next minor version immediately following the receiver.
 func (v Version) Next() Version {
-	lastMinorVersionInMajorRelease := map[int]int{
-		3: 43, // 3.43.0 -> 4.0.0
-	}
-
 	if minor, ok := lastMinorVersionInMajorRelease[v.Major]; ok && minor == v.Minor {
 		// We're at terminal minor version for some major release
 		// :tada:
@@ -58,6 +58,16 @@ func (v Version) Next() Version {
 
 	// Bump minor version
 	return NewVersion(v.Major, v.Minor+1)
+}
+
+// Previous returns the previous minor version immediately preceding the receiver.
+func (v Version) Previous() (Version, bool) {
+	if v.Minor == 0 {
+		minor, ok := lastMinorVersionInMajorRelease[v.Major-1]
+		return NewVersion(v.Major-1, minor), ok
+	}
+
+	return NewVersion(v.Major, v.Minor-1), true
 }
 
 // UpgradeRange returns all minor versions in the closed interval [from, to].

--- a/internal/oobmigration/version_test.go
+++ b/internal/oobmigration/version_test.go
@@ -59,3 +59,32 @@ func TestUpgradeRange(t *testing.T) {
 		}
 	}
 }
+
+func TestNextPrevious(t *testing.T) {
+	chain := []Version{
+		NewVersion(3, 41),
+		NewVersion(3, 42),
+		NewVersion(3, 43),
+		NewVersion(4, 0),
+		NewVersion(4, 1),
+		NewVersion(4, 2),
+	}
+
+	for i, version := range chain {
+		if i != 0 {
+			previous, ok := version.Previous()
+			if !ok {
+				t.Fatalf("no previous for %q", version)
+			}
+			if have, want := chain[i-1], previous; have.String() != want.String() {
+				t.Fatalf("unexpected previous for %q. want=%q have=%q", version, want, have)
+			}
+		}
+
+		if i+1 < len(chain) {
+			if have, want := version.Next(), chain[i+1]; have.String() != want.String() {
+				t.Fatalf("unexpected next for %q. want=%q have=%q", version, want, have)
+			}
+		}
+	}
+}


### PR DESCRIPTION
In addition to `Version.Next()`, we need to detect the _previous_ version relative to upgrades (respecting the 4.0 transition).

## Test plan

N/A.