### PR TITLE
repo stats: add another test and fix test helper

### DIFF
--- a/internal/database/repo_statistics_test.go
+++ b/internal/database/repo_statistics_test.go
@@ -126,8 +126,8 @@ func TestRepoStatistics(t *testing.T) {
 	}, []GitserverReposStatistic{
 		{ShardID: ""},
 		{ShardID: shards[0], Total: 2, Cloning: 2, FailedFetch: 1},
-		{ShardID: shards[1], Total: 1, Cloning: 1, FailedFetch: 1},
-		{ShardID: shards[2], Total: 3, Cloning: 2, NotCloned: 1},
+		{ShardID: shards[1], Total: 1, Cloning: 1, FailedFetch: 0},
+		{ShardID: shards[2], Total: 3, Cloning: 2, NotCloned: 1, FailedFetch: 1},
 	})
 	// Now we move a repo and set an error
 	setLastError(t, db, repos[1].Name, shards[1], "internet broke repo-2")
@@ -137,8 +137,104 @@ func TestRepoStatistics(t *testing.T) {
 	}, []GitserverReposStatistic{
 		{ShardID: ""},
 		{ShardID: shards[0], Total: 1, Cloning: 1, FailedFetch: 1},
-		{ShardID: shards[1], Total: 2, Cloning: 2, FailedFetch: 2},
-		{ShardID: shards[2], Total: 3, Cloning: 2, NotCloned: 1},
+		{ShardID: shards[1], Total: 2, Cloning: 2, FailedFetch: 1},
+		{ShardID: shards[2], Total: 3, Cloning: 2, NotCloned: 1, FailedFetch: 1},
+	})
+}
+
+func TestRepoStatistics_DeleteAndUndelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
+
+	shards := []string{
+		"shard-1",
+		"shard-2",
+		"shard-3",
+	}
+	repos := types.Repos{
+		&types.Repo{Name: "repo1"},
+		&types.Repo{Name: "repo2"},
+		&types.Repo{Name: "repo3"},
+		&types.Repo{Name: "repo4"},
+		&types.Repo{Name: "repo5"},
+		&types.Repo{Name: "repo6"},
+	}
+
+	createTestRepos(ctx, t, db, repos)
+
+	assertRepoStatistics(t, ctx, s, RepoStatistics{
+		Total: 6, NotCloned: 6, SoftDeleted: 0,
+	}, []GitserverReposStatistic{
+		{ShardID: "", Total: 6, NotCloned: 6},
+	})
+
+	// Move to to shards[0] as cloning
+	setCloneStatus(t, db, repos[0].Name, shards[0], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[1].Name, shards[0], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[2].Name, shards[0], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[3].Name, shards[0], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[4].Name, shards[0], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[5].Name, shards[0], types.CloneStatusCloning)
+
+	assertRepoStatistics(t, ctx, s, RepoStatistics{
+		Total: 6, SoftDeleted: 0, Cloning: 6,
+	}, []GitserverReposStatistic{
+		{ShardID: ""},
+		{ShardID: shards[0], Total: 6, Cloning: 6},
+	})
+
+	// Soft delete repos
+	if err := db.Repos().Delete(ctx, repos[2].ID); err != nil {
+		t.Fatal(err)
+	}
+	deletedRepoName := queryRepoName(t, ctx, s, repos[2].ID)
+
+	assertRepoStatistics(t, ctx, s, RepoStatistics{
+		// correct
+		Total: 5, SoftDeleted: 1, Cloning: 5,
+	}, []GitserverReposStatistic{
+		{ShardID: ""},
+		{ShardID: shards[0], Total: 6, Cloning: 6},
+	})
+
+	// Until we remove it from disk in gitserver, which causes the clone status
+	// to be set to not_cloned:
+	setCloneStatus(t, db, deletedRepoName, shards[0], types.CloneStatusNotCloned)
+
+	assertRepoStatistics(t, ctx, s, RepoStatistics{
+		Total: 5, SoftDeleted: 1, Cloning: 5,
+	}, []GitserverReposStatistic{
+		{ShardID: ""},
+		{ShardID: shards[0], Total: 6, Cloning: 5, NotCloned: 1},
+	})
+
+	// Undelete it
+	err := s.Exec(ctx, sqlf.Sprintf("UPDATE repo SET deleted_at = NULL WHERE name = %s;", deletedRepoName))
+	if err != nil {
+		t.Fatalf("failed to query repo name: %s", err)
+	}
+	assertRepoStatistics(t, ctx, s, RepoStatistics{
+		Total: 6, SoftDeleted: 0, Cloning: 5, NotCloned: 1,
+	}, []GitserverReposStatistic{
+		{ShardID: ""},
+		{ShardID: shards[0], Total: 6, Cloning: 5, NotCloned: 1},
+	})
+
+	// reshard and clone
+	setCloneStatus(t, db, deletedRepoName, shards[1], types.CloneStatusCloning)
+
+	assertRepoStatistics(t, ctx, s, RepoStatistics{
+		Total: 6, SoftDeleted: 0, Cloning: 6, NotCloned: 0,
+	}, []GitserverReposStatistic{
+		{ShardID: ""},
+		{ShardID: shards[0], Total: 5, Cloning: 5, NotCloned: 0},
+		{ShardID: shards[1], Total: 1, Cloning: 1, NotCloned: 0},
 	})
 }
 
@@ -262,7 +358,7 @@ func assertRepoStatistics(t *testing.T, ctx context.Context, s RepoStatisticsSto
 	}
 
 	if diff := cmp.Diff(haveRepoStats, wantRepoStats); diff != "" {
-		t.Fatalf("repoStatistics differ: %s", diff)
+		t.Errorf("repoStatistics differ: %s", diff)
 	}
 
 	haveGitserverStats, err := s.GetGitserverReposStatistics(ctx)
@@ -273,7 +369,7 @@ func assertRepoStatistics(t *testing.T, ctx context.Context, s RepoStatisticsSto
 	sort.Slice(haveGitserverStats, func(i, j int) bool { return haveGitserverStats[i].ShardID < haveGitserverStats[j].ShardID })
 	sort.Slice(wantGitserverStats, func(i, j int) bool { return wantGitserverStats[i].ShardID < wantGitserverStats[j].ShardID })
 
-	if diff := cmp.Diff(haveRepoStats, wantRepoStats); diff != "" {
+	if diff := cmp.Diff(haveGitserverStats, wantGitserverStats); diff != "" {
 		t.Fatalf("gitserverReposStatistics differ: %s", diff)
 	}
 }


### PR DESCRIPTION
@eseliger and I wrote this test while debugging some behaviour of the
repo statistics table in production.

We also realized that a refactoring of the test helper made it useless,
so this fixes that too.

## Test plan

- These tests