### PR TITLE
casetransform: optimize out capture groups

### DIFF
--- a/internal/search/casetransform/regexp.go
+++ b/internal/search/casetransform/regexp.go
@@ -4,6 +4,7 @@ import (
 	"regexp/syntax"
 
 	"github.com/grafana/regexp"
+	"github.com/sourcegraph/zoekt/query"
 )
 
 // Regexp is a light wrapper over *regexp.Regexp that optimizes for case-insensitive search.
@@ -24,13 +25,9 @@ type Regexp struct {
 }
 
 func CompileRegexp(expr string, ignoreCase bool) (*Regexp, error) {
-	if ignoreCase {
-		syn, err := syntax.Parse(expr, syntax.Perl)
-		if err != nil {
-			return nil, err
-		}
-		LowerRegexpASCII(syn)
-		expr = syn.String()
+	expr, err := transformExpression(expr, ignoreCase)
+	if err != nil {
+		return nil, err
 	}
 
 	re, err := regexp.Compile(expr)
@@ -41,6 +38,24 @@ func CompileRegexp(expr string, ignoreCase bool) (*Regexp, error) {
 		re:         re,
 		ignoreCase: ignoreCase,
 	}, nil
+}
+
+func transformExpression(expr string, ignoreCase bool) (string, error) {
+	syn, err := syntax.Parse(expr, syntax.Perl)
+	if err != nil {
+		return "", err
+	}
+
+	if ignoreCase {
+		LowerRegexpASCII(syn)
+	}
+
+	// OptimizeRegexp currently only converts capture groups into non-capture
+	// groups (faster for stdlib regexp to execute). This is safe to do since
+	// Regexp doesn't expose an API to capture subgroups.
+	syn = query.OptimizeRegexp(syn, syntax.Perl)
+
+	return syn.String(), nil
 }
 
 func (r *Regexp) FindAllIndex(b []byte, n int, lowerBuf *[]byte) [][]int {


### PR DESCRIPTION
Zoekt exposes OptimizeRegexp which is targets transformations which make the go regex engine faster for text search use case. Right now this is just transforming capture groups into non-capture groups. This is safe for casetransform since it doesn't expose subgroups in its API.

The only user of casetransform.Regexp is gitserver search, so this might translate into a noticeable difference for queries using groups.

Test Plan: CI, optimize regexp has already had its own testing.
