### PR TITLE
disable flaky integration tests in TestSubRepoPermissionsPerforce

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -39,7 +39,8 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 		}
 	})
 
-	t.Run("cannot read hack.sh", func(t *testing.T) {
+	// flaky test
+	t.Skip("cannot read hack.sh", func(t *testing.T) {
 		// Should not be able to read hack.sh
 		blob, err := userClient.GitBlob(repoName, "master", "Security/hack.sh")
 		if err != nil {
@@ -55,7 +56,8 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 		}
 	})
 
-	t.Run("file list excludes excluded files", func(t *testing.T) {
+	// flaky test
+	t.Skip("file list excludes excluded files", func(t *testing.T) {
 		files, err := userClient.GitListFilenames(repoName, "master")
 		if err != nil {
 			t.Fatal(err)

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -41,7 +41,9 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 
 	// flaky test
 	// https://github.com/sourcegraph/sourcegraph/issues/40882
-	t.Skip("cannot read hack.sh", func(t *testing.T) {
+	t.Run("cannot read hack.sh", func(t *testing.T) {
+		t.Skip("skipping because flaky")
+
 		// Should not be able to read hack.sh
 		blob, err := userClient.GitBlob(repoName, "master", "Security/hack.sh")
 		if err != nil {
@@ -59,7 +61,9 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 
 	// flaky test
 	// https://github.com/sourcegraph/sourcegraph/issues/40883
-	t.Skip("file list excludes excluded files", func(t *testing.T) {
+	t.Run("file list excludes excluded files", func(t *testing.T) {
+		t.Skip("skipping because flaky")
+
 		files, err := userClient.GitListFilenames(repoName, "master")
 		if err != nil {
 			t.Fatal(err)

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -40,6 +40,7 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 	})
 
 	// flaky test
+	// https://github.com/sourcegraph/sourcegraph/issues/40882
 	t.Skip("cannot read hack.sh", func(t *testing.T) {
 		// Should not be able to read hack.sh
 		blob, err := userClient.GitBlob(repoName, "master", "Security/hack.sh")
@@ -57,6 +58,7 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 	})
 
 	// flaky test
+	// https://github.com/sourcegraph/sourcegraph/issues/40883
 	t.Skip("file list excludes excluded files", func(t *testing.T) {
 		files, err := userClient.GitListFilenames(repoName, "master")
 		if err != nil {


### PR DESCRIPTION
Disable `TestSubRepoPermissionsPerforce/cannot_read_hack.sh` and `TestSubRepoPermissionsPerforce/file_list_excludes_excluded_files` as flaky.

Link to build with flake (scroll down for success on retry): https://buildkite.com/sourcegraph/sourcegraph/builds/169326#0182d7a7-632b-4827-ac70-140abd1f42f4

## Test plan
Disabled flaky tests, other integration tests pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
