### PR TITLE
Aggregation: Improve error states for aggregation UI

### DIFF
--- a/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
@@ -1,5 +1,18 @@
 .container {
     position: relative;
+    overflow: auto;
+}
+
+.error-container {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+}
+
+.error {
+    overflow: auto;
+    margin: 0;
+    margin-bottom: 0.5rem;
 }
 
 .chart-overlay {
@@ -13,6 +26,7 @@
     justify-content: center;
     color: var(--text-muted);
     padding: 1rem;
+    overflow: auto;
 }
 
 .missing-label-count {

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
@@ -3,30 +3,29 @@
     overflow: auto;
 }
 
+// Container for both errors (business-like and internal error alerts messages)
 .error-container {
     display: flex;
     flex-direction: column;
-    margin: 0;
-}
-
-.error {
     overflow: auto;
     margin: 0;
-    margin-bottom: 0.5rem;
+
+    // Small mode is used for side panel (the standard size is used for the full UI)
+    &--small {
+        font-size: 0.75rem;
+    }
 }
 
-.chart-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-muted);
-    padding: 1rem;
+// Internal error-alert UI
+.error-alert {
+    margin: 0 0 0.5rem 0;
     overflow: auto;
+}
+
+// Custom search availability error message UI
+.error-message {
+    margin: auto;
+    padding: 0 0.5rem;
 }
 
 .missing-label-count {

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -3,10 +3,11 @@ import { HTMLAttributes, ReactElement, MouseEvent } from 'react'
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
 
+import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { SearchAggregationMode } from '@sourcegraph/shared/src/graphql-operations'
 import { Text, Link, Tooltip } from '@sourcegraph/wildcard'
 
-import { SearchAggregationDatum } from '../../graphql-operations'
+import { GetSearchAggregationResult, SearchAggregationDatum } from '../../graphql-operations'
 
 import { AggregationChart } from './AggregationChart'
 
@@ -17,48 +18,88 @@ const getValue = (datum: SearchAggregationDatum): number => datum.count
 const getColor = (datum: SearchAggregationDatum): string => (datum.label ? 'var(--primary)' : 'var(--text-muted)')
 const getLink = (datum: SearchAggregationDatum): string => datum.query ?? ''
 
-export enum AggregationCardMode {
-    Data,
-    Loading,
-    Error,
+/**
+ * Nested aggregation results types from {@link AGGREGATION_SEARCH_QUERY} GQL query
+ */
+type SearchAggregationResult = GetSearchAggregationResult['searchQueryAggregate']['aggregations']
+
+function getAggregationError(aggregation?: SearchAggregationResult): Error | undefined {
+    if (aggregation?.__typename === 'SearchAggregationNotAvailable') {
+        return new Error(aggregation.reason)
+    }
+
+    return
 }
 
-type AggregationChartCardStateProps =
-    | { type: AggregationCardMode.Data; data: SearchAggregationDatum[] }
-    | { type: AggregationCardMode.Loading }
-    | { type: AggregationCardMode.Error; errorMessage: string }
+export function getAggregationData(aggregations: SearchAggregationResult): SearchAggregationDatum[] {
+    switch (aggregations?.__typename) {
+        case 'ExhaustiveSearchAggregationResult':
+        case 'NonExhaustiveSearchAggregationResult':
+            return aggregations.groups
 
-interface AggregationChartCardSharedProps extends HTMLAttributes<HTMLDivElement> {
+        default:
+            return []
+    }
+}
+
+export function getOtherGroupCount(aggregations: SearchAggregationResult): number {
+    switch (aggregations?.__typename) {
+        case 'ExhaustiveSearchAggregationResult':
+            return aggregations.otherGroupCount ?? 0
+        case 'NonExhaustiveSearchAggregationResult':
+            return aggregations.approximateOtherGroupCount ?? 0
+
+        default:
+            return 0
+    }
+}
+
+interface AggregationChartCardProps extends HTMLAttributes<HTMLDivElement> {
+    data?: SearchAggregationResult
+    error?: Error
+    loading: boolean
     mode?: SearchAggregationMode | null
-    missingCount?: number
     onBarLinkClick?: (query: string) => void
 }
 
-type AggregationChartCardProps = AggregationChartCardSharedProps & AggregationChartCardStateProps
+export function AggregationChartCard(props: AggregationChartCardProps): ReactElement | null {
+    const { data, error, loading, mode, className, onBarLinkClick, 'aria-label': ariaLabel } = props
 
-export function AggregationChartCard(props: AggregationChartCardProps): ReactElement {
-    const { type, mode, className, missingCount, onBarLinkClick, 'aria-label': ariaLabel } = props
-
-    const handleDatumLinkClick = (event: MouseEvent, datum: SearchAggregationDatum): void => {
-        event.preventDefault()
-        onBarLinkClick?.(getLink(datum))
+    if (error) {
+        return (
+            <div className={classNames(className, styles.errorContainer)}>
+                <ErrorAlert className={styles.error} error={error} />
+            </div>
+        )
     }
 
-    if (type === AggregationCardMode.Loading || type === AggregationCardMode.Error) {
+    const aggregationError = getAggregationError(data)
+
+    if (loading || aggregationError) {
         return (
             <div className={classNames(styles.container, className)}>
                 <div className={styles.chartOverlay}>
-                    {type === AggregationCardMode.Loading ? (
+                    {loading ? (
                         'Loading...'
-                    ) : (
+                    ) : aggregationError ? (
                         <div>
-                            We couldn’t provide aggregation for this query. {props.errorMessage}.{' '}
+                            We couldn’t provide aggregation for this query. {aggregationError?.message}.{' '}
                             <Link to="">Learn more</Link>
                         </div>
-                    )}
+                    ) : null}
                 </div>
             </div>
         )
+    }
+
+    if (!data) {
+        return null
+    }
+
+    const missingCount = getOtherGroupCount(data)
+    const handleDatumLinkClick = (event: MouseEvent, datum: SearchAggregationDatum): void => {
+        event.preventDefault()
+        onBarLinkClick?.(getLink(datum))
     }
 
     return (
@@ -69,7 +110,7 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
                         aria-label={ariaLabel}
                         width={parent.width}
                         height={parent.height}
-                        data={props.data}
+                        data={getAggregationData(data)}
                         mode={mode}
                         getDatumValue={getValue}
                         getDatumColor={getColor}

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -3,7 +3,7 @@ import { HTMLAttributes, ReactElement, MouseEvent } from 'react'
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
 
-import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { ErrorAlert, ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
 import { SearchAggregationMode } from '@sourcegraph/shared/src/graphql-operations'
 import { Text, Link, Tooltip } from '@sourcegraph/wildcard'
 
@@ -59,16 +59,22 @@ interface AggregationChartCardProps extends HTMLAttributes<HTMLDivElement> {
     error?: Error
     loading: boolean
     mode?: SearchAggregationMode | null
+    size?: 'sm' | 'md'
     onBarLinkClick?: (query: string) => void
 }
 
 export function AggregationChartCard(props: AggregationChartCardProps): ReactElement | null {
-    const { data, error, loading, mode, className, onBarLinkClick, 'aria-label': ariaLabel } = props
+    const { data, error, loading, mode, className, size = 'sm', 'aria-label': ariaLabel, onBarLinkClick } = props
 
+    // Internal error
     if (error) {
         return (
-            <div className={classNames(className, styles.errorContainer)}>
-                <ErrorAlert className={styles.error} error={error} />
+            <div
+                className={classNames(className, styles.errorContainer, {
+                    [styles.errorContainerSmall]: size === 'sm',
+                })}
+            >
+                <ErrorAlert error={error} className={styles.errorAlert} />
             </div>
         )
     }
@@ -77,15 +83,19 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
 
     if (loading || aggregationError) {
         return (
-            <div className={classNames(styles.container, className)}>
-                <div className={styles.chartOverlay}>
+            <div
+                className={classNames(styles.errorContainer, className, {
+                    [styles.errorContainerSmall]: size === 'sm',
+                })}
+            >
+                <div className={styles.errorMessage}>
                     {loading ? (
                         'Loading...'
                     ) : aggregationError ? (
-                        <div>
-                            We couldn’t provide aggregation for this query. {aggregationError?.message}.{' '}
-                            <Link to="">Learn more</Link>
-                        </div>
+                        <>
+                            We couldn’t provide an aggregation for this query. <ErrorMessage error={aggregationError} />
+                            . <Link to="">Learn more</Link>
+                        </>
                     ) : null}
                 </div>
             </div>

--- a/client/search-ui/src/results/aggregation/AggregationModeControls.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationModeControls.tsx
@@ -25,6 +25,15 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
         return store
     }, {} as Partial<Record<SearchAggregationMode, SearchAggregationModeAvailability>>)
 
+    const isModeAvailable = (mode: SearchAggregationMode): boolean => {
+        const isAvailable = availabilityGroups[mode]?.available
+
+        // Returns true by default because we don't want to disable all modes
+        // in case if we don't have availability information from the backend
+        // (for example in case of network request failure)
+        return isAvailable ?? true
+    }
+
     return (
         <div
             {...attributes}
@@ -37,7 +46,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     size={size}
                     outline={mode !== SearchAggregationMode.REPO}
                     data-testid="repo-aggregation-mode"
-                    disabled={!availabilityGroups[SearchAggregationMode.REPO]?.available}
+                    disabled={!isModeAvailable(SearchAggregationMode.REPO)}
                     onClick={() => onModeChange(SearchAggregationMode.REPO)}
                 >
                     Repository
@@ -49,7 +58,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     variant="secondary"
                     size={size}
                     outline={mode !== SearchAggregationMode.PATH}
-                    disabled={!availabilityGroups[SearchAggregationMode.PATH]?.available}
+                    disabled={!isModeAvailable(SearchAggregationMode.PATH)}
                     data-testid="file-aggregation-mode"
                     onClick={() => onModeChange(SearchAggregationMode.PATH)}
                 >
@@ -62,7 +71,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     variant="secondary"
                     size={size}
                     outline={mode !== SearchAggregationMode.AUTHOR}
-                    disabled={!availabilityGroups[SearchAggregationMode.AUTHOR]?.available}
+                    disabled={!isModeAvailable(SearchAggregationMode.AUTHOR)}
                     data-testid="author-aggregation-mode"
                     onClick={() => onModeChange(SearchAggregationMode.AUTHOR)}
                 >
@@ -75,7 +84,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     variant="secondary"
                     size={size}
                     outline={mode !== SearchAggregationMode.CAPTURE_GROUP}
-                    disabled={!availabilityGroups[SearchAggregationMode.CAPTURE_GROUP]?.available}
+                    disabled={!isModeAvailable(SearchAggregationMode.CAPTURE_GROUP)}
                     data-testid="captureGroup-aggregation-mode"
                     onClick={() => onModeChange(SearchAggregationMode.CAPTURE_GROUP)}
                 >

--- a/client/search-ui/src/results/aggregation/SearchAggregationResult.tsx
+++ b/client/search-ui/src/results/aggregation/SearchAggregationResult.tsx
@@ -5,15 +5,9 @@ import { mdiArrowCollapse } from '@mdi/js'
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { Button, H2, Icon } from '@sourcegraph/wildcard'
 
-import { AggregationCardMode, AggregationChartCard } from './AggregationChartCard'
+import { AggregationChartCard, getAggregationData } from './AggregationChartCard'
 import { AggregationModeControls } from './AggregationModeControls'
-import {
-    getAggregationData,
-    getOtherGroupCount,
-    useAggregationSearchMode,
-    useAggregationUIMode,
-    useSearchAggregationData,
-} from './hooks'
+import { useAggregationSearchMode, useAggregationUIMode, useSearchAggregationData } from './hooks'
 import { AggregationUIMode } from './types'
 
 import styles from './SearchAggregationResult.module.scss'
@@ -73,34 +67,19 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
                 />
             </div>
 
-            {loading ? (
-                <AggregationChartCard
-                    aria-label="Expanded search aggregation chart"
-                    type={AggregationCardMode.Loading}
-                    className={styles.chartContainer}
-                />
-            ) : error ? (
-                <AggregationChartCard
-                    aria-label="Expanded search aggregation chart"
-                    type={AggregationCardMode.Error}
-                    errorMessage={error.message}
-                    className={styles.chartContainer}
-                />
-            ) : (
-                <AggregationChartCard
-                    aria-label="Expanded search aggregation chart"
-                    mode={aggregationMode}
-                    type={AggregationCardMode.Data}
-                    data={getAggregationData(data)}
-                    missingCount={getOtherGroupCount(data)}
-                    className={styles.chartContainer}
-                    onBarLinkClick={onQuerySubmit}
-                />
-            )}
+            <AggregationChartCard
+                aria-label="Expanded search aggregation chart"
+                mode={aggregationMode}
+                data={data?.searchQueryAggregate?.aggregations}
+                loading={loading}
+                error={error}
+                className={styles.chartContainer}
+                onBarLinkClick={onQuerySubmit}
+            />
 
             {data && (
                 <ul className={styles.listResult}>
-                    {getAggregationData(data).map(datum => (
+                    {getAggregationData(data.searchQueryAggregate.aggregations).map(datum => (
                         <li key={datum.label} className={styles.listResultItem}>
                             <span>{datum.label}</span>
                             <span>{datum.count}</span>

--- a/client/search-ui/src/results/aggregation/SearchAggregationResult.tsx
+++ b/client/search-ui/src/results/aggregation/SearchAggregationResult.tsx
@@ -73,6 +73,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
                 data={data?.searchQueryAggregate?.aggregations}
                 loading={loading}
                 error={error}
+                size="md"
                 className={styles.chartContainer}
                 onBarLinkClick={onQuerySubmit}
             />

--- a/client/search-ui/src/results/aggregation/hooks.ts
+++ b/client/search-ui/src/results/aggregation/hooks.ts
@@ -202,6 +202,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
             skip: aggregationMode !== null && calculatedAggregationModeRef.current === aggregationMode,
             onError: () => {
                 calculatedAggregationModeRef.current = null
+                setData(undefined)
             },
             onCompleted: data => {
                 const calculatedAggregationMode = getCalculatedAggregationMode(data)

--- a/client/search-ui/src/results/aggregation/hooks.ts
+++ b/client/search-ui/src/results/aggregation/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { ApolloError, gql, useQuery } from '@apollo/client'
 import { useHistory, useLocation } from 'react-router'
@@ -185,12 +185,24 @@ type SearchAggregationResults =
 export const useSearchAggregationData = (input: SearchAggregationDataInput): SearchAggregationResults => {
     const { query, patternType, aggregationMode, limit } = input
 
+    const calculatedAggregationModeRef = useRef<SearchAggregationMode | null>(null)
     const [, setAggregationMode] = useAggregationSearchMode()
-    const { data, error, loading } = useQuery<GetSearchAggregationResult, GetSearchAggregationVariables>(
+
+    const [data, setData] = useState<GetSearchAggregationResult | undefined>()
+    const { error, loading } = useQuery<GetSearchAggregationResult, GetSearchAggregationVariables>(
         AGGREGATION_SEARCH_QUERY,
         {
             fetchPolicy: 'cache-first',
             variables: { query, patternType, mode: aggregationMode, limit },
+
+            // Skip extra API request when we had no aggregation mode, and then
+            // we got calculated aggregation mode from the BE. We should update
+            // FE aggregationMode but this shouldn't trigger AGGREGATION_SEARCH_QUERY
+            // fetching.
+            skip: aggregationMode !== null && calculatedAggregationModeRef.current === aggregationMode,
+            onError: () => {
+                calculatedAggregationModeRef.current = null
+            },
             onCompleted: data => {
                 const calculatedAggregationMode = getCalculatedAggregationMode(data)
 
@@ -205,12 +217,26 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
 
                 // Catch initial page mount when aggregation mode isn't set on the FE and BE
                 // calculated aggregation mode automatically on the backend based on given query
-                if (calculatedAggregationMode && aggregationMode === null) {
+                if (calculatedAggregationMode !== aggregationMode) {
                     setAggregationMode(calculatedAggregationMode)
                 }
+
+                // Preserve calculated aggregation mode in order to use it for skipping
+                // extra API calls in useQuery "skip" field.
+                calculatedAggregationModeRef.current = calculatedAggregationMode
+
+                // skip: true resets data field in the useQuery hook, in order to use previously
+                // saved data we use useState to store data outside useQuery hook
+                setData(data)
             },
         }
     )
+
+    useEffect(() => {
+        // If query or pattern type have been changed we should "reset" our assumptions
+        // about calculated aggregation mode and make another api call to determine it
+        calculatedAggregationModeRef.current = null
+    }, [query, patternType])
 
     if (loading) {
         return { data: undefined, error: undefined, loading: true }

--- a/client/search-ui/src/results/aggregation/index.ts
+++ b/client/search-ui/src/results/aggregation/index.ts
@@ -2,6 +2,6 @@ export * from './types'
 export * from './hooks'
 export * from './constants'
 
-export { AggregationChartCard, AggregationCardMode } from './AggregationChartCard'
+export { AggregationChartCard } from './AggregationChartCard'
 export { AggregationModeControls } from './AggregationModeControls'
 export { SearchAggregationResult } from './SearchAggregationResult'

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -10,11 +10,8 @@ import {
     AggregationUIMode,
     useAggregationSearchMode,
     useAggregationUIMode,
-    AggregationCardMode,
     AggregationChartCard,
     useSearchAggregationData,
-    getAggregationData,
-    getOtherGroupCount,
 } from '../aggregation'
 
 import styles from './SearchAggregations.module.scss'
@@ -55,30 +52,15 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                 onModeChange={setAggregationMode}
             />
 
-            {loading ? (
-                <AggregationChartCard
-                    aria-label="Sidebar search aggregation chart"
-                    type={AggregationCardMode.Loading}
-                    className={styles.chartContainer}
-                />
-            ) : error ? (
-                <AggregationChartCard
-                    aria-label="Sidebar search aggregation chart"
-                    type={AggregationCardMode.Error}
-                    errorMessage={error.message}
-                    className={styles.chartContainer}
-                />
-            ) : (
-                <AggregationChartCard
-                    aria-label="Sidebar search aggregation chart"
-                    mode={aggregationMode}
-                    type={AggregationCardMode.Data}
-                    data={getAggregationData(data)}
-                    missingCount={getOtherGroupCount(data)}
-                    className={styles.chartContainer}
-                    onBarLinkClick={onQuerySubmit}
-                />
-            )}
+            <AggregationChartCard
+                aria-label="Sidebar search aggregation chart"
+                data={data?.searchQueryAggregate?.aggregations}
+                loading={loading}
+                error={error}
+                mode={aggregationMode}
+                className={styles.chartContainer}
+                onBarLinkClick={onQuerySubmit}
+            />
 
             <footer className={styles.actions}>
                 <Button

--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -6,21 +6,21 @@ import { SearchAggregationMode, SearchGraphQlOperations } from '@sourcegraph/sea
 import { GetSearchAggregationResult } from '@sourcegraph/search-ui'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchEvent } from '@sourcegraph/shared/src/search/stream'
-import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
+import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import { WebGraphQlOperations } from '../graphql-operations'
 
-import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
+import { createWebIntegrationTestContext, WebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults } from './graphQlResults'
 import { createEditorAPI } from './utils'
 
-const aggregationDefaultMock: GetSearchAggregationResult = {
+const aggregationDefaultMock = (mode: SearchAggregationMode): GetSearchAggregationResult => ({
     searchQueryAggregate: {
         __typename: 'SearchQueryAggregate',
         aggregations: {
             __typename: 'ExhaustiveSearchAggregationResult',
-            mode: SearchAggregationMode.REPO,
+            mode,
             otherGroupCount: 100,
             groups: [
                 {
@@ -76,7 +76,8 @@ const aggregationDefaultMock: GetSearchAggregationResult = {
             },
         ],
     },
-}
+})
+
 const mockDefaultStreamEvents: SearchEvent[] = [
     {
         type: 'matches',
@@ -144,7 +145,7 @@ describe('Search aggregation', () => {
         })
         testContext.overrideGraphQL({
             ...commonSearchGraphQLResults,
-            GetSearchAggregation: () => aggregationDefaultMock,
+            GetSearchAggregation: ({ mode }) => aggregationDefaultMock(mode ?? SearchAggregationMode.REPO),
         })
         testContext.overrideSearchStreamEvents(mockDefaultStreamEvents)
     })

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -1181,7 +1181,7 @@ extend type Query {
     """
     Returns information about aggregating the potential results of a search query.
     """
-    searchQueryAggregate(query: String!, patternType: SearchPatternType!): SearchQueryAggregate
+    searchQueryAggregate(query: String!, patternType: SearchPatternType!): SearchQueryAggregate!
 }
 
 """
@@ -1207,7 +1207,7 @@ type SearchQueryAggregate {
     A result of aggregating a search query for the specified aggregation mode.
     Limit - is the maximum number of aggregation groups to return, this limit will not override any internal limits.
     """
-    aggregations(mode: SearchAggregationMode, limit: Int = 50): SearchAggregationResult
+    aggregations(mode: SearchAggregationMode, limit: Int = 50): SearchAggregationResult!
 }
 
 """


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/40940
Based on https://github.com/sourcegraph/sourcegraph/pull/40905

## Background
In aggregation UI we usually can have two types of errors 
- internal error that something happened with frontend service or network request
- business-logic errors when we can't run aggregation against current query (or we do not support some of pattern type value) 

Prior to this PR we use just muted text for all types of errors and put this text in a middle of the chart layout. 

In this PR we separate UI for different cases 

| Search is not available error  | Internal backend error |
| ------------- | ------------- |
| <img width="1158" alt="Screenshot 2022-08-26 at 17 59 24" src="https://user-images.githubusercontent.com/18492575/186948269-2b65bd6c-726d-46e0-88be-559118ce1905.png">  | <img width="1158" alt="Screenshot 2022-08-26 at 17 59 27" src="https://user-images.githubusercontent.com/18492575/186948314-ad31249c-6019-4d56-88ed-231dfc3d5d88.png">  |

## Tech note
In this PR as well we changed gql schema in order to avoid handling nested optional fields on the frontend. 

## Test plan
- Make sure that both side panel and full UI mode have a proper UI for both types of error
- Make sure that CI doesn't fail (This PR changes gql schema so it worth checking go tasks as well)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
