### PR TITLE
FilteredConnection: fix history comparison that messes with ScrollManager

### DIFF
--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -343,7 +343,7 @@ export class FilteredConnection<
                     ({ connectionOrError, previousPage, ...rest }) => {
                         if (this.props.useURLQuery) {
                             const searchFragment = this.urlQuery({ visibleResultCount: previousPage.length })
-                            if (this.props.location.search !== searchFragment) {
+                            if (this.props.location.search !== `?${searchFragment}`) {
                                 this.props.history.replace({
                                     search: searchFragment,
                                     hash: this.props.location.hash,


### PR DESCRIPTION
This fixes `ScrollManager` being messed with by `FilteredConnection` and scrolling back up on every poll-request here: https://sourcegraph.com/site-admin/repositories?status=failed-fetch

This fixes https://github.com/sourcegraph/sourcegraph/issues/40369

## Test plan

- Lots of manual testing

## App preview:

- [Web](https://sg-web-mrn-fix-scroll-back-up.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zxqplxbxsx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

