### PR TITLE
Fix site-admin client e2e tests

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -140,7 +140,7 @@ export const AnalyticsOverviewPage: React.FunctionComponent<IProps> = ({ activat
         <>
             <AnalyticsPageTitle>Overview</AnalyticsPageTitle>
 
-            <Card className="p-3">
+            <Card className="p-3" data-testid="product-certificate">
                 <div className="d-flex justify-content-between align-items-start mb-3 text-nowrap">
                     <div>
                         <H2 className="mb-3">{data.site.productSubscription.productNameWithBrand}</H2>
@@ -183,7 +183,7 @@ export const AnalyticsOverviewPage: React.FunctionComponent<IProps> = ({ activat
                     <HorizontalSelect<typeof dateRange.value> {...dateRange} />
                 </div>
                 {showGetStarted && activation && (
-                    <div className={classNames('my-3', styles.padded)}>
+                    <div className={classNames('my-3', styles.padded)} data-testid="site-admin-overview-menu">
                         <div className={styles.getStartedBox}>
                             <div className="d-flex justify-content-between align-items-center">
                                 <H3>Get started with Sourcegraph</H3>


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/sourcegraph/pull/40989.

It turned out that there were e2e test selectors which were checking for old "statistics/overview" page sections. However, in a recent PR, it was replaced with a new "analytics/overview" page. This PR adds test-id selectors to the corresponding sections.

## Test plan
- Check the diff, if possible run client e2e tests locally.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
