### PR TITLE
Revert "feat(vscode): Prompt to get an access token when authentication fails"

### DIFF
--- a/client/vscode/src/backend/instanceVersion.ts
+++ b/client/vscode/src/backend/instanceVersion.ts
@@ -9,25 +9,6 @@ import { requestGraphQLFromVSCode } from './requestGraphQl'
 /**
  * Regular instance version format: ex 3.38.2
  * Insider version format: ex 134683_2022-03-02_5188fes0101
- */
-export async function getInstanceVersionNumber(): Promise<string | undefined> {
-    try {
-        const siteVersionResult = await requestGraphQLFromVSCode<SiteVersionResult>(siteVersionQuery, {})
-        if (siteVersionResult.data) {
-            // assume instance version longer than 8 is using insider version
-            const flattenVersion =
-                siteVersionResult.data.site.productVersion.length > 8
-                    ? '999999'
-                    : siteVersionResult.data.site.productVersion.split('.').join('')
-            return flattenVersion
-        }
-    } catch (error) {
-        console.error('Failed to get instance version from host:', error)
-    }
-    return
-}
-
-/**
  * This function will return the EventSource Type based
  * on the instance version
  */
@@ -38,16 +19,25 @@ export function initializeInstanceVersionNumber(
 ): EventSource {
     // Check only if a user is trying to connect to a private instance with a valid access token provided
     if (instanceURL !== 'https://sourcegraph.com' && accessToken) {
-        getInstanceVersionNumber().then(async flattenVersion => {
-            if (flattenVersion) {
-                if (flattenVersion < '3320') {
-                    displayWarning(
-                        'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
-                    ).catch(() => {})
+        requestGraphQLFromVSCode<SiteVersionResult>(siteVersionQuery, {})
+            .then(async siteVersionResult => {
+                if (siteVersionResult.data) {
+                    // assume instance version longer than 8 is using insider version
+                    const flattenVersion =
+                        siteVersionResult.data.site.productVersion.length > 8
+                            ? '999999'
+                            : siteVersionResult.data.site.productVersion.split('.').join('')
+                    if (flattenVersion < '3320') {
+                        displayWarning(
+                            'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
+                        ).catch(() => {})
+                    }
+                    await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
                 }
-                await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
-            }
-        })
+            })
+            .catch(error => {
+                console.error('Failed to get instance version from host:', error)
+            })
         const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
         // instances below 3.38.0 does not support EventSource.IDEEXTENSION and should fallback to BACKEND source
         return versionNumber >= '3380' ? EventSource.IDEEXTENSION : EventSource.BACKEND

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode'
 
 import { readConfiguration } from './readConfiguration'
-import { endpointHostnameSetting, endpointProtocolSetting } from './endpointSetting'
-import { getInstanceVersionNumber } from '../backend/instanceVersion'
 
 export function accessTokenSetting(): string | undefined {
     return readConfiguration().get<string>('accessToken')
@@ -21,25 +19,7 @@ export async function handleAccessTokenError(badToken?: string, endpointURL?: st
             ? `A valid access token is required to connect to ${endpointURL}`
             : `Connection to ${endpointURL} failed because the token is invalid. Please reload VS Code if your Sourcegraph instance URL has changed.`
 
-        const instanceVersion = await getInstanceVersionNumber()
-        const supportsTokenCallback = instanceVersion && instanceVersion < '3410'
-        const action = await vscode.window.showErrorMessage(message, 'Get Token', 'Open Settings')
-
-        if (action === 'Open Settings') {
-            vscode.commands.executeCommand('workbench.action.openSettings', 'sourcegraph.accessToken')
-        } else if (action === 'Get Token') {
-            const path = supportsTokenCallback ? '/user/settings/tokens/new/callback' : '/user/settings/'
-            const query = supportsTokenCallback ? 'requestFrom=VSCEAUTH' : ''
-
-            vscode.env.openExternal(
-                vscode.Uri.from({
-                    scheme: endpointProtocolSetting().slice(0, -1),
-                    authority: endpointHostnameSetting(),
-                    path,
-                    query,
-                })
-            )
-        }
+        await vscode.window.showErrorMessage(message)
         showingAccessTokenErrorMessage = false
     }
 }

--- a/client/vscode/src/settings/endpointSetting.ts
+++ b/client/vscode/src/settings/endpointSetting.ts
@@ -18,10 +18,6 @@ export function endpointPortSetting(): number {
     return port ? parseInt(port, 10) : 443
 }
 
-export function endpointProtocolSetting(): string {
-    return new URL(endpointSetting()).protocol
-}
-
 export function endpointAccessTokenSetting(): boolean {
     if (readConfiguration().get<string>('accessToken')) {
         return true


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#40584.

Currently breaking build on ESLint failure: https://buildkite.com/sourcegraph/sourcegraph/builds/169299#0182d743-f9e3-4e42-8c39-dbd790596af7

> /root/buildkite/build/sourcegraph/client/vscode/src/backend/instanceVersion.ts
  | 41:9  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  |  
  | /root/buildkite/build/sourcegraph/client/vscode/src/settings/accessTokenSetting.ts
  | 4:1   error  There should be at least one empty line between import groups                                                                                                       import/order
  | 4:1   error  `./endpointSetting` import should occur before import of `./readConfiguration`                                                                                      import/order
  | 5:1   error  `../backend/instanceVersion` import should occur before import of `./readConfiguration`                                                                             import/order
  | 29:13  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  | 34:13  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  |  
  | ✖ 6 problems (6 errors, 0 warnings)
  | 3 errors and 0 warnings potentially fixable with the `--fix` option.
 

<br class="Apple-interchange-newline">

(Dunno why the lint didn't fire in the PR)

## App preview:

- [Web](https://sg-web-revert-40584-get-token.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ofgjccyuww.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

## Test plan
it's a revert
