### PR TITLE
errors: Add package level IsWarning function

### DIFF
--- a/lib/errors/warning.go
+++ b/lib/errors/warning.go
@@ -58,8 +58,8 @@ func NewWarningError(err error) *warning {
 	}
 }
 
-func (ce *warning) Error() string {
-	return ce.error.Error()
+func (w *warning) Error() string {
+	return w.error.Error()
 }
 
 // IsWarning always returns true. It exists to differentiate regular errors with Warning
@@ -78,5 +78,14 @@ func (w *warning) As(target any) bool {
 		return true
 	}
 
+	return false
+}
+
+// IsWarning is a helper to check whether the specified err is a Warning
+func IsWarning(err error) bool {
+	var ref Warning
+	if As(err, &ref) {
+		return ref.IsWarning()
+	}
 	return false
 }

--- a/lib/errors/warning_test.go
+++ b/lib/errors/warning_test.go
@@ -28,4 +28,8 @@ func TestWarningError(t *testing.T) {
 	if !w.IsWarning() {
 		t.Error("Expecting warning.IsWarning to return true but got false")
 	}
+
+	if !IsWarning(w) {
+		t.Error("Expecting IsWarning to return true but got false")
+	}
 }


### PR DESCRIPTION
This makes it easier to check if an error is a warning from without
resorting to errors.As
