### PR TITLE
FilteredConnection: more robust searchFragment check & tests

### DIFF
--- a/client/web/src/components/FilteredConnection/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor, act } from '@testing-library/react'
 import { createLocation, createMemoryHistory } from 'history'
-import { BehaviorSubject, from } from 'rxjs'
+import { BehaviorSubject } from 'rxjs'
 import sinon from 'sinon'
 
 import { ConnectionNodes } from './ConnectionNodes'

--- a/client/web/src/components/FilteredConnection/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.test.tsx
@@ -1,8 +1,10 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { createLocation } from 'history'
+import { cleanup, fireEvent, render, screen, waitFor, act } from '@testing-library/react'
+import { createLocation, createMemoryHistory } from 'history'
+import { BehaviorSubject, from } from 'rxjs'
 import sinon from 'sinon'
 
 import { ConnectionNodes } from './ConnectionNodes'
+import { FilteredConnection } from './FilteredConnection'
 
 function fakeConnection<N>({
     hasNextPage,
@@ -36,6 +38,53 @@ const defaultConnectionNodesProps = {
     pluralNoun: 'cats',
     query: '',
 }
+
+describe('FilteredConnection', () => {
+    afterAll(cleanup)
+
+    describe('useURLQuery', () => {
+        it('does not update the history if searchFragment didnt change', async () => {
+            const history = createMemoryHistory()
+            history.push('/?foo=bar')
+
+            // Hook into history.replace to detect when FilteredConnection updates search
+            // fragment
+            const oldReplaceHistory = history.replace.bind(history)
+            const fakeReplaceHistory = sinon.spy(args => oldReplaceHistory(args))
+            history.replace = fakeReplaceHistory
+
+            // This is the fake connection
+            const connection = fakeConnection({ hasNextPage: true, totalCount: 2, nodes: [{}] })
+            const connectionSubject = new BehaviorSubject(connection)
+
+            render(
+                <FilteredConnection
+                    {...defaultConnectionNodesProps}
+                    location={history.location}
+                    history={history}
+                    useURLQuery={true}
+                    queryConnection={() => connectionSubject}
+                />
+            )
+
+            act(() => {
+                // Emulate polling by re-emiting the connection again.
+                // This should not lead to history being updated
+                connectionSubject.next(connection)
+                connectionSubject.next(connection)
+                connectionSubject.next(connection)
+            })
+
+            // Click "Show more" button, should cause history to be updated
+            fireEvent.click(screen.getByRole('button')!)
+            expect(history.location.search).toEqual('?foo=bar&first=40')
+            fireEvent.click(screen.getByRole('button')!)
+            expect(history.location.search).toEqual('?foo=bar&first=80')
+
+            await waitFor(() => sinon.assert.calledTwice(fakeReplaceHistory))
+        })
+    })
+})
 
 describe('ConnectionNodes', () => {
     afterAll(cleanup)

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import * as H from 'history'
-import { uniq } from 'lodash'
+import { uniq, isEqual } from 'lodash'
 import { combineLatest, merge, Observable, of, Subject, Subscription } from 'rxjs'
 import {
     catchError,
@@ -343,7 +343,13 @@ export class FilteredConnection<
                     ({ connectionOrError, previousPage, ...rest }) => {
                         if (this.props.useURLQuery) {
                             const searchFragment = this.urlQuery({ visibleResultCount: previousPage.length })
-                            if (this.props.location.search !== `?${searchFragment}`) {
+                            const searchFragmentParams = new URLSearchParams(searchFragment)
+                            searchFragmentParams.sort()
+
+                            const oldParams = new URLSearchParams(this.props.location.search)
+                            oldParams.sort()
+
+                            if (!isEqual(Array.from(searchFragmentParams), Array.from(oldParams))) {
                                 this.props.history.replace({
                                     search: searchFragment,
                                     hash: this.props.location.hash,


### PR DESCRIPTION
Follow-up to #41046 that makes this a bit more robust and adds a test.

## Test plan

- Added test
- Manual testing

## App preview:

- [Web](https://sg-web-mrn-refactor-scroll-fix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-niwhsnqbwk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
