### PR TITLE
Remove fallback to global credentials in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - `"observability.tracing": { "type": "opentelemetry" }` is now the default tracer type. To revert to existing behaviour, set `"type": "jaeger"` instead. The legacy values `"type": "opentracing"` and `"type": "datadog"` have been removed. [#41242](https://github.com/sourcegraph/sourcegraph/pull/41242)
 - `"observability.tracing": { "urlTemplate": "" }` is now the default, and if `"urlTemplate"` is left empty, no trace URLs are generated. To revert to existing behaviour, set `"urlTemplate": "{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}"` instead. [#41242](https://github.com/sourcegraph/sourcegraph/pull/41242)
 - External service credentials are no longer used as a fallback for syncing changesets in Batch Changes. [https://github.com/sourcegraph/sourcegraph/issues/25394](#25394)
+- Code host connection tokens are no longer supported as a fallback method for syncing changesets in Batch Changes. [https://github.com/sourcegraph/sourcegraph/issues/25394](#25394)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - [Sourcegraph with Docker Compose](https://docs.sourcegraph.com/admin/deploy/docker-compose): The `jaeger` service has been replaced by an [OpenTelemetry Collector](https://docs.sourcegraph.com/admin/observability/opentelemetry) service. The bundled Jaeger instance is now disabled by default, instead of enabled. [#40455](https://github.com/sourcegraph/sourcegraph/issues/40455)
 - `"observability.tracing": { "type": "opentelemetry" }` is now the default tracer type. To revert to existing behaviour, set `"type": "jaeger"` instead. The legacy values `"type": "opentracing"` and `"type": "datadog"` have been removed. [#41242](https://github.com/sourcegraph/sourcegraph/pull/41242)
 - `"observability.tracing": { "urlTemplate": "" }` is now the default, and if `"urlTemplate"` is left empty, no trace URLs are generated. To revert to existing behaviour, set `"urlTemplate": "{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}"` instead. [#41242](https://github.com/sourcegraph/sourcegraph/pull/41242)
+- External service credentials are no longer used as a fallback for syncing changesets in Batch Changes. [https://github.com/sourcegraph/sourcegraph/issues/25394](#25394)
 
 ### Fixed
 

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -11,14 +11,16 @@ import styles from './BatchChangesListIntro.module.scss'
 export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <DismissibleAlert
         className={styles.batchChangesListIntroAlert}
-        partialStorageKey="batch-changes-list-intro-changelog-3.42"
+        partialStorageKey="batch-changes-list-intro-changelog-4.0"
     >
         <Card className={classNames(styles.batchChangesListIntroCard, 'h-100')}>
             <CardBody>
-                <H4 as={H3}>Batch Changes updates in version 3.42</H4>
+                <H4 as={H3}>Batch Changes updates in version 4.0</H4>
                 <ul className="mb-0 pl-3">
-                    <li>Mounted files can be cached when executing a batch spec.</li>
-                    <li>Improved keyboard navigation for server-side execution flow.</li>
+                    <li>
+                        External service credentials are no longer used as a fallback for syncing changesets in Batch
+                        Changes.
+                    </li>
                 </ul>
             </CardBody>
         </Card>

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -18,8 +18,8 @@ export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWith
                 <H4 as={H3}>Batch Changes updates in version 4.0</H4>
                 <ul className="mb-0 pl-3">
                     <li>
-                        Code host connection tokens are no longer supported as a fallback method for syncing changesets in
-                        Batch Changes.
+                        Code host connection tokens are no longer supported as a fallback method for syncing changesets
+                        in Batch Changes.
                     </li>
                 </ul>
             </CardBody>

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -18,8 +18,8 @@ export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWith
                 <H4 as={H3}>Batch Changes updates in version 4.0</H4>
                 <ul className="mb-0 pl-3">
                     <li>
-                        External service credentials are no longer used as a fallback for syncing changesets in Batch
-                        Changes.
+                        Code host connection tokens are no longer supported as a fallback method for syncing changesets in
+                        Batch Changes.
                     </li>
                 </ul>
             </CardBody>

--- a/doc/batch_changes/how-tos/configuring_credentials.md
+++ b/doc/batch_changes/how-tos/configuring_credentials.md
@@ -74,7 +74,9 @@ The code host's indicator should revert to the empty red circle once the token i
 
 Global credentials are usable by all users of the Sourcegraph instance who have not added their own personal access tokens for Batch Changes. This makes them a handy fallback, but not strictly required if users are adding their own tokens for publishing changesets.
 
-Sourcegraph also uses the global service account to [track existing changesets](./tracking_existing_changesets.md) and keep changesets up to date. If it is not configured, webhooks will be the only source of updates.
+However, currently a global service account token is required for [importing existing changesets](./tracking_existing_changesets.md) on your code hosts into batch changes.
+
+Additionally, if you have not [configured webhooks](../../admin/config/batch_changes.md#incoming-webhooks) from your code host,  Sourcegraph requires a global service account keep changesets up to date.
 
 If [forks are enabled](../../admin/config/batch_changes.md#forks), then note that repositories will also be forked into the service account.
 

--- a/doc/batch_changes/how-tos/configuring_credentials.md
+++ b/doc/batch_changes/how-tos/configuring_credentials.md
@@ -1,7 +1,5 @@
 # Configuring credentials
 
-> NOTE: This page describes functionality added in Sourcegraph 3.22. Older Sourcegraph versions only allow batch changes to be applied and managed by site admins.
-
 Interacting with a code host (such as creating, updating, or syncing changesets) is made possible by configuring an access token for that code host. Sourcegraph uses these tokens to manage changesets on your behalf, and with your specific permissions.
 
 ## Requirements
@@ -11,11 +9,10 @@ Interacting with a code host (such as creating, updating, or syncing changesets)
 
 ## Types of access tokens used by Batch Changes
 
-There are three types of access token that can be configured for use with Batch Changes:
+There are two types of access token that can be configured for use with Batch Changes:
 
 1. [**Personal access token**](#personal-access-tokens) - A token set by an individual Batch Changes user for their personal code host user account.
-1. [**Global service account token**](#global-service-account-tokens) (*Admins only*) - A token that can be used by any Batch Changes user who does not have a personal access token configured.
-1. [**Sourcegraph code host connection token**](#code-host-connection-tokens) (*Admins only*) - A token that is typically set when connecting Sourcegraph to a code host for the first time and is used across the entire Sourcegraph instance. **Using the code host connection token with Batch Changes will be deprecated in the future.**
+1. [**Global service account token**](#global-service-account-tokens) (*Admins only*) - A token that can be used by any Batch Changes user who does not have a personal access token configured. These will also be used for syncing changeset state from the code host.
 
 Different tokens are used for different types of operations, as is illustrated in the hierarchy table below.
 
@@ -25,24 +22,22 @@ Different tokens are used for different types of operations, as is illustrated i
 
 🔴  **Unsupported** - Sourcegraph cannot use this token for this operation.
 
-Operation | [Personal Access Token](#personal-access-tokens) | [Global Service Account Token](#global-service-account-tokens) | [Code Host Connection Token](#code-host-connection-tokens)
---------- | :-: | :-: | :-:
-Pushing a branch with the changes | 🟢 | 🟡 | 🔴
-[Publishing a changeset](./publishing_changesets.md) | 🟢 | 🟡 | 🔴
-Updating a changeset | 🟢 | 🟡 | 🔴
-Closing a changeset | 🟢 | 🟡 | 🔴
-[Importing a changeset](./tracking_existing_changesets.md) | 🔴 | 🟢 | 🟡
-Syncing a changeset | 🟢 | 🟡 | 🟡
+Operation | [Personal Access Token](#personal-access-tokens) | [Global Service Account Token](#global-service-account-tokens)
+--------- | :-: | :-:
+Pushing a branch with the changes | 🟢 | 🟡
+[Publishing a changeset](./publishing_changesets.md) | 🟢 | 🟡
+Updating a changeset | 🟢 | 🟡
+Closing a changeset | 🟢 | 🟡
+[Importing a changeset](./tracking_existing_changesets.md) | 🔴 | 🟢
+Syncing a changeset | 🔴 | 🟢
 
 When writing a changeset to the code host, the author will reflect the token used (e.g., on GitHub, the pull request author will be you). It is for this reason that a personal access token is preferred for most operations.
-
-> WARNING: Using the code host connection token with Batch Changes will be deprecated in the future; therefore, we highly recommend that admins configure a global service account token for Batch Changes instead.
 
 ## Personal access tokens
 
 ### Do I need to add a personal access token?
 
-Personal access tokens are not required if a global access token has also been configured, but users should add one if they want Sourcegraph to create changesets under their name.
+Personal access tokens are not strictly required if a global access token has also been configured, but users should add one if they want Sourcegraph to create changesets under their name.
 
 > NOTE: Commit author is determined by your spec file or local git config at the time of running `src batch [apply|preview]`, completely independent from code host credentials.
 
@@ -75,13 +70,11 @@ The code host's indicator should revert to the empty red circle once the token i
 
 ## Global service account tokens
 
-> NOTE: This section describes functionality added in Sourcegraph 3.27, and which is only accessible to **site administrators**.
-
 ### Do I need to add a global service account token?
 
-Global credentials are usable by all users of the Sourcegraph instance who have not added their own personal access tokens for Batch Changes. This makes them a handy fallback, but not strictly required if users are adding their own tokens.
+Global credentials are usable by all users of the Sourcegraph instance who have not added their own personal access tokens for Batch Changes. This makes them a handy fallback, but not strictly required if users are adding their own tokens for publishing changesets.
 
-Sourcegraph also uses the global service account to [track existing changesets](./tracking_existing_changesets.md) and keep changesets up to date. If no global service account token is set, we can currently fall back to the [token configured for the code host connection](#code-host-connection-tokens). However, this fallback will be deprecated in the future, so for this reason we highly recommend setting up a global service account.
+Sourcegraph also uses the global service account to [track existing changesets](./tracking_existing_changesets.md) and keep changesets up to date. If it is not configured, webhooks will be the only source of updates.
 
 If [forks are enabled](../../admin/config/batch_changes.md#forks), then note that repositories will also be forked into the service account.
 
@@ -99,14 +92,6 @@ Code hosts with tokens configured are indicated by a green tick to the left of t
 ### Removing a token
 
 To remove a token, navigate back to the same section of the site admin area, then click **Remove**. The code host's indicator should revert to the empty red circle once the token is removed.
-
-## Code host connection tokens
-
-> WARNING: Using code host connection tokens with Batch Changes will be deprecated and removed in future versions of Sourcegraph.
-
-[Code host connection tokens](../../admin/external_service.md) are typically configured the first time a site administrator is connecting Sourcegraph to the external code host. Within Batch Changes, they are only used for syncing and importing changesets when a global service account token is not configured.
-
-> NOTE: Prior to Sourcegraph 3.29, admin users were also able to use the code host connection token as a fallback for other Batch Changes operations, such as creating and updating changesets. However, non-admin users were unable to apply batch changes without another form of access token being configured.
 
 ## Creating a code host token
 

--- a/doc/batch_changes/how-tos/configuring_credentials.md
+++ b/doc/batch_changes/how-tos/configuring_credentials.md
@@ -12,7 +12,7 @@ Interacting with a code host (such as creating, updating, or syncing changesets)
 There are two types of access token that can be configured for use with Batch Changes:
 
 1. [**Personal access token**](#personal-access-tokens) - A token set by an individual Batch Changes user for their personal code host user account.
-1. [**Global service account token**](#global-service-account-tokens) (*Admins only*) - A token that can be used by any Batch Changes user who does not have a personal access token configured. These will also be used for syncing changeset state from the code host.
+1. [**Global service account token**](#global-service-account-tokens) (*Admins only*) - A token that can be used by any Batch Changes user who does not have a personal access token configured. These are also required for [importing changesets](./tracking_existing_changesets.md) and syncing changeset state from the code host when webhooks are not configured.
 
 Different tokens are used for different types of operations, as is illustrated in the hierarchy table below.
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -27,6 +27,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -64,7 +65,6 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			DisplayName: "GitHub",
 			Config: extsvc.NewUnencryptedConfig(bt.MarshalJSON(t, &schema.GitHubConnection{
 				Url:      "https://github.com",
-				Token:    token,
 				Repos:    []string{"sourcegraph/sourcegraph"},
 				Webhooks: []*schema.GitHubWebhook{{Org: "sourcegraph", Secret: secret}},
 			})),
@@ -91,6 +91,16 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 		}
 
 		s := store.NewWithClock(db, &observation.TestContext, nil, clock)
+		if err := s.CreateSiteCredential(ctx, &btypes.SiteCredential{
+			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
+			ExternalServiceID:   githubRepo.ExternalRepo.ServiceID,
+		},
+			&auth.OAuthBearerTokenWithSSH{
+				OAuthBearerToken: auth.OAuthBearerToken{Token: token},
+			},
+		); err != nil {
+			t.Fatal(err)
+		}
 		sourcer := sources.NewSourcer(cf)
 
 		spec := &btypes.BatchSpec{
@@ -138,7 +148,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 		})
 		defer state.Unmock()
 
-		src, err := sourcer.ForRepo(ctx, s, githubRepo)
+		src, err := sourcer.ForChangeset(ctx, s, changeset)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/batches/processor/bulk_processor.go
+++ b/enterprise/internal/batches/processor/bulk_processor.go
@@ -76,13 +76,9 @@ func (b *bulkProcessor) Process(ctx context.Context, job *btypes.ChangesetJob) (
 	}
 
 	// Construct changeset source.
-	b.css, err = b.sourcer.ForRepo(ctx, b.tx, b.repo)
+	b.css, err = b.sourcer.ForUser(ctx, b.tx, job.UserID, b.repo)
 	if err != nil {
 		return errors.Wrap(err, "loading ChangesetSource")
-	}
-	b.css, err = sources.WithAuthenticatorForUser(ctx, b.tx, b.css, job.UserID, b.repo)
-	if err != nil {
-		return errors.Wrap(err, "authenticating ChangesetSource")
 	}
 
 	log15.Info("processing changeset job", "type", job.JobType)

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -184,7 +184,7 @@ func (e *executor) pushChangesetPatch(ctx context.Context) (err error) {
 		return errCannotPushToArchivedRepo
 	}
 
-	pushConf, err := css.GitserverPushConfig(ctx, remoteRepo)
+	pushConf, err := css.GitserverPushConfig(remoteRepo)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -184,7 +184,7 @@ func (e *executor) pushChangesetPatch(ctx context.Context) (err error) {
 		return errCannotPushToArchivedRepo
 	}
 
-	pushConf, err := css.GitserverPushConfig(ctx, e.tx.ExternalServices(), remoteRepo)
+	pushConf, err := css.GitserverPushConfig(ctx, remoteRepo)
 	if err != nil {
 		return err
 	}
@@ -528,14 +528,7 @@ func (e *executor) decorateChangesetBody(ctx context.Context) (string, error) {
 }
 
 func loadChangesetSource(ctx context.Context, s *store.Store, sourcer sources.Sourcer, ch *btypes.Changeset, repo *types.Repo) (sources.ChangesetSource, error) {
-	// This is a ChangesetSource authenticated with the external service
-	// token.
-	css, err := sourcer.ForRepo(ctx, s, repo)
-	if err != nil {
-		return nil, err
-	}
-
-	css, err = sources.WithAuthenticatorForChangeset(ctx, s, css, ch, repo, false)
+	css, err := sourcer.ForChangeset(ctx, s, ch)
 	if err != nil {
 		switch err {
 		case sources.ErrMissingCredentials:

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -1019,16 +1019,16 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 		user           *types.User
 		extSvc         *types.ExternalService
 		repo           *types.Repo
-		credentials    auth.Authenticator
+		credential     auth.Authenticator
 		wantErr        bool
 		wantPushConfig *gitprotocol.PushConfig
 	}{
 		{
-			name:        "github OAuthBearerToken",
-			user:        user,
-			extSvc:      gitHubExtSvc,
-			repo:        gitHubRepo,
-			credentials: &auth.OAuthBearerToken{Token: "my-secret-github-token"},
+			name:       "github OAuthBearerToken",
+			user:       user,
+			extSvc:     gitHubExtSvc,
+			repo:       gitHubRepo,
+			credential: &auth.OAuthBearerToken{Token: "my-secret-github-token"},
 			wantPushConfig: &gitprotocol.PushConfig{
 				RemoteURL: "https://my-secret-github-token@github.com/sourcegraph/" + string(gitHubRepo.Name),
 			},
@@ -1048,11 +1048,11 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:        "gitlab OAuthBearerToken",
-			user:        user,
-			extSvc:      gitLabExtSvc,
-			repo:        gitLabRepo,
-			credentials: &auth.OAuthBearerToken{Token: "my-secret-gitlab-token"},
+			name:       "gitlab OAuthBearerToken",
+			user:       user,
+			extSvc:     gitLabExtSvc,
+			repo:       gitLabRepo,
+			credential: &auth.OAuthBearerToken{Token: "my-secret-gitlab-token"},
 			wantPushConfig: &gitprotocol.PushConfig{
 				RemoteURL: "https://git:my-secret-gitlab-token@gitlab.com/sourcegraph/" + string(gitLabRepo.Name),
 			},
@@ -1072,11 +1072,11 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:        "bitbucketServer BasicAuth",
-			user:        user,
-			extSvc:      bbsExtSvc,
-			repo:        bbsRepo,
-			credentials: &auth.BasicAuth{Username: "fredwoard johnssen", Password: "my-secret-bbs-token"},
+			name:       "bitbucketServer BasicAuth",
+			user:       user,
+			extSvc:     bbsExtSvc,
+			repo:       bbsRepo,
+			credential: &auth.BasicAuth{Username: "fredwoard johnssen", Password: "my-secret-bbs-token"},
 			wantPushConfig: &gitprotocol.PushConfig{
 				RemoteURL: "https://fredwoard%20johnssen:my-secret-bbs-token@bitbucket.sourcegraph.com/scm/" + string(bbsRepo.Name),
 			},
@@ -1114,7 +1114,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			user:   admin,
 			extSvc: bbsSSHExtsvc,
 			repo:   bbsSSHRepo,
-			credentials: &auth.OAuthBearerTokenWithSSH{
+			credential: &auth.OAuthBearerTokenWithSSH{
 				OAuthBearerToken: auth.OAuthBearerToken{Token: "test"},
 				PrivateKey:       "private key",
 				PublicKey:        "public key",
@@ -1127,24 +1127,24 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			},
 		},
 		{
-			name:        "ssh clone URL non-SSH credential",
-			user:        admin,
-			extSvc:      bbsSSHExtsvc,
-			repo:        bbsSSHRepo,
-			credentials: &auth.OAuthBearerToken{Token: "test"},
-			wantErr:     true,
+			name:       "ssh clone URL non-SSH credential",
+			user:       admin,
+			extSvc:     bbsSSHExtsvc,
+			repo:       bbsSSHRepo,
+			credential: &auth.OAuthBearerToken{Token: "test"},
+			wantErr:    true,
 		},
 	}
 
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.credentials != nil {
+			if tt.credential != nil {
 				cred, err := bstore.UserCredentials().Create(ctx, database.UserCredentialScope{
 					Domain:              database.UserCredentialDomainBatches,
 					UserID:              tt.user.ID,
 					ExternalServiceType: tt.repo.ExternalRepo.ServiceType,
 					ExternalServiceID:   tt.repo.ExternalRepo.ServiceID,
-				}, tt.credentials)
+				}, tt.credential)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1166,7 +1166,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			})
 
 			gitClient := &bt.FakeGitserverClient{ResponseErr: nil}
-			fakeSource := &stesting.FakeChangesetSource{Svc: tt.extSvc}
+			fakeSource := &stesting.FakeChangesetSource{Svc: tt.extSvc, CurrentAuthenticator: tt.credential}
 			sourcer := stesting.NewFakeSourcer(nil, fakeSource)
 
 			err := executePlan(

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -606,6 +606,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 				Err:                     tc.sourcerErr,
 				ChangesetExists:         tc.alreadyExists,
 				IsArchivedPushErrorTrue: tc.isRepoArchived,
+				CurrentAuthenticator:    &auth.OAuthBearerTokenWithSSH{OAuthBearerToken: auth.OAuthBearerToken{Token: "token"}},
 			}
 
 			if tc.sourcerMetadata != nil {

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -135,7 +136,11 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 
 			// Setup the sourcer that's used to create a Source with which
 			// to create/update a changeset.
-			fakeSource := &stesting.FakeChangesetSource{Svc: extSvc, FakeMetadata: githubPR}
+			fakeSource := &stesting.FakeChangesetSource{
+				Svc:                  extSvc,
+				FakeMetadata:         githubPR,
+				CurrentAuthenticator: &auth.OAuthBearerTokenWithSSH{},
+			}
 			if changesetSpec != nil {
 				fakeSource.WantHeadRef = changesetSpec.HeadRef
 				fakeSource.WantBaseRef = changesetSpec.BaseRef

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -1129,14 +1129,11 @@ func (s *Service) FetchUsernameForBitbucketServerToken(ctx context.Context, exte
 	ctx, _, endObservation := s.operations.fetchUsernameForBitbucketServerToken.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	css, err := s.sourcer.ForExternalService(ctx, s.store, store.GetExternalServiceIDsOpts{
+	// Get a changeset source for the external service and use the given authenticator.
+	css, err := s.sourcer.ForExternalService(ctx, s.store, &auth.OAuthBearerToken{Token: token}, store.GetExternalServiceIDsOpts{
 		ExternalServiceType: externalServiceType,
 		ExternalServiceID:   externalServiceID,
 	})
-	if err != nil {
-		return "", err
-	}
-	css, err = css.WithAuthenticator(&auth.OAuthBearerToken{Token: token})
 	if err != nil {
 		return "", err
 	}
@@ -1171,14 +1168,11 @@ func (s *Service) ValidateAuthenticator(ctx context.Context, externalServiceID, 
 		return Mocks.ValidateAuthenticator(ctx, externalServiceID, externalServiceType, a)
 	}
 
-	css, err := s.sourcer.ForExternalService(ctx, s.store, store.GetExternalServiceIDsOpts{
+	// Get a changeset source for the external service and use the given authenticator.
+	css, err := s.sourcer.ForExternalService(ctx, s.store, a, store.GetExternalServiceIDsOpts{
 		ExternalServiceType: externalServiceType,
 		ExternalServiceID:   externalServiceID,
 	})
-	if err != nil {
-		return err
-	}
-	css, err = css.WithAuthenticator(a)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/batches/sources/bitbucketcloud.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud.go
@@ -56,8 +56,8 @@ func NewBitbucketCloudSource(ctx context.Context, svc *types.ExternalService, cf
 
 // GitserverPushConfig returns an authenticated push config used for pushing
 // commits to the code host.
-func (s BitbucketCloudSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(ctx, repo, s.client.Authenticator())
+func (s BitbucketCloudSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(repo, s.client.Authenticator())
 }
 
 // WithAuthenticator returns a copy of the original Source configured to use the

--- a/enterprise/internal/batches/sources/bitbucketcloud.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	bbcs "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/bitbucketcloud"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
@@ -57,8 +56,8 @@ func NewBitbucketCloudSource(ctx context.Context, svc *types.ExternalService, cf
 
 // GitserverPushConfig returns an authenticated push config used for pushing
 // commits to the code host.
-func (s BitbucketCloudSource) GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(ctx, store, repo, s.client.Authenticator())
+func (s BitbucketCloudSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.client.Authenticator())
 }
 
 // WithAuthenticator returns a copy of the original Source configured to use the

--- a/enterprise/internal/batches/sources/bitbucketcloud_test.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud_test.go
@@ -13,7 +13,6 @@ import (
 	bbcs "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/bitbucketcloud"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
@@ -61,15 +60,6 @@ func TestBitbucketCloudSource_GitserverPushConfig(t *testing.T) {
 	s, client := mockBitbucketCloudSource()
 	client.AuthenticatorFunc.SetDefaultReturn(&au)
 
-	ctx := context.Background()
-
-	svc := types.ExternalService{
-		Kind:   extsvc.KindBitbucketCloud,
-		Config: extsvc.NewEmptyConfig(),
-	}
-	store := database.NewStrictMockExternalServiceStore()
-	store.ListFunc.SetDefaultReturn([]*types.ExternalService{&svc}, nil)
-
 	repo := &types.Repo{
 		ExternalRepo: api.ExternalRepoSpec{
 			ServiceType: extsvc.TypeBitbucketCloud,
@@ -92,7 +82,7 @@ func TestBitbucketCloudSource_GitserverPushConfig(t *testing.T) {
 		},
 	}
 
-	pushConfig, err := s.GitserverPushConfig(ctx, store, repo)
+	pushConfig, err := s.GitserverPushConfig(repo)
 	assert.Nil(t, err)
 	assert.NotNil(t, pushConfig)
 	assert.Equal(t, "https://user:pass@bitbucket.org/clone/link", pushConfig.RemoteURL)

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -57,8 +57,8 @@ func NewBitbucketServerSource(ctx context.Context, svc *types.ExternalService, c
 	}, nil
 }
 
-func (s BitbucketServerSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(ctx, repo, s.au)
+func (s BitbucketServerSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(repo, s.au)
 }
 
 func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/inconshreveable/log15"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -58,8 +57,8 @@ func NewBitbucketServerSource(ctx context.Context, svc *types.ExternalService, c
 	}, nil
 }
 
-func (s BitbucketServerSource) GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(ctx, store, repo, s.au)
+func (s BitbucketServerSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.au)
 }
 
 func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/common.go
+++ b/enterprise/internal/batches/sources/common.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -66,7 +65,7 @@ type ForkableChangesetSource interface {
 type ChangesetSource interface {
 	// GitserverPushConfig returns an authenticated push config used for pushing
 	// commits to the code host.
-	GitserverPushConfig(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)
+	GitserverPushConfig(context.Context, *types.Repo) (*protocol.PushConfig, error)
 	// WithAuthenticator returns a copy of the original Source configured to use
 	// the given authenticator, provided that authenticator type is supported by
 	// the code host.

--- a/enterprise/internal/batches/sources/common.go
+++ b/enterprise/internal/batches/sources/common.go
@@ -65,7 +65,7 @@ type ForkableChangesetSource interface {
 type ChangesetSource interface {
 	// GitserverPushConfig returns an authenticated push config used for pushing
 	// commits to the code host.
-	GitserverPushConfig(context.Context, *types.Repo) (*protocol.PushConfig, error)
+	GitserverPushConfig(*types.Repo) (*protocol.PushConfig, error)
 	// WithAuthenticator returns a copy of the original Source configured to use
 	// the given authenticator, provided that authenticator type is supported by
 	// the code host.

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -73,8 +73,8 @@ func newGithubSource(urn string, c *schema.GitHubConnection, cf *httpcli.Factory
 	}, nil
 }
 
-func (s GithubSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(ctx, repo, s.au)
+func (s GithubSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(repo, s.au)
 }
 
 func (s GithubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -74,8 +73,8 @@ func newGithubSource(urn string, c *schema.GitHubConnection, cf *httpcli.Factory
 	}, nil
 }
 
-func (s GithubSource) GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(ctx, store, repo, s.au)
+func (s GithubSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.au)
 }
 
 func (s GithubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -76,8 +76,8 @@ func newGitLabSource(urn string, c *schema.GitLabConnection, cf *httpcli.Factory
 	}, nil
 }
 
-func (s GitLabSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(ctx, repo, s.au)
+func (s GitLabSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(repo, s.au)
 }
 
 func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
@@ -77,8 +76,8 @@ func newGitLabSource(urn string, c *schema.GitLabConnection, cf *httpcli.Factory
 	}, nil
 }
 
-func (s GitLabSource) GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(ctx, store, repo, s.au)
+func (s GitLabSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.au)
 }
 
 func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/mocks_test.go
+++ b/enterprise/internal/batches/sources/mocks_test.go
@@ -77,7 +77,7 @@ func NewMockChangesetSource() *MockChangesetSource {
 			},
 		},
 		GitserverPushConfigFunc: &ChangesetSourceGitserverPushConfigFunc{
-			defaultHook: func(context.Context, database.ExternalServiceStore, *types.Repo) (r0 *protocol.PushConfig, r1 error) {
+			defaultHook: func(*types.Repo) (r0 *protocol.PushConfig, r1 error) {
 				return
 			},
 		},
@@ -134,7 +134,7 @@ func NewStrictMockChangesetSource() *MockChangesetSource {
 			},
 		},
 		GitserverPushConfigFunc: &ChangesetSourceGitserverPushConfigFunc{
-			defaultHook: func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error) {
+			defaultHook: func(*types.Repo) (*protocol.PushConfig, error) {
 				panic("unexpected invocation of MockChangesetSource.GitserverPushConfig")
 			},
 		},
@@ -539,24 +539,24 @@ func (c ChangesetSourceCreateCommentFuncCall) Results() []interface{} {
 // GitserverPushConfig method of the parent MockChangesetSource instance is
 // invoked.
 type ChangesetSourceGitserverPushConfigFunc struct {
-	defaultHook func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)
-	hooks       []func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)
+	defaultHook func(*types.Repo) (*protocol.PushConfig, error)
+	hooks       []func(*types.Repo) (*protocol.PushConfig, error)
 	history     []ChangesetSourceGitserverPushConfigFuncCall
 	mutex       sync.Mutex
 }
 
 // GitserverPushConfig delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockChangesetSource) GitserverPushConfig(v0 context.Context, v1 database.ExternalServiceStore, v2 *types.Repo) (*protocol.PushConfig, error) {
-	r0, r1 := m.GitserverPushConfigFunc.nextHook()(v0, v1, v2)
-	m.GitserverPushConfigFunc.appendCall(ChangesetSourceGitserverPushConfigFuncCall{v0, v1, v2, r0, r1})
+func (m *MockChangesetSource) GitserverPushConfig(v0 *types.Repo) (*protocol.PushConfig, error) {
+	r0, r1 := m.GitserverPushConfigFunc.nextHook()(v0)
+	m.GitserverPushConfigFunc.appendCall(ChangesetSourceGitserverPushConfigFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the GitserverPushConfig
 // method of the parent MockChangesetSource instance is invoked and the hook
 // queue is empty.
-func (f *ChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)) {
+func (f *ChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(*types.Repo) (*protocol.PushConfig, error)) {
 	f.defaultHook = hook
 }
 
@@ -565,7 +565,7 @@ func (f *ChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(contex
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *ChangesetSourceGitserverPushConfigFunc) PushHook(hook func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)) {
+func (f *ChangesetSourceGitserverPushConfigFunc) PushHook(hook func(*types.Repo) (*protocol.PushConfig, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -574,19 +574,19 @@ func (f *ChangesetSourceGitserverPushConfigFunc) PushHook(hook func(context.Cont
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ChangesetSourceGitserverPushConfigFunc) SetDefaultReturn(r0 *protocol.PushConfig, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error) {
+	f.SetDefaultHook(func(*types.Repo) (*protocol.PushConfig, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ChangesetSourceGitserverPushConfigFunc) PushReturn(r0 *protocol.PushConfig, r1 error) {
-	f.PushHook(func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error) {
+	f.PushHook(func(*types.Repo) (*protocol.PushConfig, error) {
 		return r0, r1
 	})
 }
 
-func (f *ChangesetSourceGitserverPushConfigFunc) nextHook() func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error) {
+func (f *ChangesetSourceGitserverPushConfigFunc) nextHook() func(*types.Repo) (*protocol.PushConfig, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -622,13 +622,7 @@ func (f *ChangesetSourceGitserverPushConfigFunc) History() []ChangesetSourceGits
 type ChangesetSourceGitserverPushConfigFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 database.ExternalServiceStore
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 *types.Repo
+	Arg0 *types.Repo
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *protocol.PushConfig
@@ -640,7 +634,7 @@ type ChangesetSourceGitserverPushConfigFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ChangesetSourceGitserverPushConfigFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
@@ -1367,7 +1361,7 @@ func NewMockForkableChangesetSource() *MockForkableChangesetSource {
 			},
 		},
 		GitserverPushConfigFunc: &ForkableChangesetSourceGitserverPushConfigFunc{
-			defaultHook: func(context.Context, database.ExternalServiceStore, *types.Repo) (r0 *protocol.PushConfig, r1 error) {
+			defaultHook: func(*types.Repo) (r0 *protocol.PushConfig, r1 error) {
 				return
 			},
 		},
@@ -1435,7 +1429,7 @@ func NewStrictMockForkableChangesetSource() *MockForkableChangesetSource {
 			},
 		},
 		GitserverPushConfigFunc: &ForkableChangesetSourceGitserverPushConfigFunc{
-			defaultHook: func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error) {
+			defaultHook: func(*types.Repo) (*protocol.PushConfig, error) {
 				panic("unexpected invocation of MockForkableChangesetSource.GitserverPushConfig")
 			},
 		},
@@ -2079,24 +2073,24 @@ func (c ForkableChangesetSourceGetUserForkFuncCall) Results() []interface{} {
 // when the GitserverPushConfig method of the parent
 // MockForkableChangesetSource instance is invoked.
 type ForkableChangesetSourceGitserverPushConfigFunc struct {
-	defaultHook func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)
-	hooks       []func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)
+	defaultHook func(*types.Repo) (*protocol.PushConfig, error)
+	hooks       []func(*types.Repo) (*protocol.PushConfig, error)
 	history     []ForkableChangesetSourceGitserverPushConfigFuncCall
 	mutex       sync.Mutex
 }
 
 // GitserverPushConfig delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockForkableChangesetSource) GitserverPushConfig(v0 context.Context, v1 database.ExternalServiceStore, v2 *types.Repo) (*protocol.PushConfig, error) {
-	r0, r1 := m.GitserverPushConfigFunc.nextHook()(v0, v1, v2)
-	m.GitserverPushConfigFunc.appendCall(ForkableChangesetSourceGitserverPushConfigFuncCall{v0, v1, v2, r0, r1})
+func (m *MockForkableChangesetSource) GitserverPushConfig(v0 *types.Repo) (*protocol.PushConfig, error) {
+	r0, r1 := m.GitserverPushConfigFunc.nextHook()(v0)
+	m.GitserverPushConfigFunc.appendCall(ForkableChangesetSourceGitserverPushConfigFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the GitserverPushConfig
 // method of the parent MockForkableChangesetSource instance is invoked and
 // the hook queue is empty.
-func (f *ForkableChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)) {
+func (f *ForkableChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(*types.Repo) (*protocol.PushConfig, error)) {
 	f.defaultHook = hook
 }
 
@@ -2105,7 +2099,7 @@ func (f *ForkableChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook fun
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *ForkableChangesetSourceGitserverPushConfigFunc) PushHook(hook func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)) {
+func (f *ForkableChangesetSourceGitserverPushConfigFunc) PushHook(hook func(*types.Repo) (*protocol.PushConfig, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2114,19 +2108,19 @@ func (f *ForkableChangesetSourceGitserverPushConfigFunc) PushHook(hook func(cont
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ForkableChangesetSourceGitserverPushConfigFunc) SetDefaultReturn(r0 *protocol.PushConfig, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error) {
+	f.SetDefaultHook(func(*types.Repo) (*protocol.PushConfig, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ForkableChangesetSourceGitserverPushConfigFunc) PushReturn(r0 *protocol.PushConfig, r1 error) {
-	f.PushHook(func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error) {
+	f.PushHook(func(*types.Repo) (*protocol.PushConfig, error) {
 		return r0, r1
 	})
 }
 
-func (f *ForkableChangesetSourceGitserverPushConfigFunc) nextHook() func(context.Context, database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error) {
+func (f *ForkableChangesetSourceGitserverPushConfigFunc) nextHook() func(*types.Repo) (*protocol.PushConfig, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2163,13 +2157,7 @@ func (f *ForkableChangesetSourceGitserverPushConfigFunc) History() []ForkableCha
 type ForkableChangesetSourceGitserverPushConfigFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 database.ExternalServiceStore
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 *types.Repo
+	Arg0 *types.Repo
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *protocol.PushConfig
@@ -2181,7 +2169,7 @@ type ForkableChangesetSourceGitserverPushConfigFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ForkableChangesetSourceGitserverPushConfigFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
@@ -2849,9 +2837,6 @@ func (c ForkableChangesetSourceWithAuthenticatorFuncCall) Results() []interface{
 // github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources)
 // used for unit testing.
 type MockSourcerStore struct {
-	// DatabaseDBFunc is an instance of a mock function object controlling
-	// the behavior of the method DatabaseDB.
-	DatabaseDBFunc *SourcerStoreDatabaseDBFunc
 	// ExternalServicesFunc is an instance of a mock function object
 	// controlling the behavior of the method ExternalServices.
 	ExternalServicesFunc *SourcerStoreExternalServicesFunc
@@ -2876,11 +2861,6 @@ type MockSourcerStore struct {
 // methods return zero values for all results, unless overwritten.
 func NewMockSourcerStore() *MockSourcerStore {
 	return &MockSourcerStore{
-		DatabaseDBFunc: &SourcerStoreDatabaseDBFunc{
-			defaultHook: func() (r0 database.DB) {
-				return
-			},
-		},
 		ExternalServicesFunc: &SourcerStoreExternalServicesFunc{
 			defaultHook: func() (r0 database.ExternalServiceStore) {
 				return
@@ -2918,11 +2898,6 @@ func NewMockSourcerStore() *MockSourcerStore {
 // interface. All methods panic on invocation, unless overwritten.
 func NewStrictMockSourcerStore() *MockSourcerStore {
 	return &MockSourcerStore{
-		DatabaseDBFunc: &SourcerStoreDatabaseDBFunc{
-			defaultHook: func() database.DB {
-				panic("unexpected invocation of MockSourcerStore.DatabaseDB")
-			},
-		},
 		ExternalServicesFunc: &SourcerStoreExternalServicesFunc{
 			defaultHook: func() database.ExternalServiceStore {
 				panic("unexpected invocation of MockSourcerStore.ExternalServices")
@@ -2961,9 +2936,6 @@ func NewStrictMockSourcerStore() *MockSourcerStore {
 // overwritten.
 func NewMockSourcerStoreFrom(i SourcerStore) *MockSourcerStore {
 	return &MockSourcerStore{
-		DatabaseDBFunc: &SourcerStoreDatabaseDBFunc{
-			defaultHook: i.DatabaseDB,
-		},
 		ExternalServicesFunc: &SourcerStoreExternalServicesFunc{
 			defaultHook: i.ExternalServices,
 		},
@@ -2983,105 +2955,6 @@ func NewMockSourcerStoreFrom(i SourcerStore) *MockSourcerStore {
 			defaultHook: i.UserCredentials,
 		},
 	}
-}
-
-// SourcerStoreDatabaseDBFunc describes the behavior when the DatabaseDB
-// method of the parent MockSourcerStore instance is invoked.
-type SourcerStoreDatabaseDBFunc struct {
-	defaultHook func() database.DB
-	hooks       []func() database.DB
-	history     []SourcerStoreDatabaseDBFuncCall
-	mutex       sync.Mutex
-}
-
-// DatabaseDB delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockSourcerStore) DatabaseDB() database.DB {
-	r0 := m.DatabaseDBFunc.nextHook()()
-	m.DatabaseDBFunc.appendCall(SourcerStoreDatabaseDBFuncCall{r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the DatabaseDB method of
-// the parent MockSourcerStore instance is invoked and the hook queue is
-// empty.
-func (f *SourcerStoreDatabaseDBFunc) SetDefaultHook(hook func() database.DB) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// DatabaseDB method of the parent MockSourcerStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *SourcerStoreDatabaseDBFunc) PushHook(hook func() database.DB) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *SourcerStoreDatabaseDBFunc) SetDefaultReturn(r0 database.DB) {
-	f.SetDefaultHook(func() database.DB {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *SourcerStoreDatabaseDBFunc) PushReturn(r0 database.DB) {
-	f.PushHook(func() database.DB {
-		return r0
-	})
-}
-
-func (f *SourcerStoreDatabaseDBFunc) nextHook() func() database.DB {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *SourcerStoreDatabaseDBFunc) appendCall(r0 SourcerStoreDatabaseDBFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of SourcerStoreDatabaseDBFuncCall objects
-// describing the invocations of this function.
-func (f *SourcerStoreDatabaseDBFunc) History() []SourcerStoreDatabaseDBFuncCall {
-	f.mutex.Lock()
-	history := make([]SourcerStoreDatabaseDBFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// SourcerStoreDatabaseDBFuncCall is an object that describes an invocation
-// of method DatabaseDB on an instance of MockSourcerStore.
-type SourcerStoreDatabaseDBFuncCall struct {
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 database.DB
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c SourcerStoreDatabaseDBFuncCall) Args() []interface{} {
-	return []interface{}{}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c SourcerStoreDatabaseDBFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // SourcerStoreExternalServicesFunc describes the behavior when the

--- a/enterprise/internal/batches/sources/sources.go
+++ b/enterprise/internal/batches/sources/sources.go
@@ -292,13 +292,10 @@ func loadExternalService(ctx context.Context, s database.ExternalServiceStore, o
 		}
 
 		switch cfg.(type) {
-		case *schema.GitHubConnection:
-			return e, nil
-		case *schema.BitbucketServerConnection:
-			return e, nil
-		case *schema.GitLabConnection:
-			return e, nil
-		case *schema.BitbucketCloudConnection:
+		case *schema.GitHubConnection,
+			*schema.BitbucketServerConnection,
+			*schema.GitLabConnection,
+			*schema.BitbucketCloudConnection:
 			return e, nil
 		}
 	}

--- a/enterprise/internal/batches/sources/sources.go
+++ b/enterprise/internal/batches/sources/sources.go
@@ -6,8 +6,6 @@ import (
 	"net/url"
 	"sort"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -16,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -43,7 +40,6 @@ func (e ErrNoPushCredentials) Error() string {
 var ErrNoSSHCredential = errors.New("authenticator doesn't support SSH")
 
 type SourcerStore interface {
-	DatabaseDB() database.DB
 	GetBatchChange(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error)
 	GetSiteCredential(ctx context.Context, opts store.GetSiteCredentialOpts) (*btypes.SiteCredential, error)
 	GetExternalServiceIDs(ctx context.Context, opts store.GetExternalServiceIDsOpts) ([]int64, error)
@@ -55,9 +51,25 @@ type SourcerStore interface {
 // Sourcer exposes methods to get a ChangesetSource based on a changeset, repo or
 // external service.
 type Sourcer interface {
+	// ForChangeset returns a ChangesetSource for the given changeset. The changeset.RepoID
+	// is used to find the matching code host.
+	// It authenticates the given ChangesetSource with a
+	// credential appropriate to sync or reconcile the given changeset. If the
+	// changeset was created by a batch change, then authentication will be based on
+	// the first available option of:
+	//
+	// 1. The last applying user's credentials.
+	// 2. Any available site credential matching the changesets repo.
+	//
+	// If the changeset was not created by a batch change, then a site credential
+	// will be used.
 	ForChangeset(ctx context.Context, tx SourcerStore, ch *btypes.Changeset) (ChangesetSource, error)
-	ForRepo(ctx context.Context, tx SourcerStore, repo *types.Repo) (ChangesetSource, error)
-	ForExternalService(ctx context.Context, tx SourcerStore, opts store.GetExternalServiceIDsOpts) (ChangesetSource, error)
+	// ForUser returns a ChangesetSource for changesets on the given repo.
+	// It will be authenticated with the given authenticator.
+	ForUser(ctx context.Context, tx SourcerStore, uid int32, repo *types.Repo) (ChangesetSource, error)
+	// ForExternalService returns a ChangesetSource based on the provided external service opts.
+	// It will be authenticated with the given authenticator.
+	ForExternalService(ctx context.Context, tx SourcerStore, au auth.Authenticator, opts store.GetExternalServiceIDsOpts) (ChangesetSource, error)
 }
 
 type sourcer struct {
@@ -71,29 +83,52 @@ func NewSourcer(cf *httpcli.Factory) Sourcer {
 	}
 }
 
-// ForChangeset returns a ChangesetSource for the given changeset. The changeset.RepoID
-// is used to find the matching code host.
 func (s *sourcer) ForChangeset(ctx context.Context, tx SourcerStore, ch *btypes.Changeset) (ChangesetSource, error) {
 	repo, err := tx.Repos().Get(ctx, ch.RepoID)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading changeset repo")
 	}
-	return s.ForRepo(ctx, tx, repo)
-}
-
-// ForRepo returns a ChangesetSource for the given repo.
-func (s *sourcer) ForRepo(ctx context.Context, tx SourcerStore, repo *types.Repo) (ChangesetSource, error) {
 	// Consider all available external services for this repo.
-	return s.loadBatchesSource(ctx, tx, repo.ExternalServiceIDs())
+	css, err := s.loadBatchesSource(ctx, tx, repo.ExternalServiceIDs())
+	if err != nil {
+		return nil, err
+	}
+	if ch.OwnedByBatchChangeID != 0 {
+		batchChange, err := loadBatchChange(ctx, tx, ch.OwnedByBatchChangeID)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load owning batch change")
+		}
+
+		return withAuthenticatorForUser(ctx, tx, css, batchChange.LastApplierID, repo)
+	}
+
+	return withSiteAuthenticator(ctx, tx, css, repo)
 }
 
-// ForExternalService returns a ChangesetSource based on the provided external service opts.
-func (s *sourcer) ForExternalService(ctx context.Context, tx SourcerStore, opts store.GetExternalServiceIDsOpts) (ChangesetSource, error) {
+func (s *sourcer) ForUser(ctx context.Context, tx SourcerStore, uid int32, repo *types.Repo) (ChangesetSource, error) {
+	// Consider all available external services for this repo.
+	css, err := s.loadBatchesSource(ctx, tx, repo.ExternalServiceIDs())
+	if err != nil {
+		return nil, err
+	}
+	return withAuthenticatorForUser(ctx, tx, css, uid, repo)
+}
+
+func (s *sourcer) ForExternalService(ctx context.Context, tx SourcerStore, au auth.Authenticator, opts store.GetExternalServiceIDsOpts) (ChangesetSource, error) {
+	// Empty authenticators are not allowed.
+	if au == nil {
+		return nil, ErrNoPushCredentials{}
+	}
+
 	extSvcIDs, err := tx.GetExternalServiceIDs(ctx, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading external service IDs")
 	}
-	return s.loadBatchesSource(ctx, tx, extSvcIDs)
+	css, err := s.loadBatchesSource(ctx, tx, extSvcIDs)
+	if err != nil {
+		return nil, err
+	}
+	return css.WithAuthenticator(au)
 }
 
 func (s *sourcer) loadBatchesSource(ctx context.Context, tx SourcerStore, externalServiceIDs []int64) (ChangesetSource, error) {
@@ -107,74 +142,61 @@ func (s *sourcer) loadBatchesSource(ctx context.Context, tx SourcerStore, extern
 	if err != nil {
 		return nil, errors.Wrap(err, "building changeset source")
 	}
-	// TODO: This should be the default, once we don't use external service tokens anymore.
-	// This ensures that we never use a changeset source without an authenticator.
-	// cred, err := loadSiteCredential(ctx, tx, repo)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// if cred != nil {
-	// 	return css.WithAuthenticator(cred)
-	// }
 	return css, nil
 }
 
 // GitserverPushConfig creates a push configuration given a repo and an
 // authenticator. This function is only public for testing purposes, and should
 // not be used otherwise.
-func GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo, au auth.Authenticator) (*protocol.PushConfig, error) {
+func GitserverPushConfig(ctx context.Context, repo *types.Repo, au auth.Authenticator) (*protocol.PushConfig, error) {
 	// Empty authenticators are not allowed.
 	if au == nil {
 		return nil, ErrNoPushCredentials{}
 	}
 
-	extSvcType := repo.ExternalRepo.ServiceType
-	cloneURL, err := extractCloneURL(ctx, store, repo)
+	cloneURL, err := extractCloneURL(ctx, repo)
 	if err != nil {
 		return nil, err
 	}
-	u, err := vcs.ParseURL(cloneURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing repository clone URL")
-	}
 
 	// If the repo is cloned using SSH, we need to pass along a private key and passphrase.
-	if u.IsSSH() {
+	if cloneURL.IsSSH() {
 		sshA, ok := au.(auth.AuthenticatorWithSSH)
 		if !ok {
 			return nil, ErrNoSSHCredential
 		}
 		privateKey, passphrase := sshA.SSHPrivateKey()
 		return &protocol.PushConfig{
-			RemoteURL:  cloneURL,
+			RemoteURL:  cloneURL.String(),
 			PrivateKey: privateKey,
 			Passphrase: passphrase,
 		}, nil
 	}
 
+	extSvcType := repo.ExternalRepo.ServiceType
 	switch av := au.(type) {
 	case *auth.OAuthBearerTokenWithSSH:
-		if err := setOAuthTokenAuth(u, extSvcType, av.Token); err != nil {
+		if err := setOAuthTokenAuth(cloneURL, extSvcType, av.Token); err != nil {
 			return nil, err
 		}
 	case *auth.OAuthBearerToken:
-		if err := setOAuthTokenAuth(u, extSvcType, av.Token); err != nil {
+		if err := setOAuthTokenAuth(cloneURL, extSvcType, av.Token); err != nil {
 			return nil, err
 		}
 
 	case *auth.BasicAuthWithSSH:
-		if err := setBasicAuth(u, extSvcType, av.Username, av.Password); err != nil {
+		if err := setBasicAuth(cloneURL, extSvcType, av.Username, av.Password); err != nil {
 			return nil, err
 		}
 	case *auth.BasicAuth:
-		if err := setBasicAuth(u, extSvcType, av.Username, av.Password); err != nil {
+		if err := setBasicAuth(cloneURL, extSvcType, av.Username, av.Password); err != nil {
 			return nil, err
 		}
 	default:
 		return nil, ErrNoPushCredentials{CredentialsType: fmt.Sprintf("%T", au)}
 	}
 
-	return &protocol.PushConfig{RemoteURL: u.String()}, nil
+	return &protocol.PushConfig{RemoteURL: cloneURL.String()}, nil
 }
 
 // ToDraftChangesetSource returns a DraftChangesetSource, if the underlying
@@ -185,42 +207,6 @@ func ToDraftChangesetSource(css ChangesetSource) (DraftChangesetSource, error) {
 		return nil, errors.New("changeset source doesn't implement DraftChangesetSource")
 	}
 	return draftCss, nil
-}
-
-// WithAuthenticatorForChangeset authenticates the given ChangesetSource with a
-// credential appropriate to sync or reconcile the given changeset. If the
-// changeset was created by a batch change, then authentication will be based on
-// the first available option of:
-//
-// 1. The last applying user's credentials.
-// 2. Any available site credential.
-//
-// If the changeset was not created by a batch change, then a site credential
-// will be used.
-func WithAuthenticatorForChangeset(
-	ctx context.Context, tx SourcerStore, css ChangesetSource,
-	ch *btypes.Changeset, repo *types.Repo, allowExternalServiceFallback bool,
-) (ChangesetSource, error) {
-	if ch.OwnedByBatchChangeID != 0 {
-		batchChange, err := loadBatchChange(ctx, tx, ch.OwnedByBatchChangeID)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to load owning batch change")
-		}
-
-		a, err := WithAuthenticatorForUser(ctx, tx, css, batchChange.LastApplierID, repo)
-		// FIXME: If there's no credential, then we fall back through to
-		// withSiteAuthenticator below, which will ultimately use the external
-		// service configuration credential if no site credential is available.
-		// We want to remove that.
-		if err == ErrMissingCredentials && allowExternalServiceFallback {
-			return css, nil
-		}
-		return a, err
-	}
-
-	// Imported changesets are always allowed to fall back to the global token
-	// at present.
-	return withSiteAuthenticator(ctx, tx, css, repo, true)
 }
 
 type getBatchChanger interface {
@@ -242,11 +228,11 @@ func loadBatchChange(ctx context.Context, tx getBatchChanger, id int64) (*btypes
 	return batchChange, nil
 }
 
-// WithAuthenticatorForUser authenticates the given ChangesetSource with a credential
+// withAuthenticatorForUser authenticates the given ChangesetSource with a credential
 // usable by the given user with userID. User credentials are preferred, with a
 // fallback to site credentials. If none of these exist, ErrMissingCredentials
 // is returned.
-func WithAuthenticatorForUser(ctx context.Context, tx SourcerStore, css ChangesetSource, userID int32, repo *types.Repo) (ChangesetSource, error) {
+func withAuthenticatorForUser(ctx context.Context, tx SourcerStore, css ChangesetSource, userID int32, repo *types.Repo) (ChangesetSource, error) {
 	cred, err := loadUserCredential(ctx, tx, userID, repo)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading user credential")
@@ -255,42 +241,30 @@ func WithAuthenticatorForUser(ctx context.Context, tx SourcerStore, css Changese
 		return css.WithAuthenticator(cred)
 	}
 
-	cred, err = loadSiteCredential(ctx, tx, repo)
-	if err != nil {
-		return nil, errors.Wrap(err, "loading site credential")
-	}
-	if cred != nil {
-		return css.WithAuthenticator(cred)
-	}
-
-	// Otherwise, we can't authenticate the given ChangesetSource, so we need to bail out.
-	return nil, ErrMissingCredentials
+	// Fall back to site credentials.
+	return withSiteAuthenticator(ctx, tx, css, repo)
 }
 
 // withSiteAuthenticator uses the site credential of the code host of the passed-in repo.
 // If no credential is found, the original source is returned and uses the external service
 // config.
-func withSiteAuthenticator(
-	ctx context.Context, tx SourcerStore, css ChangesetSource,
-	repo *types.Repo, allowExternalServiceFallback bool,
-) (ChangesetSource, error) {
-	cred, err := loadSiteCredential(ctx, tx, repo)
+func withSiteAuthenticator(ctx context.Context, tx SourcerStore, css ChangesetSource, repo *types.Repo) (ChangesetSource, error) {
+	cred, err := loadSiteCredential(ctx, tx, store.GetSiteCredentialOpts{
+		ExternalServiceType: repo.ExternalRepo.ServiceType,
+		ExternalServiceID:   repo.ExternalRepo.ServiceID,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "loading site credential")
 	}
 	if cred != nil {
 		return css.WithAuthenticator(cred)
 	}
-	if allowExternalServiceFallback {
-		// FIXME: this branch shouldn't exist.
-		return css, nil
-	}
 	return nil, ErrMissingCredentials
 }
 
 // loadExternalService looks up all external services that are connected to the given repo.
-// The first external service to have a token configured will be returned then.
-// If no external service matching the above criteria is found, an error is returned.
+// Global external services are preferred over user-owned external services.
+// If no external service matching the given criteria is found, an error is returned.
 func loadExternalService(ctx context.Context, s database.ExternalServiceStore, opts database.ExternalServicesListOptions) (*types.ExternalService, error) {
 	es, err := s.List(ctx, opts)
 	if err != nil {
@@ -309,32 +283,23 @@ func loadExternalService(ctx context.Context, s database.ExternalServiceStore, o
 			return nil, err
 		}
 
-		switch cfg := cfg.(type) {
+		switch cfg.(type) {
 		case *schema.GitHubConnection:
-			if cfg.Token != "" {
-				return e, nil
-			}
+			return e, nil
 		case *schema.BitbucketServerConnection:
-			if cfg.Token != "" {
-				return e, nil
-			}
+			return e, nil
 		case *schema.GitLabConnection:
-			if cfg.Token != "" {
-				return e, nil
-			}
+			return e, nil
 		case *schema.BitbucketCloudConnection:
-			if cfg.AppPassword != "" {
-				return e, nil
-			}
+			return e, nil
 		}
 	}
 
-	// TODO: Allow external service configs with no token, too.
 	return nil, errors.New("no external services found")
 }
 
-// buildChangesetSource get an authenticated ChangesetSource for the given repo
-// to load the changeset state from.
+// buildChangesetSource builds a ChangesetSource for the given repo to load the
+// changeset state from.
 func buildChangesetSource(ctx context.Context, cf *httpcli.Factory, externalService *types.ExternalService) (ChangesetSource, error) {
 	switch externalService.Kind {
 	case extsvc.KindGitHub:
@@ -370,11 +335,8 @@ func loadUserCredential(ctx context.Context, s SourcerStore, userID int32, repo 
 
 // loadSiteCredential attempts to find a site credential for the given repo.
 // When no credential is found, nil is returned.
-func loadSiteCredential(ctx context.Context, s SourcerStore, repo *types.Repo) (auth.Authenticator, error) {
-	cred, err := s.GetSiteCredential(ctx, store.GetSiteCredentialOpts{
-		ExternalServiceType: repo.ExternalRepo.ServiceType,
-		ExternalServiceID:   repo.ExternalRepo.ServiceID,
-	})
+func loadSiteCredential(ctx context.Context, s SourcerStore, opts store.GetSiteCredentialOpts) (auth.Authenticator, error) {
+	cred, err := s.GetSiteCredential(ctx, opts)
 	if err != nil && err != store.ErrNoResults {
 		return nil, err
 	}
@@ -420,34 +382,16 @@ func setBasicAuth(u *vcs.URL, extSvcType, username, password string) error {
 }
 
 // extractCloneURL returns a remote URL from the repo, preferring HTTPS over SSH.
-func extractCloneURL(ctx context.Context, s database.ExternalServiceStore, repo *types.Repo) (string, error) {
+func extractCloneURL(ctx context.Context, repo *types.Repo) (*vcs.URL, error) {
 	if len(repo.Sources) == 0 {
-		return "", errors.New("no clone URL found for repo")
+		return nil, errors.New("no clone URL found for repo")
 	}
 
-	externalServiceIDs := make([]int64, 0, len(repo.Sources))
-	for _, source := range repo.Sources {
-		externalServiceIDs = append(externalServiceIDs, source.ExternalServiceID())
-	}
-
-	svcs, err := s.List(ctx, database.ExternalServicesListOptions{
-		IDs: externalServiceIDs,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	cloneURLs := make([]*vcs.URL, 0, len(svcs))
-	for _, svc := range svcs {
-		// build the clone url using the external service config instead of using
-		// the source CloneURL field
-		cloneURL, err := repos.EncryptableCloneURL(ctx, log.Scoped("CloneURL", ""), svc.Kind, svc.Config, repo)
+	cloneURLs := make([]*vcs.URL, 0, len(repo.Sources))
+	for _, src := range repo.Sources {
+		parsedURL, err := vcs.ParseURL(src.CloneURL)
 		if err != nil {
-			return "", err
-		}
-		parsedURL, err := vcs.ParseURL(cloneURL)
-		if err != nil {
-			return "", err
+			return nil, err
 		}
 		cloneURLs = append(cloneURLs, parsedURL)
 	}
@@ -455,10 +399,12 @@ func extractCloneURL(ctx context.Context, s database.ExternalServiceStore, repo 
 		return !cloneURLs[i].IsSSH()
 	})
 	cloneURL := cloneURLs[0]
-	// TODO: Do this once we don't want to use existing credentials anymore.
-	// // Remove any existing credentials from the clone URL.
-	// parsedU.User = nil
-	return cloneURL.String(), nil
+	// Remove any existing credentials from the clone URL, external service clone
+	// URLs aren't meant to be used in batch changes.
+	// The CloneURLs on repo.Sources should never contain credentials anymore, but
+	// just be safe.
+	cloneURL.User = nil
+	return cloneURL, nil
 }
 
 var ErrChangesetSourceCannotFork = errors.New("forking is enabled, but the changeset source does not support forks")

--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -592,16 +592,3 @@ func newMockSourcer(css ChangesetSource) Sourcer {
 		return css, nil
 	})
 }
-
-// func TestLoadChangesetSource(t *testing.T) {
-// 	t.Run("owned by missing batch change", func(t *testing.T) {
-// 		fakeSource := &stesting.FakeChangesetSource{}
-// 		sourcer := stesting.NewFakeSourcer(nil, fakeSource)
-// 		_, err := loadChangesetSource(ctx, bstore, sourcer, &btypes.Changeset{
-// 			OwnedByBatchChangeID: 1234,
-// 		}, repo)
-// 		if err == nil {
-// 			t.Error("unexpected nil error")
-// 		}
-// 	})
-// }

--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -453,13 +453,8 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			tx.UserCredentialsFunc.SetDefaultReturn(credStore)
 
 			css := NewMockChangesetSource()
-			want := errors.New("validator was called")
-			css.ValidateAuthenticatorFunc.SetDefaultReturn(want)
-
-			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch)
-			assert.NoError(t, err)
-			assert.Same(t, css, have)
-			assert.Same(t, want, css.ValidateAuthenticator(ctx))
+			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch)
+			assert.Error(t, err)
 		})
 	})
 
@@ -508,10 +503,8 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			want := errors.New("validator was called")
 			css.ValidateAuthenticatorFunc.SetDefaultReturn(want)
 
-			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch)
-			assert.NoError(t, err)
-			assert.Same(t, css, have)
-			assert.Same(t, want, css.ValidateAuthenticator(ctx))
+			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch)
+			assert.Error(t, err)
 		})
 	})
 }
@@ -601,171 +594,14 @@ func newMockSourcer(css ChangesetSource) Sourcer {
 }
 
 // func TestLoadChangesetSource(t *testing.T) {
-// 	ctx := context.Background()
-// 	cf := httpcli.NewFactory(
-// 		func(cli httpcli.Doer) httpcli.Doer {
-// 			return httpcli.DoerFunc(func(req *http.Request) (*http.Response, error) {
-// 				// Don't actually execute the request, just dump the authorization header
-// 				// in the error, so we can assert on it further down.
-// 				return nil, errors.New(req.Header.Get("Authorization"))
-// 			})
-// 		},
-// 		httpcli.NewTimeoutOpt(1*time.Second),
-// 	)
-
-// 	externalService := types.ExternalService{
-// 		ID:          1,
-// 		Kind:        extsvc.KindGitHub,
-// 		DisplayName: "GitHub.com",
-// 		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "token": "123", "authorization": {}}`),
-// 	}
-// 	repo := &types.Repo{
-// 		Name:    api.RepoName("test-repo"),
-// 		URI:     "test-repo",
-// 		Private: true,
-// 		ExternalRepo: api.ExternalRepoSpec{
-// 			ID:          "external-id-123",
-// 			ServiceType: extsvc.TypeGitHub,
-// 			ServiceID:   "https://github.com/",
-// 		},
-// 		Sources: map[string]*types.SourceInfo{
-// 			externalService.URN(): {
-// 				ID:       externalService.URN(),
-// 				CloneURL: "https://123@github.com/sourcegraph/sourcegraph",
-// 			},
-// 		},
-// 	}
-
-// 	newMockStore := func() *MockSyncStore {
-// 		syncStore := newTestStore()
-
-// 		ess := database.NewMockExternalServiceStore()
-// 		ess.ListFunc.SetDefaultHook(func(ctx context.Context, options database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
-// 			return []*types.ExternalService{&externalService}, nil
-// 		})
-// 		syncStore.ExternalServicesFunc.SetDefaultReturn(ess)
-
-// 		return syncStore
-// 	}
-
-// 	t.Run("imported changesets", func(t *testing.T) {
-// 		// Store mocks.
-// 		hasCredential := false
-// 		syncStore := newMockStore()
-// 		syncStore.GetSiteCredentialFunc.SetDefaultHook(func(ctx context.Context, opts store.GetSiteCredentialOpts) (*btypes.SiteCredential, error) {
-// 			if hasCredential {
-// 				cred := &btypes.SiteCredential{Credential: database.NewEmptyCredential()}
-// 				cred.SetAuthenticator(ctx, &auth.OAuthBearerToken{Token: "456"})
-// 				return cred, nil
-// 			}
-// 			return nil, store.ErrNoResults
-// 		})
-
-// 		ch := &btypes.Changeset{OwnedByBatchChangeID: 0}
-
-// 		// If no site-credential exists, the token from the external service should be used.
-// 		src, err := loadChangesetSource(ctx, cf, syncStore, ch, repo)
-// 		if err != nil {
-// 			t.Fatal(err)
+// 	t.Run("owned by missing batch change", func(t *testing.T) {
+// 		fakeSource := &stesting.FakeChangesetSource{}
+// 		sourcer := stesting.NewFakeSourcer(nil, fakeSource)
+// 		_, err := loadChangesetSource(ctx, bstore, sourcer, &btypes.Changeset{
+// 			OwnedByBatchChangeID: 1234,
+// 		}, repo)
+// 		if err == nil {
+// 			t.Error("unexpected nil error")
 // 		}
-// 		if err := src.ValidateAuthenticator(ctx); err == nil {
-// 			t.Fatal("unexpected nil error")
-// 		} else if have, want := err.Error(), "Bearer 123"; have != want {
-// 			t.Fatalf("invalid token used, want=%q have=%q", want, have)
-// 		}
-
-// 		// If one exists, prefer that one over the external service config ones.
-// 		hasCredential = true
-// 		src, err = loadChangesetSource(ctx, cf, syncStore, ch, repo)
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		if err := src.ValidateAuthenticator(ctx); err == nil {
-// 			t.Fatal("unexpected nil error")
-// 		} else if have, want := err.Error(), "Bearer 456"; have != want {
-// 			t.Fatalf("invalid token used, want=%q have=%q", want, have)
-// 		}
-// 	})
-
-// 	t.Run("owned changesets", func(t *testing.T) {
-// 		t.Run("has user credential", func(t *testing.T) {
-// 			bc := &btypes.BatchChange{ID: 1, LastApplierID: 42}
-// 			ch := &btypes.Changeset{OwnedByBatchChangeID: bc.ID}
-
-// 			credStore := database.NewMockUserCredentialsStore()
-// 			credStore.GetByScopeFunc.SetDefaultHook(func(ctx context.Context, opts database.UserCredentialScope) (*database.UserCredential, error) {
-// 				assert.EqualValues(t, repo.ExternalRepo.ServiceID, opts.ExternalServiceID)
-// 				assert.EqualValues(t, repo.ExternalRepo.ServiceType, opts.ExternalServiceType)
-// 				assert.EqualValues(t, bc.LastApplierID, opts.UserID)
-// 				cred := &database.UserCredential{Credential: database.NewEmptyCredential()}
-// 				cred.SetAuthenticator(ctx, &auth.OAuthBearerToken{Token: "789"})
-// 				return cred, nil
-// 			})
-
-// 			syncStore := newMockStore()
-// 			syncStore.UserCredentialsFunc.SetDefaultReturn(credStore)
-// 			syncStore.GetBatchChangeFunc.SetDefaultHook(func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
-// 				assert.EqualValues(t, bc.ID, opts.ID)
-// 				return bc, nil
-// 			})
-
-// 			src, err := loadChangesetSource(ctx, cf, syncStore, ch, repo)
-// 			assert.NoError(t, err)
-
-// 			err = src.ValidateAuthenticator(ctx)
-// 			assert.Error(t, err)
-// 			assert.Equal(t, "Bearer 789", err.Error())
-// 		})
-
-// 		t.Run("site credential only", func(t *testing.T) {
-// 			bc := &btypes.BatchChange{ID: 1, LastApplierID: 42}
-// 			ch := &btypes.Changeset{OwnedByBatchChangeID: bc.ID}
-
-// 			credStore := database.NewMockUserCredentialsStore()
-// 			credStore.GetByScopeFunc.SetDefaultReturn(nil, database.UserCredentialNotFoundErr{})
-
-// 			syncStore := newMockStore()
-// 			syncStore.UserCredentialsFunc.SetDefaultReturn(credStore)
-// 			syncStore.GetBatchChangeFunc.SetDefaultHook(func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
-// 				assert.EqualValues(t, bc.ID, opts.ID)
-// 				return bc, nil
-// 			})
-// 			syncStore.GetSiteCredentialFunc.SetDefaultHook(func(ctx context.Context, opts store.GetSiteCredentialOpts) (*btypes.SiteCredential, error) {
-// 				assert.EqualValues(t, repo.ExternalRepo.ServiceID, opts.ExternalServiceID)
-// 				assert.EqualValues(t, repo.ExternalRepo.ServiceType, opts.ExternalServiceType)
-// 				cred := &btypes.SiteCredential{Credential: database.NewEmptyCredential()}
-// 				cred.SetAuthenticator(ctx, &auth.OAuthBearerToken{Token: "456"})
-// 				return cred, nil
-// 			})
-
-// 			src, err := loadChangesetSource(ctx, cf, syncStore, ch, repo)
-// 			assert.NoError(t, err)
-
-// 			err = src.ValidateAuthenticator(ctx)
-// 			assert.Error(t, err)
-// 			assert.Equal(t, "Bearer 456", err.Error())
-// 		})
-
-// 		t.Run("no user or site credential", func(t *testing.T) {
-// 			bc := &btypes.BatchChange{ID: 1, LastApplierID: 42}
-// 			ch := &btypes.Changeset{OwnedByBatchChangeID: bc.ID}
-
-// 			credStore := database.NewMockUserCredentialsStore()
-// 			credStore.GetByScopeFunc.SetDefaultReturn(nil, database.UserCredentialNotFoundErr{})
-
-// 			syncStore := newMockStore()
-// 			syncStore.UserCredentialsFunc.SetDefaultReturn(credStore)
-// 			syncStore.GetBatchChangeFunc.SetDefaultHook(func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
-// 				assert.EqualValues(t, bc.ID, opts.ID)
-// 				return bc, nil
-// 			})
-
-// 			src, err := loadChangesetSource(ctx, cf, syncStore, ch, repo)
-// 			assert.NoError(t, err)
-
-// 			err = src.ValidateAuthenticator(ctx)
-// 			assert.Error(t, err)
-// 			assert.Equal(t, "Bearer 123", err.Error())
-// 		})
 // 	})
 // }

--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -367,7 +367,9 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			})
 
 			tx := NewMockSourcerStore()
-			tx.ReposFunc.SetDefaultReturn(database.NewMockRepoStore())
+			rs := database.NewMockRepoStore()
+			rs.GetFunc.SetDefaultReturn(repo, nil)
+			tx.ReposFunc.SetDefaultReturn(rs)
 			tx.GetBatchChangeFunc.SetDefaultHook(func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
 				assert.EqualValues(t, bc.ID, opts.ID)
 				return bc, nil
@@ -396,6 +398,9 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			})
 
 			tx := NewMockSourcerStore()
+			rs := database.NewMockRepoStore()
+			rs.GetFunc.SetDefaultReturn(repo, nil)
+			tx.ReposFunc.SetDefaultReturn(rs)
 			tx.GetBatchChangeFunc.SetDefaultHook(func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
 				assert.EqualValues(t, bc.ID, opts.ID)
 				return bc, nil
@@ -433,6 +438,9 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			})
 
 			tx := NewMockSourcerStore()
+			rs := database.NewMockRepoStore()
+			rs.GetFunc.SetDefaultReturn(repo, nil)
+			tx.ReposFunc.SetDefaultReturn(rs)
 			tx.GetBatchChangeFunc.SetDefaultHook(func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
 				assert.EqualValues(t, bc.ID, opts.ID)
 				return bc, nil
@@ -460,6 +468,9 @@ func TestSourcer_ForChangeset(t *testing.T) {
 
 		t.Run("with site credential", func(t *testing.T) {
 			tx := NewMockSourcerStore()
+			rs := database.NewMockRepoStore()
+			rs.GetFunc.SetDefaultReturn(repo, nil)
+			tx.ReposFunc.SetDefaultReturn(rs)
 			tx.GetSiteCredentialFunc.SetDefaultHook(func(ctx context.Context, opts store.GetSiteCredentialOpts) (*btypes.SiteCredential, error) {
 				assert.EqualValues(t, repo.ExternalRepo.ServiceID, opts.ExternalServiceID)
 				assert.EqualValues(t, repo.ExternalRepo.ServiceType, opts.ExternalServiceType)
@@ -484,6 +495,9 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			// When we remove the fallback to the external service
 			// configuration, this test is expected to fail.
 			tx := NewMockSourcerStore()
+			rs := database.NewMockRepoStore()
+			rs.GetFunc.SetDefaultReturn(repo, nil)
+			tx.ReposFunc.SetDefaultReturn(rs)
 			tx.GetSiteCredentialFunc.SetDefaultHook(func(ctx context.Context, opts store.GetSiteCredentialOpts) (*btypes.SiteCredential, error) {
 				assert.EqualValues(t, repo.ExternalRepo.ServiceID, opts.ExternalServiceID)
 				assert.EqualValues(t, repo.ExternalRepo.ServiceType, opts.ExternalServiceType)

--- a/enterprise/internal/batches/sources/testing/fake.go
+++ b/enterprise/internal/batches/sources/testing/fake.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -31,11 +30,11 @@ func (s *fakeSourcer) ForChangeset(ctx context.Context, tx sources.SourcerStore,
 	return s.source, s.err
 }
 
-func (s *fakeSourcer) ForRepo(ctx context.Context, tx sources.SourcerStore, repo *types.Repo) (sources.ChangesetSource, error) {
+func (s *fakeSourcer) ForUser(ctx context.Context, tx sources.SourcerStore, uid int32, repo *types.Repo) (sources.ChangesetSource, error) {
 	return s.source, s.err
 }
 
-func (s *fakeSourcer) ForExternalService(ctx context.Context, tx sources.SourcerStore, opts store.GetExternalServiceIDsOpts) (sources.ChangesetSource, error) {
+func (s *fakeSourcer) ForExternalService(ctx context.Context, tx sources.SourcerStore, au auth.Authenticator, opts store.GetExternalServiceIDsOpts) (sources.ChangesetSource, error) {
 	return s.source, s.err
 }
 
@@ -297,8 +296,8 @@ func (s *FakeChangesetSource) CreateComment(ctx context.Context, c *sources.Chan
 	return s.Err
 }
 
-func (s *FakeChangesetSource) GitserverPushConfig(ctx context.Context, store database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
-	return sources.GitserverPushConfig(ctx, store, repo, s.CurrentAuthenticator)
+func (s *FakeChangesetSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
+	return sources.GitserverPushConfig(repo, s.CurrentAuthenticator)
 }
 
 func (s *FakeChangesetSource) WithAuthenticator(a auth.Authenticator) (sources.ChangesetSource, error) {

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -483,7 +483,13 @@ func (s *changesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 		return err
 	}
 
-	source, err := loadChangesetSource(ctx, s.httpFactory, s.syncStore, cs, repo)
+	// TODO: After this change the syncer will only be able to sync
+	// - changesets created by batch changes
+	// - imported changesets, if a site credential exists.
+	// It can NOT sync imported changesets anymore when only a user credential
+	// is present.
+	srcer := sources.NewSourcer(s.httpFactory)
+	source, err := srcer.ForChangeset(ctx, s.syncStore, cs)
 	if err != nil {
 		if errors.Is(err, store.ErrDeletedNamespace) {
 			syncLogger.Debug("SyncChangeset skipping changeset: namespace deleted")
@@ -536,19 +542,4 @@ func SyncChangeset(ctx context.Context, syncStore SyncStore, source sources.Chan
 	}
 
 	return tx.UpsertChangesetEvents(ctx, events...)
-}
-
-func loadChangesetSource(
-	ctx context.Context, cf *httpcli.Factory, syncStore SyncStore,
-	ch *btypes.Changeset, repo *types.Repo,
-) (sources.ChangesetSource, error) {
-	srcer := sources.NewSourcer(cf)
-	// This is a ChangesetSource authenticated with the external service
-	// token.
-	source, err := srcer.ForRepo(ctx, syncStore, repo)
-	if err != nil {
-		return nil, err
-	}
-
-	return sources.WithAuthenticatorForChangeset(ctx, syncStore, source, ch, repo, true)
 }

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -483,11 +483,6 @@ func (s *changesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 		return err
 	}
 
-	// TODO: After this change the syncer will only be able to sync
-	// - changesets created by batch changes
-	// - imported changesets, if a site credential exists.
-	// It can NOT sync imported changesets anymore when only a user credential
-	// is present.
 	srcer := sources.NewSourcer(s.httpFactory)
 	source, err := srcer.ForChangeset(ctx, s.syncStore, cs)
 	if err != nil {

--- a/enterprise/internal/batches/syncer/syncer_test.go
+++ b/enterprise/internal/batches/syncer/syncer_test.go
@@ -2,7 +2,6 @@ package syncer
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -17,8 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -384,175 +381,5 @@ func TestSyncRegistry_EnqueueChangesetSyncsForRepos(t *testing.T) {
 
 		assert.NoError(t, s.EnqueueChangesetSyncsForRepos(ctx, []api.RepoID{1}))
 		assert.ElementsMatch(t, []int64{1, 2}, <-s.priorityNotify)
-	})
-}
-
-func TestLoadChangesetSource(t *testing.T) {
-	ctx := context.Background()
-	cf := httpcli.NewFactory(
-		func(cli httpcli.Doer) httpcli.Doer {
-			return httpcli.DoerFunc(func(req *http.Request) (*http.Response, error) {
-				// Don't actually execute the request, just dump the authorization header
-				// in the error, so we can assert on it further down.
-				return nil, errors.New(req.Header.Get("Authorization"))
-			})
-		},
-		httpcli.NewTimeoutOpt(1*time.Second),
-	)
-
-	externalService := types.ExternalService{
-		ID:          1,
-		Kind:        extsvc.KindGitHub,
-		DisplayName: "GitHub.com",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "token": "123", "authorization": {}}`),
-	}
-	repo := &types.Repo{
-		Name:    api.RepoName("test-repo"),
-		URI:     "test-repo",
-		Private: true,
-		ExternalRepo: api.ExternalRepoSpec{
-			ID:          "external-id-123",
-			ServiceType: extsvc.TypeGitHub,
-			ServiceID:   "https://github.com/",
-		},
-		Sources: map[string]*types.SourceInfo{
-			externalService.URN(): {
-				ID:       externalService.URN(),
-				CloneURL: "https://123@github.com/sourcegraph/sourcegraph",
-			},
-		},
-	}
-
-	newMockStore := func() *MockSyncStore {
-		syncStore := newTestStore()
-
-		ess := database.NewMockExternalServiceStore()
-		ess.ListFunc.SetDefaultHook(func(ctx context.Context, options database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
-			return []*types.ExternalService{&externalService}, nil
-		})
-		syncStore.ExternalServicesFunc.SetDefaultReturn(ess)
-
-		return syncStore
-	}
-
-	t.Run("imported changesets", func(t *testing.T) {
-		// Store mocks.
-		hasCredential := false
-		syncStore := newMockStore()
-		syncStore.GetSiteCredentialFunc.SetDefaultHook(func(ctx context.Context, opts store.GetSiteCredentialOpts) (*btypes.SiteCredential, error) {
-			if hasCredential {
-				cred := &btypes.SiteCredential{Credential: database.NewEmptyCredential()}
-				cred.SetAuthenticator(ctx, &auth.OAuthBearerToken{Token: "456"})
-				return cred, nil
-			}
-			return nil, store.ErrNoResults
-		})
-
-		ch := &btypes.Changeset{OwnedByBatchChangeID: 0}
-
-		// If no site-credential exists, the token from the external service should be used.
-		src, err := loadChangesetSource(ctx, cf, syncStore, ch, repo)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := src.ValidateAuthenticator(ctx); err == nil {
-			t.Fatal("unexpected nil error")
-		} else if have, want := err.Error(), "Bearer 123"; have != want {
-			t.Fatalf("invalid token used, want=%q have=%q", want, have)
-		}
-
-		// If one exists, prefer that one over the external service config ones.
-		hasCredential = true
-		src, err = loadChangesetSource(ctx, cf, syncStore, ch, repo)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := src.ValidateAuthenticator(ctx); err == nil {
-			t.Fatal("unexpected nil error")
-		} else if have, want := err.Error(), "Bearer 456"; have != want {
-			t.Fatalf("invalid token used, want=%q have=%q", want, have)
-		}
-	})
-
-	t.Run("owned changesets", func(t *testing.T) {
-		t.Run("has user credential", func(t *testing.T) {
-			bc := &btypes.BatchChange{ID: 1, LastApplierID: 42}
-			ch := &btypes.Changeset{OwnedByBatchChangeID: bc.ID}
-
-			credStore := database.NewMockUserCredentialsStore()
-			credStore.GetByScopeFunc.SetDefaultHook(func(ctx context.Context, opts database.UserCredentialScope) (*database.UserCredential, error) {
-				assert.EqualValues(t, repo.ExternalRepo.ServiceID, opts.ExternalServiceID)
-				assert.EqualValues(t, repo.ExternalRepo.ServiceType, opts.ExternalServiceType)
-				assert.EqualValues(t, bc.LastApplierID, opts.UserID)
-				cred := &database.UserCredential{Credential: database.NewEmptyCredential()}
-				cred.SetAuthenticator(ctx, &auth.OAuthBearerToken{Token: "789"})
-				return cred, nil
-			})
-
-			syncStore := newMockStore()
-			syncStore.UserCredentialsFunc.SetDefaultReturn(credStore)
-			syncStore.GetBatchChangeFunc.SetDefaultHook(func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
-				assert.EqualValues(t, bc.ID, opts.ID)
-				return bc, nil
-			})
-
-			src, err := loadChangesetSource(ctx, cf, syncStore, ch, repo)
-			assert.NoError(t, err)
-
-			err = src.ValidateAuthenticator(ctx)
-			assert.Error(t, err)
-			assert.Equal(t, "Bearer 789", err.Error())
-		})
-
-		t.Run("site credential only", func(t *testing.T) {
-			bc := &btypes.BatchChange{ID: 1, LastApplierID: 42}
-			ch := &btypes.Changeset{OwnedByBatchChangeID: bc.ID}
-
-			credStore := database.NewMockUserCredentialsStore()
-			credStore.GetByScopeFunc.SetDefaultReturn(nil, database.UserCredentialNotFoundErr{})
-
-			syncStore := newMockStore()
-			syncStore.UserCredentialsFunc.SetDefaultReturn(credStore)
-			syncStore.GetBatchChangeFunc.SetDefaultHook(func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
-				assert.EqualValues(t, bc.ID, opts.ID)
-				return bc, nil
-			})
-			syncStore.GetSiteCredentialFunc.SetDefaultHook(func(ctx context.Context, opts store.GetSiteCredentialOpts) (*btypes.SiteCredential, error) {
-				assert.EqualValues(t, repo.ExternalRepo.ServiceID, opts.ExternalServiceID)
-				assert.EqualValues(t, repo.ExternalRepo.ServiceType, opts.ExternalServiceType)
-				cred := &btypes.SiteCredential{Credential: database.NewEmptyCredential()}
-				cred.SetAuthenticator(ctx, &auth.OAuthBearerToken{Token: "456"})
-				return cred, nil
-			})
-
-			src, err := loadChangesetSource(ctx, cf, syncStore, ch, repo)
-			assert.NoError(t, err)
-
-			err = src.ValidateAuthenticator(ctx)
-			assert.Error(t, err)
-			assert.Equal(t, "Bearer 456", err.Error())
-		})
-
-		t.Run("no user or site credential", func(t *testing.T) {
-			bc := &btypes.BatchChange{ID: 1, LastApplierID: 42}
-			ch := &btypes.Changeset{OwnedByBatchChangeID: bc.ID}
-
-			credStore := database.NewMockUserCredentialsStore()
-			credStore.GetByScopeFunc.SetDefaultReturn(nil, database.UserCredentialNotFoundErr{})
-
-			syncStore := newMockStore()
-			syncStore.UserCredentialsFunc.SetDefaultReturn(credStore)
-			syncStore.GetBatchChangeFunc.SetDefaultHook(func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
-				assert.EqualValues(t, bc.ID, opts.ID)
-				return bc, nil
-			})
-
-			src, err := loadChangesetSource(ctx, cf, syncStore, ch, repo)
-			assert.NoError(t, err)
-
-			err = src.ValidateAuthenticator(ctx)
-			assert.Error(t, err)
-			assert.Equal(t, "Bearer 123", err.Error())
-		})
 	})
 }

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -40,7 +40,7 @@ func TestRepo(t *testing.T, store database.ExternalServiceStore, serviceKind str
 
 	repo := TestRepoWithService(t, store, fmt.Sprintf("repo-%d", svc.ID), &svc)
 
-	repo.Sources[svc.URN()].CloneURL = "https://secrettoken@github.com/sourcegraph/sourcegraph"
+	repo.Sources[svc.URN()].CloneURL = "https://github.com/sourcegraph/sourcegraph"
 	return repo
 }
 
@@ -103,6 +103,8 @@ func CreateTestRepos(t *testing.T, ctx context.Context, db database.DB, count in
 			URL:           fmt.Sprintf("https://github.com/sourcegraph/%s", string(r.Name)),
 		}
 
+		r.Sources[ext.URN()].CloneURL = fmt.Sprintf("https://github.com/sourcegraph/%s", string(r.Name))
+
 		rs = append(rs, r)
 	}
 
@@ -140,6 +142,8 @@ func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db database.DB, co
 				HTTPURLToRepo: fmt.Sprintf("https://gitlab.com/sourcegraph/%s", string(r.Name)),
 			},
 		}
+
+		r.Sources[ext.URN()].CloneURL = fmt.Sprintf("https://gitlab.com/sourcegraph/%s", string(r.Name))
 
 		rs = append(rs, r)
 	}
@@ -244,6 +248,7 @@ func createBbsRepos(t *testing.T, ctx context.Context, db database.DB, ext *type
 			Href: cloneBaseURL + "/" + string(r.Name),
 		})
 		r.Metadata = &metadata
+		r.Sources[ext.URN()].CloneURL = fmt.Sprintf("%s/%s", cloneBaseURL, string(r.Name))
 		rs = append(rs, r)
 	}
 


### PR DESCRIPTION
This PR completes the deprecation of external service tokens to be used with batch changes.
From now on, all `ChangesetSources` returned from `Sourcer` methods are ensured to be properly authenticated with either a site credential or user credential, where applicable. This will also make sure that we will never accidentally use other tokens. That also means that we don't need so strict constraints on the external service anymore, so we can simply read the `repo.Sources.CloneURL` field and don't have to check if an external service has a token configured. Overall, the logic got much simpler and I was able to eliminate many now redundant tests, as they all just use the already tested sourcer methods now. 

Closes https://github.com/sourcegraph/sourcegraph/issues/25394

## Test plan

Verified locally that things still work, also adjusted the test suite accordingly.