### PR TITLE
Add memoization level for the search aggregation fetch hook

### DIFF
--- a/client/search-ui/src/results/aggregation/AggregationModeControls.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationModeControls.tsx
@@ -25,6 +25,15 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
         return store
     }, {} as Partial<Record<SearchAggregationMode, SearchAggregationModeAvailability>>)
 
+    const isModeAvailable = (mode: SearchAggregationMode): boolean => {
+        const isAvailable = availabilityGroups[mode]?.available
+
+        // Returns true by default because we don't want to disable all modes
+        // in case if we don't have availability information from the backend
+        // (for example in case of network request failure)
+        return isAvailable ?? true
+    }
+
     return (
         <div
             {...attributes}
@@ -37,7 +46,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     size={size}
                     outline={mode !== SearchAggregationMode.REPO}
                     data-testid="repo-aggregation-mode"
-                    disabled={!availabilityGroups[SearchAggregationMode.REPO]?.available}
+                    disabled={!isModeAvailable(SearchAggregationMode.REPO)}
                     onClick={() => onModeChange(SearchAggregationMode.REPO)}
                 >
                     Repository
@@ -49,7 +58,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     variant="secondary"
                     size={size}
                     outline={mode !== SearchAggregationMode.PATH}
-                    disabled={!availabilityGroups[SearchAggregationMode.PATH]?.available}
+                    disabled={!isModeAvailable(SearchAggregationMode.PATH)}
                     data-testid="file-aggregation-mode"
                     onClick={() => onModeChange(SearchAggregationMode.PATH)}
                 >
@@ -62,7 +71,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     variant="secondary"
                     size={size}
                     outline={mode !== SearchAggregationMode.AUTHOR}
-                    disabled={!availabilityGroups[SearchAggregationMode.AUTHOR]?.available}
+                    disabled={!isModeAvailable(SearchAggregationMode.AUTHOR)}
                     data-testid="author-aggregation-mode"
                     onClick={() => onModeChange(SearchAggregationMode.AUTHOR)}
                 >
@@ -75,7 +84,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     variant="secondary"
                     size={size}
                     outline={mode !== SearchAggregationMode.CAPTURE_GROUP}
-                    disabled={!availabilityGroups[SearchAggregationMode.CAPTURE_GROUP]?.available}
+                    disabled={!isModeAvailable(SearchAggregationMode.CAPTURE_GROUP)}
                     data-testid="captureGroup-aggregation-mode"
                     onClick={() => onModeChange(SearchAggregationMode.CAPTURE_GROUP)}
                 >

--- a/client/search-ui/src/results/aggregation/hooks.ts
+++ b/client/search-ui/src/results/aggregation/hooks.ts
@@ -202,6 +202,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
             skip: aggregationMode !== null && calculatedAggregationModeRef.current === aggregationMode,
             onError: () => {
                 calculatedAggregationModeRef.current = null
+                setData(undefined)
             },
             onCompleted: data => {
                 const calculatedAggregationMode = getCalculatedAggregationMode(data)

--- a/client/search-ui/src/results/aggregation/hooks.ts
+++ b/client/search-ui/src/results/aggregation/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { ApolloError, gql, useQuery } from '@apollo/client'
 import { useHistory, useLocation } from 'react-router'
@@ -185,12 +185,24 @@ type SearchAggregationResults =
 export const useSearchAggregationData = (input: SearchAggregationDataInput): SearchAggregationResults => {
     const { query, patternType, aggregationMode, limit } = input
 
+    const calculatedAggregationModeRef = useRef<SearchAggregationMode | null>(null)
     const [, setAggregationMode] = useAggregationSearchMode()
-    const { data, error, loading } = useQuery<GetSearchAggregationResult, GetSearchAggregationVariables>(
+
+    const [data, setData] = useState<GetSearchAggregationResult | undefined>()
+    const { error, loading } = useQuery<GetSearchAggregationResult, GetSearchAggregationVariables>(
         AGGREGATION_SEARCH_QUERY,
         {
             fetchPolicy: 'cache-first',
             variables: { query, patternType, mode: aggregationMode, limit },
+
+            // Skip extra API request when we had no aggregation mode, and then
+            // we got calculated aggregation mode from the BE. We should update
+            // FE aggregationMode but this shouldn't trigger AGGREGATION_SEARCH_QUERY
+            // fetching.
+            skip: aggregationMode !== null && calculatedAggregationModeRef.current === aggregationMode,
+            onError: () => {
+                calculatedAggregationModeRef.current = null
+            },
             onCompleted: data => {
                 const calculatedAggregationMode = getCalculatedAggregationMode(data)
 
@@ -205,12 +217,26 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
 
                 // Catch initial page mount when aggregation mode isn't set on the FE and BE
                 // calculated aggregation mode automatically on the backend based on given query
-                if (calculatedAggregationMode && aggregationMode === null) {
+                if (calculatedAggregationMode !== aggregationMode) {
                     setAggregationMode(calculatedAggregationMode)
                 }
+
+                // Preserve calculated aggregation mode in order to use it for skipping
+                // extra API calls in useQuery "skip" field.
+                calculatedAggregationModeRef.current = calculatedAggregationMode
+
+                // skip: true resets data field in the useQuery hook, in order to use previously
+                // saved data we use useState to store data outside useQuery hook
+                setData(data)
             },
         }
     )
+
+    useEffect(() => {
+        // If query or pattern type have been changed we should "reset" our assumptions
+        // about calculated aggregation mode and make another api call to determine it
+        calculatedAggregationModeRef.current = null
+    }, [query, patternType])
 
     if (loading) {
         return { data: undefined, error: undefined, loading: true }

--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -6,21 +6,21 @@ import { SearchAggregationMode, SearchGraphQlOperations } from '@sourcegraph/sea
 import { GetSearchAggregationResult } from '@sourcegraph/search-ui'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchEvent } from '@sourcegraph/shared/src/search/stream'
-import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
+import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import { WebGraphQlOperations } from '../graphql-operations'
 
-import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
+import { createWebIntegrationTestContext, WebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults } from './graphQlResults'
 import { createEditorAPI } from './utils'
 
-const aggregationDefaultMock: GetSearchAggregationResult = {
+const aggregationDefaultMock = (mode: SearchAggregationMode): GetSearchAggregationResult => ({
     searchQueryAggregate: {
         __typename: 'SearchQueryAggregate',
         aggregations: {
             __typename: 'ExhaustiveSearchAggregationResult',
-            mode: SearchAggregationMode.REPO,
+            mode,
             otherGroupCount: 100,
             groups: [
                 {
@@ -76,7 +76,8 @@ const aggregationDefaultMock: GetSearchAggregationResult = {
             },
         ],
     },
-}
+})
+
 const mockDefaultStreamEvents: SearchEvent[] = [
     {
         type: 'matches',
@@ -144,7 +145,7 @@ describe('Search aggregation', () => {
         })
         testContext.overrideGraphQL({
             ...commonSearchGraphQLResults,
-            GetSearchAggregation: () => aggregationDefaultMock,
+            GetSearchAggregation: ({ mode }) => aggregationDefaultMock(mode ?? SearchAggregationMode.REPO),
         })
         testContext.overrideSearchStreamEvents(mockDefaultStreamEvents)
     })


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/40902
## Background 
This PR does two things
- Adds extra logic to avoid unnecessary extra API network requests in the search page initial mount  
- Fixes aggregation mode availability when aggregation query has got an error. 

## Test plan
- Open your dev tools and go to the homepage 
- Try to search anything 
- Check that the network tab has only one request about search aggregation `GetSearchAggregation.`
- Check that search aggregation controls work as expected and have no regressions (changing query re-triggers aggregation, changing pattern type re-triggers aggregation, changing aggregation mode re-triggers aggregation)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-extra-aggregation-api-call.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-llywhohply.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
