### PR TITLE
test: enabled prettier check

### DIFF
--- a/client/vscode/.eslintignore
+++ b/client/vscode/.eslintignore
@@ -1,3 +1,4 @@
+src/graphql-operations.ts
 dist/
 package.json
 src/vendor/*.js

--- a/client/vscode/.eslintrc.js
+++ b/client/vscode/.eslintrc.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const baseConfig = require('../../.eslintrc.js')
+const baseConfig = require('../../.eslintrc')
 
 module.exports = {
   extends: '../../.eslintrc.js',

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -217,7 +217,7 @@
     }
   },
   "scripts": {
-    "eslint": "eslint --cache '**/*.[jt]s?(x)'",
+    "lint:js": "eslint --cache '**/*.[jt]s?(x)'",
     "test": "ts-node ./tests/runTests.ts",
     "package": "ts-node ./scripts/package.ts",
     "prebuild": "yarn build-inline-extensions",

--- a/client/vscode/scripts/publish.ts
+++ b/client/vscode/scripts/publish.ts
@@ -39,7 +39,17 @@ const commands = {
 try {
     // Get the latest release version nubmer of the last release from VS Code Marketplace using the vsce cli tool
     const response = childProcess.execSync(commands.vscode_info).toString()
-    const latestVersion: string = JSON.parse(response).versions[0].version
+    /*
+        `vscode_info` command output is extension info prepended by command name and arguments, e.g.
+        $ /Users/taras/projects/sourcegraph/node_modules/.bin/vsce show sourcegraph.sourcegraph --json
+        {
+            ...json
+        }
+        We cut everything before the json object so that we can parse it as json.
+    */
+    const trimmedResponse = response.slice(Math.max(0, response.indexOf('{')))
+    const latestVersion: string = JSON.parse(trimmedResponse).versions[0].version
+
     if (hasTokens && (version === latestVersion || !semver.valid(latestVersion) || !semver.valid(version))) {
         throw new Error(
             version === latestVersion

--- a/client/vscode/src/backend/eventLogger.ts
+++ b/client/vscode/src/backend/eventLogger.ts
@@ -1,7 +1,8 @@
 import { EMPTY, Subject } from 'rxjs'
 import { bufferTime, catchError, concatMap } from 'rxjs/operators'
 
-import { gql } from '@sourcegraph/http-client/src/graphql/graphql'
+import { gql } from '@sourcegraph/http-client'
+// eslint-disable-next-line no-restricted-imports
 import { LogEventsResult, LogEventsVariables, Event } from '@sourcegraph/web/src/graphql-operations'
 
 import { requestGraphQLFromVSCode } from './requestGraphQl'

--- a/client/vscode/src/backend/instanceVersion.ts
+++ b/client/vscode/src/backend/instanceVersion.ts
@@ -9,6 +9,25 @@ import { requestGraphQLFromVSCode } from './requestGraphQl'
 /**
  * Regular instance version format: ex 3.38.2
  * Insider version format: ex 134683_2022-03-02_5188fes0101
+ */
+export async function getInstanceVersionNumber(): Promise<string | undefined> {
+    try {
+        const siteVersionResult = await requestGraphQLFromVSCode<SiteVersionResult>(siteVersionQuery, {})
+        if (siteVersionResult.data) {
+            // assume instance version longer than 8 is using insider version
+            const flattenVersion =
+                siteVersionResult.data.site.productVersion.length > 8
+                    ? '999999'
+                    : siteVersionResult.data.site.productVersion.split('.').join('')
+            return flattenVersion
+        }
+    } catch (error) {
+        console.error('Failed to get instance version from host:', error)
+    }
+    return
+}
+
+/**
  * This function will return the EventSource Type based
  * on the instance version
  */
@@ -19,14 +38,9 @@ export function initializeInstanceVersionNumber(
 ): EventSource {
     // Check only if a user is trying to connect to a private instance with a valid access token provided
     if (instanceURL !== 'https://sourcegraph.com' && accessToken) {
-        requestGraphQLFromVSCode<SiteVersionResult>(siteVersionQuery, {})
-            .then(async siteVersionResult => {
-                if (siteVersionResult.data) {
-                    // assume instance version longer than 8 is using insider version
-                    const flattenVersion =
-                        siteVersionResult.data.site.productVersion.length > 8
-                            ? '999999'
-                            : siteVersionResult.data.site.productVersion.split('.').join('')
+        getInstanceVersionNumber()
+            .then(async flattenVersion => {
+                if (flattenVersion) {
                     if (flattenVersion < '3320') {
                         displayWarning(
                             'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
@@ -34,9 +48,6 @@ export function initializeInstanceVersionNumber(
                     }
                     await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
                 }
-            })
-            .catch(error => {
-                console.error('Failed to get instance version from host:', error)
             })
         const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
         // instances below 3.38.0 does not support EventSource.IDEEXTENSION and should fallback to BACKEND source

--- a/client/vscode/src/backend/instanceVersion.ts
+++ b/client/vscode/src/backend/instanceVersion.ts
@@ -38,17 +38,16 @@ export function initializeInstanceVersionNumber(
 ): EventSource {
     // Check only if a user is trying to connect to a private instance with a valid access token provided
     if (instanceURL !== 'https://sourcegraph.com' && accessToken) {
-        getInstanceVersionNumber()
-            .then(async flattenVersion => {
-                if (flattenVersion) {
-                    if (flattenVersion < '3320') {
-                        displayWarning(
-                            'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
-                        ).catch(() => {})
-                    }
-                    await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
+        getInstanceVersionNumber().then(async flattenVersion => {
+            if (flattenVersion) {
+                if (flattenVersion < '3320') {
+                    displayWarning(
+                        'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
+                    ).catch(() => {})
                 }
-            })
+                await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
+            }
+        })
         const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
         // instances below 3.38.0 does not support EventSource.IDEEXTENSION and should fallback to BACKEND source
         return versionNumber >= '3380' ? EventSource.IDEEXTENSION : EventSource.BACKEND

--- a/client/vscode/src/backend/requestGraphQl.ts
+++ b/client/vscode/src/backend/requestGraphQl.ts
@@ -1,5 +1,6 @@
 import { asError } from '@sourcegraph/common'
 import { checkOk, GraphQLResult, GRAPHQL_URI, isHTTPAuthError } from '@sourcegraph/http-client'
+
 import { accessTokenSetting, handleAccessTokenError } from '../settings/accessTokenSetting'
 import { endpointSetting, endpointRequestHeadersSetting } from '../settings/endpointSetting'
 

--- a/client/vscode/src/contract.ts
+++ b/client/vscode/src/contract.ts
@@ -6,6 +6,7 @@ import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { EventSource } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchMatch, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+// eslint-disable-next-line no-restricted-imports
 import { Event } from '@sourcegraph/web/src/graphql-operations'
 
 import { VSCEQueryState, VSCEState, VSCEStateMachine } from './state'
@@ -55,7 +56,7 @@ export interface ExtensionCoreAPI {
     /** Local Storage Item */
     getLocalStorageItem: (key: string) => string
     setLocalStorageItem: (key: string, value: string) => Promise<boolean>
-    /**  For Telemetry Service / logging */
+    /** For Telemetry Service / logging */
     logEvents: (variables: Event) => void
     /** Get EventSource Type to use based on instance version */
     getEventSource: EventSource

--- a/client/vscode/src/file-system/initialize.ts
+++ b/client/vscode/src/file-system/initialize.ts
@@ -32,7 +32,6 @@ export function initializeSourcegraphFileSystem({
             if (typeof uri === 'string') {
                 await openSourcegraphUriCommand(fs, SourcegraphUri.parse(uri))
             } else {
-                 
                 log.error(`extension.openRemoteFile(${uri}) argument is not a string`)
             }
         })

--- a/client/vscode/src/file-system/initialize.ts
+++ b/client/vscode/src/file-system/initialize.ts
@@ -32,7 +32,7 @@ export function initializeSourcegraphFileSystem({
             if (typeof uri === 'string') {
                 await openSourcegraphUriCommand(fs, SourcegraphUri.parse(uri))
             } else {
-                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+                 
                 log.error(`extension.openRemoteFile(${uri}) argument is not a string`)
             }
         })

--- a/client/vscode/src/log.ts
+++ b/client/vscode/src/log.ts
@@ -3,7 +3,7 @@ import vscode from 'vscode'
 const outputChannel = vscode.window.createOutputChannel('Sourcegraph')
 
 export const log = {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     error: (what: string, error?: any): void => {
         outputChannel.appendLine(`ERROR ${errorMessage(what, error)}`)
     },

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
-import { readConfiguration } from './readConfiguration'
 import { endpointHostnameSetting, endpointProtocolSetting } from './endpointSetting'
+import { readConfiguration } from './readConfiguration'
 import { getInstanceVersionNumber } from '../backend/instanceVersion'
 
 export function accessTokenSetting(): string | undefined {

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode'
 
 import { readConfiguration } from './readConfiguration'
+import { endpointHostnameSetting, endpointProtocolSetting } from './endpointSetting'
+import { getInstanceVersionNumber } from '../backend/instanceVersion'
 
 export function accessTokenSetting(): string | undefined {
     return readConfiguration().get<string>('accessToken')
@@ -19,7 +21,18 @@ export async function handleAccessTokenError(badToken?: string, endpointURL?: st
             ? `A valid access token is required to connect to ${endpointURL}`
             : `Connection to ${endpointURL} failed because the token is invalid. Please reload VS Code if your Sourcegraph instance URL has changed.`
 
-        await vscode.window.showErrorMessage(message)
+        const instanceVersion = await getInstanceVersionNumber()
+        const supportsTokenCallback = instanceVersion && instanceVersion < '3410'
+        const action = await vscode.window.showErrorMessage(message, "Get Token", "Open Settings")
+
+        if (action === "Open Settings") {
+            vscode.commands.executeCommand('workbench.action.openSettings', 'sourcegraph.accessToken')
+        } else if (action === "Get Token") {
+            const path = supportsTokenCallback ? '/user/settings/tokens/new/callback' : '/user/settings/'
+            const query = supportsTokenCallback ? 'requestFrom=VSCEAUTH' : ''
+
+            vscode.env.openExternal(vscode.Uri.from({ scheme: endpointProtocolSetting().slice(0, -1), authority: endpointHostnameSetting(), path, query }))
+        }
         showingAccessTokenErrorMessage = false
     }
 }

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -23,15 +23,22 @@ export async function handleAccessTokenError(badToken?: string, endpointURL?: st
 
         const instanceVersion = await getInstanceVersionNumber()
         const supportsTokenCallback = instanceVersion && instanceVersion < '3410'
-        const action = await vscode.window.showErrorMessage(message, "Get Token", "Open Settings")
+        const action = await vscode.window.showErrorMessage(message, 'Get Token', 'Open Settings')
 
-        if (action === "Open Settings") {
+        if (action === 'Open Settings') {
             vscode.commands.executeCommand('workbench.action.openSettings', 'sourcegraph.accessToken')
-        } else if (action === "Get Token") {
+        } else if (action === 'Get Token') {
             const path = supportsTokenCallback ? '/user/settings/tokens/new/callback' : '/user/settings/'
             const query = supportsTokenCallback ? 'requestFrom=VSCEAUTH' : ''
 
-            vscode.env.openExternal(vscode.Uri.from({ scheme: endpointProtocolSetting().slice(0, -1), authority: endpointHostnameSetting(), path, query }))
+            vscode.env.openExternal(
+                vscode.Uri.from({
+                    scheme: endpointProtocolSetting().slice(0, -1),
+                    authority: endpointHostnameSetting(),
+                    path,
+                    query,
+                })
+            )
         }
         showingAccessTokenErrorMessage = false
     }

--- a/client/vscode/src/settings/endpointSetting.ts
+++ b/client/vscode/src/settings/endpointSetting.ts
@@ -18,6 +18,10 @@ export function endpointPortSetting(): number {
     return port ? parseInt(port, 10) : 443
 }
 
+export function endpointProtocolSetting(): string {
+    return new URL(endpointSetting()).protocol
+}
+
 export function endpointAccessTokenSetting(): boolean {
     if (readConfiguration().get<string>('accessToken')) {
         return true

--- a/client/vscode/src/webview/initialize.ts
+++ b/client/vscode/src/webview/initialize.ts
@@ -24,16 +24,16 @@ export async function initializeSearchPanelWebview({
     webviewPanel: vscode.WebviewPanel
 }> {
     const webviewPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webview')
-    const extensionsDistPath = vscode.Uri.joinPath(extensionUri, 'dist', 'extensions')
+    const extensionsDistributionPath = vscode.Uri.joinPath(extensionUri, 'dist', 'extensions')
 
     const panel = vscode.window.createWebviewPanel('sourcegraphSearch', 'Sourcegraph', vscode.ViewColumn.One, {
         enableScripts: true,
         retainContextWhenHidden: true,
         enableFindWidget: true,
-        localResourceRoots: [webviewPath, extensionsDistPath],
+        localResourceRoots: [webviewPath, extensionsDistributionPath],
     })
 
-    const extensionsDistWebviewPath = panel.webview.asWebviewUri(extensionsDistPath)
+    const extensionsDistributionWebviewPath = panel.webview.asWebviewUri(extensionsDistributionPath)
     const scriptSource = panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewPath, 'searchPanel.js'))
     const cssModuleSource = panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewPath, 'searchPanel.css'))
     const styleSource = panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewPath, 'style.css'))
@@ -63,7 +63,7 @@ export async function initializeSearchPanelWebview({
     // panel.webview.cspSource comes from the webview object
     // debt: load codicon ourselves.
     panel.webview.html = `<!DOCTYPE html>
-    <html lang="en" data-panel-id="${panelId}" data-extensions-dist-path=${extensionsDistWebviewPath.toString()}>
+    <html lang="en" data-panel-id="${panelId}" data-extensions-dist-path=${extensionsDistributionWebviewPath.toString()}>
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -109,12 +109,12 @@ export function initializeSearchSidebarWebview({
     searchSidebarAPI: Comlink.Remote<SearchSidebarAPI>
 } {
     const webviewPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webview')
-    const extensionsDistPath = vscode.Uri.joinPath(extensionUri, 'dist', 'extensions')
-    const extensionsDistWebviewPath = webviewView.webview.asWebviewUri(extensionsDistPath)
+    const extensionsDistributionPath = vscode.Uri.joinPath(extensionUri, 'dist', 'extensions')
+    const extensionsDistributionWebviewPath = webviewView.webview.asWebviewUri(extensionsDistributionPath)
 
     webviewView.webview.options = {
         enableScripts: true,
-        localResourceRoots: [webviewPath, extensionsDistPath],
+        localResourceRoots: [webviewPath, extensionsDistributionPath],
     }
 
     const scriptSource = webviewView.webview.asWebviewUri(vscode.Uri.joinPath(webviewPath, 'searchSidebar.js'))
@@ -133,7 +133,7 @@ export function initializeSearchSidebarWebview({
     // Apply Content-Security-Policy
     // debt: load codicon ourselves.
     webviewView.webview.html = `<!DOCTYPE html>
-    <html lang="en" data-panel-id="${panelId}" data-instance-url=${endpointSetting()} data-extensions-dist-path=${extensionsDistWebviewPath.toString()}>
+    <html lang="en" data-panel-id="${panelId}" data-instance-url=${endpointSetting()} data-extensions-dist-path=${extensionsDistributionWebviewPath.toString()}>
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/client/vscode/src/webview/search-panel/components/HomeFooter.tsx
+++ b/client/vscode/src/webview/search-panel/components/HomeFooter.tsx
@@ -6,7 +6,7 @@ import { QueryState } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Card } from '@sourcegraph/wildcard'
+import { Card, Text } from '@sourcegraph/wildcard'
 
 import { ModalVideo } from '../alias/ModalVideo'
 
@@ -63,7 +63,7 @@ const SearchExamples: React.FunctionComponent<React.PropsWithChildren<SearchExam
                                 </div>
                             </div>
                         </Card>
-                        <p className={styles.searchExampleLabel}>{example.label}</p>
+                        <Text className={styles.searchExampleLabel}>{example.label}</Text>
                     </div>
                 ))}
             </div>

--- a/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
+++ b/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
@@ -204,7 +204,7 @@ const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<SavedSear
                     {props.defaultValues?.notify && (
                         <div>
                             {/* Label is for visual benefit, input has more specific label attached */}
-                            { }
+                            {}
                             <Label className={styles.label} id="saved-search-form-email-notifications">
                                 Email notifications
                             </Label>

--- a/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
+++ b/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
@@ -204,7 +204,7 @@ const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<SavedSear
                     {props.defaultValues?.notify && (
                         <div>
                             {/* Label is for visual benefit, input has more specific label attached */}
-                            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                            { }
                             <Label className={styles.label} id="saved-search-form-email-notifications">
                                 Email notifications
                             </Label>

--- a/cmd/frontend/graphqlbackend/search_contexts.graphql
+++ b/cmd/frontend/graphqlbackend/search_contexts.graphql
@@ -192,7 +192,7 @@ input SearchContextInput {
     Search context name. Not the same as the search context spec. Search context namespace and search context name
     are used to construct the fully-qualified search context spec.
     Example mappings from search context spec to search context name: global -> global, @user -> user, @org -> org,
-    @user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx.
+    "@user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx."
     """
     name: String!
     """
@@ -226,7 +226,7 @@ input SearchContextEditInput {
     Search context name. Not the same as the search context spec. Search context namespace and search context name
     are used to construct the fully-qualified search context spec.
     Example mappings from search context spec to search context name: global -> global, @user -> user, @org -> org,
-    @user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx.
+    "@user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx."
     """
     name: String!
     """

--- a/cmd/frontend/graphqlbackend/search_contexts.graphql
+++ b/cmd/frontend/graphqlbackend/search_contexts.graphql
@@ -192,7 +192,7 @@ input SearchContextInput {
     Search context name. Not the same as the search context spec. Search context namespace and search context name
     are used to construct the fully-qualified search context spec.
     Example mappings from search context spec to search context name: global -> global, @user -> user, @org -> org,
-    "@user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx."
+    @user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx.
     """
     name: String!
     """
@@ -226,7 +226,7 @@ input SearchContextEditInput {
     Search context name. Not the same as the search context spec. Search context namespace and search context name
     are used to construct the fully-qualified search context spec.
     Example mappings from search context spec to search context name: global -> global, @user -> user, @org -> org,
-    "@user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx."
+    @user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx.
     """
     name: String!
     """

--- a/dev/foreach-ts-project.sh
+++ b/dev/foreach-ts-project.sh
@@ -10,28 +10,31 @@ parallel_run() {
 
 export ARGS=$*
 
+# Keep the list of client workspaces in alphabetical order!
 DIRS=(
-  client/web
-  client/shared
   client/branded
   client/browser
   client/build-config
-  client/common
-  client/search
-  client/search-ui
-  client/http-client
+  client/client-api
   client/codeintellify
-  client/wildcard
-  client/template-parser
+  client/common
   client/extension-api
   client/extension-api-types
-  client/storybook
-  client/client-api
+  client/http-client
   client/jetbrains
   client/observability-client
   client/observability-server
+  client/search
+  client/search-ui
+  client/shared
+  client/storybook
+  client/template-parser
+  client/vscode
+  client/web
+  client/wildcard
   dev/release
 )
+# Keep the list of client workspaces in alphabetical order!
 
 run_command() {
   local MAYBE_TIME_PREFIX=""


### PR DESCRIPTION
## Context

Testing commit that re-enables prettier [here](https://github.com/sourcegraph/sourcegraph/pull/40836) on top of [the PR](https://github.com/sourcegraph/sourcegraph/pull/40584) where we found the original `prettier` issue.

## Test plan

1. CI is green.
2. The ESLint check fails with errors caused by the external contribution commit. 
3. The prettier check is green.

## App preview:

- [Web](https://sg-web-vb-get-token.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

