### PR TITLE
web: do not parse failed requests in Apollo Client

### DIFF
--- a/client/http-client/src/graphql/apollo/client.ts
+++ b/client/http-client/src/graphql/apollo/client.ts
@@ -1,7 +1,8 @@
-import { ApolloClient, createHttpLink, from, NormalizedCacheObject } from '@apollo/client'
+import { ApolloClient, createHttpLink, from, HttpOptions, NormalizedCacheObject } from '@apollo/client'
 import { LocalStorageWrapper, CachePersistor } from 'apollo3-cache-persist'
 import { once } from 'lodash'
 
+import { checkOk } from '../../http-status-error'
 import { buildGraphQLUrl } from '../graphql'
 import { ConcurrentRequestsLink } from '../links/concurrent-requests-link'
 
@@ -74,6 +75,7 @@ export const getGraphQLClient = once(
                     uri: ({ operationName }) => `${uri}?${operationName}`,
                     headers,
                     credentials,
+                    fetch: customFetch,
                 }),
             ]),
         })
@@ -81,3 +83,5 @@ export const getGraphQLClient = once(
         return Promise.resolve(apolloClient)
     }
 )
+
+const customFetch: HttpOptions['fetch'] = (uri, options) => fetch(uri, options).then(checkOk)

--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -120,10 +120,8 @@ batchedEvents
             }
             return EMPTY
         }),
-        catchError(error => {
-            console.error('Error logging events:', error)
-            return []
-        })
+        // TODO: log errors to Sentry
+        catchError(() => [])
     )
     // eslint-disable-next-line rxjs/no-ignored-subscription
     .subscribe()


### PR DESCRIPTION
## Context

Throw `HTTPStatusError` on unsuccessful HTTP requests made by Apollo Client.
Closes #39911

## Test plan

1. `sg start web-standalone`.
2. Open the web application with the k8s API as a backend
3. See that 401 are thrown before Apollo Client tries to parse HTML responses as JSON.

## App preview:

- [Web](https://sg-web-vb-apollo-client-fetch.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ebnpowaqdl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
