### PR TITLE
Better fix for INC-140

### DIFF
--- a/client/web/src/lsif/html.ts
+++ b/client/web/src/lsif/html.ts
@@ -71,18 +71,10 @@ function highlightSlice(html: HtmlBuilder, kind: SyntaxKind | undefined, slice: 
 // Currently assumes that no ranges overlap in the occurrences.
 export function render(info: DocumentInfo): string {
     const occurrences = Occurrence.fromInfo(info)
-    if (!occurrences) {
+
+    if (occurrences.length === 0) {
         return ''
     }
-
-    // Sort by line, and then by start character.
-    occurrences.sort((a, b) => {
-        if (a.range.start.line !== b.range.start.line) {
-            return a.range.start.line - b.range.start.line
-        }
-
-        return a.range.start.character - b.range.start.character
-    })
 
     const lines = info.content.replaceAll('\r\n', '\n').split('\n')
     const html = new HtmlBuilder()

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -231,7 +231,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                         }
 
                         // Replace html with lsif generated HTML, if available
-                        if (!enableCodeMirror && !blob.highlight.html && blob.highlight.lsif) {
+                        if (!enableCodeMirror && blob.highlight.lsif) {
                             const html = renderLsifHtml({ lsif: blob.highlight.lsif, content: blob.content })
                             if (html) {
                                 blob.highlight.html = html


### PR DESCRIPTION
The previous fix didn't address the root regression from the PR
https://github.com/sourcegraph/sourcegraph/pull/40610

The value of `occurrences` went from `undefined` to `[]`, causing the if
condition to fail where it used to pass because `[]` is a truthy value
in JavaScript.

## Test plan

See the CI go green. I manually validated that syntax highlighting is still working as expected, and I'm still investigating why the integration tests didn't catch the original regression.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
