### PR TITLE
batches: Batch spec list improvements

### DIFF
--- a/client/web/src/enterprise/batches/BatchSpecNode.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.tsx
@@ -8,15 +8,16 @@ import {
     mdiChevronDown,
     mdiChevronRight,
     mdiStar,
+    mdiPencil,
 } from '@mdi/js'
 import classNames from 'classnames'
-import { parseISO } from 'date-fns'
 import { upperFirst } from 'lodash'
 
-import { BatchSpecState } from '@sourcegraph/shared/src/graphql-operations'
+import { BatchSpecSource, BatchSpecState } from '@sourcegraph/shared/src/graphql-operations'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Button, Link, Icon, H3, H4, Tooltip } from '@sourcegraph/wildcard'
 
+import { Duration } from '../../components/time/Duration'
 import { Timestamp } from '../../components/time/Timestamp'
 import { BatchSpecListFields, Scalars } from '../../graphql-operations'
 
@@ -53,8 +54,11 @@ export const BatchSpecNode: React.FunctionComponent<React.PropsWithChildren<Batc
                 <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />
             </Button>
             <div className="d-flex flex-column justify-content-center align-items-center px-2 pb-1">
-                <StateIcon state={node.state} />
-                <span className="text-muted">{upperFirst(node.state.toLowerCase())}</span>
+                <StateIcon source={node.source} state={node.state} />
+                <span className="text-muted">
+                    {node.source === BatchSpecSource.LOCAL && 'Uploaded'}
+                    {node.source !== BatchSpecSource.LOCAL && upperFirst(node.state.toLowerCase())}
+                </span>
             </div>
             <div className="px-2 pb-1">
                 <H3 className="pr-2">
@@ -71,7 +75,7 @@ export const BatchSpecNode: React.FunctionComponent<React.PropsWithChildren<Batc
                                     </Tooltip>{' '}
                                 </>
                             )}
-                            Executed by <strong>{node.creator?.username}</strong>{' '}
+                            Created by <strong>{node.creator?.username}</strong>{' '}
                             <Timestamp date={node.createdAt} now={now} />
                         </Link>
                     )}
@@ -91,13 +95,13 @@ export const BatchSpecNode: React.FunctionComponent<React.PropsWithChildren<Batc
                 </H3>
                 {!currentSpecID && (
                     <small className="text-muted d-block">
-                        Executed by <strong>{node.creator?.username}</strong>{' '}
+                        Created by <strong>{node.creator?.username}</strong>{' '}
                         <Timestamp date={node.createdAt} now={now} />
                     </small>
                 )}
             </div>
             <div className="text-center pb-1">
-                <Duration start={parseISO(node.createdAt)} end={node.finishedAt ? new Date(node.finishedAt) : now()} />
+                {node.startedAt && <Duration start={node.startedAt} end={node.finishedAt ?? undefined} />}
             </div>
             {isExpanded && (
                 <div className={styles.nodeExpandedSection}>
@@ -114,7 +118,16 @@ export const BatchSpecNode: React.FunctionComponent<React.PropsWithChildren<Batc
     )
 }
 
-const StateIcon: React.FunctionComponent<React.PropsWithChildren<{ state: BatchSpecState }>> = ({ state }) => {
+const StateIcon: React.FunctionComponent<
+    React.PropsWithChildren<{ state: BatchSpecState; source: BatchSpecSource }>
+> = ({ state, source }) => {
+    if (source === BatchSpecSource.LOCAL) {
+        ;<Icon
+            aria-hidden={true}
+            className={classNames(styles.nodeStateIcon, 'text-success mb-1')}
+            svgPath={mdiCheckCircle}
+        />
+    }
     switch (state) {
         case BatchSpecState.COMPLETED:
             return (
@@ -146,7 +159,6 @@ const StateIcon: React.FunctionComponent<React.PropsWithChildren<{ state: BatchS
             )
 
         case BatchSpecState.FAILED:
-        default:
             return (
                 <Icon
                     aria-hidden={true}
@@ -154,24 +166,13 @@ const StateIcon: React.FunctionComponent<React.PropsWithChildren<{ state: BatchS
                     svgPath={mdiAlertCircle}
                 />
             )
+        case BatchSpecState.PENDING:
+            return (
+                <Icon
+                    aria-hidden={true}
+                    className={classNames(styles.nodeStateIcon, 'text-muted mb-1')}
+                    svgPath={mdiPencil}
+                />
+            )
     }
-}
-
-const Duration: React.FunctionComponent<React.PropsWithChildren<{ start: Date; end: Date }>> = ({ start, end }) => {
-    // The duration in seconds.
-    let duration = (end.getTime() - start.getTime()) / 1000
-    const hours = Math.floor(duration / (60 * 60))
-    duration -= hours * 60 * 60
-    const minutes = Math.floor(duration / 60)
-    duration -= minutes * 60
-    const seconds = Math.round(duration)
-    return (
-        <>
-            {ensureTwoDigits(hours)}:{ensureTwoDigits(minutes)}:{ensureTwoDigits(seconds)}
-        </>
-    )
-}
-
-function ensureTwoDigits(value: number): string {
-    return value < 10 ? `0${value}` : `${value}`
 }

--- a/client/web/src/enterprise/batches/BatchSpecNode.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.tsx
@@ -122,7 +122,7 @@ const StateIcon: React.FunctionComponent<
     React.PropsWithChildren<{ state: BatchSpecState; source: BatchSpecSource }>
 > = ({ state, source }) => {
     if (source === BatchSpecSource.LOCAL) {
-        ;<Icon
+        return <Icon
             aria-hidden={true}
             className={classNames(styles.nodeStateIcon, 'text-success mb-1')}
             svgPath={mdiCheckCircle}

--- a/client/web/src/enterprise/batches/BatchSpecNode.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.tsx
@@ -122,11 +122,13 @@ const StateIcon: React.FunctionComponent<
     React.PropsWithChildren<{ state: BatchSpecState; source: BatchSpecSource }>
 > = ({ state, source }) => {
     if (source === BatchSpecSource.LOCAL) {
-        return <Icon
-            aria-hidden={true}
-            className={classNames(styles.nodeStateIcon, 'text-success mb-1')}
-            svgPath={mdiCheckCircle}
-        />
+        return (
+            <Icon
+                aria-hidden={true}
+                className={classNames(styles.nodeStateIcon, 'text-success mb-1')}
+                svgPath={mdiCheckCircle}
+            />
+        )
     }
     switch (state) {
         case BatchSpecState.COMPLETED:

--- a/client/web/src/enterprise/batches/backend.ts
+++ b/client/web/src/enterprise/batches/backend.ts
@@ -86,8 +86,10 @@ const BATCH_SPEC_LIST_FIELDS_FRAGMENT = gql`
         __typename
         id
         state
+        startedAt
         finishedAt
         createdAt
+        source
         description {
             name
         }

--- a/client/web/src/enterprise/batches/testData.ts
+++ b/client/web/src/enterprise/batches/testData.ts
@@ -1,15 +1,17 @@
 import { subSeconds } from 'date-fns'
 
-import { BatchSpecListFields, BatchSpecState } from '../../graphql-operations'
+import { BatchSpecListFields, BatchSpecSource, BatchSpecState } from '../../graphql-operations'
 
 const COMMON_NODE_FIELDS = {
     __typename: 'BatchSpec',
     createdAt: subSeconds(new Date(), 30).toISOString(),
+    startedAt: subSeconds(new Date(), 25).toISOString(),
     finishedAt: new Date().toISOString(),
     originalInput: 'name: super-cool-spec',
     description: {
         name: 'super-cool-spec',
     },
+    source: BatchSpecSource.LOCAL,
     namespace: {
         url: '/users/courier-new',
         namespaceName: 'courier-new',

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -269,11 +269,13 @@ const BatchChangeBatchSpecs: (variables: BatchChangeBatchSpecsVariables) => Batc
                     __typename: 'BatchSpec',
                     id: 'Execution',
                     state: BatchSpecState.COMPLETED,
-                    finishedAt: null,
+                    finishedAt: '2022-07-06T23:21:45Z',
                     createdAt: '2022-07-06T23:21:45Z',
                     description: {
                         name: 'test-batch-change',
                     },
+                    source: BatchSpecSource.REMOTE,
+                    startedAt: '2022-07-06T23:21:45Z',
                     namespace: {
                         namespaceName: 'alice',
                         url: '/users/alice',


### PR DESCRIPTION
This page was quickly created for debugging but we never got around putting some more effort into it. Timebox worked on this for a bit to make some improvements.

- Use the Duration component we already made public which has lots of improvements over this one, including live timers and fixed-width handling
- Improve state icons, a pending change should not be text-danger
- Added separate state for src-cli batch specs
- Tweaked wording of executed to created, because not all of them have been executed yet, kinda lazy fix, I know
- Fix execution time calculation, we used createdAt for it before which is incorrect, should be startedAt



## Test plan

Verified things still work and don't look worse than before.

## App preview:

- [Web](https://sg-web-es-batch-spec-list.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-plcioqbfzj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
