### PR TITLE
status messages: tiny refactor & show numbers in messages

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -318,21 +318,19 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
 
     private renderMessage(noActivityOrStatus: Message, isSiteAdmin: boolean): JSX.Element | JSX.Element[] {
         const userSettings = `/users/${this.props.user.username}/settings`
-        const makeGetCodeHostLink = (isSiteAdmin: boolean) => (id: string): string =>
-            isSiteAdmin ? `/site-admin/external-services/${id}` : `${userSettings}/code-hosts`
 
         const roleLinks = {
             admin: {
                 viewRepositories: '/site-admin/repositories',
                 manageRepositories: '/site-admin/external-services',
                 manageCodeHosts: '/site-admin/external-services',
-                getCodeHostLink: makeGetCodeHostLink(true),
+                getCodeHostLink: (id: string) => `/site-admin/external-services/${id}`,
             },
             nonAdmin: {
                 viewRepositories: `${userSettings}/repositories`,
                 manageRepositories: `${userSettings}/repositories/manage`,
                 manageCodeHosts: `${userSettings}/code-hosts`,
-                getCodeHostLink: makeGetCodeHostLink(false),
+                getCodeHostLink: () => `${userSettings}/code-hosts`,
             },
         }
 
@@ -349,7 +347,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                     key="up-to-date"
                     message="Repositories available for search"
                     linkTo={links.viewRepositories}
-                    linkText="Manage repositories"
+                    linkText="View repositories"
                     linkOnClick={this.toggleIsOpen}
                     entryType="success"
                 />

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -30,6 +30,10 @@ func FetchStatusMessages(ctx context.Context, db database.DB, u *types.User) ([]
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching sync errors")
 	}
+	// Return early since we don't have any affiliated external services
+	if len(externalServiceSyncErrors) == 0 {
+		return messages, nil
+	}
 
 	extsvcIDs := make([]int64, 0, len(externalServiceSyncErrors))
 
@@ -46,47 +50,72 @@ func FetchStatusMessages(ctx context.Context, db database.DB, u *types.User) ([]
 		}
 	}
 
-	// Return early since the user doesn't have any affiliated external services
-	if len(extsvcIDs) == 0 {
+	// If the user is not a site-admin we can't rely on the stats table for
+	// counts and need to query the repo/gitserver_repos tables. But since the
+	// COUNTs aren't cheap, we filter down and use limit=1 to check whether >=1
+	// repos with the given parameters exist.
+	if !u.SiteAdmin {
+		opts := database.ReposListOptions{
+			NoCloned:           true,
+			ExternalServiceIDs: extsvcIDs,
+			LimitOffset: &database.LimitOffset{
+				Limit: 1,
+			},
+		}
+		notCloned, err := db.Repos().ListMinimalRepos(ctx, opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "listing not-cloned repos")
+		}
+		if len(notCloned) > 0 {
+			messages = append(messages, StatusMessage{
+				Cloning: &CloningProgress{
+					Message: "Some repositories cloning...",
+				},
+			})
+		}
+
+		// Look for any repository that we could not sync
+		opts = database.ReposListOptions{
+			FailedFetch:        true,
+			ExternalServiceIDs: extsvcIDs,
+			LimitOffset: &database.LimitOffset{
+				Limit: 1,
+			},
+		}
+		failedSync, err := db.Repos().ListMinimalRepos(ctx, opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "counting repo sync failures")
+		}
+		if len(failedSync) > 0 {
+			messages = append(messages, StatusMessage{
+				SyncError: &SyncError{
+					Message: "Some repositories could not be synced",
+				},
+			})
+		}
 		return messages, nil
 	}
 
-	// Look for any repository that is not yet been cloned
-	opts := database.ReposListOptions{
-		NoCloned:           true,
-		ExternalServiceIDs: extsvcIDs,
-		LimitOffset: &database.LimitOffset{
-			Limit: 1,
-		},
-	}
-	notCloned, err := db.Repos().ListMinimalRepos(ctx, opts)
+	// If the user is a site-admin we assume they can see all repositories
+	// (since authz was only enforced for admins in the old sourcegraph-dot-com
+	// Cloud v1 model).
+	stats, err := db.RepoStatistics().GetRepoStatistics(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "listing not-cloned repos")
+		return nil, errors.Wrap(err, "loading repo statistics")
 	}
-	if len(notCloned) > 0 {
+
+	if uncloned := stats.NotCloned + stats.Cloning; uncloned > 0 {
 		messages = append(messages, StatusMessage{
 			Cloning: &CloningProgress{
-				Message: fmt.Sprintf("%d %s cloning...", len(notCloned), pluralize(len(notCloned), "repository", "repositories")),
+				Message: fmt.Sprintf("%d %s cloning...", uncloned, pluralize(uncloned, "repository", "repositories")),
 			},
 		})
 	}
 
-	// Look for any repository that we could not sync
-	opts = database.ReposListOptions{
-		FailedFetch:        true,
-		ExternalServiceIDs: extsvcIDs,
-		LimitOffset: &database.LimitOffset{
-			Limit: 1,
-		},
-	}
-	failedSync, err := db.Repos().ListMinimalRepos(ctx, opts)
-	if err != nil {
-		return nil, errors.Wrap(err, "counting repo sync failures")
-	}
-	if len(failedSync) > 0 {
+	if stats.FailedFetch > 0 {
 		messages = append(messages, StatusMessage{
 			SyncError: &SyncError{
-				Message: fmt.Sprintf("%d %s could not be synced", len(failedSync), pluralize(len(failedSync), "repository", "repositories")),
+				Message: fmt.Sprintf("%d %s could not be synced", stats.FailedFetch, pluralize(stats.FailedFetch, "repository", "repositories")),
 			},
 		})
 	}

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -3,6 +3,7 @@ package repos
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -105,9 +106,16 @@ func FetchStatusMessages(ctx context.Context, db database.DB, u *types.User) ([]
 	}
 
 	if uncloned := stats.NotCloned + stats.Cloning; uncloned > 0 {
+		var sentences []string
+		if stats.NotCloned > 0 {
+			sentences = append(sentences, fmt.Sprintf("%d %s enqueued for cloning.", stats.NotCloned, pluralize(stats.NotCloned, "repository", "repositories")))
+		}
+		if stats.Cloning > 0 {
+			sentences = append(sentences, fmt.Sprintf("%d %s currently cloning...", stats.Cloning, pluralize(stats.Cloning, "repository", "repositories")))
+		}
 		messages = append(messages, StatusMessage{
 			Cloning: &CloningProgress{
-				Message: fmt.Sprintf("%d %s cloning...", uncloned, pluralize(uncloned, "repository", "repositories")),
+				Message: strings.Join(sentences, " "),
 			},
 		})
 	}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -116,7 +116,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
-						Message: "1 repository cloning...",
+						Message: "1 repository currently cloning...",
 					},
 				},
 			},
@@ -139,6 +139,37 @@ func TestStatusMessages(t *testing.T) {
 			},
 		},
 		{
+			name: "site-admin: multiple not cloned, multiple cloning, multiple cloned",
+			repos: []*types.Repo{
+				{Name: "repo-1"},
+				{Name: "repo-2"},
+				{Name: "repo-3"},
+				{Name: "repo-4"},
+				{Name: "repo-5"},
+				{Name: "repo-6"},
+			},
+			user: admin,
+			cloneStatus: map[string]types.CloneStatus{
+				"repo-1": types.CloneStatusCloning,
+				"repo-2": types.CloneStatusCloning,
+				"repo-3": types.CloneStatusNotCloned,
+				"repo-4": types.CloneStatusNotCloned,
+				"repo-5": types.CloneStatusCloned,
+				"repo-6": types.CloneStatusCloned,
+			},
+			repoOwner: map[api.RepoName]*types.ExternalService{
+				"foobar": siteLevelService,
+				"barfoo": siteLevelService,
+			},
+			res: []StatusMessage{
+				{
+					Cloning: &CloningProgress{
+						Message: "2 repositories enqueued for cloning. 2 repositories currently cloning...",
+					},
+				},
+			},
+		},
+		{
 			name:        "site-admin: subset cloned",
 			repos:       []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
 			user:        admin,
@@ -150,7 +181,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
-						Message: "1 repository cloning...",
+						Message: "1 repository enqueued for cloning.",
 					},
 				},
 			},
@@ -197,7 +228,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
-						Message: "2 repositories cloning...",
+						Message: "2 repositories enqueued for cloning.",
 					},
 				},
 			},


### PR DESCRIPTION
This does some tiny, tiny refactors that I came across while trying to find out whether we can't add concrete counts to the messages instead of saying "Some".

It also changes two messages to have a concrete count in them.

## Screenshot

<img width="1334" alt="screenshot_2022-08-26_14 31 56@2x" src="https://user-images.githubusercontent.com/1185253/186903983-ec5c9a73-068b-49cf-a82e-961259f89f6e.png">

## Test plan

- Existing tests
