### PR TITLE
site-admin: rename "Repository status" in sidebar to "Repositories"

### DIFF
--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -61,7 +61,7 @@ export const repositoriesGroup: SiteAdminSideBarGroup = {
             to: '/site-admin/external-services',
         },
         {
-            label: 'Repository status',
+            label: 'Repositories',
             to: '/site-admin/repositories',
         },
     ],


### PR DESCRIPTION
The page is called "Repositories". The URL is `/repositories`. Every
other "list page" we have in the site-admin area ("users", "orgs", ...)
is also called "<plural noun>" and not "<plural noun> status".

## Test plan

- Manual testing locally

## App preview:

- [Web](https://sg-web-mrn-rename-repos-sidebar.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vayenpfeoz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
