### PR TITLE
migrator: Beautify status of oobmigration runners

### DIFF
--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -113,7 +113,7 @@ func runOutOfBandMigrations(
 	bars := make([]output.ProgressBar, 0, len(ids))
 	for _, id := range ids {
 		bars = append(bars, output.ProgressBar{
-			Label: fmt.Sprintf("Migraton #%d", id),
+			Label: fmt.Sprintf("Migration #%d", id),
 			Max:   1.0,
 		})
 	}

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -117,7 +117,13 @@ func runOutOfBandMigrations(
 		})
 	}
 	progress := out.Progress(bars, nil)
-	defer progress.Destroy()
+	defer func() {
+		progress.Destroy()
+
+		if err == nil {
+			out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Out of band migrations complete"))
+		}
+	}()
 
 	ticker := time.NewTicker(time.Second).C
 	for {
@@ -147,9 +153,6 @@ func runOutOfBandMigrations(
 		case <-ticker:
 		}
 	}
-
-	out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Out of band migrations complete"))
-	return nil
 }
 
 func getMigrations(ctx context.Context, store *oobmigration.Store, ids []int) ([]oobmigration.Migration, error) {

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -117,13 +117,13 @@ func runOutOfBandMigrations(
 
 		sort.Slice(migrations, func(i, j int) bool { return migrations[i].ID < migrations[j].ID })
 
-		incomplete := migrations[:0]
+		complete := true
 		for _, m := range migrations {
 			if !m.Complete() {
-				incomplete = append(incomplete, m)
+				complete = false
 			}
 		}
-		if len(incomplete) == 0 {
+		if complete {
 			break
 		}
 		for _, m := range migrations {

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -102,7 +102,6 @@ func runOutOfBandMigrations(
 	sort.Ints(ids)
 
 	out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleReset, "Running out of band migrations %v", ids))
-
 	if dryRun {
 		return nil
 	}
@@ -126,7 +125,6 @@ func runOutOfBandMigrations(
 		if err != nil {
 			return err
 		}
-
 		sort.Slice(migrations, func(i, j int) bool { return migrations[i].ID < migrations[j].ID })
 
 		for i, m := range migrations {

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -143,10 +143,6 @@ func runOutOfBandMigrations(
 }
 
 func getMigrations(ctx context.Context, store *oobmigration.Store, ids []int) ([]oobmigration.Migration, error) {
-	if len(ids) == 0 {
-		return store.List(ctx)
-	}
-
 	migrations := make([]oobmigration.Migration, 0, len(ids))
 	for _, id := range ids {
 		migration, ok, err := store.GetByID(ctx, id)

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -126,7 +126,7 @@ func runOutOfBandMigrations(
 		if len(incomplete) == 0 {
 			break
 		}
-		for _, m := range incomplete {
+		for _, m := range migrations {
 			out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleReset, "Out of band migration #%d is at %.2f%%", m.ID, m.Progress*100))
 		}
 

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -108,7 +108,8 @@ func runOutOfBandMigrations(
 	go runner.StartPartial(ids)
 	defer runner.Stop()
 
-	for range time.NewTicker(time.Second).C {
+	ticker := time.NewTicker(time.Second).C
+	for {
 		migrations, err := getMigrations(ctx, store, ids)
 		if err != nil {
 			return err
@@ -127,6 +128,12 @@ func runOutOfBandMigrations(
 		}
 		for _, m := range incomplete {
 			out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleReset, "Out of band migration #%d is at %.2f%%", m.ID, m.Progress*100))
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker:
 		}
 	}
 

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -122,6 +122,8 @@ func runOutOfBandMigrations(
 
 		if err == nil {
 			out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Out of band migrations complete"))
+		} else {
+			out.WriteLine(output.Linef(output.EmojiFailure, output.StyleFailure, "Out of band migrations failed: %s", err))
 		}
 	}()
 

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -117,6 +117,10 @@ func runOutOfBandMigrations(
 
 		sort.Slice(migrations, func(i, j int) bool { return migrations[i].ID < migrations[j].ID })
 
+		for _, m := range migrations {
+			out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleReset, "Out of band migration #%d is at %.2f%%", m.ID, m.Progress*100))
+		}
+
 		complete := true
 		for _, m := range migrations {
 			if !m.Complete() {
@@ -125,9 +129,6 @@ func runOutOfBandMigrations(
 		}
 		if complete {
 			break
-		}
-		for _, m := range migrations {
-			out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleReset, "Out of band migration #%d is at %.2f%%", m.ID, m.Progress*100))
 		}
 
 		select {

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -144,7 +144,7 @@ func runOutOfBandMigrations(
 			}
 		}
 		if complete {
-			break
+			return nil
 		}
 
 		select {


### PR DESCRIPTION
Update the status output of the migrator `upgrade` and `run-out-of-band-migrations` commands to use progress barz.

## Test plan

Tested locally.