### PR TITLE
search: add `has` aliases for `contains` predicates

### DIFF
--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -25,15 +25,20 @@ type Predicate interface {
 var DefaultPredicateRegistry = PredicateRegistry{
 	FieldRepo: {
 		"contains.file":         func() Predicate { return &RepoContainsFilePredicate{} },
+		"has.file":              func() Predicate { return &RepoContainsFilePredicate{} },
 		"contains.path":         func() Predicate { return &RepoContainsPathPredicate{} },
+		"has.path":              func() Predicate { return &RepoContainsPathPredicate{} },
 		"contains.content":      func() Predicate { return &RepoContainsContentPredicate{} },
+		"has.content":           func() Predicate { return &RepoContainsContentPredicate{} },
 		"contains.commit.after": func() Predicate { return &RepoContainsCommitAfterPredicate{} },
+		"has.commit.after":      func() Predicate { return &RepoContainsCommitAfterPredicate{} },
 		"has.description":       func() Predicate { return &RepoHasDescriptionPredicate{} },
 		"has.tag":               func() Predicate { return &RepoHasTagPredicate{} },
 		"has":                   func() Predicate { return &RepoHasKVPPredicate{} },
 	},
 	FieldFile: {
 		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
+		"has.content":      func() Predicate { return &FileContainsContentPredicate{} },
 		"contains":         func() Predicate { return &FileContainsContentPredicate{} },
 		"has.owner":        func() Predicate { return &FileHasOwnerPredicate{} },
 	},

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -386,12 +386,8 @@ func (p Parameters) RepoHasFileContent() (res []RepoHasFileContentArgs) {
 }
 
 func (p Parameters) FileContainsContent() (include []string) {
-	VisitPredicate(toNodes(p), func(field, name, value string) {
-		if field == FieldFile && (name == "contains" || name == "contains.content") {
-			var pred FileContainsContentPredicate
-			pred.ParseParams(value)
-			include = append(include, pred.Pattern)
-		}
+	VisitTypedPredicate(toNodes(p), func(pred *FileContainsContentPredicate, negated bool) {
+		include = append(include, pred.Pattern)
 	})
 	return include
 }

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -102,7 +102,7 @@ func VisitTypedPredicate[T any, PT predicatePointer[T]](nodes []Node, f func(pre
 		}
 
 		predName, predArgs := ParseAsPredicate(value)
-		if predName != zeroPred.Name() { // NOTE(camdencheek): we don't handle aliases here
+		if DefaultPredicateRegistry.Get(zeroPred.Field(), predName).Name() != zeroPred.Name() { // allow aliases
 			return // skip unrequested predicates
 		}
 

--- a/internal/search/query/visitor_test.go
+++ b/internal/search/query/visitor_test.go
@@ -33,6 +33,9 @@ func TestVisitTypedPredicate(t *testing.T) {
 	}, {
 		"repo:test repo:contains.file(path:test)",
 		autogold.Want("one predicate", []*RepoContainsFilePredicate{{Path: "test"}}),
+	}, {
+		"repo:test repo:has.file(path:test)",
+		autogold.Want("one predicate", []*RepoContainsFilePredicate{{Path: "test"}}),
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Part of #39767

- Introduce the following aliases:
  - `repo:has.file` == `repo:contains.file`
  - `repo:has.content` == `repo:contains.content`
  - `repo:has.path` == `repo:contains.path`
  - `repo:has.commit.after` == `repo:contains.commit.after`
  - `file:has.content` == `file.contains.content`
- Update `VisitTypedPredicate()` to handle aliases
- Update `FileContainsContent()` to use `VisitTypedPredicate()` now that it handles aliases

## Test plan
Add test for `VisitTypedPredicate()` to make sure aliases are recognized.
Manually test that `has` aliases return the same results as `contains`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
