### PR TITLE
search: structural search streams up to 500 results, instead of 30

### DIFF
--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -636,7 +636,7 @@ func TestNewPlanJob(t *testing.T) {
   (TIMEOUT
     (timeout . 20s)
     (LIMIT
-      (limit . 30)
+      (limit . 500)
       (PARALLEL
         (REPOSCOMPUTEEXCLUDED
           )

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -38,7 +38,7 @@ func (inputs Inputs) MaxResults() int {
 
 // DefaultLimit is the default limit to use if not specified in query.
 func (inputs Inputs) DefaultLimit() int {
-	if inputs.Protocol == Batch || inputs.PatternType == query.SearchTypeStructural {
+	if inputs.Protocol == Batch {
 		return limits.DefaultMaxSearchResults
 	}
 	return limits.DefaultMaxSearchResultsStreaming


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/40874.

As in title.

## Test plan
Updates job creation test to reflect change
