### PR TITLE
gitlab: use baseURL to match the correct OAuth context

### DIFF
--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -234,7 +234,7 @@ func isGitLabDotComURL(baseURL *url.URL) bool {
 // base path.
 func (c *Client) do(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
 	req.URL = c.baseURL.ResolveReference(req.URL)
-	return c.doWithBaseURL(ctx, getOAuthContext(), req, result)
+	return c.doWithBaseURL(ctx, getOAuthContext(c.baseURL), req, result)
 }
 
 // doWithBaseURL doesn't amend the request URL. When an OAuth Bearer token is
@@ -346,7 +346,7 @@ func (c *Client) GetAuthenticatedUserOAuthScopes(ctx context.Context) ([]string,
 		Scopes []string `json:"scopes,omitempty"`
 	}{}
 
-	_, _, err = c.doWithBaseURL(ctx, getOAuthContext(), req, &v)
+	_, _, err = c.doWithBaseURL(ctx, getOAuthContext(c.baseURL), req, &v)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting oauth scopes")
 	}
@@ -435,16 +435,23 @@ func (e ProjectNotFoundError) NotFound() bool { return true }
 
 var MockGetOAuthContext func() *oauthutil.OAuthContext
 
-func getOAuthContext() *oauthutil.OAuthContext {
+// getOAuthContext matches the corresponding auth provider using the given
+// baseURL and returns the oauthutil.OAuthContext of it.
+func getOAuthContext(baseURL *url.URL) *oauthutil.OAuthContext {
 	if MockGetOAuthContext != nil {
 		return MockGetOAuthContext()
 	}
 
+	baseURL.Path = "" // Cut out path like "/api/v4"
+	rootURL := strings.TrimSuffix(baseURL.String(), "/")
 	for _, authProvider := range conf.SiteConfig().AuthProviders {
 		if authProvider.Gitlab != nil {
 			p := authProvider.Gitlab
-
 			glURL := strings.TrimSuffix(p.Url, "/")
+			if glURL != rootURL {
+				continue
+			}
+
 			return &oauthutil.OAuthContext{
 				ClientID:     p.ClientID,
 				ClientSecret: p.ClientSecret,

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
@@ -152,19 +151,14 @@ func TestGetOAuthContext(t *testing.T) {
 	)
 	defer conf.Mock(nil)
 
-	gitlabDotComAPIURL, err := url.Parse("https://gitlab.com/api/v4/")
-	require.NoError(t, err)
-	selfHostGitLabAPIURL, err := url.Parse("https://gitlab.example.com/api/v4/")
-	require.NoError(t, err)
-
 	tests := []struct {
 		name    string
-		baseURL *url.URL
+		baseURL string
 		want    *oauthutil.OAuthContext
 	}{
 		{
 			name:    "match with API URL",
-			baseURL: gitlabDotComAPIURL,
+			baseURL: "https://gitlab.com/api/v4/",
 			want: &oauthutil.OAuthContext{
 				ClientID:     "my-client-id",
 				ClientSecret: "my-client-secret",
@@ -178,7 +172,7 @@ func TestGetOAuthContext(t *testing.T) {
 		},
 		{
 			name:    "match with root URL",
-			baseURL: extsvc.GitLabDotComURL,
+			baseURL: "https://gitlab.com/",
 			want: &oauthutil.OAuthContext{
 				ClientID:     "my-client-id",
 				ClientSecret: "my-client-secret",
@@ -192,7 +186,7 @@ func TestGetOAuthContext(t *testing.T) {
 		},
 		{
 			name:    "no match",
-			baseURL: selfHostGitLabAPIURL,
+			baseURL: "https://gitlab.example.com/api/v4/",
 			want:    nil,
 		},
 	}

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -12,13 +12,17 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestGetAuthenticatedUserOAuthScopes(t *testing.T) {
@@ -120,4 +124,82 @@ func TestClient_doWithBaseURL(t *testing.T) {
 	var result map[string]any
 	_, _, err = client.doWithBaseURL(ctx, mockOauthContext, req, &result)
 	require.NoError(t, err)
+}
+
+func TestGetOAuthContext(t *testing.T) {
+	conf.Mock(
+		&conf.Unified{
+			SiteConfiguration: schema.SiteConfiguration{
+				AuthProviders: []schema.AuthProviders{
+					{
+						Github: &schema.GitHubAuthProvider{
+							Url: "https://gitlab.com/", // Matching URL but wrong provider
+						},
+					}, {
+						Gitlab: &schema.GitLabAuthProvider{
+							Url: "https://gitlab.myexample.com/", // URL doesn't match
+						},
+					}, {
+						Gitlab: &schema.GitLabAuthProvider{
+							ClientID:     "my-client-id",
+							ClientSecret: "my-client-secret",
+							Url:          "https://gitlab.com/", // Good
+						},
+					},
+				},
+			},
+		},
+	)
+	defer conf.Mock(nil)
+
+	gitlabDotComAPIURL, err := url.Parse("https://gitlab.com/api/v4/")
+	require.NoError(t, err)
+	selfHostGitLabAPIURL, err := url.Parse("https://gitlab.example.com/api/v4/")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		baseURL *url.URL
+		want    *oauthutil.OAuthContext
+	}{
+		{
+			name:    "match with API URL",
+			baseURL: gitlabDotComAPIURL,
+			want: &oauthutil.OAuthContext{
+				ClientID:     "my-client-id",
+				ClientSecret: "my-client-secret",
+				Endpoint: oauthutil.Endpoint{
+					AuthURL:   "https://gitlab.com/oauth/authorize",
+					TokenURL:  "https://gitlab.com/oauth/token",
+					AuthStyle: 0,
+				},
+				Scopes: []string{"read_user", "api"},
+			},
+		},
+		{
+			name:    "match with root URL",
+			baseURL: extsvc.GitLabDotComURL,
+			want: &oauthutil.OAuthContext{
+				ClientID:     "my-client-id",
+				ClientSecret: "my-client-secret",
+				Endpoint: oauthutil.Endpoint{
+					AuthURL:   "https://gitlab.com/oauth/authorize",
+					TokenURL:  "https://gitlab.com/oauth/token",
+					AuthStyle: 0,
+				},
+				Scopes: []string{"read_user", "api"},
+			},
+		},
+		{
+			name:    "no match",
+			baseURL: selfHostGitLabAPIURL,
+			want:    nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := getOAuthContext(test.baseURL)
+			assert.Equal(t, test.want, got)
+		})
+	}
 }


### PR DESCRIPTION
Previously in https://github.com/sourcegraph/sourcegraph/pull/39840, we would always pick the first GitLab auth provider to obtain the OAuth context, which isn't a problem when there is only one GitLab auth provider configured (in most of the cases). However, this would give us incorrect OAuth context when there are more than one GitLab auth providers configured.

This PR fixes that by using the root URL for determining the correct auth provider to get OAuth context.

## Test plan

Unit tests

---

Followup of https://github.com/sourcegraph/sourcegraph/pull/39840#discussion_r951759885
