### PR TITLE
Add a GHA to check PRs on 4.0, blocking them if label is not present (only post release date)

### DIFF
--- a/.github/workflows/fourpointoh-protector.yml
+++ b/.github/workflows/fourpointoh-protector.yml
@@ -23,6 +23,7 @@ jobs:
               exit 0
             else 
               echo "❌ Label 'i-acknowledge-this-goes-into-4.0' is absent"
+              echo "👉 If you are 100% sure your changes should go in 4.0, label your PR with 'i-acknowledge-this-goes-into-4.0''"
               exit 1
             fi
           else

--- a/.github/workflows/fourpointoh-protector.yml
+++ b/.github/workflows/fourpointoh-protector.yml
@@ -1,4 +1,4 @@
-name: Release 4.0 protection
+name: Sourcegraph 4.0 code freeze
 on:
   pull_request:
     types: [ closed, edited, opened, synchronize, ready_for_review, labeled, unlabeled]
@@ -13,19 +13,19 @@ jobs:
       - name: Check date and labels
         id: check-date-and-labels
         run: |
-          has_label="${{contains(github.event.pull_request.labels.*.name, 'must-go-in-4.0')}}"
+          has_label="${{contains(github.event.pull_request.labels.*.name, 'i-acknowledge-this-goes-into-4.0')}}"
           today=$(date +'%Y%m%d%H%M')
           dday="202209090000"
 
           if [ "$today" -gt "$dday" ]; then
             if [ "$has_label" = "true" ]; then
-              echo "✅ Label 'must-go-in-4.0' is present"
+              echo "✅ Label 'i-acknowledge-this-goes-into-4.0' is present"
               exit 0
             else 
-              echo "❌ Label 'must-go-in-4.0' is absent"
+              echo "❌ Label 'i-acknowledge-this-goes-into-4.0' is absent"
               exit 1
             fi
           else
-            echo "📅 Not enabled, we're not yet on 2022-09-09 and 4.0 has not been released." 
+            echo "📅 Not enabled, we're not yet on 2022-09-09 and 4.0 code freeze has not started yet." 
             exit 0
           fi

--- a/.github/workflows/fourpointoh-protector.yml
+++ b/.github/workflows/fourpointoh-protector.yml
@@ -23,7 +23,7 @@ jobs:
               exit 0
             else 
               echo "❌ Label 'i-acknowledge-this-goes-into-4.0' is absent"
-              echo "👉 If you are 100% sure your changes should go in 4.0, label your PR with 'i-acknowledge-this-goes-into-4.0''"
+              echo "👉 We're in the Sourcegraph 4.0 code freeze. If you are 100% sure your changes should go in 4.0 or provide no risk to the release 4.0, add the label your PR with 'i-acknowledge-this-goes-into-4.0''"
               exit 1
             fi
           else

--- a/.github/workflows/fourpointoh-protector.yml
+++ b/.github/workflows/fourpointoh-protector.yml
@@ -1,0 +1,31 @@
+name: Release 4.0 protection
+on:
+  pull_request:
+    types: [ closed, edited, opened, synchronize, ready_for_review, labeled, unlabeled]
+    branches: 
+      # only run on branches targeting the `main` branch.
+      - main
+
+jobs:
+  protect-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check date and labels
+        id: check-date-and-labels
+        run: |
+          has_label="${{contains(github.event.pull_request.labels.*.name, 'must-go-in-4.0')}}"
+          today=$(date +'%Y%m%d%H%M')
+          dday="202109090000"
+
+          if [ "$today" -gt "$dday" ]; then
+            if [ "$has_label" = "true" ]; then
+              echo "✅ Label 'must-go-in-4.0' is present"
+              exit 0
+            else 
+              echo "❌ Label 'must-go-in-4.0' is absent"
+              exit 1
+            fi
+          else
+            echo "📅 Not enabled, we're not yet on 2022-09-09 and 4.0 has not been released." 
+            exit 0
+          fi

--- a/.github/workflows/fourpointoh-protector.yml
+++ b/.github/workflows/fourpointoh-protector.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           has_label="${{contains(github.event.pull_request.labels.*.name, 'must-go-in-4.0')}}"
           today=$(date +'%Y%m%d%H%M')
-          dday="202109090000"
+          dday="202209090000"
 
           if [ "$today" -gt "$dday" ]; then
             if [ "$has_label" = "true" ]; then


### PR DESCRIPTION
Adds a GitHub action that will check that after *2022-09-09* the `must-be-in-4.0` label is present, or the check will fail otherwise. If we are before that day, the check will always be green.

Later this week, I'll add this check as mandatory.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Run with dday set to 2021-09-09 and no label:
  - 🔴 https://github.com/sourcegraph/sourcegraph/runs/8072123819?check_suite_focus=true
- Run with dday set to 2021-09-09 and with the label: 
  - 🟢 https://github.com/sourcegraph/sourcegraph/runs/8072108225?check_suite_focus=true
- Run with dday set to *2022-09-09* and no label: 
  - 🟢 https://github.com/sourcegraph/sourcegraph/runs/8072144421?check_suite_focus=true 