### PR TITLE
oobmigration: Add `applyReverse` flag to Progress

### DIFF
--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator.go
@@ -37,7 +37,7 @@ func (m *SSHMigrator) Interval() time.Duration { return time.Second * 5 }
 
 // Progress returns the percentage (ranged [0, 1]) of external services without a marker
 // indicating that this migration has been applied to that row.
-func (m *SSHMigrator) Progress(ctx context.Context) (float64, error) {
+func (m *SSHMigrator) Progress(ctx context.Context, _ bool) (float64, error) {
 	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(sshMigratorProgressQuery, "batches", "batches")))
 	return progress, err
 }

--- a/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/ssh_migrator_test.go
@@ -48,7 +48,7 @@ func TestSSHMigrator(t *testing.T) {
 	})
 
 	migrator := NewSSHMigratorWithDB(store, key, 5)
-	progress, err := migrator.Progress(ctx)
+	progress, err := migrator.Progress(ctx, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestSSHMigrator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	progress, err = migrator.Progress(ctx)
+	progress, err = migrator.Progress(ctx, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestSSHMigrator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	progress, err = migrator.Progress(ctx)
+	progress, err = migrator.Progress(ctx, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestSSHMigrator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	progress, err = migrator.Progress(ctx)
+	progress, err = migrator.Progress(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/oobmigration/migrations/codeintel/diagnostics_count_test.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/diagnostics_count_test.go
@@ -21,8 +21,8 @@ func TestDiagnosticsCountMigrator(t *testing.T) {
 	migrator := NewDiagnosticsCountMigrator(store, 250)
 	serializer := newSerializer()
 
-	assertProgress := func(expectedProgress float64) {
-		if progress, err := migrator.Progress(context.Background()); err != nil {
+	assertProgress := func(expectedProgress float64, applyReverse bool) {
+		if progress, err := migrator.Progress(context.Background(), applyReverse); err != nil {
 			t.Fatalf("unexpected error querying progress: %s", err)
 		} else if progress != expectedProgress {
 			t.Errorf("unexpected progress. want=%.2f have=%.2f", expectedProgress, progress)
@@ -64,27 +64,27 @@ func TestDiagnosticsCountMigrator(t *testing.T) {
 		}
 	}
 
-	assertProgress(0)
+	assertProgress(0, false)
 
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(0.5)
+	assertProgress(0.5, false)
 
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(1)
+	assertProgress(1, false)
 
 	assertCounts(expectedCounts)
 
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0.5)
+	assertProgress(0.5, true)
 
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0)
+	assertProgress(0, true)
 }

--- a/enterprise/internal/oobmigration/migrations/codeintel/document_column_split_test.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/document_column_split_test.go
@@ -23,8 +23,8 @@ func TestDocumentColumnSplitMigrator(t *testing.T) {
 	migrator := NewDocumentColumnSplitMigrator(store, 250)
 	serializer := newSerializer()
 
-	assertProgress := func(expectedProgress float64) {
-		if progress, err := migrator.Progress(context.Background()); err != nil {
+	assertProgress := func(expectedProgress float64, applyReverse bool) {
+		if progress, err := migrator.Progress(context.Background(), applyReverse); err != nil {
 			t.Fatalf("unexpected error querying progress: %s", err)
 		} else if progress != expectedProgress {
 			t.Errorf("unexpected progress. want=%.2f have=%.2f", expectedProgress, progress)
@@ -96,27 +96,27 @@ func TestDocumentColumnSplitMigrator(t *testing.T) {
 		}
 	}
 
-	assertProgress(0)
+	assertProgress(0, false)
 
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(0.5)
+	assertProgress(0.5, false)
 
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(1)
+	assertProgress(1, false)
 
 	assertCounts(expectedCounts)
 
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0.5)
+	assertProgress(0.5, true)
 
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0)
+	assertProgress(0, true)
 }

--- a/enterprise/internal/oobmigration/migrations/codeintel/locations_count_test.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/locations_count_test.go
@@ -22,8 +22,8 @@ func TestLocationsCountMigrator(t *testing.T) {
 	migrator := newLocationsCountMigrator(store, 10, time.Second, "lsif_data_definitions", 250)
 	serializer := newSerializer()
 
-	assertProgress := func(expectedProgress float64) {
-		if progress, err := migrator.Progress(context.Background()); err != nil {
+	assertProgress := func(expectedProgress float64, applyReverse bool) {
+		if progress, err := migrator.Progress(context.Background(), applyReverse); err != nil {
 			t.Fatalf("unexpected error querying progress: %s", err)
 		} else if progress != expectedProgress {
 			t.Errorf("unexpected progress. want=%.2f have=%.2f", expectedProgress, progress)
@@ -64,27 +64,27 @@ func TestLocationsCountMigrator(t *testing.T) {
 		}
 	}
 
-	assertProgress(0)
+	assertProgress(0, false)
 
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(0.5)
+	assertProgress(0.5, false)
 
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(1)
+	assertProgress(1, false)
 
 	assertCounts(expectedCounts)
 
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0.5)
+	assertProgress(0.5, true)
 
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0)
+	assertProgress(0, true)
 }

--- a/enterprise/internal/oobmigration/migrations/codeintel/migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/migrator_test.go
@@ -87,37 +87,37 @@ func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
 		}
 	}
 
-	assertProgress(0, true)
+	assertProgress(0, false)
 
 	// process dump 43 (updates bounds)
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(1.0/3.0, true)
+	assertProgress(1.0/3.0, false)
 
 	// process dump 44 (updates bounds)
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(2.0/3.0, true)
+	assertProgress(2.0/3.0, false)
 
 	// process dump 45 (deletes schema version record with no data)
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(1.0, true)
+	assertProgress(1.0, false)
 
 	// reverse migration of first of remaining two dumps
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0.5, false)
+	assertProgress(0.5, true)
 
 	// reverse migration of second of remaining two dumps
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0.0, false)
+	assertProgress(0.0, true)
 }
 
 type testMigrationDriver struct{}

--- a/enterprise/internal/oobmigration/migrations/codeintel/migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/migrator_test.go
@@ -29,8 +29,8 @@ func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
 		},
 	})
 
-	assertProgress := func(expectedProgress float64) {
-		if progress, err := migrator.Progress(context.Background()); err != nil {
+	assertProgress := func(expectedProgress float64, applyReverse bool) {
+		if progress, err := migrator.Progress(context.Background(), applyReverse); err != nil {
 			t.Fatalf("unexpected error querying progress: %s", err)
 		} else if progress != expectedProgress {
 			t.Errorf("unexpected progress. want=%.2f have=%.2f", expectedProgress, progress)
@@ -87,37 +87,37 @@ func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
 		}
 	}
 
-	assertProgress(0)
+	assertProgress(0, true)
 
 	// process dump 43 (updates bounds)
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(1.0 / 3.0)
+	assertProgress(1.0/3.0, true)
 
 	// process dump 44 (updates bounds)
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(2.0 / 3.0)
+	assertProgress(2.0/3.0, true)
 
 	// process dump 45 (deletes schema version record with no data)
 	if err := migrator.Up(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	assertProgress(1.0)
+	assertProgress(1.0, true)
 
 	// reverse migration of first of remaining two dumps
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0.5)
+	assertProgress(0.5, false)
 
 	// reverse migration of second of remaining two dumps
 	if err := migrator.Down(context.Background()); err != nil {
 		t.Fatalf("unexpected error performing down migration: %s", err)
 	}
-	assertProgress(0.0)
+	assertProgress(0.0, false)
 }
 
 type testMigrationDriver struct{}

--- a/enterprise/internal/oobmigration/migrations/iam/license_key_field_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/iam/license_key_field_migrator.go
@@ -32,7 +32,7 @@ func NewLicenseKeyFieldsMigrator(store *basestore.Store, batchSize int) *license
 func (m *licenseKeyFieldsMigrator) ID() int                 { return 16 }
 func (m *licenseKeyFieldsMigrator) Interval() time.Duration { return time.Second * 5 }
 
-func (m *licenseKeyFieldsMigrator) Progress(ctx context.Context) (float64, error) {
+func (m *licenseKeyFieldsMigrator) Progress(ctx context.Context, _ bool) (float64, error) {
 	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(licenseKeyFieldsMigratorProgressQuery)))
 	return progress, err
 }

--- a/enterprise/internal/oobmigration/migrations/iam/license_key_field_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/iam/license_key_field_migrator_test.go
@@ -38,7 +38,7 @@ func TestLicenseKeyFieldsMigrator(t *testing.T) {
 
 	// Ensure there is no progress before migration
 	migrator := NewLicenseKeyFieldsMigrator(store, 500)
-	progress, err := migrator.Progress(ctx)
+	progress, err := migrator.Progress(ctx, false)
 	require.NoError(t, err)
 	require.Equal(t, 0.0, progress)
 
@@ -46,7 +46,7 @@ func TestLicenseKeyFieldsMigrator(t *testing.T) {
 	err = migrator.Up(ctx)
 	require.NoError(t, err)
 
-	progress, err = migrator.Progress(ctx)
+	progress, err = migrator.Progress(ctx, false)
 	require.NoError(t, err)
 	require.Equal(t, 1.0, progress)
 

--- a/enterprise/internal/oobmigration/migrations/iam/subscription_account_number_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/iam/subscription_account_number_migrator.go
@@ -27,7 +27,7 @@ func NewSubscriptionAccountNumberMigrator(store *basestore.Store, batchSize int)
 func (m *subscriptionAccountNumberMigrator) ID() int                 { return 15 }
 func (m *subscriptionAccountNumberMigrator) Interval() time.Duration { return time.Second * 5 }
 
-func (m *subscriptionAccountNumberMigrator) Progress(ctx context.Context) (float64, error) {
+func (m *subscriptionAccountNumberMigrator) Progress(ctx context.Context, _ bool) (float64, error) {
 	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(subscriptionAccountNumberMigratorProgressQuery)))
 	return progress, err
 }

--- a/enterprise/internal/oobmigration/migrations/iam/subscription_account_number_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/iam/subscription_account_number_migrator_test.go
@@ -33,7 +33,7 @@ func TestSubscriptionAccountNumberMigrator(t *testing.T) {
 
 	// Ensure there is no progress before migration
 	migrator := NewSubscriptionAccountNumberMigrator(store, 500)
-	progress, err := migrator.Progress(ctx)
+	progress, err := migrator.Progress(ctx, false)
 	require.NoError(t, err)
 	require.Equal(t, 0.0, progress)
 
@@ -41,7 +41,7 @@ func TestSubscriptionAccountNumberMigrator(t *testing.T) {
 	err = migrator.Up(ctx)
 	require.NoError(t, err)
 
-	progress, err = migrator.Progress(ctx)
+	progress, err = migrator.Progress(ctx, false)
 	require.NoError(t, err)
 	require.Equal(t, 1.0, progress)
 

--- a/enterprise/internal/oobmigration/migrations/insights/migrator.go
+++ b/enterprise/internal/oobmigration/migrations/insights/migrator.go
@@ -32,7 +32,7 @@ func NewMigrator(frontendDB, insightsDB *basestore.Store) *insightsMigrator {
 func (m *insightsMigrator) ID() int                 { return 14 }
 func (m *insightsMigrator) Interval() time.Duration { return time.Second * 10 }
 
-func (m *insightsMigrator) Progress(ctx context.Context) (float64, error) {
+func (m *insightsMigrator) Progress(ctx context.Context, _ bool) (float64, error) {
 	if !insights.IsEnabled() {
 		return 1, nil
 	}

--- a/enterprise/internal/oobmigration/migrations/insights/migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/insights/migrator_test.go
@@ -115,7 +115,7 @@ func TestInsightsMigrator(t *testing.T) {
 
 	i := 0
 	for {
-		progress, err := migrator.Progress(ctx)
+		progress, err := migrator.Progress(ctx, false)
 		if err != nil {
 			t.Fatalf("unexpected error checking progress: %s", err)
 		}

--- a/internal/oobmigration/migrations/batches/extsvc_webhook_migrator.go
+++ b/internal/oobmigration/migrations/batches/extsvc_webhook_migrator.go
@@ -38,7 +38,7 @@ func (m *externalServiceWebhookMigrator) Interval() time.Duration { return time.
 
 // Progress returns the percentage (ranged [0, 1]) of external services with a
 // populated has_webhooks column.
-func (m *externalServiceWebhookMigrator) Progress(ctx context.Context) (float64, error) {
+func (m *externalServiceWebhookMigrator) Progress(ctx context.Context, _ bool) (float64, error) {
 	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(externalServiceWebhookMigratorProgressQuery)))
 	return progress, err
 }

--- a/internal/oobmigration/migrations/batches/extsvc_webhook_migrator_test.go
+++ b/internal/oobmigration/migrations/batches/extsvc_webhook_migrator_test.go
@@ -143,13 +143,13 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 
 		// By default, all the external services should have non-NULL
 		// has_webhooks.
-		progress, err := m.Progress(ctx)
+		progress, err := m.Progress(ctx, false)
 		assert.Nil(t, err)
 		assert.EqualValues(t, 1., progress)
 
 		// Now we'll clear that flag and ensure the progress drops to zero.
 		clearHasWebhooks(t, ctx, store)
-		progress, err = m.Progress(ctx)
+		progress, err = m.Progress(ctx, true)
 		assert.Nil(t, err)
 		assert.EqualValues(t, 0., progress)
 	})

--- a/internal/oobmigration/migrator.go
+++ b/internal/oobmigration/migrator.go
@@ -8,10 +8,12 @@ import "context"
 // (e.g., gob-encode or gzipped payloads).
 type Migrator interface {
 	// Progress returns a percentage (in the range range [0, 1]) of data records that need
-	// to be upgraded in the forward direction. A value of 1 means that no further action
-	// is required. A value < 1 denotes that a future invocation of the Up method could
-	// migrate additional data (excluding error conditions and prerequisite migrations).
-	Progress(ctx context.Context) (float64, error)
+	// to be migrated in the up direction. A value of 0 means that no data has been changedk.
+	// A value of 1 means that the underlying data has been completely migrated. A value < 1
+	// denotes that a future invocation of the Up method may affect additional data, excluding
+	// error conditions and prerequisite migrations. A value > 0 denotes that a future invocation
+	// of the Down method may affect additional data.
+	Progress(ctx context.Context, applyReverse bool) (float64, error)
 
 	// Up runs a batch of the migration. This method is called repeatedly until the Progress
 	// method reports completion. Errors returned from this method will be associated with the

--- a/internal/oobmigration/runner.go
+++ b/internal/oobmigration/runner.go
@@ -392,7 +392,7 @@ func runMigrationFunction(ctx context.Context, store storeIface, migration *Migr
 // updateProgress invokes the Progress method on the given migrator, updates the Progress field of the
 // given migration record, and updates the record in the database.
 func updateProgress(ctx context.Context, store storeIface, migration *Migration, migrator Migrator) error {
-	progress, err := migrator.Progress(ctx)
+	progress, err := migrator.Progress(ctx, migration.ApplyReverse)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Code intelligence progress is determined by a bounded range of versions, meaning that we need to know the migration direction to accurately figure out the percentage on downgrades.

## Test plan

Tested downgrades locally. 