### PR TITLE
searcher: specify HEAD in tarArchive test helper

### DIFF
--- a/cmd/searcher/internal/search/store_test.go
+++ b/cmd/searcher/internal/search/store_test.go
@@ -255,13 +255,14 @@ func tarArchive(dir string) (*tar.Reader, error) {
 		"archive",
 		"--worktree-attributes",
 		"--format=tar",
-		"master",
+		"HEAD",
 		"--",
 	}
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	b := bytes.Buffer{}
 	cmd.Stdout = &b
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If a dev machine has configured the default branch in new repos to be main, then master is an invalid ref. Instead we can just specify HEAD.

Test Plan: go test now works on Erik's machine.
