### PR TITLE
searcher: optimize capture groups

### DIFF
--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -93,6 +93,18 @@ func BenchmarkSearchRegex_large_re_anchor(b *testing.B) {
 	})
 }
 
+func BenchmarkSearchRegex_large_capture_group(b *testing.B) {
+	benchSearchRegex(b, &protocol.Request{
+		Repo:   "github.com/golang/go",
+		Commit: "0ebaca6ba27534add5930a95acffa9acff182e2b",
+		PatternInfo: protocol.PatternInfo{
+			Pattern:         "(TODO|FIXME)",
+			IsRegExp:        true,
+			IsCaseSensitive: true,
+		},
+	})
+}
+
 func BenchmarkSearchRegex_large_path(b *testing.B) {
 	do := func(b *testing.B, content, path bool) {
 		benchSearchRegex(b, &protocol.Request{
@@ -162,6 +174,18 @@ func BenchmarkSearchRegex_small_re_anchor(b *testing.B) {
 		Commit: "4193810334683f87b8ed5d896aa4753f0dfcdf20",
 		PatternInfo: protocol.PatternInfo{
 			Pattern:         "^func +[A-Z]",
+			IsRegExp:        true,
+			IsCaseSensitive: true,
+		},
+	})
+}
+
+func BenchmarkSearchRegex_small_capture_group(b *testing.B) {
+	benchSearchRegex(b, &protocol.Request{
+		Repo:   "github.com/sourcegraph/go-langserver",
+		Commit: "4193810334683f87b8ed5d896aa4753f0dfcdf20",
+		PatternInfo: protocol.PatternInfo{
+			Pattern:         "(TODO|FIXME)",
 			IsRegExp:        true,
 			IsCaseSensitive: true,
 		},


### PR DESCRIPTION
Capture groups are slow in go's regexp engine. However, we don't ever use the group captures so we can instead convert the groups into non-capturing groups. We do this by zoekt's OptimizeRegexp function which currently only does this transformation. However, it we plan on it containing more optimizations targetted at the text search use case in the future.

Test Plan: go test and benchmarks. Benchmarks didn't change, except for the new benchmark which uses capture groups

```
name                                old time/op    new time/op    delta
SearchRegex_large_capture_group-32     205ms ±12%     183ms ±16%  -11.04%  (p=0.008 n=9+10)
SearchRegex_small_capture_group-32    4.31ms ± 5%    3.71ms ± 3%  -14.00%  (p=0.000 n=9+8)

name                                old alloc/op   new alloc/op   delta
SearchRegex_large_capture_group-32    3.11MB ± 1%    2.98MB ± 1%   -4.22%  (p=0.000 n=9+10)
SearchRegex_small_capture_group-32    16.1kB ± 1%    15.7kB ± 1%   -2.61%  (p=0.000 n=9+8)

name                                old allocs/op  new allocs/op  delta
SearchRegex_large_capture_group-32     18.1k ± 0%     18.1k ± 0%     ~     (p=0.051 n=8+10)
SearchRegex_small_capture_group-32       193 ± 0%       193 ± 0%     ~     (all equal)
```