### PR TITLE
batches: hide "Create" button on search results unless enabled

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -53,6 +53,7 @@ export interface SearchResultsInfoBarProps
     query?: string
     resultsFound: boolean
 
+    batchChangesEnabled?: boolean
     /** Whether running batch changes server-side is enabled */
     batchChangesExecutionEnabled?: boolean
 
@@ -135,7 +136,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                     props.query,
                     props.patternType,
                     props.authenticatedUser,
-                    props.batchChangesExecutionEnabled
+                    props.batchChangesEnabled && props.batchChangesExecutionEnabled
                 ),
                 getSearchContextCreateAction(props.query, props.authenticatedUser),
                 getInsightsCreateAction(
@@ -150,6 +151,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
             props.enableCodeInsights,
             props.patternType,
             props.query,
+            props.batchChangesEnabled,
             props.batchChangesExecutionEnabled,
         ]
     )


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/40612.

Just adds an additional site settings check to only show the "Create Batch Change" button on the search results page if the instance has batch changes enabled in its configuration. Since we changed the default for the experimental flag `batchChangesExecutionEnabled` to `true` for beta, the condition to show this button was evaluating to true even if the entire instance didn't have batch changes enabled.

<sub>
<em>I could use this as an opportunity to launch into a big, pedantic lecture about how the *correct* solution is to redesign our settings matrix to not allow such impossible states (e.g. where batch changes is disabled and simultaneously server-side execution is enabled), but I don't think this is a battle anyone can reasonably fight at this point. 😅</em></sub>


## Test plan

Manually verified:

`batchChanges.enabled` | `experimentalFeatures.batchChangesExecution` | Button present?
:--:|:--:|:--:
`true` | `true` | ✅ 
`false` | `true` | ❌ 
`true` | `false` | ❌ 
`true` | unset (= `true`) | ✅  

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-no-create-when-disabled.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ebntrmgjkq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
