### PR TITLE
frontend/symbols: Map rbi extension to Ruby.

### DIFF
--- a/cmd/frontend/internal/highlight/syntect_language_map.go
+++ b/cmd/frontend/internal/highlight/syntect_language_map.go
@@ -268,6 +268,7 @@ var SyntectLanguageMap = map[string]string{
 	"rest":                 "rest",
 	"ruby":                 "rb",
 	"rb":                   "rb",
+	"rbi":                  "rb",
 	"appfile":              "Appfile",
 	"appraisals":           "Appraisals",
 	"berksfile":            "Berksfile",

--- a/cmd/symbols/squirrel/language-file-extensions.json
+++ b/cmd/symbols/squirrel/language-file-extensions.json
@@ -284,6 +284,7 @@
   ],
   "ruby": [
     "rb",
+    "rbi",
     "builder",
     "eye",
     "gemspec",


### PR DESCRIPTION
These are Ruby interface files, used by Sorbet.

## Test plan

n/a