### PR TITLE
upgrade: Allow single failed or pending migration log

### DIFF
--- a/internal/database/migration/cliutil/upgrade_runner.go
+++ b/internal/database/migration/cliutil/upgrade_runner.go
@@ -62,18 +62,18 @@ func runUpgrade(
 			len(plan.steps),
 		))
 
-		operations := make([]runner.MigrationOperation, 0, len(step.schemaMigrationLeafIDsBySchemaName))
-		for schemaName, leafMigrationIDs := range step.schemaMigrationLeafIDsBySchemaName {
-			operations = append(operations, runner.MigrationOperation{
-				SchemaName:     schemaName,
-				Type:           runner.MigrationOperationTypeTargetedUp,
-				TargetVersions: leafMigrationIDs,
-			})
-		}
-
 		out.WriteLine(output.Line(output.EmojiFingerPointRight, output.StyleReset, "Running schema migrations"))
 
 		if !dryRun {
+			operations := make([]runner.MigrationOperation, 0, len(step.schemaMigrationLeafIDsBySchemaName))
+			for schemaName, leafMigrationIDs := range step.schemaMigrationLeafIDsBySchemaName {
+				operations = append(operations, runner.MigrationOperation{
+					SchemaName:     schemaName,
+					Type:           runner.MigrationOperationTypeTargetedUp,
+					TargetVersions: leafMigrationIDs,
+				})
+			}
+
 			if err := r.Run(ctx, runner.Options{
 				Operations:           operations,
 				PrivilegedMode:       runner.ApplyPrivilegedMigrations,

--- a/internal/database/migration/cliutil/upgrade_runner.go
+++ b/internal/database/migration/cliutil/upgrade_runner.go
@@ -75,10 +75,11 @@ func runUpgrade(
 			}
 
 			if err := r.Run(ctx, runner.Options{
-				Operations:           operations,
-				PrivilegedMode:       runner.ApplyPrivilegedMigrations,
-				PrivilegedHash:       "",
-				IgnoreSingleDirtyLog: false,
+				Operations:             operations,
+				PrivilegedMode:         runner.ApplyPrivilegedMigrations,
+				PrivilegedHash:         "",
+				IgnoreSingleDirtyLog:   true,
+				IgnoreSinglePendingLog: true,
 			}); err != nil {
 				return err
 			}

--- a/internal/database/migration/runner/options.go
+++ b/internal/database/migration/runner/options.go
@@ -31,9 +31,9 @@ type Options struct {
 	// create a dummy migration log to proceed.
 	IgnoreSingleDirtyLog bool
 
-	// IgnoreSinglePendingLog controls whether or not to ignore a pending migration log. This
-	// is used during the upgrade process, which takes advisory locks at a higher level to
-	// ensure it has mutual access to the database (with respect to concurrent migrators).
+	// IgnoreSinglePendingLog controls whether or not to ignore a pending migration log in the
+	// specific case when the _next_ migration application is the only pending migration. This
+	// is meant to enable interruptable upgrades.
 	IgnoreSinglePendingLog bool
 }
 

--- a/internal/database/migration/runner/options.go
+++ b/internal/database/migration/runner/options.go
@@ -30,6 +30,11 @@ type Options struct {
 	// a short development loop where the user can re-apply the `up` command without having to
 	// create a dummy migration log to proceed.
 	IgnoreSingleDirtyLog bool
+
+	// IgnoreSinglePendingLog controls whether or not to ignore a pending migration log. This
+	// is used during the upgrade process, which takes advisory locks at a higher level to
+	// ensure it has mutual access to the database (with respect to concurrent migrators).
+	IgnoreSinglePendingLog bool
 }
 
 type PrivilegedMode uint

--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -343,8 +343,11 @@ func (r *Runner) applyMigration(
 		}
 
 		if privilegedMode == NoopPrivilegedMigrations {
-			if err := schemaContext.store.WithMigrationLog(ctx, definition, up, func() error { return nil }); err != nil {
-				return errors.Wrapf(err, "failed to apply migration %d", definition.ID)
+			noop := func() error {
+				return nil
+			}
+			if err := schemaContext.store.WithMigrationLog(ctx, definition, up, noop); err != nil {
+				return errors.Wrapf(err, "failed to create migration log %d", definition.ID)
 			}
 
 			r.logger.Warn(

--- a/internal/database/migration/runner/run_test.go
+++ b/internal/database/migration/runner/run_test.go
@@ -152,6 +152,25 @@ func TestRun(t *testing.T) {
 		}
 	})
 
+	t.Run("upgrade (dirty database, ignore single pending log)", func(t *testing.T) {
+		store := testStoreWithVersion(10003, false)
+		store.VersionsFunc.SetDefaultHook(func(ctx context.Context) ([]int, []int, []int, error) {
+			return nil, []int{10001}, nil, nil
+		})
+
+		if err := makeTestRunner(t, store).Run(ctx, Options{
+			Operations: []MigrationOperation{
+				{
+					SchemaName: "well-formed",
+					Type:       MigrationOperationTypeUpgrade,
+				},
+			},
+			IgnoreSinglePendingLog: true,
+		}); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	})
+
 	t.Run("upgrade (dirty database/dead migrations)", func(t *testing.T) {
 		store := testStoreWithVersion(10003, true)
 		store.VersionsFunc.SetDefaultReturn(nil, []int{10003}, nil, nil)

--- a/internal/database/migration/runner/runner.go
+++ b/internal/database/migration/runner/runner.go
@@ -225,8 +225,7 @@ type unlockFunc func(err error) error
 // If the ignoreSinglePendingLog flag is set to true, then the callback will be invoked if there is
 // a single pending migration log, and it's the next migration that would be applied with respect to
 // the given schema context. This is meant to be used in the upgrade process, where an interrupted
-// migrator command will appear as a concurrent upgrade attempt. To ensure that we have mutual
-// exclusion during upgrades, we hold an advisory lock prior to the upgrade sequence.
+// migrator command will appear as a concurrent upgrade attempt.
 //
 // This method returns a true-valued flag if it should be re-invoked by the caller.
 func (r *Runner) withLockedSchemaState(

--- a/internal/database/migration/runner/runner.go
+++ b/internal/database/migration/runner/runner.go
@@ -222,12 +222,19 @@ type unlockFunc func(err error) error
 // the given schema context. This is meant to enable a short development loop where the user can
 // re-apply the `up` command without having to create a dummy migration log to proceed.
 //
+// If the ignoreSinglePendingLog flag is set to true, then the callback will be invoked if there is
+// a single pending migration log, and it's the next migration that would be applied with respect to
+// the given schema context. This is meant to be used in the upgrade process, where an interrupted
+// migrator command will appear as a concurrent upgrade attempt. To ensure that we have mutual
+// exclusion during upgrades, we hold an advisory lock prior to the upgrade sequence.
+//
 // This method returns a true-valued flag if it should be re-invoked by the caller.
 func (r *Runner) withLockedSchemaState(
 	ctx context.Context,
 	schemaContext schemaContext,
 	definitions []definition.Definition,
 	ignoreSingleDirtyLog bool,
+	ignoreSinglePendingLog bool,
 	f lockedVersionCallback,
 ) (retry bool, _ error) {
 	// Take an advisory lock to determine if there are any migrator instances currently
@@ -260,7 +267,14 @@ func (r *Runner) withLockedSchemaState(
 
 	// Detect failed migrations, and determine if we need to wait longer for concurrent migrator
 	// instances to finish their current work.
-	if retry, err := validateSchemaState(ctx, schemaContext, definitions, byState, ignoreSingleDirtyLog); err != nil {
+	if retry, err := validateSchemaState(
+		ctx,
+		schemaContext,
+		definitions,
+		byState,
+		ignoreSingleDirtyLog,
+		ignoreSinglePendingLog,
+	); err != nil {
 		return false, err
 	} else if retry {
 		// An index is currently being created. We return true here to flag to the caller that
@@ -352,6 +366,7 @@ func validateSchemaState(
 	definitions []definition.Definition,
 	byState definitionsByState,
 	ignoreSingleDirtyLog bool,
+	ignoreSinglePendingLog bool,
 ) (retry bool, _ error) {
 	if ignoreSingleDirtyLog && len(byState.failed) == 1 {
 		appliedVersionMap := intSet(extractIDs(byState.applied))
@@ -365,6 +380,11 @@ func validateSchemaState(
 				return false, nil
 			}
 		}
+	}
+
+	if ignoreSinglePendingLog && len(byState.pending) == 1 {
+		schemaContext.logger.Warn("Ignoring a pending migration")
+		return false, nil
 	}
 
 	if len(byState.failed) > 0 {

--- a/internal/database/migration/runner/validate.go
+++ b/internal/database/migration/runner/validate.go
@@ -87,7 +87,7 @@ func (r *Runner) validateSchema(ctx context.Context, schemaContext schemaContext
 // validateDefinitions attempts to take an advisory lock, then re-checks the version of the database.
 // If there are still migrations to apply from the given definitions, an error is returned.
 func (r *Runner) validateDefinitions(ctx context.Context, schemaContext schemaContext, definitions []definition.Definition) (retry bool, _ error) {
-	return r.withLockedSchemaState(ctx, schemaContext, definitions, false, func(schemaVersion schemaVersion, byState definitionsByState, _ unlockFunc) error {
+	return r.withLockedSchemaState(ctx, schemaContext, definitions, false, false, func(schemaVersion schemaVersion, byState definitionsByState, _ unlockFunc) error {
 		if len(byState.applied) != len(definitions) {
 			// Return an error if all expected schemas have not been applied
 			return newOutOfDateError(schemaContext, schemaVersion)


### PR DESCRIPTION
This PR prevents an interrupted upgrade from blocking future attempts. Effort towards #40741.

## Test plan

This is a pre-requisite to work that has been tested locally. Unit tests have also been updated.