### PR TITLE
search history: add feature flag to disable

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -17,6 +17,7 @@ export type FeatureFlagName =
     | 'search-aggregation-filters'
     | 'ab-lucky-search' // To be removed at latest by 12/2022.
     | 'user-management-disabled'
+    | 'search-input-show-history'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -17,7 +17,7 @@ export type FeatureFlagName =
     | 'search-aggregation-filters'
     | 'ab-lucky-search' // To be removed at latest by 12/2022.
     | 'user-management-disabled'
-    | 'search-input-show-history'
+    | 'search-input-hide-history'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -23,6 +23,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { AuthenticatedUser } from '../../auth'
+import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { Notices } from '../../global/Notices'
 import {
     useExperimentalFeatures,
@@ -75,10 +76,11 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
         features => features.applySearchQuerySuggestionOnEnter ?? false
     )
     const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
+    const [showSearchHistory] = useFeatureFlag('search-input-show-history')
 
     const suggestionSources = useMemo(
         () =>
-            coreWorkflowImprovementsEnabled && props.authenticatedUser
+            coreWorkflowImprovementsEnabled && props.authenticatedUser && showSearchHistory
                 ? [
                       searchQueryHistorySource({
                           userId: props.authenticatedUser.id,
@@ -93,10 +95,11 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                   ]
                 : [],
         [
+            coreWorkflowImprovementsEnabled,
             props.authenticatedUser,
             props.selectedSearchContextSpec,
-            coreWorkflowImprovementsEnabled,
             props.telemetryService,
+            showSearchHistory,
         ]
     )
 

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -76,11 +76,11 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
         features => features.applySearchQuerySuggestionOnEnter ?? false
     )
     const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
-    const [showSearchHistory] = useFeatureFlag('search-input-show-history')
+    const [hideSearchHistory] = useFeatureFlag('search-input-hide-history')
 
     const suggestionSources = useMemo(
         () =>
-            coreWorkflowImprovementsEnabled && props.authenticatedUser && showSearchHistory
+            coreWorkflowImprovementsEnabled && props.authenticatedUser && !hideSearchHistory
                 ? [
                       searchQueryHistorySource({
                           userId: props.authenticatedUser.id,
@@ -99,7 +99,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
             props.authenticatedUser,
             props.selectedSearchContextSpec,
             props.telemetryService,
-            showSearchHistory,
+            hideSearchHistory,
         ]
     )
 


### PR DESCRIPTION
[Context on Slack](https://sourcegraph.slack.com/archives/C020S8AT3LN/p1661352189798649)

This adds the feature flag `search-input-hide-history` that will hide the search history shown when focusing on the search input.

![image](https://user-images.githubusercontent.com/206864/186482308-214c851a-f892-45c8-8830-b3e95330ee2f.png)

## Test plan

Use the Site Admin page to turn the feature flag on and off and check that the search history is hidden when the feature flag is on, and shown when the feature flag is off or non-existant.

![image](https://user-images.githubusercontent.com/206864/186482434-9b319368-f6b4-4fc4-88c9-a490c160990d.png)

## App preview:

- [Web](https://sg-web-jp-searchhistoryfeatureflag.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mibncgnqrw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
