### PR TITLE
batches: Changeset Spec Exceeds Database Limit

### DIFF
--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -113,7 +113,7 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.Changeset
 			// for the diff column (which is bytea) is 1GB
 			if len(c.Diff) > OneGigabyte {
 				link := "https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#transformchanges"
-				return errors.Errorf("The changeset generated is over the size limit. You can make use of [transformChanges](%s) to break down the changesets into smaller pieces.", link)
+				return errors.Errorf("The changeset patch generated is over the size limit. You can make use of [transformChanges](%s) to break down the changesets into smaller pieces.", link)
 			}
 
 			if err := inserter.Insert(

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
+	"strings"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
@@ -132,6 +133,11 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.Changeset
 				dbutil.NewNullString(c.CommitAuthorEmail),
 				c.Type,
 			); err != nil {
+				// We check if the resulting error is because the changeset is too large
+				if strings.Contains(err.Error(), "string too long to represent as jsonb string") {
+					link := "https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#transformchanges"
+					return errors.Errorf("The changeset generated is over the size limit. You can make use of [transformChanges](%s) to break down the changesets into smaller pieces.", link)
+				}
 				return err
 			}
 		}

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -76,7 +76,7 @@ var changesetSpecColumns = SQLColumns{
 	"changeset_specs.type",
 }
 
-var OneGigabyte = 1000000000
+var oneGigabyte = 1000000000
 
 // CreateChangesetSpec creates the given ChangesetSpecs.
 func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.ChangesetSpec) (err error) {
@@ -111,7 +111,7 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.Changeset
 
 			// We check if the resulting diff is greater than 1GB, since the limit
 			// for the diff column (which is bytea) is 1GB
-			if len(c.Diff) > OneGigabyte {
+			if len(c.Diff) > oneGigabyte {
 				link := "https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#transformchanges"
 				return errors.Errorf("The changeset patch generated is over the size limit. You can make use of [transformChanges](%s) to break down the changesets into smaller pieces.", link)
 			}

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
-	"strings"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
@@ -77,6 +76,8 @@ var changesetSpecColumns = SQLColumns{
 	"changeset_specs.type",
 }
 
+var OneGigabyte = 1000000000
+
 // CreateChangesetSpec creates the given ChangesetSpecs.
 func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.ChangesetSpec) (err error) {
 	ctx, _, endObservation := s.operations.createChangesetSpec.With(ctx, &err, observation.Args{LogFields: []log.Field{
@@ -108,6 +109,13 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.Changeset
 				}
 			}
 
+			// We check if the resulting diff is greater than 1GB, since the limit
+			// for the diff column (which is bytea) is 1GB
+			if len(c.Diff) > OneGigabyte {
+				link := "https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#transformchanges"
+				return errors.Errorf("The changeset generated is over the size limit. You can make use of [transformChanges](%s) to break down the changesets into smaller pieces.", link)
+			}
+
 			if err := inserter.Insert(
 				ctx,
 				c.RandID,
@@ -133,11 +141,6 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.Changeset
 				dbutil.NewNullString(c.CommitAuthorEmail),
 				c.Type,
 			); err != nil {
-				// We check if the resulting error is because the changeset is too large
-				if strings.Contains(err.Error(), "string too long to represent as jsonb string") {
-					link := "https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#transformchanges"
-					return errors.Errorf("The changeset generated is over the size limit. You can make use of [transformChanges](%s) to break down the changesets into smaller pieces.", link)
-				}
 				return err
 			}
 		}

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -422,7 +422,7 @@ ORDER BY repo_id ASC, head_ref ASC
 `
 
 func (s *Store) ListChangesetSpecsWithConflictingHeadRef(ctx context.Context, batchSpecID int64) (conflicts []ChangesetSpecHeadRefConflict, err error) {
-	ctx, _, endObservation := s.operations.createChangesetSpec.With(ctx, &err, observation.Args{})
+	ctx, _, endObservation := s.operations.listChangesetSpecsWithConflictingHeadRef.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	q := sqlf.Sprintf(listChangesetSpecsWithConflictingHeadQueryFmtstr, batchSpecID)


### PR DESCRIPTION
Closes #39242

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Before #39471, we ran into an edge case where a batch change that generated a large changeset couldn't be saved in the database. The error gotten was

```txt
ERROR: string too long to represent as jsonb string (SQLSTATE 54000)
```

This happened because the size limit for the `jsonb` field in the `changeset_specs` table was around 256MB, so running a batch spec (example attached below) would return an error.

```txt
# Generates 676.3 MB changeset spec
name: large-changeset
description: Add Hello World to READMEs

on:
  - repositoriesMatchingQuery: file:README.md repo:^github.com/odoo/odoo$

steps:
  - run: find . -name "*.po" -exec sed -i 's/b/c/g' {} \;
    container: alpine:3

changesetTemplate:
  title: Hello World
  body: My first batch change!
  branch: hello-world-1 # Push the commit to this branch.
  commit:
    message: Append Hello World to all README.md files
  published: false # Do not publish any changes to the code hosts yet
```

This PR adds a check to inform the user to make use of [transformChanges](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#transformchanges) if the size of the changeset gets too large. Since #39471, that limit has increased to 1G.