### PR TITLE
internal/trace: use otelhttp, update deprecation notices

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -28,9 +28,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/deviceid"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/requestclient"
 	tracepkg "github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
@@ -112,7 +112,7 @@ func newExternalHTTPHandler(
 	h = internalauth.ForbidAllRequestsMiddleware(h)
 	h = internalauth.OverrideAuthMiddleware(db, h)
 	h = tracepkg.HTTPMiddleware(logger, h, conf.DefaultClient())
-	h = ot.HTTPMiddleware(h)
+	h = instrumentation.HTTPMiddleware("external", h)
 
 	return h
 }
@@ -151,7 +151,7 @@ func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntel
 	h = gcontext.ClearHandler(h)
 	logger := log.Scoped("internal", "internal http handlers")
 	h = tracepkg.HTTPMiddleware(logger, h, conf.DefaultClient())
-	h = ot.HTTPMiddleware(h)
+	h = instrumentation.HTTPMiddleware("internal", h)
 	return h
 }
 

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -28,8 +28,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
+	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
@@ -100,7 +100,7 @@ func main() {
 	}
 	h = instrumentHandler(prometheus.DefaultRegisterer, h)
 	h = trace.HTTPMiddleware(logger, h, conf.DefaultClient())
-	h = ot.HTTPMiddleware(h)
+	h = instrumentation.HTTPMiddleware("", h)
 	http.Handle("/", h)
 
 	host := ""

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -56,7 +57,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/requestclient"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -172,7 +172,8 @@ func main() {
 	handler := gitserver.Handler()
 	handler = actor.HTTPMiddleware(handler)
 	handler = requestclient.HTTPMiddleware(handler)
-	handler = ot.HTTPMiddleware(trace.HTTPMiddleware(logger, handler, conf.DefaultClient()))
+	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())
+	handler = instrumentation.HTTPMiddleware("", handler)
 
 	// Ready immediately
 	ready := make(chan struct{})

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/opentracing/opentracing-go"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -44,7 +44,7 @@ func TestServer_handleRepoLookup(t *testing.T) {
 	h := ObservedHandler(
 		logger,
 		NewHandlerMetrics(),
-		opentracing.NoopTracer{},
+		trace.NewNoopTracerProvider(),
 	)(s.Handler())
 
 	repoLookup := func(t *testing.T, repo api.RepoName) (resp *protocol.RepoLookupResult, statusCode int) {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -11,11 +11,11 @@ import (
 	"strconv"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"golang.org/x/time/rate"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/log"
@@ -40,12 +40,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
+	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -226,7 +226,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		handler = repoupdater.ObservedHandler(
 			logger,
 			m,
-			opentracing.GlobalTracer(),
+			otel.GetTracerProvider(),
 		)(server.Handler())
 	}
 
@@ -256,7 +256,8 @@ func Main(enterpriseInit EnterpriseInit) {
 	httpSrv := httpserver.NewFromAddr(addr, &http.Server{
 		ReadTimeout:  75 * time.Second,
 		WriteTimeout: 10 * time.Minute,
-		Handler:      ot.HTTPMiddleware(trace.HTTPMiddleware(logger, authzBypass(handler), conf.DefaultClient())),
+		Handler: instrumentation.HTTPMiddleware("",
+			trace.HTTPMiddleware(logger, authzBypass(handler), conf.DefaultClient())),
 	})
 	goroutine.MonitorBackgroundRoutines(ctx, httpSrv)
 }

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -36,11 +36,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
+	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -183,7 +183,7 @@ func run(logger log.Logger) error {
 	// Set up handler middleware
 	handler := actor.HTTPMiddleware(service)
 	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())
-	handler = ot.HTTPMiddleware(handler)
+	handler = instrumentation.HTTPMiddleware("", handler)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -31,11 +31,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
+	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
@@ -121,7 +121,7 @@ func Main(setup SetupFunc) {
 	// Create HTTP server
 	handler := api.NewHandler(searchFunc, gitserverClient.ReadFile, handleStatus, ctagsBinary)
 	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())
-	handler = ot.HTTPMiddleware(handler)
+	handler = instrumentation.HTTPMiddleware("", handler)
 	handler = actor.HTTPMiddleware(handler)
 	server := httpserver.NewFromAddr(addr, &http.Server{
 		ReadTimeout:  75 * time.Second,

--- a/go.mod
+++ b/go.mod
@@ -408,7 +408,7 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/collector/pdata v0.56.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.33.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.33.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.9.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.9.0
 	go.opentelemetry.io/proto/otlp v0.18.0

--- a/go.mod
+++ b/go.mod
@@ -408,7 +408,7 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/collector/pdata v0.56.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.33.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.9.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.9.0
 	go.opentelemetry.io/proto/otlp v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -2322,8 +2322,6 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.3
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.33.0/go.mod h1:y/SlJpJQPd2UzfBCj0E9Flk9FDCtTyqUmaCB41qFrWI=
 go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.21.0/go.mod h1:a9cocRplhIBkUAJmak+BPDx+LVL7cTmqUPB0uBcTA4k=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.21.0/go.mod h1:JQAtechjxLEL81EjmbRwxBq/XEzGaHcsPuDHAx54hg4=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.33.0 h1:Z0lVKLXU+jxGf3ANoh+UWx9Ai5bjpQVnZXI1zEzvqS0=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.33.0/go.mod h1:U5rUt7Rw6zuORsWNfpMRy8XMNKLrmIlv/4HgLVW/d5M=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0 h1:9NkMW03wwEzPtP/KciZ4Ozu/Uz5ZA7kfqXJIObnrjGU=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0/go.mod h1:548ZsYzmT4PL4zWKRd8q/N4z0Wxzn/ZxUE+lkEpwWQA=
 go.opentelemetry.io/contrib/propagators/jaeger v1.9.0 h1:edJTgwezAtLKUINAXfjxllJ1vlsphNPV7RkuKNd/HkQ=

--- a/go.sum
+++ b/go.sum
@@ -2324,6 +2324,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.21.0/go.mod h1:JQAtechjxLEL81EjmbRwxBq/XEzGaHcsPuDHAx54hg4=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.33.0 h1:Z0lVKLXU+jxGf3ANoh+UWx9Ai5bjpQVnZXI1zEzvqS0=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.33.0/go.mod h1:U5rUt7Rw6zuORsWNfpMRy8XMNKLrmIlv/4HgLVW/d5M=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0 h1:9NkMW03wwEzPtP/KciZ4Ozu/Uz5ZA7kfqXJIObnrjGU=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0/go.mod h1:548ZsYzmT4PL4zWKRd8q/N4z0Wxzn/ZxUE+lkEpwWQA=
 go.opentelemetry.io/contrib/propagators/jaeger v1.9.0 h1:edJTgwezAtLKUINAXfjxllJ1vlsphNPV7RkuKNd/HkQ=
 go.opentelemetry.io/contrib/propagators/jaeger v1.9.0/go.mod h1:Q/AXutvrBTfEDSeRLwOmKhyviX5adJvTesg6JFTybYg=
 go.opentelemetry.io/contrib/propagators/ot v1.9.0 h1:+pYoqyFoA3H6EZ7Wie2ZQdqS4ZfG42PAGvj3eLUukHE=

--- a/internal/instrumentation/http.go
+++ b/internal/instrumentation/http.go
@@ -1,0 +1,50 @@
+package instrumentation
+
+import (
+	"fmt"
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
+)
+
+// HTTPMiddleware wraps the handler with the following:
+//
+// - If the HTTP header, X-Sourcegraph-Should-Trace, is set to a truthy value, set the
+//   shouldTraceKey context.Context value to true
+// - go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp, which applies the
+//   desired instrumentation.
+//
+// The provided operation name is used to add details to spans.
+func HTTPMiddleware(operation string, h http.Handler, opts ...otelhttp.Option) http.Handler {
+	instrumentedHandler := otelhttp.NewHandler(h, operation,
+		append(
+			[]otelhttp.Option{
+				otelhttp.WithFilter(func(r *http.Request) bool {
+					return policy.ShouldTrace(r.Context())
+				}),
+				otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
+					if operation != "" {
+						return fmt.Sprintf("%s.%s %s", operation, r.Method, r.URL.Path)
+					}
+					return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+				}),
+			},
+			opts...,
+		)...)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var trace bool
+		switch policy.GetTracePolicy() {
+		case policy.TraceSelective:
+			trace = policy.RequestWantsTracing(r)
+		case policy.TraceAll:
+			trace = true
+		default:
+			trace = false
+		}
+		// Pass through to instrumented handler with trace policy in context
+		instrumentedHandler.ServeHTTP(w, r.WithContext(policy.WithShouldTrace(r.Context(), trace)))
+	})
+}

--- a/internal/trace/ot/ot.go
+++ b/internal/trace/ot/ot.go
@@ -6,50 +6,35 @@ package ot
 
 import (
 	"context"
-	"net/http"
 
-	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 )
 
-// HTTPMiddleware wraps the handler with the following:
+// Deprecated: Use otel.Tracer(...) from go.opentelemetry.io/otel instead.
 //
-// - If the HTTP header, X-Sourcegraph-Should-Trace, is set to a truthy value, set the
-//   shouldTraceKey context.Context value to true
-// - github.com/opentracing-contrib/go-stdlib/nethttp.HTTPMiddleware, which creates a new span to track
-//   the request handler from the global tracer.
-func HTTPMiddleware(h http.Handler, opts ...nethttp.MWOption) http.Handler {
-	return MiddlewareWithTracer(opentracing.GlobalTracer(), h)
-}
-
-// MiddlewareWithTracer is like Middleware, but uses the specified tracer instead of the global
-// tracer.
-func MiddlewareWithTracer(tr opentracing.Tracer, h http.Handler, opts ...nethttp.MWOption) http.Handler {
-	nethttpMiddleware := nethttp.Middleware(tr, h, append([]nethttp.MWOption{
-		nethttp.MWSpanFilter(func(r *http.Request) bool {
-			return policy.ShouldTrace(r.Context())
-		}),
-	}, opts...)...)
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var trace bool
-		switch policy.GetTracePolicy() {
-		case policy.TraceSelective:
-			trace = policy.RequestWantsTracing(r)
-		case policy.TraceAll:
-			trace = true
-		default:
-			trace = false
-		}
-		nethttpMiddleware.ServeHTTP(w, r.WithContext(policy.WithShouldTrace(r.Context(), trace)))
-	})
-}
-
 // GetTracer returns the tracer to use for the given context. If ShouldTrace returns true, it
 // returns the global tracer. Otherwise, it returns the NoopTracer.
 func GetTracer(ctx context.Context) opentracing.Tracer {
 	return getTracer(ctx, opentracing.GlobalTracer())
+}
+
+// Deprecated: Use otel.Tracer(...).Start() from go.opentelemetry.io/otel or trace.New(...)
+// from github.com/sourcegraph/sourcegraph/internal/trace instead.
+//
+// StartSpanFromContext starts a span using the tracer returned by GetTracer.
+func StartSpanFromContext(ctx context.Context, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
+	return StartSpanFromContextWithTracer(ctx, opentracing.GlobalTracer(), operationName, opts...)
+}
+
+// Deprecated: Use otel.Tracer(...).Start() from go.opentelemetry.io/otel or trace.New(...)
+// from github.com/sourcegraph/sourcegraph/internal/trace instead.
+//
+// StartSpanFromContextWithTracer starts a span using the tracer returned by invoking getTracer with the
+// passed-in tracer.
+func StartSpanFromContextWithTracer(ctx context.Context, tracer opentracing.Tracer, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
+	return opentracing.StartSpanFromContextWithTracer(ctx, getTracer(ctx, tracer), operationName, opts...)
 }
 
 // getTracer is like GetTracer, but accepts a tracer as an argument. If ShouldTrace returns false,
@@ -63,15 +48,4 @@ func getTracer(ctx context.Context, tracer opentracing.Tracer) opentracing.Trace
 		return opentracing.GlobalTracer()
 	}
 	return tracer
-}
-
-// StartSpanFromContext starts a span using the tracer returned by GetTracer.
-func StartSpanFromContext(ctx context.Context, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
-	return StartSpanFromContextWithTracer(ctx, opentracing.GlobalTracer(), operationName, opts...)
-}
-
-// StartSpanFromContextWithTracer starts a span using the tracer returned by invoking getTracer with the
-// passed-in tracer.
-func StartSpanFromContextWithTracer(ctx context.Context, tracer opentracing.Tracer, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
-	return opentracing.StartSpanFromContextWithTracer(ctx, getTracer(ctx, tracer), operationName, opts...)
 }

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -93,15 +93,15 @@ func (t *Trace) Finish() {
 // Deprecated APIs //
 /////////////////////
 
-// LogFields logs fields to the opentracing.Span as well as the nettrace.Trace.
+// Deprecated: Use AddEvent(...) instead.
 //
-// Deprecated: Use AddEvent instead.
+// LogFields logs fields to the opentracing.Span as well as the nettrace.Trace.
 func (t *Trace) LogFields(fields ...log.Field) {
 	t.AddEvent("LogFields", otLogFieldsToOTelAttrs(fields)...)
 }
 
+// Deprecated: Use SetAttributes(...) instead.
+//
 // TagFields adds fields to the opentracing.Span as tags
 // as well as as logs to the nettrace.Trace.
-//
-// Deprecated: Use SetAttributes instead.
 func (t *Trace) TagFields(fields ...log.Field) { t.SetAttributes(otLogFieldsToOTelAttrs(fields)...) }


### PR DESCRIPTION
Swap out the OpenTracing HTTP middleware with `otelhttp`, with a default constructor provided in a new package `internal/instrumentation`. Also adds deprecation notices on `internal/trace/ot`, and updates deprecation notices in `internal/trace` so that they render properly in VS Code.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start`, run a trace

<img width="1695" alt="image" src="https://user-images.githubusercontent.com/23356519/187311692-47842a82-c659-49ab-834c-8170a5b6a576.png">


In vscode, try to autocomplete a deprecated API:

<img width="264" alt="image" src="https://user-images.githubusercontent.com/23356519/187311556-30f18d04-e7a1-4c8e-bd7a-5609a3a3129d.png">
<img width="433" alt="image" src="https://user-images.githubusercontent.com/23356519/187311632-1a9e4af0-3239-44a4-9fcd-0f5b24f72a6b.png">

