### PR TITLE
log15 migration: migrate usage of log15 in frontend auth userpasswd to use sourcegraph/log

### DIFF
--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -28,6 +28,8 @@ func NewHandler(db database.DB, logger log.Logger, githubAppSetupHandler http.Ha
 		return globals.ExternalURL().Scheme == "https"
 	}))
 
+	logger = logger.Scoped("appHandler", "handles routes for all app related requests")
+
 	r := router.Router()
 
 	m := http.NewServeMux()
@@ -58,16 +60,16 @@ func NewHandler(db database.DB, logger log.Logger, githubAppSetupHandler http.Ha
 		time.Duration(lockoutOptions.LockoutPeriod)*time.Second,
 		time.Duration(lockoutOptions.ConsecutivePeriod)*time.Second,
 	)
-	r.Get(router.SignUp).Handler(trace.Route(userpasswd.HandleSignUp(db)))
-	r.Get(router.SiteInit).Handler(trace.Route(userpasswd.HandleSiteInit(db)))
-	r.Get(router.SignIn).Handler(trace.Route(userpasswd.HandleSignIn(db, lockoutStore)))
+	r.Get(router.SignUp).Handler(trace.Route(userpasswd.HandleSignUp(logger, db)))
+	r.Get(router.SiteInit).Handler(trace.Route(userpasswd.HandleSiteInit(logger, db)))
+	r.Get(router.SignIn).Handler(trace.Route(userpasswd.HandleSignIn(logger, db, lockoutStore)))
 	r.Get(router.SignOut).Handler(trace.Route(serveSignOutHandler(db)))
-	r.Get(router.UnlockAccount).Handler(trace.Route(userpasswd.HandleUnlockAccount(db, lockoutStore)))
-	r.Get(router.ResetPasswordInit).Handler(trace.Route(userpasswd.HandleResetPasswordInit(db)))
-	r.Get(router.ResetPasswordCode).Handler(trace.Route(userpasswd.HandleResetPasswordCode(db)))
+	r.Get(router.UnlockAccount).Handler(trace.Route(userpasswd.HandleUnlockAccount(logger, db, lockoutStore)))
+	r.Get(router.ResetPasswordInit).Handler(trace.Route(userpasswd.HandleResetPasswordInit(logger, db)))
+	r.Get(router.ResetPasswordCode).Handler(trace.Route(userpasswd.HandleResetPasswordCode(logger, db)))
 	r.Get(router.VerifyEmail).Handler(trace.Route(serveVerifyEmail(db)))
 
-	r.Get(router.CheckUsernameTaken).Handler(trace.Route(userpasswd.HandleCheckUsernameTaken(db)))
+	r.Get(router.CheckUsernameTaken).Handler(trace.Route(userpasswd.HandleCheckUsernameTaken(logger, db)))
 
 	r.Get(router.RegistryExtensionBundle).Handler(trace.Route(gziphandler.GzipHandler(registry.HandleRegistryExtensionBundle(db))))
 

--- a/cmd/frontend/internal/auth/userpasswd/config.go
+++ b/cmd/frontend/internal/auth/userpasswd/config.go
@@ -3,8 +3,7 @@ package userpasswd
 import (
 	"net/http"
 
-	"github.com/inconshreveable/log15"
-
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -31,10 +30,10 @@ func getProviderConfig() (pc *schema.BuiltinAuthProvider, multiple bool) {
 	return pc, false
 }
 
-func handleEnabledCheck(w http.ResponseWriter) (handled bool) {
+func handleEnabledCheck(logger log.Logger, w http.ResponseWriter) (handled bool) {
 	pc, multiple := getProviderConfig()
 	if multiple {
-		log15.Error("At most 1 builtin auth provider may be set in site config.")
+		logger.Error("At most 1 builtin auth provider may be set in site config.")
 		http.Error(w, "Misconfigured builtin auth provider.", http.StatusInternalServerError)
 		return true
 	}

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -46,6 +46,7 @@ type unlockAccountInfo struct {
 
 // HandleSignUp handles submission of the user signup form.
 func HandleSignUp(logger log.Logger, db database.DB) http.HandlerFunc {
+	logger = logger.Scoped("HandleSignUp", "sign up request handler")
 	return func(w http.ResponseWriter, r *http.Request) {
 		if handleEnabledCheck(logger, w) {
 			return
@@ -60,6 +61,7 @@ func HandleSignUp(logger log.Logger, db database.DB) http.HandlerFunc {
 
 // HandleSiteInit handles submission of the site initialization form, where the initial site admin user is created.
 func HandleSiteInit(logger log.Logger, db database.DB) http.HandlerFunc {
+	logger = logger.Scoped("HandleSiteInit", "initial size initialization request handler")
 	return func(w http.ResponseWriter, r *http.Request) {
 		// This only succeeds if the site is not yet initialized and there are no users yet. It doesn't
 		// allow signups after those conditions become true, so we don't need to check the builtin auth
@@ -246,6 +248,7 @@ func getByEmailOrUsername(ctx context.Context, db database.DB, emailOrUsername s
 // The account will be locked out after consecutive failed attempts in a certain
 // period of time.
 func HandleSignIn(logger log.Logger, db database.DB, store LockoutStore) http.HandlerFunc {
+	logger = logger.Scoped("HandleSignin", "sign in request handler")
 	return func(w http.ResponseWriter, r *http.Request) {
 		if handleEnabledCheck(logger, w) {
 			return
@@ -333,6 +336,7 @@ func HandleSignIn(logger log.Logger, db database.DB, store LockoutStore) http.Ha
 }
 
 func HandleUnlockAccount(logger log.Logger, _ database.DB, store LockoutStore) http.HandlerFunc {
+	logger = logger.Scoped("HandleUnlockAccount", "unlock account request handler")
 	return func(w http.ResponseWriter, r *http.Request) {
 		if handleEnabledCheck(logger, w) {
 			return
@@ -398,6 +402,7 @@ func checkAccountLockout(store LockoutStore, user *types.User, event *database.S
 
 // HandleCheckUsernameTaken checks availability of username for signup form
 func HandleCheckUsernameTaken(logger log.Logger, db database.DB) http.HandlerFunc {
+	logger = logger.Scoped("HandleCheckUsernameTaken", "checks for username uniqueness")
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		username, err := auth.NormalizeUsername(vars["username"])

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -45,26 +45,26 @@ type unlockAccountInfo struct {
 }
 
 // HandleSignUp handles submission of the user signup form.
-func HandleSignUp(db database.DB) http.HandlerFunc {
+func HandleSignUp(logger log.Logger, db database.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if handleEnabledCheck(w) {
+		if handleEnabledCheck(logger, w) {
 			return
 		}
 		if pc, _ := getProviderConfig(); !pc.AllowSignup {
 			http.Error(w, "Signup is not enabled (builtin auth provider allowSignup site configuration option)", http.StatusNotFound)
 			return
 		}
-		handleSignUp(db, w, r, false)
+		handleSignUp(logger, db, w, r, false)
 	}
 }
 
 // HandleSiteInit handles submission of the site initialization form, where the initial site admin user is created.
-func HandleSiteInit(db database.DB) http.HandlerFunc {
+func HandleSiteInit(logger log.Logger, db database.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// This only succeeds if the site is not yet initialized and there are no users yet. It doesn't
 		// allow signups after those conditions become true, so we don't need to check the builtin auth
 		// provider's allowSignup in site config.
-		handleSignUp(db, w, r, true)
+		handleSignUp(logger, db, w, r, true)
 	}
 }
 
@@ -95,7 +95,7 @@ func checkEmailAbuse(ctx context.Context, db database.DB, addr string) (abused b
 //
 // 🚨 SECURITY: Any change to this function could introduce security exploits
 // and/or break sign up / initial admin account creation. Be careful.
-func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInitialSiteAdmin bool) {
+func handleSignUp(logger log.Logger, db database.DB, w http.ResponseWriter, r *http.Request, failIfNewUserIsNotInitialSiteAdmin bool) {
 	if r.Method != "POST" {
 		http.Error(w, fmt.Sprintf("unsupported method %s", r.Method), http.StatusBadRequest)
 		return
@@ -136,7 +136,7 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 	} else {
 		code, err := backend.MakeEmailVerificationCode()
 		if err != nil {
-			log15.Error("Error generating email verification code for new user.", "email", creds.Email, "username", creds.Username, "error", err)
+			logger.Error("Error generating email verification code for new user.", log.String("email", creds.Email), log.String("username", creds.Username), log.Error(err))
 			http.Error(w, defaultErrorMessage, http.StatusInternalServerError)
 			return
 		}
@@ -148,11 +148,11 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 	if conf.EmailVerificationRequired() && !newUserData.EmailIsVerified {
 		abused, reason, err := checkEmailAbuse(r.Context(), db, creds.Email)
 		if err != nil {
-			log15.Error("Error checking email abuse", "email", creds.Email, "error", err)
+			logger.Error("Error checking email abuse", log.String("email", creds.Email), log.Error(err))
 			http.Error(w, defaultErrorMessage, http.StatusInternalServerError)
 			return
 		} else if abused {
-			log15.Error("Possible email address abuse prevented", "email", creds.Email, "reason", reason)
+			logger.Error("Possible email address abuse prevented", log.String("email", creds.Email), log.String("reason", reason))
 			http.Error(w, "Email address is possibly being abused, please try again later or use a different email address.", http.StatusTooManyRequests)
 			return
 		}
@@ -180,11 +180,11 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 			message = defaultErrorMessage
 			statusCode = http.StatusInternalServerError
 		}
-		log15.Error("Error in user signup.", "email", creds.Email, "username", creds.Username, "error", err)
+		logger.Error("Error in user signup.", log.String("email", creds.Email), log.String("username", creds.Username), log.Error(err))
 		http.Error(w, message, statusCode)
 
 		if err = usagestats.LogBackendEvent(db, actor.FromContext(r.Context()).UID, deviceid.FromContext(r.Context()), "SignUpFailed", nil, nil, featureflag.GetEvaluatedFlagSet(r.Context()), nil); err != nil {
-			log15.Warn("Failed to log event SignUpFailed", "error", err)
+			logger.Warn("Failed to log event SignUpFailed", log.Error(err))
 		}
 
 		return
@@ -195,21 +195,21 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 		Perm:   authz.Read,
 		Type:   authz.PermRepos,
 	}); err != nil {
-		log15.Error("Failed to grant user pending permissions", "userID", usr.ID, "error", err)
+		logger.Error("Failed to grant user pending permissions", log.Int32("userID", usr.ID), log.Error(err))
 	}
 
 	if conf.EmailVerificationRequired() && !newUserData.EmailIsVerified {
 		if err := backend.SendUserEmailVerificationEmail(r.Context(), usr.Username, creds.Email, newUserData.EmailVerificationCode); err != nil {
-			log15.Error("failed to send email verification (continuing, user's email will be unverified)", "email", creds.Email, "err", err)
+			logger.Error("failed to send email verification (continuing, user's email will be unverified)", log.String("email", creds.Email), log.Error(err))
 		} else if err = db.UserEmails().SetLastVerification(r.Context(), usr.ID, creds.Email, newUserData.EmailVerificationCode); err != nil {
-			log15.Error("failed to set email last verification sent at (user's email is verified)", "email", creds.Email, "err", err)
+			logger.Error("failed to set email last verification sent at (user's email is verified)", log.String("email", creds.Email), log.Error(err))
 		}
 	}
 
 	// Write the session cookie
 	a := &actor.Actor{UID: usr.ID}
 	if err := session.SetActor(w, r, a, 0, usr.CreatedAt); err != nil {
-		httpLogAndError(w, "Could not create new user session", http.StatusInternalServerError, "err", err)
+		httpLogAndError(logger, w, "Could not create new user session", http.StatusInternalServerError, log.Error(err))
 	}
 
 	// Track user data
@@ -218,7 +218,7 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 	}
 
 	if err = usagestats.LogBackendEvent(db, actor.FromContext(r.Context()).UID, deviceid.FromContext(r.Context()), "SignUpSucceeded", nil, nil, featureflag.GetEvaluatedFlagSet(r.Context()), nil); err != nil {
-		log15.Warn("Failed to log event SignUpSucceeded", "error", err)
+		logger.Warn("Failed to log event SignUpSucceeded", log.Error(err))
 	}
 }
 
@@ -245,9 +245,9 @@ func getByEmailOrUsername(ctx context.Context, db database.DB, emailOrUsername s
 //
 // The account will be locked out after consecutive failed attempts in a certain
 // period of time.
-func HandleSignIn(db database.DB, store LockoutStore) http.HandlerFunc {
+func HandleSignIn(logger log.Logger, db database.DB, store LockoutStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if handleEnabledCheck(w) {
+		if handleEnabledCheck(logger, w) {
 			return
 		}
 
@@ -280,7 +280,7 @@ func HandleSignIn(db database.DB, store LockoutStore) http.HandlerFunc {
 		// Validate user. Allow login by both email and username (for convenience).
 		u, err := getByEmailOrUsername(ctx, db, creds.Email)
 		if err != nil {
-			httpLogAndError(w, "Authentication failed", http.StatusUnauthorized, "err", err)
+			httpLogAndError(logger, w, "Authentication failed", http.StatusUnauthorized, log.Error(err))
 			return
 		}
 		user = *u
@@ -293,29 +293,29 @@ func HandleSignIn(db database.DB, store LockoutStore) http.HandlerFunc {
 
 				recipient, _, err := db.UserEmails().GetPrimaryEmail(ctx, user.ID)
 				if err != nil {
-					log15.Error("Error getting primary email address", "userID", user.ID, "error", err)
+					logger.Error("Error getting primary email address", log.Int32("userID", user.ID), log.Error(err))
 					return
 				}
 
 				err = store.SendUnlockAccountEmail(ctx, user.ID, recipient)
 				if err != nil {
-					log15.Error("Error sending unlock account email", "userID", user.ID, "error", err)
+					logger.Error("Error sending unlock account email", log.Int32("userID", user.ID), log.Error(err))
 					return
 				}
 			}()
 
-			httpLogAndError(w, fmt.Sprintf("Account has been locked out due to %q", reason), http.StatusUnprocessableEntity)
+			httpLogAndError(logger, w, fmt.Sprintf("Account has been locked out due to %q", reason), http.StatusUnprocessableEntity)
 			return
 		}
 
 		// 🚨 SECURITY: check password
 		correct, err := db.Users().IsPassword(ctx, user.ID, creds.Password)
 		if err != nil {
-			httpLogAndError(w, "Error checking password", http.StatusInternalServerError, "err", err)
+			httpLogAndError(logger, w, "Error checking password", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 		if !correct {
-			httpLogAndError(w, "Authentication failed", http.StatusUnauthorized)
+			httpLogAndError(logger, w, "Authentication failed", http.StatusUnauthorized)
 			return
 		}
 
@@ -324,7 +324,7 @@ func HandleSignIn(db database.DB, store LockoutStore) http.HandlerFunc {
 			UID: user.ID,
 		}
 		if err := session.SetActor(w, r, &actor, 0, user.CreatedAt); err != nil {
-			httpLogAndError(w, "Could not create new user session", http.StatusInternalServerError, "err", err)
+			httpLogAndError(logger, w, "Could not create new user session", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 
@@ -332,10 +332,9 @@ func HandleSignIn(db database.DB, store LockoutStore) http.HandlerFunc {
 	}
 }
 
-func HandleUnlockAccount(_ database.DB, store LockoutStore) http.HandlerFunc {
+func HandleUnlockAccount(logger log.Logger, _ database.DB, store LockoutStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if handleEnabledCheck(w) {
-
+		if handleEnabledCheck(logger, w) {
 			return
 		}
 
@@ -362,7 +361,7 @@ func HandleUnlockAccount(_ database.DB, store LockoutStore) http.HandlerFunc {
 			if error != nil {
 				err = error.Error()
 			}
-			httpLogAndError(w, err, http.StatusUnauthorized)
+			httpLogAndError(logger, w, err, http.StatusUnauthorized)
 			return
 		}
 	}
@@ -398,7 +397,7 @@ func checkAccountLockout(store LockoutStore, user *types.User, event *database.S
 }
 
 // HandleCheckUsernameTaken checks availability of username for signup form
-func HandleCheckUsernameTaken(db database.DB) http.HandlerFunc {
+func HandleCheckUsernameTaken(logger log.Logger, db database.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		username, err := auth.NormalizeUsername(vars["username"])
@@ -414,7 +413,7 @@ func HandleCheckUsernameTaken(db database.DB) http.HandlerFunc {
 			return
 		}
 		if err != nil {
-			httpLogAndError(w, "Error checking username uniqueness", http.StatusInternalServerError, "err", err)
+			httpLogAndError(logger, w, "Error checking username uniqueness", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 
@@ -422,7 +421,7 @@ func HandleCheckUsernameTaken(db database.DB) http.HandlerFunc {
 	}
 }
 
-func httpLogAndError(w http.ResponseWriter, msg string, code int, errArgs ...any) {
-	log15.Error(msg, errArgs...)
+func httpLogAndError(logger log.Logger, w http.ResponseWriter, msg string, code int, errArgs ...log.Field) {
+	logger.Error(msg, errArgs...)
 	http.Error(w, msg, code)
 }

--- a/cmd/frontend/internal/auth/userpasswd/handlers_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -128,7 +129,11 @@ func TestHandleSignIn_Lockout(t *testing.T) {
 	db.UserEmailsFunc.SetDefaultReturn(database.NewMockUserEmailsStore())
 
 	lockout := NewMockLockoutStore()
-	h := HandleSignIn(db, lockout)
+	logger := logtest.NoOp(t)
+	if testing.Verbose() {
+		logger = logtest.Scoped(t)
+	}
+	h := HandleSignIn(logger, db, lockout)
 
 	// Normal authentication fail before lockout
 	{
@@ -176,7 +181,11 @@ func TestHandleAccount_Unlock(t *testing.T) {
 	db.SecurityEventLogsFunc.SetDefaultReturn(database.NewMockSecurityEventLogsStore())
 
 	lockout := NewMockLockoutStore()
-	h := HandleUnlockAccount(db, lockout)
+	logger := logtest.NoOp(t)
+	if testing.Verbose() {
+		logger = logtest.Scoped(t)
+	}
+	h := HandleUnlockAccount(logger, db, lockout)
 
 	// bad request if missing token or user id
 	{

--- a/cmd/frontend/internal/auth/userpasswd/main_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/main_test.go
@@ -5,13 +5,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log/logtest"
 )
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	if !testing.Verbose() {
-		log15.Root().SetHandler(log15.DiscardHandler())
-	}
+	logtest.Init(m)
 	os.Exit(m.Run())
 }

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -37,6 +37,7 @@ func SendResetPasswordURLEmail(ctx context.Context, email, username string, rese
 
 // HandleResetPasswordInit initiates the builtin-auth password reset flow by sending a password-reset email.
 func HandleResetPasswordInit(logger log.Logger, db database.DB) http.HandlerFunc {
+	logger = logger.Scoped("HandleResetPasswordInit", "password reset initialization flow handler")
 	return func(w http.ResponseWriter, r *http.Request) {
 		if handleEnabledCheck(logger, w) {
 			return
@@ -168,6 +169,7 @@ To set the password for {{.Username}} on Sourcegraph, follow this link:
 
 // HandleResetPasswordCode resets the password if the correct code is provided.
 func HandleResetPasswordCode(logger log.Logger, db database.DB) http.HandlerFunc {
+	logger = logger.Scoped("HandleResetPasswordCode", "verifies password reset code requests handler")
 	return func(w http.ResponseWriter, r *http.Request) {
 		if handleEnabledCheck(logger, w) {
 			return

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -36,16 +36,16 @@ func SendResetPasswordURLEmail(ctx context.Context, email, username string, rese
 }
 
 // HandleResetPasswordInit initiates the builtin-auth password reset flow by sending a password-reset email.
-func HandleResetPasswordInit(db database.DB) http.HandlerFunc {
+func HandleResetPasswordInit(logger log.Logger, db database.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if handleEnabledCheck(w) {
+		if handleEnabledCheck(logger, w) {
 			return
 		}
 		if handleNotAuthenticatedCheck(w, r) {
 			return
 		}
 		if !conf.CanSendEmail() {
-			httpLogAndError(w, "Unable to reset password because email sending is not configured on this site", http.StatusNotFound)
+			httpLogAndError(logger, w, "Unable to reset password because email sending is not configured on this site", http.StatusNotFound)
 			return
 		}
 
@@ -54,12 +54,12 @@ func HandleResetPasswordInit(db database.DB) http.HandlerFunc {
 			Email string `json:"email"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&formData); err != nil {
-			httpLogAndError(w, "Could not decode password reset request body", http.StatusBadRequest, "err", err)
+			httpLogAndError(logger, w, "Could not decode password reset request body", http.StatusBadRequest, log.Error(err))
 			return
 		}
 
 		if formData.Email == "" {
-			httpLogAndError(w, "No email specified in password reset request", http.StatusBadRequest)
+			httpLogAndError(logger, w, "No email specified in password reset request", http.StatusBadRequest)
 			return
 		}
 
@@ -68,22 +68,22 @@ func HandleResetPasswordInit(db database.DB) http.HandlerFunc {
 			// 🚨 SECURITY: We don't show an error message when the user is not found
 			// as to not leak the existence of a given e-mail address in the database.
 			if !errcode.IsNotFound(err) {
-				httpLogAndError(w, "Failed to lookup user", http.StatusInternalServerError)
+				httpLogAndError(logger, w, "Failed to lookup user", http.StatusInternalServerError)
 			}
 			return
 		}
 
 		resetURL, err := backend.MakePasswordResetURL(ctx, db, usr.ID)
 		if err == database.ErrPasswordResetRateLimit {
-			httpLogAndError(w, "Too many password reset requests. Try again in a few minutes.", http.StatusTooManyRequests, "err", err)
+			httpLogAndError(logger, w, "Too many password reset requests. Try again in a few minutes.", http.StatusTooManyRequests, log.Error(err))
 			return
 		} else if err != nil {
-			httpLogAndError(w, "Could not reset password", http.StatusBadRequest, "err", err)
+			httpLogAndError(logger, w, "Could not reset password", http.StatusBadRequest, log.Error(err))
 			return
 		}
 
 		if err := SendResetPasswordURLEmail(r.Context(), formData.Email, usr.Username, resetURL); err != nil {
-			httpLogAndError(w, "Could not send reset password email", http.StatusInternalServerError, "err", err)
+			httpLogAndError(logger, w, "Could not send reset password email", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 		database.LogPasswordEvent(ctx, db, r, database.SecurityEventNamPasswordResetRequested, usr.ID)
@@ -167,9 +167,9 @@ To set the password for {{.Username}} on Sourcegraph, follow this link:
 })
 
 // HandleResetPasswordCode resets the password if the correct code is provided.
-func HandleResetPasswordCode(db database.DB) http.HandlerFunc {
+func HandleResetPasswordCode(logger log.Logger, db database.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if handleEnabledCheck(w) {
+		if handleEnabledCheck(logger, w) {
 			return
 		}
 		if handleNotAuthenticatedCheck(w, r) {
@@ -183,7 +183,7 @@ func HandleResetPasswordCode(db database.DB) http.HandlerFunc {
 			Password string `json:"password"` // new password
 		}
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-			httpLogAndError(w, "Password reset with code: could not decode request body", http.StatusBadGateway, "err", err)
+			httpLogAndError(logger, w, "Password reset with code: could not decode request body", http.StatusBadGateway, log.Error(err))
 			return
 		}
 
@@ -194,7 +194,7 @@ func HandleResetPasswordCode(db database.DB) http.HandlerFunc {
 
 		success, err := db.Users().SetPassword(ctx, params.UserID, params.Code, params.Password)
 		if err != nil {
-			httpLogAndError(w, "Unexpected error", http.StatusInternalServerError, "err", err)
+			httpLogAndError(logger, w, "Unexpected error", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 
@@ -207,7 +207,7 @@ func HandleResetPasswordCode(db database.DB) http.HandlerFunc {
 
 		if conf.CanSendEmail() {
 			if err := backend.UserEmails.SendUserEmailOnFieldUpdate(ctx, db, params.UserID, "reset the password"); err != nil {
-				log15.Warn("Failed to send email to inform user of password reset", "error", err)
+				logger.Warn("Failed to send email to inform user of password reset", log.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
Ongoing effort to deprecate the usage of log15 in favor of using sourcegraph/log
## Test plan
Unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
