### PR TITLE
gitserver: upgrade p4-fusion to 1.11

### DIFF
--- a/cmd/gitserver/p4-fusion-install-alpine.sh
+++ b/cmd/gitserver/p4-fusion-install-alpine.sh
@@ -38,7 +38,7 @@ set -x
 # Then extract the binary from /usr/local/bin/p4-fusion. Please rename it
 # follow the format and upload to the bucket here
 # https://console.cloud.google.com/storage/browser/sourcegraph-artifacts/p4-fusion
-export P4_FUSION_VERSION=v1.10
+export P4_FUSION_VERSION=v1.11
 
 # Runtime dependencies
 echo "--- p4-fusion apk runtime-deps"
@@ -49,7 +49,7 @@ echo "--- p4-fusion prebuilt binary check"
 if wget https://storage.googleapis.com/sourcegraph-artifacts/p4-fusion/p4-fusion-"$P4_FUSION_VERSION"-musl-x86_64; then
   src=p4-fusion-"$P4_FUSION_VERSION"-musl-x86_64
   cat <<EOF | grep "$src" | sha256sum -c
-4e4b6468461e083631f1db01ba20348d0e30eb719b406318e378cf2eb51dc8eb  p4-fusion-v1.10-musl-x86_64
+98c4991b40cdd0e0cad2fd5fdbe9f8ff56901415dd1684aed5b4531fc49ab79e  p4-fusion-v1.11-musl-x86_64
 EOF
   chmod +x "$src"
   mv "$src" /usr/local/bin/p4-fusion


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/41110

Test plan:
Docker image builds successfully.
Test that p4-fusion executable works correctly.