### PR TITLE
casetransform: use stdlib regexp/syntax

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"regexp/syntax"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/grafana/regexp"
-	"github.com/grafana/regexp/syntax"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"go.uber.org/atomic"

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -7,13 +7,13 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"regexp/syntax"
 	"sort"
 	"strconv"
 	"testing"
 	"testing/iotest"
 
 	"github.com/grafana/regexp"
-	"github.com/grafana/regexp/syntax"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"

--- a/internal/search/casetransform/lower_regexp.go
+++ b/internal/search/casetransform/lower_regexp.go
@@ -1,10 +1,9 @@
 package casetransform
 
 import (
+	"regexp/syntax"
 	"unicode"
 	"unicode/utf8"
-
-	"github.com/grafana/regexp/syntax"
 )
 
 // LowerRegexpASCII lowers rune literals and expands char classes to include

--- a/internal/search/casetransform/lower_regexp_test.go
+++ b/internal/search/casetransform/lower_regexp_test.go
@@ -3,7 +3,7 @@ package casetransform
 import (
 	"testing"
 
-	"github.com/grafana/regexp/syntax"
+	"regexp/syntax"
 )
 
 func TestLowerRegexpASCII(t *testing.T) {

--- a/internal/search/casetransform/regexp.go
+++ b/internal/search/casetransform/regexp.go
@@ -1,8 +1,9 @@
 package casetransform
 
 import (
+	"regexp/syntax"
+
 	"github.com/grafana/regexp"
-	"github.com/grafana/regexp/syntax"
 )
 
 // Regexp is a light wrapper over *regexp.Regexp that optimizes for case-insensitive search.


### PR DESCRIPTION
We were using the grafana fork, but we only need the grafana fork for the regex engine, not the syntax parser. In an upcoming commit we want to use a dependency which takes regexp/syntax, motivating this change.

Test Plan: go test