### PR TITLE
upgrade: Do not print "schema migrations complete" on dry run

### DIFF
--- a/internal/database/migration/cliutil/upgrade_runner.go
+++ b/internal/database/migration/cliutil/upgrade_runner.go
@@ -81,9 +81,9 @@ func runUpgrade(
 			}); err != nil {
 				return err
 			}
-		}
 
-		out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Schema migrations complete"))
+			out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Schema migrations complete"))
+		}
 
 		if len(step.outOfBandMigrationIDs) > 0 {
 			if err := runOutOfBandMigrations(


### PR DESCRIPTION
This ensures dry runs of the upgrade process will only print what it intends to do, not statuses.

## Test plan

Tested locally.