### PR TITLE
Return disk size of repos from DB

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -146,6 +146,17 @@ func (r *RepositoryResolver) CloneInProgress(ctx context.Context) (bool, error) 
 	return r.MirrorInfo().CloneInProgress(ctx)
 }
 
+func (r *RepositoryResolver) DiskSizeBytes(ctx context.Context) (*BigInt, error) {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		if err == backend.ErrMustBeSiteAdmin || err == backend.ErrNotAuthenticated {
+			return nil, nil // not an error
+		}
+		return nil, err
+	}
+	repo, err := r.db.GitserverRepos().GetByID(ctx, r.IDInt32())
+	return &BigInt{Int: repo.RepoSizeBytes}, err
+}
+
 func (r *RepositoryResolver) BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
 	id := r.ID()
 	args.Repo = &id

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2857,6 +2857,11 @@ type Repository implements Node & GenericSearchResultInterface {
     A set of user-defined key-value pairs associated with the repo.
     """
     keyValuePairs: [KeyValuePair!]!
+
+    """
+    The size of repo when cloned on disk
+    """
+    diskSizeBytes: BigInt
 }
 
 """


### PR DESCRIPTION
Return on-disk size of repository from `gitserver_repos` table.

## Test plan

- API Console