### PR TITLE
codeintel: Change default index limit in moniker search

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/config.go
+++ b/enterprise/cmd/frontend/internal/codeintel/config.go
@@ -19,7 +19,7 @@ func (c *Config) Load() {
 	c.LSIFUploadStoreConfig.Load()
 
 	c.HunkCacheSize = c.GetInt("PRECISE_CODE_INTEL_HUNK_CACHE_SIZE", "1000", "The capacity of the git diff hunk cache.")
-	c.MaximumIndexesPerMonikerSearch = c.GetInt("PRECISE_CODE_INTEL_MAXIMUM_INDEXES_PER_MONIKER_SEARCH", "50", "The maximum number of indexes to search at once when doing cross-index code navigation.")
+	c.MaximumIndexesPerMonikerSearch = c.GetInt("PRECISE_CODE_INTEL_MAXIMUM_INDEXES_PER_MONIKER_SEARCH", "500", "The maximum number of indexes to search at once when doing cross-index code navigation.")
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/33909#issuecomment-1228530544.

## Test plan

This limit has been active in prod for a while now.