### PR TITLE
web: improve prefetch file blob

### DIFF
--- a/client/web/src/repo/blob/PrefetchableFile.tsx
+++ b/client/web/src/repo/blob/PrefetchableFile.tsx
@@ -5,9 +5,9 @@ import { Subscription } from 'rxjs'
 import { ForwardReferenceComponent } from '@sourcegraph/wildcard'
 
 import { HighlightResponseFormat } from '../../graphql-operations'
+import { useExperimentalFeatures } from '../../stores'
 
 import { fetchBlob } from './backend'
-import { useExperimentalFeatures } from '../../stores'
 
 interface PrefetchableFileProps {
     revision: string
@@ -43,7 +43,7 @@ export const PrefetchableFile = React.forwardRef(function PrefetchableFile(props
             repoName,
             format: enableCodeMirror ? HighlightResponseFormat.JSON_SCIP : HighlightResponseFormat.HTML_HIGHLIGHT,
         }).subscribe()
-    }, [filePath, repoName, revision])
+    }, [filePath, repoName, revision, enableCodeMirror])
 
     const stopPrefetch = useCallback(() => {
         if (observable.current && !observable.current.closed) {

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -3,15 +3,31 @@ import { map } from 'rxjs/operators'
 
 import { memoizeObservable } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
-import { ParsedRepoURI, makeRepoURI } from '@sourcegraph/shared/src/util/url'
+import { makeRepoURI } from '@sourcegraph/shared/src/util/url'
 
 import { requestGraphQL } from '../../backend/graphql'
 import { BlobFileFields, BlobResult, BlobVariables, HighlightResponseFormat } from '../../graphql-operations'
 
-function fetchBlobCacheKey(parsed: ParsedRepoURI & { disableTimeout?: boolean; format?: string }): string {
-    return `${makeRepoURI(parsed)}?disableTimeout=${parsed.disableTimeout}&=${parsed.format}`
+/**
+ * Makes sure that default values are applied consistently for the cache key and the `fetchBlob` function.
+ */
+function applyDefaultValuesToFetchBlobOptions(options: FetchBlobOptions): Required<FetchBlobOptions> {
+    const { disableTimeout = false, format = HighlightResponseFormat.HTML_HIGHLIGHT } = options
+
+    return {
+        ...options,
+        disableTimeout,
+        format,
+    }
 }
-interface FetchBlobArguments {
+
+function fetchBlobCacheKey(options: FetchBlobOptions): string {
+    const { disableTimeout, format } = applyDefaultValuesToFetchBlobOptions(options)
+
+    return `${makeRepoURI(options)}?disableTimeout=${disableTimeout}&=${format}`
+}
+
+interface FetchBlobOptions {
     repoName: string
     commitID: string
     filePath: string
@@ -19,60 +35,52 @@ interface FetchBlobArguments {
     format?: HighlightResponseFormat
 }
 
-export const fetchBlob = memoizeObservable(
-    ({
-        repoName,
-        commitID,
-        filePath,
-        disableTimeout = false,
-        format = HighlightResponseFormat.HTML_HIGHLIGHT,
-    }: FetchBlobArguments): Observable<BlobFileFields | null> => {
-        // We only want to include HTML data if explicitly requested. We always
-        // include LSIF because this is used for languages that are configured
-        // to be processed with tree sitter (and is used when explicitly
-        // requested via JSON_SCIP).
-        const html =
-            format === HighlightResponseFormat.HTML_PLAINTEXT || format === HighlightResponseFormat.HTML_HIGHLIGHT
+export const fetchBlob = memoizeObservable((options: FetchBlobOptions): Observable<BlobFileFields | null> => {
+    const { repoName, commitID, filePath, disableTimeout, format } = applyDefaultValuesToFetchBlobOptions(options)
 
-        return requestGraphQL<BlobResult, BlobVariables>(
-            gql`
-                query Blob(
-                    $repoName: String!
-                    $commitID: String!
-                    $filePath: String!
-                    $disableTimeout: Boolean!
-                    $format: HighlightResponseFormat!
-                    $html: Boolean!
-                ) {
-                    repository(name: $repoName) {
-                        commit(rev: $commitID) {
-                            file(path: $filePath) {
-                                ...BlobFileFields
-                            }
+    // We only want to include HTML data if explicitly requested. We always
+    // include LSIF because this is used for languages that are configured
+    // to be processed with tree sitter (and is used when explicitly
+    // requested via JSON_SCIP).
+    const html = format === HighlightResponseFormat.HTML_PLAINTEXT || format === HighlightResponseFormat.HTML_HIGHLIGHT
+
+    return requestGraphQL<BlobResult, BlobVariables>(
+        gql`
+            query Blob(
+                $repoName: String!
+                $commitID: String!
+                $filePath: String!
+                $disableTimeout: Boolean!
+                $format: HighlightResponseFormat!
+                $html: Boolean!
+            ) {
+                repository(name: $repoName) {
+                    commit(rev: $commitID) {
+                        file(path: $filePath) {
+                            ...BlobFileFields
                         }
                     }
                 }
+            }
 
-                fragment BlobFileFields on File2 {
-                    content
-                    richHTML
-                    highlight(disableTimeout: $disableTimeout, format: $format) {
-                        aborted
-                        html @include(if: $html)
-                        lsif
-                    }
+            fragment BlobFileFields on File2 {
+                content
+                richHTML
+                highlight(disableTimeout: $disableTimeout, format: $format) {
+                    aborted
+                    html @include(if: $html)
+                    lsif
                 }
-            `,
-            { repoName, commitID, filePath, disableTimeout, format, html }
-        ).pipe(
-            map(dataOrThrowErrors),
-            map(data => {
-                if (!data.repository?.commit) {
-                    throw new Error('Commit not found')
-                }
-                return data.repository.commit.file
-            })
-        )
-    },
-    fetchBlobCacheKey
-)
+            }
+        `,
+        { repoName, commitID, filePath, disableTimeout, format, html }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => {
+            if (!data.repository?.commit) {
+                throw new Error('Commit not found')
+            }
+            return data.repository.commit.file
+        })
+    )
+}, fetchBlobCacheKey)

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -11,15 +11,11 @@ import { BlobFileFields, BlobResult, BlobVariables, HighlightResponseFormat } fr
 /**
  * Makes sure that default values are applied consistently for the cache key and the `fetchBlob` function.
  */
-function applyDefaultValuesToFetchBlobOptions(options: FetchBlobOptions): Required<FetchBlobOptions> {
-    const { disableTimeout = false, format = HighlightResponseFormat.HTML_HIGHLIGHT } = options
-
-    return {
-        ...options,
-        disableTimeout,
-        format,
-    }
-}
+const applyDefaultValuesToFetchBlobOptions = ({ disableTimeout = false, format = HighlightResponseFormat.HTML_HIGHLIGHT, ...options }: FetchBlobOptions): Required<FetchBlobOptions> => ({
+    ...options,
+    disableTimeout,
+    format,
+})
 
 function fetchBlobCacheKey(options: FetchBlobOptions): string {
     const { disableTimeout, format } = applyDefaultValuesToFetchBlobOptions(options)

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -11,7 +11,11 @@ import { BlobFileFields, BlobResult, BlobVariables, HighlightResponseFormat } fr
 /**
  * Makes sure that default values are applied consistently for the cache key and the `fetchBlob` function.
  */
-const applyDefaultValuesToFetchBlobOptions = ({ disableTimeout = false, format = HighlightResponseFormat.HTML_HIGHLIGHT, ...options }: FetchBlobOptions): Required<FetchBlobOptions> => ({
+const applyDefaultValuesToFetchBlobOptions = ({
+    disableTimeout = false,
+    format = HighlightResponseFormat.HTML_HIGHLIGHT,
+    ...options
+}: FetchBlobOptions): Required<FetchBlobOptions> => ({
     ...options,
     disableTimeout,
     format,

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -38,7 +38,7 @@ export const fetchBlob = memoizeObservable((options: FetchBlobOptions): Observab
     // include LSIF because this is used for languages that are configured
     // to be processed with tree sitter (and is used when explicitly
     // requested via JSON_SCIP).
-    const html = format === HighlightResponseFormat.HTML_PLAINTEXT || format === HighlightResponseFormat.HTML_HIGHLIGHT
+    const html = [HighlightResponseFormat.HTML_PLAINTEXT, HighlightResponseFormat.HTML_HIGHLIGHT].includes(format)
 
     return requestGraphQL<BlobResult, BlobVariables>(
         gql`

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -85,6 +85,7 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                                 linkRowClick={() => props.telemetryService.log('FileTreeClick')}
                                                 isActive={false}
                                                 isSelected={false}
+                                                isGoUpTreeLink={true}
                                                 customIconPath={mdiFolderOutline}
                                                 enableMergedFileSymbolSidebar={props.enableMergedFileSymbolSidebar}
                                             />

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -51,63 +51,78 @@ interface FileProps extends ThemeProps {
     isSelected: boolean
     customIconPath?: string
     enableMergedFileSymbolSidebar: boolean
+    isGoUpTreeLink?: boolean
 
     // For core workflow inline symbols redesign
     location: H.Location
 }
 
 export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> = props => {
+    const {
+        isActive,
+        isSelected,
+        isGoUpTreeLink,
+        className,
+        entryInfo,
+        linkRowClick,
+        noopRowClick,
+        fileDecorations,
+        isLightTheme,
+        depth,
+        index,
+        location,
+        enableMergedFileSymbolSidebar,
+        customIconPath,
+    } = props
+
     const { commitID, repoName } = useTreeRootContext()
-    const prefetchFileEnabled = useExperimentalFeatures(features => features.enableSidebarFilePrefetch ?? false)
+    const isSidebarFilePrefetchEnabled = useExperimentalFeatures(
+        features => features.enableSidebarFilePrefetch ?? false
+    )
 
     const renderedFileDecorations = (
         <FileDecorator
             // If component is not specified, or it is 'sidebar', render it.
-            fileDecorations={props.fileDecorations?.filter(decoration => decoration?.where !== 'page')}
-            isLightTheme={props.isLightTheme}
-            isActive={props.isActive}
+            fileDecorations={fileDecorations?.filter(decoration => decoration?.where !== 'page')}
+            isLightTheme={isLightTheme}
+            isActive={isActive}
         />
     )
 
-    const offsetStyle = getTreeItemOffset(props.depth)
+    const offsetStyle = getTreeItemOffset(depth)
 
     return (
         <>
-            <TreeRow
-                key={props.entryInfo.path}
-                className={props.className}
-                isActive={props.isActive}
-                isSelected={props.isSelected}
-            >
+            <TreeRow key={entryInfo.path} className={className} isActive={isActive} isSelected={isSelected}>
                 <TreeLayerCell className="test-sidebar-file-decorable">
-                    {props.entryInfo.submodule ? (
-                        props.entryInfo.url ? (
+                    {entryInfo.submodule ? (
+                        entryInfo.url ? (
                             <TreeLayerRowContentsLink
-                                to={props.entryInfo.url}
-                                onClick={props.linkRowClick}
+                                to={entryInfo.url}
+                                onClick={linkRowClick}
                                 draggable={false}
-                                title={'Submodule: ' + props.entryInfo.submodule.url}
-                                data-tree-path={props.entryInfo.path}
+                                title={'Submodule: ' + entryInfo.submodule.url}
+                                data-tree-path={entryInfo.path}
                             >
                                 <TreeLayerRowContentsText>
                                     {/* TODO Improve accessibility: https://github.com/sourcegraph/sourcegraph/issues/12916 */}
-                                    <TreeRowIcon style={offsetStyle} onClick={props.noopRowClick}>
+                                    <TreeRowIcon style={offsetStyle} onClick={noopRowClick}>
                                         <Icon aria-hidden={true} svgPath={mdiSourceRepository} />
                                     </TreeRowIcon>
                                     <TreeRowLabel className="test-file-decorable-name">
-                                        {props.entryInfo.name} @ {props.entryInfo.submodule.commit.slice(0, 7)}
+                                        {entryInfo.name} @ {entryInfo.submodule.commit.slice(0, 7)}
                                     </TreeRowLabel>
                                     {renderedFileDecorations}
                                 </TreeLayerRowContentsText>
                             </TreeLayerRowContentsLink>
                         ) : (
-                            <TreeLayerRowContents title={'Submodule: ' + props.entryInfo.submodule.url}>
+                            <TreeLayerRowContents title={'Submodule: ' + entryInfo.submodule.url}>
                                 <TreeLayerRowContentsText>
                                     <TreeRowIcon style={offsetStyle}>
                                         <Icon aria-hidden={true} svgPath={mdiSourceRepository} />
                                     </TreeRowIcon>
                                     <TreeRowLabel className="test-file-decorable-name">
-                                        {props.entryInfo.name} @ {props.entryInfo.submodule.commit.slice(0, 7)}
+                                        {entryInfo.name} @ {entryInfo.submodule.commit.slice(0, 7)}
                                     </TreeRowLabel>
                                     {renderedFileDecorations}
                                 </TreeLayerRowContentsText>
@@ -115,46 +130,46 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
                         )
                     ) : (
                         <PrefetchableFile
-                            prefetch={prefetchFileEnabled}
+                            isPrefetchEnabled={isSidebarFilePrefetchEnabled && !isActive && !isGoUpTreeLink}
+                            isSelected={isSelected}
                             revision={commitID}
                             repoName={repoName}
-                            filePath={props.entryInfo.path}
+                            filePath={entryInfo.path}
                             as={TreeLayerRowContentsLink}
                             className="test-tree-file-link"
-                            to={props.entryInfo.url}
-                            onClick={props.linkRowClick}
-                            data-tree-path={props.entryInfo.path}
+                            to={entryInfo.url}
+                            onClick={linkRowClick}
+                            data-tree-path={entryInfo.path}
                             draggable={false}
-                            title={props.entryInfo.path}
+                            title={entryInfo.path}
                             // needed because of dynamic styling
                             style={offsetStyle}
                             tabIndex={-1}
-                            isSelected={props.isSelected}
                         >
                             <TreeLayerRowContentsText className="d-flex">
-                                <TreeRowIcon onClick={props.noopRowClick}>
+                                <TreeRowIcon onClick={noopRowClick}>
                                     <Icon
                                         className={treeStyles.treeIcon}
-                                        svgPath={props.customIconPath || mdiFileDocumentOutline}
+                                        svgPath={customIconPath || mdiFileDocumentOutline}
                                         aria-hidden={true}
                                     />
                                 </TreeRowIcon>
-                                <TreeRowLabel className="test-file-decorable-name">{props.entryInfo.name}</TreeRowLabel>
+                                <TreeRowLabel className="test-file-decorable-name">{entryInfo.name}</TreeRowLabel>
                                 {renderedFileDecorations}
                             </TreeLayerRowContentsText>
                         </PrefetchableFile>
                     )}
-                    {props.index === MAX_TREE_ENTRIES - 1 && (
+                    {index === MAX_TREE_ENTRIES - 1 && (
                         <TreeRowAlert
                             variant="warning"
-                            style={getTreeItemOffset(props.depth + 1)}
+                            style={getTreeItemOffset(depth + 1)}
                             error="Too many entries. Use search to find a specific file."
                         />
                     )}
                 </TreeLayerCell>
             </TreeRow>
-            {props.enableMergedFileSymbolSidebar && props.isActive && (
-                <Symbols activePath={props.entryInfo.path} location={props.location} style={offsetStyle} />
+            {enableMergedFileSymbolSidebar && isActive && (
+                <Symbols activePath={entryInfo.path} location={location} style={offsetStyle} />
             )}
         </>
     )


### PR DESCRIPTION
## Context

This PR makes sure:

1. We have a consistent `fetchBlob` cache key.
2. We do not prefetch blob on keyboard navigation if the experiment flag is not enabled.
3. We do not call the `fetchBlob` function for the go-up-the-file-tree link on hover.

https://github.com/sourcegraph/sourcegraph/pull/40354 follow-up.

## Test plan

1. Run the application with the enabled experimental flag `enableSidebarFilePrefetch`.
2. Open the blob page.
3. Navigate between blobs using the keyboard up and down arrows.
5. Notice that `fetchBlob` requests are issued once per selected/visited file. No requests are issued when the go-up-the-file-tree link is selected.

## App preview:

- [Web](https://sg-web-vb-improve-prefetch-file.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-evgikeruxu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

