### PR TITLE
Fix `ButtonGroup` styles for disabled buttons w/ `Tooltip`

### DIFF
--- a/client/wildcard/src/components/Button/Button.module.scss
+++ b/client/wildcard/src/components/Button/Button.module.scss
@@ -381,20 +381,19 @@
 
 .btn-group {
     // Prevent double borders when buttons are next to each other
-    > .btn:not(:first-child),
-    > .btn-group:not(:first-child) {
+    > *:not(:first-child) {
         margin-left: calc(-1 * var(--btn-border-width));
     }
 
     // Reset rounded corners
     > .btn:not(:last-child):not(:global(.dropdown-toggle)),
-    > .btn-group:not(:last-child) > .btn {
+    > *:not(:last-child) .btn {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
     }
 
     > .btn:not(:first-child),
-    > .btn-group:not(:first-child) > .btn {
+    > *:not(:first-child) .btn {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
     }

--- a/client/wildcard/src/components/Button/story/Button.story.tsx
+++ b/client/wildcard/src/components/Button/story/Button.story.tsx
@@ -206,3 +206,9 @@ export const Group: Story = () => {
     )
 }
 Group.storyName = 'Button Group'
+Group.parameters = {
+    chromatic: {
+        enableDarkMode: true,
+        disableSnapshot: false,
+    },
+}

--- a/client/wildcard/src/components/Button/story/Button.story.tsx
+++ b/client/wildcard/src/components/Button/story/Button.story.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import { Meta, Story } from '@storybook/react'
 import SearchIcon from 'mdi-react/SearchIcon'
 
@@ -104,18 +106,6 @@ export const AllButtons: Story = () => (
             Block
         </Button>
 
-        <H2>Button Group</H2>
-        <ButtonGroup className="mb-3">
-            <Button variant="secondary" display="block">
-                Grouped
-            </Button>
-            <Button variant="secondary" display="block">
-                Grouped
-            </Button>
-            <Button variant="secondary" display="block">
-                Grouped
-            </Button>
-        </ButtonGroup>
         <H2>Tooltips</H2>
         <Text>Buttons can have tooltips.</Text>
         <Tooltip content="Some extra context on the button.">
@@ -137,3 +127,82 @@ AllButtons.parameters = {
         disableSnapshot: false,
     },
 }
+
+export const Group: Story = () => {
+    const [selectedButton, setSelectedButton] = useState(1)
+
+    return (
+        <>
+            <div className="mb-4">
+                <H2>Standard</H2>
+
+                <ButtonGroup>
+                    <Button variant="secondary" outline={selectedButton !== 1} onClick={() => setSelectedButton(1)}>
+                        One
+                    </Button>
+                    <Button variant="secondary" outline={selectedButton !== 2} onClick={() => setSelectedButton(2)}>
+                        Two
+                    </Button>
+                    <Button variant="secondary" outline={selectedButton !== 3} onClick={() => setSelectedButton(3)}>
+                        Three
+                    </Button>
+                </ButtonGroup>
+            </div>
+
+            <div className="mb-4">
+                <H2>With Tooltips</H2>
+
+                <ButtonGroup>
+                    <Tooltip content="Option One">
+                        <Button variant="secondary" outline={selectedButton !== 1} onClick={() => setSelectedButton(1)}>
+                            One
+                        </Button>
+                    </Tooltip>
+                    <Tooltip content="Option Two">
+                        <Button variant="secondary" outline={selectedButton !== 2} onClick={() => setSelectedButton(2)}>
+                            Two
+                        </Button>
+                    </Tooltip>
+                    <Tooltip content="Option Three">
+                        <Button variant="secondary" outline={selectedButton !== 3} onClick={() => setSelectedButton(3)}>
+                            Three
+                        </Button>
+                    </Tooltip>
+                </ButtonGroup>
+            </div>
+
+            <div className="mb-4">
+                <H2>With Tooltips (Disabled Buttons)</H2>
+
+                <ButtonGroup>
+                    <Tooltip content="Option One">
+                        <Button variant="secondary" outline={selectedButton !== 1} onClick={() => setSelectedButton(1)}>
+                            One
+                        </Button>
+                    </Tooltip>
+                    <Tooltip content="Option Two">
+                        <Button
+                            disabled={true}
+                            variant="secondary"
+                            outline={selectedButton !== 2}
+                            onClick={() => setSelectedButton(2)}
+                        >
+                            Two
+                        </Button>
+                    </Tooltip>
+                    <Tooltip content="Option Three">
+                        <Button
+                            disabled={true}
+                            variant="secondary"
+                            outline={selectedButton !== 3}
+                            onClick={() => setSelectedButton(3)}
+                        >
+                            Three
+                        </Button>
+                    </Tooltip>
+                </ButtonGroup>
+            </div>
+        </>
+    )
+}
+Group.storyName = 'Button Group'


### PR DESCRIPTION
Fixes #40094.

In order for tooltips to work properly on disabled buttons, we need to wrap those buttons with additional elements. This wound up breaking styles when trying to use disabled buttons with tooltips inside of a button group.

This change adjusts the styles for button groups so that they no longer assume the element with the `.btn` class name will be a direct child. I also moved the `ButtonGroup` into its own dedicated story and included examples with tooltips to help with testing.

## Test plan

Validate visual styles in Storybook. Confirm no visual regressions with `ButtonGroup`s used in the application.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lrh-fix-button-group-tooltips.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zlpsmwrmdb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
