### PR TITLE
build-tracker: fix consecutive build count reset

### DIFF
--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -203,13 +203,15 @@ func (s *BuildStore) Add(event *Event) {
 		build.updateFromEvent(event)
 
 		// Track consecutive failures by pipeline + branch
+		// We update the global count of consecutiveFailures then we set the count on the individual build
+		// if we get a pass, we reset the global count of consecutiveFailures
 		failuresKey := fmt.Sprintf("%s/%s", build.Pipeline.name(), build.branch())
 		if build.hasFailed() {
 			s.consecutiveFailures[failuresKey] += 1
 			build.ConsecutiveFailure = s.consecutiveFailures[failuresKey]
 		} else {
-			// We got a pass, reset the count
-			s.consecutiveFailures[failuresKey] = 0
+			// We got a pass, reset the global count
+			s.consecutiveFailures[failuresKey] = 1
 		}
 	}
 

--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -208,7 +208,8 @@ func (s *BuildStore) Add(event *Event) {
 			s.consecutiveFailures[failuresKey] += 1
 			build.ConsecutiveFailure = s.consecutiveFailures[failuresKey]
 		} else {
-			s.consecutiveFailures[failuresKey] = 1
+			// We got a pass, reset the count
+			s.consecutiveFailures[failuresKey] = 0
 		}
 	}
 

--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -211,7 +211,7 @@ func (s *BuildStore) Add(event *Event) {
 			build.ConsecutiveFailure = s.consecutiveFailures[failuresKey]
 		} else {
 			// We got a pass, reset the global count
-			s.consecutiveFailures[failuresKey] = 1
+			s.consecutiveFailures[failuresKey] = 0
 		}
 	}
 

--- a/dev/build-tracker/build_test.go
+++ b/dev/build-tracker/build_test.go
@@ -93,11 +93,11 @@ func TestBuildStoreAdd(t *testing.T) {
 	failed := "failed"
 	pipeline := "bobheadxi"
 	eventFailed := func(n int) *Event {
-		return &Event{Name: "build.finished", Build: buildkite.Build{State: &failed, Number: &n, Pipeline: &buildkite.Pipeline{Name: &pipeline}}}
+		return &Event{Name: "build.finished", Build: buildkite.Build{State: &failed, Number: &n}, Pipeline: buildkite.Pipeline{Name: &pipeline}}
 	}
 	eventSucceeded := func(n int) *Event {
 		// no state === not failed
-		return &Event{Name: "build.finished", Build: buildkite.Build{State: nil, Number: &n, Pipeline: &buildkite.Pipeline{Name: &pipeline}}}
+		return &Event{Name: "build.finished", Build: buildkite.Build{State: nil, Number: &n}, Pipeline: buildkite.Pipeline{Name: &pipeline}}
 	}
 
 	store := NewBuildStore(logtest.Scoped(t))

--- a/dev/build-tracker/build_test.go
+++ b/dev/build-tracker/build_test.go
@@ -117,12 +117,20 @@ func TestBuildStoreAdd(t *testing.T) {
 	})
 
 	t.Run("a pass should reset ConsecutiveFailure", func(t *testing.T) {
-		store.Add(eventSucceeded(4))
+		store.Add(eventFailed(4))
 		build := store.GetByBuildNumber(4)
-		assert.Equal(t, build.ConsecutiveFailure, 0)
+		assert.Equal(t, build.ConsecutiveFailure, 4)
 
 		store.Add(eventSucceeded(5))
 		build = store.GetByBuildNumber(5)
+		assert.Equal(t, build.ConsecutiveFailure, 0)
+
+		store.Add(eventFailed(6))
+		build = store.GetByBuildNumber(6)
+		assert.Equal(t, build.ConsecutiveFailure, 1)
+
+		store.Add(eventSucceeded(7))
+		build = store.GetByBuildNumber(7)
 		assert.Equal(t, build.ConsecutiveFailure, 0)
 	})
 }


### PR DESCRIPTION
After one failure, I noticed that ALL failures would report their first failure as their second consecutive failure. This happened because after a pass the consecutive failure count was set to 1 instead of 0.

## Test plan
Unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
