### PR TITLE
deps: upgrade github.com/sourcegraph/log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/go-rendezvous v0.0.0-20210910070954-ef39ade5591d
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/log v0.0.0-20220829165858-090861ec23a3
+	github.com/sourcegraph/log v0.0.0-20220830171425-4bb9844c8f2c
 	github.com/sourcegraph/run v0.9.0
 	github.com/sourcegraph/scip v0.1.0
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220203145655-4d2a39d3038a

--- a/go.sum
+++ b/go.sum
@@ -2062,8 +2062,8 @@ github.com/sourcegraph/httpgzip v0.0.0-20211015085752-0bad89b3b4df h1:VaS8k40GiN
 github.com/sourcegraph/httpgzip v0.0.0-20211015085752-0bad89b3b4df/go.mod h1:RqWagzxNGCvucQQC9vX6aps474LCCOgshDpUTTyb+O8=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/log v0.0.0-20220829165858-090861ec23a3 h1:dVvsmHcSeGtv/BcQVeEzS3oBcoz2qYtsKYKEHpV6IjE=
-github.com/sourcegraph/log v0.0.0-20220829165858-090861ec23a3/go.mod h1:UxiwB6C3xk3xOySJpW1R0MDUyfGuJRFS5Z8C+SA5p2I=
+github.com/sourcegraph/log v0.0.0-20220830171425-4bb9844c8f2c h1:C9tEB0AHI1zWbgjZMzF9ZTJmzH0+bk5ltM/Bjq2M/bE=
+github.com/sourcegraph/log v0.0.0-20220830171425-4bb9844c8f2c/go.mod h1:UxiwB6C3xk3xOySJpW1R0MDUyfGuJRFS5Z8C+SA5p2I=
 github.com/sourcegraph/oauth2 v0.0.0-20210825125341-77c1d99ece3c h1:HGa4iJr6MGKnB5qbU7tI511NdGuHUHnNCqP67G6KmfE=
 github.com/sourcegraph/oauth2 v0.0.0-20210825125341-77c1d99ece3c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 github.com/sourcegraph/otelsql v0.0.0-20220825134523-e3712953a6a5 h1:gv92/ctwOCyj13tV94TX/FYXrHNdZMmGYc46AdLnmzM=


### PR DESCRIPTION
This upgrade includes https://github.com/sourcegraph/log/commit/4bb9844c8f2c64e432cd1e62f9993dfb76eb0f1e which is described in https://github.com/sourcegraph/log/pull/24, correctly re-introducing the intended behaviour of panicking if a pre-package-init-logger-initialization is detected _in dev environments_ (first outlined in https://github.com/sourcegraph/sourcegraph/pull/33956).

For a while this would panic when introduced, but issues have been resolved with:

- https://github.com/sourcegraph/sourcegraph/pull/40963
- https://github.com/sourcegraph/sourcegraph/pull/40966
- https://github.com/sourcegraph/sourcegraph/pull/40965 and #34 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start` and `sg start oss` do not panic