### PR TITLE
Remove state from repos synced alert definition

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -11716,7 +11716,7 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (state) (rate(src_repoupdater_syncer_synced_repos_total[1m]))`
+Query: `max(rate(src_repoupdater_syncer_synced_repos_total[1m]))`
 
 </details>
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -112,7 +112,7 @@ func RepoUpdater() *monitoring.Dashboard {
 						{
 							Name:        "syncer_synced_repos",
 							Description: "repositories synced",
-							Query:       `max by (state) (rate(src_repoupdater_syncer_synced_repos_total[1m]))`,
+							Query:       `max(rate(src_repoupdater_syncer_synced_repos_total[1m]))`,
 							Warning: monitoring.Alert().LessOrEqual(0).
 								AggregateBy(monitoring.AggregatorMax).
 								For(syncDurationThreshold),


### PR DESCRIPTION
Remove `by (state)` from query definition to make sure we don't alert for unchanged repos.
[Slack](https://sourcegraph.slack.com/archives/C02EDAQAJQZ/p1661438425177759) for context
## Test plan

- [x] Verified alert definition locally
