### PR TITLE
postgresdsn: add a test case for search_path

### DIFF
--- a/internal/database/postgresdsn/postgresdsn_test.go
+++ b/internal/database/postgresdsn/postgresdsn_test.go
@@ -68,6 +68,13 @@ func TestNew(t *testing.T) {
 			dsn: "postgres://foo@bar/bam",
 		},
 		{
+			name: "datasource search_path",
+			env: map[string]string{
+				"PGDATASOURCE": "postgres://sg:REDACTED@pgsql:5432/sg?sslmode=disable&search_path=application",
+			},
+			dsn: "postgres://sg:REDACTED@pgsql:5432/sg?sslmode=disable&search_path=application",
+		},
+		{
 			name: "datasource ignore",
 			env: map[string]string{
 				"PGHOST":       "pgsql",


### PR DESCRIPTION
A customer needs to specify this variable to the postgres DSN. Our code seems to work for this, but adding in a test case for it since previously we didn't cover the case of postgres parameters that we ignore (but postgres does not).

Test Plan: go test
