### PR TITLE
Finalize deprecation of api.ExternalService type

### DIFF
--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -7,7 +7,6 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -124,7 +123,7 @@ func ExternalServiceKindSupported(kind string) error {
 // result instead of using the entire repoupdater client implementation, we use a thinner API which
 // only needs the SyncExternalService method to be defined on the object.
 type repoupdaterClient interface {
-	SyncExternalService(ctx context.Context, svc api.ExternalService) (*protocol.ExternalServiceSyncResult, error)
+	SyncExternalService(ctx context.Context, externalServiceID int64) (*protocol.ExternalServiceSyncResult, error)
 }
 
 // SyncExternalService will eagerly trigger a repo-updater sync. It accepts a
@@ -149,11 +148,6 @@ func SyncExternalService(ctx context.Context, svc *types.ExternalService, timeou
 		}
 	}()
 
-	apiService, err := svc.ToAPIService(ctx)
-	if err != nil {
-		return err
-	}
-
-	_, err = client.SyncExternalService(ctx, apiService)
+	_, err = client.SyncExternalService(ctx, svc.ID)
 	return err
 }

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -191,7 +192,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	logger := s.Logger.With(log.Object("ExternalService",
-		log.Int64("id", req.ExternalService.ID), log.String("kind", req.ExternalService.Kind)),
+		log.Int64("id", req.ExternalServiceID)),
 	)
 
 	var sourcer repos.Sourcer
@@ -202,9 +203,6 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	}
 
 	externalServiceID := req.ExternalServiceID
-	if externalServiceID == 0 {
-		externalServiceID = req.ExternalService.ID
-	}
 
 	// We want to get soft-deleted external services as well, since we do a final
 	// sync when an external service gets deleted.
@@ -229,7 +227,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	err = externalServiceValidate(ctx, req, src)
+	err = externalServiceValidate(ctx, es[0], src)
 	if err == github.ErrIncompleteResults {
 		logger.Info("server.external-service-sync", log.Error(err))
 		syncResult := &protocol.ExternalServiceSyncResult{
@@ -255,13 +253,13 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	}
 
 	if s.RateLimitSyncer != nil {
-		err = s.RateLimitSyncer.SyncRateLimiters(ctx, req.ExternalService.ID)
+		err = s.RateLimitSyncer.SyncRateLimiters(ctx, req.ExternalServiceID)
 		if err != nil {
 			logger.Warn("Handling rate limiter sync", log.Error(err))
 		}
 	}
 
-	if err := s.Syncer.TriggerExternalServiceSync(ctx, req.ExternalService.ID); err != nil {
+	if err := s.Syncer.TriggerExternalServiceSync(ctx, req.ExternalServiceID); err != nil {
 		logger.Warn("Enqueueing external service sync job", log.Error(err))
 	}
 
@@ -269,8 +267,8 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	s.respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{})
 }
 
-func externalServiceValidate(ctx context.Context, req protocol.ExternalServiceSyncRequest, src repos.Source) error {
-	if !req.ExternalService.DeletedAt.IsZero() {
+func externalServiceValidate(ctx context.Context, es *types.ExternalService, src repos.Source) error {
+	if !es.DeletedAt.IsZero() {
 		// We don't need to check deleted services.
 		return nil
 	}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -821,7 +821,7 @@ func TestExternalServiceValidate_ValidatesToken(t *testing.T) {
 			return nil
 		},
 	}
-	err := externalServiceValidate(ctx, protocol.ExternalServiceSyncRequest{}, src)
+	err := externalServiceValidate(ctx, &types.ExternalService{}, src)
 	if err != nil {
 		t.Errorf("expected nil, got %v", err)
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -157,24 +157,6 @@ type Settings struct {
 	CreatedAt    time.Time       // the date when this settings value was created
 }
 
-// ExternalService represents a complete external service record.
-// TODO(eseliger): Remove this post the 3.43 release.
-type ExternalService struct {
-	ID              int64
-	Kind            string
-	DisplayName     string
-	Config          string
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
-	DeletedAt       time.Time
-	LastSyncAt      time.Time
-	NextSyncAt      time.Time
-	NamespaceUserID int32
-	NamespaceOrgID  int32
-	Unrestricted    bool
-	CloudDefault    bool
-}
-
 func cmp(a, b string) int {
 	switch {
 	case a < b:

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -235,11 +235,8 @@ func (c *Client) SchedulePermsSync(ctx context.Context, args protocol.PermsSyncR
 }
 
 // SyncExternalService requests the given external service to be synced.
-func (c *Client) SyncExternalService(
-	ctx context.Context,
-	svc api.ExternalService,
-) (*protocol.ExternalServiceSyncResult, error) {
-	req := &protocol.ExternalServiceSyncRequest{ExternalServiceID: svc.ID, ExternalService: svc}
+func (c *Client) SyncExternalService(ctx context.Context, externalServiceID int64) (*protocol.ExternalServiceSyncResult, error) {
+	req := &protocol.ExternalServiceSyncRequest{ExternalServiceID: externalServiceID}
 	resp, err := c.httpPost(ctx, "sync-external-service", req)
 	if err != nil {
 		return nil, err

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -261,8 +261,6 @@ type PermsSyncResponse struct {
 // updating an external service so that admins don't have to wait until the next sync
 // run to see their repos being synced.
 type ExternalServiceSyncRequest struct {
-	// TODO(eseliger): We can remove this after the 3.43 release, it's for backwards compatibility only.
-	ExternalService   api.ExternalService
 	ExternalServiceID int64
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -680,29 +680,6 @@ func (e *ExternalService) With(opts ...func(*ExternalService)) *ExternalService 
 	return clone
 }
 
-func (e *ExternalService) ToAPIService(ctx context.Context) (api.ExternalService, error) {
-	rawConfig, err := e.Config.Decrypt(ctx)
-	if err != nil {
-		return api.ExternalService{}, err
-	}
-
-	return api.ExternalService{
-		ID:              e.ID,
-		Kind:            e.Kind,
-		DisplayName:     e.DisplayName,
-		Config:          rawConfig,
-		CreatedAt:       e.CreatedAt,
-		UpdatedAt:       e.UpdatedAt,
-		DeletedAt:       e.DeletedAt,
-		LastSyncAt:      e.LastSyncAt,
-		NextSyncAt:      e.NextSyncAt,
-		NamespaceUserID: e.NamespaceUserID,
-		NamespaceOrgID:  e.NamespaceOrgID,
-		Unrestricted:    e.Unrestricted,
-		CloudDefault:    e.CloudDefault,
-	}, nil
-}
-
 // ExternalServices is a utility type with convenience methods for operating on
 // lists of ExternalServices.
 type ExternalServices []*ExternalService


### PR DESCRIPTION
I removed the code paths using it in 3.43, so we're good now to get rid of the fallback. We no longer need to transfer the entire external service.



## Test plan

Test suite and manually started the stack to see if it hiccups.