### PR TITLE
build-tracker: better handling of teammate data and empty slackIds

### DIFF
--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -143,7 +143,7 @@ func commitLink(msg, commit string) string {
 
 func slackMention(teammate *team.Teammate) string {
 	if teammate.SlackID == "" {
-		return fmt.Sprintf("%s (%s) - We could not locate your Slack ID. Please check that your information in team.yml of the Handbook is correct", teammate.Name, teammate.Email)
+		return fmt.Sprintf("%s (%s) - We could not locate your Slack ID. Please check that your information in the Handbook team.yml file is correct", teammate.Name, teammate.Email)
 	}
 	return fmt.Sprintf("<@%s>", teammate.SlackID)
 }

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -51,7 +51,7 @@ func (c *NotificationClient) sendFailedBuild(build *Build) error {
 	logger := c.logger.With(log.Int("buildNumber", build.number()), log.String("channel", c.channel))
 	logger.Debug("creating slack json")
 
-	blocks, err := c.createMessageBlocks(build)
+	blocks, err := c.createMessageBlocks(logger, build)
 	if err != nil {
 		return err
 	}
@@ -142,10 +142,13 @@ func commitLink(msg, commit string) string {
 }
 
 func slackMention(teammate *team.Teammate) string {
+	if teammate.SlackID == "" {
+		return fmt.Sprintf("%s (%s) - We could not locate your Slack ID. Please check that your information in team.yml of the Handbook is correct", teammate.Name, teammate.Email)
+	}
 	return fmt.Sprintf("<@%s>", teammate.SlackID)
 }
 
-func (c *NotificationClient) createMessageBlocks(build *Build) ([]slack.Block, error) {
+func (c *NotificationClient) createMessageBlocks(logger log.Logger, build *Build) ([]slack.Block, error) {
 	msg, _, _ := strings.Cut(build.message(), "\n")
 	msg += fmt.Sprintf(" (%s)", build.commit()[:7])
 	failedSection := fmt.Sprintf("> %s\n\n", commitLink(msg, build.commit()))
@@ -160,7 +163,7 @@ func (c *NotificationClient) createMessageBlocks(build *Build) ([]slack.Block, e
 		}
 	}
 
-	c.logger.Debug("getting teammate information using commit", log.String("commit", build.commit()))
+	logger.Debug("getting teammate information using commit", log.String("commit", build.commit()))
 	teammate, err := c.getTeammateForBuild(build)
 	var author string
 	if err != nil {
@@ -169,6 +172,14 @@ func (c *NotificationClient) createMessageBlocks(build *Build) ([]slack.Block, e
 		// so we set author here to that msg, so that the message can be conveyed to the person in slack
 		author = err.Error()
 	} else {
+		logger.Debug("teammate found", log.Object("teammate",
+			log.String("slackID", teammate.SlackID),
+			log.String("key", teammate.Key),
+			log.String("email", teammate.Email),
+			log.String("handbook", teammate.HandbookLink),
+			log.String("slackName", teammate.SlackName),
+			log.String("github", teammate.GitHub),
+		))
 		author = slackMention(teammate)
 	}
 

--- a/dev/build-tracker/slack_test.go
+++ b/dev/build-tracker/slack_test.go
@@ -55,6 +55,7 @@ func TestGetTeammateFromBuild(t *testing.T) {
 
 		teammate, err := client.getTeammateForBuild(build)
 		require.NoError(t, err)
+		require.NotEqual(t, teammate.SlackID, "")
 		require.Equal(t, teammate.Name, "Ryan Slade")
 	})
 	t.Run("commit author preferred over build author", func(t *testing.T) {

--- a/dev/build-tracker/slack_test.go
+++ b/dev/build-tracker/slack_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/hexops/autogold"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/dev/team"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,6 +19,28 @@ func newJob(name string, exit int) *Job {
 		Name:       &name,
 		ExitStatus: &exit,
 	}}
+}
+
+func TestSlackMention(t *testing.T) {
+	t.Run("If SlackID is empty, ask people to update their team.yml", func(t *testing.T) {
+		result := slackMention(&team.Teammate{
+			SlackID: "",
+			Name:    "Bob Burgers",
+			Email:   "bob@burgers.com",
+			GitHub:  "bobbyb",
+		})
+
+		require.Equal(t, "Bob Burgers (bob@burgers.com) - We could not locate your Slack ID. Please check that your information in team.yml of the Handbook is correct", result)
+	})
+	t.Run("Use SlackID if it exists", func(t *testing.T) {
+		result := slackMention(&team.Teammate{
+			SlackID: "USE_ME",
+			Name:    "Bob Burgers",
+			Email:   "bob@burgers.com",
+			GitHub:  "bobbyb",
+		})
+		require.Equal(t, "<@USE_ME>", result)
+	})
 }
 
 func TestGetTeammateFromBuild(t *testing.T) {
@@ -36,7 +59,7 @@ func TestGetTeammateFromBuild(t *testing.T) {
 		client := NewNotificationClient(logger, config.SlackToken, config.GithubToken, DefaultChannel)
 
 		num := 160000
-		commit := "78926a5b3b836a8a104a5d5adf891e5626b1e405"
+		commit := "ca7c44f79984ff8d645b580bfaaf08ce9a37a05d"
 		pipelineID := "sourcegraph"
 		build := &Build{
 			Build: buildkite.Build{
@@ -56,7 +79,7 @@ func TestGetTeammateFromBuild(t *testing.T) {
 		teammate, err := client.getTeammateForBuild(build)
 		require.NoError(t, err)
 		require.NotEqual(t, teammate.SlackID, "")
-		require.Equal(t, teammate.Name, "Ryan Slade")
+		require.Equal(t, teammate.Name, "Leo Papaloizos")
 	})
 	t.Run("commit author preferred over build author", func(t *testing.T) {
 		client := NewNotificationClient(logger, config.SlackToken, config.GithubToken, DefaultChannel)

--- a/dev/build-tracker/slack_test.go
+++ b/dev/build-tracker/slack_test.go
@@ -30,7 +30,7 @@ func TestSlackMention(t *testing.T) {
 			GitHub:  "bobbyb",
 		})
 
-		require.Equal(t, "Bob Burgers (bob@burgers.com) - We could not locate your Slack ID. Please check that your information in team.yml of the Handbook is correct", result)
+		require.Equal(t, "Bob Burgers (bob@burgers.com) - We could not locate your Slack ID. Please check that your information in the Handbook team.yml file is correct", result)
 	})
 	t.Run("Use SlackID if it exists", func(t *testing.T) {
 		result := slackMention(&team.Teammate{


### PR DESCRIPTION
Add additional logging to print teammate data when we fetch it using their GitHub handle. Also print a nice message to tell people to fix their data in `team.yml` of the Handbook.

## Test plan
Unit Tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
