### PR TITLE
insights: aggregations only group by the first capture group in a regex with multiple capturing groups

### DIFF
--- a/enterprise/internal/insights/aggregation/aggregation_test.go
+++ b/enterprise/internal/insights/aggregation/aggregation_test.go
@@ -393,6 +393,17 @@ func TestCaptureGroupAggregation(t *testing.T) {
 			`repo:^github\.com/sourcegraph/sourcegraph python([0-9]\.[0-9]) case:yes`,
 			autogold.Want("capture match respects case:yes", map[string]int{}),
 		},
+		{
+			types.CAPTURE_GROUP_AGGREGATION_MODE,
+			streaming.SearchEvent{
+				Results: []result.Match{
+					contentMatch("myRepo", "file.go", 1, "python2.7 python2.7"),
+					contentMatch("myRepo", "file2.go", 1, "python2.8 python2.9"),
+				},
+			},
+			`python([0-9])\.([0-9])`,
+			autogold.Want("only get values from first capture group", map[string]int{"2": 4}),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.want.Name(), func(t *testing.T) {

--- a/enterprise/internal/insights/aggregation/aggregation_test.go
+++ b/enterprise/internal/insights/aggregation/aggregation_test.go
@@ -404,6 +404,17 @@ func TestCaptureGroupAggregation(t *testing.T) {
 			`python([0-9])\.([0-9])`,
 			autogold.Want("only get values from first capture group", map[string]int{"2": 4}),
 		},
+		{
+			types.CAPTURE_GROUP_AGGREGATION_MODE,
+			streaming.SearchEvent{
+				Results: []result.Match{
+					contentMatch("myRepo", "file.go", 1, "2.7"),
+					contentMatch("myRepo", "file2.go", 1, "2.9"),
+				},
+			},
+			`([0-9]\.[0-9])`,
+			autogold.Want("whole match only", map[string]int{"2.7": 1, "2.9": 1}),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.want.Name(), func(t *testing.T) {

--- a/enterprise/internal/insights/aggregation/capture_group_helpers.go
+++ b/enterprise/internal/insights/aggregation/capture_group_helpers.go
@@ -82,6 +82,12 @@ func fromRegexpMatches(submatches []int, namedGroups []string, content string, r
 	// iterate over pairs of offsets. Cf. FindAllStringSubmatchIndex
 	// https://pkg.go.dev/regexp#Regexp.FindAllStringSubmatchIndex.
 	for j := 0; j < len(submatches); j += 2 {
+
+		// we only want the first capture group match that would be starting at indexe 2
+		if j > 2 {
+			break
+		}
+
 		start := submatches[j]
 		end := submatches[j+1]
 		if start == -1 || end == -1 {
@@ -93,7 +99,7 @@ func fromRegexpMatches(submatches []int, namedGroups []string, content string, r
 
 		if j == 0 {
 			// The first submatch is the overall match
-			// value. Don't add this to the Environment
+			// value. Don't add this
 			continue
 		}
 

--- a/enterprise/internal/insights/aggregation/capture_group_helpers.go
+++ b/enterprise/internal/insights/aggregation/capture_group_helpers.go
@@ -79,32 +79,16 @@ func extractPattern(basic *query.Basic) (*query.Pattern, error) {
 
 func fromRegexpMatches(submatches []int, namedGroups []string, content string, range_ result.Range) map[string]int {
 	counts := map[string]int{}
-	// iterate over pairs of offsets. Cf. FindAllStringSubmatchIndex
-	// https://pkg.go.dev/regexp#Regexp.FindAllStringSubmatchIndex.
-	for j := 0; j < len(submatches); j += 2 {
 
-		// we only want the first capture group match that would be starting at indexe 2
-		if j > 2 {
-			break
+	if len(submatches) >= 4 {
+		start := submatches[2]
+		end := submatches[3]
+		if start != -1 && end != -1 {
+			value := content[start:end]
+			counts[value] = 1
 		}
 
-		start := submatches[j]
-		end := submatches[j+1]
-		if start == -1 || end == -1 {
-			// The entire regexp matched, but a capture
-			// group inside it did not. Ignore this entry.
-			continue
-		}
-		value := content[start:end]
-
-		if j == 0 {
-			// The first submatch is the overall match
-			// value. Don't add this
-			continue
-		}
-
-		current, _ := counts[value]
-		counts[value] = current + 1
 	}
+
 	return counts
 }


### PR DESCRIPTION
Updates the capture group aggregation logic to only return data from the 1st capture group 

closes https://github.com/sourcegraph/sourcegraph/issues/40844
## Test plan
unit tests added and pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
