### PR TITLE
Show status messages only to site-admins and simplify code

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -378,14 +378,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
                     )}
                     {props.authenticatedUser?.siteAdmin && (
                         <NavAction>
-                            <StatusMessagesNavItem
-                                user={{
-                                    id: props.authenticatedUser.id,
-                                    username: props.authenticatedUser.username,
-                                    isSiteAdmin: props.authenticatedUser?.siteAdmin || false,
-                                }}
-                                history={history}
-                            />
+                            <StatusMessagesNavItem history={history} />
                         </NavAction>
                     )}
                     {!props.authenticatedUser ? (

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -376,20 +376,18 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
                             />
                         </NavAction>
                     )}
-                    {props.authenticatedUser &&
-                        (props.authenticatedUser.siteAdmin ||
-                            userExternalServicesEnabledFromTags(props.authenticatedUser.tags)) && (
-                            <NavAction>
-                                <StatusMessagesNavItem
-                                    user={{
-                                        id: props.authenticatedUser.id,
-                                        username: props.authenticatedUser.username,
-                                        isSiteAdmin: props.authenticatedUser?.siteAdmin || false,
-                                    }}
-                                    history={history}
-                                />
-                            </NavAction>
-                        )}
+                    {props.authenticatedUser?.siteAdmin && (
+                        <NavAction>
+                            <StatusMessagesNavItem
+                                user={{
+                                    id: props.authenticatedUser.id,
+                                    username: props.authenticatedUser.username,
+                                    isSiteAdmin: props.authenticatedUser?.siteAdmin || false,
+                                }}
+                                history={history}
+                            />
+                        </NavAction>
+                    )}
                     {!props.authenticatedUser ? (
                         <>
                             <NavAction>

--- a/client/web/src/nav/StatusMessagesNavItem.test.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.test.tsx
@@ -9,12 +9,6 @@ import { SourcegraphContext } from '../jscontext'
 import { StatusMessagesNavItem } from './StatusMessagesNavItem'
 
 describe('StatusMessagesNavItem', () => {
-    const user = {
-        id: 'VXNlcjox',
-        username: 'user',
-        isSiteAdmin: false,
-    }
-
     let oldContext: SourcegraphContext & Mocha.SuiteFunction
 
     beforeEach(() => {
@@ -29,40 +23,26 @@ describe('StatusMessagesNavItem', () => {
         const fetchMessages = (): Observable<StatusMessagesResult['statusMessages']> => of([])
         expect(
             renderWithBrandedContext(
-                <StatusMessagesNavItem fetchMessages={fetchMessages} user={user} history={createMemoryHistory()} />
+                <StatusMessagesNavItem fetchMessages={fetchMessages} history={createMemoryHistory()} />
             ).asFragment()
         ).toMatchSnapshot()
     })
 
-    describe('one CloningProgress message', () => {
+    test('one CloningProgress message', () => {
         const message: StatusMessageFields = {
             type: 'CloningProgress',
             message: 'Currently cloning repositories...',
         }
 
         const fetchMessages = () => of([message])
-        test('as non-site admin', () => {
-            expect(
-                renderWithBrandedContext(
-                    <StatusMessagesNavItem fetchMessages={fetchMessages} user={user} history={createMemoryHistory()} />
-                ).asFragment()
-            ).toMatchSnapshot()
-        })
-
-        test('as site admin', () => {
-            expect(
-                renderWithBrandedContext(
-                    <StatusMessagesNavItem
-                        fetchMessages={fetchMessages}
-                        user={{ ...user, isSiteAdmin: true }}
-                        history={createMemoryHistory()}
-                    />
-                ).asFragment()
-            ).toMatchSnapshot()
-        })
+        expect(
+            renderWithBrandedContext(
+                <StatusMessagesNavItem fetchMessages={fetchMessages} history={createMemoryHistory()} />
+            ).asFragment()
+        ).toMatchSnapshot()
     })
 
-    describe('one ExternalServiceSyncError message', () => {
+    test('one ExternalServiceSyncError message', () => {
         const message: StatusMessageFields = {
             type: 'ExternalServiceSyncError',
             message: 'failed to list organization kubernetes repos: request returned status 404: Not Found',
@@ -73,52 +53,24 @@ describe('StatusMessagesNavItem', () => {
         }
 
         const fetchMessages = () => of([message])
-        test('as non-site admin', () => {
-            expect(
-                renderWithBrandedContext(
-                    <StatusMessagesNavItem fetchMessages={fetchMessages} user={user} history={createMemoryHistory()} />
-                ).asFragment()
-            ).toMatchSnapshot()
-        })
-
-        test('as site admin', () => {
-            expect(
-                renderWithBrandedContext(
-                    <StatusMessagesNavItem
-                        fetchMessages={fetchMessages}
-                        user={{ ...user, isSiteAdmin: true }}
-                        history={createMemoryHistory()}
-                    />
-                ).asFragment()
-            ).toMatchSnapshot()
-        })
+        expect(
+            renderWithBrandedContext(
+                <StatusMessagesNavItem fetchMessages={fetchMessages} history={createMemoryHistory()} />
+            ).asFragment()
+        ).toMatchSnapshot()
     })
 
-    describe('one SyncError message', () => {
+    test('one SyncError message', () => {
         const message: StatusMessageFields = {
             type: 'SyncError',
             message: 'syncer.sync.store.upsert-repos: pg: unique constraint foobar',
         }
 
         const fetchMessages = () => of([message])
-        test('as non-site admin', () => {
-            expect(
-                renderWithBrandedContext(
-                    <StatusMessagesNavItem fetchMessages={fetchMessages} user={user} history={createMemoryHistory()} />
-                ).asFragment()
-            ).toMatchSnapshot()
-        })
-
-        test('as site admin', () => {
-            expect(
-                renderWithBrandedContext(
-                    <StatusMessagesNavItem
-                        fetchMessages={fetchMessages}
-                        user={{ ...user, isSiteAdmin: true }}
-                        history={createMemoryHistory()}
-                    />
-                ).asFragment()
-            ).toMatchSnapshot()
-        })
+        expect(
+            renderWithBrandedContext(
+                <StatusMessagesNavItem fetchMessages={fetchMessages} history={createMemoryHistory()} />
+            ).asFragment()
+        ).toMatchSnapshot()
     })
 })

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 
-import { mdiCloudOffOutline, mdiInformation, mdiAlert, mdiSync, mdiCheckboxMarkedCircle } from '@mdi/js'
+import { mdiInformation, mdiAlert, mdiSync, mdiCheckboxMarkedCircle } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import { isEqual, upperFirst } from 'lodash'
-import { Observable, Subscription, of } from 'rxjs'
-import { catchError, map, repeatWhen, delay, distinctUntilChanged, switchMap } from 'rxjs/operators'
+import { Observable, Subscription } from 'rxjs'
+import { catchError, map, repeatWhen, delay, distinctUntilChanged } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, ErrorLike, isErrorLike, repeatUntil } from '@sourcegraph/common'
-import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
+import { dataOrThrowErrors } from '@sourcegraph/http-client'
 import {
     CloudAlertIconRefresh,
     CloudSyncIconRefresh,
@@ -30,42 +30,14 @@ import {
 
 import { requestGraphQL } from '../backend/graphql'
 import { CircleDashedIcon } from '../components/CircleDashedIcon'
-import { queryExternalServices } from '../components/externalServices/backend'
 import { StatusMessagesResult } from '../graphql-operations'
 import { eventLogger } from '../tracking/eventLogger'
 
 import styles from './StatusMessagesNavItem.module.scss'
+import { STATUS_MESSAGES } from './StatusMessagesNavItemQueries'
 
 function fetchAllStatusMessages(): Observable<StatusMessagesResult['statusMessages']> {
-    return requestGraphQL<StatusMessagesResult>(
-        gql`
-            query StatusMessages {
-                statusMessages {
-                    ...StatusMessageFields
-                }
-            }
-
-            fragment StatusMessageFields on StatusMessage {
-                type: __typename
-
-                ... on CloningProgress {
-                    message
-                }
-
-                ... on SyncError {
-                    message
-                }
-
-                ... on ExternalServiceSyncError {
-                    message
-                    externalService {
-                        id
-                        displayName
-                    }
-                }
-            }
-        `
-    ).pipe(
+    return requestGraphQL<StatusMessagesResult>(STATUS_MESSAGES).pipe(
         map(dataOrThrowErrors),
         map(data => data.statusMessages)
     )
@@ -215,32 +187,16 @@ const StatusMessagesNavItemEntry: React.FunctionComponent<React.PropsWithChildre
     )
 }
 
-interface User {
-    id: string
-    username: string
-    isSiteAdmin: boolean
-}
-
 interface Props {
-    user: User
     history: H.History
     fetchMessages?: () => Observable<StatusMessagesResult['statusMessages']>
 }
 
-enum ExternalServiceNoActivityReasons {
-    NoCodehosts = 'NoCodehosts',
-    NoRepos = 'NoRepos',
-}
-
-type ExternalServiceNoActivityReason = keyof typeof ExternalServiceNoActivityReasons
-type Message = StatusMessagesResult['statusMessages'] | ExternalServiceNoActivityReason
-type MessageOrError = Message | ErrorLike
-
-const isNoActivityReason = (status: MessageOrError): status is ExternalServiceNoActivityReason =>
-    typeof status === 'string'
+type Messages = StatusMessagesResult['statusMessages']
+type MessagesOrError = Messages | ErrorLike
 
 interface State {
-    messagesOrError: MessageOrError
+    messagesOrError: MessagesOrError
     isOpen: boolean
 }
 
@@ -263,33 +219,13 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
     public componentDidMount(): void {
         let first = true
         this.subscriptions.add(
-            queryExternalServices({
-                namespace: this.props.user.id,
-                first: null,
-                after: null,
-            })
+            (this.props.fetchMessages ?? fetchAllStatusMessages)()
                 .pipe(
-                    switchMap(({ nodes: services }) => {
-                        if (!this.props.user.isSiteAdmin) {
-                            if (services.length === 0) {
-                                return of(ExternalServiceNoActivityReasons.NoCodehosts)
-                            }
-
-                            if (
-                                !services.some(service => service.repoCount !== 0) &&
-                                services.every(service => service.lastSyncError === null && service.warning === null)
-                            ) {
-                                return of(ExternalServiceNoActivityReasons.NoRepos)
-                            }
-                        }
-
-                        return (this.props.fetchMessages ?? fetchAllStatusMessages)()
-                    }),
                     catchError(error => [asError(error) as ErrorLike]),
-                    // Poll on REFRESH_INTERVAL_MS, or REFRESH_INTERVAL_AFTER_ERROR_MS if there is an error.
+                    // Poll on REFRESH_INTERVAL_MS
                     repeatUntil(messagesOrError => isErrorLike(messagesOrError), { delay: REFRESH_INTERVAL_MS }),
                     repeatWhen(completions => completions.pipe(delay(REFRESH_INTERVAL_MS))),
-                    distinctUntilChanged((a, b) => isEqual(a, b))
+                    distinctUntilChanged(isEqual)
                 )
                 .subscribe(messagesOrError => {
                     this.setState({ messagesOrError })
@@ -306,32 +242,16 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
         this.subscriptions.unsubscribe()
     }
 
-    private renderMessage(noActivityOrStatus: Message, isSiteAdmin: boolean): JSX.Element | JSX.Element[] {
-        const userSettings = `/users/${this.props.user.username}/settings`
-
-        const roleLinks = {
-            admin: {
-                viewRepositories: '/site-admin/repositories',
-                manageRepositories: '/site-admin/external-services',
-                manageCodeHosts: '/site-admin/external-services',
-                getCodeHostLink: (id: string) => `/site-admin/external-services/${id}`,
-            },
-            nonAdmin: {
-                viewRepositories: `${userSettings}/repositories`,
-                manageRepositories: `${userSettings}/repositories/manage`,
-                manageCodeHosts: `${userSettings}/code-hosts`,
-                getCodeHostLink: () => `${userSettings}/code-hosts`,
-            },
+    private renderMessage(messages: Messages): JSX.Element | JSX.Element[] {
+        const links = {
+            viewRepositories: '/site-admin/repositories',
+            manageRepositories: '/site-admin/external-services',
+            manageCodeHosts: '/site-admin/external-services',
+            getCodeHostLink: (id: string) => `/site-admin/external-services/${id}`,
         }
 
-        const links = isSiteAdmin ? roleLinks.admin : roleLinks.nonAdmin
-
         // no status messages
-        if (
-            !window.context.sourcegraphDotComMode &&
-            Array.isArray(noActivityOrStatus) &&
-            noActivityOrStatus.length === 0
-        ) {
+        if (messages.length === 0) {
             return (
                 <StatusMessagesNavItemEntry
                     key="up-to-date"
@@ -344,36 +264,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
             )
         }
 
-        // no code hosts or no repos
-        if (isNoActivityReason(noActivityOrStatus)) {
-            if (window.context.sourcegraphDotComMode) {
-                return []
-            }
-            if (noActivityOrStatus === ExternalServiceNoActivityReasons.NoRepos) {
-                return (
-                    <StatusMessagesNavItemEntry
-                        key={noActivityOrStatus}
-                        message="Add repositories to start searching your code on Sourcegraph."
-                        linkTo={links.manageRepositories}
-                        linkText="Add repositories"
-                        linkOnClick={this.toggleIsOpen}
-                        entryType="not-active"
-                    />
-                )
-            }
-            return (
-                <StatusMessagesNavItemEntry
-                    key={noActivityOrStatus}
-                    message="Connect with a code host to start adding your code to Sourcegraph."
-                    linkTo={links.manageCodeHosts}
-                    linkText="Connect with code host"
-                    linkOnClick={this.toggleIsOpen}
-                    entryType="not-active"
-                />
-            )
-        }
-
-        return noActivityOrStatus.map(status => {
+        return messages.map(status => {
             switch (status.type) {
                 case 'CloningProgress':
                     return (
@@ -424,50 +315,33 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
             )
         }
 
-        let codeHostMessage = this.state.isOpen
-            ? undefined
-            : this.state.messagesOrError === ExternalServiceNoActivityReasons.NoCodehosts
-            ? 'No code host connections'
-            : 'No repositories'
-        if (isNoActivityReason(this.state.messagesOrError)) {
-            return (
-                <Tooltip content={codeHostMessage}>
-                    <Icon
-                        svgPath={mdiCloudOffOutline}
-                        size="md"
-                        {...(codeHostMessage ? { 'aria-label': codeHostMessage } : { 'aria-hidden': true })}
-                    />
-                </Tooltip>
-            )
-        }
-
+        let codeHostMessage
+        let icon
         if (
             this.state.messagesOrError.some(({ type }) => type === 'ExternalServiceSyncError' || type === 'SyncError')
         ) {
-            codeHostMessage = this.state.isOpen ? undefined : 'Syncing repositories failed!'
-            return (
-                <Tooltip content={codeHostMessage}>
-                    <Icon aria-label={codeHostMessage ?? ''} as={CloudAlertIconRefresh} size="md" />
-                </Tooltip>
-            )
+            codeHostMessage = 'Syncing repositories failed!'
+            icon = CloudAlertIconRefresh
+        } else if (this.state.messagesOrError.some(({ type }) => type === 'CloningProgress')) {
+            codeHostMessage = 'Cloning repositories...'
+            icon = CloudSyncIconRefresh
+        } else {
+            codeHostMessage = 'Repositories up-to-date'
+            icon = CloudCheckIconRefresh
         }
-        if (this.state.messagesOrError.some(({ type }) => type === 'CloningProgress')) {
-            codeHostMessage = this.state.isOpen ? undefined : 'Cloning repositories...'
-            return (
-                <Tooltip content={codeHostMessage}>
-                    <Icon aria-label={codeHostMessage ?? ''} as={CloudSyncIconRefresh} size="md" />
-                </Tooltip>
-            )
-        }
-        codeHostMessage = this.state.isOpen ? undefined : 'Repositories up-to-date'
+
         return (
-            <Tooltip content={codeHostMessage}>
-                <Icon aria-label={codeHostMessage ?? ''} as={CloudCheckIconRefresh} size="md" />
+            <Tooltip content={this.state.isOpen ? undefined : codeHostMessage}>
+                <Icon
+                    as={icon}
+                    size="md"
+                    {...(this.state.isOpen ? { 'aria-hidden': true } : { 'aria-label': codeHostMessage })}
+                />
             </Tooltip>
         )
     }
 
-    private getOpenedNotificationsPayload(messagesOrError: MessageOrError): { status: string[] } {
+    private getOpenedNotificationsPayload(messagesOrError: MessagesOrError): { status: string[] } {
         const messageTypes =
             typeof messagesOrError === 'string'
                 ? [messagesOrError]
@@ -513,7 +387,7 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                                 error={this.state.messagesOrError}
                             />
                         ) : (
-                            this.renderMessage(this.state.messagesOrError, this.props.user.isSiteAdmin)
+                            this.renderMessage(this.state.messagesOrError)
                         )}
                     </div>
                 </PopoverContent>

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -33,8 +33,9 @@ import { CircleDashedIcon } from '../components/CircleDashedIcon'
 import { StatusMessagesResult } from '../graphql-operations'
 import { eventLogger } from '../tracking/eventLogger'
 
-import styles from './StatusMessagesNavItem.module.scss'
 import { STATUS_MESSAGES } from './StatusMessagesNavItemQueries'
+
+import styles from './StatusMessagesNavItem.module.scss'
 
 function fetchAllStatusMessages(): Observable<StatusMessagesResult['statusMessages']> {
     return requestGraphQL<StatusMessagesResult>(STATUS_MESSAGES).pipe(

--- a/client/web/src/nav/StatusMessagesNavItemQueries.ts
+++ b/client/web/src/nav/StatusMessagesNavItemQueries.ts
@@ -1,0 +1,29 @@
+import { gql } from '@sourcegraph/http-client'
+
+export const STATUS_MESSAGES = gql`
+    query StatusMessages {
+        statusMessages {
+            ...StatusMessageFields
+        }
+    }
+
+    fragment StatusMessageFields on StatusMessage {
+        type: __typename
+
+        ... on CloningProgress {
+            message
+        }
+
+        ... on SyncError {
+            message
+        }
+
+        ... on ExternalServiceSyncError {
+            message
+            externalService {
+                id
+                displayName
+            }
+        }
+    }
+`

--- a/client/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`StatusMessagesNavItem no messages 1`] = `
 </DocumentFragment>
 `;
 
-exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`] = `
+exports[`StatusMessagesNavItem one CloningProgress message 1`] = `
 <DocumentFragment>
   <button
     aria-label="Show status messages"
@@ -51,23 +51,27 @@ exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`]
     type="button"
   >
     <svg
-      aria-label="Repositories up-to-date"
+      aria-label="Cloning repositories..."
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
       data-state="closed"
       fill="currentColor"
       height="24"
       role="img"
-      viewBox="0 -4 20 20"
+      viewBox="0 0 20 20"
       width="24"
     >
       <g>
         <path
-          d="M14.4175 5.6859L14.6515 6.82244L16.1402 5.33371L16.1315 5.33301C15.5482 2.49967 13.0482 0.333008 9.96484 0.333008C7.54818 0.333008 5.46484 1.66634 4.46484 3.66634C1.88151 3.99967 -0.0351562 6.08301 -0.0351562 8.66634C-0.0351562 11.4163 2.21484 13.6663 4.96484 13.6663H10.273L8.52301 11.9163H4.96484C3.18134 11.9163 1.71484 10.4498 1.71484 8.66634C1.71484 7.00858 2.9321 5.62862 4.68879 5.40195L5.61324 5.28267L6.03009 4.44896C6.7313 3.04654 8.20576 2.08301 9.96484 2.08301C12.1965 2.08301 13.9973 3.64505 14.4175 5.6859Z"
+          d="M13.7873 7.14774C12.9858 5.90993 11.5895 5.08203 9.96484 5.08203C8.20576 5.08203 6.7313 6.04556 6.03009 7.44799L5.61324 8.28169L4.68879 8.40098C2.9321 8.62765 1.71484 10.0076 1.71484 11.6654C1.71484 13.4489 3.18134 14.9154 4.96484 14.9154H10.3872V16.6654H4.96484C2.21484 16.6654 -0.0351562 14.4154 -0.0351562 11.6654C-0.0351562 9.08203 1.88151 6.9987 4.46484 6.66536C5.46484 4.66536 7.54818 3.33203 9.96484 3.33203C12.0727 3.33203 13.9079 4.34461 15.0445 5.89054L13.7873 7.14774Z"
           fill="#798BAF"
         />
         <path
-          d="M9.74232 8.18541L8.50488 9.42285L12.7475 13.6655L19.8287 6.59486L18.5913 5.35742L12.7528 11.1959L9.74232 8.18541Z"
-          fill="#37B24D"
+          d="M12.6934 15.2025C11.353 13.8621 11.2692 11.684 12.4421 10.176L13.6149 11.4327C13.0285 12.1866 13.1961 13.3595 13.8663 14.0297C14.2851 14.3648 14.7878 14.6161 15.3742 14.6161V13.1081L17.7199 15.5376L15.3742 17.8833V16.2916C14.3689 16.2916 13.3636 15.8727 12.6934 15.2025Z"
+          fill="#5E6E8C"
+        />
+        <path
+          d="M13.8663 9.58962L16.2119 7.16016V8.75187C17.2172 8.75187 18.1388 9.17075 18.8927 9.75717C20.2331 11.0976 20.3169 13.2757 19.144 14.7836L17.9712 13.6108C18.5576 12.8568 18.3901 11.684 17.7199 11.0138C17.301 10.6787 16.7984 10.4274 16.2119 10.4274V11.9353L13.8663 9.58962Z"
+          fill="#5E6E8C"
         />
       </g>
       <defs>
@@ -86,7 +90,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as non-site admin 1`]
 </DocumentFragment>
 `;
 
-exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
+exports[`StatusMessagesNavItem one ExternalServiceSyncError message 1`] = `
 <DocumentFragment>
   <button
     aria-label="Show status messages"
@@ -94,23 +98,23 @@ exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
     type="button"
   >
     <svg
-      aria-label="Repositories up-to-date"
+      aria-label="Syncing repositories failed!"
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
       data-state="closed"
       fill="currentColor"
       height="24"
       role="img"
-      viewBox="0 -4 20 20"
+      viewBox="0 0 20 20"
       width="24"
     >
       <g>
         <path
-          d="M14.4175 5.6859L14.6515 6.82244L16.1402 5.33371L16.1315 5.33301C15.5482 2.49967 13.0482 0.333008 9.96484 0.333008C7.54818 0.333008 5.46484 1.66634 4.46484 3.66634C1.88151 3.99967 -0.0351562 6.08301 -0.0351562 8.66634C-0.0351562 11.4163 2.21484 13.6663 4.96484 13.6663H10.273L8.52301 11.9163H4.96484C3.18134 11.9163 1.71484 10.4498 1.71484 8.66634C1.71484 7.00858 2.9321 5.62862 4.68879 5.40195L5.61324 5.28267L6.03009 4.44896C6.7313 3.04654 8.20576 2.08301 9.96484 2.08301C12.1965 2.08301 13.9973 3.64505 14.4175 5.6859Z"
+          d="M15.3129 6.28624C14.2107 4.51968 12.2477 3.33203 9.96484 3.33203C7.54818 3.33203 5.46484 4.66536 4.46484 6.66536C1.88151 6.9987 -0.0351562 9.08203 -0.0351562 11.6654C-0.0351562 14.4154 2.21484 16.6654 4.96484 16.6654H9.32894L10.3379 14.9154H4.96484C3.18134 14.9154 1.71484 13.4489 1.71484 11.6654C1.71484 10.0076 2.9321 8.62765 4.68879 8.40098L5.61324 8.28169L6.03009 7.44799C6.7313 6.04556 8.20576 5.08203 9.96484 5.08203C11.9829 5.08203 13.6486 6.35936 14.2597 8.11301L15.3129 6.28624Z"
           fill="#798BAF"
         />
         <path
-          d="M9.74232 8.18541L8.50488 9.42285L12.7475 13.6655L19.8287 6.59486L18.5913 5.35742L12.7528 11.1959L9.74232 8.18541Z"
-          fill="#37B24D"
+          d="M15.4749 9.62828C15.639 9.34396 16.0494 9.34396 16.2136 9.62828L19.9071 16.0256C20.0712 16.3099 19.866 16.6653 19.5377 16.6653H12.1508C11.8224 16.6653 11.6173 16.3099 11.7814 16.0256L15.4749 9.62828Z"
+          fill="#F59F00"
         />
       </g>
       <defs>
@@ -129,7 +133,7 @@ exports[`StatusMessagesNavItem one CloningProgress message as site admin 1`] = `
 </DocumentFragment>
 `;
 
-exports[`StatusMessagesNavItem one ExternalServiceSyncError message as non-site admin 1`] = `
+exports[`StatusMessagesNavItem one SyncError message 1`] = `
 <DocumentFragment>
   <button
     aria-label="Show status messages"
@@ -137,152 +141,23 @@ exports[`StatusMessagesNavItem one ExternalServiceSyncError message as non-site 
     type="button"
   >
     <svg
-      aria-label="Repositories up-to-date"
+      aria-label="Syncing repositories failed!"
       class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
       data-state="closed"
       fill="currentColor"
       height="24"
       role="img"
-      viewBox="0 -4 20 20"
+      viewBox="0 0 20 20"
       width="24"
     >
       <g>
         <path
-          d="M14.4175 5.6859L14.6515 6.82244L16.1402 5.33371L16.1315 5.33301C15.5482 2.49967 13.0482 0.333008 9.96484 0.333008C7.54818 0.333008 5.46484 1.66634 4.46484 3.66634C1.88151 3.99967 -0.0351562 6.08301 -0.0351562 8.66634C-0.0351562 11.4163 2.21484 13.6663 4.96484 13.6663H10.273L8.52301 11.9163H4.96484C3.18134 11.9163 1.71484 10.4498 1.71484 8.66634C1.71484 7.00858 2.9321 5.62862 4.68879 5.40195L5.61324 5.28267L6.03009 4.44896C6.7313 3.04654 8.20576 2.08301 9.96484 2.08301C12.1965 2.08301 13.9973 3.64505 14.4175 5.6859Z"
+          d="M15.3129 6.28624C14.2107 4.51968 12.2477 3.33203 9.96484 3.33203C7.54818 3.33203 5.46484 4.66536 4.46484 6.66536C1.88151 6.9987 -0.0351562 9.08203 -0.0351562 11.6654C-0.0351562 14.4154 2.21484 16.6654 4.96484 16.6654H9.32894L10.3379 14.9154H4.96484C3.18134 14.9154 1.71484 13.4489 1.71484 11.6654C1.71484 10.0076 2.9321 8.62765 4.68879 8.40098L5.61324 8.28169L6.03009 7.44799C6.7313 6.04556 8.20576 5.08203 9.96484 5.08203C11.9829 5.08203 13.6486 6.35936 14.2597 8.11301L15.3129 6.28624Z"
           fill="#798BAF"
         />
         <path
-          d="M9.74232 8.18541L8.50488 9.42285L12.7475 13.6655L19.8287 6.59486L18.5913 5.35742L12.7528 11.1959L9.74232 8.18541Z"
-          fill="#37B24D"
-        />
-      </g>
-      <defs>
-        <clippath
-          id="clip0"
-        >
-          <rect
-            fill="white"
-            height="20"
-            width="20"
-          />
-        </clippath>
-      </defs>
-    </svg>
-  </button>
-</DocumentFragment>
-`;
-
-exports[`StatusMessagesNavItem one ExternalServiceSyncError message as site admin 1`] = `
-<DocumentFragment>
-  <button
-    aria-label="Show status messages"
-    class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
-    type="button"
-  >
-    <svg
-      aria-label="Repositories up-to-date"
-      class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-state="closed"
-      fill="currentColor"
-      height="24"
-      role="img"
-      viewBox="0 -4 20 20"
-      width="24"
-    >
-      <g>
-        <path
-          d="M14.4175 5.6859L14.6515 6.82244L16.1402 5.33371L16.1315 5.33301C15.5482 2.49967 13.0482 0.333008 9.96484 0.333008C7.54818 0.333008 5.46484 1.66634 4.46484 3.66634C1.88151 3.99967 -0.0351562 6.08301 -0.0351562 8.66634C-0.0351562 11.4163 2.21484 13.6663 4.96484 13.6663H10.273L8.52301 11.9163H4.96484C3.18134 11.9163 1.71484 10.4498 1.71484 8.66634C1.71484 7.00858 2.9321 5.62862 4.68879 5.40195L5.61324 5.28267L6.03009 4.44896C6.7313 3.04654 8.20576 2.08301 9.96484 2.08301C12.1965 2.08301 13.9973 3.64505 14.4175 5.6859Z"
-          fill="#798BAF"
-        />
-        <path
-          d="M9.74232 8.18541L8.50488 9.42285L12.7475 13.6655L19.8287 6.59486L18.5913 5.35742L12.7528 11.1959L9.74232 8.18541Z"
-          fill="#37B24D"
-        />
-      </g>
-      <defs>
-        <clippath
-          id="clip0"
-        >
-          <rect
-            fill="white"
-            height="20"
-            width="20"
-          />
-        </clippath>
-      </defs>
-    </svg>
-  </button>
-</DocumentFragment>
-`;
-
-exports[`StatusMessagesNavItem one SyncError message as non-site admin 1`] = `
-<DocumentFragment>
-  <button
-    aria-label="Show status messages"
-    class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
-    type="button"
-  >
-    <svg
-      aria-label="Repositories up-to-date"
-      class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-state="closed"
-      fill="currentColor"
-      height="24"
-      role="img"
-      viewBox="0 -4 20 20"
-      width="24"
-    >
-      <g>
-        <path
-          d="M14.4175 5.6859L14.6515 6.82244L16.1402 5.33371L16.1315 5.33301C15.5482 2.49967 13.0482 0.333008 9.96484 0.333008C7.54818 0.333008 5.46484 1.66634 4.46484 3.66634C1.88151 3.99967 -0.0351562 6.08301 -0.0351562 8.66634C-0.0351562 11.4163 2.21484 13.6663 4.96484 13.6663H10.273L8.52301 11.9163H4.96484C3.18134 11.9163 1.71484 10.4498 1.71484 8.66634C1.71484 7.00858 2.9321 5.62862 4.68879 5.40195L5.61324 5.28267L6.03009 4.44896C6.7313 3.04654 8.20576 2.08301 9.96484 2.08301C12.1965 2.08301 13.9973 3.64505 14.4175 5.6859Z"
-          fill="#798BAF"
-        />
-        <path
-          d="M9.74232 8.18541L8.50488 9.42285L12.7475 13.6655L19.8287 6.59486L18.5913 5.35742L12.7528 11.1959L9.74232 8.18541Z"
-          fill="#37B24D"
-        />
-      </g>
-      <defs>
-        <clippath
-          id="clip0"
-        >
-          <rect
-            fill="white"
-            height="20"
-            width="20"
-          />
-        </clippath>
-      </defs>
-    </svg>
-  </button>
-</DocumentFragment>
-`;
-
-exports[`StatusMessagesNavItem one SyncError message as site admin 1`] = `
-<DocumentFragment>
-  <button
-    aria-label="Show status messages"
-    class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
-    type="button"
-  >
-    <svg
-      aria-label="Repositories up-to-date"
-      class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-state="closed"
-      fill="currentColor"
-      height="24"
-      role="img"
-      viewBox="0 -4 20 20"
-      width="24"
-    >
-      <g>
-        <path
-          d="M14.4175 5.6859L14.6515 6.82244L16.1402 5.33371L16.1315 5.33301C15.5482 2.49967 13.0482 0.333008 9.96484 0.333008C7.54818 0.333008 5.46484 1.66634 4.46484 3.66634C1.88151 3.99967 -0.0351562 6.08301 -0.0351562 8.66634C-0.0351562 11.4163 2.21484 13.6663 4.96484 13.6663H10.273L8.52301 11.9163H4.96484C3.18134 11.9163 1.71484 10.4498 1.71484 8.66634C1.71484 7.00858 2.9321 5.62862 4.68879 5.40195L5.61324 5.28267L6.03009 4.44896C6.7313 3.04654 8.20576 2.08301 9.96484 2.08301C12.1965 2.08301 13.9973 3.64505 14.4175 5.6859Z"
-          fill="#798BAF"
-        />
-        <path
-          d="M9.74232 8.18541L8.50488 9.42285L12.7475 13.6655L19.8287 6.59486L18.5913 5.35742L12.7528 11.1959L9.74232 8.18541Z"
-          fill="#37B24D"
+          d="M15.4749 9.62828C15.639 9.34396 16.0494 9.34396 16.2136 9.62828L19.9071 16.0256C20.0712 16.3099 19.866 16.6653 19.5377 16.6653H12.1508C11.8224 16.6653 11.6173 16.3099 11.7814 16.0256L15.4749 9.62828Z"
+          fill="#F59F00"
         />
       </g>
       <defs>


### PR DESCRIPTION
Since we don't have the original Sourcegraph.com-Cloud anymore in which
a user could have repositories, we don't need to the status item to
users anymore.


## Test plan

- Manually testing

## App preview:

- [Web](https://sg-web-mrn-remove-user-repo-status.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zxiygqfegd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
