### PR TITLE
search: Decorate predicate body for `repo:has` syntax

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1493,6 +1493,66 @@ describe('getMonacoTokens()', () => {
         `)
     })
 
+    test('highlight repo:has.file predicate', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:has.file(path:foo content:bar)'))))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "metaPredicateDot"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "metaPredicateParenthesis"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "metaFilterSeparator"
+              },
+              {
+                "startIndex": 19,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 22,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 23,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 31,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 34,
+                "scopes": "metaPredicateParenthesis"
+              }
+            ]
+        `)
+    })
+
     test('highlight repo:has.description predicate', () => {
         expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:has.description(.*)')))).toMatchInlineSnapshot(`
             [

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -980,7 +980,8 @@ const decorateRepoHasBody = (body: string, offset: number): DecoratedToken[] | u
 const decoratePredicateBody = (path: string[], body: string, offset: number): DecoratedToken[] => {
     const decorated: DecoratedToken[] = []
     switch (path.join('.')) {
-        case 'contains.file': {
+        case 'contains.file':
+        case 'has.file': {
             const result = decorateContainsFileBody(body, offset)
             if (result !== undefined) {
                 return result
@@ -988,7 +989,9 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
             break
         }
         case 'contains.path':
+        case 'has.path':
         case 'contains.content':
+        case 'has.content':
         case 'has.description':
             return mapRegexpMetaSucceed({
                 type: 'pattern',


### PR DESCRIPTION
Oversight from https://github.com/sourcegraph/sourcegraph/pull/40765
Part of #39767

## Test plan
Added unit test

Before:
![Screen Shot 2022-08-24 at 10 26 04 AM](https://user-images.githubusercontent.com/70350613/186458806-0cc16953-73f3-4088-a11c-9fae7ea80074.png)

After:
![Screen Shot 2022-08-24 at 10 26 18 AM](https://user-images.githubusercontent.com/70350613/186458827-966922e3-35c7-4ae0-b54d-adb708314b55.png)
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tl-repo-has-decoration-fix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zhpseuevmd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
