### PR TITLE
insights: make aggregation not available reasons user consumable

### DIFF
--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -122,6 +122,8 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	}}, nil
 }
 
+// getDefaultAggregationMode returns a default aggregation mode for a potential query
+// this function should not fail because any search can be aggregated by repo
 func getDefaultAggregationMode(searchQuery, patternType string) types.SearchAggregationMode {
 	captureGroup, _, _ := canAggregateByCaptureGroup(searchQuery, patternType)
 	if captureGroup {

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -265,7 +265,7 @@ var invalidQueryMsg = "Grouping is disabled because the search query is not vail
 var fileUnsupportedFieldValueFmt = `Grouping by file is not available for searches with "%s:%s".`
 var authNotCommitDiffMsg = "Grouping by author is only available for diff and commit searches."
 var cgInvalidQueryMsg = "Grouping by capture group is only available for regex searches that contain a capturing group."
-var cgMultipleQueryPatternMsg = "Grouping by capture group does not support search patterns with the following: and, or negation."
+var cgMultipleQueryPatternMsg = "Grouping by capture group does not support search patterns with the following: and, or, negation."
 var cgUnsupportedSelectFmt = `Grouping by capture group is not available for searches with "%s:%s".`
 
 func canAggregateByRepo(searchQuery, patternType string) (bool, *string, error) {

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -47,38 +48,19 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	// 5 -  Generate correct resolver pass search results if valid
 	var aggregationMode types.SearchAggregationMode
 	if args.Mode == nil {
-		mode, err := getDefaultAggregationMode(r.searchQuery, r.patternType)
-		if err != nil {
-			reason := fmt.Sprintf("could not fetch a default aggregation mode: %v", err)
-			return &searchAggregationResultResolver{
-				resolver: newSearchAggregationNotAvailableResolver(reason, aggregationMode),
-			}, nil
-		}
-		aggregationMode = mode
+		aggregationMode = getDefaultAggregationMode(r.searchQuery, r.patternType)
 	} else {
 		aggregationMode = types.SearchAggregationMode(*args.Mode)
 	}
 
-	// If we had to fetch a default aggregation mode we already validated query and got an available mode.
-	if args.Mode != nil {
-		aggregationModeAvailabilityResolver := newAggregationModeAvailabilityResolver(r.searchQuery, r.patternType, aggregationMode)
-		supported, err := aggregationModeAvailabilityResolver.Available()
-		if err != nil {
-			reason := fmt.Sprintf("could not fetch mode availability: %v", err)
-			return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(reason, aggregationMode)}, nil
-		}
-		if !supported {
-			unavailableReason := ""
-			// We don't need to assert on the error because this uses the same logic as `Available()` above so it would
-			// have errored already.
-			reason, _ := aggregationModeAvailabilityResolver.ReasonUnavailable()
-			if reason == nil {
-				unavailableReason = "could not fetch unavailability reason"
-			} else {
-				unavailableReason = *reason
-			}
-			return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(unavailableReason, aggregationMode)}, nil
-		}
+	aggregationModeAvailabilityResolver := newAggregationModeAvailabilityResolver(r.searchQuery, r.patternType, aggregationMode)
+	reasonUnavailable, err := aggregationModeAvailabilityResolver.ReasonUnavailable()
+	if err != nil {
+		reason := fmt.Sprintf("could not fetch mode availability: %v", err)
+		return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(reason, aggregationMode)}, nil
+	}
+	if reasonUnavailable != nil {
+		return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(*reasonUnavailable, aggregationMode)}, nil
 	}
 
 	// If a search includes a timeout it reports as completing succesfully with the timeout is hit
@@ -140,31 +122,22 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	}}, nil
 }
 
-func getDefaultAggregationMode(searchQuery, patternType string) (types.SearchAggregationMode, error) {
-	captureGroup, err := canAggregateByCaptureGroup(searchQuery, patternType)
-	if err != nil {
-		return "", err
-	}
+func getDefaultAggregationMode(searchQuery, patternType string) types.SearchAggregationMode {
+	captureGroup, _, _ := canAggregateByCaptureGroup(searchQuery, patternType)
 	if captureGroup {
-		return types.CAPTURE_GROUP_AGGREGATION_MODE, nil
+		return types.CAPTURE_GROUP_AGGREGATION_MODE
 	}
-	author, err := canAggregateByAuthor(searchQuery, patternType)
-	if err != nil {
-		return "", err
-	}
+	author, _, _ := canAggregateByAuthor(searchQuery, patternType)
 	if author {
-		return types.AUTHOR_AGGREGATION_MODE, nil
+		return types.AUTHOR_AGGREGATION_MODE
 	}
-	file, err := canAggregateByPath(searchQuery, patternType)
-	if err != nil {
-		return "", err
-	}
+	file, _, _ := canAggregateByPath(searchQuery, patternType)
 	// We ignore the error here as the function errors if the query has multiple query steps.
 	targetsSingleRepo, _ := querybuilder.IsSingleRepoQuery(querybuilder.BasicQuery(searchQuery))
 	if file && targetsSingleRepo {
-		return types.PATH_AGGREGATION_MODE, nil
+		return types.PATH_AGGREGATION_MODE
 	}
-	return types.REPO_AGGREGATION_MODE, nil
+	return types.REPO_AGGREGATION_MODE
 }
 
 func searchSuccessful(alert *search.Alert, tabulationErrors []error, shardTimeoutOccurred bool) (bool, string) {
@@ -250,7 +223,8 @@ func (r *aggregationModeAvailabilityResolver) Available() (bool, error) {
 	if canAggregateByFunc == nil {
 		return false, nil
 	}
-	return canAggregateByFunc(r.searchQuery, r.patternType)
+	available, _, err := canAggregateByFunc(r.searchQuery, r.patternType)
+	return available, err
 }
 
 func (r *aggregationModeAvailabilityResolver) ReasonUnavailable() (*string, error) {
@@ -258,18 +232,15 @@ func (r *aggregationModeAvailabilityResolver) ReasonUnavailable() (*string, erro
 	// if not return an error
 	canAggregateByFunc := getAggregateBy(r.mode)
 	if canAggregateByFunc == nil {
-		reason := fmt.Sprintf("aggregation mode %v is not yet supported", r.mode)
+		reason := fmt.Sprintf(`Grouping by "%v" is not supported.`, r.mode)
 		return &reason, nil
 	}
-	canAggregate, err := canAggregateByFunc(r.searchQuery, r.patternType)
+	_, reason, err := canAggregateByFunc(r.searchQuery, r.patternType)
 	if err != nil {
-		return nil, err
+		return reason, err
 	}
-	if !canAggregate {
-		reason := fmt.Sprintf("this specific query does not support aggregation by %v", r.mode)
-		return &reason, nil
-	}
-	return nil, nil
+
+	return reason, nil
 }
 
 func getAggregateBy(mode types.SearchAggregationMode) canAggregateBy {
@@ -286,39 +257,48 @@ func getAggregateBy(mode types.SearchAggregationMode) canAggregateBy {
 	return canAggregateByFunc
 }
 
-type canAggregateBy func(searchQuery, patternType string) (bool, error)
+type canAggregateBy func(searchQuery, patternType string) (bool, *string, error)
 
-func canAggregateByRepo(searchQuery, patternType string) (bool, error) {
+var invalidQueryMsg = "Grouping is disabled because the search query is not vaild."
+var fileUnsupportedFieldValueFmt = `Grouping by file is not available for searches with "%s:%s".`
+var authNotCommitDiffMsg = "Grouping by author is only available for diff and commit searches."
+var cgInvalidQueryMsg = "Grouping by capture group is only available for regex searches that contain a capturing group."
+var cgMultipleQueryPatternMsg = "Grouping by capture group does not support search patterns with the following: and, or negation."
+var cgUnsupportedSelectFmt = `Grouping by capture group is not available for searches with "%s:%s".`
+
+func canAggregateByRepo(searchQuery, patternType string) (bool, *string, error) {
 	_, err := querybuilder.ParseQuery(searchQuery, patternType)
 	if err != nil {
-		return false, errors.Wrapf(err, "ParseQuery")
+		return false, &invalidQueryMsg, errors.Wrapf(err, "ParseQuery")
 	}
 	// We can always aggregate by repo.
-	return true, nil
+	return true, nil, nil
 }
 
-func canAggregateByPath(searchQuery, patternType string) (bool, error) {
+func canAggregateByPath(searchQuery, patternType string) (bool, *string, error) {
 	plan, err := querybuilder.ParseQuery(searchQuery, patternType)
 	if err != nil {
-		return false, errors.Wrapf(err, "ParseQuery")
+		return false, &invalidQueryMsg, errors.Wrapf(err, "ParseQuery")
 	}
 	parameters := querybuilder.ParametersFromQueryPlan(plan)
 	// cannot aggregate over:
 	// - searches by commit or repo
 	for _, parameter := range parameters {
 		if parameter.Field == query.FieldSelect || parameter.Field == query.FieldType {
-			if parameter.Value == "commit" || parameter.Value == "repo" {
-				return false, nil
+			if strings.EqualFold(parameter.Value, "commit") || strings.EqualFold(parameter.Value, "repo") {
+				reason := fmt.Sprintf(fileUnsupportedFieldValueFmt,
+					parameter.Field, parameter.Value)
+				return false, &reason, nil
 			}
 		}
 	}
-	return true, nil
+	return true, nil, nil
 }
 
-func canAggregateByAuthor(searchQuery, patternType string) (bool, error) {
+func canAggregateByAuthor(searchQuery, patternType string) (bool, *string, error) {
 	plan, err := querybuilder.ParseQuery(searchQuery, patternType)
 	if err != nil {
-		return false, errors.Wrapf(err, "ParseQuery")
+		return false, &invalidQueryMsg, errors.Wrapf(err, "ParseQuery")
 	}
 	parameters := querybuilder.ParametersFromQueryPlan(plan)
 	// can only aggregate over type:diff and select/type:commit searches.
@@ -326,51 +306,58 @@ func canAggregateByAuthor(searchQuery, patternType string) (bool, error) {
 	for _, parameter := range parameters {
 		if parameter.Field == query.FieldSelect || parameter.Field == query.FieldType {
 			if parameter.Value == "diff" || parameter.Value == "commit" {
-				return true, nil
+				return true, nil, nil
 			}
 		}
 	}
-	return false, nil
+	return false, &authNotCommitDiffMsg, nil
 }
 
-func canAggregateByCaptureGroup(searchQuery, patternType string) (bool, error) {
-	searchType, err := client.SearchTypeFromString(patternType)
+func canAggregateByCaptureGroup(searchQuery, patternType string) (bool, *string, error) {
+
+	plan, err := querybuilder.ParseQuery(searchQuery, patternType)
 	if err != nil {
-		return false, err
+		return false, &invalidQueryMsg, errors.Wrapf(err, "ParseQuery")
+	}
+
+	searchType, err := querybuilder.DetectSearchType(searchQuery, patternType)
+	if err != nil {
+		return false, &cgInvalidQueryMsg, err
 	}
 	if !(searchType == query.SearchTypeRegex || searchType == query.SearchTypeStandard || searchType == query.SearchTypeLucky) {
-		return false, nil
+		return false, &cgInvalidQueryMsg, nil
 	}
 
 	// A query should contain at least a regexp pattern and capture group to allow capture group aggregation.
 	// Only the first capture group will be used for aggregation.
 	replacer, err := querybuilder.NewPatternReplacer(querybuilder.BasicQuery(searchQuery), searchType)
-	// If this error is returned, it means there are no capture groups or this query contains multiple steps.
-	if err == querybuilder.UnsupportedPatternTypeErr || err == querybuilder.MultiplePatternErr {
-		return false, nil
-	}
-	// Otherwise, it's some other error and we should return it.
-	if err != nil {
-		return false, errors.Wrap(err, "pattern parsing")
-	}
-	if !replacer.HasCaptureGroups() {
-		return false, nil
+	if errors.Is(err, querybuilder.UnsupportedPatternTypeErr) {
+		return false, &cgInvalidQueryMsg, nil
+	} else if errors.Is(err, querybuilder.MultiplePatternErr) {
+		return false, &cgMultipleQueryPatternMsg, nil
+	} else if err != nil {
+		return false, &cgInvalidQueryMsg, errors.Wrap(err, "pattern parsing")
 	}
 
-	// We use ParseQuery to obtain the query parameters. The pattern is already validated in `NewPatternReplacer`.
-	plan, _ := querybuilder.ParseQuery(searchQuery, patternType)
+	if !replacer.HasCaptureGroups() {
+		return false, &cgInvalidQueryMsg, nil
+	}
+
+	// We use the plan to obtain the query parameters. The pattern is already validated in `NewPatternReplacer`.
 	parameters := querybuilder.ParametersFromQueryPlan(plan)
 	// At the moment we don't allow capture group aggregation for path and repo searches
 	for _, parameter := range parameters {
-		if parameter.Field == query.FieldSelect && (parameter.Value == "repo" || parameter.Value == "file") {
-			return false, nil
+		if strings.EqualFold(parameter.Field, query.FieldSelect) && (strings.EqualFold(parameter.Value, "repo") || strings.EqualFold(parameter.Value, "file")) {
+			reason := fmt.Sprintf(cgUnsupportedSelectFmt, strings.ToLower(parameter.Field), strings.ToLower(parameter.Value))
+			return false, &reason, nil
 		}
-		if parameter.Field == query.FieldType && (parameter.Value == "repo" || parameter.Value == "path") {
-			return false, nil
+		if strings.EqualFold(parameter.Field, query.FieldType) && (strings.EqualFold(parameter.Value, "repo") || strings.EqualFold(parameter.Value, "path")) {
+			reason := fmt.Sprintf(cgUnsupportedSelectFmt, strings.ToLower(parameter.Field), strings.ToLower(parameter.Value))
+			return false, &reason, nil
 		}
 	}
 
-	return true, nil
+	return true, nil, nil
 }
 
 // A  type to represent the GraphQL union SearchAggregationResult

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -15,6 +16,7 @@ type canAggregateTestCase struct {
 	patternType  string
 	canAggregate bool
 	err          error
+	reason       string
 }
 
 type canAggregateBySuite struct {
@@ -23,13 +25,20 @@ type canAggregateBySuite struct {
 	canAggregateByFunc canAggregateBy
 }
 
+func safeString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
 func (suite *canAggregateBySuite) Test_canAggregateBy() {
 	for _, tc := range suite.testCases {
 		suite.t.Run(tc.name, func(t *testing.T) {
 			if tc.patternType == "" {
 				tc.patternType = "literal"
 			}
-			canAggregate, err := suite.canAggregateByFunc(tc.query, tc.patternType)
+			canAggregate, reason, err := suite.canAggregateByFunc(tc.query, tc.patternType)
 			errCheck := (err == nil && tc.err == nil) || (err != nil && tc.err != nil)
 			if !errCheck {
 				t.Errorf("expected error %v, got %v", tc.err, err)
@@ -39,6 +48,9 @@ func (suite *canAggregateBySuite) Test_canAggregateBy() {
 			}
 			if canAggregate != tc.canAggregate {
 				t.Errorf("expected canAggregate to be %v, got %v", tc.canAggregate, canAggregate)
+			}
+			if !strings.EqualFold(safeString(reason), tc.reason) {
+				t.Errorf("expected reason to be %v, got %v", tc.reason, safeString(reason))
 			}
 		})
 	}
@@ -50,6 +62,7 @@ func Test_canAggregateByRepo(t *testing.T) {
 			name:         "cannot aggregate for invalid query",
 			query:        "fork:woo",
 			canAggregate: false,
+			reason:       invalidQueryMsg,
 			err:          errors.Newf("ParseQuery"),
 		},
 	}
@@ -76,17 +89,20 @@ func Test_canAggregateByPath(t *testing.T) {
 		{
 			name:         "cannot aggregate for query with select:repo parameter",
 			query:        "repo:contains.path(README) select:repo",
+			reason:       fmt.Sprintf(fileUnsupportedFieldValueFmt, "select", "repo"),
 			canAggregate: false,
 		},
 		{
 			name:         "cannot aggregate for query with type:commit parameter",
 			query:        "insights type:commit",
+			reason:       fmt.Sprintf(fileUnsupportedFieldValueFmt, "type", "commit"),
 			canAggregate: false,
 		},
 		{
 			name:         "cannot aggregate for invalid query",
 			query:        "insights type:commit fork:test",
 			canAggregate: false,
+			reason:       invalidQueryMsg,
 			err:          errors.Newf("ParseQuery"),
 		},
 	}
@@ -103,16 +119,19 @@ func Test_canAggregateByAuthor(t *testing.T) {
 		{
 			name:         "cannot aggregate for query without parameters",
 			query:        "func(t *testing.T)",
+			reason:       authNotCommitDiffMsg,
 			canAggregate: false,
 		},
 		{
 			name:         "cannot aggregate for query with case parameter",
 			query:        "func(t *testing.T) case:yes",
+			reason:       authNotCommitDiffMsg,
 			canAggregate: false,
 		},
 		{
 			name:         "cannot aggregate for query with select:repo parameter",
 			query:        "repo:contains.path(README) select:repo",
+			reason:       authNotCommitDiffMsg,
 			canAggregate: false,
 		},
 		{
@@ -138,6 +157,7 @@ func Test_canAggregateByAuthor(t *testing.T) {
 		{
 			name:         "cannot aggregate for invalid query",
 			query:        "type:diff fork:leo",
+			reason:       invalidQueryMsg,
 			canAggregate: false,
 			err:          errors.Newf("ParseQuery"),
 		},
@@ -180,18 +200,21 @@ func Test_canAggregateByCaptureGroup(t *testing.T) {
 			name:         "cannot aggregate for query with non-captured regexp pattern",
 			query:        "\\w+",
 			patternType:  "regexp",
+			reason:       cgInvalidQueryMsg,
 			canAggregate: false,
 		},
 		{
 			name:         "cannot aggregate for invalid query",
 			query:        "type:diff fork:leo func(.*)",
 			patternType:  "regexp",
+			reason:       invalidQueryMsg,
 			canAggregate: false,
-			err:          errors.Newf("pattern parsing"),
+			err:          errors.Newf("ParseQuery"),
 		},
 		{
 			name:         "cannot aggregate for select:repo query",
 			query:        "repo:contains.path(README) func(\\w+) select:repo",
+			reason:       fmt.Sprintf(cgUnsupportedSelectFmt, "select", "repo"),
 			patternType:  "regexp",
 			canAggregate: false,
 		},
@@ -199,29 +222,34 @@ func Test_canAggregateByCaptureGroup(t *testing.T) {
 			name:         "cannot aggregate for select:file query",
 			query:        "repo:contains.path(README) func(\\w+) select:file",
 			patternType:  "regexp",
+			reason:       fmt.Sprintf(cgUnsupportedSelectFmt, "select", "file"),
 			canAggregate: false,
 		},
 		{
 			name:         "cannot for type:repo query",
 			query:        "repo:contains.path(README) func(\\w+) type:repo",
 			patternType:  "regexp",
+			reason:       fmt.Sprintf(cgUnsupportedSelectFmt, "type", "repo"),
 			canAggregate: false,
 		},
 		{
 			name:         "cannot aggregate for type:path query",
 			query:        "repo:contains.path(README) func(\\w+) type:path",
+			reason:       fmt.Sprintf(cgUnsupportedSelectFmt, "type", "path"),
 			patternType:  "regexp",
 			canAggregate: false,
 		},
 		{
 			name:         "cannot aggregate for query with unsupported pattern type",
 			query:        "func(t *testing.T)",
+			reason:       cgInvalidQueryMsg,
 			patternType:  "literal",
 			canAggregate: false,
 		},
 		{
 			name:         "cannot aggregate for query with multiple steps",
 			query:        "(repo:^github\\.com/sourcegraph/sourcegraph$ file:go\\.mod$ go\\s*(\\d\\.\\d+)) or (test file:insights)",
+			reason:       cgMultipleQueryPatternMsg,
 			patternType:  "regexp",
 			canAggregate: false,
 		},
@@ -240,13 +268,12 @@ func Test_getDefaultAggregationMode(t *testing.T) {
 		query       string
 		patternType string
 		want        types.SearchAggregationMode
-		err         error
+		reason      *string
 	}{
 		{
-			name:  "invalid query returns error",
+			name:  "invalid query returns REPO",
 			query: "func fork:leo",
-			want:  "",
-			err:   errors.New("ParseQuery"),
+			want:  types.REPO_AGGREGATION_MODE,
 		},
 		{
 			name:        "literal type query does not return capture group mode",
@@ -319,10 +346,8 @@ func Test_getDefaultAggregationMode(t *testing.T) {
 			if tc.patternType != "" {
 				pt = tc.patternType
 			}
-			mode, err := getDefaultAggregationMode(tc.query, pt)
-			if (err != nil && tc.err == nil) || (err == nil && tc.err != nil) {
-				t.Errorf("expected different error behavior: got %v, want %v", err, tc.err)
-			}
+			mode := getDefaultAggregationMode(tc.query, pt)
+
 			if mode != tc.want {
 				t.Errorf("expected mode %v, got %v", tc.want, mode)
 			}

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
@@ -99,6 +99,12 @@ func Test_canAggregateByPath(t *testing.T) {
 			canAggregate: false,
 		},
 		{
+			name:         "ensure type check is case insensitive ",
+			query:        "insights TYPE:commit",
+			reason:       fmt.Sprintf(fileUnsupportedFieldValueFmt, "type", "commit"),
+			canAggregate: false,
+		},
+		{
 			name:         "cannot aggregate for invalid query",
 			query:        "insights type:commit fork:test",
 			canAggregate: false,
@@ -147,6 +153,11 @@ func Test_canAggregateByAuthor(t *testing.T) {
 		{
 			name:         "can aggregate for query with type:diff parameter",
 			query:        "repo:contains.path(README) type:diff fix",
+			canAggregate: true,
+		},
+		{
+			name:         "can aggregate for query with cased Type",
+			query:        "repo:contains.path(README) TyPe:diff fix",
 			canAggregate: true,
 		},
 		{
@@ -235,6 +246,13 @@ func Test_canAggregateByCaptureGroup(t *testing.T) {
 		{
 			name:         "cannot aggregate for type:path query",
 			query:        "repo:contains.path(README) func(\\w+) type:path",
+			reason:       fmt.Sprintf(cgUnsupportedSelectFmt, "type", "path"),
+			patternType:  "regexp",
+			canAggregate: false,
+		},
+		{
+			name:         "ensure type check is not case sensitive",
+			query:        "repo:contains.path(README) func(\\w+) TyPe:path",
 			reason:       fmt.Sprintf(cgUnsupportedSelectFmt, "type", "path"),
 			patternType:  "regexp",
 			canAggregate: false,


### PR DESCRIPTION
Updated the checks to see if grouping by a mode is possible to return the reason it is not, so that those more specific reasons can be returned to the UI.

Updated the default mode logic to remove early error returns, it should not error but continue on until it finds a type that is possible.  If the query is invalid executing the search will return an error with the reason why.

Reasons are close to each other now and if we need another round of updating will be easy.  I'll address the search timeout error message in https://github.com/sourcegraph/sourcegraph/issues/41010

closes https://github.com/sourcegraph/sourcegraph/issues/40870

## Test plan
updated unit tests
<img width="289" alt="Screen Shot 2022-08-29 at 5 03 18 PM" src="https://user-images.githubusercontent.com/6098507/187302136-dcfb6221-d720-4870-8b34-b9b6eb2c386f.png">
<img width="262" alt="Screen Shot 2022-08-29 at 5 03 30 PM" src="https://user-images.githubusercontent.com/6098507/187302156-b3709593-0099-4381-a502-c7d3a527e774.png">
<img width="300" alt="Screen Shot 2022-08-29 at 5 03 39 PM" src="https://user-images.githubusercontent.com/6098507/187302195-5cfb880d-849e-4a3c-a14a-71b14e9a1e6e.png">
<img width="326" alt="Screen Shot 2022-08-29 at 5 06 41 PM" src="https://user-images.githubusercontent.com/6098507/187302235-93566141-9c2a-4b47-9fdb-233370f4b56e.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
