### PR TITLE
insights: Fix panic in aggregation results progress

### DIFF
--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -106,7 +106,8 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	requestContext, cancelReqContext := context.WithTimeout(ctx, time.Second*searchTimeLimitSeconds)
 	defer cancelReqContext()
 	searchClient := streaming.NewInsightsSearchClient(r.baseInsightResolver.postgresDB)
-	searchResultsAggregator := aggregation.NewSearchResultsAggregator(tabulationFunc, countingFunc)
+	searchResultsAggregator := aggregation.NewSearchResultsAggregatorWithProgress(ctx, tabulationFunc, countingFunc, r.baseInsightResolver.postgresDB)
+
 	alert, err := searchClient.Search(requestContext, string(modifiedQuery), &r.patternType, searchResultsAggregator)
 	if err != nil || requestContext.Err() != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(requestContext.Err(), context.DeadlineExceeded) {

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -16,7 +16,6 @@ type RepoNamer func(ids []api.RepoID) (names []api.RepoName)
 // BuildProgressEvent builds a progress event from a final results resolver.
 func BuildProgressEvent(stats ProgressStats, namer RepoNamer) Progress {
 	stats.namer = namer
-	//stats.Timedout = []api.RepoID{1, 2}
 
 	skipped := []Skipped{}
 

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -16,7 +16,7 @@ type RepoNamer func(ids []api.RepoID) (names []api.RepoName)
 // BuildProgressEvent builds a progress event from a final results resolver.
 func BuildProgressEvent(stats ProgressStats, namer RepoNamer) Progress {
 	stats.namer = namer
-	stats.Timedout = []api.RepoID{1, 2}
+	//stats.Timedout = []api.RepoID{1, 2}
 
 	skipped := []Skipped{}
 

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -16,6 +16,7 @@ type RepoNamer func(ids []api.RepoID) (names []api.RepoName)
 // BuildProgressEvent builds a progress event from a final results resolver.
 func BuildProgressEvent(stats ProgressStats, namer RepoNamer) Progress {
 	stats.namer = namer
+	stats.Timedout = []api.RepoID{1, 2}
 
 	skipped := []Skipped{}
 


### PR DESCRIPTION
## Description

We weren't initializing the `progress` field in the `searchAggregationResults`. This fixes that. (Credit to @leonore !)

## Test plan

This panic was initially discovered on `k8s`, and can be repro'd locally by adding in a line to `/internal/search/streaming/api/progress.go` at line `19`:
```
stats.Timedout = []api.RepoID{1, 2}
```
Once the repro is verified, this fix can be applied to verify that it fixes the panic.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
