### PR TITLE
licensing: only print errors when SSO is actually configured without a license

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
@@ -22,22 +22,23 @@ func Init(db database.DB) {
 	logger := log.Scoped(pkgName, "GitHub OAuth config watch")
 	go func() {
 		conf.Watch(func() {
-			if err := licensing.Check(licensing.FeatureSSO); err != nil {
-				logger.Warn("Check license for SSO (GitHub OAuth)", log.Error(err))
+			newProviders, _ := parseConfig(conf.Get(), db)
+			if len(newProviders) == 0 {
 				providers.Update(pkgName, nil)
 				return
 			}
 
-			newProviders, _ := parseConfig(conf.Get(), db)
-			if len(newProviders) == 0 {
+			if err := licensing.Check(licensing.FeatureSSO); err != nil {
+				logger.Error("Check license for SSO (GitHub OAuth)", log.Error(err))
 				providers.Update(pkgName, nil)
-			} else {
-				newProvidersList := make([]providers.Provider, 0, len(newProviders))
-				for _, p := range newProviders {
-					newProvidersList = append(newProvidersList, p.Provider)
-				}
-				providers.Update(pkgName, newProvidersList)
+				return
 			}
+
+			newProvidersList := make([]providers.Provider, 0, len(newProviders))
+			for _, p := range newProviders {
+				newProvidersList = append(newProvidersList, p.Provider)
+			}
+			providers.Update(pkgName, newProvidersList)
 		})
 	}()
 }

--- a/enterprise/cmd/frontend/internal/auth/httpheader/config.go
+++ b/enterprise/cmd/frontend/internal/auth/httpheader/config.go
@@ -33,14 +33,14 @@ func Init() {
 	logger := log.Scoped(pkgName, "HTTP header authentication config watch")
 	go func() {
 		conf.Watch(func() {
-			if err := licensing.Check(licensing.FeatureSSO); err != nil {
-				logger.Warn("Check license for SSO (HTTP header)", log.Error(err))
+			newPC, _ := getProviderConfig()
+			if newPC == nil {
 				providers.Update(pkgName, nil)
 				return
 			}
 
-			newPC, _ := getProviderConfig()
-			if newPC == nil {
+			if err := licensing.Check(licensing.FeatureSSO); err != nil {
+				logger.Error("Check license for SSO (HTTP header)", log.Error(err))
 				providers.Update(pkgName, nil)
 				return
 			}


### PR DESCRIPTION
Previously, we would print a warning whenever there is a change to the site configuration, which is annoying and pretty much unactionable.

Now we only print errors when the instance tries to configure SSO without a license, which is actionable (i.e. delete SSO configurations). 

## Test plan

Manually tested with and without a license.
