### PR TITLE
notebooks: fix page view metrics

### DIFF
--- a/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
@@ -41,7 +41,7 @@ export const EmbeddedNotebookPage: React.FunctionComponent<React.PropsWithChildr
     extensionsController,
     ...props
 }) => {
-    useEffect(() => eventLogger.logViewEvent('EmbeddedNotebookPage'), [])
+    useEffect(() => eventLogger.logPageView('EmbeddedNotebookPage'), [])
 
     const notebookOrError = useObservable(
         useMemo(

--- a/internal/usagestats/notebooks.go
+++ b/internal/usagestats/notebooks.go
@@ -10,9 +10,9 @@ import (
 func GetNotebooksUsageStatistics(ctx context.Context, db database.DB) (*types.NotebooksUsageStatistics, error) {
 	const getNotebooksUsageStatisticsQuery = `
 SELECT
-	COUNT(*) FILTER (WHERE name = 'ViewSearchNotebookPage') AS view_notebook_page_count,
-	COUNT(*) FILTER (WHERE name = 'ViewSearchNotebooksListPage') AS view_notebooks_list_page_count,
-	COUNT(*) FILTER (WHERE name = 'ViewEmbeddedNotebookPage') AS view_embedded_notebook_page_count,
+	COUNT(*) FILTER (WHERE name = 'ViewSearchNotebookPage' OR name = 'SearchNotebookPageViewed') AS view_notebook_page_count,
+	COUNT(*) FILTER (WHERE name = 'ViewSearchNotebooksListPage' OR name = 'SearchNotebooksListPageViewed') AS view_notebooks_list_page_count,
+	COUNT(*) FILTER (WHERE name = 'ViewEmbeddedNotebookPage' OR name = 'EmbeddedNotebookPageViewed') AS view_embedded_notebook_page_count,
 	COUNT(*) FILTER (WHERE name = 'SearchNotebookCreated') AS notebooks_created_count,
 	COUNT(*) FILTER (WHERE name = 'SearchNotebookAddStar') AS added_notebook_stars_count,
 	COUNT(*) FILTER (WHERE name = 'SearchNotebookAddBlock' AND argument->>'type' = 'md') AS added_notebook_markdown_blocks_count,
@@ -23,9 +23,12 @@ SELECT
 FROM event_logs
 WHERE name IN (
 	'ViewSearchNotebookPage',
+	'SearchNotebookPageViewed',
 	'ViewSearchNotebooksListPage',
+	'SearchNotebooksListPageViewed',
 	'SearchNotebookCreated',
 	'ViewEmbeddedNotebookPage',
+	'EmbeddedNotebookPageViewed',
 	'SearchNotebookAddStar',
 	'SearchNotebookAddBlock'
 )

--- a/internal/usagestats/notebooks_test.go
+++ b/internal/usagestats/notebooks_test.go
@@ -35,7 +35,12 @@ VALUES
 	(9, 'SearchNotebookAddBlock', '{"type":"query"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day'),
 	(10, 'SearchNotebookAddBlock', '{"type":"file"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day'),
 	(11, 'SearchNotebookAddBlock', '{"type":"symbol"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day'),
-	(12, 'SearchNotebookAddBlock', '{"type":"compute"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day')
+	(12, 'SearchNotebookAddBlock', '{"type":"compute"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day'),
+	(13, 'SearchNotebookPageViewed', '{}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day'),
+	(14, 'SearchNotebookPageViewed', '{}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day'),
+	(15, 'SearchNotebooksListPageViewed', '{}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day'),
+	(16, 'SearchNotebooksListPageViewed', '{}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day'),
+	(17, 'EmbeddedNotebookPageViewed', '{}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', 'version', $1::timestamp - interval '1 day')
 `, now)
 	if err != nil {
 		t.Fatal(err)
@@ -48,11 +53,12 @@ VALUES
 
 	oneInt := int32(1)
 	twoInt := int32(2)
+	fourInt := int32(4)
 
 	want := &types.NotebooksUsageStatistics{
-		NotebookPageViews:                &twoInt,
-		NotebooksListPageViews:           &twoInt,
-		EmbeddedNotebookPageViews:        &oneInt,
+		NotebookPageViews:                &fourInt,
+		NotebooksListPageViews:           &fourInt,
+		EmbeddedNotebookPageViews:        &twoInt,
 		NotebooksCreatedCount:            &oneInt,
 		NotebookAddedStarsCount:          &oneInt,
 		NotebookAddedMarkdownBlocksCount: &oneInt,


### PR DESCRIPTION
Fixes #40850

This was a really silent bug that happened when we switched from the deprecated `logViewEvent` method to the `logPageView` method in the `eventLogger`. `logViewEvent` adds a `View` prefix to the event name but, for some reason, adds a `Viewed` **suffix**. This means you can inadvertently break the usage metrics for pings if you're not careful. 


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Covered in the usage metrics test