### PR TITLE
Don't log GitHub App warnings if normal GitHub account

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -103,13 +103,6 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 		})
 	}
 
-	installations, err := ghClient.GetUserInstallations(ctx)
-	if err != nil {
-		// Only log a warning, since we still want to create the user account
-		// even if we fail to get installations.
-		log15.Warn("Could not get GitHub App installations", "error", err)
-	}
-
 	for i, attempt := range attempts {
 		userID, safeErrMsg, err := auth.GetAndSaveUser(ctx, s.db, auth.GetAndSaveUserOp{
 			UserProps: database.NewUser{
@@ -129,27 +122,35 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 			CreateIfNotExist:    attempt.createIfNotExist,
 		})
 		if err == nil {
-			for _, installation := range installations {
-				accountID := strconv.FormatInt(*installation.ID, 10) + "/" + strconv.FormatInt(derefInt64(ghUser.ID), 10)
-				_, _, err := auth.GetAndSaveUser(ctx, s.db, auth.GetAndSaveUserOp{
-					UserProps: database.NewUser{
-						Username:        login,
-						Email:           attempt.email,
-						EmailIsVerified: true,
-						DisplayName:     deref(ghUser.Name),
-						AvatarURL:       deref(ghUser.AvatarURL),
-					},
-					ExternalAccount: extsvc.AccountSpec{
-						ServiceType: extsvc.TypeGitHubApp,
-						ServiceID:   s.ServiceID,
-						ClientID:    s.clientID,
-						AccountID:   accountID,
-					},
-					CreateIfNotExist: attempt.createIfNotExist,
-				})
-
+			if token.AccessToken[0:3] == "ghu" {
+				installations, err := ghClient.GetUserInstallations(ctx)
 				if err != nil {
-					log15.Warn("Error while saving associated user installation", "error", err)
+					// Only log a warning, since we still want to create the user account
+					// even if we fail to get installations.
+					log15.Warn("Could not get GitHub App installations", "error", err)
+				}
+				for _, installation := range installations {
+					accountID := strconv.FormatInt(*installation.ID, 10) + "/" + strconv.FormatInt(derefInt64(ghUser.ID), 10)
+					_, _, err := auth.GetAndSaveUser(ctx, s.db, auth.GetAndSaveUserOp{
+						UserProps: database.NewUser{
+							Username:        login,
+							Email:           attempt.email,
+							EmailIsVerified: true,
+							DisplayName:     deref(ghUser.Name),
+							AvatarURL:       deref(ghUser.AvatarURL),
+						},
+						ExternalAccount: extsvc.AccountSpec{
+							ServiceType: extsvc.TypeGitHubApp,
+							ServiceID:   s.ServiceID,
+							ClientID:    s.clientID,
+							AccountID:   accountID,
+						},
+						CreateIfNotExist: attempt.createIfNotExist,
+					})
+
+					if err != nil {
+						log15.Warn("Error while saving associated user installation", "error", err)
+					}
 				}
 			}
 

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -123,7 +123,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 		})
 		if err == nil {
 			// Check if GitHub App access token
-			if token.AccessToken[0:3] == "ghu" {
+			if len(token.AccessToken) > 3 && token.AccessToken[0:3] == "ghu" {
 				installations, err := ghClient.GetUserInstallations(ctx)
 				if err != nil {
 					// Only log a warning, since we still want to create the user account

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -123,7 +123,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 		})
 		if err == nil {
 			// Check if GitHub App access token
-			if len(token.AccessToken) > 3 && token.AccessToken[0:3] == "ghu" {
+			if strings.HasPrefix(token.AccessToken, "ghu") {
 				installations, err := ghClient.GetUserInstallations(ctx)
 				if err != nil {
 					// Only log a warning, since we still want to create the user account

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -122,6 +122,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 			CreateIfNotExist:    attempt.createIfNotExist,
 		})
 		if err == nil {
+			// Check if GitHub App access token
 			if token.AccessToken[0:3] == "ghu" {
 				installations, err := ghClient.GetUserInstallations(ctx)
 				if err != nil {

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -123,7 +123,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 		})
 		if err == nil {
 			// Check if GitHub App access token
-			if strings.HasPrefix(token.AccessToken, "ghu") {
+			if githubsvc.IsGitHubAppAccessToken(token.AccessToken) {
 				installations, err := ghClient.GetUserInstallations(ctx)
 				if err != nil {
 					// Only log a warning, since we still want to create the user account

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -270,7 +269,7 @@ func (s *PermsSyncer) getUserGitHubAppInstallations(ctx context.Context, acct *e
 	}
 
 	// Not a GitHub App access token
-	if !strings.HasPrefix(tok.AccessToken, "ghu") {
+	if !github.IsGitHubAppAccessToken(tok.AccessToken) {
 		return nil, nil
 	}
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -269,7 +270,7 @@ func (s *PermsSyncer) getUserGitHubAppInstallations(ctx context.Context, acct *e
 	}
 
 	// Not a GitHub App access token
-	if len(tok.AccessToken) > 3 && tok.AccessToken[0:3] != "ghu" {
+	if !strings.HasPrefix(tok.AccessToken, "ghu") {
 		return nil, nil
 	}
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -260,6 +260,11 @@ func (s *PermsSyncer) getUserGitHubAppInstallations(ctx context.Context, acct *e
 
 	_, tok, err := github.GetExternalAccountData(ctx, &acct.AccountData)
 
+	// Not a GitHub App access token
+	if tok.AccessToken[0:3] != "ghu" {
+		return nil, nil
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -260,16 +260,16 @@ func (s *PermsSyncer) getUserGitHubAppInstallations(ctx context.Context, acct *e
 
 	_, tok, err := github.GetExternalAccountData(ctx, &acct.AccountData)
 
-	// Not a GitHub App access token
-	if tok.AccessToken[0:3] != "ghu" {
-		return nil, nil
-	}
-
 	if err != nil {
 		return nil, err
 	}
 
 	if tok == nil {
+		return nil, nil
+	}
+
+	// Not a GitHub App access token
+	if len(tok.AccessToken) > 3 && tok.AccessToken[0:3] != "ghu" {
 		return nil, nil
 	}
 

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -2009,3 +2009,9 @@ func handlePullRequestError(err error) error {
 	}
 	return err
 }
+
+// IsGitHubAppAccessToken checks whether the access token starts with "ghu",
+// which is used for GitHub App access tokens.
+func IsGitHubAppAccessToken(token string) bool {
+	return strings.HasPrefix(token, "ghu")
+}


### PR DESCRIPTION
Check if GitHub access tokens start with "ghu" before doing GitHub App installation checks.

## Test plan
Tested locally to see if warning logs still appear.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
