### PR TITLE
insights: regex pattern replacer check for a search pattern

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/regexp.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp.go
@@ -175,6 +175,10 @@ func NewPatternReplacer(query BasicQuery, searchType searchquery.SearchType) (Pa
 		return nil, MultiplePatternErr
 	}
 
+	if len(patterns) == 0 {
+		return nil, UnsupportedPatternTypeErr
+	}
+
 	pattern := patterns[0]
 	if !pattern.Annotation.Labels.IsSet(searchquery.Regexp) {
 		return nil, UnsupportedPatternTypeErr

--- a/enterprise/internal/insights/query/querybuilder/regexp_test.go
+++ b/enterprise/internal/insights/query/querybuilder/regexp_test.go
@@ -236,4 +236,12 @@ func TestReplace_Invalid(t *testing.T) {
 		_, err := NewPatternReplacer("asdf", query.SearchTypeStandard)
 		require.ErrorIs(t, err, UnsupportedPatternTypeErr)
 	})
+	t.Run("no pattern", func(t *testing.T) {
+		_, err := NewPatternReplacer("", query.SearchTypeRegex)
+		require.ErrorIs(t, err, UnsupportedPatternTypeErr)
+	})
+	t.Run("filters with no pattern", func(t *testing.T) {
+		_, err := NewPatternReplacer("repo:repoA rev:3.40.0", query.SearchTypeStandard)
+		require.ErrorIs(t, err, UnsupportedPatternTypeErr)
+	})
 }


### PR DESCRIPTION
Adds a check to the regex pattern replacer to ensure there is a pattern

resolves https://github.com/sourcegraph/sourcegraph/issues/41016
## Test plan
Unit tests added
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
