### PR TITLE
analytics: Add lang breakdown to code-intel analytics page

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.module.scss
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.module.scss
@@ -7,3 +7,25 @@
     padding-right: 4rem;
     margin-top: 1.5rem;
 }
+
+.events {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+}
+
+.chart {
+    width: 300px;
+}
+
+.percent-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.percent {
+    font-weight: bold;
+    font-size: 2rem
+}

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.module.scss
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.module.scss
@@ -27,7 +27,7 @@
 
 .percent {
     font-weight: bold;
-    font-size: 2rem
+    font-size: 2rem;
 }
 
 .repos {

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.module.scss
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.module.scss
@@ -29,3 +29,11 @@
     font-weight: bold;
     font-size: 2rem
 }
+
+.repos {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: 1fr 1fr 1fr 1fr 4fr;
+    align-items: center;
+    padding-left: 2rem;
+}

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.module.scss
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.module.scss
@@ -15,7 +15,7 @@
 }
 
 .chart {
-    width: 300px;
+    width: 15rem;
 }
 
 .percent-container {

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -186,13 +186,6 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
     const repos = data?.site.analytics.repos
     const groupingLabel = startCase(grouping.value.toLowerCase())
 
-    const eventsData: { name: string; kind: Kind; value: number }[] = [
-        { name: 'Java', kind: 'search-based', value: 90 },
-        { name: 'Java', kind: 'precise', value: 30 },
-        { name: 'Go', kind: 'search-based', value: 30 },
-        { name: 'Go', kind: 'precise', value: 10 },
-    ]
-
     const topRepos: {
         name: string
         events: number
@@ -279,34 +272,36 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                 </div>
                 <div>
                     <H4 className="my-3">Events by language</H4>
-                    <div className={styles.events}>
-                        <ChartContainer className={styles.chart} labelX="Languages" labelY="Events">
-                            {width => (
-                                <>
-                                    <LegendList>
-                                        <LegendItem color={color('precise')} name="precise" />
-                                        <LegendItem color={color('search-based')} name="search-based" />
-                                    </LegendList>
-                                    <BarChart
-                                        stacked={true}
-                                        width={width}
-                                        height={300}
-                                        data={eventsData}
-                                        getDatumColor={value => color(value.kind)}
-                                        getDatumValue={value => value.value}
-                                        getDatumName={value => value.name}
-                                        getDatumHover={value => `${value.name} ${value.kind}`}
-                                    />
-                                </>
-                            )}
-                        </ChartContainer>
-                        <div className={styles.percentContainer}>
-                            <div className={styles.percent}>
-                                {preciseFraction ? (100 * preciseFraction).toFixed(1) : '...'}%
+                    {data && (
+                        <div className={styles.events}>
+                            <ChartContainer className={styles.chart} labelX="Languages" labelY="Events">
+                                {width => (
+                                    <>
+                                        <LegendList>
+                                            <LegendItem color={color('precise')} name="precise" />
+                                            <LegendItem color={color('search-based')} name="search-based" />
+                                        </LegendList>
+                                        <BarChart
+                                            stacked={true}
+                                            width={width}
+                                            height={300}
+                                            data={data.site.analytics.codeIntelByLanguage}
+                                            getDatumColor={value => color(value.precision)}
+                                            getDatumValue={value => value.count}
+                                            getDatumName={value => value.language}
+                                            getDatumHover={value => `${value.language} ${value.precision}`}
+                                        />
+                                    </>
+                                )}
+                            </ChartContainer>
+                            <div className={styles.percentContainer}>
+                                <div className={styles.percent}>
+                                    {preciseFraction ? (100 * preciseFraction).toFixed(1) : '...'}%
+                                </div>
+                                <div>Precise code navigation</div>
                             </div>
-                            <div>Precise code navigation</div>
                         </div>
-                    </div>
+                    )}
                     <H4 className="my-3">Top repositories</H4>
                     <div className={styles.repos}>
                         <div className="text-muted text-nowrap">{/* Repository */}</div>
@@ -334,10 +329,8 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
     )
 }
 
-type Kind = 'precise' | 'search-based'
-
-const color = (kind: Kind): string => {
-    switch (kind) {
+const color = (precision: string): string => {
+    switch (precision) {
         case 'precise':
             return 'rgb(255, 184, 109)'
         case 'search-based':

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -223,11 +223,19 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
         preciseNavigation: JSX.Element
     }
 
-    const urls: Record<string, string> = {
+    const langToIndexerUrl: Record<string, string> = {
         python: 'https://github.com/sourcegraph/scip-python',
         typescript: 'https://github.com/sourcegraph/scip-typescript',
         java: 'https://github.com/sourcegraph/scip-java',
         ruby: 'https://github.com/sourcegraph/scip-ruby',
+        go: 'https://github.com/sourcegraph/lsif-go',
+        rust: 'https://github.com/rust-analyzer/rust-analyzer',
+        scala: 'https://github.com/sourcegraph/lsif-java',
+        cpp: 'https://github.com/sourcegraph/lsif-clang',
+        csharp: 'https://github.com/tcz717/LsifDotnet',
+        dart: 'https://github.com/sourcegraph/lsif-dart',
+        haskell: 'https://github.com/mpickering/hie-lsif',
+        kotlin: 'https://github.com/sourcegraph/lsif-java',
     }
 
     const topRepos: TopRepo[] | undefined = (() => {
@@ -264,10 +272,10 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                             </div>
                         )
                     }
-                    if (lang in urls) {
+                    if (lang in langToIndexerUrl) {
                         return (
                             <div key={lang}>
-                                Configure precise navigation for <Link to={urls[lang]}>{lang}</Link>
+                                Configure precise navigation for <Link to={langToIndexerUrl[lang]}>{lang}</Link>
                             </div>
                         )
                     }

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -28,7 +28,7 @@ import { TimeSavedCalculatorGroup } from '../components/TimeSavedCalculatorGroup
 import { ToggleSelect } from '../components/ToggleSelect'
 import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
 import { useChartFilters } from '../useChartFilters'
-import { StandardDatum } from '../utils'
+import { formatNumber, StandardDatum } from '../utils'
 
 import { CODEINTEL_STATISTICS } from './queries'
 
@@ -186,6 +186,36 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
     const repos = data?.site.analytics.repos
     const groupingLabel = startCase(grouping.value.toLowerCase())
 
+    const eventsData: { name: string; kind: Kind; value: number }[] = [
+        { name: 'Java', kind: 'search-based', value: 90 },
+        { name: 'Java', kind: 'precise', value: 30 },
+        { name: 'Go', kind: 'search-based', value: 30 },
+        { name: 'Go', kind: 'precise', value: 10 },
+    ]
+
+    const topRepos: {
+        name: string
+        events: number
+        hoursSaved: number
+        preciseEnabled: boolean
+        preciseNavigation: string
+    }[] = [
+        {
+            name: 'github.com/gorilla/mux',
+            events: 10000,
+            hoursSaved: 10,
+            preciseEnabled: true,
+            preciseNavigation: '80% Precise coverage for Go, set up precise navigation for Python',
+        },
+        {
+            name: 'github.com/sourcegraph/sourcegraph',
+            events: 2000,
+            hoursSaved: 5,
+            preciseEnabled: false,
+            preciseNavigation: 'Set up precise navigation for Java',
+        },
+    ]
+
     return (
         <>
             <AnalyticsPageTitle>Code intel</AnalyticsPageTitle>
@@ -255,14 +285,7 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                                         stacked={true}
                                         width={width}
                                         height={300}
-                                        data={
-                                            [
-                                                { name: 'Java', kind: 'search-based', value: 90 },
-                                                { name: 'Java', kind: 'precise', value: 30 },
-                                                { name: 'Go', kind: 'search-based', value: 30 },
-                                                { name: 'Go', kind: 'precise', value: 10 },
-                                            ] as { name: string; kind: Kind; value: number }[]
-                                        }
+                                        data={eventsData}
                                         getDatumColor={value => color(value.kind)}
                                         getDatumValue={value => value.value}
                                         getDatumName={value => value.name}
@@ -275,6 +298,23 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                             <div className={styles.percent}>30%</div>
                             <div>Precise code navigation</div>
                         </div>
+                    </div>
+                    <H4 className="my-3">Top repositories</H4>
+                    <div className={styles.repos}>
+                        <div className="text-muted text-nowrap">{/* Repository */}</div>
+                        <div className="text-center text-muted text-nowrap">Events</div>
+                        <div className="text-center text-muted text-nowrap">Hours saved</div>
+                        <div className="text-center text-muted text-nowrap">Precise enabled</div>
+                        <div className="text-muted text-nowrap">Precise navigation</div>
+                        {topRepos.map((repo, index) => (
+                            <React.Fragment key={index}>
+                                <td className="text-muted">{repo.name}</td>
+                                <td className="text-center font-weight-bold">{formatNumber(repo.events)}</td>
+                                <td className="text-center font-weight-bold">{repo.hoursSaved}</td>
+                                <td className="text-center font-weight-bold">{repo.preciseEnabled ? 'Yes' : 'No'}</td>
+                                <td>{repo.preciseNavigation}</td>
+                            </React.Fragment>
+                        ))}
                     </div>
                 </div>
             </Card>

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -5,7 +5,19 @@ import { startCase } from 'lodash'
 import { RouteComponentProps } from 'react-router'
 
 import { useQuery } from '@sourcegraph/http-client'
-import { Card, H2, Text, LoadingSpinner, AnchorLink, H4, LineChart, Series } from '@sourcegraph/wildcard'
+import {
+    Card,
+    H2,
+    Text,
+    LoadingSpinner,
+    AnchorLink,
+    H4,
+    LineChart,
+    Series,
+    BarChart,
+    LegendList,
+    LegendItem,
+} from '@sourcegraph/wildcard'
 
 import { CodeIntelStatisticsResult, CodeIntelStatisticsVariables } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
@@ -229,6 +241,42 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                         )}
                     </ul>
                 </div>
+                <div>
+                    <H4 className="my-3">Events by language</H4>
+                    <div className={styles.events}>
+                        <ChartContainer className={styles.chart} labelX="Languages" labelY="Events">
+                            {width => (
+                                <>
+                                    <LegendList>
+                                        <LegendItem color={color('precise')} name="precise" />
+                                        <LegendItem color={color('search-based')} name="search-based" />
+                                    </LegendList>
+                                    <BarChart
+                                        stacked={true}
+                                        width={width}
+                                        height={300}
+                                        data={
+                                            [
+                                                { name: 'Java', kind: 'search-based', value: 90 },
+                                                { name: 'Java', kind: 'precise', value: 30 },
+                                                { name: 'Go', kind: 'search-based', value: 30 },
+                                                { name: 'Go', kind: 'precise', value: 10 },
+                                            ] as { name: string; kind: Kind; value: number }[]
+                                        }
+                                        getDatumColor={value => color(value.kind)}
+                                        getDatumValue={value => value.value}
+                                        getDatumName={value => value.name}
+                                        getDatumHover={value => `${value.name} ${value.kind}`}
+                                    />
+                                </>
+                            )}
+                        </ChartContainer>
+                        <div className={styles.percentContainer}>
+                            <div className={styles.percent}>30%</div>
+                            <div>Precise code navigation</div>
+                        </div>
+                    </div>
+                </div>
             </Card>
             <Text className="font-italic text-center mt-2">
                 All events are generated from entries in the event logs table and are updated every 24 hours.
@@ -236,4 +284,17 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
             </Text>
         </>
     )
+}
+
+type Kind = 'precise' | 'search-based'
+
+const color = (kind: Kind): string => {
+    switch (kind) {
+        case 'precise':
+            return 'rgb(255, 184, 109)'
+        case 'search-based':
+            return 'rgb(155, 211, 255)'
+        default:
+            return 'gray'
+    }
 }

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -216,6 +216,12 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
         },
     ]
 
+    const preciseFraction = data
+        ? data.site.analytics.codeIntel.preciseEvents.summary.totalCount /
+          (data.site.analytics.codeIntel.preciseEvents.summary.totalCount +
+              data.site.analytics.codeIntel.searchBasedEvents.summary.totalCount)
+        : undefined
+
     return (
         <>
             <AnalyticsPageTitle>Code intel</AnalyticsPageTitle>
@@ -295,7 +301,9 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                             )}
                         </ChartContainer>
                         <div className={styles.percentContainer}>
-                            <div className={styles.percent}>30%</div>
+                            <div className={styles.percent}>
+                                {preciseFraction ? (100 * preciseFraction).toFixed(1) : '...'}%
+                            </div>
                             <div>Precise code navigation</div>
                         </div>
                     </div>

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -303,22 +303,24 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                         </div>
                     )}
                     <H4 className="my-3">Top repositories</H4>
-                    <div className={styles.repos}>
-                        <div className="text-muted text-nowrap">{/* Repository */}</div>
-                        <div className="text-center text-muted text-nowrap">Events</div>
-                        <div className="text-center text-muted text-nowrap">Hours saved</div>
-                        <div className="text-center text-muted text-nowrap">Precise enabled</div>
-                        <div className="text-muted text-nowrap">Precise navigation</div>
-                        {topRepos.map((repo, index) => (
-                            <React.Fragment key={index}>
-                                <td className="text-muted">{repo.name}</td>
-                                <td className="text-center font-weight-bold">{formatNumber(repo.events)}</td>
-                                <td className="text-center font-weight-bold">{repo.hoursSaved}</td>
-                                <td className="text-center font-weight-bold">{repo.preciseEnabled ? 'Yes' : 'No'}</td>
-                                <td>{repo.preciseNavigation}</td>
-                            </React.Fragment>
-                        ))}
-                    </div>
+                    {data && (
+                        <div className={styles.repos}>
+                            <div className="text-muted text-nowrap">{/* Repository */}</div>
+                            <div className="text-center text-muted text-nowrap">Events</div>
+                            <div className="text-center text-muted text-nowrap">Hours saved</div>
+                            <div className="text-center text-muted text-nowrap">Precise enabled</div>
+                            <div className="text-muted text-nowrap">Precise navigation</div>
+                            {data.site.analytics.codeIntelTopRepositories.map((repo, index) => (
+                                <React.Fragment key={index}>
+                                    <td className="text-muted">{repo.name}</td>
+                                    <td className="text-center font-weight-bold">{formatNumber(repo.events)}</td>
+                                    <td className="text-center font-weight-bold">TODO</td>
+                                    <td className="text-center font-weight-bold">TODO</td>
+                                    <td>TODO</td>
+                                </React.Fragment>
+                            ))}
+                        </div>
+                    )}
                 </div>
             </Card>
             <Text className="font-italic text-center mt-2">

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -17,6 +17,7 @@ import {
     BarChart,
     LegendList,
     LegendItem,
+    Link,
 } from '@sourcegraph/wildcard'
 
 import { CodeIntelStatisticsResult, CodeIntelStatisticsVariables } from '../../../graphql-operations'
@@ -222,6 +223,13 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
         preciseNavigation: JSX.Element
     }
 
+    const urls: Record<string, string> = {
+        python: 'https://github.com/sourcegraph/scip-python',
+        typescript: 'https://github.com/sourcegraph/scip-typescript',
+        java: 'https://github.com/sourcegraph/scip-java',
+        ruby: 'https://github.com/sourcegraph/scip-ruby',
+    }
+
     const topRepos: TopRepo[] | undefined = (() => {
         const allRows = data?.site.analytics.codeIntelTopRepositories
         if (!allRows) {
@@ -248,12 +256,22 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                     )
                     const total = searchBased + precise
 
-                    return (
-                        <div key={lang}>
-                            <strong>{Math.round((precise / total) * 100)}%</strong> Precise coverage for{' '}
-                            <strong>{lang}</strong>
-                        </div>
-                    )
+                    if (precise > 0) {
+                        return (
+                            <div key={lang}>
+                                <strong>{Math.round((precise / total) * 100)}%</strong> Precise coverage for{' '}
+                                <strong>{lang}</strong>
+                            </div>
+                        )
+                    }
+                    if (lang in urls) {
+                        return (
+                            <div key={lang}>
+                                Configure precise navigation for <Link to={urls[lang]}>{lang}</Link>
+                            </div>
+                        )
+                    }
+                    return <></>
                 })
                 return <>{items}</>
             })(),

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useEffect, useState } from 'react'
 
 import classNames from 'classnames'
-import { groupBy, startCase, sumBy } from 'lodash'
+import { groupBy, sortBy, startCase, sumBy } from 'lodash'
 import { RouteComponentProps } from 'react-router'
 
 import { useQuery } from '@sourcegraph/http-client'
@@ -236,7 +236,7 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
             return undefined
         }
 
-        return Object.entries(groupBy(allRows, row => row.name)).map(([name, rows]) => ({
+        const unsortedRepos = Object.entries(groupBy(allRows, row => row.name)).map(([name, rows]) => ({
             repoName: name,
             events: sumBy(rows, row => row.events),
             hoursSaved: sumBy(
@@ -276,6 +276,8 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                 return <>{items}</>
             })(),
         }))
+
+        return sortBy(unsortedRepos, repo => -repo.events)
     })()
 
     return (

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
@@ -60,6 +60,10 @@ export const CODEINTEL_STATISTICS = gql`
                     precision
                     count
                 }
+                codeIntelTopRepositories(dateRange: $dateRange) {
+                    name
+                    events
+                }
             }
         }
     }

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
@@ -62,7 +62,11 @@ export const CODEINTEL_STATISTICS = gql`
                 }
                 codeIntelTopRepositories(dateRange: $dateRange) {
                     name
+                    language
+                    kind
+                    precision
                     events
+                    hasPrecise
                 }
             }
         }

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/queries.ts
@@ -55,6 +55,11 @@ export const CODEINTEL_STATISTICS = gql`
                         }
                     }
                 }
+                codeIntelByLanguage(dateRange: $dateRange) {
+                    language
+                    precision
+                    count
+                }
             }
         }
     }

--- a/client/web/src/site-admin/analytics/components/TimeSavedCalculatorGroup.tsx
+++ b/client/web/src/site-admin/analytics/components/TimeSavedCalculatorGroup.tsx
@@ -14,6 +14,7 @@ interface TimeSavedCalculatorGroupItem {
     label: string
     value: number
     minPerItem: number
+    onMinPerItemChange?: (minPerItem: number) => void
     description: string
     percentage?: number
     hoursSaved?: number
@@ -65,6 +66,7 @@ export const TimeSavedCalculatorGroup: React.FunctionComponent<TimeSavedCalculat
     const updateMinPerItem = (index: number, minPerItem: number): void => {
         const updatedItems = [...memoizedItems]
         updatedItems[index] = { ...memoizedItems[index], minPerItem }
+        updatedItems[index].onMinPerItemChange?.(minPerItem)
 
         setMemoizedItems(calculateHoursSaved(updatedItems))
     }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6368,6 +6368,20 @@ type AnalyticsCodeIntelByLanguageResult {
 }
 
 """
+CodeIntelTopRepositories analytics.
+"""
+type AnalyticsCodeIntelRepositoryResult {
+    """
+    Repository name
+    """
+    name: String!
+    """
+    Event count
+    """
+    events: Float!
+}
+
+"""
 Repositories summary.
 """
 type AnalyticsReposSummartResult {
@@ -6438,6 +6452,10 @@ type Analytics {
     Code-intelligence statistics grouped by language and precision.
     """
     codeIntelByLanguage(dateRange: AnalyticsDateRange): [AnalyticsCodeIntelByLanguageResult!]!
+    """
+    Top repositories by code-intelligence events.
+    """
+    codeIntelTopRepositories(dateRange: AnalyticsDateRange): [AnalyticsCodeIntelRepositoryResult!]!
     """
     Repositories summary statistics.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6376,9 +6376,25 @@ type AnalyticsCodeIntelRepositoryResult {
     """
     name: String!
     """
+    Language
+    """
+    language: String!
+    """
+    Event kind
+    """
+    kind: String!
+    """
+    Event precision (either "search-based" or "precise")
+    """
+    precision: String!
+    """
     Event count
     """
     events: Float!
+    """
+    Has precise
+    """
+    hasPrecise: Boolean!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6350,6 +6350,24 @@ type AnalyticsCodeIntelResult {
 }
 
 """
+CodeIntelByLanguage analytics.
+"""
+type AnalyticsCodeIntelByLanguageResult {
+    """
+    Language
+    """
+    language: String!
+    """
+    Precision
+    """
+    precision: String!
+    """
+    Count
+    """
+    count: Float!
+}
+
+"""
 Repositories summary.
 """
 type AnalyticsReposSummartResult {
@@ -6416,6 +6434,10 @@ type Analytics {
     Code-intelligence statistics.
     """
     codeIntel(dateRange: AnalyticsDateRange, grouping: AnalyticsGrouping): AnalyticsCodeIntelResult!
+    """
+    Code-intelligence statistics grouped by language and precision.
+    """
+    codeIntelByLanguage(dateRange: AnalyticsDateRange): [AnalyticsCodeIntelByLanguageResult!]!
     """
     Repositories summary statistics.
     """

--- a/cmd/frontend/graphqlbackend/site_analytics.go
+++ b/cmd/frontend/graphqlbackend/site_analytics.go
@@ -66,6 +66,14 @@ func (r *siteAnalyticsResolver) CodeIntel(ctx context.Context, args *struct {
 	return &adminanalytics.CodeIntel{DateRange: *args.DateRange, Grouping: *args.Grouping, DB: r.db, Cache: r.cache}
 }
 
+/* Code-intel by language */
+
+func (r *siteAnalyticsResolver) CodeIntelByLanguage(ctx context.Context, args *struct {
+	DateRange *string
+}) ([]*adminanalytics.CodeIntelByLanguage, error) {
+	return adminanalytics.GetCodeIntelByLanguage(ctx, r.db, r.cache, *args.DateRange)
+}
+
 /* Repos */
 
 func (r *siteAnalyticsResolver) Repos(ctx context.Context) (*adminanalytics.ReposSummary, error) {

--- a/cmd/frontend/graphqlbackend/site_analytics.go
+++ b/cmd/frontend/graphqlbackend/site_analytics.go
@@ -74,6 +74,14 @@ func (r *siteAnalyticsResolver) CodeIntelByLanguage(ctx context.Context, args *s
 	return adminanalytics.GetCodeIntelByLanguage(ctx, r.db, r.cache, *args.DateRange)
 }
 
+/* Code-intel by language */
+
+func (r *siteAnalyticsResolver) CodeIntelTopRepositories(ctx context.Context, args *struct {
+	DateRange *string
+}) ([]*adminanalytics.CodeIntelTopRepositories, error) {
+	return adminanalytics.GetCodeIntelTopRepositories(ctx, r.db, r.cache, *args.DateRange)
+}
+
 /* Repos */
 
 func (r *siteAnalyticsResolver) Repos(ctx context.Context) (*adminanalytics.ReposSummary, error) {

--- a/internal/adminanalytics/codeintelbylanguage.go
+++ b/internal/adminanalytics/codeintelbylanguage.go
@@ -1,0 +1,77 @@
+package adminanalytics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+type CodeIntelByLanguage struct {
+	Language_  string  `json:"language"`
+	Precision_ string  `json:"precision"`
+	Count_     float64 `json:"count"`
+}
+
+func (s *CodeIntelByLanguage) Language() string  { return s.Language_ }
+func (s *CodeIntelByLanguage) Precision() string { return s.Precision_ }
+func (s *CodeIntelByLanguage) Count() float64    { return s.Count_ }
+
+func GetCodeIntelByLanguage(ctx context.Context, db database.DB, cache bool, dateRange string) ([]*CodeIntelByLanguage, error) {
+	cacheKey := fmt.Sprintf(`CodeIntelByLanguage:%s`, dateRange)
+
+	if cache == true {
+		if nodes, err := getArrayFromCache[CodeIntelByLanguage](cacheKey); err == nil {
+			return nodes, nil
+		}
+	}
+
+	now := time.Now()
+	from, err := getFromDate(dateRange, now)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT language, precision, COUNT(*) AS count
+		FROM (
+			SELECT argument->>'languageId' AS language, CASE WHEN name LIKE '%search%' THEN 'search-based' ELSE 'precise' END AS precision
+			FROM event_logs
+			WHERE
+				timestamp BETWEEN $1 AND $2 AND
+				name IN (
+					'codeintel.searchDefinitions',
+					'codeintel.searchDefinitions.xrepo',
+					'codeintel.searchReferences',
+					'codeintel.searchReferences.xrepo',
+					'codeintel.lsifDefinitions',
+					'codeintel.lsifDefinitions.xrepo',
+					'codeintel.lsifReferences',
+					'codeintel.lsifReferences.xrepo'
+				)
+		) sub
+		GROUP BY language, precision;
+	`, from.Format(time.RFC3339), now.Format(time.RFC3339))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := []*CodeIntelByLanguage{}
+	for rows.Next() {
+		var item CodeIntelByLanguage
+
+		if err := rows.Scan(&item.Language_, &item.Precision_, &item.Count_); err != nil {
+			return nil, err
+		}
+
+		items = append(items, &item)
+	}
+
+	if _, err := setArrayToCache(cacheKey, items); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}

--- a/internal/adminanalytics/codeinteltoprepositories.go
+++ b/internal/adminanalytics/codeinteltoprepositories.go
@@ -6,15 +6,24 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type CodeIntelTopRepositories struct {
-	Name_   string  `json:"name"`
-	Events_ float64 `json:"events"`
+	LangId_     string  `json:"langId"`
+	Name_       string  `json:"name"`
+	Events_     float64 `json:"events"`
+	Kind_       string  `json:"kind"`
+	Precision_  string  `json:"precision"`
+	HasPrecise_ bool    `json:"hasPrecise"`
 }
 
-func (s *CodeIntelTopRepositories) Name() string    { return s.Name_ }
-func (s *CodeIntelTopRepositories) Events() float64 { return s.Events_ }
+func (s *CodeIntelTopRepositories) Name() string      { return s.Name_ }
+func (s *CodeIntelTopRepositories) Language() string  { return s.LangId_ }
+func (s *CodeIntelTopRepositories) Events() float64   { return s.Events_ }
+func (s *CodeIntelTopRepositories) Kind() string      { return s.Kind_ }
+func (s *CodeIntelTopRepositories) Precision() string { return s.Precision_ }
+func (s *CodeIntelTopRepositories) HasPrecise() bool  { return s.HasPrecise_ }
 
 func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool, dateRange string) ([]*CodeIntelTopRepositories, error) {
 	cacheKey := fmt.Sprintf(`CodeIntelTopRepositories:%s`, dateRange)
@@ -32,29 +41,63 @@ func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool
 	}
 
 	rows, err := db.QueryContext(ctx, `
-		SELECT name, events
-		FROM (
-			SELECT (argument->>'repositoryId')::int as id, COUNT(*) AS events
-			FROM event_logs
-			WHERE
-				timestamp BETWEEN $1 AND $2 AND
-				name IN (
-					'codeintel.searchDefinitions',
-					'codeintel.searchDefinitions.xrepo',
-					'codeintel.searchReferences',
-					'codeintel.searchReferences.xrepo',
-					'codeintel.lsifDefinitions',
-					'codeintel.lsifDefinitions.xrepo',
-					'codeintel.lsifReferences',
-					'codeintel.lsifReferences.xrepo'
-				)
-			GROUP BY argument->>'repositoryId'
-			LIMIT 5
-		) sub
-		JOIN repo ON repo.id = sub.id;
+		WITH events AS (
+			SELECT *
+			FROM (
+				SELECT argument, (
+					CASE
+					WHEN name = 'codeintel.lsifDefinitions.xrepo'                                      THEN 'crossRepo'
+					WHEN name = 'codeintel.lsifDefinitions'                                            THEN 'precise'
+					WHEN name = 'codeintel.lsifReferences.xrepo'                                       THEN 'crossRepo'
+					WHEN name = 'codeintel.lsifReferences'                                             THEN 'precise'
+					WHEN name = 'codeintel.searchDefinitions.xrepo'                                    THEN 'crossRepo'
+					WHEN name = 'codeintel.searchReferences.xrepo'                                     THEN 'crossRepo'
+					WHEN name = 'findReferences'                    AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
+					WHEN name = 'findReferences'                    AND source = 'WEB'                 THEN 'inApp'
+					WHEN name = 'goToDefinition.preloaded'          AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
+					WHEN name = 'goToDefinition.preloaded'          AND source = 'WEB'                 THEN 'inApp'
+					WHEN name = 'goToDefinition'                    AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
+					WHEN name = 'goToDefinition'                    AND source = 'WEB'                 THEN 'inApp'
+					WHEN name = 'codeintel.searchDefinitions'                                          THEN 'inApp'
+					ELSE NULL
+					END
+				) AS event_kind, (
+					CASE
+					WHEN name = 'codeintel.lsifDefinitions.xrepo' THEN 'precise'
+					WHEN name = 'codeintel.lsifDefinitions'       THEN 'precise'
+					WHEN name = 'codeintel.lsifHover'             THEN 'precise'
+					WHEN name = 'codeintel.lsifReferences.xrepo'  THEN 'precise'
+					WHEN name = 'codeintel.lsifReferences'        THEN 'precise'
+					ELSE                                               'search-based'
+					END
+				) AS event_precision
+				FROM event_logs
+				WHERE timestamp BETWEEN $1 AND $2
+			) AS _
+			WHERE event_kind IS NOT NULL
+		), top_repos AS (
+			SELECT
+				repo.id AS repo_id,
+				repo.name AS repo_name,
+				EXISTS (SELECT 1 FROM lsif_uploads WHERE repository_id = repo.id AND state = 'completed') AS has_precise
+			FROM events
+			JOIN repo ON repo.id = (argument->>'repositoryId')::int
+			GROUP BY repo.id, repo.name
+			ORDER BY COUNT(*) DESC
+			LIMIT 10
+		)
+		SELECT repo_name, lang, event_kind, event_precision, event_count, has_precise
+		FROM
+			top_repos,
+			LATERAL (
+				SELECT (argument->>'languageId')::text AS lang, event_kind, event_precision, COUNT(1) AS event_count
+				FROM events
+				WHERE (argument->>'repositoryId')::int = repo_id
+				GROUP BY (argument->>'languageId')::text, event_kind, event_precision
+			) AS langs;
 	`, from.Format(time.RFC3339), now.Format(time.RFC3339))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "GetCodeIntelTopRepositories SQL query")
 	}
 	defer rows.Close()
 
@@ -62,7 +105,7 @@ func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool
 	for rows.Next() {
 		var item CodeIntelTopRepositories
 
-		if err := rows.Scan(&item.Name_, &item.Events_); err != nil {
+		if err := rows.Scan(&item.Name_, &item.LangId_, &item.Kind_, &item.Precision_, &item.Events_, &item.HasPrecise_); err != nil {
 			return nil, err
 		}
 

--- a/internal/adminanalytics/codeinteltoprepositories.go
+++ b/internal/adminanalytics/codeinteltoprepositories.go
@@ -44,57 +44,57 @@ func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool
 		WITH events AS (
 			SELECT *
 			FROM (
-				SELECT argument, (
-					CASE
-					WHEN name = 'codeintel.lsifDefinitions.xrepo'                                      THEN 'crossRepo'
-					WHEN name = 'codeintel.lsifDefinitions'                                            THEN 'precise'
-					WHEN name = 'codeintel.lsifReferences.xrepo'                                       THEN 'crossRepo'
-					WHEN name = 'codeintel.lsifReferences'                                             THEN 'precise'
-					WHEN name = 'codeintel.searchDefinitions.xrepo'                                    THEN 'crossRepo'
-					WHEN name = 'codeintel.searchReferences.xrepo'                                     THEN 'crossRepo'
-					WHEN name = 'findReferences'                    AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
-					WHEN name = 'findReferences'                    AND source = 'WEB'                 THEN 'inApp'
-					WHEN name = 'goToDefinition.preloaded'          AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
-					WHEN name = 'goToDefinition.preloaded'          AND source = 'WEB'                 THEN 'inApp'
-					WHEN name = 'goToDefinition'                    AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
-					WHEN name = 'goToDefinition'                    AND source = 'WEB'                 THEN 'inApp'
-					WHEN name = 'codeintel.searchDefinitions'                                          THEN 'inApp'
-					ELSE NULL
-					END
-				) AS event_kind, (
-					CASE
-					WHEN name = 'codeintel.lsifDefinitions.xrepo' THEN 'precise'
-					WHEN name = 'codeintel.lsifDefinitions'       THEN 'precise'
-					WHEN name = 'codeintel.lsifHover'             THEN 'precise'
-					WHEN name = 'codeintel.lsifReferences.xrepo'  THEN 'precise'
-					WHEN name = 'codeintel.lsifReferences'        THEN 'precise'
-					ELSE                                               'search-based'
-					END
-				) AS event_precision
+				SELECT
+					(argument->>'repositoryId')::int AS repo_id,
+					(argument->>'languageId')::text AS lang,
+					(
+						CASE
+						WHEN name = 'codeintel.lsifDefinitions.xrepo'                                      THEN 'crossRepo'
+						WHEN name = 'codeintel.lsifDefinitions'                                            THEN 'precise'
+						WHEN name = 'codeintel.lsifReferences.xrepo'                                       THEN 'crossRepo'
+						WHEN name = 'codeintel.lsifReferences'                                             THEN 'precise'
+						WHEN name = 'codeintel.searchDefinitions.xrepo'                                    THEN 'crossRepo'
+						WHEN name = 'codeintel.searchReferences.xrepo'                                     THEN 'crossRepo'
+						WHEN name = 'findReferences'                    AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
+						WHEN name = 'findReferences'                    AND source = 'WEB'                 THEN 'inApp'
+						WHEN name = 'goToDefinition.preloaded'          AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
+						WHEN name = 'goToDefinition.preloaded'          AND source = 'WEB'                 THEN 'inApp'
+						WHEN name = 'goToDefinition'                    AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
+						WHEN name = 'goToDefinition'                    AND source = 'WEB'                 THEN 'inApp'
+						WHEN name = 'codeintel.searchDefinitions'                                          THEN 'inApp'
+						ELSE NULL
+						END
+					) AS kind,
+					name
 				FROM event_logs
 				WHERE timestamp BETWEEN $1 AND $2
 			) AS _
-			WHERE event_kind IS NOT NULL
+			WHERE kind IS NOT NULL
 		), top_repos AS (
-			SELECT
-				repo.id AS repo_id,
-				repo.name AS repo_name,
-				EXISTS (SELECT 1 FROM lsif_uploads WHERE repository_id = repo.id AND state = 'completed') AS has_precise
+			SELECT repo_id
 			FROM events
-			JOIN repo ON repo.id = (argument->>'repositoryId')::int
-			GROUP BY repo.id, repo.name
-			ORDER BY COUNT(*) DESC
+			GROUP BY repo_id
+			ORDER BY COUNT(1) DESC
 			LIMIT 5
 		)
-		SELECT repo_name, lang, event_kind, event_precision, event_count, has_precise
-		FROM
-			top_repos,
-			LATERAL (
-				SELECT (argument->>'languageId')::text AS lang, event_kind, event_precision, COUNT(1) AS event_count
-				FROM events
-				WHERE (argument->>'repositoryId')::int = repo_id
-				GROUP BY (argument->>'languageId')::text, event_kind, event_precision
-			) AS langs;
+		SELECT
+			(SELECT repo.name FROM repo WHERE repo.id = repo_id) AS repo_name,
+			lang,
+			kind,
+			(
+				CASE
+				WHEN name = 'codeintel.lsifDefinitions.xrepo' THEN 'precise'
+				WHEN name = 'codeintel.lsifDefinitions'       THEN 'precise'
+				WHEN name = 'codeintel.lsifHover'             THEN 'precise'
+				WHEN name = 'codeintel.lsifReferences.xrepo'  THEN 'precise'
+				WHEN name = 'codeintel.lsifReferences'        THEN 'precise'
+				ELSE                                               'search-based'
+				END
+			) AS precision,
+			COUNT(1) AS count_,
+			EXISTS (SELECT 1 FROM lsif_uploads WHERE repository_id = repo_id AND state = 'completed') AS has_precise
+		FROM top_repos JOIN events USING (repo_id)
+		GROUP BY repo_id, lang, kind, precision;
 	`, from.Format(time.RFC3339), now.Format(time.RFC3339))
 	if err != nil {
 		return nil, errors.Wrap(err, "GetCodeIntelTopRepositories SQL query")

--- a/internal/adminanalytics/codeinteltoprepositories.go
+++ b/internal/adminanalytics/codeinteltoprepositories.go
@@ -84,7 +84,7 @@ func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool
 			JOIN repo ON repo.id = (argument->>'repositoryId')::int
 			GROUP BY repo.id, repo.name
 			ORDER BY COUNT(*) DESC
-			LIMIT 10
+			LIMIT 5
 		)
 		SELECT repo_name, lang, event_kind, event_precision, event_count, has_precise
 		FROM

--- a/internal/adminanalytics/codeinteltoprepositories.go
+++ b/internal/adminanalytics/codeinteltoprepositories.go
@@ -1,0 +1,77 @@
+package adminanalytics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+type CodeIntelTopRepositories struct {
+	Name_   string  `json:"name"`
+	Events_ float64 `json:"events"`
+}
+
+func (s *CodeIntelTopRepositories) Name() string    { return s.Name_ }
+func (s *CodeIntelTopRepositories) Events() float64 { return s.Events_ }
+
+func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool, dateRange string) ([]*CodeIntelTopRepositories, error) {
+	cacheKey := fmt.Sprintf(`CodeIntelTopRepositories:%s`, dateRange)
+
+	if cache == true {
+		if nodes, err := getArrayFromCache[CodeIntelTopRepositories](cacheKey); err == nil {
+			return nodes, nil
+		}
+	}
+
+	now := time.Now()
+	from, err := getFromDate(dateRange, now)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT name, events
+		FROM (
+			SELECT (argument->>'repositoryId')::int as id, COUNT(*) AS events
+			FROM event_logs
+			WHERE
+				timestamp BETWEEN $1 AND $2 AND
+				name IN (
+					'codeintel.searchDefinitions',
+					'codeintel.searchDefinitions.xrepo',
+					'codeintel.searchReferences',
+					'codeintel.searchReferences.xrepo',
+					'codeintel.lsifDefinitions',
+					'codeintel.lsifDefinitions.xrepo',
+					'codeintel.lsifReferences',
+					'codeintel.lsifReferences.xrepo'
+				)
+			GROUP BY argument->>'repositoryId'
+			LIMIT 5
+		) sub
+		JOIN repo ON repo.id = sub.id;
+	`, from.Format(time.RFC3339), now.Format(time.RFC3339))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := []*CodeIntelTopRepositories{}
+	for rows.Next() {
+		var item CodeIntelTopRepositories
+
+		if err := rows.Scan(&item.Name_, &item.Events_); err != nil {
+			return nil, err
+		}
+
+		items = append(items, &item)
+	}
+
+	if _, err := setArrayToCache(cacheKey, items); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/issues/40345

![CleanShot 2022-08-25 at 18 00 15](https://user-images.githubusercontent.com/1387653/186789278-039c0a7e-b0a1-4a86-a6f2-9c37c48e86f9.png)

SQL query: https://explain.dalibo.com/plan/6DT#

![CleanShot 2022-08-29 at 11 13 24](https://user-images.githubusercontent.com/1387653/187256717-4ab8227c-a2b8-474c-a166-7c483567a7bd.png)

<details>
<summary>Query plan</summary>

```
 HashAggregate  (cost=2864904.82..3193313.40 rows=81078 width=141) (actual time=3284.826..3285.506 rows=24 loops=1)
   Group Key: top_repos.repoid, events.lang, events.kind, CASE WHEN (events.name = 'codeintel.lsifDefinitions.xrepo'::text) THEN 'precise'::text WHEN (events.name = 'codeintel.lsifDefinitions'::text) THEN 'precise'::text WHEN (events.name = 'codeintel.lsifHover'::text) THEN 'precise'::text WHEN (events.name = 'codeintel.lsifReferences.xrepo'::text) THEN 'precise'::text WHEN (events.name = 'codeintel.lsifReferences'::text) THEN 'precise'::text ELSE 'search-based'::text END
   CTE events
     ->  Bitmap Heap Scan on event_logs  (cost=45138.31..2708237.58 rows=3243138 width=89) (actual time=422.293..3048.902 rows=209991 loops=1)
           Recheck Cond: (("timestamp" >= (now() - '8 days'::interval)) AND ("timestamp" <= now()))
           Filter: (CASE WHEN (name = 'codeintel.lsifDefinitions.xrepo'::text) THEN 'crossRepo'::text WHEN (name = 'codeintel.lsifDefinitions'::text) THEN 'precise'::text WHEN (name = 'codeintel.lsifReferences.xrepo'::text) THEN 'crossRepo'::text WHEN (name = 'codeintel.lsifReferences'::text) THEN 'precise'::text WHEN (name = 'codeintel.searchDefinitions.xrepo'::text) THEN 'crossRepo'::text WHEN (name = 'codeintel.searchReferences.xrepo'::text) THEN 'crossRepo'::text WHEN ((name = 'findReferences'::text) AND (source = 'CODEHOSTINTEGRATION'::text)) THEN 'codeHost'::text WHEN ((name = 'findReferences'::text) AND (source = 'WEB'::text)) THEN 'inApp'::text WHEN ((name = 'goToDefinition.preloaded'::text) AND (source = 'CODEHOSTINTEGRATION'::text)) THEN 'codeHost'::text WHEN ((name = 'goToDefinition.preloaded'::text) AND (source = 'WEB'::text)) THEN 'inApp'::text WHEN ((name = 'goToDefinition'::text) AND (source = 'CODEHOSTINTEGRATION'::text)) THEN 'codeHost'::text WHEN ((name = 'goToDefinition'::text) AND (source = 'WEB'::text)) THEN 'inApp'::text WHEN (name = 'codeintel.searchDefinitions'::text) THEN 'inApp'::text ELSE NULL::text END IS NOT NULL)
           Rows Removed by Filter: 3312451
           Heap Blocks: exact=322910
           ->  Bitmap Index Scan on event_logs_timestamp  (cost=0.00..44327.52 rows=3259435 width=0) (actual time=331.695..331.695 rows=3522442 loops=1)
                 Index Cond: (("timestamp" >= (now() - '8 days'::interval)) AND ("timestamp" <= now()))
   ->  Hash Join  (cost=81083.90..155653.77 rows=81078 width=100) (actual time=3215.029..3271.950 rows=24573 loops=1)
         Hash Cond: (events.repoid = top_repos.repoid)
         ->  CTE Scan on events  (cost=0.00..64862.76 rows=3243138 width=100) (actual time=422.297..445.307 rows=209991 loops=1)
         ->  Hash  (cost=81083.83..81083.83 rows=5 width=4) (actual time=2792.700..2792.702 rows=5 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 9kB
               ->  Subquery Scan on top_repos  (cost=81083.77..81083.83 rows=5 width=4) (actual time=2792.691..2792.696 rows=5 loops=1)
                     ->  Limit  (cost=81083.77..81083.78 rows=5 width=12) (actual time=2792.689..2792.692 rows=5 loops=1)
                           ->  Sort  (cost=81083.77..81084.27 rows=200 width=12) (actual time=2792.688..2792.689 rows=5 loops=1)
                                 Sort Key: (count(1)) DESC
                                 Sort Method: top-N heapsort  Memory: 25kB
                                 ->  HashAggregate  (cost=81078.45..81080.45 rows=200 width=12) (actual time=2790.898..2791.969 rows=4765 loops=1)
                                       Group Key: events_1.repoid
                                       ->  CTE Scan on events events_1  (cost=0.00..64862.76 rows=3243138 width=4) (actual time=0.001..2724.752 rows=209991 loops=1)
   SubPlan 2
     ->  Index Scan using repo_pkey on repo  (cost=0.43..2.65 rows=1 width=38) (actual time=0.003..0.003 rows=1 loops=24)
           Index Cond: (id = top_repos.repoid)
   SubPlan 3
     ->  Index Only Scan using lsif_uploads_repository_id_commit_root_indexer on lsif_uploads  (cost=0.55..16.28 rows=19 width=0) (actual time=0.004..0.004 rows=1 loops=24)
           Index Cond: (repository_id = top_repos.repoid)
           Heap Fetches: 9
   SubPlan 4
     ->  Index Only Scan using lsif_uploads_repository_id_commit_root_indexer on lsif_uploads lsif_uploads_1  (cost=0.55..213911.11 rows=267273 width=4) (never executed)
           Heap Fetches: 0
 Planning Time: 0.795 ms
 Execution Time: 3296.456 ms
```

</details>

## Test plan

Ran locally
