### PR TITLE
flakey test: disable TestSearch repo_contains and friends

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1141,16 +1141,17 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query:  `repo:contains.file(content:does-not-exist-D2E1E74C7279) and repo:contains.file(content:nextFileFirstLine)`,
 				counts: counts{Repo: 0},
 			},
-			{
-				name:   `repo contains file then search common`,
-				query:  `repo:contains.file(path:go.mod) count:100 fmt`,
-				counts: counts{Content: 61},
-			},
-			{
-				name:   `repo contains path`,
-				query:  `repo:contains.path(go.mod) count:100 fmt`,
-				counts: counts{Content: 61},
-			},
+			// Flakey tests see: https://buildkite.com/organizations/sourcegraph/pipelines/sourcegraph/builds/169653/jobs/0182e8df-8be9-4235-8f4d-a3d458354249/raw_log
+			// {
+			// 	name:   `repo contains file then search common`,
+			// 	query:  `repo:contains.file(path:go.mod) count:100 fmt`,
+			// 	counts: counts{Content: 61},
+			// },
+			// {
+			// 	name:   `repo contains path`,
+			// 	query:  `repo:contains.path(go.mod) count:100 fmt`,
+			// 	counts: counts{Content: 61},
+			// },
 			{
 				name:   `repo contains file with matching repo filter`,
 				query:  `repo:go-diff repo:contains.file(path:diff.proto)`,


### PR DESCRIPTION
flake encountered here https://buildkite.com/organizations/sourcegraph/pipelines/sourcegraph/builds/169653/jobs/0182e8df-8be9-4235-8f4d-a3d458354249/raw_log

Corresponding issue: https://github.com/sourcegraph/sourcegraph/issues/40979

## Test plan
None, disabling tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
