### PR TITLE
site-admin repo page: overflow: auto instead of scroll

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.module.scss
@@ -1,6 +1,6 @@
 .alert-wrapper {
     margin-top: 1rem;
-    overflow-y: scroll;
+    overflow-y: auto;
     max-height: 25rem;
 }
 


### PR DESCRIPTION
I know I suggested this in the last PR, but turns out I was wrong (huh). This does look better.

Before there was always this padding on the right that looked off:

<img width="934" alt="screenshot_2022-08-22_12 44 01@2x" src="https://user-images.githubusercontent.com/1185253/185903297-83b5b2a3-014d-4a5e-b5d0-4364314f4dcf.png">

Now it only shows up when there needs to be a scrollbar:

<img width="915" alt="screenshot_2022-08-22_12 42 51@2x" src="https://user-images.githubusercontent.com/1185253/185903365-0be561cf-c0e4-4a58-8fd1-cfac968ddda1.png">
<img width="940" alt="screenshot_2022-08-22_12 43 13@2x" src="https://user-images.githubusercontent.com/1185253/185903373-2daff278-ec74-4a37-aa5f-b6136d70f623.png">


## Test plan

- Manual testing

## App preview:

- [Web](https://sg-web-mrn-repo-alert.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rohienimku.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
