### PR TITLE
oobmigration: Fix off by one error

### DIFF
--- a/internal/oobmigration/upgrade.go
+++ b/internal/oobmigration/upgrade.go
@@ -44,7 +44,7 @@ func scheduleMigrationInterrupts(from, to Version, migrations []yamlMigration) (
 		}
 
 		deprecated := Version{*m.DeprecatedVersionMajor, *m.DeprecatedVersionMinor}
-		if !(CompareVersions(from, deprecated) == VersionOrderBefore && CompareVersions(deprecated, to) == VersionOrderBefore) {
+		if !(CompareVersions(from, deprecated) == VersionOrderBefore && CompareVersions(deprecated, to) != VersionOrderAfter) {
 			// Skip migrations not deprecated within the the instance upgrade interval
 			continue
 		}

--- a/internal/oobmigration/upgrade_test.go
+++ b/internal/oobmigration/upgrade_test.go
@@ -105,7 +105,7 @@ func TestScheduleMigrationInterrupts(t *testing.T) {
 			interrupts: []MigrationInterrupt{
 				{Version: Version{3, 34}, MigrationIDs: []int{2}},
 				{Version: Version{3, 37}, MigrationIDs: []int{4}},
-				{Version: Version{3, 39}, MigrationIDs: []int{5}},
+				{Version: Version{3, 39}, MigrationIDs: []int{3, 5}},
 			},
 		},
 	} {


### PR DESCRIPTION
Ensure that if you're upgrading to an exact version at which point an oobmigration is deprecated, we include that version.

## Test plan

Existing unit tests.