### PR TITLE
batches: Fix multiple tabs racing for URL query state

### DIFF
--- a/client/web/src/enterprise/batches/BatchChangeTabs.tsx
+++ b/client/web/src/enterprise/batches/BatchChangeTabs.tsx
@@ -6,7 +6,7 @@ import styles from './BatchChangeTabs.module.scss'
 
 /** sourcegraph/wildcard `Tabs` with styling applied to prevent CLS on hovering the tabs. */
 export const BatchChangeTabs: React.FunctionComponent<TabsProps> = props => (
-    <Tabs className={styles.batchChangeTabs} {...props} />
+    <Tabs className={styles.batchChangeTabs} lazy={true} {...props} />
 )
 
 /** sourcegraph/wildcard `TabsList` with BC visual styling applied. */


### PR DESCRIPTION
After switching back to wildcard tabs, it was forgotten that before those components would not render at the same time. 
https://github.com/sourcegraph/sourcegraph/pull/40110 migrated to using the wildcard components directly, but forgot to port over the lazy parameter: https://github.com/sourcegraph/sourcegraph/pull/40110/files#diff-733709eadc832fc5f74d1eb476d37c6ae449569239cc0b8653f550cac409d1d1L127

I _think_ this doesn't affect the other stuff that you wanted to address in that PR, correct @courier-new? At least I don't see why we couldn't use lazy with that new tabbing approach. 

This missing parameter causes two issues:
- Going to the bulp operations tab doesn't reload so it's unclear where the bulk operation went (noticed that while debugging)
- The Bulk operations, Executions and Changesets tabs will all three race for the `visible` (and other, likely) URL query param and keep updating it, leading to an infinite loop of updates, freezing up the page.

Closes https://github.com/sourcegraph/customer/issues/1262

## Test plan

Verified that the scenario described in https://github.com/sourcegraph/customer/issues/1262 doesn't happen anymore with this change.

## App preview:

- [Web](https://sg-web-es-no-race-batches-tabs.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wpzfeewdvc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
