### PR TITLE
Fix deadlock in migration by splitting it up in two

### DIFF
--- a/migrations/frontend/1661507724_update_repo_stats_trigger_to_avoid_all_zeros/down.sql
+++ b/migrations/frontend/1661507724_update_repo_stats_trigger_to_avoid_all_zeros/down.sql
@@ -1,3 +1,5 @@
+LOCK repo IN EXCLUSIVE MODE; -- Get a lock for the table so we don't have writes between dropping and recreating the trigger.
+
 -- Recreate old version of function
 CREATE OR REPLACE FUNCTION recalc_repo_statistics_on_repo_update() RETURNS trigger
     LANGUAGE plpgsql
@@ -33,86 +35,8 @@ CREATE OR REPLACE FUNCTION recalc_repo_statistics_on_repo_update() RETURNS trigg
       RETURN NULL;
   END
 $$;
-
--- Recreate old version of function
-CREATE OR REPLACE FUNCTION recalc_gitserver_repos_statistics_on_update() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$ BEGIN
-      INSERT INTO gitserver_repos_statistics AS grs (shard_id, total, not_cloned, cloning, cloned, failed_fetch)
-      SELECT
-        newtab.shard_id AS shard_id,
-        COUNT(*) AS total,
-        COUNT(*) FILTER(WHERE clone_status = 'not_cloned')  AS not_cloned,
-        COUNT(*) FILTER(WHERE clone_status = 'cloning') AS cloning,
-        COUNT(*) FILTER(WHERE clone_status = 'cloned') AS cloned,
-        COUNT(*) FILTER(WHERE last_error IS NOT NULL) AS failed_fetch
-      FROM
-        newtab
-      GROUP BY newtab.shard_id
-      ON CONFLICT(shard_id) DO
-      UPDATE
-      SET
-        total        = grs.total        + (excluded.total        - (SELECT COUNT(*)                                              FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
-        not_cloned   = grs.not_cloned   + (excluded.not_cloned   - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'not_cloned') FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
-        cloning      = grs.cloning      + (excluded.cloning      - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'cloning')    FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
-        cloned       = grs.cloned       + (excluded.cloned       - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'cloned')     FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
-        failed_fetch = grs.failed_fetch + (excluded.failed_fetch - (SELECT COUNT(*) FILTER(WHERE ot.last_error IS NOT NULL)      FROM oldtab ot WHERE ot.shard_id = excluded.shard_id))
-      ;
-
-      WITH moved AS (
-        SELECT
-          oldtab.shard_id AS shard_id,
-          COUNT(*) AS total,
-          COUNT(*) FILTER(WHERE oldtab.clone_status = 'not_cloned')  AS not_cloned,
-          COUNT(*) FILTER(WHERE oldtab.clone_status = 'cloning') AS cloning,
-          COUNT(*) FILTER(WHERE oldtab.clone_status = 'cloned') AS cloned,
-          COUNT(*) FILTER(WHERE oldtab.last_error IS NOT NULL) AS failed_fetch
-        FROM
-          oldtab
-        JOIN newtab ON newtab.repo_id = oldtab.repo_id
-        WHERE
-          oldtab.shard_id != newtab.shard_id
-        GROUP BY oldtab.shard_id
-      )
-      UPDATE gitserver_repos_statistics grs
-      SET
-        total        = grs.total        - moved.total,
-        not_cloned   = grs.not_cloned   - moved.not_cloned,
-        cloning      = grs.cloning      - moved.cloning,
-        cloned       = grs.cloned       - moved.cloned,
-        failed_fetch = grs.failed_fetch - moved.failed_fetch
-      FROM moved
-      WHERE moved.shard_id = grs.shard_id;
-
-      INSERT INTO repo_statistics (not_cloned, cloning, cloned, failed_fetch)
-      VALUES (
-        (
-          (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'not_cloned')
-          -
-          (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'not_cloned')
-        ),
-        (
-          (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'cloning')
-          -
-          (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'cloning')
-        ),
-        (
-          (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'cloned')
-          -
-          (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'cloned')
-        ),
-        (
-          (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.last_error IS NOT NULL)
-          -
-          (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.last_error IS NOT NULL)
-        )
-      );
-
-      RETURN NULL;
-  END
-$$;
-DROP TRIGGER IF EXISTS trig_recalc_gitserver_repos_statistics_on_update ON gitserver_repos;
-CREATE TRIGGER trig_recalc_gitserver_repos_statistics_on_update
-AFTER UPDATE ON gitserver_repos
+DROP TRIGGER IF EXISTS trig_recalc_repo_statistics_on_repo_update ON repo;
+CREATE TRIGGER trig_recalc_repo_statistics_on_repo_update
+AFTER UPDATE ON repo
 REFERENCING OLD TABLE AS oldtab NEW TABLE AS newtab
-FOR EACH STATEMENT EXECUTE FUNCTION recalc_gitserver_repos_statistics_on_update();
+FOR EACH STATEMENT EXECUTE FUNCTION recalc_repo_statistics_on_repo_update();

--- a/migrations/frontend/1661507724_update_repo_stats_trigger_to_avoid_all_zeros/up.sql
+++ b/migrations/frontend/1661507724_update_repo_stats_trigger_to_avoid_all_zeros/up.sql
@@ -1,8 +1,8 @@
--- repo UPDATE trigger
+LOCK repo IN EXCLUSIVE MODE; -- Get a lock for the table so we don't have writes between dropping and recreating the trigger.
+
 CREATE OR REPLACE FUNCTION recalc_repo_statistics_on_repo_update() RETURNS trigger
     LANGUAGE plpgsql
     AS $$ BEGIN
-      -- Insert diff of changes
       WITH diff(total, soft_deleted, not_cloned, cloning, cloned, failed_fetch) AS (
         VALUES (
           (SELECT COUNT(*) FROM newtab WHERE deleted_at IS NULL     AND blocked IS NULL) - (SELECT COUNT(*) FROM oldtab WHERE deleted_at IS NULL     AND blocked IS NULL),
@@ -49,104 +49,3 @@ CREATE TRIGGER trig_recalc_repo_statistics_on_repo_update
 AFTER UPDATE ON repo
 REFERENCING OLD TABLE AS oldtab NEW TABLE AS newtab
 FOR EACH STATEMENT EXECUTE FUNCTION recalc_repo_statistics_on_repo_update();
-
-CREATE OR REPLACE FUNCTION recalc_gitserver_repos_statistics_on_update() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$ BEGIN
-      --------------------
-      -- THIS IS UNCHANGED
-      --------------------
-      INSERT INTO gitserver_repos_statistics AS grs (shard_id, total, not_cloned, cloning, cloned, failed_fetch)
-      SELECT
-        newtab.shard_id AS shard_id,
-        COUNT(*) AS total,
-        COUNT(*) FILTER(WHERE clone_status = 'not_cloned')  AS not_cloned,
-        COUNT(*) FILTER(WHERE clone_status = 'cloning') AS cloning,
-        COUNT(*) FILTER(WHERE clone_status = 'cloned') AS cloned,
-        COUNT(*) FILTER(WHERE last_error IS NOT NULL) AS failed_fetch
-      FROM
-        newtab
-      GROUP BY newtab.shard_id
-      ON CONFLICT(shard_id) DO
-      UPDATE
-      SET
-        total        = grs.total        + (excluded.total        - (SELECT COUNT(*)                                              FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
-        not_cloned   = grs.not_cloned   + (excluded.not_cloned   - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'not_cloned') FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
-        cloning      = grs.cloning      + (excluded.cloning      - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'cloning')    FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
-        cloned       = grs.cloned       + (excluded.cloned       - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'cloned')     FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
-        failed_fetch = grs.failed_fetch + (excluded.failed_fetch - (SELECT COUNT(*) FILTER(WHERE ot.last_error IS NOT NULL)      FROM oldtab ot WHERE ot.shard_id = excluded.shard_id))
-      ;
-
-      --------------------
-      -- THIS IS UNCHANGED
-      --------------------
-      WITH moved AS (
-        SELECT
-          oldtab.shard_id AS shard_id,
-          COUNT(*) AS total,
-          COUNT(*) FILTER(WHERE oldtab.clone_status = 'not_cloned')  AS not_cloned,
-          COUNT(*) FILTER(WHERE oldtab.clone_status = 'cloning') AS cloning,
-          COUNT(*) FILTER(WHERE oldtab.clone_status = 'cloned') AS cloned,
-          COUNT(*) FILTER(WHERE oldtab.last_error IS NOT NULL) AS failed_fetch
-        FROM
-          oldtab
-        JOIN newtab ON newtab.repo_id = oldtab.repo_id
-        WHERE
-          oldtab.shard_id != newtab.shard_id
-        GROUP BY oldtab.shard_id
-      )
-      UPDATE gitserver_repos_statistics grs
-      SET
-        total        = grs.total        - moved.total,
-        not_cloned   = grs.not_cloned   - moved.not_cloned,
-        cloning      = grs.cloning      - moved.cloning,
-        cloned       = grs.cloned       - moved.cloned,
-        failed_fetch = grs.failed_fetch - moved.failed_fetch
-      FROM moved
-      WHERE moved.shard_id = grs.shard_id;
-
-      -------------------------------------------------
-      -- IMPORTANT: THIS IS CHANGED
-      -------------------------------------------------
-      WITH diff(not_cloned, cloning, cloned, failed_fetch) AS (
-        VALUES (
-          (
-            (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'not_cloned')
-            -
-            (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'not_cloned')
-          ),
-          (
-            (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'cloning')
-            -
-            (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'cloning')
-          ),
-          (
-            (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'cloned')
-            -
-            (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'cloned')
-          ),
-          (
-            (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.last_error IS NOT NULL)
-            -
-            (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.last_error IS NOT NULL)
-          )
-        )
-      )
-      INSERT INTO repo_statistics (not_cloned, cloning, cloned, failed_fetch)
-      SELECT not_cloned, cloning, cloned, failed_fetch
-      FROM diff
-      WHERE
-           not_cloned != 0
-        OR cloning != 0
-        OR cloned != 0
-        OR failed_fetch != 0
-      ;
-
-      RETURN NULL;
-  END
-$$;
-DROP TRIGGER IF EXISTS trig_recalc_gitserver_repos_statistics_on_update ON gitserver_repos;
-CREATE TRIGGER trig_recalc_gitserver_repos_statistics_on_update
-AFTER UPDATE ON gitserver_repos
-REFERENCING OLD TABLE AS oldtab NEW TABLE AS newtab
-FOR EACH STATEMENT EXECUTE FUNCTION recalc_gitserver_repos_statistics_on_update();

--- a/migrations/frontend/1661793532_update_gitserver_repos_stats_trigger_to_avoid_all_zeros/down.sql
+++ b/migrations/frontend/1661793532_update_gitserver_repos_stats_trigger_to_avoid_all_zeros/down.sql
@@ -1,0 +1,84 @@
+LOCK gitserver_repos IN EXCLUSIVE MODE; -- Get a lock for the table so we don't have writes between dropping and recreating the trigger.
+
+-- Recreate old version of function
+CREATE OR REPLACE FUNCTION recalc_gitserver_repos_statistics_on_update() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ BEGIN
+      INSERT INTO gitserver_repos_statistics AS grs (shard_id, total, not_cloned, cloning, cloned, failed_fetch)
+      SELECT
+        newtab.shard_id AS shard_id,
+        COUNT(*) AS total,
+        COUNT(*) FILTER(WHERE clone_status = 'not_cloned')  AS not_cloned,
+        COUNT(*) FILTER(WHERE clone_status = 'cloning') AS cloning,
+        COUNT(*) FILTER(WHERE clone_status = 'cloned') AS cloned,
+        COUNT(*) FILTER(WHERE last_error IS NOT NULL) AS failed_fetch
+      FROM
+        newtab
+      GROUP BY newtab.shard_id
+      ON CONFLICT(shard_id) DO
+      UPDATE
+      SET
+        total        = grs.total        + (excluded.total        - (SELECT COUNT(*)                                              FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
+        not_cloned   = grs.not_cloned   + (excluded.not_cloned   - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'not_cloned') FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
+        cloning      = grs.cloning      + (excluded.cloning      - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'cloning')    FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
+        cloned       = grs.cloned       + (excluded.cloned       - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'cloned')     FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
+        failed_fetch = grs.failed_fetch + (excluded.failed_fetch - (SELECT COUNT(*) FILTER(WHERE ot.last_error IS NOT NULL)      FROM oldtab ot WHERE ot.shard_id = excluded.shard_id))
+      ;
+
+      WITH moved AS (
+        SELECT
+          oldtab.shard_id AS shard_id,
+          COUNT(*) AS total,
+          COUNT(*) FILTER(WHERE oldtab.clone_status = 'not_cloned')  AS not_cloned,
+          COUNT(*) FILTER(WHERE oldtab.clone_status = 'cloning') AS cloning,
+          COUNT(*) FILTER(WHERE oldtab.clone_status = 'cloned') AS cloned,
+          COUNT(*) FILTER(WHERE oldtab.last_error IS NOT NULL) AS failed_fetch
+        FROM
+          oldtab
+        JOIN newtab ON newtab.repo_id = oldtab.repo_id
+        WHERE
+          oldtab.shard_id != newtab.shard_id
+        GROUP BY oldtab.shard_id
+      )
+      UPDATE gitserver_repos_statistics grs
+      SET
+        total        = grs.total        - moved.total,
+        not_cloned   = grs.not_cloned   - moved.not_cloned,
+        cloning      = grs.cloning      - moved.cloning,
+        cloned       = grs.cloned       - moved.cloned,
+        failed_fetch = grs.failed_fetch - moved.failed_fetch
+      FROM moved
+      WHERE moved.shard_id = grs.shard_id;
+
+      INSERT INTO repo_statistics (not_cloned, cloning, cloned, failed_fetch)
+      VALUES (
+        (
+          (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'not_cloned')
+          -
+          (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'not_cloned')
+        ),
+        (
+          (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'cloning')
+          -
+          (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'cloning')
+        ),
+        (
+          (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'cloned')
+          -
+          (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'cloned')
+        ),
+        (
+          (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.last_error IS NOT NULL)
+          -
+          (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.last_error IS NOT NULL)
+        )
+      );
+
+      RETURN NULL;
+  END
+$$;
+DROP TRIGGER IF EXISTS trig_recalc_gitserver_repos_statistics_on_update ON gitserver_repos;
+CREATE TRIGGER trig_recalc_gitserver_repos_statistics_on_update
+AFTER UPDATE ON gitserver_repos
+REFERENCING OLD TABLE AS oldtab NEW TABLE AS newtab
+FOR EACH STATEMENT EXECUTE FUNCTION recalc_gitserver_repos_statistics_on_update();

--- a/migrations/frontend/1661793532_update_gitserver_repos_stats_trigger_to_avoid_all_zeros/metadata.yaml
+++ b/migrations/frontend/1661793532_update_gitserver_repos_stats_trigger_to_avoid_all_zeros/metadata.yaml
@@ -1,0 +1,2 @@
+name: update_gitserver_repos_stats_trigger_to_avoid_all_zeros
+parents: [1661502186, 1661507724]

--- a/migrations/frontend/1661793532_update_gitserver_repos_stats_trigger_to_avoid_all_zeros/up.sql
+++ b/migrations/frontend/1661793532_update_gitserver_repos_stats_trigger_to_avoid_all_zeros/up.sql
@@ -1,0 +1,101 @@
+LOCK gitserver_repos IN EXCLUSIVE MODE;  -- Get a lock for the table so we don't have writes between dropping and recreating the trigger.
+CREATE OR REPLACE FUNCTION recalc_gitserver_repos_statistics_on_update() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ BEGIN
+      --------------------
+      -- THIS IS UNCHANGED
+      --------------------
+      INSERT INTO gitserver_repos_statistics AS grs (shard_id, total, not_cloned, cloning, cloned, failed_fetch)
+      SELECT
+        newtab.shard_id AS shard_id,
+        COUNT(*) AS total,
+        COUNT(*) FILTER(WHERE clone_status = 'not_cloned')  AS not_cloned,
+        COUNT(*) FILTER(WHERE clone_status = 'cloning') AS cloning,
+        COUNT(*) FILTER(WHERE clone_status = 'cloned') AS cloned,
+        COUNT(*) FILTER(WHERE last_error IS NOT NULL) AS failed_fetch
+      FROM
+        newtab
+      GROUP BY newtab.shard_id
+      ON CONFLICT(shard_id) DO
+      UPDATE
+      SET
+        total        = grs.total        + (excluded.total        - (SELECT COUNT(*)                                              FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
+        not_cloned   = grs.not_cloned   + (excluded.not_cloned   - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'not_cloned') FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
+        cloning      = grs.cloning      + (excluded.cloning      - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'cloning')    FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
+        cloned       = grs.cloned       + (excluded.cloned       - (SELECT COUNT(*) FILTER(WHERE ot.clone_status = 'cloned')     FROM oldtab ot WHERE ot.shard_id = excluded.shard_id)),
+        failed_fetch = grs.failed_fetch + (excluded.failed_fetch - (SELECT COUNT(*) FILTER(WHERE ot.last_error IS NOT NULL)      FROM oldtab ot WHERE ot.shard_id = excluded.shard_id))
+      ;
+
+      --------------------
+      -- THIS IS UNCHANGED
+      --------------------
+      WITH moved AS (
+        SELECT
+          oldtab.shard_id AS shard_id,
+          COUNT(*) AS total,
+          COUNT(*) FILTER(WHERE oldtab.clone_status = 'not_cloned')  AS not_cloned,
+          COUNT(*) FILTER(WHERE oldtab.clone_status = 'cloning') AS cloning,
+          COUNT(*) FILTER(WHERE oldtab.clone_status = 'cloned') AS cloned,
+          COUNT(*) FILTER(WHERE oldtab.last_error IS NOT NULL) AS failed_fetch
+        FROM
+          oldtab
+        JOIN newtab ON newtab.repo_id = oldtab.repo_id
+        WHERE
+          oldtab.shard_id != newtab.shard_id
+        GROUP BY oldtab.shard_id
+      )
+      UPDATE gitserver_repos_statistics grs
+      SET
+        total        = grs.total        - moved.total,
+        not_cloned   = grs.not_cloned   - moved.not_cloned,
+        cloning      = grs.cloning      - moved.cloning,
+        cloned       = grs.cloned       - moved.cloned,
+        failed_fetch = grs.failed_fetch - moved.failed_fetch
+      FROM moved
+      WHERE moved.shard_id = grs.shard_id;
+
+      -------------------------------------------------
+      -- IMPORTANT: THIS IS CHANGED
+      -------------------------------------------------
+      WITH diff(not_cloned, cloning, cloned, failed_fetch) AS (
+        VALUES (
+          (
+            (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'not_cloned')
+            -
+            (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'not_cloned')
+          ),
+          (
+            (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'cloning')
+            -
+            (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'cloning')
+          ),
+          (
+            (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.clone_status = 'cloned')
+            -
+            (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.clone_status = 'cloned')
+          ),
+          (
+            (SELECT COUNT(*) FROM newtab JOIN repo r ON newtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND newtab.last_error IS NOT NULL)
+            -
+            (SELECT COUNT(*) FROM oldtab JOIN repo r ON oldtab.repo_id = r.id WHERE r.deleted_at is NULL AND r.blocked IS NULL AND oldtab.last_error IS NOT NULL)
+          )
+        )
+      )
+      INSERT INTO repo_statistics (not_cloned, cloning, cloned, failed_fetch)
+      SELECT not_cloned, cloning, cloned, failed_fetch
+      FROM diff
+      WHERE
+           not_cloned != 0
+        OR cloning != 0
+        OR cloned != 0
+        OR failed_fetch != 0
+      ;
+
+      RETURN NULL;
+  END
+$$;
+DROP TRIGGER IF EXISTS trig_recalc_gitserver_repos_statistics_on_update ON gitserver_repos;
+CREATE TRIGGER trig_recalc_gitserver_repos_statistics_on_update
+AFTER UPDATE ON gitserver_repos
+REFERENCING OLD TABLE AS oldtab NEW TABLE AS newtab
+FOR EACH STATEMENT EXECUTE FUNCTION recalc_gitserver_repos_statistics_on_update();


### PR DESCRIPTION
This fixes the migration introduced in #40899 by splitting it up into
two.

As a single migration the previous version would crash with a deadlock
when trying to drop the 2nd trigger with

```
DROP TRIGGER IF EXISTS trig_recalc_gitserver_repos_statistics_on_update ON gitserver_repos;
```

We could replicate this in a production database console.

Splitting up the recreation of the two triggers into two transactions
avoids the deadlock.



## Test plan

- Ran migrations on production to confirm
