### PR TITLE
executors: fix and move no-forward-progress alert

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -5920,19 +5920,19 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
-## executor: executor_processor_total
+## executor: executor_handlers
 
-<p class="subtitle">handler operations every 5m</p>
+<p class="subtitle">executor active handlers</p>
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> executor: less than 0 handler operations every 5m for 5m0s
+- <span class="badge badge-critical">critical</span> executor: 0 active executor handlers and > 0 queue size for 5m0s
 
 <details>
 <summary>Technical details</summary>
 
 Custom alert query: `
-		(sum(src_executor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}) OR vector(0)) == 0
+		(sum(src_executor_processor_handlers{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}) OR vector(0)) == 0
 			AND
 		(sum by (queue)(src_executor_total{job=~"^sourcegraph-executors.*"})) > 0
 	`
@@ -5944,12 +5944,12 @@ Custom alert query: `
 - Check to see the state of any compute VMs, they may be taking longer than expected to boot.
 - Make sure the executors appear under Site Admin > Executors.
 - Check the Grafana dashboard section for APIClient, it should do frequent requests to Dequeue and Heartbeat and those must not fail.
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#executor-executor-processor-total).
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#executor-executor-handlers).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "critical_executor_executor_processor_total"
+  "critical_executor_executor_handlers"
 ]
 ```
 
@@ -5959,11 +5959,11 @@ Custom alert query: `
 
 ## executor: executor_processor_error_rate
 
-<p class="subtitle">handler operation error rate over 5m</p>
+<p class="subtitle">executor operation error rate over 5m</p>
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> executor: 100%+ handler operation error rate over 5m for 1h0m0s
+- <span class="badge badge-critical">critical</span> executor: 100%+ executor operation error rate over 5m for 1h0m0s
 
 <details>
 <summary>Technical details</summary>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -17641,9 +17641,9 @@ Query: `max by (queue)(src_executor_queued_duration_seconds_total{job=~"^(execut
 
 #### executor: executor_handlers
 
-<p class="subtitle">Handler active handlers</p>
+<p class="subtitle">Executor active handlers</p>
 
-This panel has no related alerts.
+Refer to the [alerts reference](./alerts.md#executor-executor-handlers) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100100` on your Sourcegraph instance.
 
@@ -17660,9 +17660,9 @@ Query: `sum(src_executor_processor_handlers{queue=~"${queue:regex}",sg_job=~"^so
 
 #### executor: executor_processor_total
 
-<p class="subtitle">Handler operations every 5m</p>
+<p class="subtitle">Executor operations every 5m</p>
 
-Refer to the [alerts reference](./alerts.md#executor-executor-processor-total) for 1 alert related to this panel.
+This panel has no related alerts.
 
 To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100110` on your Sourcegraph instance.
 
@@ -17679,7 +17679,7 @@ Query: `sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job
 
 #### executor: executor_processor_99th_percentile_duration
 
-<p class="subtitle">Aggregate successful handler operation duration distribution over 5m</p>
+<p class="subtitle">Aggregate successful executor operation duration distribution over 5m</p>
 
 This panel has no related alerts.
 
@@ -17698,7 +17698,7 @@ Query: `sum  by (le)(rate(src_executor_processor_duration_seconds_bucket{queue=~
 
 #### executor: executor_processor_errors_total
 
-<p class="subtitle">Handler operation errors every 5m</p>
+<p class="subtitle">Executor operation errors every 5m</p>
 
 This panel has no related alerts.
 
@@ -17717,7 +17717,7 @@ Query: `sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}"
 
 #### executor: executor_processor_error_rate
 
-<p class="subtitle">Handler operation error rate over 5m</p>
+<p class="subtitle">Executor operation error rate over 5m</p>
 
 Refer to the [alerts reference](./alerts.md#executor-executor-processor-error-rate) for 1 alert related to this panel.
 

--- a/monitoring/definitions/shared/workerutil.go
+++ b/monitoring/definitions/shared/workerutil.go
@@ -80,6 +80,8 @@ func (workerutilConstructor) LastOverTimeErrorRate(containerName string, lookbac
 
 // QueueForwardProgress creates a queue-based workerutil-specific query that yields 0 when the queue is non-empty but the
 // number of processed records is zero.
+// Two series are requred: `src_{options.MetricNameRoot}_processor_handlers` for active handlers and `src_{options.MetricNameRoot}_total`
+// for queue size.
 func (workerutilConstructor) QueueForwardProgress(containerName string, handlerOptions, queueOptions ObservableConstructorOptions) string {
 	handlerFilters := makeFilters(handlerOptions.JobLabel, containerName, handlerOptions.Filters...)
 	handlerBy, _ := makeBy(handlerOptions.By...)
@@ -88,7 +90,7 @@ func (workerutilConstructor) QueueForwardProgress(containerName string, handlerO
 	queueBy, _ := makeBy(queueOptions.By...)
 
 	return fmt.Sprintf(`
-		(sum%[1]s(src_%[2]s_total{%[3]s}) OR vector(0)) == 0
+		(sum%[1]s(src_%[2]s_processor_handlers{%[3]s}) OR vector(0)) == 0
 			AND
 		(sum%[4]s(src_%[5]s_total{%[6]s})) > 0
 	`, handlerBy, handlerOptions.MetricNameRoot, handlerFilters, queueBy, queueOptions.MetricNameRoot, queueFilters)

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -284,12 +284,15 @@ func (c *Dashboard) alertDescription(o Observable, alert *ObservableAlertDefinit
 	if alert.isEmpty() {
 		return "", errors.New("cannot generate description for empty alert")
 	}
+
 	var description string
 
 	// description based on thresholds. no special description for 'alert.strictCompare',
 	// because the description is pretty ambiguous to fit different alerts.
 	units := o.Panel.unitType.short()
-	if alert.greaterThan {
+	if alert.description != "" {
+		description = fmt.Sprintf("%s: %s", c.Name, alert.description)
+	} else if alert.greaterThan {
 		// e.g. "zoekt-indexserver: 20+ indexed search request errors every 5m by code"
 		description = fmt.Sprintf("%s: %v%s+ %s", c.Name, alert.threshold, units, o.Description)
 	} else if alert.lessThan {
@@ -311,7 +314,6 @@ func (c *Dashboard) alertDescription(o Observable, alert *ObservableAlertDefinit
 // how these work, see:
 //
 // https://docs.sourcegraph.com/admin/observability/metrics#high-level-alerting-metrics
-//
 func (c *Dashboard) renderRules() (*promRulesFile, error) {
 	group := promGroup{Name: c.Name}
 	for groupIndex, g := range c.Groups {
@@ -908,6 +910,8 @@ type ObservableAlertDefinition struct {
 	threshold float64
 	// alternative query to use for an alert instead of the observables query.
 	query string
+	// alternative description to use for an alert instead of the observables description.
+	description string
 }
 
 // GreaterOrEqual indicates the alert should fire when greater or equal the given value.
@@ -959,6 +963,13 @@ func (a *ObservableAlertDefinition) For(d time.Duration) *ObservableAlertDefinit
 // query.
 func (a *ObservableAlertDefinition) CustomQuery(query string) *ObservableAlertDefinition {
 	a.query = query
+	return a
+}
+
+// CustomDescription sets a different description to be used for this alert instead of the description
+// used for the Grafana panel.
+func (a *ObservableAlertDefinition) CustomDescription(desc string) *ObservableAlertDefinition {
+	a.description = desc
 	return a
 }
 


### PR DESCRIPTION
Somehow the alert query in https://github.com/sourcegraph/sourcegraph/pull/40570 got merged without the query being right, maybe a consequence of context switching. So this PR just fixes it up and also moves it to a more relevant panel (active handlers instead of jobs completed).

Adds some additional generated doc configuration for alert description (mostly useful in conjunction with custom alert query facility) for DevX to review

## Test plan

Correctness update for something that was already tested before
