### PR TITLE
sg: add s2 to preset environments for 'sg live'

### DIFF
--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -21,6 +21,7 @@ type environment struct {
 var environments = []environment{
 	{Name: "cloud", URL: "https://sourcegraph.com"},
 	{Name: "k8s", URL: "https://k8s.sgdev.org"},
+	{Name: "s2", URL: "https://sourcegraph.sourcegraph.com"},
 }
 
 func environmentNames() []string {

--- a/dev/sg/sg_live.go
+++ b/dev/sg/sg_live.go
@@ -20,6 +20,7 @@ var liveCommand = &cli.Command{
 # See which version is deployed on a preset environment
 sg live cloud
 sg live k8s
+sg live s2
 
 # See which version is deployed on a custom environment
 sg live https://demo.sourcegraph.com

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1107,11 +1107,13 @@ Available preset environments:
 
 * cloud
 * k8s
+* s2
 
 ```sh
 # See which version is deployed on a preset environment
 $ sg live cloud
 $ sg live k8s
+$ sg live s2
 
 # See which version is deployed on a custom environment
 $ sg live https://demo.sourcegraph.com


### PR DESCRIPTION
This makes it possible to run `sg live s2`

## Test plan

- Manually tested it by running `sg live s2`