### PR TITLE
git-combine: add startup script that sets default branches for each remote

### DIFF
--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -12,6 +12,7 @@ RUN go mod init github.com/sourcegraph/sourcegraph/internal/cmd/git-combine \
 
 
 COPY git-combine.go .
+COPY default-branch.sh .
 
 RUN go mod download \
     && go mod tidy
@@ -23,7 +24,12 @@ RUN go build .
 # alpine_base CHECK:ALPINE_OK
 FROM alpine:3.15 as alpine_base
 
-RUN apk add --no-cache git ca-certificates tini
+RUN apk add --no-cache\
+    bash \
+    ca-certificates \
+    git \
+    parallel \
+    tini
 
 COPY --from=builder /go/src/app/git-combine /usr/bin/
 

--- a/internal/cmd/git-combine/default-branch.sh
+++ b/internal/cmd/git-combine/default-branch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+cd "$GIT_DIR"
+
+# chore: get rid of GNU parallel citation spam
+{
+  mkdir -p "$HOME"/.parallel && touch "$HOME"/.parallel/will-cite
+  echo 'will cite' | parallel --citation &>/dev/null
+}
+
+function print_remote_and_default_branch() {
+  local remote="$1"
+
+  local default_branch
+  default_branch="$(git remote show "$remote" | sed -n '/HEAD branch/s/.*: //p')"
+
+  echo "${remote}" "${default_branch}"
+}
+export -f print_remote_and_default_branch
+
+# discover the current default branch for each remote
+mapfile -t remotes_to_default < <(git remote | parallel --keep-order --line-buffer print_remote_and_default_branch)
+
+# set the appropriate default branch for each remote
+for line in "${remotes_to_default[@]}"; do
+  remote="$(awk '{printf $1}' <<<"$line")"
+  default="$(awk '{printf $2}' <<<"$line")"
+
+  git remote set-branches "$remote" "$default"
+done


### PR DESCRIPTION
The gigarepo tracks 230 remotes. If any one of them changes the name of their default branch, `git fetch` will no longer work - causing the pod to go into a crash loop. 

This PR adds a simple bash script that loops over all of the remotes and sets our local git configuration to point to the current name for their default branch. `git-combine` will run this script whenever the pod restarts. 

## Test plan
This is already running on dogfood.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->