### PR TITLE
search: Update webapp to reflect new `has` syntax for predicates

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -137,10 +137,10 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         examples: ['file:.js$ httptest', 'file:internal/ httptest', 'file:.js$ -file:test http'],
     },
     {
-        ...createQueryExampleFromString('contains.content({regexp-pattern})'),
+        ...createQueryExampleFromString('has.content({regexp-pattern})'),
         field: FilterType.file,
         description: 'Search only inside files that contain content matching the provided regexp pattern.',
-        examples: ['file:contains.content(github.com/sourcegraph/sourcegraph)'],
+        examples: ['file:has.content(github.com/sourcegraph/sourcegraph)'],
     },
     {
         ...createQueryExampleFromString('{yes/only}'),
@@ -179,33 +179,33 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         ],
     },
     {
-        ...createQueryExampleFromString('contains.path({path})'),
+        ...createQueryExampleFromString('has.path({path})'),
         field: FilterType.repo,
         description: 'Search only inside repositories that contain a file path matching the regular expression.',
-        examples: ['repo:contains.path(README)', 'repo:contains.path(src/main/)'],
+        examples: ['repo:has.path(README)', 'repo:has.path(src/main/)'],
         showSuggestions: false,
     },
     {
-        ...createQueryExampleFromString('contains.content({content})'),
+        ...createQueryExampleFromString('has.content({content})'),
         field: FilterType.repo,
         description: 'Search only inside repositories that contain file content matching the regular expression.',
-        examples: ['repo:contains.content(TODO)'],
+        examples: ['repo:has.content(TODO)'],
         showSuggestions: false,
     },
     {
-        ...createQueryExampleFromString('contains.file({path:path content:content})'),
+        ...createQueryExampleFromString('has.file({path:path content:content})'),
         field: FilterType.repo,
         description:
             'Search only inside repositories that contain a file path matching the `path:` and/or `content:` filters.',
-        examples: ['repo:contains.file(path:README content:fix)'],
+        examples: ['repo:has.file(path:README content:fix)'],
         showSuggestions: false,
     },
     {
-        ...createQueryExampleFromString('contains.commit.after({date})'),
+        ...createQueryExampleFromString('has.commit.after({date})'),
         field: FilterType.repo,
         description:
             'Search only inside repositories that contain a a commit after some specified time. See [git date formats](https://github.com/git/git/blob/master/Documentation/date-formats.txt) for accepted formats. Use this to filter out stale repositories that don’t contain commits past the specified time frame. This parameter is experimental.',
-        examples: ['repo:contains.commit.after(1 month ago)', 'repo:contains.commit.after(june 25 2017)'],
+        examples: ['repo:has.commit.after(1 month ago)', 'repo:has.commit.after(june 25 2017)'],
         showSuggestions: false,
     },
     {

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -372,15 +372,16 @@ describe('getCompletionItems()', () => {
                             repository: 'repo/with a space',
                         },
                     ]),
+
                     {}
                 )
             )?.suggestions.map(({ insertText }) => insertText)
         ).toMatchInlineSnapshot(`
             [
-              "contains.path(\${1:CHANGELOG}) ",
-              "contains.content(\${1:TODO}) ",
-              "contains.file(path:\${1:CHANGELOG} content:\${2:fix}) ",
-              "contains.commit.after(\${1:1 month ago}) ",
+              "has.path(\${1:CHANGELOG}) ",
+              "has.content(\${1:TODO}) ",
+              "has.file(path:\${1:CHANGELOG} content:\${2:fix}) ",
+              "has.commit.after(\${1:1 month ago}) ",
               "has.description(\${1}) ",
               "^repo/with\\\\ a\\\\ space$ "
             ]
@@ -399,10 +400,10 @@ describe('getCompletionItems()', () => {
               "^github\\\\.com/\${1:ORGANIZATION}/.* ",
               "^github\\\\.com/\${1:ORGANIZATION}/\${2:REPO-NAME}$ ",
               "\${1:STRING} ",
-              "contains.path(\${1:CHANGELOG}) ",
-              "contains.content(\${1:TODO}) ",
-              "contains.file(path:\${1:CHANGELOG} content:\${2:fix}) ",
-              "contains.commit.after(\${1:1 month ago}) ",
+              "has.path(\${1:CHANGELOG}) ",
+              "has.content(\${1:TODO}) ",
+              "has.file(path:\${1:CHANGELOG} content:\${2:fix}) ",
+              "has.commit.after(\${1:1 month ago}) ",
               "has.description(\${1}) "
             ]
         `)

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -640,6 +640,27 @@ test('returns repo:contains.path hovers', () => {
     `)
 })
 
+test('returns repo:has.path hovers', () => {
+    const input = 'repo:has.path(foo)'
+    const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.standard))
+
+    expect(getHoverResult(scannedQuery, new Position(1, 8), editor.createModel(input))).toMatchInlineSnapshot(`
+        {
+          "contents": [
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
+            }
+          ],
+          "range": {
+            "startLineNumber": 1,
+            "endLineNumber": 1,
+            "startColumn": 6,
+            "endColumn": 19
+          }
+        }
+    `)
+})
+
 test('returns repo:contains.file hovers', () => {
     const input = 'repo:contains.file(path:foo)'
     const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.standard))
@@ -656,6 +677,69 @@ test('returns repo:contains.file hovers', () => {
             "endLineNumber": 1,
             "startColumn": 6,
             "endColumn": 29
+          }
+        }
+    `)
+})
+
+test('returns repo:has.file hovers', () => {
+    const input = 'repo:has.file(path:foo)'
+    const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.standard))
+
+    expect(getHoverResult(scannedQuery, new Position(1, 8), editor.createModel(input))).toMatchInlineSnapshot(`
+        {
+          "contents": [
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that satisfy the specified \`path:\` and \`content:\` filters. \`path:\` and \`content:\` filters should be regular expressions."
+            }
+          ],
+          "range": {
+            "startLineNumber": 1,
+            "endLineNumber": 1,
+            "startColumn": 6,
+            "endColumn": 24
+          }
+        }
+    `)
+})
+
+test('returns repo:has.content hovers', () => {
+    const input = 'repo:has.content(foo)'
+    const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.standard))
+
+    expect(getHoverResult(scannedQuery, new Position(1, 8), editor.createModel(input))).toMatchInlineSnapshot(`
+        {
+          "contents": [
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that contain **file content** matching the regular expression \`foo\`."
+            }
+          ],
+          "range": {
+            "startLineNumber": 1,
+            "endLineNumber": 1,
+            "startColumn": 6,
+            "endColumn": 22
+          }
+        }
+    `)
+})
+
+test('returns repo:has.commit.after hovers', () => {
+    const input = 'repo:has.commit.after(yesterday)'
+    const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.standard))
+
+    expect(getHoverResult(scannedQuery, new Position(1, 8), editor.createModel(input))).toMatchInlineSnapshot(`
+        {
+          "contents": [
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that have been committed to since \`yesterday\`."
+            }
+          ],
+          "range": {
+            "startLineNumber": 1,
+            "endLineNumber": 1,
+            "startColumn": 6,
+            "endColumn": 33
           }
         }
     `)

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -159,12 +159,16 @@ const toPredicateHover = (token: MetaPredicate): string => {
     const parameters = token.value.parameters.slice(1, -1)
     switch (token.value.path.join('.')) {
         case 'contains.file':
+        case 'has.file':
             return '**Built-in predicate**. Search only inside repositories that satisfy the specified `path:` and `content:` filters. `path:` and `content:` filters should be regular expressions.'
         case 'contains.path':
+        case 'has.path':
             return `**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`${parameters}\`.`
         case 'contains.content':
+        case 'has.content':
             return `**Built-in predicate**. Search only inside repositories that contain **file content** matching the regular expression \`${parameters}\`.`
         case 'contains.commit.after':
+        case 'has.commit.after':
             return `**Built-in predicate**. Search only inside repositories that have been committed to since \`${parameters}\`.`
         case 'has.description':
             return '**Built-in predicate**. Search only inside repositories that have a **description** matching the given regular expression'

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -38,7 +38,8 @@ export const PREDICATES: Access[] = [
                         fields: [{ name: 'after' }],
                     },
                     { name: 'description' },
-                    { name: 'tag' }],
+                    { name: 'tag' },
+                ],
             },
         ],
     },
@@ -173,7 +174,7 @@ export const predicateCompletion = (field: string): Completion[] => {
                 asSnippet: true,
             },
             {
-                label:'has.file(...)',
+                label: 'has.file(...)',
                 insertText: 'has.file(path:${1:CHANGELOG} content:${2:fix})',
                 asSnippet: true,
             },

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -29,7 +29,16 @@ export const PREDICATES: Access[] = [
             },
             {
                 name: 'has',
-                fields: [{ name: 'description' }, { name: 'tag' }],
+                fields: [
+                    { name: 'file' },
+                    { name: 'path' },
+                    { name: 'content' },
+                    {
+                        name: 'commit',
+                        fields: [{ name: 'after' }],
+                    },
+                    { name: 'description' },
+                    { name: 'tag' }],
             },
         ],
     },
@@ -38,6 +47,10 @@ export const PREDICATES: Access[] = [
         fields: [
             {
                 name: 'contains',
+                fields: [{ name: 'content' }],
+            },
+            {
+                name: 'has',
                 fields: [{ name: 'content' }],
             },
         ],
@@ -150,23 +163,23 @@ export const predicateCompletion = (field: string): Completion[] => {
     if (field === 'repo') {
         return [
             {
-                label: 'contains.path(...)',
-                insertText: 'contains.path(${1:CHANGELOG})',
+                label: 'has.path(...)',
+                insertText: 'has.path(${1:CHANGELOG})',
                 asSnippet: true,
             },
             {
-                label: 'contains.content(...)',
-                insertText: 'contains.content(${1:TODO})',
+                label: 'has.content(...)',
+                insertText: 'has.content(${1:TODO})',
                 asSnippet: true,
             },
             {
-                label: 'contains.file(...)',
-                insertText: 'contains.file(path:${1:CHANGELOG} content:${2:fix})',
+                label:'has.file(...)',
+                insertText: 'has.file(path:${1:CHANGELOG} content:${2:fix})',
                 asSnippet: true,
             },
             {
-                label: 'contains.commit.after(...)',
-                insertText: 'contains.commit.after(${1:1 month ago})',
+                label: 'has.commit.after(...)',
+                insertText: 'has.commit.after(${1:1 month ago})',
                 asSnippet: true,
             },
             {

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -25,15 +25,20 @@ type Predicate interface {
 var DefaultPredicateRegistry = PredicateRegistry{
 	FieldRepo: {
 		"contains.file":         func() Predicate { return &RepoContainsFilePredicate{} },
+		"has.file":              func() Predicate { return &RepoContainsFilePredicate{} },
 		"contains.path":         func() Predicate { return &RepoContainsPathPredicate{} },
+		"has.path":              func() Predicate { return &RepoContainsPathPredicate{} },
 		"contains.content":      func() Predicate { return &RepoContainsContentPredicate{} },
+		"has.content":           func() Predicate { return &RepoContainsContentPredicate{} },
 		"contains.commit.after": func() Predicate { return &RepoContainsCommitAfterPredicate{} },
+		"has.commit.after":      func() Predicate { return &RepoContainsCommitAfterPredicate{} },
 		"has.description":       func() Predicate { return &RepoHasDescriptionPredicate{} },
 		"has.tag":               func() Predicate { return &RepoHasTagPredicate{} },
 		"has":                   func() Predicate { return &RepoHasKVPPredicate{} },
 	},
 	FieldFile: {
 		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
+		"has.content":      func() Predicate { return &FileContainsContentPredicate{} },
 		"contains":         func() Predicate { return &FileContainsContentPredicate{} },
 		"has.owner":        func() Predicate { return &FileHasOwnerPredicate{} },
 	},

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -386,12 +386,8 @@ func (p Parameters) RepoHasFileContent() (res []RepoHasFileContentArgs) {
 }
 
 func (p Parameters) FileContainsContent() (include []string) {
-	VisitPredicate(toNodes(p), func(field, name, value string) {
-		if field == FieldFile && (name == "contains" || name == "contains.content") {
-			var pred FileContainsContentPredicate
-			pred.ParseParams(value)
-			include = append(include, pred.Pattern)
-		}
+	VisitTypedPredicate(toNodes(p), func(pred *FileContainsContentPredicate, negated bool) {
+		include = append(include, pred.Pattern)
 	})
 	return include
 }

--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -102,7 +102,7 @@ func VisitTypedPredicate[T any, PT predicatePointer[T]](nodes []Node, f func(pre
 		}
 
 		predName, predArgs := ParseAsPredicate(value)
-		if predName != zeroPred.Name() { // NOTE(camdencheek): we don't handle aliases here
+		if DefaultPredicateRegistry.Get(zeroPred.Field(), predName).Name() != zeroPred.Name() { // allow aliases
 			return // skip unrequested predicates
 		}
 

--- a/internal/search/query/visitor_test.go
+++ b/internal/search/query/visitor_test.go
@@ -33,6 +33,9 @@ func TestVisitTypedPredicate(t *testing.T) {
 	}, {
 		"repo:test repo:contains.file(path:test)",
 		autogold.Want("one predicate", []*RepoContainsFilePredicate{{Path: "test"}}),
+	}, {
+		"repo:test repo:has.file(path:test)",
+		autogold.Want("one predicate", []*RepoContainsFilePredicate{{Path: "test"}}),
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Stacked on #40763
Part of https://github.com/sourcegraph/sourcegraph/issues/39767

Query completion suggests predicates using the `has` syntax instead of `contains`, e.g. `repo:has.file`.
Add hovers and decoration for `repo:has` and `file:has` predicates.
Update reference panel to use `has` predicates as examples.



## Test plan
Added some unit tests for hovers.
Manually checked hovers, decoration, completion, reference panel.
![image](https://user-images.githubusercontent.com/70350613/186269303-e4c969da-9667-4d72-8da4-ce0ddbec3cf0.png)<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
