### PR TITLE
migration store: Fix golang-migrate schema table name usage

### DIFF
--- a/internal/database/migration/stitch/rewriter.go
+++ b/internal/database/migration/stitch/rewriter.go
@@ -234,7 +234,7 @@ func rewriteConcurrentIndexCreationDownMigrations(schemaName string, _ oobmigrat
 //
 // See https://github.com/sourcegraph/sourcegraph/pull/29395.
 func reorderMigrations(schemaName string, version oobmigration.Version, _ []int, contents map[string]string) {
-	if schemaName != "frontend" || !(version.Major == 3 && version.Minor < 36) {
+	if schemaName != "frontend" || !(version.Major == 3 && version.Minor == 35) {
 		// Rename occurred at v3.36
 		return
 	}

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -523,16 +523,6 @@ func humanizeSchemaName(schemaName string) string {
 	return strings.TrimSuffix(schemaName, "_schema_migrations")
 }
 
-// tableizeSchemaName converts a migration name as defined in the migrations/ directory to
-// the name of the table used by golang-migrate.
-func tableizeSchemaName(schemaName string) string {
-	if schemaName == "frontend" {
-		return "schema_migrations"
-	}
-
-	return fmt.Sprintf("%s_schema_migrations", schemaName)
-}
-
 var quote = sqlf.Sprintf
 
 // isMissingRelation returns true if the given error occurs due to a missing relation in Postgres.

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -224,7 +224,7 @@ func (s *Store) inferbackfillTargetViaMigrationLogs(ctx context.Context) (int, b
 // DO NOT call this method from inside a transaction, otherwise the absence of this relation will
 // cause a transaction rollback while this function returns a nil-valued error (hard to debug).
 func (s *Store) inferBackfillTargetViaGolangMigrate(ctx context.Context) (int, bool, error) {
-	version, ok, err := basestore.ScanFirstInt(s.Query(ctx, sqlf.Sprintf(inferBackfillTargetViaGolangMigrateQuery, quote(tableizeSchemaName(s.schemaName)))))
+	version, ok, err := basestore.ScanFirstInt(s.Query(ctx, sqlf.Sprintf(inferBackfillTargetViaGolangMigrateQuery, quote(s.schemaName))))
 	if err != nil && !isMissingRelation(err) {
 		return 0, false, err
 	}

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -180,19 +180,6 @@ func TestHumanizeSchemaName(t *testing.T) {
 	}
 }
 
-func TestTableizeSchemaName(t *testing.T) {
-	for input, expected := range map[string]string{
-		"frontend":     "schema_migrations",
-		"codeintel":    "codeintel_schema_migrations",
-		"codeinsights": "codeinsights_schema_migrations",
-		"test":         "test_schema_migrations",
-	} {
-		if output := tableizeSchemaName(input); output != expected {
-			t.Errorf("unexpected output. want=%q have=%q", expected, output)
-		}
-	}
-}
-
 func TestVersions(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := dbtest.NewDB(logger, t)

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -81,7 +81,7 @@ func testViaGolangMigrate(t *testing.T, schemaName string, version int, expected
 
 // setupGolangMigrateTest creates and populates the .*schema_migrations table with the given version.
 func setupGolangMigrateTest(ctx context.Context, store *Store, schemaName string, version int) error {
-	tableName := quote(tableizeSchemaName(schemaName))
+	tableName := quote(schemaName)
 
 	if err := store.Exec(ctx, sqlf.Sprintf(`CREATE TABLE %s (version text, dirty bool)`, tableName)); err != nil {
 		return err

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -97,7 +97,7 @@ func setupGolangMigrateTest(ctx context.Context, store *Store, schemaName string
 // the migration_logs table has an entry with the given initial version.
 func testViaMigrationLogs(t *testing.T, schemaName string, initialVersion int, expectedVersions []int) {
 	testBackfillSchemaVersion(t, schemaName, expectedVersions, func(ctx context.Context, store *Store) {
-		if err := setupGolangMigrateTest(ctx, store, schemaName, initialVersion); err != nil {
+		if err := setupMigrationLogsTest(ctx, store, schemaName, initialVersion); err != nil {
 			t.Fatalf("unexpected error preparing migration_logs tests: %s", err)
 		}
 	})


### PR DESCRIPTION
The schema name that we supply to the migration store is already the exact table name that our old golang-migrate machinery used. I incorrectly added a transform that attempts to query the `schema_migrations_schema_migrations` table, which doesn't exist (`schema_migrations` does, though).

Removing this transform uses the correct table.

## Test plan

Tested locally; updated unit tests.