### PR TITLE
Update "site-admin / Feedback survery" page UI styles

### DIFF
--- a/client/web/src/site-admin/SiteAdminSurveyResponsesPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminSurveyResponsesPage.module.scss
@@ -1,19 +1,9 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
-.container {
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
-}
-
-.item {
-    width: 32%;
-    @media (--md-breakpoint-up) {
-        width: 100%;
-        margin-bottom: 1rem;
-    }
-}
-
 .wide-border {
     border-width: 3px !important;
+}
+
+.border-right {
+    border-right: 1px solid var(--border-color-2);
 }

--- a/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
@@ -18,11 +18,11 @@ import {
     H2,
     H3,
     Text,
+    Card,
 } from '@sourcegraph/wildcard'
 
 import { FilteredConnection } from '../components/FilteredConnection'
 import { PageTitle } from '../components/PageTitle'
-import { SingleValueCard } from '../components/SingleValueCard'
 import { Timestamp } from '../components/time/Timestamp'
 import {
     SurveyResponseAggregateFields,
@@ -37,6 +37,7 @@ import {
 import { eventLogger } from '../tracking/eventLogger'
 import { userURL } from '../user'
 
+import { ValueLegendItem } from './analytics/components/ValueLegendList'
 import { USER_ACTIVITY_FILTERS } from './SiteAdminUsageStatisticsPage'
 
 import styles from './SiteAdminSurveyResponsesPage.module.scss'
@@ -235,40 +236,41 @@ class SiteAdminSurveyResponsesSummary extends React.PureComponent<{}, SiteAdminS
         } else if (this.state.summary.netPromoterScore < 0) {
             npsText = `${npsText}`
         }
-        const npsClass =
+        const npsColor =
             this.state.summary.netPromoterScore > 0
-                ? 'text-success'
+                ? 'var(--success)'
                 : this.state.summary.netPromoterScore < 0
-                ? 'text-danger'
-                : 'text-info'
+                ? 'var(--danger)'
+                : 'var(--info)'
         const roundAvg = Math.round(this.state.summary.averageScore * 10) / 10
+        const avgColor = roundAvg > 8 ? 'var(--success)' : roundAvg > 6 ? 'var(--info)' : 'var(--danger)'
         return (
-            <div className="mb-2">
-                <H3>Summary</H3>
-                <div className={styles.container}>
-                    <SingleValueCard
-                        className={styles.item}
-                        value={this.state.summary.last30DaysCount}
-                        title="Number of submissions"
-                        subTitle="Last 30 days"
-                    />
-                    <SingleValueCard
-                        className={styles.item}
-                        value={anyResults ? roundAvg : '-'}
-                        title="Average score"
-                        subTitle="Last 30 days"
-                        valueTooltip={`${roundAvg} out of 10`}
-                        valueClassName={anyResults ? `text-${scoreToClassSuffix(roundAvg)}` : ''}
-                    />
-                    <SingleValueCard
-                        className={styles.item}
-                        value={anyResults ? npsText : '-'}
-                        title="Net promoter score"
-                        subTitle="Last 30 days"
-                        valueTooltip={`${npsText} (between -100 and +100)`}
-                        valueClassName={anyResults ? npsClass : ''}
-                    />
+            <div className="mb-3">
+                <div className="d-flex">
+                    <H3>Summary</H3>
+                    <Text className="ml-2 text-muted">(Last 30 days)</Text>
                 </div>
+                <Card className="d-flex justify-content-around flex-row p-5">
+                    <ValueLegendItem
+                        className={classNames('flex-1', styles.borderRight)}
+                        value={this.state.summary.last30DaysCount}
+                        description="Number of submissions"
+                    />
+                    <ValueLegendItem
+                        className={classNames('flex-1', styles.borderRight)}
+                        value={anyResults ? roundAvg : '-'}
+                        description="Average score"
+                        color={anyResults ? avgColor : undefined}
+                        tooltip={`${roundAvg} out of 10`}
+                    />
+                    <ValueLegendItem
+                        className="flex-1"
+                        value={anyResults ? npsText : '-'}
+                        description="Net promoter score"
+                        color={anyResults ? npsColor : undefined}
+                        tooltip={`${npsText} (between -100 and +100)`}
+                    />
+                </Card>
             </div>
         )
     }

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -10,21 +10,21 @@ import { formatNumber } from '../utils'
 import styles from './index.module.scss'
 
 interface ValueLegendItemProps {
-    color: string
+    color?: string
     description: string
-    value: number
+    value: number | string
     tooltip?: string
     className?: string
 }
 
 export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     value,
-    color,
+    color = 'var(--body-color)',
     description,
     tooltip,
     className,
 }) => {
-    const formattedNumber = useMemo(() => formatNumber(value), [value])
+    const formattedNumber = useMemo(() => (typeof value === 'number' ? formatNumber(value) : value), [value])
     const unformattedNumber = `${value}`
     return (
         <div className={classNames('d-flex flex-column align-items-center mr-4 justify-content-center', className)}>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41041.

## Test plan
- `sg start`
- Open http://localhost:3080/site-admin/surveys
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## Screenshots
| Before | After |
| --: | :-- |
| <img width="939" alt="image" src="https://user-images.githubusercontent.com/6717049/187432612-7c457d2a-04fc-44c6-82db-b6ef9c6f076d.png"> | <img width="939" alt="image" src="https://user-images.githubusercontent.com/6717049/187432484-432f63a4-f434-47d7-96fa-45dd65ed3e7f.png"> |
| <img width="939" alt="image" src="https://user-images.githubusercontent.com/6717049/187432732-ce56b1a7-c24b-4038-b2cd-cae8ae5152aa.png"> |  <img width="939" alt="image" src="https://user-images.githubusercontent.com/6717049/187432354-5ef49f46-eff3-43ea-a31c-28306aca85a4.png"> | 
| <img width="939" alt="image" src="https://user-images.githubusercontent.com/6717049/187432794-b1fd9a1d-6fb2-41f1-b9da-329fadb0cd6a.png">| <img width="939" alt="image" src="https://user-images.githubusercontent.com/6717049/187432271-37d00cca-ea51-451c-8878-257a4fc3c323.png"> |
| <img width="939" alt="image" src="https://user-images.githubusercontent.com/6717049/187432886-6df9061c-2e01-4898-b1be-458188d48ff1.png">| <img width="939" alt="image" src="https://user-images.githubusercontent.com/6717049/187432096-05714608-0668-4970-b8fb-5834b6b113b2.png"> |

## App preview:

- [Web](https://sg-web-erzhtor-update-feedback-survey.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bpnlrtuysc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
