### PR TITLE
Aggregation: Fix search aggregation modes availability

### DIFF
--- a/client/search-ui/src/results/aggregation/hooks.ts
+++ b/client/search-ui/src/results/aggregation/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { ApolloError, gql, useQuery } from '@apollo/client'
 import { useHistory, useLocation } from 'react-router'
@@ -69,11 +69,7 @@ const aggregationModeDeserializer = (
         case 'CAPTURE_GROUP':
             return SearchAggregationMode.CAPTURE_GROUP
 
-        // TODO Return null FE default value instead REPO when aggregation type
-        // will be provided by the backend.
-        // see https://github.com/sourcegraph/sourcegraph/issues/40425
-        default:
-            return SearchAggregationMode.REPO
+        default: return null
     }
 }
 
@@ -194,27 +190,26 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
         {
             fetchPolicy: 'cache-first',
             variables: { query, patternType, mode: aggregationMode, limit },
+            onCompleted: data => {
+                const calculatedAggregationMode = getCalculatedAggregationMode(data)
+
+                // When we load the search result page in the first time we don't have picked
+                // aggregation mode yet (unless we open the search result page with predefined
+                // aggregation mode in the page URL)
+                // In case when we don't have set aggregation mode on the FE, BE will
+                // calculate this mode based on query that we pass to the aggregation
+                // query (see AGGREGATION_SEARCH_QUERY).
+                // When this happens we should take calculated aggregation mode and set its
+                // value on the frontend (UI controls, update URL value of aggregation mode)
+
+                // Catch initial page mount when aggregation mode isn't set on the FE and BE
+                // calculated aggregation mode automatically on the backend based on given query
+                if (calculatedAggregationMode && aggregationMode === null) {
+                    setAggregationMode(calculatedAggregationMode)
+                }
+            },
         }
     )
-
-    const calculatedAggregationMode = getCalculatedAggregationMode(data)
-
-    useEffect(() => {
-        // When we load the search result page in the first time we don't have picked
-        // aggregation mode yet (unless we open the search result page with predefined
-        // aggregation mode in the page URL)
-        // In case when we don't have set aggregation mode on the FE, BE will
-        // calculate this mode based on query that we pass to the aggregation
-        // query (see AGGREGATION_SEARCH_QUERY).
-        // When this happens we should take calculated aggregation mode and set its
-        // value on the frontend (UI controls, update URL value of aggregation mode)
-
-        // Catch initial page mount when aggregation mode isn't set on the FE and BE
-        // calculated aggregation mode automatically on the backend based on given query
-        if (calculatedAggregationMode && aggregationMode === null) {
-            setAggregationMode(calculatedAggregationMode)
-        }
-    }, [setAggregationMode, calculatedAggregationMode, aggregationMode])
 
     if (loading) {
         return { data: undefined, error: undefined, loading: true }

--- a/client/search-ui/src/results/aggregation/hooks.ts
+++ b/client/search-ui/src/results/aggregation/hooks.ts
@@ -69,7 +69,8 @@ const aggregationModeDeserializer = (
         case 'CAPTURE_GROUP':
             return SearchAggregationMode.CAPTURE_GROUP
 
-        default: return null
+        default:
+            return null
     }
 }
 

--- a/client/search-ui/src/results/aggregation/hooks.ts
+++ b/client/search-ui/src/results/aggregation/hooks.ts
@@ -182,7 +182,7 @@ interface SearchAggregationDataInput {
 
 type SearchAggregationResults =
     | { data: undefined; loading: true; error: undefined }
-    | { data: undefined; loading: false; error: Error }
+    | { data: GetSearchAggregationResult | undefined; loading: false; error: Error }
     | { data: GetSearchAggregationResult; loading: false; error: undefined }
 
 export const useSearchAggregationData = (input: SearchAggregationDataInput): SearchAggregationResults => {
@@ -223,7 +223,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
     const calculatedError = getAggregationError(error, data)
 
     if (calculatedError) {
-        return { data: undefined, error: calculatedError, loading: false }
+        return { data, error: calculatedError, loading: false }
     }
 
     return {

--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -231,6 +231,10 @@ describe('Search aggregation', () => {
             )
 
             await driver.page.waitForSelector('[aria-label="Aggregation mode picker"]')
+
+            // Wait for FE sets correct aggregation mode based on BE response
+            await delay(100)
+
             await driver.page.click('[data-testid="file-aggregation-mode"]')
             await driver.page.click('[data-testid="expand-aggregation-ui"]')
 

--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -1,3 +1,4 @@
+import delay from 'delay'
 import expect from 'expect'
 import { test } from 'mocha'
 
@@ -186,7 +187,9 @@ describe('Search aggregation', () => {
 
             await driver.page.waitForSelector('[aria-label="Aggregation mode picker"]')
 
-            // 'REPO', 'PATH', 'AUTHOR', 'CAPTURE_GROUP'
+            // Wait for FE sets correct aggregation mode based on BE response
+            await delay(100)
+
             const aggregationCases = [
                 { mode: 'REPO', id: 'repo-aggregation-mode' },
                 { mode: 'PATH', id: 'file-aggregation-mode' },


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/40856

## Test plan
- Try to aggregate by file name agains query that has `type:diff`. 
- You should be able to change aggregation type even if one of aggregation has failed

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-aggregation-button.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uwaukhrvao.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
