### PR TITLE
Aggregation UI: Add proper error UI

### DIFF
--- a/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
@@ -32,6 +32,26 @@
     overflow: auto;
 }
 
+.aggregation-error-container {
+    :global(.theme-dark) & rect {
+        fill: var(--gray-09);
+    }
+
+    :global(.theme-light) & rect {
+        fill: var(--gray-03);
+    }
+
+    // Simple UI mode theme
+    :global(.core-workflow-improvements-enabled) & {
+        :global(.theme-dark) & rect {
+            fill: var(--gray-11);
+        }
+
+        :global(.theme-light) & rect {
+            fill: var(--gray-02);
+        }
+    }
+}
 // Wrapper-container for custom search availability error message UI
 .error-message-layout {
     padding: 0 0.5rem;
@@ -43,29 +63,30 @@
     display: flex;
     flex-direction: column;
 
-    :global(.theme-dark) & {
-        background-color: rgba(20, 23, 31, 0.9);
-    }
-
-    :global(.theme-light) & {
-        background-color: rgba(249, 250, 251, 0.9);
-    }
-
-    // Simple UI mode theme
-    :global(.core-workflow-improvements-enabled) & {
-        :global(.theme-dark) & {
-            background-color: rgba(14, 16, 22, 0.9);
-        }
-
-        :global(.theme-light) & {
-            background-color: rgba(255, 255, 255, 0.92);
-        }
-    }
+    //:global(.theme-dark) & {
+    //    background-color: rgba(20, 23, 31, 0.9);
+    //}
+    //
+    //:global(.theme-light) & {
+    //    background-color: rgba(249, 250, 251, 0.9);
+    //}
+    //
+    //// Simple UI mode theme
+    //:global(.core-workflow-improvements-enabled) & {
+    //    :global(.theme-dark) & {
+    //        background-color: rgba(14, 16, 22, 0.9);
+    //    }
+    //
+    //    :global(.theme-light) & {
+    //        background-color: rgba(255, 255, 255, 0.92);
+    //    }
+    //}
 }
 
 // Custom search availability error message UI
 .error-message {
     margin: auto;
+    max-width: 500px;
 }
 
 .loading {
@@ -84,7 +105,7 @@
     // zero state block
     padding-bottom: 0.5rem;
 
-    rect {
-        fill: #a6b6d9;
-    }
+    //rect {
+    //    fill: #a6b6d9;
+    //}
 }

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
@@ -1,12 +1,22 @@
+// Chart (parent-size) container
 .container {
     position: relative;
-    overflow: auto;
+}
+
+.missing-label-count {
+    position: absolute;
+    top: 10px;
+    right: 0;
+    padding: 0.25rem;
+    background: var(--body-bg);
+    color: var(--text-muted);
 }
 
 // Container for both errors (business-like and internal error alerts messages)
 .error-container {
     display: flex;
     flex-direction: column;
+    position: relative;
     overflow: auto;
     margin: 0;
 
@@ -22,17 +32,53 @@
     overflow: auto;
 }
 
+// Wrapper-container for custom search availability error message UI
+.error-message-layout {
+    padding: 0 0.5rem;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+
+    :global(.theme-dark) & {
+        background-color: rgb(20 23 31 / 90%);
+    }
+
+    :global(.theme-light) & {
+        background-color: rgb(249 250 251 / 90%);
+    }
+
+    // Simple UI mode theme
+    :global(.core-workflow-improvements-enabled) & {
+        :global(.theme-dark) & {
+            background-color: rgba(14, 16, 22, 0.9);
+        }
+
+        :global(.theme-light) & {
+            background-color: rgb(255 255 255 / 92%);
+        }
+    }
+}
+
 // Custom search availability error message UI
 .error-message {
     margin: auto;
-    padding: 0 0.5rem;
 }
 
-.missing-label-count {
-    position: absolute;
-    top: 10px;
-    right: 0;
-    padding: 0.25rem;
-    background: var(--body-bg);
-    color: var(--text-muted);
+.zero-state-background {
+    width: 100%;
+    flex-grow: 1;
+    margin: auto;
+
+    // Visually compensate bottom spacing between error chart mock
+    // UI and aggregation controls UI which are placed below this
+    // zero state block
+    padding-bottom: 0.5rem;
+
+    rect {
+        fill: #a6b6d9;
+    }
 }

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
@@ -44,11 +44,11 @@
     flex-direction: column;
 
     :global(.theme-dark) & {
-        background-color: rgb(20 23 31 / 90%);
+        background-color: rgba(20, 23, 31, 0.9);
     }
 
     :global(.theme-light) & {
-        background-color: rgb(249 250 251 / 90%);
+        background-color: rgba(249, 250, 251, 0.9);
     }
 
     // Simple UI mode theme
@@ -58,7 +58,7 @@
         }
 
         :global(.theme-light) & {
-            background-color: rgb(255 255 255 / 92%);
+            background-color: rgba(255, 255, 255, 0.92);
         }
     }
 }

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
@@ -85,5 +85,6 @@
     // Visually compensate bottom spacing between error chart mock
     // UI and aggregation controls UI which are placed below this
     // zero state block
-    padding-bottom: 0.5rem;
+    padding-bottom: 1.5rem;
+    padding-top: 0.5rem;
 }

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
@@ -62,25 +62,6 @@
     width: 100%;
     display: flex;
     flex-direction: column;
-
-    //:global(.theme-dark) & {
-    //    background-color: rgba(20, 23, 31, 0.9);
-    //}
-    //
-    //:global(.theme-light) & {
-    //    background-color: rgba(249, 250, 251, 0.9);
-    //}
-    //
-    //// Simple UI mode theme
-    //:global(.core-workflow-improvements-enabled) & {
-    //    :global(.theme-dark) & {
-    //        background-color: rgba(14, 16, 22, 0.9);
-    //    }
-    //
-    //    :global(.theme-light) & {
-    //        background-color: rgba(255, 255, 255, 0.92);
-    //    }
-    //}
 }
 
 // Custom search availability error message UI
@@ -104,8 +85,4 @@
     // UI and aggregation controls UI which are placed below this
     // zero state block
     padding-bottom: 0.5rem;
-
-    //rect {
-    //    fill: #a6b6d9;
-    //}
 }

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
@@ -68,6 +68,12 @@
     margin: auto;
 }
 
+.loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .zero-state-background {
     width: 100%;
     flex-grow: 1;

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.module.scss
@@ -44,11 +44,12 @@
     // Simple UI mode theme
     :global(.core-workflow-improvements-enabled) & {
         :global(.theme-dark) & rect {
-            fill: var(--gray-11);
+            fill: var(--gray-10);
         }
 
         :global(.theme-light) & rect {
             fill: var(--gray-02);
+            opacity: 0.6;
         }
     }
 }

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -87,9 +87,13 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
 
     if (aggregationError) {
         return (
-            <DataLayoutContainer size={size} className={className}>
+            <DataLayoutContainer
+                data-error-layout={true}
+                size={size}
+                className={classNames(styles.aggregationErrorContainer, className)}
+            >
                 <ZeroStateBarsBackground />
-                <div data-error-layout={true} className={styles.errorMessageLayout}>
+                <div className={styles.errorMessageLayout}>
                     <div className={styles.errorMessage}>
                         We couldn’t provide an aggregation for this query. <ErrorMessage error={aggregationError} />.{' '}
                         <Link to="">Learn more</Link>

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -112,6 +112,16 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
         onBarLinkClick?.(getLink(datum))
     }
 
+    if (!data) {
+        return null
+    }
+
+    const missingCount = getOtherGroupCount(data)
+    const handleDatumLinkClick = (event: MouseEvent, datum: SearchAggregationDatum): void => {
+        event.preventDefault()
+        onBarLinkClick?.(getLink(datum))
+    }
+
     return (
         <ParentSize className={classNames(className, styles.container)}>
             {parent => (

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -92,7 +92,7 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
                 size={size}
                 className={classNames(styles.aggregationErrorContainer, className)}
             >
-                <ZeroStateBarsBackground />
+                <BarsBackground size={size} />
                 <div className={styles.errorMessageLayout}>
                     <div className={styles.errorMessage}>
                         We couldn’t provide an aggregation for this query. <ErrorMessage error={aggregationError} />.{' '}
@@ -161,26 +161,35 @@ const DataLayoutContainer = forwardRef((props, ref) => {
     )
 }) as ForwardReferenceComponent<'div', DataLayoutContainerProps>
 
-const ZeroStateBarsBackground: FC<SVGProps<SVGSVGElement>> = ({ className, ...attributes }) => (
-    <svg
-        {...attributes}
-        className={classNames(className, styles.zeroStateBackground)}
-        xmlns="http://www.w3.org/2000/svg"
-    >
-        <rect x="0%" y="5%" height="95%" width="5%" />
-        <rect x="7%" y="20%" height="80%" width="5%" />
-        <rect x="14%" y="25%" height="75%" width="5%" />
-        <rect x="21%" y="30%" height="70%" width="5%" />
-        <rect x="28%" y="32%" height="68%" width="5%" />
-        <rect x="35%" y="32%" height="68%" width="5%" />
-        <rect x="42%" y="38%" height="62%" width="5%" />
-        <rect x="49%" y="45%" height="55%" width="5%" />
-        <rect x="56%" y="60%" height="40%" width="5%" />
-        <rect x="63%" y="62%" height="38%" width="5%" />
-        <rect x="70%" y="67%" height="33%" width="5%" />
-        <rect x="77%" y="70%" height="30%" width="5%" />
-        <rect x="84%" y="75%" height="25%" width="5%" />
-        <rect x="91%" y="85%" height="15%" width="5%" />
-        <rect x="98%" y="93%" height="7%" width="5%" />
-    </svg>
-)
+const BAR_VALUES_FULL_UI = [95, 88, 83, 70, 65, 45, 35, 30, 30, 30, 30, 27, 27, 27, 27, 24, 10, 10, 10, 10, 10]
+const BAR_VALUES_SIDEBAR_UI = [95, 80, 75, 70, 68, 68, 55, 40, 38, 33, 30, 25, 15, 7]
+
+interface BarsBackgroundProps extends SVGProps<SVGSVGElement> {
+    size: 'sm' | 'md'
+}
+
+const BarsBackground: FC<BarsBackgroundProps> = props => {
+    const { size, className, ...attributes } = props
+
+    const padding = size === 'md' ? 1 : 2
+    const data = size === 'md' ? BAR_VALUES_FULL_UI : BAR_VALUES_SIDEBAR_UI
+    const barWidth = (100 - padding * (data.length - 1)) / data.length
+
+    return (
+        <svg
+            {...attributes}
+            className={classNames(className, styles.zeroStateBackground)}
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            {data.map((bar, index) => (
+                <rect
+                    key={index}
+                    x={`${index * (barWidth + padding)}%`}
+                    y={`${100 - bar}%`}
+                    height={`${bar}%`}
+                    width={`${barWidth}%`}
+                />
+            ))}
+        </svg>
+    )
+}

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -109,16 +109,6 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
         onBarLinkClick?.(getLink(datum))
     }
 
-    if (!data) {
-        return null
-    }
-
-    const missingCount = getOtherGroupCount(data)
-    const handleDatumLinkClick = (event: MouseEvent, datum: SearchAggregationDatum): void => {
-        event.preventDefault()
-        onBarLinkClick?.(getLink(datum))
-    }
-
     return (
         <ParentSize className={classNames(className, styles.container)}>
             {parent => (

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -68,7 +68,7 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
 
     if (loading) {
         return (
-            <DataLayoutContainer size={size} className={className}>
+            <DataLayoutContainer size={size} className={classNames(styles.loading, className)}>
                 Loading...
             </DataLayoutContainer>
         )

--- a/client/search-ui/src/results/aggregation/AggregationModeControls.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationModeControls.tsx
@@ -11,13 +11,14 @@ import styles from './AggregationModeControls.module.scss'
 
 interface AggregationModeControlsProps extends HTMLAttributes<HTMLDivElement> {
     mode: SearchAggregationMode | null
+    loading: boolean
     availability?: SearchAggregationModeAvailability[]
     size?: 'sm' | 'lg'
     onModeChange: (nextMode: SearchAggregationMode) => void
 }
 
 export const AggregationModeControls: FC<AggregationModeControlsProps> = props => {
-    const { mode, availability = [], onModeChange, size, className, ...attributes } = props
+    const { mode, loading, availability = [], onModeChange, size, className, ...attributes } = props
 
     const availabilityGroups = availability.reduce((store, availability) => {
         store[availability.mode] = availability
@@ -26,6 +27,12 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
     }, {} as Partial<Record<SearchAggregationMode, SearchAggregationModeAvailability>>)
 
     const isModeAvailable = (mode: SearchAggregationMode): boolean => {
+        if (loading) {
+            // Prevent changing aggregation types while data is loading
+            // disable all aggregation modes as we fetch the data.
+            return false
+        }
+
         const isAvailable = availabilityGroups[mode]?.available
 
         // Returns true by default because we don't want to disable all modes

--- a/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
+++ b/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
@@ -15,6 +15,30 @@
     min-height: 26rem;
     max-height: 26rem;
     max-width: 60rem;
+
+    // The full UI aggregation mode has different from sidebar background colors
+    // in different themes and UI search modes (standard, simple) we have to
+    // override default sidebar chart styles in order to fit it in the full UI colors.
+    [data-error-layout] {
+        :global(.theme-dark) & {
+            background-color: rgb(20 23 31 / 90%);
+        }
+
+        :global(.theme-light) & {
+            background-color: rgb(249 250 251 / 90%);
+        }
+
+        // Simple UI mode theme
+        :global(.core-workflow-improvements-enabled) & {
+            :global(.theme-dark) & {
+                background-color: rgb(20 23 31 / 90%);
+            }
+
+            :global(.theme-light) & {
+                background-color: rgb(249 250 251 / 90%);
+            }
+        }
+    }
 }
 
 .list-result {

--- a/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
+++ b/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
@@ -29,41 +29,6 @@
             fill: var(--gray-03);
         }
     }
-
-    //:global(.core-workflow-improvements-enabled) & [data-error-layout] rect {
-    //
-    //    fill: red !important;
-    //
-    //    // Simple UI mode theme
-    //    // Overrides bar zero state colors according to design review
-    //    // see https://github.com/sourcegraph/sourcegraph/pull/40959#pullrequestreview-1089168869
-    //    //:global(.theme-dark) & rect {
-    //    //    fill: var(--gray-09) !important;
-    //    //}
-    //    //
-    //    //:global(.theme-light) & rect {
-    //    //    fill: var(--gray-03) !important;
-    //    //}
-    //
-    //    //:global(.theme-dark) & {
-    //    //    background-color: rgba(20, 23, 31, 0.9);
-    //    //}
-    //    //
-    //    //:global(.theme-light) & {
-    //    //    background-color: rgba(249, 250, 251, 0.9);
-    //    //}
-    //    //
-    //    //// Simple UI mode theme
-    //    //:global(.core-workflow-improvements-enabled) & {
-    //    //    :global(.theme-dark) & {
-    //    //        background-color: rgba(20, 23, 31, 0.9);
-    //    //    }
-    //    //
-    //    //    :global(.theme-light) & {
-    //    //        background-color: rgba(249, 250, 251, 0.9);
-    //    //    }
-    //    //}
-    //}
 }
 
 .list-result {

--- a/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
+++ b/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
@@ -16,42 +16,54 @@
     max-height: 26rem;
     max-width: 60rem;
 
+    // Simple UI mode theme
     // The full UI aggregation mode has different from sidebar background colors
     // in different themes and UI search modes (standard, simple) we have to
     // override default sidebar chart styles in order to fit it in the full UI colors.
-    [data-error-layout] {
-        // Simple UI mode theme
-        // Overrides bar zero state colors according to design review
-        // see https://github.com/sourcegraph/sourcegraph/pull/40959#pullrequestreview-1089168869
-        :global(.core-workflow-improvements-enabled) & {
-            :global(.theme-dark) & rect {
-                fill: var(--gray-09);
-            }
-
-            :global(.theme-light) & rect {
-                fill: var(--gray-03);
-            }
+    :global(.core-workflow-improvements-enabled) & {
+        :global(.theme-dark) & rect {
+            fill: var(--gray-09);
         }
 
-        //:global(.theme-dark) & {
-        //    background-color: rgba(20, 23, 31, 0.9);
-        //}
-        //
-        //:global(.theme-light) & {
-        //    background-color: rgba(249, 250, 251, 0.9);
-        //}
-        //
-        //// Simple UI mode theme
-        //:global(.core-workflow-improvements-enabled) & {
-        //    :global(.theme-dark) & {
-        //        background-color: rgba(20, 23, 31, 0.9);
-        //    }
-        //
-        //    :global(.theme-light) & {
-        //        background-color: rgba(249, 250, 251, 0.9);
-        //    }
-        //}
+        :global(.theme-light) & rect {
+            fill: var(--gray-03);
+        }
     }
+
+    //:global(.core-workflow-improvements-enabled) & [data-error-layout] rect {
+    //
+    //    fill: red !important;
+    //
+    //    // Simple UI mode theme
+    //    // Overrides bar zero state colors according to design review
+    //    // see https://github.com/sourcegraph/sourcegraph/pull/40959#pullrequestreview-1089168869
+    //    //:global(.theme-dark) & rect {
+    //    //    fill: var(--gray-09) !important;
+    //    //}
+    //    //
+    //    //:global(.theme-light) & rect {
+    //    //    fill: var(--gray-03) !important;
+    //    //}
+    //
+    //    //:global(.theme-dark) & {
+    //    //    background-color: rgba(20, 23, 31, 0.9);
+    //    //}
+    //    //
+    //    //:global(.theme-light) & {
+    //    //    background-color: rgba(249, 250, 251, 0.9);
+    //    //}
+    //    //
+    //    //// Simple UI mode theme
+    //    //:global(.core-workflow-improvements-enabled) & {
+    //    //    :global(.theme-dark) & {
+    //    //        background-color: rgba(20, 23, 31, 0.9);
+    //    //    }
+    //    //
+    //    //    :global(.theme-light) & {
+    //    //        background-color: rgba(249, 250, 251, 0.9);
+    //    //    }
+    //    //}
+    //}
 }
 
 .list-result {

--- a/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
+++ b/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
@@ -20,24 +20,37 @@
     // in different themes and UI search modes (standard, simple) we have to
     // override default sidebar chart styles in order to fit it in the full UI colors.
     [data-error-layout] {
-        :global(.theme-dark) & {
-            background-color: rgba(20, 23, 31, 0.9);
-        }
-
-        :global(.theme-light) & {
-            background-color: rgba(249, 250, 251, 0.9);
-        }
-
         // Simple UI mode theme
+        // Overrides bar zero state colors according to design review
+        // see https://github.com/sourcegraph/sourcegraph/pull/40959#pullrequestreview-1089168869
         :global(.core-workflow-improvements-enabled) & {
-            :global(.theme-dark) & {
-                background-color: rgba(20, 23, 31, 0.9);
+            :global(.theme-dark) & rect {
+                fill: var(--gray-09);
             }
 
-            :global(.theme-light) & {
-                background-color: rgba(249, 250, 251, 0.9);
+            :global(.theme-light) & rect {
+                fill: var(--gray-03);
             }
         }
+
+        //:global(.theme-dark) & {
+        //    background-color: rgba(20, 23, 31, 0.9);
+        //}
+        //
+        //:global(.theme-light) & {
+        //    background-color: rgba(249, 250, 251, 0.9);
+        //}
+        //
+        //// Simple UI mode theme
+        //:global(.core-workflow-improvements-enabled) & {
+        //    :global(.theme-dark) & {
+        //        background-color: rgba(20, 23, 31, 0.9);
+        //    }
+        //
+        //    :global(.theme-light) & {
+        //        background-color: rgba(249, 250, 251, 0.9);
+        //    }
+        //}
     }
 }
 

--- a/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
+++ b/client/search-ui/src/results/aggregation/SearchAggregationResult.module.scss
@@ -21,21 +21,21 @@
     // override default sidebar chart styles in order to fit it in the full UI colors.
     [data-error-layout] {
         :global(.theme-dark) & {
-            background-color: rgb(20 23 31 / 90%);
+            background-color: rgba(20, 23, 31, 0.9);
         }
 
         :global(.theme-light) & {
-            background-color: rgb(249 250 251 / 90%);
+            background-color: rgba(249, 250, 251, 0.9);
         }
 
         // Simple UI mode theme
         :global(.core-workflow-improvements-enabled) & {
             :global(.theme-dark) & {
-                background-color: rgb(20 23 31 / 90%);
+                background-color: rgba(20, 23, 31, 0.9);
             }
 
             :global(.theme-light) & {
-                background-color: rgb(249 250 251 / 90%);
+                background-color: rgba(249, 250, 251, 0.9);
             }
         }
     }

--- a/client/search-ui/src/results/aggregation/SearchAggregationResult.tsx
+++ b/client/search-ui/src/results/aggregation/SearchAggregationResult.tsx
@@ -61,6 +61,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
 
             <div className={styles.controls}>
                 <AggregationModeControls
+                    loading={loading}
                     mode={aggregationMode}
                     availability={data?.searchQueryAggregate?.modeAvailability}
                     onModeChange={setAggregationMode}

--- a/client/search-ui/src/results/aggregation/index.ts
+++ b/client/search-ui/src/results/aggregation/index.ts
@@ -2,6 +2,6 @@ export * from './types'
 export * from './hooks'
 export * from './constants'
 
-export { AggregationChartCard } from './AggregationChartCard'
+export { AggregationChartCard, getAggregationData } from './AggregationChartCard'
 export { AggregationModeControls } from './AggregationModeControls'
 export { SearchAggregationResult } from './SearchAggregationResult'

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -5,12 +5,14 @@ import { mdiArrowExpand } from '@mdi/js'
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { Button, Icon } from '@sourcegraph/wildcard'
 
+import { GetSearchAggregationResult } from '../../graphql-operations'
 import {
     AggregationModeControls,
     AggregationUIMode,
     useAggregationSearchMode,
     useAggregationUIMode,
     AggregationChartCard,
+    getAggregationData,
     useSearchAggregationData,
 } from '../aggregation'
 
@@ -69,6 +71,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                     outline={true}
                     className={styles.detailsAction}
                     data-testid="expand-aggregation-ui"
+                    disabled={!hasAggregationData(data)}
                     onClick={() => setAggregationUIMode(AggregationUIMode.SearchPage)}
                 >
                     <Icon aria-hidden={true} svgPath={mdiArrowExpand} /> Expand
@@ -76,4 +79,12 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
             </footer>
         </article>
     )
+}
+
+function hasAggregationData(response?: GetSearchAggregationResult): boolean {
+    if (!response) {
+        return false
+    }
+
+    return getAggregationData(response.searchQueryAggregate.aggregations).length > 0
 }

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -5,14 +5,12 @@ import { mdiArrowExpand } from '@mdi/js'
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { Button, Icon } from '@sourcegraph/wildcard'
 
-import { GetSearchAggregationResult } from '../../graphql-operations'
 import {
     AggregationModeControls,
     AggregationUIMode,
     useAggregationSearchMode,
     useAggregationUIMode,
     AggregationChartCard,
-    getAggregationData,
     useSearchAggregationData,
 } from '../aggregation'
 
@@ -47,10 +45,11 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
     return (
         <article className="pt-2">
             <AggregationModeControls
-                size="sm"
-                className="mb-3"
+                loading={loading}
                 mode={aggregationMode}
                 availability={data?.searchQueryAggregate?.modeAvailability}
+                size="sm"
+                className="mb-3"
                 onModeChange={setAggregationMode}
             />
 
@@ -71,7 +70,6 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                     outline={true}
                     className={styles.detailsAction}
                     data-testid="expand-aggregation-ui"
-                    disabled={!hasAggregationData(data)}
                     onClick={() => setAggregationUIMode(AggregationUIMode.SearchPage)}
                 >
                     <Icon aria-hidden={true} svgPath={mdiArrowExpand} /> Expand
@@ -79,12 +77,4 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
             </footer>
         </article>
     )
-}
-
-function hasAggregationData(response?: GetSearchAggregationResult): boolean {
-    if (!response) {
-        return false
-    }
-
-    return getAggregationData(response.searchQueryAggregate.aggregations).length > 0
 }


### PR DESCRIPTION
Based on https://github.com/sourcegraph/sourcegraph/pull/40943
Part of https://github.com/sourcegraph/sourcegraph/issues/40766

[Figma designs](https://www.figma.com/file/cKSeCtmBh9aiPsAVoKsLgM/Aggregation-insights%3A-display-%22grouped%22-insights-for-existing-searches-%2339126-%5Bready-for-dev%5D?node-id=246%3A11)

## Background
In this PR we added zero state (bars-like) background for search unavailable error. See tables below for different themes and UI modes

**NOTE**: Error message will be changed and fixed in a separate issue (@chwarwick FYI)

| Aggregation UI | Theme  | Standard UI | Simple UI |
| ------------- | ------------- | ------------- | ------------- |
| Sidebar UI  | Light theme |  <img width="1158" alt="Screenshot 2022-08-27 at 12 21 43" src="https://user-images.githubusercontent.com/18492575/187024293-ecd772ae-a401-49c2-89b1-7e3404066309.png">| <img width="1158" alt="Screenshot 2022-08-27 at 12 21 38" src="https://user-images.githubusercontent.com/18492575/187024313-398987c3-2d7b-4872-b2ac-9e363bd4b1e8.png"> |
| Sidebar UI | Dark theme  | <img width="1158" alt="Screenshot 2022-08-27 at 12 21 48" src="https://user-images.githubusercontent.com/18492575/187024445-32fbbf19-9884-40ac-a5eb-627ee7149948.png"> | <img width="1158" alt="Screenshot 2022-08-27 at 12 21 34" src="https://user-images.githubusercontent.com/18492575/187024396-a00a2d99-2ac2-466b-8914-ed06661d0c24.png"> |
| Full UI | Light theme | <img width="1158" alt="Screenshot 2022-08-27 at 12 20 09" src="https://user-images.githubusercontent.com/18492575/187024525-66e1d67d-c957-40ff-bf59-fb415bbfc807.png"> | <img width="1158" alt="Screenshot 2022-08-27 at 12 20 15" src="https://user-images.githubusercontent.com/18492575/187024668-1eb929f0-772a-4458-a5cc-6b97cb89b637.png"> |
| Full UI | Dark theme | <img width="1158" alt="Screenshot 2022-08-27 at 12 20 03" src="https://user-images.githubusercontent.com/18492575/187024704-08df2e4f-3116-46d5-a0ec-d8d275d463a5.png"> | <img width="1158" alt="Screenshot 2022-08-27 at 12 20 21" src="https://user-images.githubusercontent.com/18492575/187024713-55633c8c-da0a-4b36-947c-c5dc2d1b15f0.png"> |

 
## Test plan
- Make sure that error state has a proper zero state bars-like background in both themes and both UI modes (and in both Aggregation UI modes sidebar and full uI). 
- @AlicjaSuska can you please take a look at colors of bars for this state? I changed them a little bit because I found that they look nice in design but in the browser they look vague and it makes harder to read the error text. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-aggregation-zero-state-bg.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-voivvamrcg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
