### PR TITLE
search: fix regex syntax example

### DIFF
--- a/client/web/src/search/home/useQueryExamples.tsx
+++ b/client/web/src/search/home/useQueryExamples.tsx
@@ -62,7 +62,7 @@ function getRepoFilterExamples(repositoryName: string): { singleRepoExample: str
     const repoOrg = repositoryNameParts[repositoryNameParts.length - 2]
     return {
         singleRepoExample: quoteIfNeeded(`${repoOrg}/${repoName}`),
-        orgReposExample: quoteIfNeeded(`${repoOrg}/*`),
+        orgReposExample: quoteIfNeeded(`${repoOrg}/.*`),
     }
 }
 


### PR DESCRIPTION
Noticed this placeholder is doing `/*` which resembles globbing, but since it's regex we should stick to `/.*` (IIRC this example was just carried over from old code, just fixing as I see it).

<img width="355" alt="Screen Shot 2022-08-22 at 5 47 58 PM" src="https://user-images.githubusercontent.com/888624/186044282-5f6e67e5-1f15-4066-970e-e5882255e52d.png">



## Test plan
Just updates a placeholder value, no semantic change. Checked manually.

## App preview:

- [Web](https://sg-web-rvt-fix-query-ex.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sdumzbwzfq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

