### PR TITLE
Drop object tag from markdown rendering

### DIFF
--- a/client/common/src/util/markdown/markdown.test.ts
+++ b/client/common/src/util/markdown/markdown.test.ts
@@ -85,10 +85,8 @@ describe('renderMarkdown', () => {
     it('does not allow arbitrary <object> tags', () => {
         expect(renderMarkdown('<object data="something"></object>')).toBe('<p></p>\n')
     })
-    it('does not allow SVG <object> tags', () => {
-        expect(renderMarkdown('<object data="something" type="image/svg+xml"></object>')).toBe(
-            '<p><object></object></p>\n'
-        )
+    it('drops SVG <object> tags', () => {
+        expect(renderMarkdown('<object data="something" type="image/svg+xml"></object>')).toBe('<p></p>\n')
     })
     it('allows <svg> tags', () => {
         const input =

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -103,7 +103,6 @@ export const renderMarkdown = (
                 'img',
                 'picture',
                 'source',
-                'object',
                 'svg',
                 'rect',
                 'defs',


### PR DESCRIPTION
Cleaning up unnecessary object tag entirely from Markdown rendering: https://github.com/sourcegraph/sourcegraph/pull/40416#discussion_r952940577.

## Test plan

- [x] automatic tests

## App preview:

- [Web](https://sg-web-vincent-cleanup-markdown-ts-object.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yjguzdzmmk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

