### PR TITLE
take two: feat(vscode): Prompt to get an access token when authentication fails

### DIFF
--- a/client/vscode/src/backend/instanceVersion.ts
+++ b/client/vscode/src/backend/instanceVersion.ts
@@ -9,6 +9,25 @@ import { requestGraphQLFromVSCode } from './requestGraphQl'
 /**
  * Regular instance version format: ex 3.38.2
  * Insider version format: ex 134683_2022-03-02_5188fes0101
+ */
+export async function getInstanceVersionNumber(): Promise<string | undefined> {
+    try {
+        const siteVersionResult = await requestGraphQLFromVSCode<SiteVersionResult>(siteVersionQuery, {})
+        if (siteVersionResult.data) {
+            // assume instance version longer than 8 is using insider version
+            const flattenVersion =
+                siteVersionResult.data.site.productVersion.length > 8
+                    ? '999999'
+                    : siteVersionResult.data.site.productVersion.split('.').join('')
+            return flattenVersion
+        }
+    } catch (error) {
+        console.error('Failed to get instance version from host:', error)
+    }
+    return
+}
+
+/**
  * This function will return the EventSource Type based
  * on the instance version
  */
@@ -19,25 +38,16 @@ export function initializeInstanceVersionNumber(
 ): EventSource {
     // Check only if a user is trying to connect to a private instance with a valid access token provided
     if (instanceURL !== 'https://sourcegraph.com' && accessToken) {
-        requestGraphQLFromVSCode<SiteVersionResult>(siteVersionQuery, {})
-            .then(async siteVersionResult => {
-                if (siteVersionResult.data) {
-                    // assume instance version longer than 8 is using insider version
-                    const flattenVersion =
-                        siteVersionResult.data.site.productVersion.length > 8
-                            ? '999999'
-                            : siteVersionResult.data.site.productVersion.split('.').join('')
-                    if (flattenVersion < '3320') {
-                        displayWarning(
-                            'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
-                        ).catch(() => {})
-                    }
-                    await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
+        getInstanceVersionNumber().then(async flattenVersion => {
+            if (flattenVersion) {
+                if (flattenVersion < '3320') {
+                    displayWarning(
+                        'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
+                    ).catch(() => {})
                 }
-            })
-            .catch(error => {
-                console.error('Failed to get instance version from host:', error)
-            })
+                await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
+            }
+        })
         const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
         // instances below 3.38.0 does not support EventSource.IDEEXTENSION and should fallback to BACKEND source
         return versionNumber >= '3380' ? EventSource.IDEEXTENSION : EventSource.BACKEND

--- a/client/vscode/src/backend/instanceVersion.ts
+++ b/client/vscode/src/backend/instanceVersion.ts
@@ -38,19 +38,20 @@ export function initializeInstanceVersionNumber(
 ): EventSource {
     // Check only if a user is trying to connect to a private instance with a valid access token provided
     if (instanceURL !== 'https://sourcegraph.com' && accessToken) {
-        getInstanceVersionNumber().then(async flattenVersion => {
-            if (flattenVersion) {
-                if (flattenVersion < '3320') {
-                    displayWarning(
-                        'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
-                    ).catch(() => {})
+        getInstanceVersionNumber()
+            .then(async flattenVersion => {
+                if (flattenVersion) {
+                    if (flattenVersion < '3320') {
+                        displayWarning(
+                            'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
+                        ).catch(() => {})
+                    }
+                    await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
                 }
-                await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
-            }
-        })
-        .catch(error => {
-            console.error('Failed to get instance version from host:', error)
-        })
+            })
+            .catch(error => {
+                console.error('Failed to get instance version from host:', error)
+            })
         const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
         // instances below 3.38.0 does not support EventSource.IDEEXTENSION and should fallback to BACKEND source
         return versionNumber >= '3380' ? EventSource.IDEEXTENSION : EventSource.BACKEND

--- a/client/vscode/src/backend/instanceVersion.ts
+++ b/client/vscode/src/backend/instanceVersion.ts
@@ -48,6 +48,9 @@ export function initializeInstanceVersionNumber(
                 await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
             }
         })
+        .catch(error => {
+            console.error('Failed to get instance version from host:', error)
+        })
         const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
         // instances below 3.38.0 does not support EventSource.IDEEXTENSION and should fallback to BACKEND source
         return versionNumber >= '3380' ? EventSource.IDEEXTENSION : EventSource.BACKEND

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode'
 
 import { readConfiguration } from './readConfiguration'
+import { endpointHostnameSetting, endpointProtocolSetting } from './endpointSetting'
+import { getInstanceVersionNumber } from '../backend/instanceVersion'
 
 export function accessTokenSetting(): string | undefined {
     return readConfiguration().get<string>('accessToken')
@@ -19,7 +21,25 @@ export async function handleAccessTokenError(badToken?: string, endpointURL?: st
             ? `A valid access token is required to connect to ${endpointURL}`
             : `Connection to ${endpointURL} failed because the token is invalid. Please reload VS Code if your Sourcegraph instance URL has changed.`
 
-        await vscode.window.showErrorMessage(message)
+        const instanceVersion = await getInstanceVersionNumber()
+        const supportsTokenCallback = instanceVersion && instanceVersion < '3410'
+        const action = await vscode.window.showErrorMessage(message, 'Get Token', 'Open Settings')
+
+        if (action === 'Open Settings') {
+            vscode.commands.executeCommand('workbench.action.openSettings', 'sourcegraph.accessToken')
+        } else if (action === 'Get Token') {
+            const path = supportsTokenCallback ? '/user/settings/tokens/new/callback' : '/user/settings/'
+            const query = supportsTokenCallback ? 'requestFrom=VSCEAUTH' : ''
+
+            vscode.env.openExternal(
+                vscode.Uri.from({
+                    scheme: endpointProtocolSetting().slice(0, -1),
+                    authority: endpointHostnameSetting(),
+                    path,
+                    query,
+                })
+            )
+        }
         showingAccessTokenErrorMessage = false
     }
 }

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode'
 
-import { readConfiguration } from './readConfiguration'
-import { endpointHostnameSetting, endpointProtocolSetting } from './endpointSetting'
 import { getInstanceVersionNumber } from '../backend/instanceVersion'
+
+import { endpointHostnameSetting, endpointProtocolSetting } from './endpointSetting'
+import { readConfiguration } from './readConfiguration'
 
 export function accessTokenSetting(): string | undefined {
     return readConfiguration().get<string>('accessToken')
@@ -26,12 +27,12 @@ export async function handleAccessTokenError(badToken?: string, endpointURL?: st
         const action = await vscode.window.showErrorMessage(message, 'Get Token', 'Open Settings')
 
         if (action === 'Open Settings') {
-            vscode.commands.executeCommand('workbench.action.openSettings', 'sourcegraph.accessToken')
+            await vscode.commands.executeCommand('workbench.action.openSettings', 'sourcegraph.accessToken')
         } else if (action === 'Get Token') {
             const path = supportsTokenCallback ? '/user/settings/tokens/new/callback' : '/user/settings/'
             const query = supportsTokenCallback ? 'requestFrom=VSCEAUTH' : ''
 
-            vscode.env.openExternal(
+            await vscode.env.openExternal(
                 vscode.Uri.from({
                     scheme: endpointProtocolSetting().slice(0, -1),
                     authority: endpointHostnameSetting(),

--- a/client/vscode/src/settings/endpointSetting.ts
+++ b/client/vscode/src/settings/endpointSetting.ts
@@ -18,6 +18,10 @@ export function endpointPortSetting(): number {
     return port ? parseInt(port, 10) : 443
 }
 
+export function endpointProtocolSetting(): string {
+    return new URL(endpointSetting()).protocol
+}
+
 export function endpointAccessTokenSetting(): boolean {
     if (readConfiguration().get<string>('accessToken')) {
         return true


### PR DESCRIPTION
This was merged (and passing on CI at the time) via https://github.com/sourcegraph/sourcegraph/pull/40584 originally; but it turned out the linter on `main` changed and so it ended up breaking `main` after merge with new linter errors not picked up on that branch at the time.

I've fixed the linter errors locally (they were simple), now re-landing it.

## Test plan

Already performed in https://github.com/sourcegraph/sourcegraph/pull/40584 - just looking for CI tests to pass.

## App preview:

- [Web](https://sg-web-sg-take2.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yvnvwjbwym.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
