### PR TITLE
executors: fix dashboard to respect $queue variable

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -17587,7 +17587,7 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100000`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (queue)(src_executor_total{job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
+Query: `max by (queue)(src_executor_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
 
 </details>
 
@@ -17612,7 +17612,7 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100001`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (queue)(increase(src_executor_total{job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m])) / sum by (queue)(increase(src_executor_processor_total{job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m]))`
+Query: `sum by (queue)(increase(src_executor_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m])) / sum by (queue)(increase(src_executor_processor_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m]))`
 
 </details>
 
@@ -17631,7 +17631,7 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100002`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (queue)(src_executor_queued_duration_seconds_total{job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
+Query: `max by (queue)(src_executor_queued_duration_seconds_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
 
 </details>
 

--- a/monitoring/definitions/executor.go
+++ b/monitoring/definitions/executor.go
@@ -39,7 +39,7 @@ func Executor() *monitoring.Dashboard {
 			},
 		},
 		Groups: []monitoring.Group{
-			shared.CodeIntelligence.NewExecutorQueueGroup(queueContainerName),
+			shared.CodeIntelligence.NewExecutorQueueGroup(queueContainerName, "$queue"),
 			shared.CodeIntelligence.NewExecutorProcessorGroup(executorsJobName),
 			shared.CodeIntelligence.NewExecutorAPIClientGroup(executorsJobName),
 			shared.CodeIntelligence.NewExecutorSetupCommandGroup(executorsJobName),

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -265,7 +265,7 @@ func (codeIntelligence) NewDependencyIndexProcessorGroup(containerName string) m
 // src_executor_total
 // src_executor_processor_total
 // src_executor_queued_duration_seconds_total
-func (codeIntelligence) NewExecutorQueueGroup(containerName string) monitoring.Group {
+func (codeIntelligence) NewExecutorQueueGroup(containerName, queueFilter string) monitoring.Group {
 	return Queue.NewGroup(containerName, monitoring.ObservableOwnerCodeIntel, QueueSizeGroupOptions{
 		GroupConstructorOptions: GroupConstructorOptions{
 			Namespace:       "executor",
@@ -275,6 +275,7 @@ func (codeIntelligence) NewExecutorQueueGroup(containerName string) monitoring.G
 			ObservableConstructorOptions: ObservableConstructorOptions{
 				MetricNameRoot:        "executor",
 				MetricDescriptionRoot: "unprocessed executor job",
+				Filters:               []string{fmt.Sprintf(`queue=~%q`, queueFilter)},
 				By:                    []string{"queue"},
 			},
 		},
@@ -297,6 +298,7 @@ func (codeIntelligence) NewExecutorQueueGroup(containerName string) monitoring.G
 // src_executor_processor_errors_total
 // src_executor_processor_handlers
 func (codeIntelligence) NewExecutorProcessorGroup(containerName string) monitoring.Group {
+	// TODO: pass in as variable like in NewExecutorQueueGroup?
 	filters := []string{`queue=~"${queue:regex}"`}
 
 	constructorOptions := ObservableConstructorOptions{

--- a/monitoring/definitions/shared/queues.go
+++ b/monitoring/definitions/shared/queues.go
@@ -93,7 +93,7 @@ type QueueSizeGroupOptions struct {
 // Requires any of the following:
 //   - gauge of the format `src_{options.MetricNameRoot}_total`
 //   - counter of the format `src_{options.MetricNameRoot}_processor_total`
-// 	 - counter of the format `src_{options.MetricNameRoot}_queued_duration_seconds_total`
+//   - counter of the format `src_{options.MetricNameRoot}_queued_duration_seconds_total`
 //
 // The queue size metric should be created via a Prometheus gauge function in the Go backend. For
 // instructions on how to create the processor metrics, see the `NewWorkerutilGroup` function in


### PR DESCRIPTION
Queue panels were not using the $queue variable, so the dropdown didn't affect them. This PR just fixes that :)

## Test plan

Ran grafana locally with dotcom data, all GOOD
