### PR TITLE
search: structural search always streams by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - The recommended [src-cli](https://github.com/sourcegraph/src-cli) version is now reported consistently. [#39468](https://github.com/sourcegraph/sourcegraph/issues/39468)
+- A performance issue affecting structural search causing results to not stream. It is much faster now. [#40872](https://github.com/sourcegraph/sourcegraph/pull/40872)
 
 ### Removed
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -371,6 +371,7 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 				UseIndex:         f.Index(),
 				ContainsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
 				RepoOpts:         repoOptions,
+				BatchRetry:       searchInputs.Protocol == search.Batch,
 			})
 		}
 
@@ -472,10 +473,6 @@ func computeFileMatchLimit(b query.Basic, p search.Protocol) int {
 		return *count
 	}
 
-	if b.IsStructural() {
-		return limits.DefaultMaxSearchResults
-	}
-
 	switch p {
 	case search.Batch:
 		return limits.DefaultMaxSearchResults
@@ -512,10 +509,6 @@ func mapSlice(values []string, f func(string) string) []string {
 func count(b query.Basic, p search.Protocol) int {
 	if count := b.Count(); count != nil {
 		return *count
-	}
-
-	if b.IsStructural() {
-		return limits.DefaultMaxSearchResults
 	}
 
 	switch p {

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -624,6 +624,28 @@ func TestNewPlanJob(t *testing.T) {
           (repoOpts.hasKVPs[0].key . tag))
         (REPOSEARCH
           (repoOpts.hasKVPs[0].key . tag))))))`),
+		}, {
+			query:      `(...)`,
+			protocol:   search.Streaming,
+			searchType: query.SearchTypeStructural,
+			want: autogold.Want("stream structural search", `
+(ALERT
+  (query . )
+  (originalQuery . )
+  (patternType . literal)
+  (TIMEOUT
+    (timeout . 20s)
+    (LIMIT
+      (limit . 500)
+      (PARALLEL
+        (ZOEKTGLOBALTEXTSEARCH
+          (query . regex:"(:_)")
+          (type . text)
+          )
+        (REPOSCOMPUTEEXCLUDED
+          )
+        (REPOSEARCH
+          (repoOpts.repoFilters.0 . (:[_])))))))`),
 		},
 	}
 


### PR DESCRIPTION
Structural search doesn't stream by default (in global more or when `count` is not set). I really think I remember seeing global structural search on Sourcegraph.com in a past so this feels like a regression, but I really can't find any evidence. Maybe we've just always had this issue.

## Test plan
unit test and `backend-integration` tests