### PR TITLE
dev/ci: treat all Markdown diffs as docs changes

### DIFF
--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -86,6 +86,11 @@ func ParseDiff(files []string) (diff Diff) {
 		if strings.HasSuffix(p, "dev/ci/yarn-test.sh") {
 			diff |= Client
 		}
+		// dev/release contains a nodejs script that doesn't have tests but needs to be
+		// linted with Client linters
+		if strings.HasPrefix(p, "dev/release/") {
+			diff |= Client
+		}
 
 		// Affects GraphQL
 		if strings.HasSuffix(p, ".graphql") {
@@ -101,11 +106,7 @@ func ParseDiff(files []string) (diff Diff) {
 		}
 
 		// Affects docs
-		if strings.HasPrefix(p, "doc/") && p != "CHANGELOG.md" {
-			diff |= Docs
-		}
-		// dev/release contains a nodejs script that doesn't have tests but needs to be linted
-		if strings.HasPrefix(p, "dev/release/") {
+		if strings.HasPrefix(p, "doc/") || strings.HasSuffix(p, ".md") {
 			diff |= Docs
 		}
 
@@ -143,7 +144,7 @@ func ParseDiff(files []string) (diff Diff) {
 		if strings.HasSuffix(p, ".sh") {
 			diff |= Shell
 		}
-
+		// Read the file to check if it is secretly a shell script
 		f, err := os.Open(p)
 		if err == nil {
 			defer f.Close()

--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -147,7 +147,6 @@ func ParseDiff(files []string) (diff Diff) {
 		// Read the file to check if it is secretly a shell script
 		f, err := os.Open(p)
 		if err == nil {
-			defer f.Close()
 			b := make([]byte, 19) // "#!/usr/bin/env bash" = 19 chars
 			_, _ = f.Read(b)
 			if bytes.Compare(b[0:2], []byte("#!")) == 0 && bytes.Contains(b, []byte("bash")) {
@@ -155,6 +154,9 @@ func ParseDiff(files []string) (diff Diff) {
 				// some shell script.
 				diff |= Shell
 			}
+			// Close the file immediately - we don't want to defer, this loop can go for
+			// quite a while.
+			f.Close()
 		}
 	}
 	return


### PR DESCRIPTION
A lot of Markdown files are in `.prettierignore` so they get skipped (for example, [all of `doc/` has been ignored for many years](https://github.com/sourcegraph/sourcegraph/commit/ccdc5a8071c1d271faa07a8548462a91cec4aa71)), but some aren't, so just to be safe let's make sure we run docs checks (which includes prettier) over everything on all Markdown diffs.

Also includes some other minor nitpicking changes to the diff detector

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a