### PR TITLE
build-tracker: always use the commit author

### DIFF
--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -25,19 +25,9 @@ type Build struct {
 	ConsecutiveFailure int `json:"consecutiveFailures"`
 }
 
-// updateFromEvent updates the current build with the build and pipeline from the event. Care is taken
-// to ensure the author is retained as the build from the event might not have an author, whereas the original build
-// does!
+// updateFromEvent updates the current build with the build and pipeline from the event.
 func (b *Build) updateFromEvent(e *Event) {
-	old := b.Build
-
 	b.Build = e.Build
-	// sometimes (typically when a build is retried) the "new" build won't have the author in it.
-	// so we make sure to retain the author, if the new build does not contain one!
-	// TODO(burmudar): maybe we should just always preserve the old author ?
-	if b.Build.Author == nil || b.Build.Author.Name == "" || b.Build.Author.Email == "" {
-		b.Build.Author = old.Author
-	}
 	b.Pipeline = e.pipeline()
 }
 

--- a/dev/build-tracker/build_test.go
+++ b/dev/build-tracker/build_test.go
@@ -43,27 +43,6 @@ func TestUpdateFromEvent(t *testing.T) {
 		Job: job.Job,
 	}
 
-	t.Run("original author get preserved over nil", func(t *testing.T) {
-		build := event.build()
-		otherEvent := event
-		otherEvent.Build.Author = nil
-
-		build.updateFromEvent(&otherEvent)
-
-		require.NotNil(t, build.Author)
-	})
-
-	t.Run("original author get preserved if new author is empty", func(t *testing.T) {
-		build := event.build()
-		otherEvent := event
-		otherEvent.Build.Author = &buildkite.Author{}
-
-		build.updateFromEvent(&otherEvent)
-
-		require.NotNil(t, build.Author)
-		require.Equal(t, build.Author, event.Build.Author)
-	})
-
 	t.Run("build gets updated with new build", func(t *testing.T) {
 		build := event.build()
 		otherEvent := event

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -44,9 +44,6 @@ func NewNotificationClient(logger log.Logger, slackToken, githubToken, channel s
 }
 
 func (c *NotificationClient) getTeammateForBuild(build *Build) (*team.Teammate, error) {
-	if build.Author == nil {
-		return nil, errors.New("nil Author")
-	}
 	return c.team.ResolveByCommitAuthor(context.Background(), "sourcegraph", "sourcegraph", build.commit())
 }
 
@@ -54,13 +51,7 @@ func (c *NotificationClient) sendFailedBuild(build *Build) error {
 	logger := c.logger.With(log.Int("buildNumber", build.number()), log.String("channel", c.channel))
 	logger.Debug("creating slack json")
 
-	logger.Debug("getting teammate information", log.String("authorName", build.authorName()), log.String("authorEmail", build.authorEmail()))
-	teammate, err := c.getTeammateForBuild(build)
-	if err != nil {
-		logger.Error("failed to find teammate", log.Error(err))
-	}
-
-	blocks, err := createMessageBlocks(logger, teammate, build)
+	blocks, err := c.createMessageBlocks(build)
 	if err != nil {
 		return err
 	}
@@ -150,19 +141,11 @@ func commitLink(msg, commit string) string {
 	return fmt.Sprintf("<%s|%s>", sgURL, msg)
 }
 
-func slackMention(teammate *team.Teammate, build *Build) string {
-	if teammate == nil {
-		authorName := build.authorName()
-		if authorName == "" {
-			authorName = "N/A"
-		}
-		return fmt.Sprintf("Teammate *%s* not found. If this is you, ensure the github field is set in your profile <https://github.com/sourcegraph/handbook/blob/main/data/team.yml|here>", authorName)
-	}
-
+func slackMention(teammate *team.Teammate) string {
 	return fmt.Sprintf("<@%s>", teammate.SlackID)
 }
 
-func createMessageBlocks(logger log.Logger, teammate *team.Teammate, build *Build) ([]slack.Block, error) {
+func (c *NotificationClient) createMessageBlocks(build *Build) ([]slack.Block, error) {
 	msg, _, _ := strings.Cut(build.message(), "\n")
 	msg += fmt.Sprintf(" (%s)", build.commit()[:7])
 	failedSection := fmt.Sprintf("> %s\n\n", commitLink(msg, build.commit()))
@@ -177,7 +160,17 @@ func createMessageBlocks(logger log.Logger, teammate *team.Teammate, build *Buil
 		}
 	}
 
-	author := slackMention(teammate, build)
+	c.logger.Debug("getting teammate information", log.String("authorName", build.authorName()), log.String("authorEmail", build.authorEmail()))
+	teammate, err := c.getTeammateForBuild(build)
+	var author string
+	if err != nil {
+		c.logger.Error("failed to find teammate", log.String("commit", build.commit()), log.Error(err))
+		// the error has some guidance on how to fix it so that teammate resolver can figure out who you are from the commit!
+		author = err.Error()
+	} else {
+		author = slackMention(teammate)
+	}
+
 	grafanaURL, err := grafanaURLFor(build)
 	if err != nil {
 		return nil, err

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -160,12 +160,13 @@ func (c *NotificationClient) createMessageBlocks(build *Build) ([]slack.Block, e
 		}
 	}
 
-	c.logger.Debug("getting teammate information", log.String("authorName", build.authorName()), log.String("authorEmail", build.authorEmail()))
+	c.logger.Debug("getting teammate information using commit", log.String("commit", build.commit()))
 	teammate, err := c.getTeammateForBuild(build)
 	var author string
 	if err != nil {
-		c.logger.Error("failed to find teammate", log.String("commit", build.commit()), log.Error(err))
+		c.logger.Error("failed to find teammate", log.Error(err))
 		// the error has some guidance on how to fix it so that teammate resolver can figure out who you are from the commit!
+		// so we set author here to that msg, so that the message can be conveyed to the person in slack
 		author = err.Error()
 	} else {
 		author = slackMention(teammate)


### PR DESCRIPTION
When a build is retried on buildkite it gets a new build number and it's author gets zeroed out. Since the build has a new build number, build-tracker tracked it as a new build trusting that it has it's author set. This lead to something like the following:

Varun retried his build twice, his first build has his name set, but subsequent builds didn't
1. [Build one](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1661274550767679)
2. [Build Two](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1661279690546399)
3. [Build Three](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1661280934474419)

To get a teammates information we used the build commit and then resolved that in github to figure out who the person was. Unfortunately, we checked the build to make sure we have an author, even though the build author isn't used AT ALL anymore! Hence the fix :D

## Test plan
Unit tests!
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
