### PR TITLE
dev: enable OpenTelemetry by default in dev, improve tracer logging

### DIFF
--- a/doc/dev/how-to/otel_local_dev.md
+++ b/doc/dev/how-to/otel_local_dev.md
@@ -6,7 +6,8 @@ General OpenTelemetry export configuration is done via environment variables acc
 
 ## Collector
 
-`sg start otel` -> runs `otel-collector` and `jaeger`. Additional configuration can be provided to export to different destinations - for example, to configure a simple Honeycomb exporter, add the following to your `sg.config.overwrite.yaml`:
+`sg start otel` runs `otel-collector` and `jaeger`, and configures `otel-collector` to forward traces to Jaeger.
+Additional configuration can be provided to export to different destinations - for example, to configure a simple Honeycomb exporter, add the following to your `sg.config.overwrite.yaml`:
 
 ```yaml
 commands:
@@ -20,18 +21,7 @@ To learn more, see [`docker-images/opentelemetry-collector`](https://github.com/
 
 ## Configuration
 
-Set `dev-private` site config to use `"observability.tracing": { "type": "opentelemetry" }` to enable OpenTelemetry export for most services.
-
-To enable Zoekt OpenTelemetry, add the following to your `sg.config.overwrite.yaml`:
-
-```yaml
-commands:
-  zoekt-web-0: &zoekt_otel
-    JAEGER_DISABLED: true
-    OPENTELEMETRY_DISABLED: false
-  zoekt-web-1:
-    <<: *zoekt_otel
-```
+Set `dev-private` site config to use `"observability.tracing": { "type": "opentelemetry" }` to enable OpenTelemetry export for most services - this should be set by default in the latest versions of `dev-private`.
 
 ## Testing
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -420,7 +420,8 @@ commands:
       env GOBIN="${PWD}/.bin" go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver
     checkBinary: .bin/zoekt-webserver
     env:
-      JAEGER_DISABLED: false
+      JAEGER_DISABLED: true
+      OPENTELEMETRY_DISABLED: false
       GOGC: 25
 
   zoekt-web-0:
@@ -804,6 +805,7 @@ commandsets:
       - minio
       - codeintel-worker
       - codeintel-executor
+      - otel-collector
       - jaeger
       - grafana
       - prometheus
@@ -903,6 +905,7 @@ commandsets:
       - docker
     commands:
       - jaeger
+      - otel-collector
       - prometheus
       - grafana
       - postgres_exporter


### PR DESCRIPTION
Companion update to https://github.com/sourcegraph/dev-private/pull/42. Since observability components are not run by default in `sg start`, we also amend the error logging of the exporter to suppress issues unless `observability.tracing.debug` is enabled.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start`