### PR TITLE
cs: disable VSCE nighgly tests

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -99,7 +99,6 @@ Base pipeline (more steps might be included based on branch changes):
 
 - ESLint (all)
 - Stylelint (all)
-- Puppeteer tests for VS Code extension
 - Upload build trace
 
 ### Tagged release

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -169,7 +169,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// If this is a VS Code extension nightly build, run the vsce-extension integration tests
 		ops = operations.NewSet(
 			addClientLintersForAllFiles,
-			addVsceIntegrationTests)
+			// TODO: fix integrations tests and re-enable
+			// addVsceIntegrationTests,
+		)
 
 	case runtype.ImagePatch:
 		// only build image for the specified image in the branch name

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -169,7 +169,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// If this is a VS Code extension nightly build, run the vsce-extension integration tests
 		ops = operations.NewSet(
 			addClientLintersForAllFiles,
-			// TODO: fix integrations tests and re-enable
+			// TODO: fix integrations tests and re-enable: https://github.com/sourcegraph/sourcegraph/issues/40891
 			// addVsceIntegrationTests,
 		)
 


### PR DESCRIPTION
Disables VSCE nightly tests
Follow-up issue: https://github.com/sourcegraph/sourcegraph/issues/40891

## Test plan
Sourcegraph build passes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
