### PR TITLE
simple ui: add back search reference panel

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchReference.module.scss
+++ b/client/search-ui/src/results/sidebar/SearchReference.module.scss
@@ -2,6 +2,10 @@
     margin-top: 0.75rem;
 }
 
+.tabs {
+    background-color: transparent;
+}
+
 .footer {
     border-top: 1px solid var(--border-color);
     padding-top: 0.75rem;

--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -561,7 +561,7 @@ const SearchReference = React.memo(
                 {hasFilter ? (
                     filterList
                 ) : (
-                    <Tabs defaultIndex={persistedTabIndex} onChange={setPersistedTabIndex}>
+                    <Tabs className={styles.tabs} defaultIndex={persistedTabIndex} onChange={setPersistedTabIndex}>
                         <TabList>
                             <Tab>Common</Tab>
                             <Tab>All filters</Tab>

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -300,24 +300,22 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                         {props.getRevisions({ repoName, onFilterClick: submitQueryWithProps })}
                     </SearchSidebarSection>
                 ) : null}
-                {!coreWorkflowImprovementsEnabled && (
-                    <SearchSidebarSection
-                        sectionId={SectionID.SEARCH_REFERENCE}
-                        className={styles.item}
-                        header="Search reference"
-                        showSearch={true}
-                        startCollapsed={collapsedSections?.[SectionID.SEARCH_REFERENCE]}
-                        onToggle={onSearchReferenceToggle}
-                        // search reference should always preserve the filter
-                        // (false is just an arbitrary but static value)
-                        clearSearchOnChange={false}
-                    >
-                        {getSearchReferenceFactory({
-                            telemetryService: props.telemetryService,
-                            setQueryState,
-                        })}
-                    </SearchSidebarSection>
-                )}
+                <SearchSidebarSection
+                    sectionId={SectionID.SEARCH_REFERENCE}
+                    className={styles.item}
+                    header="Search reference"
+                    showSearch={true}
+                    startCollapsed={collapsedSections?.[SectionID.SEARCH_REFERENCE]}
+                    onToggle={onSearchReferenceToggle}
+                    // search reference should always preserve the filter
+                    // (false is just an arbitrary but static value)
+                    clearSearchOnChange={false}
+                >
+                    {getSearchReferenceFactory({
+                        telemetryService: props.telemetryService,
+                        setQueryState,
+                    })}
+                </SearchSidebarSection>
                 <SearchSidebarSection
                     sectionId={SectionID.SEARCH_SNIPPETS}
                     className={styles.item}


### PR DESCRIPTION
Closes #40998

(review with whitespace changes hidden)

Adds back search reference panel to the sidebar when Simple UI toggle is on. Also fixes the background color of the panel.

## Test plan

Verify references panel is shown with Simple UI toggle on and off.

## App preview:

- [Web](https://sg-web-jp-refpanel.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jmpbwbfsip.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
