### PR TITLE
ci: upsert license key for backend integration tests

### DIFF
--- a/dev/ci/integration/backend/run.sh
+++ b/dev/ci/integration/backend/run.sh
@@ -8,6 +8,6 @@ set -ex
 
 echo "--- test.sh"
 
-# backend integration tests requires a Github Enterprise Token
+# Backend integration tests requires a GitHub Enterprise Token
 GITHUB_TOKEN=$GHE_GITHUB_TOKEN
 GITHUB_TOKEN=$GITHUB_TOKEN ./dev/ci/integration/run-integration.sh "${root_dir}/dev/ci/integration/backend/test.sh"

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -61,13 +61,13 @@ func TestMain(m *testing.M) {
 		log.Println("server response: ", resp)
 	}
 	if err != nil {
-		log.Fatal("Failed to check if site needs init: ", err)
+		log.Fatal("Failed to check if site needs init:", err)
 	}
 
 	if needsSiteInit {
 		client, err = gqltestutil.SiteAdminInit(*baseURL, *email, *username, *password)
 		if err != nil {
-			log.Fatal("Failed to create site admin: ", err)
+			log.Fatal("Failed to create site admin:", err)
 		}
 		log.Println("Site admin has been created:", *username)
 	} else {
@@ -76,6 +76,22 @@ func TestMain(m *testing.M) {
 			log.Fatal("Failed to sign in:", err)
 		}
 		log.Println("Site admin authenticated:", *username)
+	}
+
+	licenseKey := os.Getenv("SOURCEGRAPH_LICENSE_KEY")
+	if licenseKey != "" {
+		// Update site configuration to set up a test license key if the instance doesn't have one yet.
+		siteConfig, err := client.SiteConfiguration()
+		if err != nil {
+			log.Fatal("Failed to get site configuration:", err)
+		}
+
+		siteConfig.LicenseKey = licenseKey
+		err = client.UpdateSiteConfiguration(siteConfig)
+		if err != nil {
+			log.Fatal("Failed to update site configuration:", err)
+		}
+		log.Println("License key updated")
 	}
 
 	if !testing.Verbose() {

--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -39,7 +39,7 @@ docker run "$@" \
   -e SRC_LOG_LEVEL=dbug \
   -e DEBUG=t \
   -e ALLOW_SINGLE_DOCKER_CODE_INSIGHTS=t \
-  -e SOURCEGRAPH_LICENSE_GENERATION_KEY="$SOURCEGRAPH_LICENSE_GENERATION_KEY"
+  -e SOURCEGRAPH_LICENSE_GENERATION_KEY="$SOURCEGRAPH_LICENSE_GENERATION_KEY" \
   --volume "$DATA/config:/etc/sourcegraph" \
   --volume "$DATA/data:/var/opt/sourcegraph" \
   "$IMAGE"

--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -5,6 +5,7 @@ IMAGE=${IMAGE:-sourcegraph/server:${TAG:-insiders}}
 PORT=${PORT:-"7080"}
 URL="http://localhost:$PORT"
 DATA=${DATA:-"/tmp/sourcegraph-data"}
+SOURCEGRAPH_LICENSE_GENERATION_KEY=${SOURCEGRAPH_LICENSE_GENERATION_KEY:-""}
 
 echo "--- Checking for existing Sourcegraph instance at $URL"
 if curl --output /dev/null --silent --head --fail "$URL"; then
@@ -38,6 +39,7 @@ docker run "$@" \
   -e SRC_LOG_LEVEL=dbug \
   -e DEBUG=t \
   -e ALLOW_SINGLE_DOCKER_CODE_INSIGHTS=t \
+  -e SOURCEGRAPH_LICENSE_GENERATION_KEY="$SOURCEGRAPH_LICENSE_GENERATION_KEY"
   --volume "$DATA/config:/etc/sourcegraph" \
   --volume "$DATA/data:/var/opt/sourcegraph" \
   "$IMAGE"

--- a/internal/gqltestutil/product_subscription.go
+++ b/internal/gqltestutil/product_subscription.go
@@ -1,0 +1,41 @@
+package gqltestutil
+
+import (
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type ProductSubscription struct {
+	License *struct {
+		ProductNameWithBrand string `json:"productNameWithBrand"`
+	} `json:"license"`
+}
+
+// ProductSubscription returns information of the current product subscription.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) ProductSubscription() (*ProductSubscription, error) {
+	const query = `
+query ProductSubscription {
+	site {
+		productSubscription {
+			license {
+				productNameWithBrand
+			}
+		}
+	}
+}
+`
+
+	var resp struct {
+		Data struct {
+			Site struct {
+				ProductSubscription ProductSubscription `json:"productSubscription"`
+			} `json:"site"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, nil, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "request GraphQL")
+	}
+	return &resp.Data.Site.ProductSubscription, nil
+}


### PR DESCRIPTION
~~**Blocked by https://github.com/sourcegraph/infrastructure/pull/3862**~~

We are going to require a valid license key for repository permissions in https://github.com/sourcegraph/sourcegraph/pull/40826, thus we also need one for backend integration tests as a prerequisite.

## Test plan

CI and manually tested

---

cc @miveronese 