### PR TITLE
search: consistent QueryDescription type name

### DIFF
--- a/cmd/frontend/graphqlbackend/search_query_description.go
+++ b/cmd/frontend/graphqlbackend/search_query_description.go
@@ -2,12 +2,8 @@ package graphqlbackend
 
 import "github.com/sourcegraph/sourcegraph/internal/search"
 
-// searchQueryDescriptionResolver is a type for the SearchQueryDescription resolver used
-// by SearchAlert. This name is a bit of a misnomer but cannot be changed: It
-// must be this way to work with the GQL definition and compatibility. We use
-// our internal, resolver-agnostic alert type to do real work.
 type searchQueryDescriptionResolver struct {
-	query *search.ProposedQuery
+	query *search.QueryDescription
 }
 
 func (q searchQueryDescriptionResolver) Query() string {

--- a/cmd/frontend/internal/search/event_writer.go
+++ b/cmd/frontend/internal/search/event_writer.go
@@ -52,14 +52,14 @@ func (e *eventWriter) Error(err error) error {
 }
 
 func (e *eventWriter) Alert(alert *search.Alert) error {
-	var pqs []streamhttp.ProposedQuery
+	var pqs []streamhttp.QueryDescription
 	for _, pq := range alert.ProposedQueries {
 		annotations := make([]streamhttp.Annotation, 0, len(pq.Annotations))
 		for name, value := range pq.Annotations {
 			annotations = append(annotations, streamhttp.Annotation{Name: string(name), Value: value})
 		}
 
-		pqs = append(pqs, streamhttp.ProposedQuery{
+		pqs = append(pqs, streamhttp.QueryDescription{
 			Description: pq.Description,
 			Query:       pq.QueryString(),
 			Annotations: annotations,

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -164,9 +164,9 @@ LOOP:
 		})
 	}
 	if alert != nil {
-		var pqs []streamhttp.ProposedQuery
+		var pqs []streamhttp.QueryDescription
 		for _, pq := range alert.ProposedQueries {
-			pqs = append(pqs, streamhttp.ProposedQuery{
+			pqs = append(pqs, streamhttp.QueryDescription{
 				Description: pq.Description,
 				Query:       pq.QueryString(),
 			})

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -100,16 +100,16 @@ type SearchFileResult struct {
 	} `json:"revSpec"`
 }
 
-type ProposedQuery struct {
+type QueryDescription struct {
 	Description string `json:"description"`
 	Query       string `json:"query"`
 }
 
 // SearchAlert is an alert specific to searches (i.e. not site alert).
 type SearchAlert struct {
-	Title           string          `json:"title"`
-	Description     string          `json:"description"`
-	ProposedQueries []ProposedQuery `json:"proposedQueries"`
+	Title           string             `json:"title"`
+	Description     string             `json:"description"`
+	ProposedQueries []QueryDescription `json:"proposedQueries"`
 }
 
 // SearchFiles searches files with given query. It returns the match count and
@@ -623,7 +623,7 @@ func (s *SearchStreamClient) SearchFiles(query string) (*SearchFileResults, erro
 				Description: alert.Description,
 			}
 			for _, pq := range alert.ProposedQueries {
-				results.Alert.ProposedQueries = append(results.Alert.ProposedQueries, ProposedQuery{
+				results.Alert.ProposedQueries = append(results.Alert.ProposedQueries, QueryDescription{
 					Description: pq.Description,
 					Query:       pq.Query,
 				})

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -16,7 +16,7 @@ type Alert struct {
 	PrometheusType  string
 	Title           string
 	Description     string
-	ProposedQueries []*ProposedQuery
+	ProposedQueries []*QueryDescription
 	Kind            string // An identifier indicating the kind of alert
 	// The higher the priority the more important is the alert.
 	Priority int
@@ -47,7 +47,7 @@ func (m *MaxAlerter) Add(a *Alert) {
 	m.Unlock()
 }
 
-type ProposedQuery struct {
+type QueryDescription struct {
 	Description string
 	Query       string
 	PatternType query.SearchType
@@ -63,7 +63,7 @@ const (
 	ResultCount AnnotationName = "ResultCount"
 )
 
-func (q *ProposedQuery) QueryString() string {
+func (q *QueryDescription) QueryString() string {
 	if q.Description != "Remove quotes" {
 		switch q.PatternType {
 		case query.SearchTypeStandard:
@@ -121,7 +121,7 @@ func AlertForTimeout(usedTime time.Duration, suggestTime time.Duration, queryStr
 		PrometheusType: "timed_out",
 		Title:          "Timed out while searching",
 		Description:    fmt.Sprintf("We weren't able to find any results in %s.", usedTime.Round(time.Second)),
-		ProposedQueries: []*ProposedQuery{
+		ProposedQueries: []*QueryDescription{
 			{
 				Description: "query with longer timeout",
 				Query:       fmt.Sprintf("timeout:%v %s", suggestTime, query.OmitField(q, query.FieldTimeout)),
@@ -157,7 +157,7 @@ func AlertForStructuralSearchNotSet(queryString string) *Alert {
 		PrometheusType: "structural_search_not_set",
 		Title:          "No results",
 		Description:    "It looks like you're trying to run a structural search, but it is not enabled using the patterntype keyword or UI toggle.",
-		ProposedQueries: []*ProposedQuery{
+		ProposedQueries: []*QueryDescription{
 			{
 				Description: "Activate structural search",
 				Query:       queryString,

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -66,7 +66,7 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 
 	if len(contextFilters) == 1 && !searchcontexts.IsGlobalSearchContextSpec(contextFilters[0]) && len(repoFilters) > 0 {
 		withoutContextFilter := query.OmitField(q, query.FieldContext)
-		proposedQueries := []*search.ProposedQuery{
+		proposedQueries := []*search.QueryDescription{
 			{
 				Description: "search in the global context",
 				Query:       fmt.Sprintf("context:%s %s", searchcontexts.GlobalSearchContextName, withoutContextFilter),
@@ -98,7 +98,7 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 		}
 	}
 
-	var proposedQueries []*search.ProposedQuery
+	var proposedQueries []*search.QueryDescription
 	if forksNotSet {
 		tryIncludeForks := search.RepoOptions{
 			RepoFilters:      repoFilters,
@@ -107,7 +107,7 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 		}
 		if o.reposExist(ctx, tryIncludeForks) {
 			proposedQueries = append(proposedQueries,
-				&search.ProposedQuery{
+				&search.QueryDescription{
 					Description: "include forked repositories in your query.",
 					Query:       o.OriginalQuery + " fork:yes",
 					PatternType: o.PatternType,
@@ -126,7 +126,7 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 		}
 		if o.reposExist(ctx, tryIncludeArchived) {
 			proposedQueries = append(proposedQueries,
-				&search.ProposedQuery{
+				&search.QueryDescription{
 					Description: "include archived repositories in your query.",
 					Query:       o.OriginalQuery + " archived:yes",
 					PatternType: o.PatternType,
@@ -342,7 +342,7 @@ func needsPackageHostConfiguration(ctx context.Context, db database.DB) (bool, e
 }
 
 type errOverRepoLimit struct {
-	ProposedQueries []*search.ProposedQuery
+	ProposedQueries []*search.QueryDescription
 	Description     string
 }
 
@@ -359,7 +359,7 @@ const (
 
 type ErrLuckyQueries struct {
 	Type            LuckyAlertType
-	ProposedQueries []*search.ProposedQuery
+	ProposedQueries []*search.QueryDescription
 }
 
 func (e *ErrLuckyQueries) Error() string {

--- a/internal/search/alert/observer_test.go
+++ b/internal/search/alert/observer_test.go
@@ -56,7 +56,7 @@ func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 	wantAlert := &search.Alert{
 		PrometheusType: "no_resolved_repos__context_none_in_common",
 		Title:          "No repositories found for your query within the context @user",
-		ProposedQueries: []*search.ProposedQuery{
+		ProposedQueries: []*search.QueryDescription{
 			{
 
 				Description: "search in the global context",

--- a/internal/search/alert_test.go
+++ b/internal/search/alert_test.go
@@ -59,7 +59,7 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 			Alert: &Alert{
 				Title:       "An alert for regex",
 				Description: "An alert for regex",
-				ProposedQueries: []*ProposedQuery{
+				ProposedQueries: []*QueryDescription{
 					{
 						Description: "Some query description",
 						Query:       "repo:github.com/sourcegraph/sourcegraph",
@@ -74,7 +74,7 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 			Alert: &Alert{
 				Title:       "An alert for structural",
 				Description: "An alert for structural",
-				ProposedQueries: []*ProposedQuery{
+				ProposedQueries: []*QueryDescription{
 					{
 						Description: "Some query description",
 						Query:       "repo:github.com/sourcegraph/sourcegraph",

--- a/internal/search/lucky/feeling_lucky_search_job.go
+++ b/internal/search/lucky/feeling_lucky_search_job.go
@@ -99,7 +99,7 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	} else {
 		luckyAlertType = alertobserver.LuckyAlertAdded
 	}
-	generated := &alertobserver.ErrLuckyQueries{Type: luckyAlertType, ProposedQueries: []*search.ProposedQuery{}}
+	generated := &alertobserver.ErrLuckyQueries{Type: luckyAlertType, ProposedQueries: []*search.QueryDescription{}}
 	var autoQ *autoQuery
 	for _, next := range f.generators {
 		for {
@@ -231,7 +231,7 @@ func (n *notifier) New(count int) error {
 	}
 
 	return &alertobserver.ErrLuckyQueries{
-		ProposedQueries: []*search.ProposedQuery{{
+		ProposedQueries: []*search.QueryDescription{{
 			Description: fmt.Sprintf("%s (%s)", n.description, resultCountString),
 			Annotations: map[search.AnnotationName]string{
 				search.ResultCount: resultCountString,

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -173,14 +173,14 @@ type EventFilter struct {
 // EventAlert is GQL.SearchAlert. It replaces when sent to match existing
 // behaviour.
 type EventAlert struct {
-	Title           string          `json:"title"`
-	Description     string          `json:"description,omitempty"`
-	Kind            string          `json:"kind,omitempty"`
-	ProposedQueries []ProposedQuery `json:"proposedQueries"`
+	Title           string             `json:"title"`
+	Description     string             `json:"description,omitempty"`
+	Kind            string             `json:"kind,omitempty"`
+	ProposedQueries []QueryDescription `json:"proposedQueries"`
 }
 
-// ProposedQuery is a suggested query to run when we emit an alert.
-type ProposedQuery struct {
+// QueryDescription describes queries emitted in alerts.
+type QueryDescription struct {
 	Description string       `json:"description,omitempty"`
 	Query       string       `json:"query"`
 	Annotations []Annotation `json:"annotations,omitempty"`


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/41087.

I'm renaming the internal `search.ProposedQuery` type to `search.QueryDescription` across board because that's what it corresponds to in the GQL definition.

## Test plan
Semantics-preserving.
