### PR TITLE
sg: use `package.json` `packageManager` field to check `yarn` version

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -2,7 +2,9 @@ package dependencies
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"os/user"
@@ -290,6 +292,41 @@ func getToolVersionConstraint(ctx context.Context, tool string) (string, error) 
 	return fmt.Sprintf("~> %s", version), nil
 }
 
+type PackageJSON struct {
+	PackageManager string `json:"packageManager"`
+}
+
+func getPackageManagerConstraint(ctx context.Context, tool string) (string, error) {
+	filename := "package.json"
+	jsonFile, err := os.Open(filename)
+	if err != nil {
+		return "", errors.Wrap(err, "Open package.json")
+	}
+	defer jsonFile.Close()
+
+	jsonData, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return "", errors.Wrap(err, "Read package.json")
+	}
+
+	data := PackageJSON{}
+	if err := json.Unmarshal(jsonData, &data); err != nil {
+		return "", errors.Wrap(err, "Unmarshal package.json")
+	}
+
+	var version string
+	parts := strings.Split(data.PackageManager, "@")
+	if parts[0] == tool {
+		version = parts[1]
+	}
+
+	if version == "" {
+		return "", errors.Newf("yarn version is not found in package.json")
+	}
+
+	return fmt.Sprintf("~> %s", version), nil
+}
+
 func checkGoVersion(ctx context.Context, out *std.Output, args CheckArgs) error {
 	if err := check.InPath("go")(ctx); err != nil {
 		return err
@@ -318,7 +355,7 @@ func checkYarnVersion(ctx context.Context, out *std.Output, args CheckArgs) erro
 		return err
 	}
 
-	constraint, err := getToolVersionConstraint(ctx, "yarn")
+	constraint, err := getPackageManagerConstraint(ctx, "yarn")
 	if err != nil {
 		return err
 	}
@@ -356,7 +393,7 @@ func checkNodeVersion(ctx context.Context, out *std.Output, args CheckArgs) erro
 		return errors.Newf("no output from %q", cmd)
 	}
 
-	return check.Version("yarn", trimmed, constraint)
+	return check.Version("nodejs", trimmed, constraint)
 }
 
 func checkRustVersion(ctx context.Context, out *std.Output, args CheckArgs) error {

--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -297,8 +297,12 @@ type PackageJSON struct {
 }
 
 func getPackageManagerConstraint(ctx context.Context, tool string) (string, error) {
-	filename := "package.json"
-	jsonFile, err := os.Open(filename)
+	repoRoot, err := root.RepositoryRoot()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to determine repository root location")
+	}
+
+	jsonFile, err := os.Open(filepath.Join(repoRoot, "package.json"))
 	if err != nil {
 		return "", errors.Wrap(err, "Open package.json")
 	}

--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -292,10 +292,6 @@ func getToolVersionConstraint(ctx context.Context, tool string) (string, error) 
 	return fmt.Sprintf("~> %s", version), nil
 }
 
-type PackageJSON struct {
-	PackageManager string `json:"packageManager"`
-}
-
 func getPackageManagerConstraint(ctx context.Context, tool string) (string, error) {
 	repoRoot, err := root.RepositoryRoot()
 	if err != nil {
@@ -313,7 +309,10 @@ func getPackageManagerConstraint(ctx context.Context, tool string) (string, erro
 		return "", errors.Wrap(err, "Read package.json")
 	}
 
-	data := PackageJSON{}
+	data := struct {
+		PackageManager string `json:"packageManager"`
+	}{}
+
 	if err := json.Unmarshal(jsonData, &data); err != nil {
 		return "", errors.Wrap(err, "Unmarshal package.json")
 	}


### PR DESCRIPTION
## Context

We install `yarn v1` via `asdf` and then use `yarn v3` because of the `package.json` `packageManager` field. See more context in [the `yarn` upgrade PR](https://github.com/sourcegraph/sourcegraph/pull/39728#issuecomment-1225896996). 

This PR changes the logic of the `sg setup -check` command for the `yarn` version. It parses `package.json` and extracts the` yarn` version specified in the `packageManager` field and compares it to the output of the `yarn --version` command. 

## Test plan

1. `yarn install`
2. ensure that `yarn --version` outputs `3.2.3`.
3. `go run ./dev/sg setup -check` passed without errors.

