### PR TITLE
nix: enable esbuild by default

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -96,4 +96,6 @@ pkgs.mkShell {
   CTAGS_COMMAND = "${universal-ctags}/bin/universal-ctags";
 
   RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+
+  DEV_WEB_BUILDER = "esbuild";
 }


### PR DESCRIPTION
`esbuild` seems to be the way forward (and honestly its just so much faster), so this seems like a good idea to set as default

## Test plan

N/A, dev env
