### PR TITLE
drift: Add `-file` option

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -692,7 +692,8 @@ Flags:
 
 * `--db="<value>"`: The target `schema` to compare.
 * `--feedback`: provide feedback about this command by opening up a Github discussion
-* `--version="<value>"`: The target schema version. Must be resolvable as a git revlike on the sourcegraph repository.
+* `--file="<value>"`: The target schema description file.
+* `--version="<value>"`: The target schema version. Must be resolvable as a git revlike on the Sourcegraph repository.
 
 ### sg migration add-log
 

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -2,6 +2,8 @@ package cliutil
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 
 	"github.com/urfave/cli/v2"
 
@@ -18,13 +20,23 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 	}
 	versionFlag := &cli.StringFlag{
 		Name:     "version",
-		Usage:    "The target schema version. Must be resolvable as a git revlike on the sourcegraph repository.",
-		Required: true,
+		Usage:    "The target schema version. Must be resolvable as a git revlike on the Sourcegraph repository.",
+		Required: false,
+	}
+	fileFlag := &cli.StringFlag{
+		Name:     "file",
+		Usage:    "The target schema description file.",
+		Required: false,
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
 		schemaName := schemaNameFlag.Get(cmd)
 		version := versionFlag.Get(cmd)
+		file := fileFlag.Get(cmd)
+
+		if (version == "" && file == "") || (version != "" && file != "") {
+			return errors.New("must supply exactly one of -version or -file")
+		}
 
 		_, store, err := setupStore(ctx, factory, schemaName)
 		if err != nil {
@@ -36,24 +48,11 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 		}
 		schema := schemas["public"]
 
-		filename, err := getSchemaJSONFilename(schemaName)
-		if err != nil {
-			return err
+		if file != "" {
+			return compareByFile(schemaName, version, schema, out, file)
 		}
 
-		for _, factory := range expectedSchemaFactories {
-			expectedSchema, ok, err := factory(filename, version)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				continue
-			}
-
-			return compareSchemaDescriptions(out, schemaName, version, canonicalize(schema), canonicalize(expectedSchema))
-		}
-
-		return errors.Newf("failed to determine squash schema for version %s (expected the file %s to exist)", version, filename)
+		return compareByFactories(schemaName, version, schema, out, expectedSchemaFactories)
 	})
 
 	return &cli.Command{
@@ -64,8 +63,63 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 		Flags: []cli.Flag{
 			schemaNameFlag,
 			versionFlag,
+			fileFlag,
 		},
 	}
+}
+
+func compareByFile(
+	schemaName string,
+	version string,
+	schema descriptions.SchemaDescription,
+	out *output.Output,
+	file string,
+) error {
+	expectedSchema, err := readDescriptionFromFile(file)
+	if err != nil {
+		return err
+	}
+
+	return compareSchemaDescriptions(out, schemaName, version, canonicalize(schema), canonicalize(expectedSchema))
+}
+
+func readDescriptionFromFile(file string) (descriptions.SchemaDescription, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return descriptions.SchemaDescription{}, err
+	}
+	defer f.Close()
+
+	var expectedSchema descriptions.SchemaDescription
+	err = json.NewDecoder(f).Decode(&expectedSchema)
+	return expectedSchema, err
+}
+
+func compareByFactories(
+	schemaName string,
+	version string,
+	schema descriptions.SchemaDescription,
+	out *output.Output,
+	expectedSchemaFactories []ExpectedSchemaFactory,
+) error {
+	filename, err := getSchemaJSONFilename(schemaName)
+	if err != nil {
+		return err
+	}
+
+	for _, factory := range expectedSchemaFactories {
+		expectedSchema, ok, err := factory(filename, version)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+
+		return compareSchemaDescriptions(out, schemaName, version, canonicalize(schema), canonicalize(expectedSchema))
+	}
+
+	return errors.Newf("failed to determine squash schema for version %s (expected the file %s to exist)", version, filename)
 }
 
 func canonicalize(schemaDescription descriptions.SchemaDescription) descriptions.SchemaDescription {


### PR DESCRIPTION
This PR adds a `-file` flag that can be used in place of `-version` to supply a schema description file on-disk. Useful for air-gapped instances which cannot reach out repository via GitHub nor our GCS bucket holding historic versions. Fixes #39961.

## Test plan

Tested locally.