### PR TITLE
docs: improve running e2e and regression tests docs

### DIFF
--- a/client/shared/src/testing/config.ts
+++ b/client/shared/src/testing/config.ts
@@ -172,6 +172,7 @@ const configFields: ConfigFields = {
         parser: parseBool,
         description:
             "If true, regression tests will not clean up users, external services, or other resources they create. Set this to true if running against a dev instance (as it'll make test runs faster). Set to false if running against production.",
+        defaultValue: false,
     },
     keepBrowser: {
         envVar: 'KEEP_BROWSER',
@@ -190,6 +191,7 @@ const configFields: ConfigFields = {
         parser: parseBool,
         description:
             'If true, logs status messages to console. This does not log the browser console (use LOG_BROWSER_CONSOLE for that).',
+        defaultValue: true,
     },
     slowMo: {
         envVar: 'SLOWMO',

--- a/dev/sg/sg_tests.go
+++ b/dev/sg/sg_tests.go
@@ -28,8 +28,8 @@ var testCommand = &cli.Command{
 # Run different test suites:
 sg test backend
 sg test backend-integration
-sg test frontend
-sg test frontend-e2e
+sg test client
+sg test client-e2e
 
 # List available test suites:
 sg test -help

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -300,15 +300,15 @@ Available testsuites in `sg.config.yaml`:
 * bext-integration
 * docsite
 * frontend
-* frontend-e2e
+* client-e2e
 * web-integration
 
 ```sh
 # Run different test suites:
 $ sg test backend
 $ sg test backend-integration
-$ sg test frontend
-$ sg test frontend-e2e
+$ sg test client
+$ sg test client-e2e
 
 # List available test suites:
 $ sg test -help

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -298,9 +298,10 @@ Available testsuites in `sg.config.yaml`:
 * bext-build
 * bext-e2e
 * bext-integration
-* docsite
-* frontend
+* client
 * client-e2e
+* client-regression
+* docsite
 * web-integration
 
 ```sh

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -285,7 +285,7 @@ GH_TOKEN=XXX sg test client-e2e
 You can find the `GH_TOKEN` value in the shared 1Password vault under `BUILDKITE_GITHUBDOTCOM_TOKEN`.
 If you have access to CI secrets via the `gcloud` CLI, the `GH_TOKEN` value will be set for you.
 
-In case of running against an existing server image:
+If you run the test suite against an existing server image:
 
 ```
 SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' GH_TOKEN=XXX sg test client-e2e

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -314,7 +314,7 @@ Also, you can also run tests selectively with a command like `yarn run test:regr
 
 ##### Fixing authentication issues
 
-If you run into authentication issues, **create a user and promote it site admin**:
+If you run into authentication issues, **create a user and promote it to site admin**:
 
 ```
 sg db reset-pg --db=all && sg db add-user --username 'test' --password 'supersecurepassword'

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -251,7 +251,7 @@ There is a default mock JSContext that you can extend with object spread syntax 
 ### End-to-end tests
 
 End-to-end tests test the whole app: JavaScript, CSS styles, and backend.
-They can be found in [`web/src/end-to-end`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/web/src/end-to-end).
+They can be found in [`web/src/end-to-end`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/client/web/src/end-to-end).
 
 The **regression test suite** is a special end-to-end test suite, which was created specifically for release testing and also contains some manual verification steps. As part of moving most of our current end-to-end tests to client & backend integration tests, the regression test suite will gradually be trimmed and phased out.
 
@@ -259,19 +259,72 @@ Test coverage by end-to-end tests is tracked in [Codecov](https://codecov.io/gh/
 
 #### Running end-to-end tests
 
-To run all end-to-end tests locally, a local instance needs to be running.
-To run the tests against it, **create a user `test` with password `testtesttest` and promote it site admin**.
-Then run in the repository root:
+##### Starting a local instance
+
+To run all end-to-end tests locally, a local instance needs to be running:
 
 ```
-env TEST_USER_PASSWORD=testtesttest GITHUB_TOKEN=<token> yarn test-e2e
+sg start enterprise-e2e
 ```
 
-There's a GitHub test token in `../dev-private/enterprise/dev/external-services-config.json`.
+You can also run tests against an existing server image (note that this test must
+be run with SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' for the following to work):
+
+```
+TAG=insiders sg run server
+```
+
+##### Starting end-to-end tests
+
+In the repository root:
+
+```
+GH_TOKEN=XXX sg test client-e2e
+```
+
+You can find the `GH_TOKEN` value in the shared 1Password vault under `BUILDKITE_GITHUBDOTCOM_TOKEN`.
+If you have access to CI secrets via the `gcloud` CLI, the `GH_TOKEN` value will be set for you.
+
+In case of running against an existing server image:
+
+```
+SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' GH_TOKEN=XXX sg test client-e2e
+```
 
 This will open Chromium, add a code host, clone repositories, and execute the e2e tests.
 
-For regression tests, you can also run tests selectively with a command like `yarn run test:regression:search` in the `web/` directory, which runs the tests for search functionality.
+##### Starting regression tests
+
+1. Log in as a `test` user. See more info below on creating this user on your instance if it doesn't exist.
+2. Create a site-admin access token with the `site-admin:sudo` scope. The access tokens page can be found under user settings.
+3. Create your personal `GITHUB_TOKEN`. It should have access to all the repos in the Sourcegraph GitHub required to run these tests without scopes.
+4. Run in the repository root:
+
+```
+GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test client-regression
+```
+
+In case of running against an existing server image:
+
+```
+SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test client-regression
+```
+
+Also, you can also run tests selectively with a command like `yarn run test:regression:search` in the `client/web` directory, which runs the tests for search functionality.
+
+##### Fixing authentication issues
+
+If you run into authentication issues, **create a user and promote it site admin**:
+
+```
+sg db reset-pg --db=all && sg db add-user --username 'test' --password 'supersecurepassword'
+```
+
+The above command resets the database and creates a user like so:
+
+```
+  👉 User test (test@sourcegraph.com) has been created and its password is supersecurepassword .
+```
 
 #### Writing end-to-end tests
 

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -268,7 +268,7 @@ sg start enterprise-e2e
 ```
 
 You can also run tests against an existing server image (note that this test must
-be run with SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' for the following to work):
+be run with SOURCEGRAPH_BASE_URL=http://localhost:7080 for the following to work):
 
 ```
 TAG=insiders sg run server
@@ -288,7 +288,7 @@ If you have access to CI secrets via the `gcloud` CLI, the `GH_TOKEN` value will
 If you run the test suite against an existing server image:
 
 ```
-SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' GH_TOKEN=XXX sg test client-e2e
+SOURCEGRAPH_BASE_URL=http://localhost:7080 GH_TOKEN=XXX sg test client-e2e
 ```
 
 This will open Chromium, add a code host, clone repositories, and execute the e2e tests.
@@ -307,7 +307,7 @@ GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test client-regression
 And if you're running the test suite against an existing server image:
 
 ```
-SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test client-regression
+SOURCEGRAPH_BASE_URL=http://localhost:7080 GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test client-regression
 ```
 
 Also, you can also run tests selectively with a command like `yarn run test:regression:search` in the `client/web` directory, which runs the tests for search functionality.

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -304,7 +304,7 @@ This will open Chromium, add a code host, clone repositories, and execute the e2
 GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test client-regression
 ```
 
-In case of running against an existing server image:
+And if you're running the test suite against an existing server image:
 
 ```
 SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test client-regression

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -295,7 +295,7 @@ This will open Chromium, add a code host, clone repositories, and execute the e2
 
 ##### Starting regression tests
 
-1. Log in as a `test` user. See more info below on creating this user on your instance if it doesn't exist.
+1. Log in as a `test` user. If the user does not exist then see below for more information on how to create a user.
 2. Create a site-admin access token with the `site-admin:sudo` scope. The access tokens page can be found under user settings.
 3. Create your personal `GITHUB_TOKEN`. It should have access to all the repos in the Sourcegraph GitHub required to run these tests without scopes.
 4. Run in the repository root:

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -320,7 +320,7 @@ If you run into authentication issues, **create a user and promote it site admin
 sg db reset-pg --db=all && sg db add-user --username 'test' --password 'supersecurepassword'
 ```
 
-The above command resets the database and creates a user like so:
+The above command resets the database and creates a user like. If the command completes succesfully you'll see the following output:
 
 ```
   👉 User test (test@sourcegraph.com) has been created and its password is supersecurepassword .

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test-lighthouse": "SOURCEGRAPH_API_URL=https://sourcegraph.com lhci collect && lhci open",
     "test-e2e": "TS_NODE_PROJECT=client/web/src/end-to-end/tsconfig.json mocha ./client/web/src/end-to-end/**/*.test.ts",
     "cover-e2e": "nyc --hook-require=false --silent yarn test-e2e",
+    "test-regression": "yarn workspace @sourcegraph/web run test:regression",
     "storybook": "yarn workspace @sourcegraph/storybook run start",
     "storybook:dll": "yarn workspace @sourcegraph/storybook run start:dll",
     "storybook:branded": "yarn workspace @sourcegraph/branded run storybook",

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1011,7 +1011,7 @@ tests:
 
   client-regression:
     preamble: |
-      A Sourcegraph isntance must be already running for these tests to work, most
+      A Sourcegraph instance must be already running for these tests to work, most
       commonly with: `sg start enterprise-e2e`
 
       See more details: https://docs.sourcegraph.com/dev/how-to/testing#running-regression-tests

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -987,28 +987,15 @@ tests:
     env:
       SOURCEGRAPH_BASE_URL: https://sourcegraph.com
 
-  frontend:
+  client:
     cmd: yarn run jest --testPathIgnorePatterns end-to-end regression integration storybook
 
-  frontend-e2e:
+  client-e2e:
     preamble: |
       A Sourcegraph isntance must be already running for these tests to work, most
-      commonly with:
+      commonly with: `sg start enterprise-e2e`
 
-        sg start enterprise-e2e
-
-      You can also run tests against an existing server image (note that this test must
-      be run with SOURCEGRAPH_BASE_URL='http://127.0.0.1:7080' for the following to work):
-
-        TAG=insiders sg run server
-
-      If you run into authentication issues, you can run the following commands to fix them:
-
-        sg db reset-pg --db=all && sg db add-user --username 'test' --password 'supersecurepassword'
-
-      The above command resets the database and creates a user like so:
-
-        👉 User test (test@sourcegraph.com) has been created and its password is supersecurepassword .
+      See more details: https://docs.sourcegraph.com/dev/how-to/testing#running-end-to-end-tests
     cmd: |
       yarn run test-e2e
     env:
@@ -1021,6 +1008,21 @@ tests:
         provider: 'gcloud'
         project: 'sourcegraph-ci'
         name: 'BUILDKITE_GITHUBDOTCOM_TOKEN'
+
+  client-regression:
+    preamble: |
+      A Sourcegraph isntance must be already running for these tests to work, most
+      commonly with: `sg start enterprise-e2e`
+
+      See more details: https://docs.sourcegraph.com/dev/how-to/testing#running-regression-tests
+
+    cmd: |
+      yarn run test-regression
+    env:
+      SOURCEGRAPH_SUDO_USER: test
+      SOURCEGRAPH_BASE_URL: https://sourcegraph.test:3443
+      TEST_USER_PASSWORD: supersecurepassword
+      BROWSER: chrome
 
   docsite:
     cmd: .bin/docsite_${DOCSITE_VERSION} check ./doc


### PR DESCRIPTION
## Context

This PR updates ["Running end-to-end tests" docs](https://docs.sourcegraph.com/dev/how-to/testing#running-end-to-end-tests) based on [recent improvements made in the `sg` CLI](https://github.com/sourcegraph/sourcegraph/blob/27dfd494f71d2afcdd06aa107f59ec6302923e24/sg.config.yaml#L993).

Closes #40256 
Thanks, @courier-new, for bringing this up!

## Changes

1. Renamed sg `frontend` test to `client` to be consistent with naming in other places and avoid confusion with the `frontend` backend service.
2. Moved most of `preamble` contents from `sg.config.yaml` to docs and added docs links to preambles.
3. Added `sg test regression` command to the `sg.config.yaml`.
4. Updated `Running end-to-end tests` docs.
5. Added `Running regression tests` docs.
6. Made `LOG_STATUS_MESSAGES` and `NO_CLEANUP` env variables optional and `true` by default.

## Test plan

Run e2e and regression tests locally using the updated documentation.
