### PR TITLE
gomod: update zoekt-webserver to log to debug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -202,7 +202,7 @@ require github.com/hmarr/codeowners v0.4.0
 require go.opentelemetry.io/otel/exporters/jaeger v1.9.0
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20220824152405-063a4dfa220d
+	github.com/sourcegraph/zoekt v0.0.0-20220826062732-19e4a677f5ab
 	github.com/stretchr/objx v0.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2074,8 +2074,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220824152405-063a4dfa220d h1:U5lNtPTVDnNeH4t9lTkJR7HisG8hQqUDeo+saDTP4gk=
-github.com/sourcegraph/zoekt v0.0.0-20220824152405-063a4dfa220d/go.mod h1:AX7MgGrXM3phFyARUAPMGjRdAdhK8suOWfeCLwzui9Q=
+github.com/sourcegraph/zoekt v0.0.0-20220826062732-19e4a677f5ab h1:7jOdmpHHxiUui22sw20/QdqhcOJOuJd0EcMooTvr2S0=
+github.com/sourcegraph/zoekt v0.0.0-20220826062732-19e4a677f5ab/go.mod h1:AX7MgGrXM3phFyARUAPMGjRdAdhK8suOWfeCLwzui9Q=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
This upgrade includes only one commit:

- https://github.com/sourcegraph/zoekt/commit/19e4a677f5 webserver: downgrade search logs to debug from info

Test Plan: ci