### PR TITLE
Clean up codehost add page

### DIFF
--- a/doc/admin/external_service/gitolite.md
+++ b/doc/admin/external_service/gitolite.md
@@ -1,5 +1,7 @@
 # Gitolite
 
+> NOTE: While it is possible to connect Gitolite repositories to Sourcegraph, we currently do not recommend it. If you have specific questions, please discuss with your account team. 
+
 Site admins can link and sync Git repositories on [Gitolite](https://gitolite.com) with Sourcegraph so that users can search and navigate the repositories.
 
 To connect Gitolite to Sourcegraph:

--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -8,9 +8,9 @@ Sourcegraph can sync repositories from code hosts and other similar services.
 - [GitLab](gitlab.md)
 - [Bitbucket Cloud](bitbucket_cloud.md)
 - [Bitbucket Server / Bitbucket Data Center](bitbucket_server.md) or Bitbucket Data Center
-- [Phabricator](phabricator.md)
-- [Gitolite](gitolite.md)
-- [AWS CodeCommit](aws_codecommit.md)
+<!-- [Phabricator](phabricator.md) -->
+<!-- [Gitolite](gitolite.md) -->
+<!-- [AWS CodeCommit](aws_codecommit.md) -->
 - [Other Git code hosts (using a Git URL)](other.md)
 - [Non-Git code hosts](non-git.md)
   - [Perforce](../repo/perforce.md)

--- a/doc/admin/repo/add.md
+++ b/doc/admin/repo/add.md
@@ -1,13 +1,13 @@
 # Add repositories (from code hosts) to Sourcegraph
 
-- [Add repositories from a code host](../external_service/index.md) (GitHub, GitLab, Bitbucket Server, Bitbucket Data Center, AWS CodeCommit, Phabricator, or Gitolite)
+- [Add repositories from a code host](../external_service/index.md) (GitHub (Cloud or Self-hosted), GitLab (Cloud or Self-hosted), Bitbucket Server, Bitbucket Data Center, or Perforce)
   - [GitHub](../external_service/github.md)
   - [GitLab](../external_service/gitlab.md)
   - [Bitbucket Cloud](../external_service/bitbucket_cloud.md)
   - [Bitbucket Server / Bitbucket Data Center](../external_service/bitbucket_server.md) or Bitbucket Data Center
-  - [Phabricator](../external_service/phabricator.md)
-  - [Gitolite](../external_service/gitolite.md)
-  - [AWS CodeCommit](../external_service/aws_codecommit.md)
+<!--    - [Phabricator](../external_service/phabricator.md) -->
+<!--   - [Gitolite](../external_service/gitolite.md) -->
+<!--    - [AWS CodeCommit](../external_service/aws_codecommit.md) -->
 - [Add repositories by Git clone URLs](../external_service/other.md)
 - [Add repositories from non-Git code hosts](../external_service/non-git.md)
   - [Add Perforce repositories](perforce.md)

--- a/doc/admin/repo/add_from_local_disk.md
+++ b/doc/admin/repo/add_from_local_disk.md
@@ -1,7 +1,0 @@
----
-ignoreDisconnectedPageCheck: true
----
-
-# Pre-load repositories already cloned to disk
-
-This documentation page has been moved to "[Pre-load repositories already cloned to disk](pre_load_from_local_disk.md)".

--- a/doc/dev/how-to/index.md
+++ b/doc/dev/how-to/index.md
@@ -35,12 +35,12 @@
 - [How to run tests](testing.md)
    - See also [Testing Principles](../background-information/testing_principles.md) and [Continuous Integration](../background-information/ci/index.md)
 - [Configure a test instance of Phabricator and Gitolite](configure_phabricator_gitolite.md)
-- [Test a Phabricator and Gitolite instance](test_phabricator.md)
+<!-- [Test a Phabricator and Gitolite instance](test_phabricator.md) -->
 - [How to test changes in dogfood](testing_in_dogfood.md)
 - [How to use client app PR previews](client_pr_previews.md)
 - [How to receive a Slack notification if a specific CI step failed](receive_slack_notification_on_a_failed_ci_step.md)
 - [How to allow a CI step to fail without breaking the build and still receive a notification](ci_soft_failure_and_still_notify.md)
-- [Sync repositories from gitolite.sgdev.org](sync_repositories_from_gitolite_sgdev_org.md)
+<!-- [Sync repositories from gitolite.sgdev.org](sync_repositories_from_gitolite_sgdev_org.md) -->
 
 ## Profiling
 

--- a/doc/integration/aws_codecommit.md
+++ b/doc/integration/aws_codecommit.md
@@ -1,3 +1,7 @@
+---
+ignoreDisconnectedPageCheck: true
+---
+
 # AWS CodeCommit integration with Sourcegraph
 
 You can use Sourcegraph with Git repositories hosted on [AWS CodeCommit](https://aws.amazon.com/codecommit/).

--- a/doc/integration/gitolite.md
+++ b/doc/integration/gitolite.md
@@ -1,3 +1,7 @@
+---
+ignoreDisconnectedPageCheck: true
+---
+
 # Gitolite integration with Sourcegraph
 
 You can use Sourcegraph with [Gitolite](http://gitolite.com/).

--- a/doc/integration/index.md
+++ b/doc/integration/index.md
@@ -9,9 +9,9 @@ Sourcegraph integrates with your other tools to help you search, navigate, and r
   - [GitLab](gitlab.md)
   - [Bitbucket Cloud](bitbucket_cloud.md)
   - [Bitbucket Server / Bitbucket Data Center](bitbucket_server.md)
-  - [Phabricator](phabricator.md)
-  - [AWS CodeCommit](aws_codecommit.md)
-  - [Gitolite](gitolite.md)
+<!--  - [Phabricator](phabricator.md) -->
+<!--  - [AWS CodeCommit](aws_codecommit.md) -->
+<!--  - [Gitolite](gitolite.md) -->
   - [JVM dependencies](jvm.md)
   - [npm dependencies](npm.md)
   - [Python dependencies](python.md)


### PR DESCRIPTION
Cleaning up a few links on adding code hosts. 


## Test plan
Docs change only. Ran linter locally.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
