### PR TITLE
admin-analytics: replace sidebar "statistics" with new "analytics"

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -16,7 +16,6 @@ export type FeatureFlagName =
     | 'admin-analytics-cache-disabled'
     | 'search-aggregation-filters'
     | 'ab-lucky-search' // To be removed at latest by 12/2022.
-    | 'user-management-disabled'
     | 'search-input-hide-history'
 
 interface OrgFlagOverride {

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -140,7 +140,7 @@ const AnalyticsNavItem: React.FunctionComponent = () => {
 
     return (
         <NavAction className="d-none d-sm-flex">
-            <Link to="/site-admin/analytics/search" className={classNames('font-weight-medium', styles.link)}>
+            <Link to="/site-admin" className={classNames('font-weight-medium', styles.link)}>
                 Analytics
             </Link>
         </NavAction>

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/FeatureFlaggedUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/FeatureFlaggedUsersPage.tsx
@@ -4,4 +4,8 @@ import { UsersManagement } from './UserManagement'
 
 import { SiteAdminAllUsersPage } from '.'
 
-export const FeatureFlaggedUsersPage = withFeatureFlag('admin-analytics-disabled', SiteAdminAllUsersPage, UsersManagement)
+export const FeatureFlaggedUsersPage = withFeatureFlag(
+    'admin-analytics-disabled',
+    SiteAdminAllUsersPage,
+    UsersManagement
+)

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/FeatureFlaggedUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/FeatureFlaggedUsersPage.tsx
@@ -4,8 +4,4 @@ import { UsersManagement } from './UserManagement'
 
 import { SiteAdminAllUsersPage } from '.'
 
-export const FeatureFlaggedUsersPage = withFeatureFlag(
-    'user-management-disabled',
-    SiteAdminAllUsersPage,
-    UsersManagement
-)
+export const FeatureFlaggedUsersPage = withFeatureFlag('admin-analytics-disabled', SiteAdminAllUsersPage, UsersManagement)

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -1,7 +1,8 @@
 import React, { useLayoutEffect, useMemo, useRef } from 'react'
 
 import classNames from 'classnames'
-import ChartLineIcon from 'mdi-react/ChartLineIcon'
+import { isEqual } from 'lodash'
+import ChartLineVariantIcon from 'mdi-react/ChartLineVariantIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { Route, RouteComponentProps, Switch, useLocation } from 'react-router'
 
@@ -22,6 +23,7 @@ import { Page } from '../components/Page'
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import { RouteDescriptor } from '../util/contributions'
 
+import { overviewGroup } from './sidebaritems'
 import { SiteAdminSidebar, SiteAdminSideBarGroup, SiteAdminSideBarGroups } from './SiteAdminSidebar'
 
 import styles from './SiteAdminArea.module.scss'
@@ -73,12 +75,12 @@ interface SiteAdminAreaProps
 export const analyticsGroup: SiteAdminSideBarGroup = {
     header: {
         label: 'Analytics',
-        icon: ChartLineIcon,
+        icon: ChartLineVariantIcon,
     },
     items: [
         {
             label: 'Overview',
-            to: '/site-admin/analytics',
+            to: '/site-admin/',
             exact: true,
         },
         {
@@ -104,6 +106,10 @@ export const analyticsGroup: SiteAdminSideBarGroup = {
         {
             label: 'Extensions',
             to: '/site-admin/analytics/extensions',
+        },
+        {
+            label: 'Feedback survey',
+            to: '/site-admin/surveys',
         },
         {
             label: 'Code insights (soon)',
@@ -154,7 +160,7 @@ export const analyticsRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
     },
     {
-        path: '/analytics',
+        path: '/',
         render: lazyComponent(() => import('./analytics/AnalyticsOverviewPage'), 'AnalyticsOverviewPage'),
         exact: true,
     },
@@ -173,10 +179,13 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
 
     const [isAdminAnalyticsDisabled] = useFeatureFlag('admin-analytics-disabled', false)
 
-    const adminSideBarGroups = useMemo(
-        () => (!isAdminAnalyticsDisabled ? [analyticsGroup, ...props.sideBarGroups] : props.sideBarGroups),
-        [isAdminAnalyticsDisabled, props.sideBarGroups]
-    )
+    const adminSideBarGroups = useMemo(() => {
+        if (isAdminAnalyticsDisabled) {
+            return props.sideBarGroups
+        }
+        return [analyticsGroup, ...props.sideBarGroups.filter(group => !isEqual(group, overviewGroup))]
+    }, [isAdminAnalyticsDisabled, props.sideBarGroups])
+
     const routes = useMemo(() => (!isAdminAnalyticsDisabled ? [...analyticsRoutes, ...props.routes] : props.routes), [
         isAdminAnalyticsDisabled,
         props.routes,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39966.

This PR:
- Moves "Feedback survey" site admin sidebar to "analytics" sidebar group
- Replaces old "Statistics" sidebar group with new "Analytics sidebar group under
  - It can be disabled by setting the `admin-analytics-disabled` feature flag
- Also removes `user-management-disabled` feature flag key and uses existing `admin-analytics-disabled` for new user management disabling


## Test plan
- `sg start`
- Open http://localhost:3080/site-admin
- Check that it opens a new "analytics/overview" page and there is no "Statistics" sidebar item
  - Also check that http://localhost:3080/site-admin/users opens new user management
- Open http://localhost:3080/site-admin?feature-flag-key=admin-analytics-disabled&feature-flag-value=true
- Check that it opens the old "statistics/overview" page and there is no new "Analytics" sidebar item
  - Also check that http://localhost:3080/site-admin/users opens old user management

## Screenshots
| Before | After |
| --: | :-- |
| <img width="223" alt="image" src="https://user-images.githubusercontent.com/6717049/187212360-3bcb45de-b368-497b-9016-97c817a98784.png"> | <img width="223" alt="image" src="https://user-images.githubusercontent.com/6717049/187212606-0c2ce2c8-0a00-49ff-87d4-492f88aa0929.png"> |

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-replace-site-admin.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ysdvjmfpfo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
