### PR TITLE
Fix tests affected by changes to `repo:contains.file` syntax

### DIFF
--- a/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
@@ -69,7 +69,7 @@ func Test_canAggregateByPath(t *testing.T) {
 		},
 		{
 			name:         "cannot aggregate for query with select:repo parameter",
-			query:        "repo:contains.file(README) select:repo",
+			query:        "repo:contains.path(README) select:repo",
 			canAggregate: false,
 		},
 		{
@@ -106,22 +106,22 @@ func Test_canAggregateByAuthor(t *testing.T) {
 		},
 		{
 			name:         "cannot aggregate for query with select:repo parameter",
-			query:        "repo:contains.file(README) select:repo",
+			query:        "repo:contains.path(README) select:repo",
 			canAggregate: false,
 		},
 		{
 			name:         "can aggregate for query with type:commit parameter",
-			query:        "repo:contains.file(README) select:repo type:commit fix",
+			query:        "repo:contains.path(README) select:repo type:commit fix",
 			canAggregate: true,
 		},
 		{
 			name:         "can aggregate for query with select:commit parameter",
-			query:        "repo:contains.file(README) select:commit fix",
+			query:        "repo:contains.path(README) select:commit fix",
 			canAggregate: true,
 		},
 		{
 			name:         "can aggregate for query with type:diff parameter",
-			query:        "repo:contains.file(README) type:diff fix",
+			query:        "repo:contains.path(README) type:diff fix",
 			canAggregate: true,
 		},
 		{


### PR DESCRIPTION
Change tests using `repo:contains.file` to use `repo:contains.path`, after changes made in https://github.com/sourcegraph/sourcegraph/pull/40389



## Test plan
Tests pass.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
