### PR TITLE
searcher: set observation context to benchmarks

### DIFF
--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/pathmatch"
 )
 
@@ -401,8 +402,9 @@ func TestPathMatches(t *testing.T) {
 
 // githubStore fetches from github and caches across test runs.
 var githubStore = &Store{
-	FetchTar: fetchTarFromGithub,
-	Path:     "/tmp/search_test/store",
+	FetchTar:           fetchTarFromGithub,
+	Path:               "/tmp/search_test/store",
+	ObservationContext: &observation.TestContext,
 }
 
 func fetchTarFromGithub(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {


### PR DESCRIPTION
Benchmarks panic without this.

Test Plan: go test