### PR TITLE
Experiment with non-proactive mode

### DIFF
--- a/client/search-ui/src/results/aggregation/SearchAggregationResult.tsx
+++ b/client/search-ui/src/results/aggregation/SearchAggregationResult.tsx
@@ -8,7 +8,6 @@ import { Button, H2, Icon } from '@sourcegraph/wildcard'
 import { AggregationChartCard, getAggregationData } from './AggregationChartCard'
 import { AggregationModeControls } from './AggregationModeControls'
 import {
-    SearchAggregationModeUi,
     useAggregationSearchMode,
     useAggregationUIMode,
     useSearchAggregationData,
@@ -28,7 +27,7 @@ interface SearchAggregationResultProps extends HTMLAttributes<HTMLElement> {
     /** Current search query pattern type. */
     patternType: SearchPatternType
 
-    disableProactiveSearchAggregations?: boolean
+    disableProactiveSearchAggregations: boolean
 
     /**
      * Emits whenever a user clicks one of aggregation chart segments (bars).
@@ -42,7 +41,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
     const { query, patternType, disableProactiveSearchAggregations, onQuerySubmit, ...attributes } = props
 
     const [, setAggregationUIMode] = useAggregationUIMode()
-    const [aggregationMode, setAggregationMode] = useAggregationSearchMode(disableProactiveSearchAggregations)
+    const [aggregationMode, setAggregationMode] = useAggregationSearchMode()
     const { data, error, loading } = useSearchAggregationData({
         query,
         patternType,
@@ -80,20 +79,16 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
                 />
             </div>
 
-            {aggregationMode !== SearchAggregationModeUi.NONE ? (
-                <AggregationChartCard
-                    aria-label="Expanded search aggregation chart"
-                    mode={aggregationMode}
-                    data={data?.searchQueryAggregate?.aggregations}
-                    loading={loading}
-                    error={error}
-                    size="md"
-                    className={styles.chartContainer}
-                    onBarLinkClick={onQuerySubmit}
-                />
-            ) : (
-                <div>Select a grouping to aggregate this search</div>
-            )}
+            <AggregationChartCard
+                aria-label="Expanded search aggregation chart"
+                mode={aggregationMode}
+                data={data?.searchQueryAggregate?.aggregations}
+                loading={loading}
+                error={error}
+                size="md"
+                className={styles.chartContainer}
+                onBarLinkClick={onQuerySubmit}
+            />
 
             {data && (
                 <ul className={styles.listResult}>

--- a/client/search-ui/src/results/sidebar/SearchAggregations.tsx
+++ b/client/search-ui/src/results/sidebar/SearchAggregations.tsx
@@ -12,7 +12,6 @@ import {
     useAggregationUIMode,
     AggregationChartCard,
     useSearchAggregationData,
-    SearchAggregationModeUi,
 } from '../aggregation'
 
 import styles from './SearchAggregations.module.scss'
@@ -28,7 +27,7 @@ interface SearchAggregationsProps {
     /** Current search query pattern type. */
     patternType: SearchPatternType
 
-    disableProactiveSearchAggregations?: boolean
+    disableProactiveSearchAggregations: boolean
 
     /**
      * Emits whenever a user clicks one of aggregation chart segments (bars).
@@ -42,7 +41,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
     const { query, patternType, disableProactiveSearchAggregations, onQuerySubmit } = props
 
     const [, setAggregationUIMode] = useAggregationUIMode()
-    const [aggregationMode, setAggregationMode] = useAggregationSearchMode(disableProactiveSearchAggregations)
+    const [aggregationMode, setAggregationMode] = useAggregationSearchMode()
     const { data, error, loading } = useSearchAggregationData({
         query,
         patternType,
@@ -65,7 +64,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
                 onModeChange={setAggregationMode}
             />
 
-            {aggregationMode !== SearchAggregationModeUi.NONE && (
+            {!!disableProactiveSearchAggregations && aggregationMode !== null && (
                 <AggregationChartCard
                     aria-label="Sidebar search aggregation chart"
                     data={data?.searchQueryAggregate?.aggregations}

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -199,7 +199,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
     if (collapsedSections) {
         body = (
             <>
-                {props.enableSearchAggregation && aggregationUIMode === AggregationUIMode.Sidebar && (
+                {props.enableSearchAggregation && aggregationUIMode === AggregationUIMode.Sidebar && props.disableProactiveSearchAggregations !== undefined && (
                     <SearchSidebarSection
                         sectionId={SectionID.GROUPED_BY}
                         className={styles.item}

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -88,7 +88,7 @@ export const StreamingSearchResults: React.FunctionComponent<
     // Log lucky search events. To be removed at latest by 12/2022.
     const [luckySearchEnabled] = useFeatureFlag('ab-lucky-search')
     const [enableSearchAggregations] = useFeatureFlag('search-aggregation-filters', false)
-    const [disableProactiveSearchAggregations] = useFeatureFlag('disable-proactive-insight-aggregation', false)
+    const [disableProactiveSearchAggregations, status] = useFeatureFlag('disable-proactive-insight-aggregation')
     const enableCodeMonitoring = useExperimentalFeatures(features => features.codeMonitoring ?? false)
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext ?? false)
     const [selectedTab] = useTemporarySetting('search.sidebar.selectedTab', 'filters')
@@ -299,7 +299,7 @@ export const StreamingSearchResults: React.FunctionComponent<
                 buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
             />
 
-            {aggregationUIMode === AggregationUIMode.SearchPage && (
+            {aggregationUIMode === AggregationUIMode.SearchPage && status === 'loaded' && (
                 <SearchAggregationResult
                     query={query}
                     patternType={patternType}


### PR DESCRIPTION

Thoughts and experiments for https://github.com/sourcegraph/sourcegraph/pull/40772

## Test plan
- N/A
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-non-poractive-mode.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

