### PR TITLE
Reference panel: display unhighlighted code in preview on timeout

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -689,16 +689,9 @@ const SideBlob: React.FunctionComponent<
         return <>Nothing found</>
     }
 
-    const { html, aborted, lsif } = data?.repository?.commit?.blob?.highlight
-    if (aborted) {
-        return (
-            <Text alignment="center" className="text-warning">
-                <i>
-                    Highlighting <Code>{props.activeLocation.file}</Code> failed
-                </i>
-            </Text>
-        )
-    }
+    const { html, lsif } = data?.repository?.commit?.blob?.highlight
+
+    // TODO: display a helpful message if syntax highlighting aborted, see https://github.com/sourcegraph/sourcegraph/issues/40841
 
     return (
         <BlobComponent


### PR DESCRIPTION
Previously, the preview panel didn't show the actual code if syntax
highlighting timed out. Now, the preview pane shows unhighlighted code
instead.

Fixes #40835


## Test plan

Run `sg start` without the syntax-highlighter service to simulate a timeout for all files, and validate that the reference panel shows unhighlighted code

![CleanShot 2022-08-25 at 13 34 25](https://user-images.githubusercontent.com/1408093/186654463-63409dfd-92e5-4c28-a3be-2d1857ca57d6.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-ref.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zqjakbztzp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
