### PR TITLE
ci: reenable prettier and enable ESLint for all workspaces

### DIFF
--- a/client/vscode/.eslintignore
+++ b/client/vscode/.eslintignore
@@ -1,3 +1,4 @@
+src/graphql-operations.ts
 dist/
 package.json
 src/vendor/*.js

--- a/client/vscode/.eslintrc.js
+++ b/client/vscode/.eslintrc.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const baseConfig = require('../../.eslintrc.js')
+const baseConfig = require('../../.eslintrc')
 
 module.exports = {
   extends: '../../.eslintrc.js',

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -217,7 +217,7 @@
     }
   },
   "scripts": {
-    "eslint": "eslint --cache '**/*.[jt]s?(x)'",
+    "lint:js": "eslint --cache '**/*.[jt]s?(x)'",
     "test": "ts-node ./tests/runTests.ts",
     "package": "ts-node ./scripts/package.ts",
     "prebuild": "yarn build-inline-extensions",

--- a/client/vscode/scripts/publish.ts
+++ b/client/vscode/scripts/publish.ts
@@ -47,7 +47,7 @@ try {
         }
         We cut everything before the json object so that we can parse it as json.
     */
-    const trimmedResponse = response.substring(response.indexOf('{'))
+    const trimmedResponse = response.slice(Math.max(0, response.indexOf('{')))
     const latestVersion: string = JSON.parse(trimmedResponse).versions[0].version
     if (hasTokens && (version === latestVersion || !semver.valid(latestVersion) || !semver.valid(version))) {
         throw new Error(

--- a/client/vscode/src/backend/eventLogger.ts
+++ b/client/vscode/src/backend/eventLogger.ts
@@ -1,7 +1,8 @@
 import { EMPTY, Subject } from 'rxjs'
 import { bufferTime, catchError, concatMap } from 'rxjs/operators'
 
-import { gql } from '@sourcegraph/http-client/src/graphql/graphql'
+import { gql } from '@sourcegraph/http-client'
+// eslint-disable-next-line no-restricted-imports
 import { LogEventsResult, LogEventsVariables, Event } from '@sourcegraph/web/src/graphql-operations'
 
 import { requestGraphQLFromVSCode } from './requestGraphQl'

--- a/client/vscode/src/backend/requestGraphQl.ts
+++ b/client/vscode/src/backend/requestGraphQl.ts
@@ -1,5 +1,6 @@
 import { asError } from '@sourcegraph/common'
 import { checkOk, GraphQLResult, GRAPHQL_URI, isHTTPAuthError } from '@sourcegraph/http-client'
+
 import { accessTokenSetting, handleAccessTokenError } from '../settings/accessTokenSetting'
 import { endpointSetting, endpointRequestHeadersSetting } from '../settings/endpointSetting'
 

--- a/client/vscode/src/contract.ts
+++ b/client/vscode/src/contract.ts
@@ -6,6 +6,7 @@ import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { EventSource } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchMatch, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+// eslint-disable-next-line no-restricted-imports
 import { Event } from '@sourcegraph/web/src/graphql-operations'
 
 import { VSCEQueryState, VSCEState, VSCEStateMachine } from './state'
@@ -55,7 +56,7 @@ export interface ExtensionCoreAPI {
     /** Local Storage Item */
     getLocalStorageItem: (key: string) => string
     setLocalStorageItem: (key: string, value: string) => Promise<boolean>
-    /**  For Telemetry Service / logging */
+    /** For Telemetry Service / logging */
     logEvents: (variables: Event) => void
     /** Get EventSource Type to use based on instance version */
     getEventSource: EventSource

--- a/client/vscode/src/file-system/initialize.ts
+++ b/client/vscode/src/file-system/initialize.ts
@@ -32,7 +32,6 @@ export function initializeSourcegraphFileSystem({
             if (typeof uri === 'string') {
                 await openSourcegraphUriCommand(fs, SourcegraphUri.parse(uri))
             } else {
-                 
                 log.error(`extension.openRemoteFile(${uri}) argument is not a string`)
             }
         })

--- a/client/vscode/src/file-system/initialize.ts
+++ b/client/vscode/src/file-system/initialize.ts
@@ -32,7 +32,7 @@ export function initializeSourcegraphFileSystem({
             if (typeof uri === 'string') {
                 await openSourcegraphUriCommand(fs, SourcegraphUri.parse(uri))
             } else {
-                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+                 
                 log.error(`extension.openRemoteFile(${uri}) argument is not a string`)
             }
         })

--- a/client/vscode/src/log.ts
+++ b/client/vscode/src/log.ts
@@ -3,7 +3,7 @@ import vscode from 'vscode'
 const outputChannel = vscode.window.createOutputChannel('Sourcegraph')
 
 export const log = {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     error: (what: string, error?: any): void => {
         outputChannel.appendLine(`ERROR ${errorMessage(what, error)}`)
     },

--- a/client/vscode/src/webview/initialize.ts
+++ b/client/vscode/src/webview/initialize.ts
@@ -24,16 +24,16 @@ export async function initializeSearchPanelWebview({
     webviewPanel: vscode.WebviewPanel
 }> {
     const webviewPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webview')
-    const extensionsDistPath = vscode.Uri.joinPath(extensionUri, 'dist', 'extensions')
+    const extensionsDistributionPath = vscode.Uri.joinPath(extensionUri, 'dist', 'extensions')
 
     const panel = vscode.window.createWebviewPanel('sourcegraphSearch', 'Sourcegraph', vscode.ViewColumn.One, {
         enableScripts: true,
         retainContextWhenHidden: true,
         enableFindWidget: true,
-        localResourceRoots: [webviewPath, extensionsDistPath],
+        localResourceRoots: [webviewPath, extensionsDistributionPath],
     })
 
-    const extensionsDistWebviewPath = panel.webview.asWebviewUri(extensionsDistPath)
+    const extensionsDistributionWebviewPath = panel.webview.asWebviewUri(extensionsDistributionPath)
     const scriptSource = panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewPath, 'searchPanel.js'))
     const cssModuleSource = panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewPath, 'searchPanel.css'))
     const styleSource = panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewPath, 'style.css'))
@@ -63,7 +63,7 @@ export async function initializeSearchPanelWebview({
     // panel.webview.cspSource comes from the webview object
     // debt: load codicon ourselves.
     panel.webview.html = `<!DOCTYPE html>
-    <html lang="en" data-panel-id="${panelId}" data-extensions-dist-path=${extensionsDistWebviewPath.toString()}>
+    <html lang="en" data-panel-id="${panelId}" data-extensions-dist-path=${extensionsDistributionWebviewPath.toString()}>
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -109,12 +109,12 @@ export function initializeSearchSidebarWebview({
     searchSidebarAPI: Comlink.Remote<SearchSidebarAPI>
 } {
     const webviewPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webview')
-    const extensionsDistPath = vscode.Uri.joinPath(extensionUri, 'dist', 'extensions')
-    const extensionsDistWebviewPath = webviewView.webview.asWebviewUri(extensionsDistPath)
+    const extensionsDistributionPath = vscode.Uri.joinPath(extensionUri, 'dist', 'extensions')
+    const extensionsDistributionWebviewPath = webviewView.webview.asWebviewUri(extensionsDistributionPath)
 
     webviewView.webview.options = {
         enableScripts: true,
-        localResourceRoots: [webviewPath, extensionsDistPath],
+        localResourceRoots: [webviewPath, extensionsDistributionPath],
     }
 
     const scriptSource = webviewView.webview.asWebviewUri(vscode.Uri.joinPath(webviewPath, 'searchSidebar.js'))
@@ -133,7 +133,7 @@ export function initializeSearchSidebarWebview({
     // Apply Content-Security-Policy
     // debt: load codicon ourselves.
     webviewView.webview.html = `<!DOCTYPE html>
-    <html lang="en" data-panel-id="${panelId}" data-instance-url=${endpointSetting()} data-extensions-dist-path=${extensionsDistWebviewPath.toString()}>
+    <html lang="en" data-panel-id="${panelId}" data-instance-url=${endpointSetting()} data-extensions-dist-path=${extensionsDistributionWebviewPath.toString()}>
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/client/vscode/src/webview/search-panel/components/HomeFooter.tsx
+++ b/client/vscode/src/webview/search-panel/components/HomeFooter.tsx
@@ -6,7 +6,7 @@ import { QueryState } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Card } from '@sourcegraph/wildcard'
+import { Card, Text } from '@sourcegraph/wildcard'
 
 import { ModalVideo } from '../alias/ModalVideo'
 
@@ -63,7 +63,7 @@ const SearchExamples: React.FunctionComponent<React.PropsWithChildren<SearchExam
                                 </div>
                             </div>
                         </Card>
-                        <p className={styles.searchExampleLabel}>{example.label}</p>
+                        <Text className={styles.searchExampleLabel}>{example.label}</Text>
                     </div>
                 ))}
             </div>

--- a/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
+++ b/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
@@ -204,7 +204,6 @@ const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<SavedSear
                     {props.defaultValues?.notify && (
                         <div>
                             {/* Label is for visual benefit, input has more specific label attached */}
-                            { }
                             <Label className={styles.label} id="saved-search-form-email-notifications">
                                 Email notifications
                             </Label>

--- a/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
+++ b/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
@@ -204,7 +204,7 @@ const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<SavedSear
                     {props.defaultValues?.notify && (
                         <div>
                             {/* Label is for visual benefit, input has more specific label attached */}
-                            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                            { }
                             <Label className={styles.label} id="saved-search-form-email-notifications">
                                 Email notifications
                             </Label>

--- a/cmd/frontend/graphqlbackend/search_contexts.graphql
+++ b/cmd/frontend/graphqlbackend/search_contexts.graphql
@@ -192,7 +192,7 @@ input SearchContextInput {
     Search context name. Not the same as the search context spec. Search context namespace and search context name
     are used to construct the fully-qualified search context spec.
     Example mappings from search context spec to search context name: global -> global, @user -> user, @org -> org,
-    @user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx.
+    "@user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx."
     """
     name: String!
     """
@@ -226,7 +226,7 @@ input SearchContextEditInput {
     Search context name. Not the same as the search context spec. Search context namespace and search context name
     are used to construct the fully-qualified search context spec.
     Example mappings from search context spec to search context name: global -> global, @user -> user, @org -> org,
-    @user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx.
+    "@user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx."
     """
     name: String!
     """

--- a/cmd/frontend/graphqlbackend/search_contexts.graphql
+++ b/cmd/frontend/graphqlbackend/search_contexts.graphql
@@ -192,7 +192,7 @@ input SearchContextInput {
     Search context name. Not the same as the search context spec. Search context namespace and search context name
     are used to construct the fully-qualified search context spec.
     Example mappings from search context spec to search context name: global -> global, @user -> user, @org -> org,
-    "@user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx."
+    @user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx.
     """
     name: String!
     """
@@ -226,7 +226,7 @@ input SearchContextEditInput {
     Search context name. Not the same as the search context spec. Search context namespace and search context name
     are used to construct the fully-qualified search context spec.
     Example mappings from search context spec to search context name: global -> global, @user -> user, @org -> org,
-    "@user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx."
+    @user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx.
     """
     name: String!
     """

--- a/dev/foreach-ts-project.sh
+++ b/dev/foreach-ts-project.sh
@@ -10,28 +10,31 @@ parallel_run() {
 
 export ARGS=$*
 
+# Keep the list of client workspaces in alphabetical order!
 DIRS=(
-  client/web
-  client/shared
   client/branded
   client/browser
   client/build-config
-  client/common
-  client/search
-  client/search-ui
-  client/http-client
+  client/client-api
   client/codeintellify
-  client/wildcard
-  client/template-parser
+  client/common
   client/extension-api
   client/extension-api-types
-  client/storybook
-  client/client-api
+  client/http-client
   client/jetbrains
   client/observability-client
   client/observability-server
+  client/search
+  client/search-ui
+  client/shared
+  client/storybook
+  client/template-parser
+  client/vscode
+  client/web
+  client/wildcard
   dev/release
 )
+# Keep the list of client workspaces in alphabetical order!
 
 run_command() {
   local MAYBE_TIME_PREFIX=""

--- a/dev/sg/linters/prettier.go
+++ b/dev/sg/linters/prettier.go
@@ -12,8 +12,7 @@ import (
 )
 
 var prettier = &linter{
-	Name:    "Prettier",
-	Enabled: disabled("seems to produce unreliable results"),
+	Name: "Prettier",
 	// TODO unfortunate that we have to use 'dev/ci/yarn-run.sh'
 	Check: func(ctx context.Context, out *std.Output, args *repo.State) error {
 		return root.Run(run.Cmd(ctx, "dev/ci/yarn-run.sh format:check")).


### PR DESCRIPTION
## Context

Re-enabling the prettier CI check disabled [here](https://github.com/sourcegraph/sourcegraph/pull/40817).
The original issue was found in [the external contribution PR](https://github.com/sourcegraph/sourcegraph/pull/40584) and was discussed in [the Slack thread](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1661302782941279).

During the investigation of the prettier issue, I found out that we do not run the ESLint check for the VSCode package. This PR fixes that. Changes from this PR are tested on top of the external contribution changes in [this draft PR](https://github.com/sourcegraph/sourcegraph/pull/40837).

## Test plan

1. CI is green.
2. The prettier check is stable. 
3. The VSCode package is linted with ESLint on CI.
