### PR TITLE
otel-collector: set default logging exporter to 'warn' level

### DIFF
--- a/docker-images/opentelemetry-collector/configs/logging.yaml
+++ b/docker-images/opentelemetry-collector/configs/logging.yaml
@@ -8,7 +8,10 @@ receivers:
 
 exporters:
   logging:
-    loglevel: info
+    # If you want to see the contents of spans in output, you can set logLevel to 'debug',
+    # but you probably want to configure another exporter - this is mostly here becasue
+    # we're not allowed to configure no exporters.
+    loglevel: warn
     sampling_initial: 5
     sampling_thereafter: 200
 


### PR DESCRIPTION
`debug` dumps details about spans, but is _super_ verbose, and `info` just logspams with "spans received", which is not terribly useful either. Since this is mostly placeholder config, we set the log level to `warn` instead.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start`

`sg start otel`