### PR TITLE
[SG-40884] - Update `eslint-config` to `v0.32.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@pollyjs/persister-fs": "^5.0.0",
     "@sentry/webpack-plugin": "^1.18.9",
     "@slack/web-api": "^5.15.0",
-    "@sourcegraph/eslint-config": "0.31.0",
+    "@sourcegraph/eslint-config": "0.32.0",
     "@sourcegraph/eslint-plugin-sourcegraph": "^1.0.5",
     "@sourcegraph/eslint-plugin-wildcard": "1.0.0",
     "@sourcegraph/prettierrc": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4090,10 +4090,10 @@
     "@sourcegraph/codemod-toolkit-packages" "1.0.1"
     "@sourcegraph/codemod-toolkit-ts" "1.0.1"
 
-"@sourcegraph/eslint-config@0.31.0":
-  version "0.31.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/eslint-config/-/eslint-config-0.31.0.tgz#d6508841a340b52ba2b1ece35b054d89df7ab38d"
-  integrity sha512-a4MthnWhw37z/t94lnXZyH/zTAbG2IIXyGKi3du5PUNrF+B2E1KITRbhIUrv7kSfGADVkuV0t2imNEwXQcCgMQ==
+"@sourcegraph/eslint-config@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/eslint-config/-/eslint-config-0.32.0.tgz#9e8922d35bfba3c6399d0552c2ae53951abacf8a"
+  integrity sha512-vy9tewUjx7w+4WpQ+vVADYypBI9/yXjYy3BJ23e3XbXPOEJBL6Upt8s6tphDSVGfeRUUnYv/1BnG5nlH68XPSw==
   dependencies:
     "@sourcegraph/prettierrc" "^3.0.3"
     "@typescript-eslint/eslint-plugin" "^5.20.0"


### PR DESCRIPTION
## Description
Upgrade to `v0.32.0` @sourcegraph/eslint-config

## Ref:
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-40884)
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/40884)

## Test Plan
- Install new version of package
- Confirm that you can now use abbreviation on codebase e.g (`func`).

## App [preview:](url)

- [Web](https://sg-web-contractors-sg-40884.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vziurpxuxm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
