### PR TITLE
repos page: add explanatory tooltip to site-admin repos page

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -169,7 +169,8 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 value: data.repositoryStats.total,
                 description: 'Repositories',
                 color: 'var(--purple)',
-                tooltip: 'Total number of repositories in the Sourcegraph instance.',
+                tooltip:
+                    'Total number of repositories in the Sourcegraph instance. This number might be higher than the total number of repositories in the list below in case repository permissions do not allow you to view some repositories.',
             },
             {
                 value: data.repositoryStats.notCloned,


### PR DESCRIPTION
Should be really rare for site-admins (since authz for site-admins was only enforced on cloud v1), but still makes sense to add this).

## Test plan

- N/A

## App preview:

- [Web](https://sg-web-mrn-explanatory-tooltip.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-airaxtwxog.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
