### PR TITLE
Modify Release calendar events to reflect Cloud upgrade SLA

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -20,6 +20,7 @@
     "threeWorkingDaysBeforeRelease": "17 August 2022 10:00 PST",
     "releaseDate": "22 August 2022 10:00 PST",
     "oneWorkingDayAfterRelease": "23 August 2022 10:00 PST",
+    "oneWorkingWeekAfterRelease": "29 August 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "eng-announce",
     // Email for preparing calendar events

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -21,6 +21,7 @@ export interface Config {
     threeWorkingDaysBeforeRelease: string
     releaseDate: string
     oneWorkingDayAfterRelease: string
+    oneWorkingWeekAfterRelease: string
 
     slackAnnounceChannel: string
 

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -149,12 +149,20 @@ const steps: Step[] = [
                     ...calendarTime(config.releaseDate),
                 },
                 {
-                    title: `Deploy Sourcegraph ${name} to managed instances`,
+                    title: `Start deploying Sourcegraph ${name} to Cloud instances`,
                     description: '(This is not an actual event to attend, just a calendar marker.)',
                     anyoneCanAddSelf: true,
                     attendees: [config.teamEmail],
                     transparency: 'transparent',
                     ...calendarTime(config.oneWorkingDayAfterRelease),
+                },
+                {
+                    title: `All Cloud instances upgraded to Sourcegraph ${name}`,
+                    description: '(This is not an actual event to attend, just a calendar marker.)',
+                    anyoneCanAddSelf: true,
+                    attendees: [config.teamEmail],
+                    transparency: 'transparent',
+                    ...calendarTime(config.oneWorkingWeekAfterRelease),
                 },
             ]
 


### PR DESCRIPTION
[Cloud upgrade SLA](https://handbook.sourcegraph.com/departments/cloud/#slas-for-managed-instances) is 1 week from release - updating generated Calendar events to reflect this.
## Test plan

- [x] `yarn run release _test:config`
