### PR TITLE
Some polish of the admin pages

### DIFF
--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -205,9 +205,10 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                 <span
                   class=""
                 >
-                   
                   <span>
-                    file1.txt
+                    <span>
+                      file1.txt
+                    </span>
                   </span>
                 </span>
               </span>
@@ -234,9 +235,10 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                 <span
                   class=""
                 >
-                   
                   <span>
-                    file2.txt
+                    <span>
+                      file2.txt
+                    </span>
                   </span>
                 </span>
               </span>

--- a/client/shared/src/components/RepoLink.tsx
+++ b/client/shared/src/components/RepoLink.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Link } from '@sourcegraph/wildcard'
+import { LinkOrSpan } from './LinkOrSpan'
 
 /**
  * Returns the friendly display form of the repository name (e.g., removing "github.com/").
@@ -45,18 +45,14 @@ export const RepoLink: React.FunctionComponent<React.PropsWithChildren<Props>> =
 }) => {
     const [repoBase, repoName] = splitPath(displayRepoName(fullRepoName))
     const children = (
-        <span className={className || ''}>
-            {' '}
+        <span className={className}>
             {repoBase ? `${repoBase}/` : null}
             <span className={repoClassName}>{repoName}</span>
         </span>
     )
-    if (to === null) {
-        return children
-    }
     return (
-        <Link className={className || ''} to={to} onClick={onClick}>
+        <LinkOrSpan className={className} to={to} onClick={onClick}>
             {children}
-        </Link>
+        </LinkOrSpan>
     )
 }

--- a/client/shared/src/components/__snapshots__/RepoLink.test.tsx.snap
+++ b/client/shared/src/components/__snapshots__/RepoLink.test.tsx.snap
@@ -5,9 +5,11 @@ exports[`RepoLink renders a fragment when "to" is null 1`] = `
   <span
     class=""
   >
-     my/
     <span>
-      repo
+      my/
+      <span>
+        repo
+      </span>
     </span>
   </span>
 </DocumentFragment>
@@ -19,10 +21,8 @@ exports[`RepoLink renders a link when "to" is set 1`] = `
     class=""
     href="http://example.com"
   >
-    <span
-      class=""
-    >
-       my/
+    <span>
+      my/
       <span>
         repo
       </span>

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -119,6 +119,7 @@ export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildr
                     listClassName="list-group list-group-flush mb-0"
                     noun="code host"
                     pluralNoun="code hosts"
+                    withCenteredSummary={true}
                     queryConnection={queryConnection}
                     nodeComponent={ExternalServiceNode}
                     nodeComponentProps={{
@@ -128,7 +129,6 @@ export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildr
                         afterDeleteRoute,
                     }}
                     hideSearch={true}
-                    noSummaryIfAllNodesVisible={true}
                     cursorPaging={true}
                     updates={updates}
                     history={history}

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -32,7 +32,7 @@ import phabricatorSchemaJSON from '../../../../../schema/phabricator.schema.json
 import pythonPackagesJSON from '../../../../../schema/python-packages.schema.json'
 import rustPackagesJSON from '../../../../../schema/rust-packages.schema.json'
 import { ExternalRepositoryFields, ExternalServiceKind } from '../../graphql-operations'
-import { EditorAction } from '../../site-admin/configHelpers'
+import { EditorAction } from '../../settings/EditorActionsGroup'
 import { PerforceIcon } from '../PerforceIcon'
 
 /**

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.tsx
@@ -118,11 +118,11 @@ export const CodeIntelIndexesPage: FunctionComponent<CodeIntelIndexesPageProps> 
             {!!location.state && <FlashMessage state={location.state.modal} message={location.state.message} />}
 
             <Container>
-                <div className="list-group position-relative">
+                <div className="position-relative">
                     <FilteredConnection<LsifIndexFields, Omit<CodeIntelIndexNodeProps, 'node'>>
                         listComponent="div"
-                        inputClassName="w-auto"
-                        listClassName={classNames(styles.grid, 'mb-3')}
+                        inputClassName="flex-1"
+                        listClassName={classNames('list-group', styles.grid, 'mb-3')}
                         noun="index"
                         pluralNoun="indexes"
                         querySubject={querySubject}

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.tsx
@@ -168,7 +168,7 @@ export const CodeIntelUploadsPage: FunctionComponent<React.PropsWithChildren<Cod
                     <FilteredConnection<LsifUploadFields, Omit<CodeIntelUploadNodeProps, 'node'>>
                         listComponent="div"
                         listClassName={classNames(styles.grid, 'mb-3')}
-                        inputClassName="w-auto"
+                        inputClassName="flex-1"
                         noun="upload"
                         pluralNoun="uploads"
                         nodeComponent={CodeIntelUploadNode}

--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -6,14 +6,12 @@ import { Subscription } from 'rxjs'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Button, LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { SaveToolbarProps, SaveToolbar, SaveToolbarPropsGenerator } from '../components/SaveToolbar'
-import { EditorAction } from '../site-admin/configHelpers'
 
+import { EditorAction, EditorActionsGroup } from './EditorActionsGroup'
 import * as _monacoSettingsEditorModule from './MonacoSettingsEditor'
-
-import adminConfigurationStyles from '../site-admin/SiteAdminConfigurationPage.module.scss'
 
 /**
  * Converts a Monaco/vscode style Disposable object to a simple function that can be added to a rxjs Subscription
@@ -134,21 +132,7 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
         return (
             <div className={this.props.className || ''}>
                 {this.props.actions && (
-                    <div className={adminConfigurationStyles.actionGroups}>
-                        <div className={adminConfigurationStyles.actions}>
-                            {this.props.actions.map(({ id, label }) => (
-                                <Button
-                                    key={id}
-                                    className={adminConfigurationStyles.action}
-                                    onClick={() => this.runAction(id, this.configEditor)}
-                                    variant="secondary"
-                                    size="sm"
-                                >
-                                    {label}
-                                </Button>
-                            ))}
-                        </div>
-                    </div>
+                    <EditorActionsGroup actions={this.props.actions} onClick={this.runAction.bind(this)} />
                 )}
                 <React.Suspense fallback={<LoadingSpinner className="mt-2" />}>
                     <MonacoSettingsEditor
@@ -236,9 +220,9 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
         }
     }
 
-    private runAction(id: string, editor?: _monaco.editor.ICodeEditor): void {
-        if (editor) {
-            const action = editor.getAction(id)
+    private runAction(id: string): void {
+        if (this.configEditor) {
+            const action = this.configEditor.getAction(id)
             action.run().then(
                 () => undefined,
                 error => console.error(error)

--- a/client/web/src/settings/EditorActionsGroup.module.scss
+++ b/client/web/src/settings/EditorActionsGroup.module.scss
@@ -1,0 +1,9 @@
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.action {
+    margin: 0.5rem 0.5rem 0 0;
+    flex: 0 auto;
+}

--- a/client/web/src/settings/EditorActionsGroup.tsx
+++ b/client/web/src/settings/EditorActionsGroup.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+import classNames from 'classnames'
+import * as jsonc from 'jsonc-parser'
+
+import { Button, Text } from '@sourcegraph/wildcard'
+
+import styles from './EditorActionsGroup.module.scss'
+
+/**
+ * A helper function that modifies site configuration to configure specific
+ * common things, such as syncing GitHub repositories.
+ */
+export type ConfigInsertionFunction = (
+    configJSON: string
+) => {
+    /** The edits to make to the input configuration to insert the new configuration. */
+    edits: jsonc.Edit[]
+
+    /** Select text in inserted JSON. */
+    selectText?: string | number
+
+    /**
+     * If set, the selection is an empty selection that begins at the left-hand match of selectText plus this
+     * offset. For example, if selectText is "foo" and cursorOffset is 2, then the final selection will be a cursor
+     * "|" positioned as "fo|o".
+     */
+    cursorOffset?: number
+}
+
+export interface EditorAction {
+    id: string
+    label: string
+    run: ConfigInsertionFunction
+}
+
+export interface EditorActionsGroupProps {
+    actions: EditorAction[]
+    onClick: (id: string) => void
+}
+
+export const EditorActionsGroup: React.FunctionComponent<EditorActionsGroupProps> = ({ actions, onClick }) => (
+    <>
+        <Text className="mb-1">
+            <strong>Quick actions:</strong>
+        </Text>
+        <div className={classNames(styles.actions, 'mb-2')}>
+            {actions.map(({ id, label }) => (
+                <Button key={id} className={styles.action} onClick={() => onClick(id)} variant="secondary" size="sm">
+                    {label}
+                </Button>
+            ))}
+        </div>
+    </>
+)

--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -19,12 +19,11 @@ import * as GQL from '@sourcegraph/shared/src/schema'
 import { gqlToCascade, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { PageHeader } from '@sourcegraph/wildcard'
+import { LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { queryGraphQL } from '../backend/graphql'
 import { HeroPage } from '../components/HeroPage'
-import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 
 import { mergeSettingsSchemas } from './configuration'
@@ -126,7 +125,7 @@ export class SettingsArea extends React.Component<Props, State> {
 
     public render(): JSX.Element | null {
         if (this.state.dataOrError === LOADING) {
-            return null // loading
+            return <LoadingSpinner inline={false} />
         }
         if (isErrorLike(this.state.dataOrError)) {
             return (
@@ -170,7 +169,6 @@ export class SettingsArea extends React.Component<Props, State> {
 
         return (
             <div className={classNames('h-100 d-flex flex-column', this.props.className)}>
-                <PageTitle title="Settings" />
                 <PageHeader headingElement="h2" path={[{ text: `${term} settings` }]} className="mb-3" />
                 {this.props.extraHeader}
                 <Switch>

--- a/client/web/src/settings/SettingsFile.tsx
+++ b/client/web/src/settings/SettingsFile.tsx
@@ -9,13 +9,14 @@ import { distinctUntilChanged, filter, map, startWith } from 'rxjs/operators'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Button, LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { SaveToolbar } from '../components/SaveToolbar'
 import { settingsActions } from '../site-admin/configHelpers'
 import { eventLogger } from '../tracking/eventLogger'
 
-import adminConfigurationStyles from '../site-admin/SiteAdminConfigurationPage.module.scss'
+import { EditorActionsGroup } from './EditorActionsGroup'
+
 import styles from './SettingsFile.module.scss'
 
 interface Props extends ThemeProps, TelemetryProps {
@@ -168,21 +169,7 @@ export class SettingsFile extends React.PureComponent<Props, State> {
 
         return (
             <div className={classNames('test-settings-file d-flex flex-grow-1 flex-column', styles.settingsFile)}>
-                <div className={adminConfigurationStyles.actionGroups}>
-                    <div className={adminConfigurationStyles.actions}>
-                        {settingsActions.map(({ id, label }) => (
-                            <Button
-                                key={id}
-                                className={adminConfigurationStyles.action}
-                                onClick={() => this.runAction(id)}
-                                variant="secondary"
-                                size="sm"
-                            >
-                                {label}
-                            </Button>
-                        ))}
-                    </div>
-                </div>
+                <EditorActionsGroup actions={settingsActions} onClick={this.runAction.bind(this)} />
                 <React.Suspense fallback={<LoadingSpinner className="mt-2" />}>
                     <MonacoSettingsEditor
                         value={contents}

--- a/client/web/src/settings/SettingsPage.tsx
+++ b/client/web/src/settings/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps } from 'react-router'
 import { overwriteSettings } from '@sourcegraph/shared/src/settings/edit'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { Container } from '@sourcegraph/wildcard'
 
 import { SettingsAreaPageProps } from './SettingsArea'
 import { SettingsFile } from './SettingsFile'
@@ -30,16 +31,18 @@ export class SettingsPage extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element | null {
         return (
-            <SettingsFile
-                settings={this.props.data.subjects[this.props.data.subjects.length - 1].latestSettings}
-                jsonSchema={this.props.data.settingsJSONSchema}
-                commitError={this.state.commitError}
-                onDidCommit={this.onDidCommit}
-                onDidDiscard={this.onDidDiscard}
-                history={this.props.history}
-                isLightTheme={this.props.isLightTheme}
-                telemetryService={this.props.telemetryService}
-            />
+            <Container className="mb-3">
+                <SettingsFile
+                    settings={this.props.data.subjects[this.props.data.subjects.length - 1].latestSettings}
+                    jsonSchema={this.props.data.settingsJSONSchema}
+                    commitError={this.state.commitError}
+                    onDidCommit={this.onDidCommit}
+                    onDidDiscard={this.onDidDiscard}
+                    history={this.props.history}
+                    isLightTheme={this.props.isLightTheme}
+                    telemetryService={this.props.telemetryService}
+                />
+            </Container>
         )
     }
 

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.module.scss
@@ -20,23 +20,3 @@
         justify-content: space-between;
     }
 }
-
-.action-groups {
-    background-color: var(--color-bg-2);
-    padding-bottom: 0.5rem;
-    padding-left: 0.5rem;
-}
-
-.action-group-header {
-    font-weight: bold;
-}
-
-.actions {
-    display: flex;
-    flex-wrap: wrap;
-}
-
-.action {
-    margin: 0.5rem 0.5rem 0 0;
-    flex: 0 auto;
-}

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -12,7 +12,7 @@ import * as GQL from '@sourcegraph/shared/src/schema'
 import { SiteConfiguration } from '@sourcegraph/shared/src/schema/site.schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Button, LoadingSpinner, Link, Alert, Code, H2, Text } from '@sourcegraph/wildcard'
+import { Button, LoadingSpinner, Link, Alert, Code, Text, PageHeader, Container } from '@sourcegraph/wildcard'
 
 import siteSchemaJSON from '../../../../schema/site.schema.json'
 import { PageTitle } from '../components/PageTitle'
@@ -376,39 +376,47 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
         return (
             <div>
                 <PageTitle title="Configuration - Admin" />
-                <H2>Site configuration</H2>
-                <Text>
-                    View and edit the Sourcegraph site configuration. See{' '}
-                    <Link to="/help/admin/config/site_config">documentation</Link> for more information.
-                </Text>
-                <div>{alerts}</div>
-                {this.state.loading && <LoadingSpinner />}
-                {this.state.site?.configuration && (
-                    <div>
-                        <DynamicallyImportedMonacoSettingsEditor
-                            value={contents || ''}
-                            jsonSchema={siteSchemaJSON}
-                            canEdit={true}
-                            saving={this.state.saving}
-                            loading={isReloading || this.state.saving}
-                            height={600}
-                            isLightTheme={this.props.isLightTheme}
-                            onSave={this.onSave}
-                            actions={quickConfigureActions}
-                            history={this.props.history}
-                            telemetryService={this.props.telemetryService}
-                            explanation={
-                                <Text className="form-text text-muted">
-                                    <small>
-                                        Use Ctrl+Space for completion, and hover over JSON properties for documentation.
-                                        For more information, see the{' '}
-                                        <Link to="/help/admin/config/site_config">documentation</Link>.
-                                    </small>
-                                </Text>
-                            }
-                        />
-                    </div>
-                )}
+                <PageHeader
+                    path={[{ text: 'Site configuration' }]}
+                    headingElement="h2"
+                    description={
+                        <>
+                            View and edit the Sourcegraph site configuration. See{' '}
+                            <Link to="/help/admin/config/site_config">documentation</Link> for more information.
+                        </>
+                    }
+                    className="mb-3"
+                />
+                <Container className="mb-3">
+                    <div>{alerts}</div>
+                    {this.state.loading && <LoadingSpinner />}
+                    {this.state.site?.configuration && (
+                        <div>
+                            <DynamicallyImportedMonacoSettingsEditor
+                                value={contents || ''}
+                                jsonSchema={siteSchemaJSON}
+                                canEdit={true}
+                                saving={this.state.saving}
+                                loading={isReloading || this.state.saving}
+                                height={600}
+                                isLightTheme={this.props.isLightTheme}
+                                onSave={this.onSave}
+                                actions={quickConfigureActions}
+                                history={this.props.history}
+                                telemetryService={this.props.telemetryService}
+                                explanation={
+                                    <Text className="form-text text-muted">
+                                        <small>
+                                            Use Ctrl+Space for completion, and hover over JSON properties for
+                                            documentation. For more information, see the{' '}
+                                            <Link to="/help/admin/config/site_config">documentation</Link>.
+                                        </small>
+                                    </Text>
+                                }
+                            />
+                        </div>
+                    )}
+                </Container>
             </div>
         )
     }

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -2,14 +2,14 @@ import React, { useCallback, useMemo } from 'react'
 
 import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import { RouteComponentProps, useHistory } from 'react-router'
+import { RouteComponentProps } from 'react-router'
 import { of, Observable, forkJoin } from 'rxjs'
 import { catchError, map, mergeMap } from 'rxjs/operators'
 
 import { asError, ErrorLike, isErrorLike, pluralize } from '@sourcegraph/common'
 import { aggregateStreamingSearch, ContentMatch, LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Link, PageHeader, Container, Button, Code, H3, Text, Icon, Tooltip } from '@sourcegraph/wildcard'
+import { Link, PageHeader, Container, Code, H3, Text, Icon, Tooltip, ButtonLink } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionFilter } from '../components/FilteredConnection'
 import { PageTitle } from '../components/PageTitle'
@@ -123,8 +123,6 @@ const filters: FilteredConnectionFilter[] = [
 export const SiteAdminFeatureFlagsPage: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminFeatureFlagsPageProps>
 > = ({ fetchFeatureFlags = defaultFetchFeatureFlags, productVersion = window.context.version, ...props }) => {
-    const history = useHistory()
-
     // Try to parse out a git rev based on the product version, otherwise just fall back
     // to main.
     const productGitVersion = parseProductReference(productVersion)
@@ -193,22 +191,20 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<
                 ]}
                 description={
                     <>
-                        <Text>
-                            Feature flags, as opposed to experimental features, are intended to be strictly short-lived.
-                            They are designed to be useful for A/B testing, and the values of all active feature flags
-                            are added to every event log for the purpose of analytics. To learn more, refer to{' '}
-                            <Link target="_blank" rel="noopener noreferrer" to="/help/dev/how-to/use_feature_flags">
-                                How to use feature flags
-                            </Link>
-                            .
-                        </Text>
+                        Feature flags, as opposed to experimental features, are intended to be strictly short-lived.
+                        They are designed to be useful for A/B testing, and the values of all active feature flags are
+                        added to every event log for the purpose of analytics. To learn more, refer to{' '}
+                        <Link target="_blank" rel="noopener noreferrer" to="/help/dev/how-to/use_feature_flags">
+                            How to use feature flags
+                        </Link>
+                        .
                     </>
                 }
                 className="mb-3"
                 actions={
-                    <Button variant="primary" onClick={() => history.push('./feature-flags/configuration/new')}>
+                    <ButtonLink variant="primary" to="./feature-flags/configuration/new">
                         Create feature flag
-                    </Button>
+                    </ButtonLink>
                 }
             />
 

--- a/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
@@ -10,7 +10,18 @@ import { parse as _parseVersion, SemVer } from 'semver'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { LoadingSpinner, useObservable, Alert, Icon, Code, H2, H3, Text, Tooltip } from '@sourcegraph/wildcard'
+import {
+    LoadingSpinner,
+    useObservable,
+    Alert,
+    Container,
+    Icon,
+    Code,
+    H3,
+    Text,
+    Tooltip,
+    PageHeader,
+} from '@sourcegraph/wildcard'
 
 import { Collapsible } from '../components/Collapsible'
 import { FilteredConnection, FilteredConnectionFilter, Connection } from '../components/FilteredConnection'
@@ -127,20 +138,26 @@ export const SiteAdminMigrationsPage: React.FunctionComponent<
             ) : (
                 <>
                     <PageTitle title="Out of band migrations - Admin" />
-                    <H2>Out-of-band migrations</H2>
-
-                    <Text>
-                        Out-of-band migrations run in the background of the Sourcegraph instance convert data from an
-                        old format into a new format. Consult this page prior to upgrading your Sourcegraph instance to
-                        ensure that all expected migrations have completed.
-                    </Text>
+                    <PageHeader
+                        path={[{ text: 'Out-of-band migrations' }]}
+                        headingElement="h2"
+                        description={
+                            <>
+                                Out-of-band migrations run in the background of the Sourcegraph instance convert data
+                                from an old format into a new format. Consult this page prior to upgrading your
+                                Sourcegraph instance to ensure that all expected migrations have completed.
+                            </>
+                        }
+                        className="mb-3"
+                    />
 
                     <MigrationBanners migrations={migrationsOrError} fetchSiteUpdateCheck={fetchSiteUpdateCheck} />
 
-                    <div className="list-group">
+                    <Container className="mb-3">
                         <FilteredConnection<OutOfBandMigrationFields, Omit<MigrationNodeProps, 'node'>>
+                            className="mb-0"
                             listComponent="div"
-                            listClassName={classNames('mb-3', styles.migrationsGrid)}
+                            listClassName={classNames('list-group mb-3', styles.migrationsGrid)}
                             noun="migration"
                             pluralNoun="migrations"
                             queryConnection={queryMigrations}
@@ -150,7 +167,7 @@ export const SiteAdminMigrationsPage: React.FunctionComponent<
                             location={props.location}
                             filters={filters}
                         />
-                    </div>
+                    </Container>
                 </>
             )}
         </div>

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -4,10 +4,22 @@ import { mdiCloudDownload, mdiCog } from '@mdi/js'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 
+import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { useQuery } from '@sourcegraph/http-client'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Code, Button, Link, Alert, Icon, H2, Text, Tooltip, Container, LoadingSpinner } from '@sourcegraph/wildcard'
+import {
+    Code,
+    Button,
+    Link,
+    Alert,
+    Icon,
+    Text,
+    Tooltip,
+    Container,
+    LoadingSpinner,
+    PageHeader,
+} from '@sourcegraph/wildcard'
 
 import {
     FilteredConnection,
@@ -36,7 +48,7 @@ interface RepositoryNodeProps {
 
 const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<RepositoryNodeProps>> = ({ node }) => (
     <li
-        className="repository-node list-group-item py-2"
+        className="repository-node list-group-item px-0 py-2"
         data-test-repository={node.name}
         data-test-cloned={node.mirrorInfo.cloned}
     >
@@ -216,25 +228,32 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                     statuses are displayed below.
                 </Alert>
             )}
-            <H2>Repositories</H2>
-            <Text>
-                Repositories are synced from connected{' '}
-                <Link to="/site-admin/external-services" data-testid="test-repositories-code-host-connections-link">
-                    code hosts
-                </Link>
-                .
-            </Text>
+            <PageHeader
+                path={[{ text: 'Repositories' }]}
+                headingElement="h2"
+                description={
+                    <>
+                        Repositories are synced from connected{' '}
+                        <Link
+                            to="/site-admin/external-services"
+                            data-testid="test-repositories-code-host-connections-link"
+                        >
+                            code hosts
+                        </Link>
+                        .
+                    </>
+                }
+                className="mb-3"
+            />
             <Container className="mb-3">
-                {error && !loading && (
-                    <Alert variant="warning" as="p">
-                        {error.message}
-                    </Alert>
-                )}
+                {error && !loading && <ErrorAlert error={error} />}
                 {loading && !error && <LoadingSpinner />}
                 {legends && <ValueLegendList className="mb-3" items={legends} />}
                 <FilteredConnection<SiteAdminRepositoryFields, Omit<RepositoryNodeProps, 'node'>>
                     className="mb-0"
-                    listClassName="list-group list-group-flush mt-3"
+                    listClassName="list-group list-group-flush mb-0"
+                    summaryClassName="mt-2"
+                    withCenteredSummary={true}
                     noun="repository"
                     pluralNoun="repositories"
                     queryConnection={queryRepositories}

--- a/client/web/src/site-admin/SiteAdminSidebar.module.scss
+++ b/client/web/src/site-admin/SiteAdminSidebar.module.scss
@@ -1,0 +1,3 @@
+.nav-item {
+    border-radius: 0;
+}

--- a/client/web/src/site-admin/SiteAdminSidebar.story.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.story.tsx
@@ -19,7 +19,6 @@ export const AdminSidebarItems: Story = () => (
         {webProps => (
             <SiteAdminSidebar
                 {...webProps}
-                className="site-admin-sidebar"
                 groups={siteAdminSidebarGroups}
                 isSourcegraphDotCom={false}
                 batchChangesEnabled={false}

--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import classNames from 'classnames'
-
 import { Link, Icon } from '@sourcegraph/wildcard'
 
 import { BatchChangesProps } from '../batches'
 import { SidebarGroup, SidebarCollapseItems, SidebarNavItem } from '../components/Sidebar'
 import { NavGroupDescriptor } from '../util/contributions'
+
+import styles from './SiteAdminSidebar.module.scss'
 
 export interface SiteAdminSideBarGroupContext extends BatchChangesProps {
     isSourcegraphDotCom: boolean
@@ -20,7 +20,7 @@ export interface SiteAdminSidebarProps extends BatchChangesProps {
     isSourcegraphDotCom: boolean
     /** The items for the side bar, by group */
     groups: SiteAdminSideBarGroups
-    className: string
+    className?: string
 }
 
 /**
@@ -31,7 +31,7 @@ export const SiteAdminSidebar: React.FunctionComponent<React.PropsWithChildren<S
     groups,
     ...props
 }) => (
-    <SidebarGroup className={classNames('site-admin-sidebar', className)}>
+    <SidebarGroup className={className}>
         <ul className="list-group">
             {groups.map(
                 ({ header, items, condition = () => true }, index) =>
@@ -42,7 +42,13 @@ export const SiteAdminSidebar: React.FunctionComponent<React.PropsWithChildren<S
                                 {items.map(
                                     ({ label, to, source = 'client', condition = () => true }) =>
                                         condition(props) && (
-                                            <SidebarNavItem to={to} exact={true} key={label} source={source}>
+                                            <SidebarNavItem
+                                                to={to}
+                                                exact={true}
+                                                key={label}
+                                                source={source}
+                                                className={styles.navItem}
+                                            >
                                                 {label}
                                             </SidebarNavItem>
                                         )
@@ -54,8 +60,10 @@ export const SiteAdminSidebar: React.FunctionComponent<React.PropsWithChildren<S
                             <Link to={items[0].to} className="bg-2 border-0 d-flex list-group-item-action p-2 w-100">
                                 <span>
                                     {header?.icon && (
-                                        <Icon className="sidebar__icon mr-1" as={header.icon} aria-hidden={true} />
-                                    )}{' '}
+                                        <>
+                                            <Icon className="sidebar__icon mr-1" as={header.icon} aria-hidden={true} />{' '}
+                                        </>
+                                    )}
                                     {items[0].label}
                                 </span>
                             </Link>

--- a/client/web/src/site-admin/configHelpers.ts
+++ b/client/web/src/site-admin/configHelpers.ts
@@ -1,5 +1,6 @@
 import { ModificationOptions, modify } from 'jsonc-parser'
 
+import { EditorAction } from '../settings/EditorActionsGroup'
 import { ConfigInsertionFunction } from '../settings/MonacoSettingsEditor'
 
 const defaultModificationOptions: ModificationOptions = {
@@ -31,12 +32,6 @@ const addQuickLinkToSettings: ConfigInsertionFunction = config => {
     }
     const edits = modify(config, ['quicklinks', -1], value, defaultModificationOptions)
     return { edits, selectText: '<name>' }
-}
-
-export interface EditorAction {
-    id: string
-    label: string
-    run: ConfigInsertionFunction
 }
 
 export const settingsActions: EditorAction[] = [


### PR DESCRIPTION
Had a spare hour that I wanted to put to something useful, this is the result of a timeboxed effort. I added a lot of inline comments explaining the changes.


## Test plan

Verified things don't look worse than before and still work like I expect them to.

## App preview:

- [Web](https://sg-web-es-admin-polish.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wchkwlbzza.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

