### PR TITLE
licensing: bundle Code Insights to new plans

### DIFF
--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -95,9 +95,11 @@ var planFeatures = map[Plan][]Feature{
 
 	business0: {
 		FeatureSSO,
+		FeatureCodeInsights,
 	},
 	enterprise1: {
 		FeatureSSO,
+		FeatureCodeInsights,
 	},
 }
 

--- a/enterprise/internal/licensing/features_test.go
+++ b/enterprise/internal/licensing/features_test.go
@@ -120,6 +120,9 @@ func TestCheckFeature(t *testing.T) {
 			check(t, feature, license(plan(team)), false)
 			check(t, feature, license(plan(enterprise0)), false)
 			check(t, feature, license(plan(enterprise0), string(feature)), true)
+
+			check(t, feature, license(plan(business0)), true)
+			check(t, feature, license(plan(enterprise1)), true)
 		}
 	}
 	// Code Insights


### PR DESCRIPTION
This PR bundles the Code Insights into the new "business-0" and "enterprise-1" plans per 4.0 packaging.

## Test plan

Unit test

---

Part of https://github.com/sourcegraph/sourcegraph/issues/40064