### PR TITLE
syntax-highlighter: Use sourcegraph/syntect, not slimsag/syntect.

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -801,12 +801,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,15 +1892,15 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "4.4.0"
-source = "git+https://github.com/slimsag/syntect#bbb71bc0cb5af9488f31a10de5ef409f5b347617"
+version = "4.7.0"
+source = "git+https://github.com/sourcegraph/syntect#7e02c5b4085e6d935b960b8106cdd85da04532d2"
 dependencies = [
  "bincode",
  "bitflags",
  "flate2",
  "fnv",
  "lazy_static",
- "lazycell",
+ "once_cell",
  "onig",
  "plist",
  "regex-syntax",

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-syntect = { git = "https://github.com/slimsag/syntect" }
+syntect = { git = "https://github.com/sourcegraph/syntect" }
 rocket = { version = "0.5.0-rc.1", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/docker-images/syntax-highlighter/crates/sg-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/Cargo.toml
@@ -9,7 +9,7 @@ include = ["src/**/*", "queries/**/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syntect = { git = "https://github.com/slimsag/syntect" }
+syntect = { git = "https://github.com/sourcegraph/syntect" }
 rocket = { git = "https://github.com/SergioBenitez/Rocket", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/docker-images/syntax-highlighter/src/bin/scip-syntect.rs
+++ b/docker-images/syntax-highlighter/src/bin/scip-syntect.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut html_generator =
         ClassedHTMLGenerator::new_with_class_style(syntax_def, &syntax_set, ClassStyle::Spaced);
     for line in contents.lines() {
-        html_generator.parse_html_for_line(line);
+        html_generator.parse_html_for_line_which_includes_newline(line);
     }
     let html = html_generator.finalize();
     println!("{}", html);


### PR DESCRIPTION
@tjdevries can you double-check that there's no behavior change with this? I tested a few languages visually.

## Test plan

The tests in sourcegraph/syntect are passing. Visually inspected the highlighting for different languages like JavaScript, Ruby and Markdown with this change -- didn't see any regression.