### PR TITLE
Aggregation: Add aggregation FE pings

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchFilterSection.module.scss
+++ b/client/search-ui/src/results/sidebar/SearchFilterSection.module.scss
@@ -9,6 +9,13 @@
         padding: 0;
     }
 
+    &__header {
+        flex-grow: 1;
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+    }
+
     &__collapse-button {
         display: flex;
         align-items: center;

--- a/client/search-ui/src/results/sidebar/SearchFilterSection.tsx
+++ b/client/search-ui/src/results/sidebar/SearchFilterSection.tsx
@@ -13,7 +13,7 @@ import styles from './SearchFilterSection.module.scss'
 
 export interface SearchFilterSectionProps {
     sectionId: string
-    header: string
+    header: ReactNode
     children?: React.ReactNode | React.ReactNode[] | ((filter: string) => React.ReactNode)
     className?: string
     showSearch?: boolean // Search only works if children are FilterLink
@@ -149,7 +149,11 @@ export const SearchFilterSection: FC<SearchFilterSectionProps> = memo(props => {
                     outline={true}
                     variant="secondary"
                 >
-                    <H5 as={H2} className="flex-grow-1" id={`search-sidebar-section-header-${sectionId}`}>
+                    <H5
+                        as={H2}
+                        id={`search-sidebar-section-header-${sectionId}`}
+                        className={styles.sidebarSectionHeader}
+                    >
                         {header}
                     </H5>
                     <Icon

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -9,7 +9,7 @@ import {
     useMemo,
 } from 'react'
 
-import { mdiInformationOutline, mdiClose } from '@mdi/js'
+import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 import { noop } from 'lodash'
 import StickyBox from 'react-sticky-box'
@@ -97,6 +97,7 @@ export const SearchSidebar: FC<PropsWithChildren<SearchSidebarProps>> = props =>
 interface SearchSidebarSectionProps
     extends Omit<ComponentProps<typeof SearchFilterSection>, 'startCollapsed' | 'onToggle'> {
     sectionId: SectionID
+    onToggle?: (open: boolean) => void
 }
 
 /**
@@ -104,14 +105,22 @@ interface SearchSidebarSectionProps
  * and persist expand/collapse state with temporal settings.
  */
 export const SearchSidebarSection: FC<SearchSidebarSectionProps> = props => {
-    const { className, sectionId, ...attributes } = props
+    const { className, sectionId, onToggle, ...attributes } = props
     const { collapsedSections, persistToggleState } = useContext(SearchSidebarContext)
+
+    const handleToggle = useCallback(
+        (id: string, open: boolean) => {
+            onToggle?.(open)
+            persistToggleState(id, open)
+        },
+        [onToggle, persistToggleState]
+    )
 
     return (
         <SearchFilterSection
             sectionId={sectionId}
             startCollapsed={collapsedSections?.[sectionId]}
-            onToggle={persistToggleState}
+            onToggle={handleToggle}
             className={classNames(className, styles.item)}
             {...attributes}
         />

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -9,7 +9,7 @@ import {
     useMemo,
 } from 'react'
 
-import { mdiClose } from '@mdi/js'
+import { mdiInformationOutline, mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 import { noop } from 'lodash'
 import StickyBox from 'react-sticky-box'

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState, FC } from 'react'
 
 import classNames from 'classnames'
 import * as H from 'history'
@@ -63,9 +63,7 @@ export interface StreamingSearchResultsProps
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
 
-export const StreamingSearchResults: React.FunctionComponent<
-    React.PropsWithChildren<StreamingSearchResultsProps>
-> = props => {
+export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => {
     const {
         streamSearch,
         location,

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -320,6 +320,7 @@ export const StreamingSearchResults: React.FunctionComponent<
                     aria-label="Aggregation results panel"
                     className={styles.contents}
                     onQuerySubmit={handleSearchAggregationBarClick}
+                    telemetryService={props.telemetryService}
                 />
             )}
 

--- a/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
@@ -65,7 +65,7 @@ interface AggregationChartCardProps extends HTMLAttributes<HTMLDivElement> {
     loading: boolean
     mode?: SearchAggregationMode | null
     size?: 'sm' | 'md'
-    onBarLinkClick?: (query: string) => void
+    onBarLinkClick?: (query: string, barIndex: number) => void
     onBarHover?: () => void
 }
 
@@ -124,9 +124,9 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
     }
 
     const missingCount = getOtherGroupCount(data)
-    const handleDatumLinkClick = (event: MouseEvent, datum: SearchAggregationDatum): void => {
+    const handleDatumLinkClick = (event: MouseEvent, datum: SearchAggregationDatum, index: number): void => {
         event.preventDefault()
-        onBarLinkClick?.(getLink(datum))
+        onBarLinkClick?.(getLink(datum), index)
     }
 
     return (

--- a/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
@@ -66,10 +66,21 @@ interface AggregationChartCardProps extends HTMLAttributes<HTMLDivElement> {
     mode?: SearchAggregationMode | null
     size?: 'sm' | 'md'
     onBarLinkClick?: (query: string) => void
+    onBarHover?: () => void
 }
 
 export function AggregationChartCard(props: AggregationChartCardProps): ReactElement | null {
-    const { data, error, loading, mode, className, size = 'sm', 'aria-label': ariaLabel, onBarLinkClick } = props
+    const {
+        data,
+        error,
+        loading,
+        mode,
+        className,
+        size = 'sm',
+        'aria-label': ariaLabel,
+        onBarLinkClick,
+        onBarHover,
+    } = props
 
     if (loading) {
         return (
@@ -131,6 +142,7 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
                     getDatumName={getName}
                     getDatumLink={getLink}
                     onDatumLinkClick={handleDatumLinkClick}
+                    onDatumHover={onBarHover}
                     className={styles.chart}
                 />
 

--- a/client/web/src/search/results/components/aggregation/AggregationModeControls.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationModeControls.tsx
@@ -3,23 +3,23 @@ import { FC, HTMLAttributes } from 'react'
 import classNames from 'classnames'
 
 import { SearchAggregationMode } from '@sourcegraph/shared/src/graphql-operations'
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Tooltip } from '@sourcegraph/wildcard'
 
 import { SearchAggregationModeAvailability } from '../../../../graphql-operations'
 
 import styles from './AggregationModeControls.module.scss'
 
-interface AggregationModeControlsProps extends TelemetryProps, HTMLAttributes<HTMLDivElement> {
+interface AggregationModeControlsProps extends HTMLAttributes<HTMLDivElement> {
     mode: SearchAggregationMode | null
     loading: boolean
     availability?: SearchAggregationModeAvailability[]
     size?: 'sm' | 'lg'
     onModeChange: (nextMode: SearchAggregationMode) => void
+    onModeHover: (aggregationMode: SearchAggregationMode, available: boolean) => void
 }
 
 export const AggregationModeControls: FC<AggregationModeControlsProps> = props => {
-    const { mode, loading, availability = [], onModeChange, size, className, telemetryService, ...attributes } = props
+    const { mode, loading, availability = [], size, className, onModeChange, onModeHover, ...attributes } = props
 
     const availabilityGroups = availability.reduce((store, availability) => {
         store[availability.mode] = availability
@@ -43,9 +43,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
     }
 
     const handleModeHover = (aggregationMode: SearchAggregationMode): void => {
-        if (!isModeAvailable(aggregationMode)) {
-            telemetryService.log(`GroupResults${aggregationMode}DisabledHover`)
-        }
+        onModeHover(aggregationMode, isModeAvailable(aggregationMode))
     }
 
     return (

--- a/client/web/src/search/results/components/aggregation/AggregationModeControls.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationModeControls.tsx
@@ -3,13 +3,14 @@ import { FC, HTMLAttributes } from 'react'
 import classNames from 'classnames'
 
 import { SearchAggregationMode } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Tooltip } from '@sourcegraph/wildcard'
 
 import { SearchAggregationModeAvailability } from '../../../../graphql-operations'
 
 import styles from './AggregationModeControls.module.scss'
 
-interface AggregationModeControlsProps extends HTMLAttributes<HTMLDivElement> {
+interface AggregationModeControlsProps extends TelemetryProps, HTMLAttributes<HTMLDivElement> {
     mode: SearchAggregationMode | null
     loading: boolean
     availability?: SearchAggregationModeAvailability[]
@@ -18,7 +19,7 @@ interface AggregationModeControlsProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export const AggregationModeControls: FC<AggregationModeControlsProps> = props => {
-    const { mode, loading, availability = [], onModeChange, size, className, ...attributes } = props
+    const { mode, loading, availability = [], onModeChange, size, className, telemetryService, ...attributes } = props
 
     const availabilityGroups = availability.reduce((store, availability) => {
         store[availability.mode] = availability
@@ -41,63 +42,86 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
         return isAvailable ?? true
     }
 
+    const handleModeChange = (aggregationMode: SearchAggregationMode): void => {
+        telemetryService.log(`GroupResults${aggregationMode}`)
+        onModeChange(aggregationMode)
+    }
+
+    const handleModeHover = (aggregationMode: SearchAggregationMode): void => {
+        if (!isModeAvailable(aggregationMode)) {
+            telemetryService.log(`GroupResults${aggregationMode}DisabledHover`)
+        }
+    }
+
     return (
         <div
             {...attributes}
             aria-label="Aggregation mode picker"
             className={classNames(className, styles.aggregationGroup)}
         >
-            <Tooltip content={availabilityGroups[SearchAggregationMode.REPO]?.reasonUnavailable}>
-                <Button
-                    variant="secondary"
-                    size={size}
-                    outline={mode !== SearchAggregationMode.REPO}
-                    data-testid="repo-aggregation-mode"
-                    disabled={!isModeAvailable(SearchAggregationMode.REPO)}
-                    onClick={() => onModeChange(SearchAggregationMode.REPO)}
-                >
-                    Repository
-                </Button>
-            </Tooltip>
+            <div
+                // Div onMounterEnter is needed here because button with disabled true doesn't
+                // emit any mouse or pointer events.
+                onMouseEnter={() => handleModeHover(SearchAggregationMode.REPO)}
+            >
+                <Tooltip content={availabilityGroups[SearchAggregationMode.REPO]?.reasonUnavailable}>
+                    <Button
+                        variant="secondary"
+                        size={size}
+                        outline={mode !== SearchAggregationMode.REPO}
+                        data-testid="repo-aggregation-mode"
+                        disabled={!isModeAvailable(SearchAggregationMode.REPO)}
+                        onClick={() => handleModeChange(SearchAggregationMode.REPO)}
+                    >
+                        Repository
+                    </Button>
+                </Tooltip>
+            </div>
 
-            <Tooltip content={availabilityGroups[SearchAggregationMode.PATH]?.reasonUnavailable}>
-                <Button
-                    variant="secondary"
-                    size={size}
-                    outline={mode !== SearchAggregationMode.PATH}
-                    disabled={!isModeAvailable(SearchAggregationMode.PATH)}
-                    data-testid="file-aggregation-mode"
-                    onClick={() => onModeChange(SearchAggregationMode.PATH)}
-                >
-                    File
-                </Button>
-            </Tooltip>
+            <div onMouseEnter={() => handleModeHover(SearchAggregationMode.PATH)}>
+                <Tooltip content={availabilityGroups[SearchAggregationMode.PATH]?.reasonUnavailable}>
+                    <Button
+                        variant="secondary"
+                        size={size}
+                        outline={mode !== SearchAggregationMode.PATH}
+                        disabled={!isModeAvailable(SearchAggregationMode.PATH)}
+                        data-testid="file-aggregation-mode"
+                        onClick={() => handleModeChange(SearchAggregationMode.PATH)}
+                    >
+                        File
+                    </Button>
+                </Tooltip>
+            </div>
 
-            <Tooltip content={availabilityGroups[SearchAggregationMode.AUTHOR]?.reasonUnavailable}>
-                <Button
-                    variant="secondary"
-                    size={size}
-                    outline={mode !== SearchAggregationMode.AUTHOR}
-                    disabled={!isModeAvailable(SearchAggregationMode.AUTHOR)}
-                    data-testid="author-aggregation-mode"
-                    onClick={() => onModeChange(SearchAggregationMode.AUTHOR)}
-                >
-                    Author
-                </Button>
-            </Tooltip>
+            <div onMouseEnter={() => handleModeHover(SearchAggregationMode.AUTHOR)}>
+                <Tooltip content={availabilityGroups[SearchAggregationMode.AUTHOR]?.reasonUnavailable}>
+                    <Button
+                        variant="secondary"
+                        size={size}
+                        outline={mode !== SearchAggregationMode.AUTHOR}
+                        disabled={!isModeAvailable(SearchAggregationMode.AUTHOR)}
+                        data-testid="author-aggregation-mode"
+                        onClick={() => handleModeChange(SearchAggregationMode.AUTHOR)}
+                    >
+                        Author
+                    </Button>
+                </Tooltip>
+            </div>
 
-            <Tooltip content={availabilityGroups[SearchAggregationMode.CAPTURE_GROUP]?.reasonUnavailable}>
-                <Button
-                    variant="secondary"
-                    size={size}
-                    outline={mode !== SearchAggregationMode.CAPTURE_GROUP}
-                    disabled={!isModeAvailable(SearchAggregationMode.CAPTURE_GROUP)}
-                    data-testid="captureGroup-aggregation-mode"
-                    onClick={() => onModeChange(SearchAggregationMode.CAPTURE_GROUP)}
-                >
-                    Capture group
-                </Button>
-            </Tooltip>
+            <div onMouseEnter={() => handleModeHover(SearchAggregationMode.CAPTURE_GROUP)}>
+                <Tooltip content={availabilityGroups[SearchAggregationMode.CAPTURE_GROUP]?.reasonUnavailable}>
+                    <Button
+                        variant="secondary"
+                        size={size}
+                        outline={mode !== SearchAggregationMode.CAPTURE_GROUP}
+                        disabled={!isModeAvailable(SearchAggregationMode.CAPTURE_GROUP)}
+                        data-testid="captureGroup-aggregation-mode"
+                        onClick={() => handleModeChange(SearchAggregationMode.CAPTURE_GROUP)}
+                    >
+                        Capture group
+                    </Button>
+                </Tooltip>
+            </div>
         </div>
     )
 }

--- a/client/web/src/search/results/components/aggregation/AggregationModeControls.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationModeControls.tsx
@@ -42,11 +42,6 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
         return isAvailable ?? true
     }
 
-    const handleModeChange = (aggregationMode: SearchAggregationMode): void => {
-        telemetryService.log(`GroupResults${aggregationMode}`)
-        onModeChange(aggregationMode)
-    }
-
     const handleModeHover = (aggregationMode: SearchAggregationMode): void => {
         if (!isModeAvailable(aggregationMode)) {
             telemetryService.log(`GroupResults${aggregationMode}DisabledHover`)
@@ -71,7 +66,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                         outline={mode !== SearchAggregationMode.REPO}
                         data-testid="repo-aggregation-mode"
                         disabled={!isModeAvailable(SearchAggregationMode.REPO)}
-                        onClick={() => handleModeChange(SearchAggregationMode.REPO)}
+                        onClick={() => onModeChange(SearchAggregationMode.REPO)}
                     >
                         Repository
                     </Button>
@@ -86,7 +81,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                         outline={mode !== SearchAggregationMode.PATH}
                         disabled={!isModeAvailable(SearchAggregationMode.PATH)}
                         data-testid="file-aggregation-mode"
-                        onClick={() => handleModeChange(SearchAggregationMode.PATH)}
+                        onClick={() => onModeChange(SearchAggregationMode.PATH)}
                     >
                         File
                     </Button>
@@ -101,7 +96,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                         outline={mode !== SearchAggregationMode.AUTHOR}
                         disabled={!isModeAvailable(SearchAggregationMode.AUTHOR)}
                         data-testid="author-aggregation-mode"
-                        onClick={() => handleModeChange(SearchAggregationMode.AUTHOR)}
+                        onClick={() => onModeChange(SearchAggregationMode.AUTHOR)}
                     >
                         Author
                     </Button>
@@ -116,7 +111,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                         outline={mode !== SearchAggregationMode.CAPTURE_GROUP}
                         disabled={!isModeAvailable(SearchAggregationMode.CAPTURE_GROUP)}
                         data-testid="captureGroup-aggregation-mode"
-                        onClick={() => handleModeChange(SearchAggregationMode.CAPTURE_GROUP)}
+                        onClick={() => onModeChange(SearchAggregationMode.CAPTURE_GROUP)}
                     >
                         Capture group
                     </Button>

--- a/client/web/src/search/results/components/aggregation/AggregationModeControls.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationModeControls.tsx
@@ -53,7 +53,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
             className={classNames(className, styles.aggregationGroup)}
         >
             <div
-                // Div onMounterEnter is needed here because button with disabled true doesn't
+                // Div onMouseEnter is needed here because button with disabled true doesn't
                 // emit any mouse or pointer events.
                 onMouseEnter={() => handleModeHover(SearchAggregationMode.REPO)}
             >

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
@@ -5,6 +5,7 @@ import { noop } from 'lodash'
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { GetSearchAggregationResult, SearchAggregationMode } from '../../../../graphql-operations'
@@ -98,7 +99,12 @@ export const SearchAggregationResultDemo: Story = () => (
     <BrandedStory>
         {() => (
             <MockedTestProvider mocks={[SEARCH_AGGREGATION_MOCK]}>
-                <SearchAggregationResult query="" patternType={SearchPatternType.literal} onQuerySubmit={noop} />
+                <SearchAggregationResult
+                    query=""
+                    patternType={SearchPatternType.literal}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    onQuerySubmit={noop}
+                />
             </MockedTestProvider>
         )}
     </BrandedStory>

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -2,7 +2,7 @@ import { FC, HTMLAttributes } from 'react'
 
 import { mdiArrowCollapse } from '@mdi/js'
 
-import { SearchPatternType } from '@sourcegraph/shared/src/schema'
+import { SearchAggregationMode, SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, H2, Icon, Code, Card, CardBody } from '@sourcegraph/wildcard'
 
@@ -73,6 +73,11 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
         )
     }
 
+    const handleAggregationModeChange = (mode: SearchAggregationMode): void => {
+        setAggregationMode(mode)
+        telemetryService.log(`GroupResults${aggregationMode}`, { uiMode: 'resultsScreen' }, { uiMode: 'resultsScreen' })
+    }
+
     return (
         <section {...attributes}>
             <header className={styles.header}>
@@ -99,7 +104,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
                         mode={aggregationMode}
                         availability={data?.searchQueryAggregate?.modeAvailability}
                         telemetryService={telemetryService}
-                    onModeChange={setAggregationMode}
+                    onModeChange={handleAggregationModeChange}
                 />{isNonExhaustiveAggregationResults(data) && <AggregationLimitLabel size="md" />}
                 </div>
 

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -120,20 +120,21 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
                         availability={data?.searchQueryAggregate?.modeAvailability}
                         onModeChange={handleAggregationModeChange}
                         onModeHover={handleAggregationModeHover}
-                />{isNonExhaustiveAggregationResults(data) && <AggregationLimitLabel size="md" />}
+                    />
+                    {isNonExhaustiveAggregationResults(data) && <AggregationLimitLabel size="md" />}
                 </div>
 
-            <AggregationChartCard
-                aria-label="Expanded search aggregation chart"
-                mode={aggregationMode}
-                data={data?.searchQueryAggregate?.aggregations}
-                loading={loading}
-                error={error}
-                size="md"
-                className={styles.chartContainer}
-                onBarLinkClick={handleBarLinkClick}
-                onBarHover={handleBarHover}
-            />
+                <AggregationChartCard
+                    aria-label="Expanded search aggregation chart"
+                    mode={aggregationMode}
+                    data={data?.searchQueryAggregate?.aggregations}
+                    loading={loading}
+                    error={error}
+                    size="md"
+                    className={styles.chartContainer}
+                    onBarLinkClick={handleBarLinkClick}
+                    onBarHover={handleBarHover}
+                />
 
                 {data && (
                     <ul className={styles.listResult}>

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -54,7 +54,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
 
     const handleCollapseClick = (): void => {
         setAggregationUIMode(AggregationUIMode.Sidebar)
-        telemetryService.log(GroupResultsPing.CollapseFullViewPanel)
+        telemetryService.log(GroupResultsPing.CollapseFullViewPanel, { aggregationMode }, { aggregationMode })
     }
 
     const handleBarLinkClick = (query: string, index: number): void => {

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -15,6 +15,7 @@ import {
     useAggregationUIMode,
     useSearchAggregationData,
 } from './hooks'
+import { GroupResultsPing } from './pings'
 import { AggregationUIMode } from './types'
 
 import styles from './SearchAggregationResult.module.scss'
@@ -53,21 +54,21 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
 
     const handleCollapseClick = (): void => {
         setAggregationUIMode(AggregationUIMode.Sidebar)
-        telemetryService.log('GroupResultsExpandedViewCollapse', { aggregationMode }, { aggregationMode })
+        telemetryService.log(GroupResultsPing.CollapseFullViewPanel)
     }
 
-    const handleBarLinkClick = (query: string): void => {
+    const handleBarLinkClick = (query: string, index: number): void => {
         onQuerySubmit(query)
         telemetryService.log(
-            'GroupResultsChartBarClick',
-            { aggregationMode, uiMode: 'resultsScreen' },
-            { aggregationMode, uiMode: 'resultsScreen' }
+            GroupResultsPing.ChartBarClick,
+            { aggregationMode, index, uiMode: 'resultsScreen' },
+            { aggregationMode, index, uiMode: 'resultsScreen' }
         )
     }
 
     const handleBarHover = (): void => {
         telemetryService.log(
-            'GroupResultsChartBarHover',
+            GroupResultsPing.ChartBarHover,
             { aggregationMode, uiMode: 'resultsScreen' },
             { aggregationMode, uiMode: 'resultsScreen' }
         )
@@ -75,7 +76,21 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
 
     const handleAggregationModeChange = (mode: SearchAggregationMode): void => {
         setAggregationMode(mode)
-        telemetryService.log(`GroupResults${aggregationMode}`, { uiMode: 'resultsScreen' }, { uiMode: 'resultsScreen' })
+        telemetryService.log(
+            GroupResultsPing.ModeClick,
+            { aggregationMode: mode, uiMode: 'resultsScreen' },
+            { aggregationMode: mode, uiMode: 'resultsScreen' }
+        )
+    }
+
+    const handleAggregationModeHover = (aggregationMode: SearchAggregationMode, available: boolean): void => {
+        if (!available) {
+            telemetryService.log(
+                GroupResultsPing.ModeDisabledHover,
+                { aggregationMode, uiMode: 'resultsScreen' },
+                { aggregationMode, uiMode: 'resultsScreen' }
+            )
+        }
     }
 
     return (
@@ -103,8 +118,8 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
                         loading={loading}
                         mode={aggregationMode}
                         availability={data?.searchQueryAggregate?.modeAvailability}
-                        telemetryService={telemetryService}
-                    onModeChange={handleAggregationModeChange}
+                        onModeChange={handleAggregationModeChange}
+                        onModeHover={handleAggregationModeHover}
                 />{isNonExhaustiveAggregationResults(data) && <AggregationLimitLabel size="md" />}
                 </div>
 

--- a/client/web/src/search/results/components/aggregation/index.ts
+++ b/client/web/src/search/results/components/aggregation/index.ts
@@ -5,3 +5,4 @@ export { AggregationChartCard, getAggregationData } from './AggregationChartCard
 export { AggregationModeControls } from './AggregationModeControls'
 export { SearchAggregationResult } from './SearchAggregationResult'
 export { AggregationLimitLabel } from './AggregationLimitLabel'
+export { GroupResultsPing } from './pings'

--- a/client/web/src/search/results/components/aggregation/pings.ts
+++ b/client/web/src/search/results/components/aggregation/pings.ts
@@ -1,0 +1,16 @@
+export enum GroupResultsPing {
+    // Aggregation chart events
+    ChartBarClick = 'GroupResultsChartBarClick',
+    ChartBarHover = 'GroupResultsChartBarHover',
+
+    // Aggregation mode events
+    ModeClick = 'GroupAggregationModeClicked',
+    ModeDisabledHover = 'GroupAggregationModeDisabledHover',
+
+    // Other UI
+    CollapseSidebarSection = 'GroupResultsCollapseSection',
+    ExpandSidebarSection = 'GroupResultsOpenSection',
+    ExpandFullViewPanel = 'GroupResultsExpandViewOpen',
+    CollapseFullViewPanel = 'GroupResultsExpandedViewCollapse',
+    InfoIconHover = 'GroupResultsInfoIconHover',
+}

--- a/client/web/src/search/results/components/aggregation/pings.ts
+++ b/client/web/src/search/results/components/aggregation/pings.ts
@@ -10,7 +10,7 @@ export enum GroupResultsPing {
     // Other UI
     CollapseSidebarSection = 'GroupResultsCollapseSection',
     ExpandSidebarSection = 'GroupResultsOpenSection',
-    ExpandFullViewPanel = 'GroupResultsExpandViewOpen',
+    ExpandFullViewPanel = 'GroupResultsExpandedViewOpen',
     CollapseFullViewPanel = 'GroupResultsExpandedViewCollapse',
     InfoIconHover = 'GroupResultsInfoIconHover',
 }

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -74,7 +74,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
 
     const handleExpandClick = (): void => {
         setAggregationUIMode(AggregationUIMode.SearchPage)
-        telemetryService.log(GroupResultsPing.ExpandFullViewPanel, { aggregationMode: mode }, { aggregationMode: mode })
+        telemetryService.log(GroupResultsPing.ExpandFullViewPanel, { aggregationMode }, { aggregationMode })
     }
 
     const handleAggregationModeChange = (mode: SearchAggregationMode): void => {

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -99,9 +99,9 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
     return (
         <article className="pt-2">
             <AggregationModeControls
+                availability={data?.searchQueryAggregate?.modeAvailability}
                 loading={loading}
                 mode={aggregationMode}
-                availability={data?.searchQueryAggregate?.modeAvailability}
                 size="sm"
                 onModeChange={handleAggregationModeChange}
                 onModeHover={handleAggregationModeHover}

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -74,7 +74,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
 
     const handleExpandClick = (): void => {
         setAggregationUIMode(AggregationUIMode.SearchPage)
-        telemetryService.log(GroupResultsPing.ExpandFullViewPanel)
+        telemetryService.log(GroupResultsPing.ExpandFullViewPanel, { aggregationMode: mode }, { aggregationMode: mode })
     }
 
     const handleAggregationModeChange = (mode: SearchAggregationMode): void => {

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 import { mdiArrowExpand } from '@mdi/js'
 
-import { SearchPatternType } from '@sourcegraph/shared/src/schema'
+import { SearchAggregationMode, SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon } from '@sourcegraph/wildcard'
 
@@ -76,6 +76,11 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
         telemetryService.log('GroupResultsExpandViewOpen', { aggregationMode }, { aggregationMode })
     }
 
+    const handleAggregationModeChange = (mode: SearchAggregationMode): void => {
+        setAggregationMode(mode)
+        telemetryService.log(`GroupResults${aggregationMode}`, { uiMode: 'sidebar' }, { uiMode: 'sidebar' })
+    }
+
     return (
         <article className="pt-2">
             <AggregationModeControls
@@ -84,7 +89,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                 availability={data?.searchQueryAggregate?.modeAvailability}
                 size="sm"
                 telemetryService={telemetryService}
-                onModeChange={setAggregationMode}
+                onModeChange={handleAggregationModeChange}
             />
 
             {(proactive || aggregationMode !== null) && (

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -103,7 +103,6 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                 mode={aggregationMode}
                 availability={data?.searchQueryAggregate?.modeAvailability}
                 size="sm"
-                telemetryService={telemetryService}
                 onModeChange={handleAggregationModeChange}
                 onModeHover={handleAggregationModeHover}
             />

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -15,6 +15,7 @@ import {
     useAggregationUIMode,
     useSearchAggregationData,
     isNonExhaustiveAggregationResults,
+    GroupResultsPing,
 } from '../components/aggregation'
 
 import styles from './SearchAggregations.module.scss'
@@ -54,18 +55,18 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
         limit: 10,
     })
 
-    const handleBarLinkClick = (query: string): void => {
+    const handleBarLinkClick = (query: string, index: number): void => {
         onQuerySubmit(query)
         telemetryService.log(
-            'GroupResultsChartBarClick',
-            { aggregationMode, uiMode: 'sidebar' },
-            { aggregationMode, uiMode: 'sidebar' }
+            GroupResultsPing.ChartBarClick,
+            { aggregationMode, index, uiMode: 'sidebar' },
+            { aggregationMode, index, uiMode: 'sidebar' }
         )
     }
 
     const handleBarHover = (): void => {
         telemetryService.log(
-            'GroupResultsChartBarHover',
+            GroupResultsPing.ChartBarHover,
             { aggregationMode, uiMode: 'sidebar' },
             { aggregationMode, uiMode: 'sidebar' }
         )
@@ -73,12 +74,26 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
 
     const handleExpandClick = (): void => {
         setAggregationUIMode(AggregationUIMode.SearchPage)
-        telemetryService.log('GroupResultsExpandViewOpen', { aggregationMode }, { aggregationMode })
+        telemetryService.log(GroupResultsPing.ExpandFullViewPanel)
     }
 
     const handleAggregationModeChange = (mode: SearchAggregationMode): void => {
         setAggregationMode(mode)
-        telemetryService.log(`GroupResults${aggregationMode}`, { uiMode: 'sidebar' }, { uiMode: 'sidebar' })
+        telemetryService.log(
+            GroupResultsPing.ModeClick,
+            { aggregationMode: mode, uiMode: 'sidebar' },
+            { aggregationMode: mode, uiMode: 'sidebar' }
+        )
+    }
+
+    const handleAggregationModeHover = (aggregationMode: SearchAggregationMode, available: boolean): void => {
+        if (!available) {
+            telemetryService.log(
+                GroupResultsPing.ModeDisabledHover,
+                { aggregationMode, uiMode: 'sidebar' },
+                { aggregationMode, uiMode: 'sidebar' }
+            )
+        }
     }
 
     return (
@@ -90,6 +105,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                 size="sm"
                 telemetryService={telemetryService}
                 onModeChange={handleAggregationModeChange}
+                onModeHover={handleAggregationModeHover}
             />
 
             {(proactive || aggregationMode !== null) && (

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -1,5 +1,7 @@
 import { FC, ReactNode, ReactElement, useCallback, useMemo, HTMLAttributes, memo, PropsWithChildren } from 'react'
 
+import { mdiInformationOutline } from '@mdi/js'
+
 import { QueryStateUpdate, QueryUpdate } from '@sourcegraph/search'
 import {
     SearchSidebar,
@@ -12,6 +14,8 @@ import {
     getSearchTypeLinks,
     getFiltersOfKind,
     useLastRepoName,
+    AggregationUIMode,
+    GroupResultsPing,
 } from '@sourcegraph/search-ui'
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
@@ -21,7 +25,7 @@ import { SectionID } from '@sourcegraph/shared/src/settings/temporary/searchSide
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Code } from '@sourcegraph/wildcard'
+import { Code, Tooltip, Icon } from '@sourcegraph/wildcard'
 
 import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import { buildSearchURLQueryFromQueryState } from '../../../stores'
@@ -87,17 +91,29 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
         onSearchSubmit([{ type: 'replaceQuery', value: query }])
     }
 
+    const handleGroupedByToggle = useCallback(
+        (open: boolean): void => {
+            telemetryService.log(open ? GroupResultsPing.ExpandSidebarSection : GroupResultsPing.CollapseSidebarSection)
+        },
+        [telemetryService]
+    )
+
     return (
         <SearchSidebar {...attributes} onClose={() => setSelectedTab(null)}>
             {children}
 
             {/* Need to check status so that the feature flag is available before we render */}
             {enableSearchAggregations && status === 'loaded' && aggregationUIMode === AggregationUIMode.Sidebar && (
-                <SearchSidebarSection sectionId={SectionID.GROUPED_BY} header="Group results by">
+                <SearchSidebarSection
+                    sectionId={SectionID.GROUPED_BY}
+                    header={<CustomAggregationHeading telemetryService={props.telemetryService} />}
+                    onToggle={handleGroupedByToggle}
+                >
                     <SearchAggregations
                         query={submittedURLQuery}
                         patternType={patternType}
                         proactive={!disableProactiveSearchAggregations}
+                        telemetryService={telemetryService}
                         onQuerySubmit={handleAggregationBarLinkClick}
                     />
                 </SearchSidebarSection>
@@ -196,4 +212,18 @@ const getRepoFilterNoResultText = (repoFilterLinks: ReactElement[]): ReactNode =
         None of the top {repoFilterLinks.length} repositories in your results match this filter. Try a{' '}
         <Code>repo:</Code> search in the main search bar instead.
     </span>
+)
+
+const CustomAggregationHeading: FC<TelemetryProps> = ({ telemetryService }) => (
+    <>
+        Group results by
+        <Tooltip content="Aggregation is based on results with no count limitation (count:all).">
+            <Icon
+                aria-label="Info icon about aggregation run"
+                size="md"
+                svgPath={mdiInformationOutline}
+                onMouseEnter={() => telemetryService.log(GroupResultsPing.InfoIconHover)}
+            />
+        </Tooltip>
+    </>
 )

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -14,8 +14,6 @@ import {
     getSearchTypeLinks,
     getFiltersOfKind,
     useLastRepoName,
-    AggregationUIMode,
-    GroupResultsPing,
 } from '@sourcegraph/search-ui'
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
@@ -29,7 +27,7 @@ import { Code, Tooltip, Icon } from '@sourcegraph/wildcard'
 
 import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import { buildSearchURLQueryFromQueryState } from '../../../stores'
-import { AggregationUIMode } from '../components/aggregation'
+import { AggregationUIMode, GroupResultsPing } from '../components/aggregation'
 
 import { getRevisions } from './Revisions'
 import { SearchAggregations } from './SearchAggregations'

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -75,10 +75,10 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         [categories]
     )
 
-    const handleBarClick = (event: MouseEvent, datum: Datum): void => {
+    const handleBarClick = (event: MouseEvent, datum: Datum, index: number): void => {
         const link = getDatumLink(datum)
 
-        onDatumLinkClick?.(event, datum)
+        onDatumLinkClick?.(event, datum, index)
 
         if (!event.isDefaultPrevented() && link) {
             window.open(link)

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -26,6 +26,8 @@ export interface BarChartProps<Datum> extends CategoricalLikeChart<Datum>, SVGPr
     getScaleXTicks?: <T>(options: GetScaleTicksOptions) => T[]
     getTruncatedXTick?: (formattedTick: string) => string
     getCategory?: (datum: Datum) => string | undefined
+
+    onDatumHover?: (datum: Datum) => void
 }
 
 export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
@@ -47,6 +49,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         getDatumLink = DEFAULT_LINK_GETTER,
         getCategory = getDatumName,
         onDatumLinkClick,
+        onDatumHover,
         ...attributes
     } = props
 
@@ -112,6 +115,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
                         getDatumColor={getDatumColor}
                         getDatumLink={getDatumLink}
                         onBarClick={handleBarClick}
+                        onBarHover={onDatumHover}
                     />
                 )}
             </SvgContent>

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
@@ -30,6 +30,7 @@ interface BarChartContentProps<Datum> extends SVGProps<SVGGElement> {
     getDatumColor: (datum: Datum) => string | undefined
     getDatumLink: (datum: Datum) => string | undefined | null
     onBarClick: (event: MouseEvent, datum: Datum) => void
+    onBarHover?: (datum: Datum) => void
 }
 
 export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): ReactElement {
@@ -48,6 +49,7 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
         getDatumColor,
         getDatumLink,
         onBarClick,
+        onBarHover,
         ...attributes
     } = props
 
@@ -55,6 +57,11 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
     const [activeSegment, setActiveSegment] = useState<ActiveSegment<Datum> | null>(null)
 
     const withActiveLink = activeSegment?.datum ? getDatumLink(activeSegment?.datum) : null
+
+    const handleBarHover = (datum: Datum, category: Category<Datum>): void => {
+        setActiveSegment({ datum, category })
+        onBarHover?.(datum)
+    }
 
     return (
         <Group
@@ -72,7 +79,7 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
                     getDatumValue={getDatumValue}
                     getDatumColor={getDatumColor}
                     height={+height}
-                    onBarHover={(datum, category) => setActiveSegment({ datum, category })}
+                    onBarHover={handleBarHover}
                     onBarLeave={() => setActiveSegment(null)}
                     onBarClick={onBarClick}
                 />
@@ -89,7 +96,7 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
                     getDatumLink={getDatumLink}
                     height={+height}
                     width={+width}
-                    onBarHover={(datum, category) => setActiveSegment({ datum, category })}
+                    onBarHover={handleBarHover}
                     onBarLeave={() => setActiveSegment(null)}
                     onBarClick={onBarClick}
                 />

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
@@ -29,7 +29,7 @@ interface BarChartContentProps<Datum> extends SVGProps<SVGGElement> {
     getDatumHover?: (datum: Datum) => string
     getDatumColor: (datum: Datum) => string | undefined
     getDatumLink: (datum: Datum) => string | undefined | null
-    onBarClick: (event: MouseEvent, datum: Datum) => void
+    onBarClick: (event: MouseEvent, datum: Datum, index: number) => void
     onBarHover?: (datum: Datum) => void
 }
 

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
@@ -25,7 +25,7 @@ interface GroupedBarsProps<Datum> extends ComponentProps<typeof Group> {
     getDatumLink: (datum: Datum) => string | undefined | null
     onBarHover: (datum: Datum, category: Category<Datum>) => void
     onBarLeave: () => void
-    onBarClick: (event: MouseEvent, datum: Datum) => void
+    onBarClick: (event: MouseEvent, datum: Datum, index: number) => void
 }
 
 const isSafari = getBrowserName() === 'safari'
@@ -77,10 +77,10 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
     }
 
     const handleGroupClick = (event: MouseEvent): void => {
-        const [datum] = getActiveBar({ event, xScale, xCategoriesScale, categories })
+        const [datum, , index] = getActiveBar({ event, xScale, xCategoriesScale, categories })
 
-        if (datum) {
-            onBarClick(event, datum)
+        if (datum && index !== null) {
+            onBarClick(event, datum, index)
         }
     }
 
@@ -88,7 +88,7 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
         <Group {...attributes} pointerEvents="bounding-rect">
             {categories.map(category => (
                 <Group key={category.id} left={xScale(category.id)} height={height}>
-                    {category.data.map(datum => {
+                    {category.data.map((datum, index) => {
                         const isOneDatumCategory = category.data.length === 1
                         const barWidth = isOneDatumCategory ? xScale.bandwidth() : xCategoriesScale.bandwidth()
                         const barHeight = height - yScale(getDatumValue(datum))
@@ -100,7 +100,7 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
                                 key={`bar-group-bar-${category.id}-${getDatumName(datum)}`}
                                 to={getDatumLink(datum)}
                                 onFocus={() => onBarHover(datum, category)}
-                                onClick={event => onBarClick(event, datum)}
+                                onClick={event => onBarClick(event, datum, index)}
                             >
                                 <rect
                                     x={barX}
@@ -157,7 +157,9 @@ function scaleBandInvert(scale: ScaleBand<string>): (x: number) => number {
     }
 }
 
-function getActiveBar<Datum>(input: GetActiveBarInput<Datum>): [datum: Datum | null, category: Category<Datum> | null] {
+type ActiveBarTuple<Datum> = [datum: Datum | null, category: Category<Datum> | null, index: number | null]
+
+function getActiveBar<Datum>(input: GetActiveBarInput<Datum>): ActiveBarTuple<Datum> {
     const { event, xCategoriesScale, categories, xScale } = input
 
     const targetRectangle = (event.currentTarget as Element).getBoundingClientRect()
@@ -168,13 +170,13 @@ function getActiveBar<Datum>(input: GetActiveBarInput<Datum>): [datum: Datum | n
     const category = categories[categoryPossibleIndex]
 
     if (!category) {
-        return [null, null]
+        return [null, null, null]
     }
 
     const isOneDatumCategory = category.data.length === 1
 
     if (isOneDatumCategory) {
-        return [category.data[0], category]
+        return [category.data[0], category, 0]
     }
 
     const invertCategories = scaleBandInvert(xCategoriesScale)
@@ -182,8 +184,8 @@ function getActiveBar<Datum>(input: GetActiveBarInput<Datum>): [datum: Datum | n
     const possibleBarIndex = invertCategories(xCord - categoryWindow)
 
     if (category.data[possibleBarIndex]) {
-        return [category.data[possibleBarIndex], category]
+        return [category.data[possibleBarIndex], category, possibleBarIndex]
     }
 
-    return [null, null]
+    return [null, null, null]
 }

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
@@ -59,10 +59,18 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
     )
 
     const handleGroupMouseMove = (event: MouseEvent): void => {
-        const [category, datum] = getActiveBar({ event, xScale, xCategoriesScale, categories })
+        const [datum, category] = getActiveBar({ event, xScale, xCategoriesScale, categories })
 
         if (category && datum) {
-            onBarHover(category, datum)
+            if (!activeSegment?.datum) {
+                onBarHover(datum, category)
+                return
+            }
+
+            // Do not call onBarHover every time we mouse move over the same datum
+            if (getDatumName(activeSegment.datum) !== getDatumName(datum)) {
+                onBarHover(datum, category)
+            }
         } else {
             onBarLeave()
         }

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/StackedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/StackedBars.tsx
@@ -16,7 +16,7 @@ interface StackedBarsProps<Datum> extends ComponentProps<typeof Group> {
     getDatumColor: (datum: Datum) => string | undefined
     onBarHover: (datum: Datum, category: Category<Datum>) => void
     onBarLeave: () => void
-    onBarClick: (event: MouseEvent, datum: Datum) => void
+    onBarClick: (event: MouseEvent, datum: Datum, index: number) => void
 }
 
 export function StackedBars<Datum>(props: StackedBarsProps<Datum>): ReactElement {
@@ -60,7 +60,7 @@ export function StackedBars<Datum>(props: StackedBarsProps<Datum>): ReactElement
                                 bottom={isFirstBar}
                                 top={isLastBar}
                                 onMouseEnter={() => onBarHover(stackedDatum.datum, category)}
-                                onClick={event => onBarClick(event, stackedDatum.datum)}
+                                onClick={event => onBarClick(event, stackedDatum.datum, index)}
                                 onMouseLeave={onBarLeave}
                             />
                         )

--- a/client/wildcard/src/components/Charts/components/pie-chart/PieChart.tsx
+++ b/client/wildcard/src/components/Charts/components/pie-chart/PieChart.tsx
@@ -105,7 +105,7 @@ export function PieChart<Datum>(props: PieChartProps<Datum>): ReactElement | nul
                                         aria-label={`Element ${index + 1} of ${arcs.length}. Name: ${getDatumName(
                                             arc.data
                                         )}. Value: ${getSubtitle(arc, total)}.`}
-                                        onClick={event => onDatumLinkClick(event, arc.data)}
+                                        onClick={event => onDatumLinkClick(event, arc.data, index)}
                                     >
                                         <PieArc
                                             arc={arc}

--- a/client/wildcard/src/components/Charts/types.ts
+++ b/client/wildcard/src/components/Charts/types.ts
@@ -18,7 +18,7 @@ export interface CategoricalLikeChart<Datum> {
     getDatumHover?: (datum: Datum) => string
     getDatumColor: (datum: Datum) => string | undefined
     getDatumLink?: (datum: Datum) => string | undefined
-    onDatumLinkClick?: (event: React.MouseEvent, datum: Datum) => void
+    onDatumLinkClick?: (event: React.MouseEvent, datum: Datum, index: number) => void
 }
 
 export interface Series<Datum> {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1388,31 +1388,51 @@ type ExtensionUsageStatistics struct {
 }
 
 type CodeInsightsUsageStatistics struct {
-	WeeklyUsageStatisticsByInsight               []*InsightUsageStatistics
-	WeeklyInsightsPageViews                      *int32
-	WeeklyStandaloneInsightPageViews             *int32
-	WeeklyStandaloneDashboardClicks              *int32
-	WeeklyStandaloneEditClicks                   *int32
-	WeeklyInsightsGetStartedPageViews            *int32
-	WeeklyInsightsUniquePageViews                *int32
-	WeeklyInsightsGetStartedUniquePageViews      *int32
-	WeeklyStandaloneInsightUniquePageViews       *int32
-	WeeklyStandaloneInsightUniqueDashboardClicks *int32
-	WeeklyStandaloneInsightUniqueEditClicks      *int32
-	WeeklyInsightConfigureClick                  *int32
-	WeeklyInsightAddMoreClick                    *int32
-	WeekStart                                    time.Time
-	WeeklyInsightCreators                        *int32
-	WeeklyFirstTimeInsightCreators               *int32
-	WeeklyAggregatedUsage                        []AggregatedPingStats
-	WeeklyGetStartedTabClickByTab                []InsightGetStartedTabClickPing
-	WeeklyGetStartedTabMoreClickByTab            []InsightGetStartedTabClickPing
-	InsightTimeIntervals                         []InsightTimeIntervalPing
-	InsightOrgVisible                            []OrgVisibleInsightPing
-	InsightTotalCounts                           InsightTotalCounts
-	TotalOrgsWithDashboard                       *int32
-	TotalDashboardCount                          *int32
-	InsightsPerDashboard                         InsightsPerDashboardPing
+	WeeklyUsageStatisticsByInsight                 []*InsightUsageStatistics
+	WeeklyInsightsPageViews                        *int32
+	WeeklyStandaloneInsightPageViews               *int32
+	WeeklyStandaloneDashboardClicks                *int32
+	WeeklyStandaloneEditClicks                     *int32
+	WeeklyInsightsGetStartedPageViews              *int32
+	WeeklyInsightsUniquePageViews                  *int32
+	WeeklyInsightsGetStartedUniquePageViews        *int32
+	WeeklyStandaloneInsightUniquePageViews         *int32
+	WeeklyStandaloneInsightUniqueDashboardClicks   *int32
+	WeeklyStandaloneInsightUniqueEditClicks        *int32
+	WeeklyInsightConfigureClick                    *int32
+	WeeklyInsightAddMoreClick                      *int32
+	WeekStart                                      time.Time
+	WeeklyInsightCreators                          *int32
+	WeeklyFirstTimeInsightCreators                 *int32
+	WeeklyAggregatedUsage                          []AggregatedPingStats
+	WeeklyGetStartedTabClickByTab                  []InsightGetStartedTabClickPing
+	WeeklyGetStartedTabMoreClickByTab              []InsightGetStartedTabClickPing
+	InsightTimeIntervals                           []InsightTimeIntervalPing
+	InsightOrgVisible                              []OrgVisibleInsightPing
+	InsightTotalCounts                             InsightTotalCounts
+	TotalOrgsWithDashboard                         *int32
+	TotalDashboardCount                            *int32
+	InsightsPerDashboard                           InsightsPerDashboardPing
+	WeeklyGroupResultsOpenSection                  *int32
+	WeeklyGroupResultsCollapseSection              *int32
+	WeeklyGroupResultsInfoIconHover                *int32
+	WeeklyGroupResultsExpandedViewOpen             []GroupResultExpandedViewPing
+	WeeklyGroupResultsExpandedViewCollapse         []GroupResultExpandedViewPing
+	WeeklyGroupResultsChartBarHover                []GroupResultPing
+	WeeklyGroupResultsChartBarClick                []GroupResultPing
+	WeeklyGroupResultsAggregationModeClicked       []GroupResultPing
+	WeeklyGroupResultsAggregationModeDisabledHover []GroupResultPing
+}
+
+type GroupResultPing struct {
+	AggregationMode *string
+	UIMode          *string
+	Count           *int32
+}
+
+type GroupResultExpandedViewPing struct {
+	AggregationMode *string
+	Count           *int32
 }
 
 type CodeInsightsCriticalTelemetry struct {

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -31,9 +31,14 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 		COUNT(distinct user_id) FILTER (WHERE name = 'StandaloneInsightPageEditClick')  AS weekly_standalone_insight_unique_edit_clicks,
 		COUNT(distinct user_id) FILTER (WHERE name = 'InsightAddition')					AS weekly_insight_creators,
 		COUNT(*) FILTER (WHERE name = 'InsightConfigureClick') 							AS weekly_insight_configure_click,
-		COUNT(*) FILTER (WHERE name = 'InsightAddMoreClick') 							AS weekly_insight_add_more_click
+		COUNT(*) FILTER (WHERE name = 'InsightAddMoreClick') 							AS weekly_insight_add_more_click,
+		COUNT(*) FILTER (WHERE name = 'GroupResultsOpenSection') 						AS weekly_group_results_open_section,
+		COUNT(*) FILTER (WHERE name = 'GroupResultsCollapseSection') 					AS weekly_group_results_collapse_section,
+		COUNT(*) FILTER (WHERE name = 'GroupResultsInfoIconHover') 						AS weekly_group_results_info_icon_hover
 	FROM event_logs
-	WHERE name in ('ViewInsights', 'StandaloneInsightPageViewed', 'StandaloneInsightDashboardClick', 'StandaloneInsightPageEditClick', 'ViewInsightsGetStartedPage', 'InsightAddition', 'InsightConfigureClick', 'InsightAddMoreClick')
+	WHERE name in ('ViewInsights', 'StandaloneInsightPageViewed', 'StandaloneInsightDashboardClick', 'StandaloneInsightPageEditClick',
+			'ViewInsightsGetStartedPage', 'InsightAddition', 'InsightConfigureClick', 'InsightAddMoreClick', 'GroupResultsOpenSection',
+			'GroupResultsCollapseSection', 'GroupResultsInfoIconHover')
 		AND timestamp > DATE_TRUNC('week', $1::timestamp);
 	`
 
@@ -51,6 +56,9 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 		&stats.WeeklyInsightCreators,
 		&stats.WeeklyInsightConfigureClick,
 		&stats.WeeklyInsightAddMoreClick,
+		&stats.WeeklyGroupResultsOpenSection,
+		&stats.WeeklyGroupResultsCollapseSection,
+		&stats.WeeklyGroupResultsInfoIconHover,
 	); err != nil {
 		return nil, err
 	}
@@ -182,6 +190,42 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 		return nil, errors.Wrap(err, "GetInsightsPerDashboard")
 	}
 	stats.InsightsPerDashboard = insightsPerDashboard
+
+	weeklyGroupResultsAggregationModeClicked, err := GetGroupResultsPing(ctx, db, "GroupAggregationModeClicked")
+	if err != nil {
+		return nil, errors.Wrap(err, "WeeklyGroupResultsAggregationModeClicked")
+	}
+	stats.WeeklyGroupResultsAggregationModeClicked = weeklyGroupResultsAggregationModeClicked
+
+	weeklyGroupResultsAggregationModeDisabledHover, err := GetGroupResultsPing(ctx, db, "GroupAggregationModeDisabledHover")
+	if err != nil {
+		return nil, errors.Wrap(err, "WeeklyGroupResultsAggregationModeDisabledHover")
+	}
+	stats.WeeklyGroupResultsAggregationModeDisabledHover = weeklyGroupResultsAggregationModeDisabledHover
+
+	weeklyGroupResultsChartBarClick, err := GetGroupResultsPing(ctx, db, "GroupResultsChartBarClick")
+	if err != nil {
+		return nil, errors.Wrap(err, "GroupResultsChartBarClick")
+	}
+	stats.WeeklyGroupResultsChartBarClick = weeklyGroupResultsChartBarClick
+
+	weeklyGroupResultsChartBarHover, err := GetGroupResultsPing(ctx, db, "GroupResultsChartBarHover")
+	if err != nil {
+		return nil, errors.Wrap(err, "GroupResultsChartBarHover")
+	}
+	stats.WeeklyGroupResultsChartBarHover = weeklyGroupResultsChartBarHover
+
+	weeklyGroupResultsExpandedViewOpen, err := GetGroupResultsExpandedViewPing(ctx, db, "GroupResultsExpandedViewOpen")
+	if err != nil {
+		return nil, errors.Wrap(err, "WeeklyGroupResultsExpandedViewOpen")
+	}
+	stats.WeeklyGroupResultsExpandedViewOpen = weeklyGroupResultsExpandedViewOpen
+
+	weeklyGroupResultsExpandedViewCollapse, err := GetGroupResultsExpandedViewPing(ctx, db, "GroupResultsExpandedViewCollapse")
+	if err != nil {
+		return nil, errors.Wrap(err, "WeeklyGroupResultsExpandedViewCollapse")
+	}
+	stats.WeeklyGroupResultsExpandedViewCollapse = weeklyGroupResultsExpandedViewCollapse
 
 	return &stats, nil
 }
@@ -341,6 +385,55 @@ func GetInsightsPerDashboard(ctx context.Context, db database.DB) (types.Insight
 	return insightsPerDashboardStats, nil
 }
 
+func GetGroupResultsPing(ctx context.Context, db database.DB, pingName string) ([]types.GroupResultPing, error) {
+	groupResultsPings := []types.GroupResultPing{}
+	rows, err := db.QueryContext(ctx, getGroupResultsSql, pingName, timeNow())
+
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		groupResultsPing := types.GroupResultPing{}
+		if err := rows.Scan(
+			&groupResultsPing.Count,
+			&groupResultsPing.AggregationMode,
+			&groupResultsPing.UIMode,
+		); err != nil {
+			return nil, err
+		}
+
+		groupResultsPings = append(groupResultsPings, groupResultsPing)
+	}
+	return groupResultsPings, nil
+}
+
+func GetGroupResultsExpandedViewPing(ctx context.Context, db database.DB, pingName string) ([]types.GroupResultExpandedViewPing, error) {
+	groupResultsExpandedViewPings := []types.GroupResultExpandedViewPing{}
+	rows, err := db.QueryContext(ctx, getGroupResultsSql, pingName, timeNow())
+
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var noop *string
+	for rows.Next() {
+		groupResultsExpandedViewPing := types.GroupResultExpandedViewPing{}
+		if err := rows.Scan(
+			&groupResultsExpandedViewPing.Count,
+			&groupResultsExpandedViewPing.AggregationMode,
+			&noop,
+		); err != nil {
+			return nil, err
+		}
+
+		groupResultsExpandedViewPings = append(groupResultsExpandedViewPings, groupResultsExpandedViewPing)
+	}
+	return groupResultsExpandedViewPings, nil
+}
+
 // WithAll adds multiple pings by name to this builder
 func (b *PingQueryBuilder) WithAll(pings []types.PingName) *PingQueryBuilder {
 	for _, p := range pings {
@@ -448,6 +541,12 @@ GROUP BY argument;
 const getStartedTabMoreClickSql = `
 SELECT COUNT(*), argument::json->>'tabName' as argument FROM event_logs
 WHERE name = 'InsightsGetStartedTabMoreClick' AND timestamp > DATE_TRUNC('week', $1::TIMESTAMP)
+GROUP BY argument;
+`
+
+const getGroupResultsSql = `
+SELECT COUNT(*), argument::json->>'aggregationMode' as aggregationMode, argument::json->>'uiMode' as uiMode FROM event_logs
+WHERE name = $1::TEXT AND timestamp > DATE_TRUNC('week', $2::TIMESTAMP)
 GROUP BY argument;
 `
 

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -107,6 +107,9 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 		WeeklyStandaloneInsightUniqueDashboardClicks: &zeroInt,
 		WeeklyStandaloneInsightPageViews:             &zeroInt,
 		WeeklyStandaloneEditClicks:                   &zeroInt,
+		WeeklyGroupResultsOpenSection:                &zeroInt,
+		WeeklyGroupResultsCollapseSection:            &zeroInt,
+		WeeklyGroupResultsInfoIconHover:              &zeroInt,
 	}
 
 	wantedWeeklyUsage := []types.AggregatedPingStats{
@@ -116,6 +119,13 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 	want.WeeklyAggregatedUsage = wantedWeeklyUsage
 	want.InsightTimeIntervals = []types.InsightTimeIntervalPing{}
 	want.InsightOrgVisible = []types.OrgVisibleInsightPing{}
+
+	want.WeeklyGroupResultsExpandedViewOpen = []types.GroupResultExpandedViewPing{}
+	want.WeeklyGroupResultsExpandedViewCollapse = []types.GroupResultExpandedViewPing{}
+	want.WeeklyGroupResultsChartBarHover = []types.GroupResultPing{}
+	want.WeeklyGroupResultsChartBarClick = []types.GroupResultPing{}
+	want.WeeklyGroupResultsAggregationModeClicked = []types.GroupResultPing{}
+	want.WeeklyGroupResultsAggregationModeDisabledHover = []types.GroupResultPing{}
 
 	if diff := cmp.Diff(want, have); diff != "" {
 		t.Fatal(diff)


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/39922

## Background
[Aggregation Pings RFC](https://docs.google.com/document/d/1v6-T0UTGfQ1H7SBybuNXlPFAm4Ilu7r1aU23p_5MhrE/edit#)
[Figma design with pings spec](https://www.figma.com/file/cKSeCtmBh9aiPsAVoKsLgM/Aggregation-insights%3A-display-%22grouped%22-insights-for-existing-searches-%2339126-%5Bready-for-dev%5D?node-id=2377%3A42151)
 
In this PR we add pings event for the aggregation project. To be more specific this PR adds
- `GroupResultsCollapseSection` and `GroupResultsOpenSection` whenever we open/close aggregation panel in the sidebar
- `GroupResults[$filter-name]` whenever users click on aggregation controls buttons (from the sidepanel and from the full UI aggregation mode)
   - `GroupResultsREPO`
   - `GroupResultsPATH`
   - `GroupResultsAUTHOR`
   - `GroupResultsCAPTURE_GROUP`
-`GroupResults[$filter-name]DisabledHover`simular to above events about aggregation modes. Whenever user hovers any disable aggregation button. 
- `GroupResultsChartBarClick` whenever user clicks one of the chart bars
- `GroupResultsChartBarHover` whenever user hovers one of the chart bars
- `GroupResultsExpandViewOpen` whenever users clicks expand button (button that leads to the full aggregation UI)
- `GroupResultsInfoIconHover` whenever user hovers info icon in the sidebar panel section heading
- `GroupResultsExpandedViewCollapse` whenever user clicks on the collapse button in the full UI mode.

**Event that are not in this PR** because of we cut of scope or they are no longer needed
- `GroupResultsExpandedViewInfoIconHover` we changed our layout and there is no longer tooltip icon (just plain text below the heading  see [design](https://www.figma.com/file/cKSeCtmBh9aiPsAVoKsLgM/Aggregation-insights%3A-display-%22grouped%22-insights-for-existing-searches-%2339126-%5Bready-for-dev%5D?node-id=1913%3A35438))
- `GroupResultsExpandedView[$filter-name]` instead we use `GroupResults[$filter-name]` with `uiMode` body variable `resultsScreen`
- `GroupResultsExpandedViewChartBarClick` instead we use `GroupResultsChartBarClick ` with uiMode` body variable `resultsScreen`
- `GroupResultsExpandedViewChartBarHover` also don't use and use `GroupResultsChartBarHover` instead

- `GroupResultsExpandedViewListRowClick` and `GroupResultsExpandedViewListRowHover` out of scope. List items are not clickable in the v1 of aggregation UI. 
- `GroupResultsSaveInsightDisabledHover` and `GroupResultsExpandedViewSaveInsight` out of scope
- `GroupResultsMemoryHitHover` out of scope we don't have any info to show such information in the UI. 

## TODO 
- [x] Add pings events on the frontend
- [x] Update BigQuery schema
- [ ] Add newly added pings in the ping documentation

## Test plan
- Make sure that all pings that are listed above in the background section is sent by the frontend with proper event body 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-aggregation-fe-pings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dwkazbjcwz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
