### PR TITLE
nix: use go 1.19

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -29,8 +29,8 @@ let
   pkgs = import
     (fetchTarball {
       url =
-        "https://github.com/NixOS/nixpkgs/archive/cbe587c735b734405f56803e267820ee1559e6c1.tar.gz";
-      sha256 = "0jii8slqbwbvrngf9911z3al1s80v7kk8idma9p9k0d5fm3g4z7h";
+        "https://github.com/NixOS/nixpkgs/archive/6f38b43c8c84c800f93465b2241156419fd4fd52.tar.gz";
+      sha256 = "0xw3y3jx1bcnwsc0imacbp5m8f51b66s9h8kk8qnfbckwv67dhgd";
     })
     { overlays = [ ctags-overlay ]; };
   # pkgs.universal-ctags installs the binary as "ctags", not "universal-ctags"
@@ -59,7 +59,7 @@ pkgs.mkShell {
     universal-ctags
 
     # Build our backend.
-    go_1_18
+    go_1_19
 
     # Lots of our tooling and go tests rely on git et al.
     git


### PR DESCRIPTION
This updates the version of nixpkgs to one from 18 days ago.

Test Plan: run go version in nix-shell.
