### PR TITLE
vscode: disable automatic Watch Typescript task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,9 +15,6 @@
       "isBackground": true,
       "command": ["node_modules/.bin/tsc"],
       "args": ["--build", "tsconfig.all.json", "--watch", "--incremental"],
-      "runOptions": {
-        "runOn": "folderOpen",
-      },
     },
     {
       "label": "Watch web app",


### PR DESCRIPTION
Im not sure what changed, but as of recently Ive noticed this task auto starting and opening a terminal panel. I don't want this to auto start and hijack my terminal, we have `sg` for build errors as well as vscode's `tsserver` lang server

## Test plan

N/A, dev environment