### PR TITLE
authz: Add scanprotects tool and increase debug logging

### DIFF
--- a/enterprise/internal/authz/perforce/authz.go
+++ b/enterprise/internal/authz/perforce/authz.go
@@ -3,6 +3,8 @@ package perforce
 import (
 	"strings"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -55,7 +57,7 @@ func newAuthzProvider(
 		}
 	}
 
-	return NewProvider(urn, host, user, password, depotIDs, db)
+	return NewProvider(log.Scoped("authzProvider", ""), urn, host, user, password, depotIDs, db)
 }
 
 // ValidateAuthz validates the authorization fields of the given Perforce

--- a/enterprise/internal/authz/perforce/cmd/scanprotects/.gitignore
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/.gitignore
@@ -1,0 +1,1 @@
+scanprotects

--- a/enterprise/internal/authz/perforce/cmd/scanprotects/README.md
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/README.md
@@ -1,0 +1,48 @@
+# scanprotects
+
+`scanprotects` is a command line tool that can scan a Perforce protection table and output debug information about how it was interpreted. 
+
+It is intended to be used to debug our parsing logic for protection tables as we often don't have access to them ourselves, so, instead we can send this program to the customer and ask them to run it against their `p4 protects` output.
+
+
+## Usage
+
+The intention is to pipe the output of `p4 protects` into this tool:
+
+```
+p4 protects -u USER | ./scanprotects -d "//some/test/depot/"
+```
+
+## Example output
+
+```
+...
+DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "list group everyone * -//..."}
+DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": ["//depot/main/"]}
+DEBUG fullRepoPermsScanner perforce/protects.go:426 Adding exclude rules {"rules": ["//**"]}
+DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "read group readonly * //..."}
+DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": ["//depot/main/"]}
+DEBUG fullRepoPermsScanner perforce/protects.go:391 Adding include rules {"rules": ["//**"]}
+DEBUG fullRepoPermsScanner perforce/protects.go:404 Removing conflicting exclude rule {"rule": "//**"}
+DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "write group dev * //depot/main/..."}
+DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": ["//depot/main/"]}
+DEBUG fullRepoPermsScanner perforce/protects.go:391 Adding include rules {"rules": ["**"]}
+DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "open group dev * //depot/main/migration/..."}
+DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": ["//depot/main/"]}
+DEBUG fullRepoPermsScanner perforce/protects.go:391 Adding include rules {"rules": ["migration/**"]}
+DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "write group dev * //depot/training/..."}
+DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
+DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "write group dev * //depot/test/..."}
+DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
+DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "read group baseapp_readonly * //depot/630/..."}
+DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
+DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "read group baseapp_readonly * //depot/636/..."}
+DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
+DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "write group dev * //depot/630/..."}
+DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
+...
+DEBUG scanprotects scanprotects/main.go:50 Depot {"depot": "//depot/main/"}
+DEBUG scanprotects scanprotects/main.go:53 Sub repo permissions {"depot": "//depot/main/"}
+DEBUG scanprotects scanprotects/main.go:55 Include rule {"rule": "base/foo/**"}
+DEBUG scanprotects scanprotects/main.go:55 Include rule {"rule": "base/jkl/**"}
+```

--- a/enterprise/internal/authz/perforce/cmd/scanprotects/main.go
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/perforce"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/hostname"
+	"github.com/sourcegraph/sourcegraph/internal/version"
+)
+
+var depot = flag.String("d", "", "depot name")
+
+func main() {
+	flag.Parse()
+	if depot == nil || *depot == "" {
+		fail("required: -d DEPOT")
+	}
+
+	if err := os.Setenv(log.EnvLogLevel, "DEBUG"); err != nil {
+		fail("Setting SRC_LOG_LEVEL")
+	}
+	if err := os.Setenv(log.EnvDevelopment, "true"); err != nil {
+		fail("Setting SRC_LOG_LEVEL")
+	}
+	liblog := log.Init(log.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer liblog.Sync()
+
+	logger := log.Scoped("scanprotects", "")
+	run(logger, *depot, os.Stdin)
+}
+
+func run(logger log.Logger, depot string, input io.Reader) {
+	perms, err := perforce.PerformDebugScan(input, extsvc.RepoID(depot))
+	if err != nil {
+		fail(fmt.Sprintf("Error parsing permissions: %s", err))
+	}
+
+	for _, exact := range perms.Exacts {
+		logger.Debug("Depot", log.String("depot", string(exact)))
+	}
+	for depot, subRepo := range perms.SubRepoPermissions {
+		logger.Debug("Sub repo permissions", log.String("depot", string(depot)))
+		for _, include := range subRepo.PathIncludes {
+			logger.Debug("Include rule", log.String("rule", include))
+		}
+		for _, exclude := range subRepo.PathExcludes {
+			logger.Debug("Include rule", log.String("rule", exclude))
+		}
+	}
+}
+
+func fail(reason string) {
+	fmt.Println(reason)
+	os.Exit(1)
+}

--- a/enterprise/internal/authz/perforce/cmd/scanprotects/main.go
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/main.go
@@ -41,7 +41,7 @@ func main() {
 }
 
 func run(logger log.Logger, depot string, input io.Reader) {
-	perms, err := perforce.PerformDebugScan(input, extsvc.RepoID(depot))
+	perms, err := perforce.PerformDebugScan(logger, input, extsvc.RepoID(depot))
 	if err != nil {
 		fail(fmt.Sprintf("Error parsing permissions: %s", err))
 	}

--- a/enterprise/internal/authz/perforce/cmd/scanprotects/main_test.go
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+)
+
+func TestPerformDebugScan(t *testing.T) {
+	logger := logtest.Scoped(t)
+
+	input, err := os.Open("../../testdata/sample-protects-a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := input.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	run(logger, "//depot/main/", input)
+}

--- a/enterprise/internal/authz/perforce/cmd/scanprotects/main_test.go
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/main_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPerformDebugScan(t *testing.T) {
-	logger := logtest.Scoped(t)
+	logger, exporter := logtest.Captured(t)
 
 	input, err := os.Open("../../testdata/sample-protects-a.txt")
 	if err != nil {
@@ -21,4 +22,11 @@ func TestPerformDebugScan(t *testing.T) {
 	})
 
 	run(logger, "//depot/main/", input)
+
+	logged := exporter()
+	// For now we'll just check that the count as well as first and last lines are
+	// what we expect
+	assert.Len(t, logged, 395)
+	assert.Equal(t, "Converted depot to glob", logged[0].Message)
+	assert.Equal(t, "Include rule", logged[len(logged)-1].Message)
 }

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -12,6 +12,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -29,6 +30,8 @@ const cacheTTL = time.Hour
 
 // Provider implements authz.Provider for Perforce depot permissions.
 type Provider struct {
+	logger log.Logger
+
 	urn      string
 	codeHost *extsvc.CodeHost
 	depots   []extsvc.RepoID
@@ -60,9 +63,10 @@ type p4Execer interface {
 // host, user and password to talk to a Perforce Server that is the source of
 // truth for permissions. It assumes emails of Sourcegraph accounts match 1-1
 // with emails of Perforce Server users.
-func NewProvider(urn, host, user, password string, depots []extsvc.RepoID, db database.DB) *Provider {
+func NewProvider(logger log.Logger, urn, host, user, password string, depots []extsvc.RepoID, db database.DB) *Provider {
 	baseURL, _ := url.Parse(host)
 	return &Provider{
+		logger:             logger,
 		urn:                urn,
 		codeHost:           extsvc.NewCodeHost(baseURL, extsvc.TypePerforce),
 		depots:             depots,
@@ -175,11 +179,11 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	// Pull permissions from protects file.
 	perms := &authz.ExternalUserPermissions{}
 	if len(p.depots) == 0 {
-		err = errors.Wrap(scanProtects(rc, repoIncludesExcludesScanner(perms)), "repoIncludesExcludesScanner")
+		err = errors.Wrap(scanProtects(p.logger, rc, repoIncludesExcludesScanner(perms)), "repoIncludesExcludesScanner")
 	} else {
 		// SubRepoPermissions-enabled code path
 		perms.SubRepoPermissions = make(map[extsvc.RepoID]*authz.SubRepoPermissions, len(p.depots))
-		err = errors.Wrap(scanProtects(rc, fullRepoPermsScanner(perms, p.depots)), "fullRepoPermsScanner")
+		err = errors.Wrap(scanProtects(p.logger, rc, fullRepoPermsScanner(p.logger, perms, p.depots)), "fullRepoPermsScanner")
 	}
 
 	// As per interface definition for this method, implementation should return
@@ -346,7 +350,7 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 	defer func() { _ = rc.Close() }()
 
 	users := make(map[string]struct{})
-	if err := scanProtects(rc, allUsersScanner(ctx, p, users)); err != nil {
+	if err := scanProtects(p.logger, rc, allUsersScanner(ctx, p, users)); err != nil {
 		return nil, errors.Wrap(err, "scanning protects")
 	}
 

--- a/enterprise/internal/authz/perforce/protects.go
+++ b/enterprise/internal/authz/perforce/protects.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/gobwas/glob"
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -183,6 +183,17 @@ func matchesAgainstDepot(match globMatch, depot string) bool {
 	return false
 }
 
+// PerformDebugScan will scan protections rules from r and log detailed
+// information about how each line was parsed.
+func PerformDebugScan(r io.Reader, depot extsvc.RepoID) (*authz.ExternalUserPermissions, error) {
+	perms := &authz.ExternalUserPermissions{
+		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
+	}
+	scanner := fullRepoPermsScanner(perms, []extsvc.RepoID{depot})
+	err := scanProtects(r, scanner)
+	return perms, err
+}
+
 // protectsScanner provides callbacks for scanning the output of `p4 protects`.
 type protectsScanner struct {
 	// Called on the parsed contents of each `p4 protects` line.
@@ -195,6 +206,7 @@ type protectsScanner struct {
 // It handles skipping comments, cleaning whitespace, parsing relevant fields, and
 // skipping entries that do not affect read access.
 func scanProtects(rc io.Reader, s *protectsScanner) error {
+	logger := log.Scoped("scanProtects", "")
 	scanner := bufio.NewScanner(rc)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -213,9 +225,12 @@ func scanProtects(rc io.Reader, s *protectsScanner) error {
 		// Trim whitespace
 		line = strings.TrimSpace(line)
 
+		logger.Debug("Scanning protects line", log.String("line", line))
+
 		// Split into fields
 		fields := strings.Fields(line)
 		if len(fields) < 5 {
+			logger.Debug("Line has less than 5 fields, discarding")
 			continue
 		}
 
@@ -234,6 +249,7 @@ func scanProtects(rc io.Reader, s *protectsScanner) error {
 		// We only care about read access. If the permission doesn't change read access,
 		// then we exit early.
 		if !parsedLine.affectsReadAccess() {
+			logger.Debug("Line does not affect read access, discarding")
 			continue
 		}
 
@@ -309,17 +325,19 @@ func repoIncludesExcludesScanner(perms *authz.ExternalUserPermissions) *protects
 // fullRepoPermsScanner converts `p4 protects` to a 1:1 implementation of Sourcegraph
 // authorization, including sub-repo perms and exact depot-as-repo matches.
 func fullRepoPermsScanner(perms *authz.ExternalUserPermissions, configuredDepots []extsvc.RepoID) *protectsScanner {
+	logger := log.Scoped("fullRepoPermsScanner", "")
 	// Get glob equivalents of all depots
 	var configuredDepotMatches []globMatch
 	for _, depot := range configuredDepots {
 		// treat depots as wildcards
 		m, err := convertToGlobMatch(string(depot) + "**")
 		if err != nil {
-			log15.Error("unexpected failure to convert depot to pattern - using a no-op pattern",
-				"depot", depot,
-				"error", err)
+			logger.Error("unexpected failure to convert depot to pattern - using a no-op pattern",
+				log.String("depot", string(depot)),
+				log.Error(err))
 			continue
 		}
+		logger.Debug("Converted depot to glob", log.String("depot", string(depot)), log.String("glob", m.pattern))
 		// preserve original name by overriding the wildcard version of the original text
 		m.original = string(depot)
 		configuredDepotMatches = append(configuredDepotMatches, m)
@@ -357,12 +375,20 @@ func fullRepoPermsScanner(perms *authz.ExternalUserPermissions, configuredDepots
 			// Depots that this match pertains to
 			depots := relevantDepots(match)
 
+			depotStrings := make([]string, len(depots))
+			for i := range depots {
+				depotStrings[i] = string(depots[i])
+			}
+			logger.Debug("Relevant depots", log.Strings("depots", depotStrings))
+
 			// Handle inclusions
 			if !line.isExclusion {
 				// Grant access to specified paths
 				for _, depot := range depots {
 					srp := getSubRepoPerms(depot)
-					srp.PathIncludes = append(srp.PathIncludes, convertRulesForWildcardDepotMatch(match, depot, patternsToGlob)...)
+					newIncludes := convertRulesForWildcardDepotMatch(match, depot, patternsToGlob)
+					srp.PathIncludes = append(srp.PathIncludes, newIncludes...)
+					logger.Debug("Adding include rules", log.Strings("rules", newIncludes))
 
 					var i int
 					for _, exclude := range srp.PathExcludes {
@@ -375,6 +401,7 @@ func fullRepoPermsScanner(perms *authz.ExternalUserPermissions, configuredDepots
 						}
 						checkWithDepotAdded := !strings.HasPrefix(originalExclude.pattern, "//") && match.Match(string(depot)+originalExclude.pattern)
 						if originalExclude.Match(match.original) || checkWithDepotAdded {
+							logger.Debug("Removing conflicting exclude rule", log.String("rule", originalExclude.pattern))
 							srp.PathExcludes = append(srp.PathExcludes[:i], srp.PathExcludes[i+1:]...)
 						} else {
 							i++
@@ -390,22 +417,26 @@ func fullRepoPermsScanner(perms *authz.ExternalUserPermissions, configuredDepots
 
 				// Special case: exclude entire depot
 				if strings.TrimPrefix(match.original, string(depot)) == perforceWildcardMatchAll {
+					logger.Debug("Exclude entire depot, removing all include rules")
 					srp.PathIncludes = nil
 				}
 
-				srp.PathExcludes = append(srp.PathExcludes, convertRulesForWildcardDepotMatch(match, depot, patternsToGlob)...)
+				newExcludes := convertRulesForWildcardDepotMatch(match, depot, patternsToGlob)
+				srp.PathExcludes = append(srp.PathExcludes, newExcludes...)
+				logger.Debug("Adding exclude rules", log.Strings("rules", newExcludes))
 
 				var i int
 				for _, include := range srp.PathIncludes {
 					// Perforce ACLs can have conflicting rules and the later one wins, so
 					// if we get a match here we drop the existing rule.
-					includeGlob, exists := patternsToGlob[include]
+					originalInclude, exists := patternsToGlob[include]
 					if !exists {
 						i++
 						continue
 					}
-					checkWithDepotAdded := !strings.HasPrefix(includeGlob.pattern, "//") && match.Match(string(depot)+includeGlob.pattern)
-					if match.Match(includeGlob.original) || checkWithDepotAdded {
+					checkWithDepotAdded := !strings.HasPrefix(originalInclude.pattern, "//") && match.Match(string(depot)+originalInclude.pattern)
+					if match.Match(originalInclude.original) || checkWithDepotAdded {
+						logger.Debug("Removing conflicting include rule", log.String("rule", originalInclude.pattern))
 						srp.PathIncludes = append(srp.PathIncludes[:i], srp.PathIncludes[i+1:]...)
 					} else {
 						i++
@@ -450,6 +481,7 @@ func fullRepoPermsScanner(perms *authz.ExternalUserPermissions, configuredDepots
 }
 
 func convertRulesForWildcardDepotMatch(match globMatch, depot extsvc.RepoID, patternsToGlob map[string]globMatch) []string {
+	logger := log.Scoped("convertRulesForWildcardDepotMatch", "")
 	if !strings.Contains(match.pattern, "**") && !strings.Contains(match.pattern, "*") {
 		return []string{match.pattern}
 	}
@@ -463,7 +495,7 @@ func convertRulesForWildcardDepotMatch(match globMatch, depot extsvc.RepoID, pat
 		maybePathRule := strings.Join(parts[i+1:], "/")
 		depotMatchGlob, err := glob.Compile(maybeDepotMatch, '/')
 		if err != nil {
-			log15.Warn(fmt.Sprintf("error compiling %s to glob: %v", maybeDepotMatch, err))
+			logger.Warn(fmt.Sprintf("error compiling %s to glob: %v", maybeDepotMatch, err))
 			continue
 		}
 		if depotMatchGlob.Match(trimmedDepot) {
@@ -479,7 +511,7 @@ func convertRulesForWildcardDepotMatch(match globMatch, depot extsvc.RepoID, pat
 				depotOnlyMatchesDoubleWildcard = false
 				newGlobMatch, err := convertToGlobMatch(maybePathRule)
 				if err != nil {
-					log15.Warn(fmt.Sprintf("error converting to glob match: %s\n", err))
+					logger.Warn(fmt.Sprintf("error converting to glob match: %s\n", err))
 				}
 				patternsToGlob[newGlobMatch.pattern] = newGlobMatch
 			}
@@ -495,6 +527,7 @@ func convertRulesForWildcardDepotMatch(match globMatch, depot extsvc.RepoID, pat
 
 // allUsersScanner converts `p4 protects` to a map of users within the protection rules.
 func allUsersScanner(ctx context.Context, p *Provider, users map[string]struct{}) *protectsScanner {
+	logger := log.Scoped("allUsersScanner", "")
 	return &protectsScanner{
 		processLine: func(line p4ProtectLine) error {
 			if line.isExclusion {
@@ -512,7 +545,7 @@ func allUsersScanner(ctx context.Context, p *Provider, users map[string]struct{}
 						return err
 					}
 				default:
-					log15.Warn("authz.perforce.Provider.FetchRepoPerms.unrecognizedType", "type", line.entityType)
+					logger.Warn("authz.perforce.Provider.FetchRepoPerms.unrecognizedType", log.String("type", line.entityType))
 				}
 
 				return nil
@@ -536,7 +569,7 @@ func allUsersScanner(ctx context.Context, p *Provider, users map[string]struct{}
 					return err
 				}
 			default:
-				log15.Warn("authz.perforce.Provider.FetchRepoPerms.unrecognizedType", "type", line.entityType)
+				logger.Warn("authz.perforce.Provider.FetchRepoPerms.unrecognizedType", log.String("type", line.entityType))
 			}
 
 			return nil

--- a/enterprise/internal/authz/perforce/protects.go
+++ b/enterprise/internal/authz/perforce/protects.go
@@ -185,12 +185,12 @@ func matchesAgainstDepot(match globMatch, depot string) bool {
 
 // PerformDebugScan will scan protections rules from r and log detailed
 // information about how each line was parsed.
-func PerformDebugScan(r io.Reader, depot extsvc.RepoID) (*authz.ExternalUserPermissions, error) {
+func PerformDebugScan(logger log.Logger, r io.Reader, depot extsvc.RepoID) (*authz.ExternalUserPermissions, error) {
 	perms := &authz.ExternalUserPermissions{
 		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 	}
-	scanner := fullRepoPermsScanner(perms, []extsvc.RepoID{depot})
-	err := scanProtects(r, scanner)
+	scanner := fullRepoPermsScanner(logger, perms, []extsvc.RepoID{depot})
+	err := scanProtects(logger, r, scanner)
 	return perms, err
 }
 
@@ -205,8 +205,8 @@ type protectsScanner struct {
 // scanProtects is a utility function for processing values from `p4 protects`.
 // It handles skipping comments, cleaning whitespace, parsing relevant fields, and
 // skipping entries that do not affect read access.
-func scanProtects(rc io.Reader, s *protectsScanner) error {
-	logger := log.Scoped("scanProtects", "")
+func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner) error {
+	logger = logger.Scoped("scanProtects", "")
 	scanner := bufio.NewScanner(rc)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -324,8 +324,8 @@ func repoIncludesExcludesScanner(perms *authz.ExternalUserPermissions) *protects
 
 // fullRepoPermsScanner converts `p4 protects` to a 1:1 implementation of Sourcegraph
 // authorization, including sub-repo perms and exact depot-as-repo matches.
-func fullRepoPermsScanner(perms *authz.ExternalUserPermissions, configuredDepots []extsvc.RepoID) *protectsScanner {
-	logger := log.Scoped("fullRepoPermsScanner", "")
+func fullRepoPermsScanner(logger log.Logger, perms *authz.ExternalUserPermissions, configuredDepots []extsvc.RepoID) *protectsScanner {
+	logger = logger.Scoped("fullRepoPermsScanner", "")
 	// Get glob equivalents of all depots
 	var configuredDepotMatches []globMatch
 	for _, depot := range configuredDepots {

--- a/enterprise/internal/authz/perforce/protects_test.go
+++ b/enterprise/internal/authz/perforce/protects_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -212,6 +213,7 @@ func TestMatchesAgainstDepot(t *testing.T) {
 }
 
 func TestScanFullRepoPermissions(t *testing.T) {
+	logger := logtest.Scoped(t)
 	f, err := os.Open("testdata/sample-protects-u.txt")
 	if err != nil {
 		t.Fatal(err)
@@ -230,7 +232,7 @@ func TestScanFullRepoPermissions(t *testing.T) {
 		return rc, nil, nil
 	})
 
-	p := NewTestProvider("", "ssl:111.222.333.444:1666", "admin", "password", execer)
+	p := NewTestProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", execer)
 	p.depots = []extsvc.RepoID{
 		"//depot/main/",
 		"//depot/training/",
@@ -241,7 +243,7 @@ func TestScanFullRepoPermissions(t *testing.T) {
 	perms := &authz.ExternalUserPermissions{
 		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 	}
-	if err := scanProtects(rc, fullRepoPermsScanner(perms, p.depots)); err != nil {
+	if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -299,6 +301,7 @@ func TestScanFullRepoPermissions(t *testing.T) {
 }
 
 func TestScanFullRepoPermissionsWithWildcardMatchingDepot(t *testing.T) {
+	logger := logtest.Scoped(t)
 	f, err := os.Open("testdata/sample-protects-m.txt")
 	if err != nil {
 		t.Fatal(err)
@@ -317,14 +320,14 @@ func TestScanFullRepoPermissionsWithWildcardMatchingDepot(t *testing.T) {
 		return rc, nil, nil
 	})
 
-	p := NewTestProvider("", "ssl:111.222.333.444:1666", "admin", "password", execer)
+	p := NewTestProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", execer)
 	p.depots = []extsvc.RepoID{
 		"//depot/main/base/",
 	}
 	perms := &authz.ExternalUserPermissions{
 		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 	}
-	if err := scanProtects(rc, fullRepoPermsScanner(perms, p.depots)); err != nil {
+	if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -477,6 +480,7 @@ read  group     Rome    *  //depot/dev/...
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			logger := logtest.Scoped(t)
 			if !strings.HasPrefix(tc.depot, "/") {
 				t.Fatal("depot must end in '/'")
 			}
@@ -513,14 +517,14 @@ read  group     Rome    *  //depot/dev/...
 			execer := p4ExecFunc(func(ctx context.Context, host, user, password string, args ...string) (io.ReadCloser, http.Header, error) {
 				return rc, nil, nil
 			})
-			p := NewTestProvider("", "ssl:111.222.333.444:1666", "admin", "password", execer)
+			p := NewTestProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", execer)
 			p.depots = []extsvc.RepoID{
 				extsvc.RepoID(tc.depot),
 			}
 			perms := &authz.ExternalUserPermissions{
 				SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 			}
-			if err := scanProtects(rc, fullRepoPermsScanner(perms, p.depots)); err != nil {
+			if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots)); err != nil {
 				t.Fatal(err)
 			}
 			rules, ok := perms.SubRepoPermissions[extsvc.RepoID(tc.depot)]
@@ -561,6 +565,7 @@ read  group     Rome    *  //depot/dev/...
 }
 
 func TestFullScanWildcardDepotMatching(t *testing.T) {
+	logger := logtest.Scoped(t)
 	f, err := os.Open("testdata/sample-protects-x.txt")
 	if err != nil {
 		t.Fatal(err)
@@ -579,14 +584,14 @@ func TestFullScanWildcardDepotMatching(t *testing.T) {
 		return rc, nil, nil
 	})
 
-	p := NewTestProvider("", "ssl:111.222.333.444:1666", "admin", "password", execer)
+	p := NewTestProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", execer)
 	p.depots = []extsvc.RepoID{
 		"//depot/654/deploy/base/",
 	}
 	perms := &authz.ExternalUserPermissions{
 		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 	}
-	if err := scanProtects(rc, fullRepoPermsScanner(perms, p.depots)); err != nil {
+	if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -709,6 +714,7 @@ func TestCheckWildcardDepotMatch(t *testing.T) {
 }
 
 func TestScanAllUsers(t *testing.T) {
+	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	f, err := os.Open("testdata/sample-protects-a.txt")
 	if err != nil {
@@ -729,7 +735,7 @@ func TestScanAllUsers(t *testing.T) {
 		return rc, nil, nil
 	})
 
-	p := NewTestProvider("", "ssl:111.222.333.444:1666", "admin", "password", execer)
+	p := NewTestProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", execer)
 	p.cachedGroupMembers = map[string][]string{
 		"dev": {"user1", "user2"},
 	}
@@ -739,7 +745,7 @@ func TestScanAllUsers(t *testing.T) {
 	}
 
 	users := make(map[string]struct{})
-	if err := scanProtects(rc, allUsersScanner(ctx, p, users)); err != nil {
+	if err := scanProtects(logger, rc, allUsersScanner(ctx, p, users)); err != nil {
 		t.Fatal(err)
 	}
 	want := map[string]struct{}{


### PR DESCRIPTION
Added a lot of extra debugging to perforce protection file scanning.

Also added a command line tool, `scanprotects` that can be used to scan
the output of a protection file and log the details.

Note that we also needed to thread our new logging library into the provider and 
scanner code in ordere to capture logs for test assertions.

## Test plan

New tests added
