### PR TITLE
team/codintel - implemented symbol-pagerank POC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/crewjam/saml v0.4.6
 	github.com/davecgh/go-spew v1.1.1
 	github.com/daviddengcn/go-colortext v1.0.0
+	github.com/dcadenas/pagerank v1.0.0
 	github.com/derision-test/glock v1.0.0
 	github.com/derision-test/go-mockgen v1.3.4
 	github.com/dghubble/gologin v2.2.0+incompatible

--- a/lib/codeintel/tools/lsif-pagerank/README.md
+++ b/lib/codeintel/tools/lsif-pagerank/README.md
@@ -1,0 +1,41 @@
+# Pagerank generator for lsif indexes
+
+This directory contains a quick-and-dirty tool for using an lsif index to run the Google PageRank algorithm on the symbol graph.
+
+## Motivation
+
+The intuition is that by treating symbols as "virtual web pages", and references between symbols as virtual links, then running pagerank on the resulting reference graph will bubble the most important symbols to the top.
+
+The symbol-pagerank ranking could potentially be used as an additional signal for scoring file results in any context; e.g., in regular zoekt queries.
+
+## Approach
+
+Pagerank is computed from a graph of directed, unweighted edges. Our edges are from the symbol-reference graph, which only contains as much information as is recorded by the indexers.
+
+The lsif graph model is not a symbol database, and we do not record very much information about symbol scopes. Hence for now, we consider all symbols to be file-scoped. The lsif-pagerank tool walks the references in an input lsif file, computes the edges between file vertices for the referenced symbol and its definition location(s), and feeds those edges into the PageRank calculator.
+
+The result is a sorted list of all the file paths from the index, ranked by their computed PageRank.
+
+## Limitations
+
+- PageRank itself is a fairly simplistic model for estimating importance, and it's probably only useful as a tie-breaking signal during regular ranking.
+- Running the algorithm on code graphs is currently non-deterministic: the rankings change each time you run it, though the results always look pretty reasonable. It tends to surface core library routines over application/tool code, which is the desired behavior.
+- PageRank should probably be computed at upload time; this manual tool-based design is a POC.
+- This tool assumes the whole lsif file is in memory--the computation should eventually be sharded.
+- We only have file-level ranking, which is less accurate/fine-grained than symbol-level ranking.
+- PageRank scores should be cached in the database or blob store, and added to the codeintel APIs.
+- There should be tests, although perhaps not until it is actually integrated properly.
+
+## Future directions
+
+The current design and implementation of Symbol PageRank are naive and could be improved in several ways, including improving the reference-graph modeling and fidelity, adding cross-repo pagerank calculation, and generally studying how the algorithm might be tweaked and tuned for best results on code graphs.
+
+### Integration with Zoekt
+
+This PageRank library emits scores between 0.0 and 1.0, with real-world scores ranging from perhaps 0.1-0.2 max down to 10e-4 at the low end.
+
+Zoekt scores are integral and range from tens to perhaps hundreds of thousands. PageRank might be integrated in as an extra file scoring factor of, say, 1+PR(E). Normally a search result gets a 10.0 score for its file weight. If we factor in the PR for this page, and it is, say, 0.05 (a rather high score), then the file match score factor for that file would be 10.0 * (1 + 0.05) = 10.5.
+
+## PageRank 3P Library
+
+The PageRank implementation used by the lsif-pagerank tool is from [dcadenas on GitHub](https://github.com/dcadenas/pagerank), MIT licensed, and has not been tested or vetted for correctness or performance.

--- a/lib/codeintel/tools/lsif-pagerank/args.go
+++ b/lib/codeintel/tools/lsif-pagerank/args.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"flag"
+)
+
+var (
+	indexFilePath  = flag.String("index-file", "dump.lsif", "The LSIF index to rank.")
+	outputFilePath = flag.String("output-file", "", "Output file; defaults to input + '-pagerank'.")
+	addImplEdges   = flag.Bool("include-impls", false, "True to include implementation edges")
+)

--- a/lib/codeintel/tools/lsif-pagerank/main.go
+++ b/lib/codeintel/tools/lsif-pagerank/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// This tool reads the specified lsif file and prints pagerank-sorted
+// file paths in space-delimited output to stdout:  filepath rank
+func main() {
+	flag.Parse()
+
+	indexFile, err := os.OpenFile(*indexFilePath, os.O_RDONLY, 0)
+	if err != nil {
+		die("Unable to open index file %v: %v", *indexFilePath, err)
+	}
+	defer indexFile.Close()
+
+	rankings, err := PageRankLsif(indexFile)
+	if err != nil {
+		die("Error computing pagerank: %v", err)
+	}
+
+	// For now, write file names and their rankings (sorted) to stdout.
+	sorter := *rankings
+	sort.Slice(sorter, func(i, j int) bool {
+		return sorter[i].rank > sorter[j].rank
+	})
+
+	for _, doc := range sorter {
+		fmt.Printf("%v  %v\n", doc.filePath, doc.rank)
+	}
+}
+
+func die(msg string, args ...any) {
+	fmt.Fprintf(os.Stderr, "\nerror: "+fmt.Sprintf(msg, args))
+	os.Exit(1)
+}

--- a/lib/codeintel/tools/lsif-pagerank/pagerank.go
+++ b/lib/codeintel/tools/lsif-pagerank/pagerank.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"io"
+
+	"github.com/dcadenas/pagerank"
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/conversion"
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/conversion/datastructures"
+)
+
+const (
+	// Chance of following a link rather than jumping randomly.
+	FOLLOW_LINK_CHANCE = 0.85
+	// Smaller number here yields a more exact result; more CPU cycles required.
+	TOLERANCE = 0.00001
+)
+
+type Document struct {
+	docId    int
+	filePath string
+	rank     float64
+}
+
+// Read LSIF data from the given reader and return the files from the
+// index along with their pagerank. The results are not sorted.
+func PageRankLsif(indexFile io.Reader) (*[]Document, error) {
+	// Build a conversion.State representing the input lsif index.
+	state, err := conversion.CorrelateInMemory(context.TODO(), indexFile, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	edges := addReferenceEdges(state)
+
+	if *addImplEdges {
+		addImplementationEdges(state, edges)
+	}
+
+	return runPageRanker(state, edges), nil
+}
+
+func addReferenceEdges(state *conversion.State) *map[int]int {
+	// First, we need a map of range id -> doc id for the whole index.
+	// Even for a very large index it's likely only to be a few million entries.
+	// Since we're the only use case needing this lookup, we build it ephemerally.
+	// TODO(stevey):  Can we get this info from State without preprocessing?
+	rangeToDoc := make(map[int]int)
+	state.Contains.Each(func(docId int, rangeIDs *datastructures.IDSet) {
+		rangeIDs.Each(func(rangeId int) {
+			rangeToDoc[rangeId] = docId
+		})
+	})
+
+	// Walk the references and find each one's file, and also the file(s)
+	// containing the definition being referenced. These two files make an edge.
+	// We omit links from files referencing themselves because PageRank ignores them.
+	edges := make(map[int]int)
+	for _, documentMap := range state.ReferenceData {
+		documentMap.Each(func(docId int, ranges *datastructures.IDSet) {
+			ranges.Each(func(rangeId int) {
+				// Pagerank source node is doc ID for this reference range.
+				refDocId := rangeToDoc[rangeId]
+
+				// Pagerank dest nodes are doc IDs for the associated definition range(s).
+				// I.e., if a definition is split across files, they each get an edge for now.
+				if data, ok := state.DefinitionData[state.RangeData[rangeId].DefinitionResultID]; ok {
+					for _, defDocId := range data.UnorderedKeys() {
+						// Insert a link for the PageRank calculator.
+						if refDocId != defDocId {
+							edges[refDocId] = defDocId
+						}
+					}
+				}
+			})
+		})
+	}
+	return &edges
+}
+
+// Treat implementations as references to the type being implemented.
+//
+// Note: These edges seem to have a dramatic impact on the results. This adds in millions
+// of edges and tends to push up interfaces and classes with lots of implementations. This
+// leads to their effect being a bit overwhelming, compared to when only call/use references
+// are included as pagerank edges. Moreover, some very strange results seem to be bubbling
+// up for Java indexes (about 20% don't look like they should be in the top results).
+//
+// So for now this is disabled by default.
+// TODO(stevey): pagerank.go shouldn't read the flag; it should be passed as a config option.
+func addImplementationEdges(state *conversion.State, edges *map[int]int) {
+	graph := *edges
+	for _, docMap := range state.ImplementationData {
+		docMap.Each(func(docId int, ranges *datastructures.IDSet) {
+			// We interpret the destination vertex as the thing being implemented
+			// (e.g., the definition of an interface or abstract class).
+			destNode := docId
+			ranges.Each(func(rangeId int) {
+				if data, ok := state.ImplementationData[state.RangeData[rangeId].ImplementationResultID]; ok {
+					for _, implDocId := range data.UnorderedKeys() {
+						if destNode != implDocId { // skip self-references for pagerank
+							graph[implDocId] = destNode
+						}
+					}
+				}
+			})
+		})
+	}
+}
+
+// The API to this PageRank package is that you get one shot at seeing the results.
+// Rank the graph, and toss each file/rank pair into the result set.
+func runPageRanker(state *conversion.State, edges *map[int]int) *[]Document {
+	graph := pagerank.New()
+
+	for srcDocId, targetDocId := range *edges {
+		graph.Link(srcDocId, targetDocId)
+	}
+
+	rankings := make([]Document, 0, len(state.DocumentData))
+
+	graph.Rank(FOLLOW_LINK_CHANCE, TOLERANCE, func(docId int, rank float64) {
+		rankings = append(rankings, Document{docId: docId, filePath: state.DocumentData[docId], rank: rank})
+	})
+	return &rankings
+}

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/cockroachdb/redact v1.1.3 // indirect
 	github.com/dave/jennifer v1.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dcadenas/pagerank v0.0.0-20171013173705-af922e3ceea8 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/getsentry/sentry-go v0.13.0 // indirect

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -57,6 +57,8 @@ github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpT
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dcadenas/pagerank v0.0.0-20171013173705-af922e3ceea8 h1:YG9TGUT3wOhOPxE99qpcd99TZE5zuxBaAvqjuuLMBBI=
+github.com/dcadenas/pagerank v0.0.0-20171013173705-af922e3ceea8/go.mod h1:s8JxxWxUtKGji2M1VIqcZEBQj3FPXSTt7aBsAjfYeh8=
 github.com/derision-test/go-mockgen v1.1.2 h1:bMNCerr4I3dz2/UlguwgMuMuJDQXqRnBw17ezXkGvyI=
 github.com/derision-test/go-mockgen v1.1.2/go.mod h1:9H3VGTWYnL1VJoHHCuPKDpPFmNQ1uVyNlpX6P63l5Sk=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=


### PR DESCRIPTION
This CL implements a simple version of symbol-pagerank.

The intuition is that if you treat symbols as web pages, and
calls and references to symbols as hyperlinks, then PageRank
would provide a good estimate of the "importance" of each
symbol.

We do not store much symbol scope information, so I have squashed all
the symbols to be file-scoped. Source files inherit the incoming links
(and corresponding page rank) for all symbols they contain.

It's implemented as a command-line tool in the lib/codeintel tree. It
relies heavily on the code that handles lsif uploads, and constructs
the symbol reference graph from the in-memory lsif representation
before it's chunked out.

I also provide an option for including the "implements" graph as file
links--that is to say, edges between implementable things (such as
interfaces, or abstract classes) and their implementation sites. You
can think of these as being just another kind of symbol reference.
Depending on the indexer, edges may represent implementations, method
overrides, or other specific symbol relationships. This information
was available in the index, so I threw it in. However, although it was
clearly effective in raising prominence for implementable types, it
still suffers from various issues and is not yet ready to be a
default.

The implementation overall suffers from various shortcomings and
should not be considered production-ready. The PageRank Go
implementation is MIT-licensed on GitHub and needs a security
and legal review, and also a review for accuracy, performance, etc.

The output of the tool is a list of all filenames in the lsif index,
paired with their page rank. It writes text lines to stdout for now.
You can run it on any lsif index to see how the files rank; note
that the algorithm is nondeterministic because it involves random
jumps, and each time it runs, the list will be different. However,
page ranks do not usually vary widely from run to run.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
