### PR TITLE
Check for account list length when marking llinked accounts as expired

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -443,10 +443,10 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 					return nil, nil, errors.Wrapf(err, "list linked accounts for %d", acct.ID)
 				}
 
-				acctIDs := make([]int32, len(linkedAccts)+1)
-				acctIDs[0] = acct.ID
-				for i, linkedAcct := range linkedAccts {
-					acctIDs[i+1] = linkedAcct.ID
+				acctIDs := make([]int32, 0, len(linkedAccts)+1)
+				acctIDs = append(acctIDs, acct.ID)
+				for _, linkedAcct := range linkedAccts {
+					acctIDs = append(acctIDs, linkedAcct.ID)
 				}
 				if err = accounts.TouchExpired(ctx, acctIDs...); err != nil {
 					return nil, nil, errors.Wrapf(err, "set expired for external account IDs %v", acctIDs)

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -443,18 +443,15 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 					return nil, nil, errors.Wrapf(err, "list linked accounts for %d", acct.ID)
 				}
 
-				linkedAcctIDs := make([]int32, len(linkedAccts))
+				acctIDs := make([]int32, len(linkedAccts)+1)
+				acctIDs[0] = acct.ID
 				for i, linkedAcct := range linkedAccts {
-					linkedAcctIDs[i] = linkedAcct.ID
+					acctIDs[i+1] = linkedAcct.ID
 				}
-				if err = accounts.TouchExpired(ctx, linkedAcctIDs...); err != nil {
-					return nil, nil, errors.Wrapf(err, "set expired for external accounts %v", linkedAcctIDs)
+				if err = accounts.TouchExpired(ctx, acctIDs...); err != nil {
+					return nil, nil, errors.Wrapf(err, "set expired for external account IDs %v", acctIDs)
 				}
 
-				err = accounts.TouchExpired(ctx, acct.ID)
-				if err != nil {
-					return nil, nil, errors.Wrapf(err, "set expired for external account %d", acct.ID)
-				}
 				if unauthorized {
 					acctLogger.Warn("setExternalAccountExpired, token is revoked",
 						log.Bool("unauthorized", unauthorized),

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -299,6 +299,10 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 }
 
 func (s *userExternalAccountsStore) TouchExpired(ctx context.Context, ids ...int32) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
 	idStrings := make([]string, len(ids))
 	for i, id := range ids {
 		idStrings[i] = strconv.Itoa(int(id))

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -299,7 +299,6 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 }
 
 func (s *userExternalAccountsStore) TouchExpired(ctx context.Context, ids ...int32) error {
-	// If no ids are supplied, return an error, as this should be unintentional
 	if len(ids) == 0 {
 		return nil
 	}

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -299,8 +299,9 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 }
 
 func (s *userExternalAccountsStore) TouchExpired(ctx context.Context, ids ...int32) error {
+	// If no ids are supplied, return an error, as this should be unintentional
 	if len(ids) == 0 {
-		return nil
+		return errors.New("empty ids list provided")
 	}
 
 	idStrings := make([]string, len(ids))

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -301,7 +301,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 func (s *userExternalAccountsStore) TouchExpired(ctx context.Context, ids ...int32) error {
 	// If no ids are supplied, return an error, as this should be unintentional
 	if len(ids) == 0 {
-		return errors.New("empty ids list provided")
+		return nil
 	}
 
 	idStrings := make([]string, len(ids))

--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -730,6 +730,6 @@ func TestExternalAccounts_TouchExpiredList(t *testing.T) {
 
 		acctIds := []int32{}
 		err := db.UserExternalAccounts().TouchExpired(ctx, acctIds...)
-		require.NoError(t, err)
+		require.Error(t, err)
 	})
 }

--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -673,48 +673,63 @@ func TestExternalAccounts_UpdateGitHubAppInstallations(t *testing.T) {
 }
 
 func TestExternalAccounts_TouchExpiredList(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
-	ctx := context.Background()
+	t.Run("non-empty list", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip()
+		}
+		t.Parallel()
+		logger := logtest.Scoped(t)
+		db := NewDB(logger, dbtest.NewDB(logger, t))
+		ctx := context.Background()
 
-	spec := extsvc.AccountSpec{
-		ServiceType: "xa",
-		ServiceID:   "xb",
-		ClientID:    "xc",
-		AccountID:   "xd",
-	}
+		spec := extsvc.AccountSpec{
+			ServiceType: "xa",
+			ServiceID:   "xb",
+			ClientID:    "xc",
+			AccountID:   "xd",
+		}
 
-	userID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
-	spec.ServiceID = "xb2"
-	require.NoError(t, err)
-	err = db.UserExternalAccounts().Insert(ctx, userID, spec, extsvc.AccountData{})
-	require.NoError(t, err)
-	spec.ServiceID = "xb3"
-	err = db.UserExternalAccounts().Insert(ctx, userID, spec, extsvc.AccountData{})
-	require.NoError(t, err)
+		userID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
+		spec.ServiceID = "xb2"
+		require.NoError(t, err)
+		err = db.UserExternalAccounts().Insert(ctx, userID, spec, extsvc.AccountData{})
+		require.NoError(t, err)
+		spec.ServiceID = "xb3"
+		err = db.UserExternalAccounts().Insert(ctx, userID, spec, extsvc.AccountData{})
+		require.NoError(t, err)
 
-	accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1})
-	require.NoError(t, err)
-	require.Equal(t, 3, len(accts))
+		accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1})
+		require.NoError(t, err)
+		require.Equal(t, 3, len(accts))
 
-	acctIds := []int32{}
-	for _, acct := range accts {
-		acctIds = append(acctIds, acct.ID)
-	}
+		acctIds := []int32{}
+		for _, acct := range accts {
+			acctIds = append(acctIds, acct.ID)
+		}
 
-	err = db.UserExternalAccounts().TouchExpired(ctx, acctIds...)
-	require.NoError(t, err)
+		err = db.UserExternalAccounts().TouchExpired(ctx, acctIds...)
+		require.NoError(t, err)
 
-	// Confirm all accounts are expired
-	accts, err = db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1, OnlyExpired: true})
-	require.NoError(t, err)
-	require.Equal(t, 3, len(accts))
+		// Confirm all accounts are expired
+		accts, err = db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1, OnlyExpired: true})
+		require.NoError(t, err)
+		require.Equal(t, 3, len(accts))
 
-	accts, err = db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1, ExcludeExpired: true})
-	require.NoError(t, err)
-	require.Equal(t, 0, len(accts))
+		accts, err = db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1, ExcludeExpired: true})
+		require.NoError(t, err)
+		require.Equal(t, 0, len(accts))
+	})
+	t.Run("empty list", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip()
+		}
+		t.Parallel()
+		logger := logtest.Scoped(t)
+		db := NewDB(logger, dbtest.NewDB(logger, t))
+		ctx := context.Background()
+
+		acctIds := []int32{}
+		err := db.UserExternalAccounts().TouchExpired(ctx, acctIds...)
+		require.NoError(t, err)
+	})
 }

--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -673,11 +673,11 @@ func TestExternalAccounts_UpdateGitHubAppInstallations(t *testing.T) {
 }
 
 func TestExternalAccounts_TouchExpiredList(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
 	t.Run("non-empty list", func(t *testing.T) {
-		if testing.Short() {
-			t.Skip()
-		}
-		t.Parallel()
 		logger := logtest.Scoped(t)
 		db := NewDB(logger, dbtest.NewDB(logger, t))
 		ctx := context.Background()
@@ -720,16 +720,12 @@ func TestExternalAccounts_TouchExpiredList(t *testing.T) {
 		require.Equal(t, 0, len(accts))
 	})
 	t.Run("empty list", func(t *testing.T) {
-		if testing.Short() {
-			t.Skip()
-		}
-		t.Parallel()
 		logger := logtest.Scoped(t)
 		db := NewDB(logger, dbtest.NewDB(logger, t))
 		ctx := context.Background()
 
 		acctIds := []int32{}
 		err := db.UserExternalAccounts().TouchExpired(ctx, acctIds...)
-		require.Error(t, err)
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Resolves an issue where accounts cannot be marked as expired because the supplied Account ID list has no entries.

## Test plan

Added unit test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
