### PR TITLE
sg: add sg page to automate alerts creation

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -281,6 +281,7 @@ var sg = &cli.App{
 		updateCommand,
 		installCommand,
 		funkyLogoCommand,
+    pageCommand, 
 	},
 	ExitErrHandler: func(cmd *cli.Context, err error) {
 		if err == nil {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -281,7 +281,7 @@ var sg = &cli.App{
 		updateCommand,
 		installCommand,
 		funkyLogoCommand,
-    pageCommand, 
+		pageCommand,
 	},
 	ExitErrHandler: func(cmd *cli.Context, err error) {
 		if err == nil {

--- a/dev/sg/sg_page.go
+++ b/dev/sg/sg_page.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"flag"
-	"fmt"
 
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
@@ -134,6 +134,6 @@ func parseOpsGeniePriority(p string) (alert.Priority, error) {
 	case "P5":
 		return alert.P5, nil
 	default:
-		return alert.Priority(""), fmt.Errorf("invalid priority %q", p)
+		return alert.Priority(""), errors.Errorf("invalid priority %q", p)
 	}
 }

--- a/dev/sg/sg_page.go
+++ b/dev/sg/sg_page.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+)
+
+var (
+	pageToken               string
+	pageMessage             string
+	pageDesc                string
+	pagePriority            string
+	pageURL                 string
+	pageResponderEscalation string
+	pageResponderSchedule   string
+)
+
+var pageCommand = &cli.Command{
+	Name:      "page",
+	UsageText: "sg page --opsgenie.token [TOKEN] --message \"something is broken\" --responder.schedule [my-schedule-on-ops-genie]",
+	Usage:     "Utility to page engineers, mostly used within scripts to automate paging alerts.",
+	Category:  CategoryUtil,
+	Action:    pageExec,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:        "opsgenie.token",
+			Usage:       "OpsGenie token",
+			Required:    true,
+			Destination: &pageToken,
+		},
+		&cli.StringFlag{
+			Name:        "message",
+			Usage:       "Message for the paging alert",
+			Required:    true,
+			Destination: &pageMessage,
+		},
+		&cli.StringFlag{
+			Name:        "description",
+			Usage:       "Description for the paging alert",
+			Destination: &pageDesc,
+		},
+		&cli.StringFlag{
+			Name:        "priority",
+			Usage:       "Alert priority, importance decreases from P1 (critical) to P5 (lowest), defaults to P5",
+			Value:       "P5",
+			Destination: &pagePriority,
+		},
+		&cli.StringFlag{
+			Name:        "url",
+			Usage:       "URL field for alert details (optional)",
+			Destination: &pageURL,
+		},
+		&cli.StringFlag{
+			Name:        "responder.schedule",
+			Usage:       "Schedule team to alert (at least one responder must be given)",
+			Destination: &pageResponderSchedule,
+		},
+		&cli.StringFlag{
+			Name:        "responder.escalation",
+			Usage:       "Escalation team to alert (at least one responder must be given)",
+			Destination: &pageResponderEscalation,
+		},
+	},
+}
+
+func pageExec(ctx *cli.Context) error {
+	logger := log.Scoped("pager", "paging client for SG")
+	var err error
+	var prio alert.Priority
+	if prio, err = parseOpsGeniePriority(pagePriority); err != nil {
+		logger.Fatal("cannot parse ops priority", log.Error(err))
+	}
+	if pageResponderSchedule == "" && pageResponderEscalation == "" {
+		// At least one responder must be given.
+		flag.Usage()
+		return flag.ErrHelp
+	}
+
+	alertClient, err := alert.NewClient(&client.Config{
+		ApiKey: pageToken,
+	})
+	if err != nil {
+		logger.Fatal("cannot create client", log.Error(err))
+	}
+
+	req := &alert.CreateAlertRequest{
+		Message:  pageMessage,
+		Priority: prio,
+	}
+
+	req.Description = ctx.String("description")
+
+	if pageURL != "" {
+		req.Details = map[string]string{
+			"url": pageURL,
+		}
+	}
+	if pageResponderSchedule != "" {
+		req.Responders = append(req.Responders, alert.Responder{Type: alert.ScheduleResponder, Name: pageResponderSchedule})
+	}
+	if pageResponderEscalation != "" {
+		req.Responders = append(req.Responders, alert.Responder{Type: alert.EscalationResponder, Name: pageResponderEscalation})
+	}
+
+	createResult, err := alertClient.Create(ctx.Context, req)
+
+	if err != nil {
+		if createResult != nil {
+			logger.Fatal("failed to post the alert on ops genie", log.Error(err), log.String("result", createResult.Result))
+		} else {
+			logger.Fatal("failed to post the alert on ops genie", log.Error(err))
+		}
+	}
+	return nil
+}
+
+func parseOpsGeniePriority(p string) (alert.Priority, error) {
+	switch p {
+	case "P1":
+		return alert.P1, nil
+	case "P2":
+		return alert.P2, nil
+	case "P3":
+		return alert.P3, nil
+	case "P4":
+		return alert.P4, nil
+	case "P5":
+		return alert.P5, nil
+	default:
+		return alert.Priority(""), fmt.Errorf("invalid priority %q", p)
+	}
+}

--- a/dev/sg/sg_page.go
+++ b/dev/sg/sg_page.go
@@ -25,7 +25,7 @@ var (
 var pageCommand = &cli.Command{
 	Name:      "page",
 	UsageText: "sg page --opsgenie.token [TOKEN] --message \"something is broken\" --responder.schedule [my-schedule-on-ops-genie]",
-	Usage:     "Utility to page engineers, mostly used within scripts to automate paging alerts.",
+	Usage:     "Utility to page engineers, mostly used within scripts to automate paging alerts",
 	Category:  CategoryUtil,
 	Action:    pageExec,
 	Flags: []cli.Flag{

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1270,3 +1270,22 @@ Arguments: `[classic]`
 Flags:
 
 * `--feedback`: provide feedback about this command by opening up a Github discussion
+
+## sg page
+
+Utility to page engineers, mostly used within scripts to automate paging alerts..
+
+```sh
+$ sg page --opsgenie.token [TOKEN] --message "something is broken" --responder.schedule [my-schedule-on-ops-genie]
+```
+
+Flags:
+
+* `--description="<value>"`: Description for the paging alert
+* `--feedback`: provide feedback about this command by opening up a Github discussion
+* `--message="<value>"`: Message for the paging alert
+* `--opsgenie.token="<value>"`: OpsGenie token
+* `--priority="<value>"`: Alert priority, importance decreases from P1 (critical) to P5 (lowest), defaults to P5 (default: P5)
+* `--responder.escalation="<value>"`: Escalation team to alert (at least one responder must be given)
+* `--responder.schedule="<value>"`: Schedule team to alert (at least one responder must be given)
+* `--url="<value>"`: URL field for alert details (optional)

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1273,7 +1273,7 @@ Flags:
 
 ## sg page
 
-Utility to page engineers, mostly used within scripts to automate paging alerts..
+Utility to page engineers, mostly used within scripts to automate paging alerts.
 
 ```sh
 $ sg page --opsgenie.token [TOKEN] --message "something is broken" --responder.schedule [my-schedule-on-ops-genie]

--- a/go.mod
+++ b/go.mod
@@ -201,12 +201,16 @@ require github.com/XSAM/otelsql v0.15.0
 require (
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/onsi/ginkgo v1.16.4 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
 )
 
 require github.com/hmarr/codeowners v0.4.0
 
-require go.opentelemetry.io/otel/exporters/jaeger v1.9.0
+require (
+	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.13
+	go.opentelemetry.io/otel/exporters/jaeger v1.9.0
+)
 
 require (
 	github.com/sourcegraph/zoekt v0.0.0-20220826062732-19e4a677f5ab

--- a/go.sum
+++ b/go.sum
@@ -1287,6 +1287,7 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
+github.com/hashicorp/go-retryablehttp v0.5.1/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
@@ -1828,6 +1829,8 @@ github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYr
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.13 h1:nV98dkBpqaYbDnhefmOQ+Rn4hE+jD6AtjYHXaU5WyJI=
+github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.13/go.mod h1:4OjcxgwdXzezqytxN534MooNmrxRD50geWZxTD7845s=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -2020,6 +2023,7 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/slack-go/slack v0.10.1 h1:BGbxa0kMsGEvLOEoZmYs8T1wWfoZXwmQFBb6FgYCXUA=
 github.com/slack-go/slack v0.10.1/go.mod h1:wWL//kk0ho+FcQXcBTmEafUI5dz4qz5f4mMk8oIkioQ=


### PR DESCRIPTION
Port the script in https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/17235/files in `sg` so we can use it in various places where we want to raise alerts, like failed deployments and others. 

Part of https://github.com/sourcegraph/sourcegraph/issues/31854

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested in the other PR. 
