### PR TITLE
dev/sg: disable prettier linter

### DIFF
--- a/dev/sg/linters/prettier.go
+++ b/dev/sg/linters/prettier.go
@@ -12,7 +12,8 @@ import (
 )
 
 var prettier = &linter{
-	Name: "Prettier",
+	Name:    "Prettier",
+	Enabled: disabled("seems to produce unreliable results"),
 	// TODO unfortunate that we have to use 'dev/ci/yarn-run.sh'
 	Check: func(ctx context.Context, out *std.Output, args *repo.State) error {
 		return root.Run(run.Cmd(ctx, "dev/ci/yarn-run.sh format:check")).


### PR DESCRIPTION
Produces unreliable results causing persistent failures in main: https://sourcegraph.slack.com/archives/C01N83PS4TU/p1661302782941279

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go run ./dev/sg lint docs`