### PR TITLE
insights: return unavailable reason rather than error when resolving availability 

### DIFF
--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -47,7 +47,8 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	aggregationModeAvailabilityResolver := newAggregationModeAvailabilityResolver(r.searchQuery, r.patternType, aggregationMode)
 	supported, err := aggregationModeAvailabilityResolver.Available()
 	if err != nil {
-		return nil, err
+		reason := fmt.Sprintf("could not fetch mode availability: %v", err)
+		return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(reason, aggregationMode)}, nil
 	}
 	if !supported {
 		unavailableReason := ""


### PR DESCRIPTION
when we determine a mode's availability we can fail on query parsing. we should not fully error on this and return a `SearchAggregationNotAvailable` resolver instead

## Test plan
```gql
query searchQueryAggregate {
  searchQueryAggregate(query: "fix fork:file context:global", patternType: literal) {
    aggregations(limit: 10) {
      __typename
      ... on ExhaustiveSearchAggregationResult {
        groups {
          label
          count
          query
        }
        otherResultCount
        otherGroupCount
      }
      ... on NonExhaustiveSearchAggregationResult {
          groups {
          label
          count
          query
        }
        otherResultCount
        approximateOtherGroupCount
      }
      ... on SearchAggregationNotAvailable {
        reason
      }
    }
  }
}
```
returns
```json
{
  "data": {
    "searchQueryAggregate": {
      "aggregations": {
        "__typename": "SearchAggregationNotAvailable",
        "reason": "could not fetch mode availability: ParseQuery: query.Pipeline: invalid value \"file\" for field \"fork\". Valid values are: yes, only, no"
      }
    }
  }
}
```