### PR TITLE
site-admin repos page: use Code for errors instead of TerminalLine

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -7,9 +7,8 @@ import { Observable } from 'rxjs'
 import { useQuery } from '@sourcegraph/http-client'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Link, Alert, Icon, H2, Text, Tooltip, Container, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Code, Button, Link, Alert, Icon, H2, Text, Tooltip, Container, LoadingSpinner } from '@sourcegraph/wildcard'
 
-import { TerminalLine } from '../auth/Terminal'
 import {
     FilteredConnection,
     FilteredConnectionFilter,
@@ -66,9 +65,7 @@ const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Repository
             <div className={styles.alertWrapper}>
                 <Alert variant="warning">
                     <Text className="font-weight-bold">Error syncing repository:</Text>
-                    <TerminalLine className={styles.alertContent}>
-                        {node.mirrorInfo.lastError.replaceAll('\r', '\n')}
-                    </TerminalLine>
+                    <Code className={styles.alertContent}>{node.mirrorInfo.lastError.replaceAll('\r', '\n')}</Code>
                 </Alert>
             </div>
         )}


### PR DESCRIPTION
The `<TerminalLine />` component renders a `<li />` and needs to be
inside a `<Terminal />` which looks a bit weird here and throws an error
in dev mode, so I'm using `<Code>` instead.

![screenshot_2022-08-30_15 26 53@2x](https://user-images.githubusercontent.com/1185253/187449539-5443c328-819a-40ea-9920-158d83c1bf9b.png)


## Test plan

- Tested manually