### PR TITLE
Don't render LSIF highlighting if HTML highlighting exists

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -231,7 +231,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                         }
 
                         // Replace html with lsif generated HTML, if available
-                        if (!enableCodeMirror && blob.highlight.lsif) {
+                        if (!enableCodeMirror && !blob.highlight.html && blob.highlight.lsif) {
                             const html = renderLsifHtml({ lsif: blob.highlight.lsif, content: blob.content })
                             if (html) {
                                 blob.highlight.html = html


### PR DESCRIPTION
Fix for #inc-140-syntax-highlighting-is-not-working-on-sourcegraphcom

## Test plan

I don't know why this regression was not caught by integration tests before. The CI should not be green if files are not getting highlighted.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-inc-140.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fxshcoawsu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
