### PR TITLE
2.0.1: Use BrowserUtil for opening external browser

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Sourcegraph Changelog
 
+## [Unreleased]
+
+- Improve Fedora Linux compatibility: Using `BrowserUtil.browse()` rather than `Desktop.getDesktop().browse()` to open
+  links in the browser.
+
 ## [2.0.0]
 
-- Added a new UI to search with Sourcegraph from inside the IDE. Open it with <kbd>Alt+S</kbd> (<kbd>⌥S</kbd> on Mac) by default.
+- Added a new UI to search with Sourcegraph from inside the IDE. Open it with <kbd>Alt+S</kbd> (<kbd>⌥S</kbd> on Mac) by
+  default.
 - Added a settings UI to conveniently configure the plugin
 - General revamp on the existing features
-- Source code is now at [https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains](https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains)
+- Source code is now
+  at [https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains](https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains)
 
 ## [1.2.4]
 

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=2.0.0
+pluginVersion=2.0.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserOpener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserOpener.java
@@ -1,0 +1,39 @@
+package com.sourcegraph.common;
+
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.config.ConfigUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class BrowserOpener {
+    public static void openRelativeUrlInBrowser(@NotNull Project project, @NotNull String relativeUrl) {
+        openInBrowser(project, ConfigUtil.getSourcegraphUrl(project) + "/" + relativeUrl);
+    }
+
+    public static void openInBrowser(@NotNull Project project, @NotNull String absoluteUrl) {
+        try {
+            openInBrowser(project, new URI(absoluteUrl));
+        } catch (URISyntaxException e) {
+            Logger logger = Logger.getInstance(BrowserOpener.class);
+            logger.warn("Error while creating URL from \"" + absoluteUrl + "\": " + e.getMessage());
+        }
+    }
+
+    public static void openInBrowser(@NotNull Project project, @NotNull URI uri) {
+        try {
+            BrowserUtil.browse(uri);
+        } catch (Exception e) {
+            try {
+                Desktop.getDesktop().browse(uri);
+            } catch (IOException | UnsupportedOperationException e2) {
+                BrowserErrorNotification.show(project, uri);
+            }
+        }
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -6,23 +6,18 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.KeyboardShortcut;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import com.sourcegraph.Icons;
-import com.sourcegraph.common.BrowserErrorNotification;
+import com.sourcegraph.common.BrowserOpener;
 import com.sourcegraph.find.FindService;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import java.awt.*;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 public class NotificationActivity implements StartupActivity.DumbAware {
     @Override
@@ -82,19 +77,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
                 String whatsNewUrl = "https://plugins.jetbrains.com/plugin/9682-sourcegraph#:~:text=What%E2%80%99s%20New";
 
-                URI uri;
-                try {
-                    uri = new URI(whatsNewUrl);
-                } catch (URISyntaxException e) {
-                    Logger logger = Logger.getInstance(this.getClass());
-                    logger.warn("Unable to create URI for url " + whatsNewUrl);
-                    return;
-                }
-                try {
-                    Desktop.getDesktop().browse(uri);
-                } catch (IOException | UnsupportedOperationException e) {
-                    BrowserErrorNotification.show(project, uri);
-                }
+                BrowserOpener.openInBrowser(project, whatsNewUrl);
             }
         };
         notification.setIcon(Icons.SourcegraphLogo);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewContent.java
@@ -9,15 +9,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
-import com.sourcegraph.common.BrowserErrorNotification;
-import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.common.BrowserOpener;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.awt.*;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
@@ -191,11 +186,13 @@ public class PreviewContent {
             && Objects.equals(relativeUrl, other.relativeUrl);
     }
 
-    public void openInEditorOrBrowser() throws URISyntaxException {
+    public void openInEditorOrBrowser() {
         if (opensInEditor()) {
             openInEditor();
         } else {
-            openInBrowser();
+            if (relativeUrl != null) {
+                BrowserOpener.openRelativeUrlInBrowser(project, relativeUrl);
+            }
         }
     }
 
@@ -214,16 +211,6 @@ public class PreviewContent {
         PsiFile file = PsiManager.getInstance(project).findFile(virtualFile);
         if (file != null) {
             DaemonCodeAnalyzer.getInstance(project).setHighlightingEnabled(file, false);
-        }
-    }
-
-    private void openInBrowser() throws URISyntaxException {
-        URI uri = new URI(ConfigUtil.getSourcegraphUrl(project) + "/" + relativeUrl);
-        // Source: https://stackoverflow.com/questions/5226212/how-to-open-the-default-webbrowser-using-java
-        try {
-            Desktop.getDesktop().browse(uri);
-        } catch (IOException | UnsupportedOperationException e) {
-            BrowserErrorNotification.show(project, uri);
         }
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenFileAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenFileAction.java
@@ -1,22 +1,12 @@
 package com.sourcegraph.website;
 
 import com.intellij.openapi.project.Project;
-import com.sourcegraph.common.BrowserErrorNotification;
+import com.sourcegraph.common.BrowserOpener;
 import org.jetbrains.annotations.NotNull;
-
-import java.awt.*;
-import java.io.IOException;
-import java.net.URI;
 
 public class OpenFileAction extends FileActionBase {
     @Override
     protected void handleFileUri(@NotNull Project project, @NotNull String url) {
-        URI uri = URI.create(url);
-
-        try {
-            Desktop.getDesktop().browse(uri);
-        } catch (IOException | UnsupportedOperationException e) {
-            BrowserErrorNotification.show(project, uri);
-        }
+        BrowserOpener.openInBrowser(project, url);
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -9,7 +9,7 @@ import com.intellij.openapi.vcs.VcsDataKeys;
 import com.intellij.openapi.vcs.history.VcsFileRevision;
 import com.intellij.vcs.log.VcsLog;
 import com.intellij.vcs.log.VcsLogDataKeys;
-import com.sourcegraph.common.BrowserErrorNotification;
+import com.sourcegraph.common.BrowserOpener;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.git.CommitViewUriBuilder;
 import com.sourcegraph.git.GitUtil;
@@ -17,8 +17,6 @@ import com.sourcegraph.git.RepoInfo;
 import com.sourcegraph.git.RevisionContext;
 import org.jetbrains.annotations.NotNull;
 
-import java.awt.*;
-import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
 
@@ -85,11 +83,7 @@ public class OpenRevisionAction extends DumbAwareAction {
             logger.warn("Unable to build commit view URI for url " + ConfigUtil.getSourcegraphUrl(project) + ", revision " + context.getRevisionNumber() + ", product " + productName + ", version " + productVersion, e);
             return;
         }
-        try {
-            Desktop.getDesktop().browse(uri);
-        } catch (IOException | UnsupportedOperationException e) {
-            BrowserErrorNotification.show(project, uri);
-        }
+        BrowserOpener.openInBrowser(project, uri);
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.website;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
@@ -12,20 +11,15 @@ import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.sourcegraph.common.BrowserErrorNotification;
+import com.sourcegraph.common.BrowserOpener;
 import com.sourcegraph.find.SourcegraphVirtualFile;
 import com.sourcegraph.git.GitUtil;
 import com.sourcegraph.git.RepoInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.awt.*;
-import java.io.IOException;
-import java.net.URI;
-
 public abstract class SearchActionBase extends DumbAwareAction {
     public void actionPerformedMode(@NotNull AnActionEvent event, @NotNull Scope scope) {
-        Logger logger = Logger.getInstance(this.getClass());
         final Project project = event.getProject();
 
         String selectedText = getSelectedText(project);
@@ -49,19 +43,7 @@ public abstract class SearchActionBase extends DumbAwareAction {
             url = URLBuilder.buildEditorSearchUrl(project, selectedText, remoteUrl, branchName);
         }
 
-        // Open the URL in the browser.
-        URI uri;
-        try {
-            uri = URI.create(url);
-        } catch (IllegalArgumentException e) {
-            logger.warn("Unable to create URI for url " + url);
-            return;
-        }
-        try {
-            Desktop.getDesktop().browse(uri);
-        } catch (IOException | UnsupportedOperationException e) {
-            BrowserErrorNotification.show(project, uri);
-        }
+        BrowserOpener.openInBrowser(project, url);
     }
 
     enum Scope {


### PR DESCRIPTION
Solves half of the problems in [#40452](https://github.com/sourcegraph/sourcegraph/issues/40452) and [#41031](https://github.com/sourcegraph/sourcegraph/issues/41031)

**Old behavior:** Use `Desktop`, then fall back on displaying a failure notification
**New behavior:** Use `BrowserUtil`, fall back to `Desktop`, then fall back on displaying a failure notification

Also bumped version to 2.0.1 to prepare for releasing this.

## Test plan

I've tested three of the calls in this [1-min Loom](https://www.loom.com/share/0f6c90a6f0f84d11a5de94b0086668de)

## App preview:

- [Web](https://sg-web-dv-use-browserutil.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zdrmrelivr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
