### PR TITLE
cmd/gitserver/server: Extract arg to conf.Cached into a func for testability

### DIFF
--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -102,9 +102,9 @@ type tlsConfig struct {
 	SSLCAInfo string
 }
 
-// getTlsExternal exists as a function instead of being passed directly to conf.Cached below so just
-// so that we can test it.
-func getTlsExternal() *tlsConfig {
+// getTlsExternalDoNotInvoke as the name suggests, exists as a function instead of being passed
+// directly to conf.Cached below just so that we can test it.
+func getTlsExternalDoNotInvoke() *tlsConfig {
 	exp := conf.ExperimentalFeatures()
 	c := exp.TlsExternal
 
@@ -139,7 +139,7 @@ func getTlsExternal() *tlsConfig {
 // tlsExternal will create a new cache for this gitserer process and store the certificates set in
 // the site config.
 // This creates a long lived
-var tlsExternal = conf.Cached(getTlsExternal)
+var tlsExternal = conf.Cached(getTlsExternalDoNotInvoke)
 
 // runWith runs the command after applying the remote options. If progress is not
 // nil, all output is written to it in a separate goroutine.

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -139,7 +139,7 @@ func getTlsExternal() *tlsConfig {
 // tlsExternal will create a new cache for this gitserer process and store the certificates set in
 // the site config.
 // This creates a long lived
-var tlsExternal = conf.Cached(getTlsExternal)()
+var tlsExternal = conf.Cached(getTlsExternal)
 
 // runWith runs the command after applying the remote options. If progress is not
 // nil, all output is written to it in a separate goroutine.
@@ -150,7 +150,7 @@ func runWith(ctx context.Context, cmd *exec.Cmd, configRemoteOpts bool, progress
 		if cmd.Env == nil {
 			cmd.Env = os.Environ()
 		}
-		configureRemoteGitCommand(cmd, tlsExternal)
+		configureRemoteGitCommand(cmd, tlsExternal())
 	}
 
 	var b interface {

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -144,7 +144,6 @@ var tlsExternal = conf.Cached(getTlsExternal)()
 // runWith runs the command after applying the remote options. If progress is not
 // nil, all output is written to it in a separate goroutine.
 func runWith(ctx context.Context, cmd *exec.Cmd, configRemoteOpts bool, progress io.Writer) ([]byte, error) {
-
 	if configRemoteOpts {
 		// Inherit process environment. This allows admins to configure
 		// variables like http_proxy/etc.

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -9,7 +10,47 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
+
+func TestGetTlsExternal(t *testing.T) {
+	t.Run("test multiple certs", func(t *testing.T) {
+		conf.Mock(&conf.Unified{
+			SiteConfiguration: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					TlsExternal: &schema.TlsExternal{
+						Certificates: []string{
+							"foo",
+							"bar",
+							"baz",
+						},
+					},
+				},
+			},
+		})
+
+		tls := getTlsExternal()
+
+		if tls.SSLNoVerify {
+			t.Error("expected SSLNoVerify to be false, but got true")
+		}
+
+		got, err := os.ReadFile(tls.SSLCAInfo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want := `foo
+bar
+baz
+`
+
+		if diff := cmp.Diff(want, string(got)); diff != "" {
+			t.Errorf("mismatch in contenst of SSLCAInfo file (-want +got):\n%s", diff)
+		}
+	})
+}
 
 func TestConfigureRemoteGitCommand(t *testing.T) {
 	expectedEnv := []string{

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -30,7 +30,7 @@ func TestGetTlsExternal(t *testing.T) {
 			},
 		})
 
-		tls := getTlsExternal()
+		tls := getTlsExternalDoNotInvoke()
 
 		if tls.SSLNoVerify {
 			t.Error("expected SSLNoVerify to be false, but got true")

--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -139,7 +139,9 @@ func Watch(f func()) {
 // Cached will return a wrapper around f which caches the response. The value
 // will be recomputed every time the config is updated.
 //
-// IMPORTANT: The first call to wrapped will block on config initialization.
+// IMPORTANT: The first call to wrapped will block on config initialization.  It will also create a
+// long lived goroutine when DefaultClient().Cached is invoked. As a result it's important to NEVER
+// call it inside a function to avoid unbounded goroutines that never return.
 func Cached[T any](f func() T) (wrapped func() T) {
 	g := func() any {
 		return f()


### PR DESCRIPTION
Making this into a function allows us to test the code to guarantee
that multiple certificates configured in the config are written into
the SSLCAInfo file correctly.

Also we don't need the type hint anymore since the type is now inferred
from the return type of the function itself. Which makes the code easier
to read.

Change inspiration out of looking into https://github.com/sourcegraph/customer/issues/1136 and https://github.com/sourcegraph/sourcegraph/issues/38128 respectively this week.



## Test plan

Added a test case.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
