### PR TITLE
otel: add sampling but respect ShouldTrace

### DIFF
--- a/internal/tracer/otel_test.go
+++ b/internal/tracer/otel_test.go
@@ -1,0 +1,40 @@
+package tracer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func Test_shouldTracePolicySampler(t *testing.T) {
+	t.Run("with shouldTrace", func(t *testing.T) {
+		s := shouldTracePolicySampler{ratio: 0.0}
+		ctx := policy.WithShouldTrace(context.Background(), true)
+
+		res := s.ShouldSample(trace.SamplingParameters{ParentContext: ctx})
+		want := trace.RecordAndSample
+		if got := res.Decision; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("without shouldTrace", func(t *testing.T) {
+		t.Run("ratio: 1.0", func(t *testing.T) {
+			s := shouldTracePolicySampler{ratio: 1.0}
+			res := s.ShouldSample(trace.SamplingParameters{ParentContext: context.Background()})
+			want := trace.RecordAndSample
+			if got := res.Decision; got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+		t.Run("ratio: 0.0", func(t *testing.T) {
+			s := shouldTracePolicySampler{ratio: 0.0}
+			res := s.ShouldSample(trace.SamplingParameters{ParentContext: context.Background()})
+			want := trace.Drop
+			if got := res.Decision; got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	})
+}

--- a/internal/tracer/otel_test.go
+++ b/internal/tracer/otel_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_shouldTracePolicySampler(t *testing.T) {
 	t.Run("with shouldTrace", func(t *testing.T) {
-		s := shouldTracePolicySampler{ratio: 0.0}
+		s := shouldTracePolicySampler{}
 		ctx := policy.WithShouldTrace(context.Background(), true)
 
 		res := s.ShouldSample(trace.SamplingParameters{ParentContext: ctx})
@@ -20,21 +20,11 @@ func Test_shouldTracePolicySampler(t *testing.T) {
 		}
 	})
 	t.Run("without shouldTrace", func(t *testing.T) {
-		t.Run("ratio: 1.0", func(t *testing.T) {
-			s := shouldTracePolicySampler{ratio: 1.0}
-			res := s.ShouldSample(trace.SamplingParameters{ParentContext: context.Background()})
-			want := trace.RecordAndSample
-			if got := res.Decision; got != want {
-				t.Errorf("got %q, want %q", got, want)
-			}
-		})
-		t.Run("ratio: 0.0", func(t *testing.T) {
-			s := shouldTracePolicySampler{ratio: 0.0}
-			res := s.ShouldSample(trace.SamplingParameters{ParentContext: context.Background()})
-			want := trace.Drop
-			if got := res.Decision; got != want {
-				t.Errorf("got %q, want %q", got, want)
-			}
-		})
+		s := shouldTracePolicySampler{}
+		res := s.ShouldSample(trace.SamplingParameters{ParentContext: context.Background()})
+		want := trace.Drop
+		if got := res.Decision; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
 	})
 }


### PR DESCRIPTION
Right now our trace policy is only really respected for search - if you choose sampling: selective, background jobs will still emit tons of traces. This PR changes that by enabling sampling unless explicitly requested to trace. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI. 