### PR TITLE
fix 'target must be a non-nil pointer'

### DIFF
--- a/internal/codeintel/autoindexing/background/scheduler/init.go
+++ b/internal/codeintel/autoindexing/background/scheduler/init.go
@@ -30,7 +30,7 @@ func NewScheduler(
 		MetricLabelValues: []string{"HandleIndexSchedule"},
 		Metrics:           m,
 		ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
-			if errors.As(err, inference.LimitError{}) {
+			if errors.As(err, &inference.LimitError{}) {
 				return observation.EmitForDefault.Without(observation.EmitForMetrics)
 			}
 			return observation.EmitForDefault


### PR DESCRIPTION
Reported in slack:
```
[         worker] 2022/08/31 12:35:31 goroutine panic: errors.As: target must be a non-nil pointer, found inference.LimitError
[         worker] goroutine 647 [running]:
[         worker] runtime/debug.Stack()
[         worker]       /Users/thorstenball/.asdf/installs/golang/1.18.1/go/src/runtime/debug/stack.go:24 +0x64
[         worker] github.com/sourcegraph/sourcegraph/internal/goroutine.Go.func1.1()
[         worker]       /Users/thorstenball/work/sourcegraph/internal/goroutine/goroutine.go:19 +0x3c
[         worker] panic({0x108661220, 0x14001c797b0})
[         worker]       /Users/thorstenball/.asdf/installs/golang/1.18.1/go/src/runtime/panic.go:844 +0x26c
[         worker] github.com/cockroachdb/errors/errutil.As({0x0, 0x0}, {0x1085dfce0, 0x10a027d80})
[         worker]       /Users/thorstenball/code/go/pkg/mod/github.com/cockroachdb/errors@v1.9.0/errutil/as.go:46 +0x4a4
[         worker] github.com/cockroachdb/errors.As({0x0, 0x0}, {0x1085dfce0, 0x10a027d80})
[         worker]       /Users/thorstenball/code/go/pkg/mod/github.com/cockroachdb/errors@v1.9.0/errutil_api.go:194 +0x44
[         worker] github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/background/scheduler.NewScheduler.func1({0x0, 0x0})
[         worker]       /Users/thorstenball/work/sourcegraph/internal/codeintel/autoindexing/background/scheduler/init.go:33 +0x84
[         worker] github.com/sourcegraph/sourcegraph/internal/observation.(*Operation).applyErrorFilter(0x14002242f80, 0x1400103e440, 0x4)
[         worker]       /Users/thorstenball/work/sourcegraph/internal/observation/observation.go:417 +0xa0
[         worker] github.com/sourcegraph/sourcegraph/internal/observation.(*Operation).With.func1(0x3ff0000000000000, {{0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}})
[         worker]       /Users/thorstenball/work/sourcegraph/internal/observation/observation.go:332 +0x640
[         worker] github.com/sourcegraph/sourcegraph/internal/goroutine.runPeriodicHandler({0x10894dfc0, 0x140026b26f0}, {0x1089256c0, 0x1400216bae0}, 0x14002242f80)
[         worker]       /Users/thorstenball/work/sourcegraph/internal/goroutine/periodic.go:153 +0x33c
[         worker] github.com/sourcegraph/sourcegraph/internal/goroutine.(*PeriodicGoroutine).Start(0x1400216bb30)
[         worker]       /Users/thorstenball/work/sourcegraph/internal/goroutine/periodic.go:111 +0xec
[         worker] github.com/sourcegraph/sourcegraph/internal/goroutine.startAll.func1()
[         worker]       /Users/thorstenball/work/sourcegraph/internal/goroutine/background.go:73 +0x90
[         worker] github.com/sourcegraph/sourcegraph/internal/goroutine.Go.func1()
[         worker]       /Users/thorstenball/work/sourcegraph/internal/goroutine/goroutine.go:24 +0x50
[         worker] created by github.com/sourcegraph/sourcegraph/internal/goroutine.Go
[         worker]       /Users/thorstenball/work/sourcegraph/internal/goroutine/goroutine.go:16 +0x78
```

programming was a mistake

## Test plan

I ran it locally