### PR TITLE
insights: fix double `.` and duplicate string in aggregation error message

### DIFF
--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -25,11 +25,7 @@ type SearchAggregationResult = GetSearchAggregationResult['searchQueryAggregate'
 
 function getAggregationError(aggregation?: SearchAggregationResult): Error | undefined {
     if (aggregation?.__typename === 'SearchAggregationNotAvailable') {
-        let reason = aggregation.reason
-        if (!reason.endsWith('.')) {
-            reason = reason + '.'
-        }
-        return new Error(reason)
+        return new Error(aggregation.reason)
     }
 
     return

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -26,7 +26,7 @@ type SearchAggregationResult = GetSearchAggregationResult['searchQueryAggregate'
 function getAggregationError(aggregation?: SearchAggregationResult): Error | undefined {
     if (aggregation?.__typename === 'SearchAggregationNotAvailable') {
         let reason = aggregation.reason
-        if (reason.length > 0 && !reason.endsWith('.')) {
+        if (!reason.endsWith('.')) {
             reason = reason + '.'
         }
         return new Error(reason)

--- a/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
+++ b/client/search-ui/src/results/aggregation/AggregationChartCard.tsx
@@ -25,7 +25,11 @@ type SearchAggregationResult = GetSearchAggregationResult['searchQueryAggregate'
 
 function getAggregationError(aggregation?: SearchAggregationResult): Error | undefined {
     if (aggregation?.__typename === 'SearchAggregationNotAvailable') {
-        return new Error(aggregation.reason)
+        let reason = aggregation.reason
+        if (reason.length > 0 && !reason.endsWith('.')) {
+            reason = reason + '.'
+        }
+        return new Error(reason)
     }
 
     return
@@ -95,7 +99,7 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
                 <BarsBackground size={size} />
                 <div className={styles.errorMessageLayout}>
                     <div className={styles.errorMessage}>
-                        We couldn’t provide an aggregation for this query. <ErrorMessage error={aggregationError} />.{' '}
+                        We couldn’t provide an aggregation for this query. <ErrorMessage error={aggregationError} />{' '}
                         <Link to="">Learn more</Link>
                     </div>
                 </div>

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -34,8 +34,8 @@ const cgMultipleQueryPatternMsg = "Grouping by capture group does not support se
 const cgUnsupportedSelectFmt = `Grouping by capture group is not available for searches with "%s:%s".`
 
 // Possible reasons that grouping would fail
-const shardTimeoutMsg = "We couldn't provide an aggregation for this query. The query was unable to complete in the allocated time."
-const generalTimeoutMsg = "We couldn't provide an aggregation for this query. The query was unable to complete in the allocated time."
+const shardTimeoutMsg = "The query was unable to complete in the allocated time."
+const generalTimeoutMsg = "The query was unable to complete in the allocated time."
 
 // These should be very rare
 const unknowAggregationModeMsg = "The requested grouping is not supported."                     // example if a request with mode = NOT_A_REAL_MODE came in, should fail at graphql level


### PR DESCRIPTION

## Test plan

| before | after |
| ---- | ----| 
| <img width="267" alt="Screenshot 2022-08-31 at 10 49 39" src="https://user-images.githubusercontent.com/29406849/187651046-cf73fce9-f7c7-4724-99a0-dd16a3d5c7cb.png"> | <img width="268" alt="Screenshot 2022-08-31 at 10 49 21" src="https://user-images.githubusercontent.com/29406849/187651023-e66758bd-28ed-4754-aa50-b61fff82f6e9.png"> |

nb. I didn't make any visual changes just the string, dogfood just hasn't been updated yet
