### PR TITLE
src-cli: Fix version output

### DIFF
--- a/cmd/frontend/internal/httpapi/src_cli.go
+++ b/cmd/frontend/internal/httpapi/src_cli.go
@@ -173,7 +173,9 @@ func (h *srcCliVersionHandler) handleDownload(w http.ResponseWriter, r *http.Req
 }
 
 func (h *srcCliVersionHandler) handleVersion(w http.ResponseWriter) {
-	writeJSON(w, h.Version())
+	writeJSON(w, struct {
+		Version string `json:"version"`
+	}{Version: h.Version()})
 }
 
 func isExpectedRelease(filename string) bool {

--- a/cmd/frontend/internal/httpapi/src_cli_test.go
+++ b/cmd/frontend/internal/httpapi/src_cli_test.go
@@ -71,7 +71,7 @@ func TestSrcCliVersionHandler_ServeHTTP(t *testing.T) {
 
 		handler.ServeHTTP(rec, req)
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "\"3.42.1\"\n", rec.Body.String())
+		assert.Equal(t, `{"version":"3.42.1"}`+"\n", rec.Body.String())
 	})
 
 	t.Run("download", func(t *testing.T) {


### PR DESCRIPTION
`src version` attempts to read this shape of struct from the Sourcegraph API. This seems like a regression from #40828 (see [here](https://github.com/sourcegraph/sourcegraph/pull/40828/files#r955966089)).

## Test plan

Updated unit tests.