### PR TITLE
Fix `null` handling of publication state in changeset_specs

### DIFF
--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -99,9 +99,12 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.Changeset
 				}
 			}
 
-			published, err := json.Marshal(c.Published)
-			if err != nil {
-				return err
+			var published []byte
+			if c.Published.Val != nil {
+				published, err = json.Marshal(c.Published)
+				if err != nil {
+					return err
+				}
 			}
 
 			if err := inserter.Insert(
@@ -570,8 +573,10 @@ func scanChangesetSpec(c *btypes.ChangesetSpec, s dbutil.Scanner) error {
 
 	c.Type = btypes.ChangesetSpecType(typ)
 
-	if err := json.Unmarshal(published, &c.Published); err != nil {
-		return err
+	if len(published) != 0 {
+		if err := json.Unmarshal(published, &c.Published); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This didn't fully work, it kinda by accident worked with new data, but it doesn't work with existing, migrated data (which is actually in the correct shape).

The problem:
We marshalled anything to json, regardless if the value was unset (nil). That writes `'null'` to the column (the string value null).
Then, when we scan the changeset spec, that happily passes as `'null'` is a valid json string, it unmarshals into `nil`, just as desired. This isn't very clean though.
However: Existing values have been written as `NULL` (the literal) in the migration. Those are `[]byte{}` and cannot be interpreted as json.
This PR fixes marshalling `null` as proper NULL literals and also fixes unmarshalling. Next release we can run a quick migration to consolidate the state again.

## Test plan

Verified the observed error disappeared.