### PR TITLE
Remove unused IndexingProgress and IndexingStatus messages

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -80,7 +80,6 @@ interface StatusMessageEntryProps {
     entryType: EntryType
     linkOnClick: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void
     messageHint?: string
-    progressHint?: string
     title?: string
 }
 
@@ -212,7 +211,6 @@ const StatusMessagesNavItemEntry: React.FunctionComponent<React.PropsWithChildre
                     </Link>
                 </div>
             )}
-            {props.progressHint && <small className="text-muted">{props.progressHint}</small>}
         </div>
     )
 }
@@ -387,7 +385,6 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                             linkText="View status"
                             linkOnClick={this.toggleIsOpen}
                             entryType="progress"
-                            progressHint={''}
                         />
                     )
                 case 'ExternalServiceSyncError':

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -52,15 +52,7 @@ function fetchAllStatusMessages(): Observable<StatusMessagesResult['statusMessag
                     message
                 }
 
-                ... on IndexingProgress {
-                    message
-                }
-
                 ... on SyncError {
-                    message
-                }
-
-                ... on IndexingError {
                     message
                 }
 
@@ -383,13 +375,6 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
             )
         }
 
-        const cloningProgress = noActivityOrStatus.find(message_ => message_.type === 'CloningProgress')
-        const indexing = noActivityOrStatus.find(message_ => message_.type === 'IndexingProgress')
-
-        if (cloningProgress && indexing) {
-            noActivityOrStatus = noActivityOrStatus.filter(message_ => message_.type !== 'IndexingProgress')
-        }
-
         return noActivityOrStatus.map(status => {
             switch (status.type) {
                 case 'CloningProgress':
@@ -402,19 +387,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                             linkText="View status"
                             linkOnClick={this.toggleIsOpen}
                             entryType="progress"
-                            progressHint={indexing && indexing.type === 'IndexingProgress' ? indexing.message : ''}
-                        />
-                    )
-                case 'IndexingProgress':
-                    return (
-                        <StatusMessagesNavItemEntry
-                            key={status.message}
-                            message="Repositories available for search"
-                            linkTo={links.viewRepositories}
-                            linkText="Manage repositories"
-                            linkOnClick={this.toggleIsOpen}
-                            entryType="success"
-                            progressHint={status.message}
+                            progressHint={''}
                         />
                     )
                 case 'ExternalServiceSyncError':
@@ -439,18 +412,6 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                             linkText="Manage repositories"
                             linkOnClick={this.toggleIsOpen}
                             entryType="error"
-                        />
-                    )
-                case 'IndexingError':
-                    return (
-                        <StatusMessagesNavItemEntry
-                            key={status.message}
-                            message={status.message}
-                            messageHint="Your repositories are up-to-date, but search speed may be slower than usual."
-                            linkTo={links.viewRepositories}
-                            linkText="Troubleshoot"
-                            linkOnClick={this.toggleIsOpen}
-                            entryType="warning"
                         />
                     )
             }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7198,16 +7198,6 @@ type CloningProgress {
 }
 
 """
-FOR INTERNAL USE ONLY: A status message produced when repositories are being indexed
-"""
-type IndexingProgress {
-    """
-    The message of this status message
-    """
-    message: String!
-}
-
-"""
 FOR INTERNAL USE ONLY: A status message produced when repositories could not
 be synced from an external service
 """
@@ -7234,20 +7224,9 @@ type SyncError {
 }
 
 """
-FOR INTERNAL USE ONLY: A status message produced when repositories could not
-be indexed
-"""
-type IndexingError {
-    """
-    The message of this status message
-    """
-    message: String!
-}
-
-"""
 FOR INTERNAL USE ONLY: A status message
 """
-union StatusMessage = CloningProgress | IndexingProgress | ExternalServiceSyncError | SyncError | IndexingError
+union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
 
 """
 An arbitrarily large integer encoded as a decimal string.

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -44,20 +44,12 @@ func (r *statusMessageResolver) ToCloningProgress() (*statusMessageResolver, boo
 	return r, r.message.Cloning != nil
 }
 
-func (r *statusMessageResolver) ToIndexingProgress() (*statusMessageResolver, bool) {
-	return r, r.message.Indexing != nil
-}
-
 func (r *statusMessageResolver) ToExternalServiceSyncError() (*statusMessageResolver, bool) {
 	return r, r.message.ExternalServiceSyncError != nil
 }
 
 func (r *statusMessageResolver) ToSyncError() (*statusMessageResolver, bool) {
 	return r, r.message.SyncError != nil
-}
-
-func (r *statusMessageResolver) ToIndexingError() (*statusMessageResolver, bool) {
-	return r, r.message.IndexingError != nil
 }
 
 func (r *statusMessageResolver) Message() (string, error) {
@@ -69,9 +61,6 @@ func (r *statusMessageResolver) Message() (string, error) {
 	}
 	if r.message.SyncError != nil {
 		return r.message.SyncError.Message, nil
-	}
-	if r.message.IndexingError != nil {
-		return r.message.IndexingError.Message, nil
 	}
 	return "", errors.New("status message is of unknown type")
 }

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -25,10 +25,6 @@ func TestStatusMessages(t *testing.T) {
 					message
 				}
 
-				... on IndexingError {
-					message
-				}
-
 				... on ExternalServiceSyncError {
 					message
 					externalService {
@@ -110,11 +106,6 @@ func TestStatusMessages(t *testing.T) {
 						Message: "Could not save to database",
 					},
 				},
-				{
-					IndexingError: &repos.IndexingError{
-						Message: "Could not complete indexing.",
-					},
-				},
 			}
 			return res, nil
 		}
@@ -142,10 +133,6 @@ func TestStatusMessages(t *testing.T) {
 							{
 								"__typename": "SyncError",
 								"message": "Could not save to database"
-							},
-							{
-								"__typename": "IndexingError",
-								"message": "Could not complete indexing."
 							}
 						]
 					}

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -142,10 +142,6 @@ type CloningProgress struct {
 	Message string
 }
 
-type IndexingProgress struct {
-	Message string
-}
-
 type ExternalServiceSyncError struct {
 	Message           string
 	ExternalServiceId int64
@@ -155,14 +151,8 @@ type SyncError struct {
 	Message string
 }
 
-type IndexingError struct {
-	Message string
-}
-
 type StatusMessage struct {
 	Cloning                  *CloningProgress          `json:"cloning"`
-	Indexing                 *IndexingProgress         `json:"indexing"`
 	ExternalServiceSyncError *ExternalServiceSyncError `json:"external_service_sync_error"`
 	SyncError                *SyncError                `json:"sync_error"`
-	IndexingError            *IndexingError            `json:"indexing_error"`
 }


### PR DESCRIPTION
These two status messages were added (example: https://github.com/sourcegraph/sourcegraph/pull/18679) but never used. This removes them and makes code easier on frontend.

## Test plan

- Existing tests and manual testing.