### PR TITLE
insights: when parsing query check for pattern type override in query

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/parser.go
+++ b/enterprise/internal/insights/query/querybuilder/parser.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	searchquery "github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 

--- a/enterprise/internal/insights/query/querybuilder/parser.go
+++ b/enterprise/internal/insights/query/querybuilder/parser.go
@@ -17,7 +17,7 @@ func DetectSearchType(rawQuery string, patternType string) (query.SearchType, er
 		return -1, errors.Wrap(err, "query.Parse")
 	}
 	q = query.LowercaseFieldNames(q)
-	query.VisitField(q, "patterntype", func(value string, _ bool, _ query.Annotation) {
+	query.VisitField(q, searchquery.FieldPatternType, func(value string, _ bool, _ query.Annotation) {
 		if value != "" {
 			searchType, err = client.SearchTypeFromString(value)
 		}

--- a/enterprise/internal/insights/query/querybuilder/parser.go
+++ b/enterprise/internal/insights/query/querybuilder/parser.go
@@ -2,31 +2,36 @@ package querybuilder
 
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
+	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func searchTypeFromString(pt string) query.SearchType {
-	var searchType query.SearchType
-	switch pt {
-	case "literal":
-		searchType = query.SearchTypeLiteral
-	case "structural":
-		searchType = query.SearchTypeStructural
-	case "regexp", "regex":
-		searchType = query.SearchTypeRegex
-	case "standard":
-		searchType = query.SearchTypeStandard
-	case "lucky":
-		searchType = query.SearchTypeLucky
-	default:
-		searchType = query.SearchTypeLiteral
+func DetectSearchType(rawQuery string, patternType string) (query.SearchType, error) {
+	searchType, err := client.SearchTypeFromString(patternType)
+	if err != nil {
+		return -1, errors.Wrap(err, "client.SearchTypeFromString")
 	}
-	return searchType
+	q, err := query.Parse(rawQuery, searchType)
+	if err != nil {
+		return -1, errors.Wrap(err, "query.Parse")
+	}
+	q = query.LowercaseFieldNames(q)
+	query.VisitField(q, "patterntype", func(value string, _ bool, _ query.Annotation) {
+		if value != "" {
+			searchType, err = client.SearchTypeFromString(value)
+		}
+	})
+	return searchType, err
+
 }
 
 func ParseQuery(q string, patternType string) (query.Plan, error) {
-	plan, err := query.Pipeline(query.Init(q, searchTypeFromString(patternType)))
+	searchType, err := DetectSearchType(q, patternType)
+	if err != nil {
+		return nil, errors.Wrap(err, "overrideSearchType")
+	}
+	plan, err := query.Pipeline(query.Init(q, searchType))
 	if err != nil {
 		return nil, errors.Wrap(err, "query.Pipeline")
 	}


### PR DESCRIPTION
Adds an additional check in ParseQuery function to use the pattern type specified in the query if present.  Also exposes a function to get the patternType either from the submitted version or the override.

## Test plan
Unit tests added and pass 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
