### PR TITLE
CodeMirror blob: override browser's search to trigger CM search

### DIFF
--- a/client/shared/src/keyboardShortcuts/keyboardShortcuts.ts
+++ b/client/shared/src/keyboardShortcuts/keyboardShortcuts.ts
@@ -9,6 +9,7 @@ type KEYBOARD_SHORTCUT_IDENTIFIERS =
     | 'focusSearch'
     | 'fuzzyFinder'
     | 'copyFullQuery'
+    | 'searchCodeMirrorBlob'
 
 export type KEYBOARD_SHORTCUT_MAPPING = Record<KEYBOARD_SHORTCUT_IDENTIFIERS, KeyboardShortcut>
 
@@ -38,5 +39,9 @@ export const KEYBOARD_SHORTCUTS: KEYBOARD_SHORTCUT_MAPPING = {
     copyFullQuery: {
         title: 'Copy full query',
         keybindings: [{ held: [isMacPlatform() ? 'Meta' : 'Control', 'Shift'], ordered: ['c'] }],
+    },
+    searchCodeMirrorBlob: {
+        title: 'Search in the current file',
+        keybindings: [{ held: [isMacPlatform() ? 'Meta' : 'Control'], ordered: ['f'] }],
     },
 }


### PR DESCRIPTION
Towards #40724.


## Test plan

Manually tested this change by triggering Cmd+F without an active focus on the blob view.

Note that Cmd+F still triggers the browser's "Find" feature if the search bar is focused, and it's automatically focused when reloading a blob view page. This issue can be addressed separately.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-cm-shortcuts.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zsxecznxfw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
