### PR TITLE
support whitespace in author fields by wrapping in parenthesis (regex…

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -256,7 +256,7 @@ func AddAuthorFilter(query BasicQuery, author string) (BasicQuery, error) {
 		}
 		modified = append(modified, searchquery.Parameter{
 			Field:      searchquery.FieldAuthor,
-			Value:      regexp.QuoteMeta(author),
+			Value:      fmt.Sprintf("(%s)", regexp.QuoteMeta(author)),
 			Negated:    false,
 			Annotation: searchquery.Annotation{},
 		})

--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -256,7 +256,7 @@ func AddAuthorFilter(query BasicQuery, author string) (BasicQuery, error) {
 		}
 		modified = append(modified, searchquery.Parameter{
 			Field:      searchquery.FieldAuthor,
-			Value:      fmt.Sprintf("(%s)", regexp.QuoteMeta(author)),
+			Value:      fmt.Sprintf("(%s$)", regexp.QuoteMeta(author)),
 			Negated:    false,
 			Annotation: searchquery.Annotation{},
 		})

--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -256,7 +256,7 @@ func AddAuthorFilter(query BasicQuery, author string) (BasicQuery, error) {
 		}
 		modified = append(modified, searchquery.Parameter{
 			Field:      searchquery.FieldAuthor,
-			Value:      fmt.Sprintf("(%s$)", regexp.QuoteMeta(author)),
+			Value:      fmt.Sprintf("(^%s$)", regexp.QuoteMeta(author)),
 			Negated:    false,
 			Annotation: searchquery.Annotation{},
 		})

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -469,27 +469,27 @@ func Test_addAuthorFilter(t *testing.T) {
 		{
 			input:  "myquery repo:myrepo type:commit",
 			author: "santa",
-			want:   autogold.Want("no initial author field in commit search", BasicQuery("repo:myrepo type:commit author:(santa$) myquery")),
+			want:   autogold.Want("no initial author field in commit search", BasicQuery("repo:myrepo type:commit author:(^santa$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:commit",
 			author: "xtreme[username]",
-			want:   autogold.Want("ensure author is escaped", BasicQuery("repo:myrepo type:commit author:(xtreme\\[username\\]$) myquery")),
+			want:   autogold.Want("ensure author is escaped", BasicQuery("repo:myrepo type:commit author:(^xtreme\\[username\\]$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:commit author:claus",
 			author: "santa",
-			want:   autogold.Want("one initial author field in commit search", BasicQuery("repo:myrepo type:commit author:claus author:(santa$) myquery")),
+			want:   autogold.Want("one initial author field in commit search", BasicQuery("repo:myrepo type:commit author:claus author:(^santa$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:diff",
 			author: "santa",
-			want:   autogold.Want("no initial author field in diff search", BasicQuery("repo:myrepo type:diff author:(santa$) myquery")),
+			want:   autogold.Want("no initial author field in diff search", BasicQuery("repo:myrepo type:diff author:(^santa$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:diff author:claus",
 			author: "santa",
-			want:   autogold.Want("one initial author field in diff search", BasicQuery("repo:myrepo type:diff author:claus author:(santa$) myquery")),
+			want:   autogold.Want("one initial author field in diff search", BasicQuery("repo:myrepo type:diff author:claus author:(^santa$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:file author:claus",
@@ -504,12 +504,12 @@ func Test_addAuthorFilter(t *testing.T) {
 		{
 			input:  "(myquery repo:myrepo type:repo) or (type:diff repo:asdf findme)",
 			author: "santa",
-			want:   autogold.Want("compound query where one side is author and one side is repo", BasicQuery("(repo:myrepo type:repo myquery OR type:diff repo:asdf author:(santa$) findme)")),
+			want:   autogold.Want("compound query where one side is author and one side is repo", BasicQuery("(repo:myrepo type:repo myquery OR type:diff repo:asdf author:(^santa$) findme)")),
 		},
 		{
 			input:  "insights type:commit",
 			author: "Santa Claus",
-			want:   autogold.Want("author with whitespace in name", BasicQuery("type:commit author:(Santa Claus$) insights")),
+			want:   autogold.Want("author with whitespace in name", BasicQuery("type:commit author:(^Santa Claus$) insights")),
 		},
 	}
 	for _, test := range tests {

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -469,27 +469,27 @@ func Test_addAuthorFilter(t *testing.T) {
 		{
 			input:  "myquery repo:myrepo type:commit",
 			author: "santa",
-			want:   autogold.Want("no initial author field in commit search", BasicQuery("repo:myrepo type:commit author:santa myquery")),
+			want:   autogold.Want("no initial author field in commit search", BasicQuery("repo:myrepo type:commit author:(santa) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:commit",
 			author: "xtreme[username]",
-			want:   autogold.Want("ensure author is escaped", BasicQuery("repo:myrepo type:commit author:xtreme\\[username\\] myquery")),
+			want:   autogold.Want("ensure author is escaped", BasicQuery("repo:myrepo type:commit author:(xtreme\\[username\\]) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:commit author:claus",
 			author: "santa",
-			want:   autogold.Want("one initial author field in commit search", BasicQuery("repo:myrepo type:commit author:claus author:santa myquery")),
+			want:   autogold.Want("one initial author field in commit search", BasicQuery("repo:myrepo type:commit author:claus author:(santa) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:diff",
 			author: "santa",
-			want:   autogold.Want("no initial author field in diff search", BasicQuery("repo:myrepo type:diff author:santa myquery")),
+			want:   autogold.Want("no initial author field in diff search", BasicQuery("repo:myrepo type:diff author:(santa) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:diff author:claus",
 			author: "santa",
-			want:   autogold.Want("one initial author field in diff search", BasicQuery("repo:myrepo type:diff author:claus author:santa myquery")),
+			want:   autogold.Want("one initial author field in diff search", BasicQuery("repo:myrepo type:diff author:claus author:(santa) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:file author:claus",
@@ -504,7 +504,12 @@ func Test_addAuthorFilter(t *testing.T) {
 		{
 			input:  "(myquery repo:myrepo type:repo) or (type:diff repo:asdf findme)",
 			author: "santa",
-			want:   autogold.Want("compound query where one side is author and one side is repo", BasicQuery("(repo:myrepo type:repo myquery OR type:diff repo:asdf author:santa findme)")),
+			want:   autogold.Want("compound query where one side is author and one side is repo", BasicQuery("(repo:myrepo type:repo myquery OR type:diff repo:asdf author:(santa) findme)")),
+		},
+		{
+			input:  "insights type:commit",
+			author: "Santa Claus",
+			want:   autogold.Want("author with whitespace in name", BasicQuery("type:commit author:(Santa Claus) insights")),
 		},
 	}
 	for _, test := range tests {

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -469,27 +469,27 @@ func Test_addAuthorFilter(t *testing.T) {
 		{
 			input:  "myquery repo:myrepo type:commit",
 			author: "santa",
-			want:   autogold.Want("no initial author field in commit search", BasicQuery("repo:myrepo type:commit author:(santa) myquery")),
+			want:   autogold.Want("no initial author field in commit search", BasicQuery("repo:myrepo type:commit author:(santa$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:commit",
 			author: "xtreme[username]",
-			want:   autogold.Want("ensure author is escaped", BasicQuery("repo:myrepo type:commit author:(xtreme\\[username\\]) myquery")),
+			want:   autogold.Want("ensure author is escaped", BasicQuery("repo:myrepo type:commit author:(xtreme\\[username\\]$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:commit author:claus",
 			author: "santa",
-			want:   autogold.Want("one initial author field in commit search", BasicQuery("repo:myrepo type:commit author:claus author:(santa) myquery")),
+			want:   autogold.Want("one initial author field in commit search", BasicQuery("repo:myrepo type:commit author:claus author:(santa$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:diff",
 			author: "santa",
-			want:   autogold.Want("no initial author field in diff search", BasicQuery("repo:myrepo type:diff author:(santa) myquery")),
+			want:   autogold.Want("no initial author field in diff search", BasicQuery("repo:myrepo type:diff author:(santa$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:diff author:claus",
 			author: "santa",
-			want:   autogold.Want("one initial author field in diff search", BasicQuery("repo:myrepo type:diff author:claus author:(santa) myquery")),
+			want:   autogold.Want("one initial author field in diff search", BasicQuery("repo:myrepo type:diff author:claus author:(santa$) myquery")),
 		},
 		{
 			input:  "myquery repo:myrepo type:file author:claus",
@@ -504,12 +504,12 @@ func Test_addAuthorFilter(t *testing.T) {
 		{
 			input:  "(myquery repo:myrepo type:repo) or (type:diff repo:asdf findme)",
 			author: "santa",
-			want:   autogold.Want("compound query where one side is author and one side is repo", BasicQuery("(repo:myrepo type:repo myquery OR type:diff repo:asdf author:(santa) findme)")),
+			want:   autogold.Want("compound query where one side is author and one side is repo", BasicQuery("(repo:myrepo type:repo myquery OR type:diff repo:asdf author:(santa$) findme)")),
 		},
 		{
 			input:  "insights type:commit",
 			author: "Santa Claus",
-			want:   autogold.Want("author with whitespace in name", BasicQuery("type:commit author:(Santa Claus) insights")),
+			want:   autogold.Want("author with whitespace in name", BasicQuery("type:commit author:(Santa Claus$) insights")),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
[#40707](https://github.com/sourcegraph/sourcegraph/issues/40707)

Supports whitespace in author field by wrapping the resulting regexp in a group.

## Test plan

Unit tests and tested locally
``` json
{
            "label": "coury-clark",
            "count": 198,
            "query": "type:commit author:(^coury-clark$) insight"
},
```