### PR TITLE
Web: Fix flaky aggregation integration test

### DIFF
--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -297,8 +297,11 @@ describe('Search aggregation', () => {
 
             expect(await editor.getValue()).toStrictEqual('insights repo:sourcegraph/sourcegraph')
 
+            await driver.page.waitForSelector('[data-testid="expand-aggregation-ui"]')
             await driver.page.click('[data-testid="expand-aggregation-ui"]')
-            await driver.page.waitForSelector('[aria-label="chart content group"] g:nth-child(2) a')
+            await driver.page.waitForSelector(
+                '[aria-label="Expanded search aggregation chart"] [aria-label="chart content group"] g:nth-child(2) a'
+            )
             await driver.page.click(
                 '[aria-label="Expanded search aggregation chart"] [aria-label="chart content group"] g:nth-child(2) a'
             )


### PR DESCRIPTION
This PR simply tries to tune element selectors in the aggregation test to avoid false positive fails, A bit statistic. I run this flaky test 30 times locally with this PR fix and without it (the current version into the main branch) 

*Second-try passes - the number of tests in which the first run failed but the second run passed. 

| First Header | Run | Fails |  Second-try passes | 
| ------------- | ------------- | ------------- | ------------- |
| Main  | 30 | 2  | 3 |
| This PR  | 30 | 0  | 0 |

## Test plan
- N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-flaky-aggregation.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-menublgxbn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
