### PR TITLE
Add a flag for max_idle postgres connections

### DIFF
--- a/internal/database/dbconn/open.go
+++ b/internal/database/dbconn/open.go
@@ -36,6 +36,16 @@ var defaultMaxOpen = func() int {
 	return v
 }()
 
+var defaultMaxIdle = func() int {
+	// For now, use the old default of max_idle == max_open
+	str := env.Get("SRC_PGSQL_MAX_IDLE", "30", "Maximum number of idle connections to Postgres")
+	v, err := strconv.Atoi(str)
+	if err != nil {
+		log.Fatalln("SRC_PGSQL_MAX_IDLE:", err)
+	}
+	return v
+}()
+
 func newWithConfig(cfg *pgx.ConnConfig) (*sql.DB, error) {
 	db, err := openDBWithStartupWait(cfg)
 	if err != nil {
@@ -101,7 +111,7 @@ func open(cfg *pgx.ConnConfig) (*sql.DB, error) {
 	}
 
 	db.SetMaxOpenConns(maxOpen)
-	db.SetMaxIdleConns(maxOpen)
+	db.SetMaxIdleConns(defaultMaxIdle)
 	db.SetConnMaxIdleTime(time.Minute)
 
 	return db, nil


### PR DESCRIPTION
Add a flag that allows us to tune maximum number of idle Postgres connections (instead of setting it to the maximum size of connection pool).
## Test plan

- [x] Tested locally 
- [x] Doesn't change the default behaviour
