### PR TITLE
codeintel: dont emit error metric when inference limit hit

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -49,6 +50,14 @@ type invocationFunctionTable struct {
 	linearize    func(recognizer *luatypes.Recognizer) []*luatypes.Recognizer
 	callback     func(recognizer *luatypes.Recognizer) *baselua.LFunction
 	scanLuaValue func(value baselua.LValue) ([]indexJobOrHint, error)
+}
+
+type LimitError struct {
+	description string
+}
+
+func (e LimitError) Error() string {
+	return e.description
 }
 
 func newService(
@@ -378,10 +387,22 @@ func (s *Service) resolveFileContents(
 		}
 
 		if len(contentsByPath) >= s.maximumFilesWithContentCount {
-			return nil, errors.Newf("inference limit: requested content for more than %d files", s.maximumFilesWithContentCount)
+			return nil, LimitError{
+				description: fmt.Sprintf(
+					"inference limit: requested content for more than %d (%d) files",
+					s.maximumFilesWithContentCount,
+					len(contentsByPath),
+				),
+			}
 		}
 		if int(header.Size) > s.maximumFileWithContentSizeBytes {
-			return nil, errors.Newf("inference limit: requested content for a file larger than %d bytes", s.maximumFileWithContentSizeBytes)
+			return nil, LimitError{
+				description: fmt.Sprintf(
+					"inference limit: requested content for a file larger than %d (%d) bytes",
+					s.maximumFileWithContentSizeBytes,
+					int(header.Size),
+				),
+			}
 		}
 
 		var buf bytes.Buffer

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -48,8 +48,12 @@ const (
 	EmitForTraces
 	EmitForHoney
 
-	EmitForDefault = EmitForMetrics | EmitForLogs | EmitForTraces
+	EmitForDefault = EmitForMetrics | EmitForLogs | EmitForTraces | EmitForHoney
 )
+
+func (b ErrorFilterBehaviour) Without(e ErrorFilterBehaviour) ErrorFilterBehaviour {
+	return b ^ e
+}
 
 // Op configures an Operation instance.
 type Op struct {


### PR DESCRIPTION
Previously, we would emit an error metric if we didn't infer anything because of hitting file count or file size limits. This caused unnecessary noise in the error rate panel attributable to a reasonable reason to "soft-fail".

This PR makes us ignore limit errors for metrics, but continue emitting them for logs etc

## Test plan

Only affects monitoring output, essentially an if statement
