### PR TITLE
git-combine: add cli arg to tune how often git gc --aggressive runs

### DIFF
--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -4,12 +4,18 @@ WORKDIR /go/src/app
 
 ENV CGO_ENABLE=0
 
-# We only have one dependency. When building we just use the latest version of
-# it rather than maintaining our own go.mod just in this directory.
+# We only have two dependencies. When building we just use the latest version of
+# them rather than maintaining our own go.mod just in this directory.
 RUN go mod init github.com/sourcegraph/sourcegraph/internal/cmd/git-combine \
-    && go get github.com/go-git/go-git/v5
+    && go get github.com/go-git/go-git/v5 \
+    && go get github.com/sourcegraph/sourcegraph/lib/errors
+
 
 COPY git-combine.go .
+
+RUN go mod download \
+    && go mod tidy
+
 RUN go build .
 
 # Does not need to use sourcegraph-alpine since this is only deployed for


### PR DESCRIPTION
This pr makes git-combine periodically run `git gc --aggressive` for maintenance purposes against the repository it's maintaining. The frequency of `git gc --aggressive` is controlled by a new `gc-ratio` command line argument, which defaults to running it roughly once every 3 days. 

On dogfood, gitserver was unable to clone the gigarepo until `git gc --aggressive` was manually run. As a result of repository size went from ~75 gigabytes to ~25 gigabytes.


## Test plan

This change is for a utility command, and doesn't affect the main sourcegraph application. 
