### PR TITLE
codeintel: Improve `UpdateReferenceCounts`

### DIFF
--- a/internal/codeintel/stores/dbstore/uploads.go
+++ b/internal/codeintel/stores/dbstore/uploads.go
@@ -1189,16 +1189,19 @@ ranked_uploads_providing_packages AS (
 canonical_package_reference_counts AS (
 	SELECT
 		ru.id,
-		count(*) AS count
-	FROM ranked_uploads_providing_packages ru
-	JOIN lsif_references r
-	ON
-		r.scheme = ru.scheme AND
-		r.name = ru.name AND
-		r.version = ru.version AND
-		r.dump_id != ru.id
+		rc.count
+	FROM ranked_uploads_providing_packages ru,
+	LATERAL (
+		SELECT
+			COUNT(*) AS count
+		FROM lsif_references r
+		WHERE
+			r.scheme = ru.scheme AND
+			r.name = ru.name AND
+			r.version = ru.version AND
+			r.dump_id != ru.id
+	) rc
 	WHERE ru.rank = 1
-	GROUP BY ru.id
 ),
 
 -- Count (and ranks) the set of edges that cross over from the target list of uploads

--- a/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -665,16 +665,19 @@ ranked_uploads_providing_packages AS (
 canonical_package_reference_counts AS (
 	SELECT
 		ru.id,
-		count(*) AS count
-	FROM ranked_uploads_providing_packages ru
-	JOIN lsif_references r
-	ON
-		r.scheme = ru.scheme AND
-		r.name = ru.name AND
-		r.version = ru.version AND
-		r.dump_id != ru.id
+		rc.count
+	FROM ranked_uploads_providing_packages ru,
+	LATERAL (
+		SELECT
+			COUNT(*) AS count
+		FROM lsif_references r
+		WHERE
+			r.scheme = ru.scheme AND
+			r.name = ru.name AND
+			r.version = ru.version AND
+			r.dump_id != ru.id
+	) rc
 	WHERE ru.rank = 1
-	GROUP BY ru.id
 ),
 
 -- Count (and ranks) the set of edges that cross over from the target list of uploads


### PR DESCRIPTION
Observation: In [this query plan](https://explain.dalibo.com/plan/ztP#plan/node/35) we materialize 106 million rows by a product of `lsif_references` and the canonical package providers. What we actually want is a _count_ for each of the 1,210 uploads. The way that the original query achieved this was by materializing the full join, sorting by id, then grouping. This took ~1.4GB to sort on disk each query.

Alternatively, we can use a correlated subquery/lateral join to do a single count per row. This is mechanically the same as the nested loop join that was previously used, except now we skip to the aggregate value instead of blowing up the intermediate resuelt.

I don't know in practice if this will help us with our current low queue throughput, but it should advance the bad-SQL part of the queries for now. We should still look into reducing lock contention on the `lsif_uploads` table.

## Test plan

Existing unit tests.