### PR TITLE
Use separate experimental feature flag for merged file and symbol sidebar

### DIFF
--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -36,6 +36,7 @@ export interface Settings {
         extensionsAsCoreFeatures?: boolean
         enableLegacyExtensions?: boolean
         enableLazyFileResultSyntaxHighlighting?: boolean
+        enableMergedFileSymbolSidebar?: boolean
     }
     [key: string]: any
 

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -23,6 +23,7 @@ interface ChildTreeLayerProps extends Pick<TreeRootProps, Exclude<keyof TreeRoot
     singleChildTreeEntry: SingleChildGitTree
     /** The children entries of a SingleChildTreeLayer. Will be undefined if there is no SingleChildTreeLayer to render. */
     childrenEntries?: SingleChildGitTree[]
+    enableMergedFileSymbolSidebar: boolean
     onHover: (filePath: string) => void
 }
 
@@ -85,6 +86,7 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                                 isActive={false}
                                                 isSelected={false}
                                                 customIconPath={mdiFolderOutline}
+                                                enableMergedFileSymbolSidebar={props.enableMergedFileSymbolSidebar}
                                             />
                                         )}
                                     </TreeRootContext.Consumer>
@@ -106,6 +108,7 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                     fileDecorationsByPath={props.fileDecorationsByPath}
                                     fileDecorations={props.fileDecorationsByPath[props.singleChildTreeEntry.path]}
                                     telemetryService={props.telemetryService}
+                                    enableMergedFileSymbolSidebar={props.enableMergedFileSymbolSidebar}
                                 />
                             ) : (
                                 props.entries.map((item, index) => (
@@ -118,6 +121,7 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                         entryInfo={item}
                                         fileDecorations={props.fileDecorationsByPath[item.path]}
                                         telemetryService={props.telemetryService}
+                                        enableMergedFileSymbolSidebar={props.enableMergedFileSymbolSidebar}
                                     />
                                 ))
                             )}

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -10,7 +10,6 @@ import { NavLink } from 'react-router-dom'
 import { FileDecoration } from 'sourcegraph'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
-import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { SymbolTag } from '@sourcegraph/shared/src/symbols/SymbolTag'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Icon, LoadingSpinner } from '@sourcegraph/wildcard'
@@ -49,14 +48,13 @@ interface FileProps extends ThemeProps {
     isActive: boolean
     isSelected: boolean
     customIconPath?: string
+    enableMergedFileSymbolSidebar: boolean
 
     // For core workflow inline symbols redesign
     location: H.Location
 }
 
 export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> = props => {
-    const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
-
     const renderedFileDecorations = (
         <FileDecorator
             // If component is not specified, or it is 'sidebar', render it.
@@ -144,7 +142,7 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
                     )}
                 </TreeLayerCell>
             </TreeRow>
-            {coreWorkflowImprovementsEnabled && props.isActive && (
+            {props.enableMergedFileSymbolSidebar && props.isActive && (
                 <Symbols activePath={props.entryInfo.path} location={props.location} style={offsetStyle} />
             )}
         </>

--- a/client/web/src/tree/Tree.tsx
+++ b/client/web/src/tree/Tree.tsx
@@ -34,6 +34,7 @@ interface Props extends AbsoluteRepo, ExtensionsControllerProps, ThemeProps, Tel
     /** The localStorage key that stores the current size of the (resizable) RepoRevisionSidebar. */
     sizeKey: string
     repoID: Scalars['ID']
+    enableMergedFileSymbolSidebar: boolean
 }
 
 interface State {
@@ -346,6 +347,7 @@ export class Tree extends React.PureComponent<Props, State> {
                     extensionsController={this.props.extensionsController}
                     isLightTheme={this.props.isLightTheme}
                     telemetryService={this.props.telemetryService}
+                    enableMergedFileSymbolSidebar={this.props.enableMergedFileSymbolSidebar}
                 />
             </div>
         )

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -44,6 +44,7 @@ export interface TreeLayerProps extends Omit<TreeRootProps, 'sizeKey'> {
     fileDecorations?: FileDecoration[]
     onHover: (filePath: string) => void
     repoID: Scalars['ID']
+    enableMergedFileSymbolSidebar: boolean
 }
 
 const LOADING = 'loading' as const
@@ -309,6 +310,9 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                                         childrenEntries={singleChildTreeEntry.children}
                                                         setChildNodes={this.setChildNode}
                                                         fileDecorationsByPath={this.state.fileDecorationsByPath}
+                                                        enableMergedFileSymbolSidebar={
+                                                            this.props.enableMergedFileSymbolSidebar
+                                                        }
                                                     />
                                                 )
                                             )}
@@ -329,6 +333,7 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                 isActive={isActive}
                                 isSelected={isSelected}
                                 location={this.props.location}
+                                enableMergedFileSymbolSidebar={this.props.enableMergedFileSymbolSidebar}
                             />
                         )}
                     </tbody>

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -59,6 +59,7 @@ export interface TreeRootProps extends AbsoluteRepo, ExtensionsControllerProps, 
     setChildNodes: (node: TreeNode, index: number) => void
     setActiveNode: (node: TreeNode) => void
     repoID: Scalars['ID']
+    enableMergedFileSymbolSidebar: boolean
 }
 
 const LOADING = 'loading' as const
@@ -230,6 +231,9 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                                                     onHover={this.fetchChildContents}
                                                     setChildNodes={this.setChildNode}
                                                     fileDecorationsByPath={this.state.fileDecorationsByPath}
+                                                    enableMergedFileSymbolSidebar={
+                                                        this.props.enableMergedFileSymbolSidebar
+                                                    }
                                                 />
                                             </TreeRootContext.Provider>
                                         )

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1783,6 +1783,8 @@ type SettingsExperimentalFeatures struct {
 	EnableLazyBlobSyntaxHighlighting *bool `json:"enableLazyBlobSyntaxHighlighting,omitempty"`
 	// EnableLazyFileResultSyntaxHighlighting description: Fetch un-highlighted file result contents to render immediately, decorate with syntax highlighting once loaded.
 	EnableLazyFileResultSyntaxHighlighting *bool `json:"enableLazyFileResultSyntaxHighlighting,omitempty"`
+	// EnableMergedFileSymbolSidebar description: Enables the new file sidebar experience with merged file and symbol entries.
+	EnableMergedFileSymbolSidebar *bool `json:"enableMergedFileSymbolSidebar,omitempty"`
 	// EnableSearchStack description: REMOVED: This feature can now be enabled/disabled via the notepad button on the notebooks list page.
 	EnableSearchStack *bool `json:"enableSearchStack,omitempty"`
 	// EnableSmartQuery description: REMOVED. Previously, added more syntax highlighting and hovers for queries in the web app. This behavior is active by default now.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -197,6 +197,14 @@
             "pointer": true
           }
         },
+        "enableMergedFileSymbolSidebar": {
+          "description": "Enables the new file sidebar experience with merged file and symbol entries.",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
+        },
         "fuzzyFinder": {
           "description": "Enables fuzzy finder with the keyboard shortcut `Cmd+K` on macOS and `Ctrl+K` on Linux/Windows.",
           "type": "boolean",


### PR DESCRIPTION
Fixes #40671

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Turn on Simple UI
* Go to file page
* Files and symbols should be in separate tabs
* Turn on the new experimental feature `enableMergedFileSymbolSidebar`
* Files and symbols should bow be merged