### PR TITLE
repo stats tables: fix migration to only update function

### DIFF
--- a/migrations/frontend/1661507724_update_repo_stats_trigger_to_avoid_all_zeros/down.sql
+++ b/migrations/frontend/1661507724_update_repo_stats_trigger_to_avoid_all_zeros/down.sql
@@ -111,8 +111,3 @@ CREATE OR REPLACE FUNCTION recalc_gitserver_repos_statistics_on_update() RETURNS
       RETURN NULL;
   END
 $$;
-DROP TRIGGER IF EXISTS trig_recalc_gitserver_repos_statistics_on_update ON gitserver_repos;
-CREATE TRIGGER trig_recalc_gitserver_repos_statistics_on_update
-AFTER UPDATE ON gitserver_repos
-REFERENCING OLD TABLE AS oldtab NEW TABLE AS newtab
-FOR EACH STATEMENT EXECUTE FUNCTION recalc_gitserver_repos_statistics_on_update();

--- a/migrations/frontend/1661507724_update_repo_stats_trigger_to_avoid_all_zeros/up.sql
+++ b/migrations/frontend/1661507724_update_repo_stats_trigger_to_avoid_all_zeros/up.sql
@@ -44,11 +44,6 @@ CREATE OR REPLACE FUNCTION recalc_repo_statistics_on_repo_update() RETURNS trigg
       RETURN NULL;
   END
 $$;
-DROP TRIGGER IF EXISTS trig_recalc_repo_statistics_on_repo_update ON repo;
-CREATE TRIGGER trig_recalc_repo_statistics_on_repo_update
-AFTER UPDATE ON repo
-REFERENCING OLD TABLE AS oldtab NEW TABLE AS newtab
-FOR EACH STATEMENT EXECUTE FUNCTION recalc_repo_statistics_on_repo_update();
 
 CREATE OR REPLACE FUNCTION recalc_gitserver_repos_statistics_on_update() RETURNS trigger
     LANGUAGE plpgsql
@@ -145,8 +140,3 @@ CREATE OR REPLACE FUNCTION recalc_gitserver_repos_statistics_on_update() RETURNS
       RETURN NULL;
   END
 $$;
-DROP TRIGGER IF EXISTS trig_recalc_gitserver_repos_statistics_on_update ON gitserver_repos;
-CREATE TRIGGER trig_recalc_gitserver_repos_statistics_on_update
-AFTER UPDATE ON gitserver_repos
-REFERENCING OLD TABLE AS oldtab NEW TABLE AS newtab
-FOR EACH STATEMENT EXECUTE FUNCTION recalc_gitserver_repos_statistics_on_update();


### PR DESCRIPTION
I assumed that I had to drop&recreate the trigger, but testing confirms
that I only need to `CREATE OR REPLACE FUNCTION` for the new code to be
executed.

I also added tests to confirm this behaviour.


## Test plan

- Test script here to check whether this is the behaviour: https://gist.github.com/mrnugget/627952cfeeceeb1fdc38fe523d5d1edc
- These tests
