### PR TITLE
Fix tooltip for batch change state pills

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.tsx
@@ -36,7 +36,7 @@ export const WorkspaceStateIcon: React.FunctionComponent<React.PropsWithChildren
                 <Tooltip content="This workspace is currently executing.">
                     <Icon
                         aria-label="This workspace is currently executing."
-                        className={classNames('text-muted', className)}
+                        className={className}
                         as={LoadingSpinner}
                     />
                 </Tooltip>

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
@@ -49,7 +49,7 @@ export const BatchChangeStatePillStory: Story = () => (
         {props => (
             <div className="d-flex flex-column align-items-start">
                 {STATE_COMBINATIONS.map(({ state, latestExecutionState, currentSpecID, latestSpecID }) => (
-                    <React.Fragment key={`${state}-${latestExecutionState || ''}`}>
+                    <React.Fragment key={`${state}-${latestExecutionState || ''}-${currentSpecID}-${latestSpecID}`}>
                         <H3>
                             {upperFirst(state.toLowerCase())}
                             {latestExecutionState ? `, ${upperFirst(latestExecutionState.toLowerCase())}` : ''}

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react'
 import { mdiHistory } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Badge, Tooltip, Icon } from '@sourcegraph/wildcard'
+import { Badge, Icon } from '@sourcegraph/wildcard'
 
 import { BatchChangeState, BatchSpecState, Scalars } from '../../../graphql-operations'
 
@@ -103,44 +103,48 @@ const ExecutionStatePill: React.FunctionComponent<
         case BatchSpecState.PROCESSING:
         case BatchSpecState.QUEUED:
             return (
-                <Tooltip
-                    content={`This batch change has a new spec ${
+                <Badge
+                    variant="warning"
+                    tooltip={`This batch change has a new spec ${
                         latestExecutionState === BatchSpecState.QUEUED
                             ? 'queued for execution'
                             : 'in the process of executing'
                     }.`}
+                    className={styles.executionPill}
                 >
-                    <Badge variant="warning" className={styles.executionPill}>
-                        <Icon
-                            className={styles.executionIcon}
-                            svgPath={mdiHistory}
-                            inline={false}
-                            aria-label={`This batch change has a new spec ${
-                                latestExecutionState === BatchSpecState.QUEUED
-                                    ? 'queued for execution'
-                                    : 'in the process of executing'
-                            }.`}
-                        />
-                    </Badge>
-                </Tooltip>
+                    <Icon
+                        className={styles.executionIcon}
+                        svgPath={mdiHistory}
+                        inline={false}
+                        aria-label={`This batch change has a new spec ${
+                            latestExecutionState === BatchSpecState.QUEUED
+                                ? 'queued for execution'
+                                : 'in the process of executing'
+                        }.`}
+                    />
+                </Badge>
             )
 
         case BatchSpecState.COMPLETED:
             return (
-                <Tooltip content="This batch change has a newer batch spec execution that is ready to be applied.">
-                    <Badge variant="primary" className={styles.executionPill}>
-                        <Icon className={styles.executionIcon} svgPath={mdiHistory} inline={false} aria-hidden={true} />
-                    </Badge>
-                </Tooltip>
+                <Badge
+                    variant="primary"
+                    tooltip="This batch change has a newer batch spec execution that is ready to be applied."
+                    className={styles.executionPill}
+                >
+                    <Icon className={styles.executionIcon} svgPath={mdiHistory} inline={false} aria-hidden={true} />
+                </Badge>
             )
         case BatchSpecState.FAILED:
         default:
             return (
-                <Tooltip content="The latest batch spec execution for this batch change failed.">
-                    <Badge variant="danger" className={styles.executionPill}>
-                        <Icon className={styles.executionIcon} svgPath={mdiHistory} inline={false} aria-hidden={true} />
-                    </Badge>
-                </Tooltip>
+                <Badge
+                    variant="danger"
+                    tooltip="The latest batch spec execution for this batch change failed."
+                    className={styles.executionPill}
+                >
+                    <Icon className={styles.executionIcon} svgPath={mdiHistory} inline={false} aria-hidden={true} />
+                </Badge>
             )
     }
 }


### PR DESCRIPTION
Seems like badge doesn't like tooltips around it, fixed here. Also verified we don't use this elsewhere in batches.

## Test plan

Verified tooltips show up again.

## App preview:

- [Web](https://sg-web-es-fix-bc-pill.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-guvgznvnom.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
