### PR TITLE
Docs update: fix reference links format

### DIFF
--- a/doc/integration/editor.md
+++ b/doc/integration/editor.md
@@ -18,6 +18,6 @@ We currently have integrations with these editors:
 
 ## References
 
-[Installation guide for Gitpod](gitpod.md)
-[Sourcegraph on Open VSX Registry](https://open-vsx.org/extension/sourcegraph/sourcegraph)
-[VS Code Extension Troubleshooting Docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#vs-code-extension)
+- [Installation guide for Gitpod](gitpod.md)
+- [Sourcegraph on Open VSX Registry](https://open-vsx.org/extension/sourcegraph/sourcegraph)
+- [VS Code Extension Troubleshooting Docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#vs-code-extension)


### PR DESCRIPTION
The links under the reference section are currently displayed in the same line: 
<img width="830" alt="image" src="https://user-images.githubusercontent.com/68532117/185880918-5e1c4337-ea68-4a0b-874c-3a71fc219ba8.png">

Updated to list it as an unordered list. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Test not required for formatting updates.