### PR TITLE
Restore crates.io syncer in worker job

### DIFF
--- a/cmd/worker/internal/codeintel/crates_syncer.go
+++ b/cmd/worker/internal/codeintel/crates_syncer.go
@@ -1,0 +1,32 @@
+package codeintel
+
+import (
+	"context"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/background/cratesyncer"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+type cratesSyncerJob struct{}
+
+func NewCratesSyncerJob() job.Job { return &cratesSyncerJob{} }
+
+func (j *cratesSyncerJob) Description() string  { return "" }
+func (j *cratesSyncerJob) Config() []env.Config { return nil }
+
+func (j *cratesSyncerJob) Routines(ctx context.Context, logger log.Logger) ([]goroutine.BackgroundRoutine, error) {
+	db, err := workerdb.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	return []goroutine.BackgroundRoutine{
+		cratesyncer.NewCratesSyncer(database.NewDB(logger, db)),
+	}, nil
+}

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -45,6 +45,7 @@ func Start(logger log.Logger, additionalJobs map[string]job.Job, registerEnterpr
 		"out-of-band-migrations":                workermigrations.NewMigrator(registerMigrators),
 		"codeintel-documents-indexer":           codeintel.NewDocumentsIndexerJob(),
 		"codeintel-policies-repository-matcher": codeintel.NewPoliciesRepositoryMatcherJob(),
+		"codeintel-crates-syncer":               codeintel.NewCratesSyncerJob(),
 		"gitserver-metrics":                     gitserver.NewMetricsJob(),
 		"record-encrypter":                      encryption.NewRecordEncrypterJob(),
 		"repo-statistics-compactor":             repostatistics.NewCompactor(),

--- a/doc/admin/workers.md
+++ b/doc/admin/workers.md
@@ -38,6 +38,10 @@ This job will eventually replace `codeintel-auto-indexing`.
 
 This job periodically updates an index of policy repository patterns to matching repository names.
 
+#### `codeintel-crates-syncer`
+
+This job periodically updates the crates.io packages on the instance by syncing the crates.io index.
+
 #### `codeintel-commitgraph`
 
 This job periodically updates the set of code graph data indexes that are visible from each relevant commit for a repository. The commit graph for a repository is marked as stale (to be recalculated) after repository updates and code graph data uploads and updated asynchronously by this job.


### PR DESCRIPTION
This job was accidentally removed in #39742 as part of the
`dependencies_job.go`.

The commit here restores it by restoring the `cratessyncer` in a
separate worker job.

That fixes #37698.

## Test plan

- Manually decreased the interval time, added debug logging, ran `sg start` and checked that worker ran.