### PR TITLE
internal/httpcli: check if resp is nil before attempting to log fields

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -191,13 +191,11 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	logger := s.Logger.With(log.Object("ExternalService",
-		log.Int64("id", req.ExternalServiceID)),
-	)
+	logger := s.Logger.With(log.Int64("ExternalServiceID", req.ExternalServiceID))
 
 	var sourcer repos.Sourcer
 	if sourcer = s.Sourcer; sourcer == nil {
-		sourcerLogger := s.Logger.Scoped("repos.Sourcer", "repositories source")
+		sourcerLogger := logger.Scoped("repos.Sourcer", "repositories source")
 
 		db := database.NewDBWith(sourcerLogger.Scoped("db", "sourcer database"), s)
 		depsSvc := livedependencies.GetService(db)

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -311,14 +311,16 @@ func NewLoggingMiddleware(logger log.Logger) Middleware {
 			// Gather fields about this request. When adding fields set into context,
 			// make sure to test that the fields get propagated and picked up correctly
 			// in TestLoggingMiddleware.
-			fields := []log.Field{
+			fields := append(make([]log.Field, 0, 5), // preallocate some space
 				log.String("host", r.URL.Host),
 				log.String("path", r.URL.Path),
-				log.Int("code", resp.StatusCode),
 				log.Duration("duration", time.Since(start)),
-				log.Error(err),
+				log.Error(err))
+			// Response may be nil sometimes it seems
+			if resp != nil {
+				fields = append(fields, log.Int("code", resp.StatusCode))
 			}
-			// From NewRetryPolicy
+			// Get fields from NewRetryPolicy
 			if attempt, ok := resp.Request.Context().Value(requestRetryAttemptKey).(rehttp.Attempt); ok {
 				fields = append(fields, log.Object("retry",
 					log.Int("attempts", attempt.Index),

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -314,11 +314,12 @@ func NewLoggingMiddleware(logger log.Logger) Middleware {
 			fields := append(make([]log.Field, 0, 5), // preallocate some space
 				log.String("host", r.URL.Host),
 				log.String("path", r.URL.Path),
-				log.Duration("duration", time.Since(start)),
-				log.Error(err))
-			// Response may be nil sometimes it seems
+				log.Duration("duration", time.Since(start)))
 			if resp != nil {
 				fields = append(fields, log.Int("code", resp.StatusCode))
+			}
+			if err != nil {
+				fields = append(fields, log.Error(err))
 			}
 			// Get fields from NewRetryPolicy
 			if attempt, ok := resp.Request.Context().Value(requestRetryAttemptKey).(rehttp.Attempt); ok {

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -327,7 +327,7 @@ func NewLoggingMiddleware(logger log.Logger) Middleware {
 			// Gather fields from request context. When adding fields set into context,
 			// make sure to test that the fields get propagated and picked up correctly
 			// in TestLoggingMiddleware.
-			if attempt, ok := resp.Request.Context().Value(requestRetryAttemptKey).(rehttp.Attempt); ok {
+			if attempt, ok := ctx.Value(requestRetryAttemptKey).(rehttp.Attempt); ok {
 				// Get fields from NewRetryPolicy
 				fields = append(fields, log.Object("retry",
 					log.Int("attempts", attempt.Index),

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -308,28 +308,34 @@ func NewLoggingMiddleware(logger log.Logger) Middleware {
 			start := time.Now()
 			resp, err := d.Do(r)
 
-			// Gather fields about this request. When adding fields set into context,
-			// make sure to test that the fields get propagated and picked up correctly
-			// in TestLoggingMiddleware.
+			// Gather fields about this request.
 			fields := append(make([]log.Field, 0, 5), // preallocate some space
 				log.String("host", r.URL.Host),
 				log.String("path", r.URL.Path),
 				log.Duration("duration", time.Since(start)))
-			if resp != nil {
-				fields = append(fields, log.Int("code", resp.StatusCode))
-			}
 			if err != nil {
 				fields = append(fields, log.Error(err))
 			}
-			// Get fields from NewRetryPolicy
+			// Check incoming request context, unless a response is available, in which
+			// case we check the request associated with the response in case it is not
+			// the same as the original request (e.g. due to retries)
+			ctx := r.Context()
+			if resp != nil {
+				ctx = resp.Request.Context()
+				fields = append(fields, log.Int("code", resp.StatusCode))
+			}
+			// Gather fields from request context. When adding fields set into context,
+			// make sure to test that the fields get propagated and picked up correctly
+			// in TestLoggingMiddleware.
 			if attempt, ok := resp.Request.Context().Value(requestRetryAttemptKey).(rehttp.Attempt); ok {
+				// Get fields from NewRetryPolicy
 				fields = append(fields, log.Object("retry",
 					log.Int("attempts", attempt.Index),
 					log.Error(attempt.Error)))
 			}
 
 			// Log results with link to trace if present
-			trace.Logger(resp.Request.Context(), logger).
+			trace.Logger(ctx, logger).
 				Debug("request", fields...)
 
 			return resp, err


### PR DESCRIPTION
Seeing in main that the response might be nil - https://buildkite.com/sourcegraph/sourcegraph/builds/170045#0182efc0-4e36-4231-81ed-57db47c6fdcc - presumably in the error case. Bug introduced in https://github.com/sourcegraph/sourcegraph/pull/40963

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

this branch runs backend integration tests, should pass