### PR TITLE
frontend: wrap watch error with path for config overrides

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -396,7 +396,7 @@ func watchPaths(ctx context.Context, paths ...string) (<-chan error, error) {
 			continue
 		}
 		if err := watcher.Add(p); err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed to add %s to watcher", p)
 		}
 	}
 


### PR DESCRIPTION
This is currently failing in production with a very opaque error:

```
error="no such file or directory"
```

Test Plan: go test