### PR TITLE
Wire up extension registry gating code to use the feature flag

### DIFF
--- a/cmd/frontend/registry/api/gating.go
+++ b/cmd/frontend/registry/api/gating.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func ExtensionRegistryReadEnabled() error {
@@ -15,11 +17,10 @@ func ExtensionRegistryReadEnabled() error {
 }
 
 func ExtensionRegistryWriteEnabled() error {
-	// @TODO(@philipp-spiess): Enable this once we shipped a fix for #40085 and make the flag dynamic
-	// cfg := conf.Get()
-	// if cfg.ExperimentalFeatures != nil && cfg.ExperimentalFeatures.EnableLegacyExtensions == false {
-	// 	return errors.Errorf("Extensions are disabled. See https://docs.sourcegraph.com/extensions/deprecation")
-	// }
+	cfg := conf.Get()
+	if cfg.ExperimentalFeatures != nil && cfg.ExperimentalFeatures.EnableLegacyExtensions != nil && *cfg.ExperimentalFeatures.EnableLegacyExtensions == false {
+		return errors.Errorf("Extensions are disabled. See https://docs.sourcegraph.com/extensions/deprecation")
+	}
 
 	// @TODO(@philipp-spiess): Change the default when we roll out 4.0
 	return nil


### PR DESCRIPTION
Closes #40556

Wire up the extension gating logic to use the feature flag.

## Test plan

Tested locally by configuring the feature flags and calling out to extension registry APIs:

![Screenshot 2022-08-30 at 10 58 29](https://user-images.githubusercontent.com/458591/187395443-1591c27c-1074-4439-9535-830f47b934bc.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
