### PR TITLE
Allow external service card to be disabled with required tiers

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -45,7 +45,7 @@ export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChil
     const [displayName, setDisplayName] = useState(externalService.defaultDisplayName)
 
     useEffect(() => {
-        telemetryService.logViewEvent('AddExternalService')
+        telemetryService.logPageView('AddExternalService')
     }, [telemetryService])
 
     const getExternalServiceInput = useCallback(

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -4,7 +4,8 @@ import * as H from 'history'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { useLocalStorage, Button, Link, Alert, H2, H3, Text } from '@sourcegraph/wildcard'
+import { useLocalStorage, Button, Link, Alert, H2, H3, Icon, Text } from '@sourcegraph/wildcard'
+import { mdiInformation } from '@mdi/js'
 
 import { Scalars } from '../../graphql-operations'
 import { PageTitle } from '../PageTitle'
@@ -78,6 +79,9 @@ export const AddExternalServicesPage: React.FunctionComponent<
         }
     }
 
+    const tier = "business"
+    const numCodeHosts = 0
+
     return (
         <div className="add-external-services-page mt-3">
             <PageTitle title="Add repositories" />
@@ -132,9 +136,16 @@ export const AddExternalServicesPage: React.FunctionComponent<
                     </div>
                 </Alert>
             )}
-            {Object.entries(codeHostExternalServices).map(([id, externalService]) => (
+            {Object.entries(codeHostExternalServices).filter(([_, externalService]) => externalService.tiers.includes(tier)).map(([id, externalService]) => (
                 <div className={styles.addExternalServicesPageCard} key={id}>
                     <ExternalServiceCard to={getAddURL(id)} {...externalService} />
+                </div>
+            ))}
+            <br/>
+            <p><Icon aria-label="Information icon" svgPath={mdiInformation}></Icon> Upgrade to Sourcegraph Enterprise to add repositories from other code hosts.</p>
+            {Object.entries(codeHostExternalServices).filter(([_, externalService]) => !externalService.tiers.includes(tier)).map(([id, externalService]) => (
+                <div className={styles.addExternalServicesPageCard} key={id}>
+                    <ExternalServiceCard to={getAddURL(id)} {...externalService} enabled={false} requiredTier={'enterprise'}/>
                 </div>
             ))}
             {Object.entries(nonCodeHostExternalServices).length > 0 && (

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -81,7 +81,7 @@ export const AddExternalServicesPage: React.FunctionComponent<
     }
 
     const licenseInfo = window.context.licenseInfo
-    var allowedCodeHosts: ExternalServiceKind[] | null = null
+    let allowedCodeHosts: ExternalServiceKind[] | null = null
     if (licenseInfo && licenseInfo.currentPlan === 'business-0') {
         allowedCodeHosts = [ExternalServiceKind.GITHUB, ExternalServiceKind.GITLAB, ExternalServiceKind.BITBUCKETCLOUD]
     }
@@ -141,26 +141,25 @@ export const AddExternalServicesPage: React.FunctionComponent<
                 </Alert>
             )}
             {Object.entries(codeHostExternalServices)
-                .filter(([_, externalService]) => !allowedCodeHosts || allowedCodeHosts.includes(externalService.kind))
+                .filter(
+                    ([_id, externalService]) => !allowedCodeHosts || allowedCodeHosts.includes(externalService.kind)
+                )
                 .map(([id, externalService]) => (
                     <div className={styles.addExternalServicesPageCard} key={id}>
-                        <ExternalServiceCard
-                            to={getAddURL(id)}
-                            {...externalService}
-                        />
+                        <ExternalServiceCard to={getAddURL(id)} {...externalService} />
                     </div>
                 ))}
             {allowedCodeHosts && (
                 <>
                     <br />
-                    <p>
+                    <Text>
                         <Icon aria-label="Information icon" svgPath={mdiInformation}></Icon> Upgrade to{' '}
                         <Link to="https://about.sourcegraph.com/pricing">Sourcegraph Enterprise</Link> to add
                         repositories from other code hosts.
-                    </p>
+                    </Text>
                     {Object.entries(codeHostExternalServices)
                         .filter(
-                            ([_, externalService]) =>
+                            ([_id, externalService]) =>
                                 allowedCodeHosts && !allowedCodeHosts.includes(externalService.kind)
                         )
                         .map(([id, externalService]) => (
@@ -170,9 +169,7 @@ export const AddExternalServicesPage: React.FunctionComponent<
                                     {...externalService}
                                     enabled={false}
                                     badge={'enterprise'}
-                                    tooltip={
-                                        'Upgrade to Sourcegraph Enterprise to add repositories from other code hosts'
-                                    }
+                                    tooltip="Upgrade to Sourcegraph Enterprise to add repositories from other code hosts"
                                 />
                             </div>
                         ))}

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -141,9 +141,7 @@ export const AddExternalServicesPage: React.FunctionComponent<
                 </Alert>
             )}
             {Object.entries(codeHostExternalServices)
-                .filter(
-                    externalService => !allowedCodeHosts || allowedCodeHosts.includes(externalService[1].kind)
-                )
+                .filter(externalService => !allowedCodeHosts || allowedCodeHosts.includes(externalService[1].kind))
                 .map(([id, externalService]) => (
                     <div className={styles.addExternalServicesPageCard} key={id}>
                         <ExternalServiceCard to={getAddURL(id)} {...externalService} />
@@ -153,14 +151,13 @@ export const AddExternalServicesPage: React.FunctionComponent<
                 <>
                     <br />
                     <Text>
-                        <Icon aria-label="Information icon" svgPath={mdiInformation}/> Upgrade to{' '}
+                        <Icon aria-label="Information icon" svgPath={mdiInformation} /> Upgrade to{' '}
                         <Link to="https://about.sourcegraph.com/pricing">Sourcegraph Enterprise</Link> to add
                         repositories from other code hosts.
                     </Text>
                     {Object.entries(codeHostExternalServices)
                         .filter(
-                            externalService =>
-                                allowedCodeHosts && !allowedCodeHosts.includes(externalService[1].kind)
+                            externalService => allowedCodeHosts && !allowedCodeHosts.includes(externalService[1].kind)
                         )
                         .map(([id, externalService]) => (
                             <div className={styles.addExternalServicesPageCard} key={id}>

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 
+import { mdiInformation } from '@mdi/js'
 import * as H from 'history'
 
+import { ExternalServiceKind } from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useLocalStorage, Button, Link, Alert, H2, H3, Icon, Text } from '@sourcegraph/wildcard'
-import { mdiInformation } from '@mdi/js'
 
 import { Scalars } from '../../graphql-operations'
 import { PageTitle } from '../PageTitle'
@@ -15,7 +16,6 @@ import { ExternalServiceCard } from './ExternalServiceCard'
 import { allExternalServices, AddExternalServiceOptions } from './externalServices'
 
 import styles from './AddExternalServicesPage.module.scss'
-import { ExternalServiceKind } from '@sourcegraph/shared/src/schema'
 
 export interface AddExternalServicesPageProps extends ThemeProps, TelemetryProps {
     history: H.History
@@ -142,7 +142,7 @@ export const AddExternalServicesPage: React.FunctionComponent<
             )}
             {Object.entries(codeHostExternalServices)
                 .filter(
-                    ([_id, externalService]) => !allowedCodeHosts || allowedCodeHosts.includes(externalService.kind)
+                    externalService => !allowedCodeHosts || allowedCodeHosts.includes(externalService[1].kind)
                 )
                 .map(([id, externalService]) => (
                     <div className={styles.addExternalServicesPageCard} key={id}>
@@ -153,14 +153,14 @@ export const AddExternalServicesPage: React.FunctionComponent<
                 <>
                     <br />
                     <Text>
-                        <Icon aria-label="Information icon" svgPath={mdiInformation}></Icon> Upgrade to{' '}
+                        <Icon aria-label="Information icon" svgPath={mdiInformation}/> Upgrade to{' '}
                         <Link to="https://about.sourcegraph.com/pricing">Sourcegraph Enterprise</Link> to add
                         repositories from other code hosts.
                     </Text>
                     {Object.entries(codeHostExternalServices)
                         .filter(
-                            ([_id, externalService]) =>
-                                allowedCodeHosts && !allowedCodeHosts.includes(externalService.kind)
+                            externalService =>
+                                allowedCodeHosts && !allowedCodeHosts.includes(externalService[1].kind)
                         )
                         .map(([id, externalService]) => (
                             <div className={styles.addExternalServicesPageCard} key={id}>
@@ -168,7 +168,7 @@ export const AddExternalServicesPage: React.FunctionComponent<
                                     to={getAddURL(id)}
                                     {...externalService}
                                     enabled={false}
-                                    badge={'enterprise'}
+                                    badge="enterprise"
                                     tooltip="Upgrade to Sourcegraph Enterprise to add repositories from other code hosts"
                                 />
                             </div>

--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { mdiAccount, mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Icon, Link, H3, Text } from '@sourcegraph/wildcard'
+import { Icon, Link, H3, Text, Tooltip, Badge } from '@sourcegraph/wildcard'
 
 import { ExternalServiceFields, ExternalServiceKind } from '../../graphql-operations'
 
@@ -31,6 +31,8 @@ interface ExternalServiceCardProps {
 
     to?: string
     className?: string
+    enabled?: boolean
+    requiredTier?: string
 }
 
 export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildren<ExternalServiceCardProps>> = ({
@@ -41,12 +43,10 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
     kind,
     namespace,
     className = '',
+    enabled = true,
+    requiredTier = '',
 }) => {
-    const children = (
-        <div className={classNames('p-3 d-flex align-items-start border', className)}>
-            <Icon className={classNames('mb-0 mr-3', styles.icon)} as={CardIcon} aria-hidden={true} />
-            <div className="flex-1">
-                <H3 className={shortDescription ? 'mb-0' : 'mt-1 mb-0'}>
+    let cardTitle = (<H3 className={shortDescription ? 'mb-0' : 'mt-1 mb-0'}>
                     {title}
                     {namespace && (
                         <small>
@@ -56,13 +56,24 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
                             <Link to={namespace.url}>{namespace.namespaceName}</Link>
                         </small>
                     )}
-                </H3>
+                </H3>)
+    cardTitle = !enabled && requiredTier ? (
+        <Tooltip content="Test">
+            {cardTitle}
+        </Tooltip>
+        ) : cardTitle
+    const children = (
+        <div className={classNames('p-3 d-flex align-items-start border' + (enabled ? '' : ' text-muted'), className)}>
+            <Icon disabled={!enabled} className={classNames('mb-0 mr-3', styles.icon)} as={CardIcon} aria-hidden={true} />
+            <div className="flex-1">
+                {cardTitle}
                 {shortDescription && <Text className="mb-0 text-muted">{shortDescription}</Text>}
             </div>
-            {to && <Icon className="align-self-center" svgPath={mdiChevronRight} inline={false} aria-hidden={true} />}
+            {to && enabled && <Icon className="align-self-center" svgPath={mdiChevronRight} inline={false} aria-hidden={true} />}
+            {!enabled && <Badge className="align-self-center" variant="outlineSecondary">{requiredTier.toUpperCase()}</Badge>}
         </div>
     )
-    return to ? (
+    return to && enabled ? (
         <Link
             className="d-block text-left text-body text-decoration-none"
             to={to}

--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -32,7 +32,8 @@ interface ExternalServiceCardProps {
     to?: string
     className?: string
     enabled?: boolean
-    requiredTier?: string
+    badge?: string
+    tooltip?: string
 }
 
 export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildren<ExternalServiceCardProps>> = ({
@@ -44,33 +45,45 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
     namespace,
     className = '',
     enabled = true,
-    requiredTier = '',
+    badge = '',
+    tooltip = '',
 }) => {
-    let cardTitle = (<H3 className={shortDescription ? 'mb-0' : 'mt-1 mb-0'}>
-                    {title}
-                    {namespace && (
-                        <small>
-                            {' '}
-                            by
-                            <Icon aria-hidden={true} svgPath={mdiAccount} />
-                            <Link to={namespace.url}>{namespace.namespaceName}</Link>
-                        </small>
-                    )}
-                </H3>)
-    cardTitle = !enabled && requiredTier ? (
-        <Tooltip content="Test">
-            {cardTitle}
-        </Tooltip>
-        ) : cardTitle
+    let cardTitle = (
+        <H3 className={shortDescription ? 'mb-0' : 'mt-1 mb-0'}>
+            {title}
+            {namespace && (
+                <small>
+                    {' '}
+                    by
+                    <Icon aria-hidden={true} svgPath={mdiAccount} />
+                    <Link to={namespace.url}>{namespace.namespaceName}</Link>
+                </small>
+            )}
+        </H3>
+    )
+    cardTitle = tooltip ? <Tooltip content={tooltip}>{cardTitle}</Tooltip> : cardTitle
     const children = (
         <div className={classNames('p-3 d-flex align-items-start border' + (enabled ? '' : ' text-muted'), className)}>
-            <Icon disabled={!enabled} className={classNames('mb-0 mr-3', styles.icon)} as={CardIcon} aria-hidden={true} />
-            <div className="flex-1">
+            <Icon
+                disabled={!enabled}
+                className={classNames('mb-0 mr-3', styles.icon)}
+                as={CardIcon}
+                aria-hidden={true}
+            />
+            <div>
                 {cardTitle}
                 {shortDescription && <Text className="mb-0 text-muted">{shortDescription}</Text>}
             </div>
-            {to && enabled && <Icon className="align-self-center" svgPath={mdiChevronRight} inline={false} aria-hidden={true} />}
-            {!enabled && <Badge className="align-self-center" variant="outlineSecondary">{requiredTier.toUpperCase()}</Badge>}
+            <div className={"flex-1 align-self-center"}>
+            {to && enabled && (
+                <Icon className="float-right" svgPath={mdiChevronRight} inline={false} aria-hidden={true} />
+            )}
+            {badge && (
+                <Badge className="float-right" variant="outlineSecondary">
+                    {badge.toUpperCase()}
+                </Badge>
+            )}
+            </div>
         </div>
     )
     return to && enabled ? (

--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -74,15 +74,15 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
                 {cardTitle}
                 {shortDescription && <Text className="mb-0 text-muted">{shortDescription}</Text>}
             </div>
-            <div className={"flex-1 align-self-center"}>
-            {to && enabled && (
-                <Icon className="float-right" svgPath={mdiChevronRight} inline={false} aria-hidden={true} />
-            )}
-            {badge && (
-                <Badge className="float-right" variant="outlineSecondary">
-                    {badge.toUpperCase()}
-                </Badge>
-            )}
+            <div className={'flex-1 align-self-center'}>
+                {to && enabled && (
+                    <Icon className="float-right" svgPath={mdiChevronRight} inline={false} aria-hidden={true} />
+                )}
+                {badge && (
+                    <Badge className="float-right" variant="outlineSecondary">
+                        {badge.toUpperCase()}
+                    </Badge>
+                )}
             </div>
         </div>
     )

--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -74,7 +74,7 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
                 {cardTitle}
                 {shortDescription && <Text className="mb-0 text-muted">{shortDescription}</Text>}
             </div>
-            <div className={'flex-1 align-self-center'}>
+            <div className="flex-1 align-self-center">
                 {to && enabled && (
                     <Icon className="float-right" svgPath={mdiChevronRight} inline={false} aria-hidden={true} />
                 )}

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -77,6 +77,11 @@ export interface AddExternalServiceOptions {
     defaultDisplayName: string
 
     /**
+     * List of tiers in which this configuration is available
+     */
+    tiers: string[]
+
+    /**
      * Default external service configuration
      */
     defaultConfig: string
@@ -529,6 +534,7 @@ const GITHUB_DOTCOM: AddExternalServiceOptions = {
   "token": "<access token>",
   "orgs": []
 }`,
+    tiers: ['free', 'business', 'enterprise'],
 }
 const GITHUB_ENTERPRISE: AddExternalServiceOptions = {
     ...GITHUB_DOTCOM,
@@ -660,6 +666,7 @@ const AWS_CODE_COMMIT: AddExternalServiceOptions = {
             },
         },
     ],
+    tiers: ['enterprise'],
 }
 const BITBUCKET_CLOUD: AddExternalServiceOptions = {
     kind: ExternalServiceKind.BITBUCKETCLOUD,
@@ -748,6 +755,7 @@ const BITBUCKET_CLOUD: AddExternalServiceOptions = {
             </Text>
         </div>
     ),
+    tiers: ['free', 'business', 'enterprise'],
 }
 const BITBUCKET_SERVER: AddExternalServiceOptions = {
     kind: ExternalServiceKind.BITBUCKETSERVER,
@@ -911,6 +919,7 @@ const BITBUCKET_SERVER: AddExternalServiceOptions = {
             },
         },
     ],
+    tiers: ['enterprise'],
 }
 const GITLAB_DOTCOM: AddExternalServiceOptions = {
     kind: ExternalServiceKind.GITLAB,
@@ -927,6 +936,7 @@ const GITLAB_DOTCOM: AddExternalServiceOptions = {
 }`,
     editorActions: gitlabEditorActions(false),
     instructions: gitlabInstructions(false),
+    tiers: ['free', 'business', 'enterprise'],
 }
 const GITLAB_SELF_MANAGED: AddExternalServiceOptions = {
     ...GITLAB_DOTCOM,
@@ -980,6 +990,7 @@ const SRC_SERVE_GIT: AddExternalServiceOptions = {
             },
         },
     ],
+    tiers: ['enterprise'],
 }
 const GITOLITE: AddExternalServiceOptions = {
     kind: ExternalServiceKind.GITOLITE,
@@ -1036,6 +1047,7 @@ const GITOLITE: AddExternalServiceOptions = {
             },
         },
     ],
+    tiers: ['enterprise'],
 }
 const PHABRICATOR_SERVICE: AddExternalServiceOptions = {
     kind: ExternalServiceKind.PHABRICATOR,
@@ -1086,6 +1098,7 @@ const PHABRICATOR_SERVICE: AddExternalServiceOptions = {
             },
         },
     ],
+    tiers: ['enterprise'],
 }
 const GENERIC_GIT: AddExternalServiceOptions = {
     kind: ExternalServiceKind.OTHER,
@@ -1141,6 +1154,7 @@ const GENERIC_GIT: AddExternalServiceOptions = {
             },
         },
     ],
+    tiers: ['enterprise'],
 }
 const PERFORCE: AddExternalServiceOptions = {
     kind: ExternalServiceKind.PERFORCE,
@@ -1200,6 +1214,7 @@ const PERFORCE: AddExternalServiceOptions = {
             },
         },
     ],
+    tiers: ['enterprise'],
 }
 const JVM_PACKAGES: AddExternalServiceOptions = {
     kind: ExternalServiceKind.JVMPACKAGES,
@@ -1233,6 +1248,7 @@ const JVM_PACKAGES: AddExternalServiceOptions = {
         </div>
     ),
     editorActions: [],
+    tiers: ['enterprise'],
 }
 
 const PAGURE: AddExternalServiceOptions = {
@@ -1254,6 +1270,7 @@ const PAGURE: AddExternalServiceOptions = {
         </div>
     ),
     editorActions: [],
+    tiers: ['enterprise'],
 }
 
 const GERRIT: AddExternalServiceOptions = {
@@ -1275,6 +1292,7 @@ const GERRIT: AddExternalServiceOptions = {
         </div>
     ),
     editorActions: [],
+    tiers: ['enterprise'],
 }
 
 const NPM_PACKAGES: AddExternalServiceOptions = {
@@ -1310,6 +1328,7 @@ const NPM_PACKAGES: AddExternalServiceOptions = {
         </div>
     ),
     editorActions: [],
+    tiers: ['enterprise'],
 }
 
 const GO_MODULES = {
@@ -1341,6 +1360,7 @@ const GO_MODULES = {
         </div>
     ),
     editorActions: [],
+    tiers: ['enterprise'],
 }
 
 const PYTHON_PACKAGES = {
@@ -1373,6 +1393,7 @@ const PYTHON_PACKAGES = {
         </div>
     ),
     editorActions: [],
+    tiers: ['enterprise'],
 }
 
 const RUST_PACKAGES = {
@@ -1397,6 +1418,7 @@ const RUST_PACKAGES = {
         </div>
     ),
     editorActions: [],
+    tiers: ['enterprise'],
 }
 
 export const codeHostExternalServices: Record<string, AddExternalServiceOptions> = {

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -77,11 +77,6 @@ export interface AddExternalServiceOptions {
     defaultDisplayName: string
 
     /**
-     * List of tiers in which this configuration is available
-     */
-    tiers: string[]
-
-    /**
      * Default external service configuration
      */
     defaultConfig: string
@@ -534,7 +529,6 @@ const GITHUB_DOTCOM: AddExternalServiceOptions = {
   "token": "<access token>",
   "orgs": []
 }`,
-    tiers: ['free', 'business', 'enterprise'],
 }
 const GITHUB_ENTERPRISE: AddExternalServiceOptions = {
     ...GITHUB_DOTCOM,
@@ -666,7 +660,6 @@ const AWS_CODE_COMMIT: AddExternalServiceOptions = {
             },
         },
     ],
-    tiers: ['enterprise'],
 }
 const BITBUCKET_CLOUD: AddExternalServiceOptions = {
     kind: ExternalServiceKind.BITBUCKETCLOUD,
@@ -755,7 +748,6 @@ const BITBUCKET_CLOUD: AddExternalServiceOptions = {
             </Text>
         </div>
     ),
-    tiers: ['free', 'business', 'enterprise'],
 }
 const BITBUCKET_SERVER: AddExternalServiceOptions = {
     kind: ExternalServiceKind.BITBUCKETSERVER,
@@ -919,7 +911,6 @@ const BITBUCKET_SERVER: AddExternalServiceOptions = {
             },
         },
     ],
-    tiers: ['enterprise'],
 }
 const GITLAB_DOTCOM: AddExternalServiceOptions = {
     kind: ExternalServiceKind.GITLAB,
@@ -936,7 +927,6 @@ const GITLAB_DOTCOM: AddExternalServiceOptions = {
 }`,
     editorActions: gitlabEditorActions(false),
     instructions: gitlabInstructions(false),
-    tiers: ['free', 'business', 'enterprise'],
 }
 const GITLAB_SELF_MANAGED: AddExternalServiceOptions = {
     ...GITLAB_DOTCOM,
@@ -990,7 +980,6 @@ const SRC_SERVE_GIT: AddExternalServiceOptions = {
             },
         },
     ],
-    tiers: ['enterprise'],
 }
 const GITOLITE: AddExternalServiceOptions = {
     kind: ExternalServiceKind.GITOLITE,
@@ -1047,7 +1036,6 @@ const GITOLITE: AddExternalServiceOptions = {
             },
         },
     ],
-    tiers: ['enterprise'],
 }
 const PHABRICATOR_SERVICE: AddExternalServiceOptions = {
     kind: ExternalServiceKind.PHABRICATOR,
@@ -1098,7 +1086,6 @@ const PHABRICATOR_SERVICE: AddExternalServiceOptions = {
             },
         },
     ],
-    tiers: ['enterprise'],
 }
 const GENERIC_GIT: AddExternalServiceOptions = {
     kind: ExternalServiceKind.OTHER,
@@ -1154,7 +1141,6 @@ const GENERIC_GIT: AddExternalServiceOptions = {
             },
         },
     ],
-    tiers: ['enterprise'],
 }
 const PERFORCE: AddExternalServiceOptions = {
     kind: ExternalServiceKind.PERFORCE,
@@ -1214,7 +1200,6 @@ const PERFORCE: AddExternalServiceOptions = {
             },
         },
     ],
-    tiers: ['enterprise'],
 }
 const JVM_PACKAGES: AddExternalServiceOptions = {
     kind: ExternalServiceKind.JVMPACKAGES,
@@ -1248,7 +1233,6 @@ const JVM_PACKAGES: AddExternalServiceOptions = {
         </div>
     ),
     editorActions: [],
-    tiers: ['enterprise'],
 }
 
 const PAGURE: AddExternalServiceOptions = {
@@ -1270,7 +1254,6 @@ const PAGURE: AddExternalServiceOptions = {
         </div>
     ),
     editorActions: [],
-    tiers: ['enterprise'],
 }
 
 const GERRIT: AddExternalServiceOptions = {
@@ -1292,7 +1275,6 @@ const GERRIT: AddExternalServiceOptions = {
         </div>
     ),
     editorActions: [],
-    tiers: ['enterprise'],
 }
 
 const NPM_PACKAGES: AddExternalServiceOptions = {
@@ -1328,7 +1310,6 @@ const NPM_PACKAGES: AddExternalServiceOptions = {
         </div>
     ),
     editorActions: [],
-    tiers: ['enterprise'],
 }
 
 const GO_MODULES = {
@@ -1360,7 +1341,6 @@ const GO_MODULES = {
         </div>
     ),
     editorActions: [],
-    tiers: ['enterprise'],
 }
 
 const PYTHON_PACKAGES = {
@@ -1393,7 +1373,6 @@ const PYTHON_PACKAGES = {
         </div>
     ),
     editorActions: [],
-    tiers: ['enterprise'],
 }
 
 const RUST_PACKAGES = {
@@ -1418,7 +1397,6 @@ const RUST_PACKAGES = {
         </div>
     ),
     editorActions: [],
-    tiers: ['enterprise'],
 }
 
 export const codeHostExternalServices: Record<string, AddExternalServiceOptions> = {

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -165,7 +165,7 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
 
     /** Contains information about the product license. */
     licenseInfo?: {
-        currentPlan?: string
+        currentPlan: 'old-starter-0' | 'old-enterprise-0' | 'team-0' | 'enterprise-0' | 'business-0' | 'enterprise-1'
 
         codeScaleLimit?: string
         codeScaleCloseToLimit?: boolean

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/external_services.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/external_services.go
@@ -2,7 +2,6 @@ package enforcement
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
@@ -37,21 +36,6 @@ func NewBeforeCreateExternalServiceHook() func(ctx context.Context, store databa
 		}
 
 		switch info.Plan() {
-		case licensing.PlanTeam0: // The "team-0" plan can have at most one code host connection
-			currentCount, err := store.Count(ctx, database.ExternalServicesListOptions{})
-			if err != nil {
-				return errors.Wrap(err, "count external services")
-			}
-			if currentCount > 0 {
-				return errcode.NewPresentationError(
-					fmt.Sprintf(
-						"Unable to create code host connection: the current plan cannot exceed %d code host connection (this instance now has %d). [**Upgrade your license.**](/site-admin/license)",
-						1,
-						currentCount,
-					),
-				)
-			}
-
 		case licensing.PlanBusiness0: // The "business-0" plan can only have cloud code hosts (GitHub.com/GitLab.com/Bitbucket.org)
 			config, err := es.Configuration(ctx)
 			if err != nil {

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/external_services_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/external_services_test.go
@@ -28,21 +28,6 @@ func TestNewBeforeCreateExternalServiceHook(t *testing.T) {
 		},
 
 		{
-			name:                 "team-0 exceeded limit",
-			license:              &license.Info{Tags: []string{"plan:team-0"}},
-			externalServiceCount: 1,
-			externalService:      nil,
-			wantErr:              true,
-		},
-		{
-			name:                 "team-0 within limit",
-			license:              &license.Info{Tags: []string{"plan:team-0"}},
-			externalServiceCount: 0,
-			externalService:      nil,
-			wantErr:              false,
-		},
-
-		{
 			name:    "business-0 with self-hosted GitHub",
 			license: &license.Info{Tags: []string{"plan:business-0"}},
 			externalService: &types.ExternalService{


### PR DESCRIPTION
UI changes to limit external services options on Business plan. Also removed an unused plan check that is no longer relevant.

When on business plan:
![image](https://user-images.githubusercontent.com/6427795/187833239-c72587cb-cdec-4cf3-ba49-4455dfb58f4f.png)

## Test plan

Visual tests, all UI changes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-40920-code-host-licensing.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-eslmzhvfth.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

