### PR TITLE
status messages: change to admin-only, remove old code

### DIFF
--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -12,17 +12,12 @@ import (
 )
 
 func (r *schemaResolver) StatusMessages(ctx context.Context) ([]*statusMessageResolver, error) {
-	currentUser, err := backend.CurrentUser(ctx, r.db)
-	if err != nil {
+	// 🚨 SECURITY: Only site admins can fetch status messages.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
-	if currentUser == nil {
-		return nil, backend.ErrNotAuthenticated
-	}
 
-	// 🚨 SECURITY: Users will fetch status messages for any external services they
-	// own. In addition, site admins will also fetch site level external services.
-	messages, err := repos.FetchStatusMessages(ctx, r.db, currentUser)
+	messages, err := repos.FetchStatusMessages(ctx, r.db)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -56,7 +56,7 @@ func TestStatusMessages(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
-		repos.MockStatusMessages = func(_ context.Context, _ *types.User) ([]repos.StatusMessage, error) {
+		repos.MockStatusMessages = func(_ context.Context) ([]repos.StatusMessage, error) {
 			return []repos.StatusMessage{}, nil
 		}
 		defer func() { repos.MockStatusMessages = nil }()
@@ -88,7 +88,7 @@ func TestStatusMessages(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 		db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
-		repos.MockStatusMessages = func(_ context.Context, _ *types.User) ([]repos.StatusMessage, error) {
+		repos.MockStatusMessages = func(_ context.Context) ([]repos.StatusMessage, error) {
 			res := []repos.StatusMessage{
 				{
 					Cloning: &repos.CloningProgress{

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -68,13 +68,11 @@ type ExternalServiceStore interface {
 	// DistinctKinds returns the distinct list of external services kinds that are stored in the database.
 	DistinctKinds(ctx context.Context) ([]string, error)
 
-	// GetAffiliatedSyncErrors returns the most recent sync failure message for each
-	// external service affiliated with the supplied user. If the latest run did not
-	// have an error, the string will be empty. We fetch external services owned by
-	// the supplied user and if they are a site admin we additionally return site
-	// level external services. We exclude cloud_default repos as they are never
-	// synced.
-	GetAffiliatedSyncErrors(ctx context.Context, u *types.User) (map[int64]string, error)
+	// GetLatestSyncErrors returns the most recent sync failure message for
+	// each external service. If the latest sync did not have an error, the
+	// string will be empty. We exclude cloud_default external services as they
+	// are never synced.
+	GetLatestSyncErrors(ctx context.Context) (map[int64]string, error)
 
 	// GetByID returns the external service for id.
 	//
@@ -1181,10 +1179,7 @@ LIMIT 1
 	return lastError, err
 }
 
-func (e *externalServiceStore) GetAffiliatedSyncErrors(ctx context.Context, u *types.User) (map[int64]string, error) {
-	if u == nil {
-		return nil, errors.New("nil user")
-	}
+func (e *externalServiceStore) GetLatestSyncErrors(ctx context.Context) (map[int64]string, error) {
 	q := sqlf.Sprintf(`
 SELECT DISTINCT ON (es.id) es.id, essj.failure_message
 FROM external_services es
@@ -1193,14 +1188,11 @@ FROM external_services es
                        AND essj.state IN ('completed', 'errored', 'failed')
                        AND essj.finished_at IS NOT NULL
 WHERE
-  (
-    (es.namespace_user_id = %s) OR
-    (%s AND es.namespace_user_id IS NULL AND es.namespace_org_id IS NULL)
-  )
+  es.namespace_user_id IS NULL AND es.namespace_org_id IS NULL
   AND es.deleted_at IS NULL
   AND NOT es.cloud_default
 ORDER BY es.id, essj.finished_at DESC
-`, u.ID, u.SiteAdmin)
+`)
 
 	rows, err := e.Query(ctx, q)
 	if err != nil {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1187,10 +1187,7 @@ FROM external_services es
                    ON es.id = essj.external_service_id
                        AND essj.state IN ('completed', 'errored', 'failed')
                        AND essj.finished_at IS NOT NULL
-WHERE
-  es.namespace_user_id IS NULL AND es.namespace_org_id IS NULL
-  AND es.deleted_at IS NULL
-  AND NOT es.cloud_default
+WHERE es.deleted_at IS NULL AND NOT es.cloud_default
 ORDER BY es.id, essj.finished_at DESC
 `)
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -12688,15 +12688,15 @@ type MockExternalServiceStore struct {
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *ExternalServiceStoreDoneFunc
-	// GetAffiliatedSyncErrorsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetAffiliatedSyncErrors.
-	GetAffiliatedSyncErrorsFunc *ExternalServiceStoreGetAffiliatedSyncErrorsFunc
 	// GetByIDFunc is an instance of a mock function object controlling the
 	// behavior of the method GetByID.
 	GetByIDFunc *ExternalServiceStoreGetByIDFunc
 	// GetLastSyncErrorFunc is an instance of a mock function object
 	// controlling the behavior of the method GetLastSyncError.
 	GetLastSyncErrorFunc *ExternalServiceStoreGetLastSyncErrorFunc
+	// GetLatestSyncErrorsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetLatestSyncErrors.
+	GetLatestSyncErrorsFunc *ExternalServiceStoreGetLatestSyncErrorsFunc
 	// GetSyncJobByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method GetSyncJobByID.
 	GetSyncJobByIDFunc *ExternalServiceStoreGetSyncJobByIDFunc
@@ -12770,11 +12770,6 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 				return
 			},
 		},
-		GetAffiliatedSyncErrorsFunc: &ExternalServiceStoreGetAffiliatedSyncErrorsFunc{
-			defaultHook: func(context.Context, *types.User) (r0 map[int64]string, r1 error) {
-				return
-			},
-		},
 		GetByIDFunc: &ExternalServiceStoreGetByIDFunc{
 			defaultHook: func(context.Context, int64) (r0 *types.ExternalService, r1 error) {
 				return
@@ -12782,6 +12777,11 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 		},
 		GetLastSyncErrorFunc: &ExternalServiceStoreGetLastSyncErrorFunc{
 			defaultHook: func(context.Context, int64) (r0 string, r1 error) {
+				return
+			},
+		},
+		GetLatestSyncErrorsFunc: &ExternalServiceStoreGetLatestSyncErrorsFunc{
+			defaultHook: func(context.Context) (r0 map[int64]string, r1 error) {
 				return
 			},
 		},
@@ -12883,11 +12883,6 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 				panic("unexpected invocation of MockExternalServiceStore.Done")
 			},
 		},
-		GetAffiliatedSyncErrorsFunc: &ExternalServiceStoreGetAffiliatedSyncErrorsFunc{
-			defaultHook: func(context.Context, *types.User) (map[int64]string, error) {
-				panic("unexpected invocation of MockExternalServiceStore.GetAffiliatedSyncErrors")
-			},
-		},
 		GetByIDFunc: &ExternalServiceStoreGetByIDFunc{
 			defaultHook: func(context.Context, int64) (*types.ExternalService, error) {
 				panic("unexpected invocation of MockExternalServiceStore.GetByID")
@@ -12896,6 +12891,11 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 		GetLastSyncErrorFunc: &ExternalServiceStoreGetLastSyncErrorFunc{
 			defaultHook: func(context.Context, int64) (string, error) {
 				panic("unexpected invocation of MockExternalServiceStore.GetLastSyncError")
+			},
+		},
+		GetLatestSyncErrorsFunc: &ExternalServiceStoreGetLatestSyncErrorsFunc{
+			defaultHook: func(context.Context) (map[int64]string, error) {
+				panic("unexpected invocation of MockExternalServiceStore.GetLatestSyncErrors")
 			},
 		},
 		GetSyncJobByIDFunc: &ExternalServiceStoreGetSyncJobByIDFunc{
@@ -12984,14 +12984,14 @@ func NewMockExternalServiceStoreFrom(i ExternalServiceStore) *MockExternalServic
 		DoneFunc: &ExternalServiceStoreDoneFunc{
 			defaultHook: i.Done,
 		},
-		GetAffiliatedSyncErrorsFunc: &ExternalServiceStoreGetAffiliatedSyncErrorsFunc{
-			defaultHook: i.GetAffiliatedSyncErrors,
-		},
 		GetByIDFunc: &ExternalServiceStoreGetByIDFunc{
 			defaultHook: i.GetByID,
 		},
 		GetLastSyncErrorFunc: &ExternalServiceStoreGetLastSyncErrorFunc{
 			defaultHook: i.GetLastSyncError,
+		},
+		GetLatestSyncErrorsFunc: &ExternalServiceStoreGetLatestSyncErrorsFunc{
+			defaultHook: i.GetLatestSyncErrors,
 		},
 		GetSyncJobByIDFunc: &ExternalServiceStoreGetSyncJobByIDFunc{
 			defaultHook: i.GetSyncJobByID,
@@ -13674,118 +13674,6 @@ func (c ExternalServiceStoreDoneFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// ExternalServiceStoreGetAffiliatedSyncErrorsFunc describes the behavior
-// when the GetAffiliatedSyncErrors method of the parent
-// MockExternalServiceStore instance is invoked.
-type ExternalServiceStoreGetAffiliatedSyncErrorsFunc struct {
-	defaultHook func(context.Context, *types.User) (map[int64]string, error)
-	hooks       []func(context.Context, *types.User) (map[int64]string, error)
-	history     []ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetAffiliatedSyncErrors delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockExternalServiceStore) GetAffiliatedSyncErrors(v0 context.Context, v1 *types.User) (map[int64]string, error) {
-	r0, r1 := m.GetAffiliatedSyncErrorsFunc.nextHook()(v0, v1)
-	m.GetAffiliatedSyncErrorsFunc.appendCall(ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetAffiliatedSyncErrors method of the parent MockExternalServiceStore
-// instance is invoked and the hook queue is empty.
-func (f *ExternalServiceStoreGetAffiliatedSyncErrorsFunc) SetDefaultHook(hook func(context.Context, *types.User) (map[int64]string, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetAffiliatedSyncErrors method of the parent MockExternalServiceStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *ExternalServiceStoreGetAffiliatedSyncErrorsFunc) PushHook(hook func(context.Context, *types.User) (map[int64]string, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ExternalServiceStoreGetAffiliatedSyncErrorsFunc) SetDefaultReturn(r0 map[int64]string, r1 error) {
-	f.SetDefaultHook(func(context.Context, *types.User) (map[int64]string, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ExternalServiceStoreGetAffiliatedSyncErrorsFunc) PushReturn(r0 map[int64]string, r1 error) {
-	f.PushHook(func(context.Context, *types.User) (map[int64]string, error) {
-		return r0, r1
-	})
-}
-
-func (f *ExternalServiceStoreGetAffiliatedSyncErrorsFunc) nextHook() func(context.Context, *types.User) (map[int64]string, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ExternalServiceStoreGetAffiliatedSyncErrorsFunc) appendCall(r0 ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall objects describing
-// the invocations of this function.
-func (f *ExternalServiceStoreGetAffiliatedSyncErrorsFunc) History() []ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall {
-	f.mutex.Lock()
-	history := make([]ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall is an object that
-// describes an invocation of method GetAffiliatedSyncErrors on an instance
-// of MockExternalServiceStore.
-type ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 *types.User
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 map[int64]string
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ExternalServiceStoreGetAffiliatedSyncErrorsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // ExternalServiceStoreGetByIDFunc describes the behavior when the GetByID
 // method of the parent MockExternalServiceStore instance is invoked.
 type ExternalServiceStoreGetByIDFunc struct {
@@ -14003,6 +13891,115 @@ func (c ExternalServiceStoreGetLastSyncErrorFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ExternalServiceStoreGetLastSyncErrorFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ExternalServiceStoreGetLatestSyncErrorsFunc describes the behavior when
+// the GetLatestSyncErrors method of the parent MockExternalServiceStore
+// instance is invoked.
+type ExternalServiceStoreGetLatestSyncErrorsFunc struct {
+	defaultHook func(context.Context) (map[int64]string, error)
+	hooks       []func(context.Context) (map[int64]string, error)
+	history     []ExternalServiceStoreGetLatestSyncErrorsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetLatestSyncErrors delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockExternalServiceStore) GetLatestSyncErrors(v0 context.Context) (map[int64]string, error) {
+	r0, r1 := m.GetLatestSyncErrorsFunc.nextHook()(v0)
+	m.GetLatestSyncErrorsFunc.appendCall(ExternalServiceStoreGetLatestSyncErrorsFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetLatestSyncErrors
+// method of the parent MockExternalServiceStore instance is invoked and the
+// hook queue is empty.
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultHook(hook func(context.Context) (map[int64]string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetLatestSyncErrors method of the parent MockExternalServiceStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushHook(hook func(context.Context) (map[int64]string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultReturn(r0 map[int64]string, r1 error) {
+	f.SetDefaultHook(func(context.Context) (map[int64]string, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushReturn(r0 map[int64]string, r1 error) {
+	f.PushHook(func(context.Context) (map[int64]string, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) nextHook() func(context.Context) (map[int64]string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) appendCall(r0 ExternalServiceStoreGetLatestSyncErrorsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// ExternalServiceStoreGetLatestSyncErrorsFuncCall objects describing the
+// invocations of this function.
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) History() []ExternalServiceStoreGetLatestSyncErrorsFuncCall {
+	f.mutex.Lock()
+	history := make([]ExternalServiceStoreGetLatestSyncErrorsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExternalServiceStoreGetLatestSyncErrorsFuncCall is an object that
+// describes an invocation of method GetLatestSyncErrors on an instance of
+// MockExternalServiceStore.
+type ExternalServiceStoreGetLatestSyncErrorsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[int64]string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExternalServiceStoreGetLatestSyncErrorsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExternalServiceStoreGetLatestSyncErrorsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -6,28 +6,21 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var MockStatusMessages func(context.Context, *types.User) ([]StatusMessage, error)
+var MockStatusMessages func(context.Context) ([]StatusMessage, error)
 
-// FetchStatusMessages fetches repo related status messages. When fetching
-// external service sync errors we'll fetch any external services owned by the
-// user. In addition, if the user is a site admin we'll also fetch site level
-// external services.
-func FetchStatusMessages(ctx context.Context, db database.DB, u *types.User) ([]StatusMessage, error) {
+// FetchStatusMessages fetches repo related status messages.
+func FetchStatusMessages(ctx context.Context, db database.DB) ([]StatusMessage, error) {
 	if MockStatusMessages != nil {
-		return MockStatusMessages(ctx, u)
-	}
-	if u == nil {
-		return nil, errors.New("nil user")
+		return MockStatusMessages(ctx)
 	}
 	var messages []StatusMessage
 
 	// We first fetch affiliated sync errors since this will also find all the
 	// external services the user cares about.
-	externalServiceSyncErrors, err := db.ExternalServices().GetAffiliatedSyncErrors(ctx, u)
+	externalServiceSyncErrors, err := db.ExternalServices().GetLatestSyncErrors(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching sync errors")
 	}
@@ -36,11 +29,7 @@ func FetchStatusMessages(ctx context.Context, db database.DB, u *types.User) ([]
 		return messages, nil
 	}
 
-	extsvcIDs := make([]int64, 0, len(externalServiceSyncErrors))
-
 	for id, failure := range externalServiceSyncErrors {
-		extsvcIDs = append(extsvcIDs, id)
-
 		if failure != "" {
 			messages = append(messages, StatusMessage{
 				ExternalServiceSyncError: &ExternalServiceSyncError{
@@ -51,55 +40,6 @@ func FetchStatusMessages(ctx context.Context, db database.DB, u *types.User) ([]
 		}
 	}
 
-	// If the user is not a site-admin we can't rely on the stats table for
-	// counts and need to query the repo/gitserver_repos tables. But since the
-	// COUNTs aren't cheap, we filter down and use limit=1 to check whether >=1
-	// repos with the given parameters exist.
-	if !u.SiteAdmin {
-		opts := database.ReposListOptions{
-			NoCloned:           true,
-			ExternalServiceIDs: extsvcIDs,
-			LimitOffset: &database.LimitOffset{
-				Limit: 1,
-			},
-		}
-		notCloned, err := db.Repos().ListMinimalRepos(ctx, opts)
-		if err != nil {
-			return nil, errors.Wrap(err, "listing not-cloned repos")
-		}
-		if len(notCloned) > 0 {
-			messages = append(messages, StatusMessage{
-				Cloning: &CloningProgress{
-					Message: "Some repositories cloning...",
-				},
-			})
-		}
-
-		// Look for any repository that we could not sync
-		opts = database.ReposListOptions{
-			FailedFetch:        true,
-			ExternalServiceIDs: extsvcIDs,
-			LimitOffset: &database.LimitOffset{
-				Limit: 1,
-			},
-		}
-		failedSync, err := db.Repos().ListMinimalRepos(ctx, opts)
-		if err != nil {
-			return nil, errors.Wrap(err, "counting repo sync failures")
-		}
-		if len(failedSync) > 0 {
-			messages = append(messages, StatusMessage{
-				SyncError: &SyncError{
-					Message: "Some repositories could not be synced",
-				},
-			})
-		}
-		return messages, nil
-	}
-
-	// If the user is a site-admin we assume they can see all repositories
-	// (since authz was only enforced for admins in the old sourcegraph-dot-com
-	// Cloud v1 model).
 	stats, err := db.RepoStatistics().GetRepoStatistics(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading repo statistics")

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -34,39 +34,13 @@ func TestStatusMessages(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := NewStore(logtest.Scoped(t), db)
 
-	admin, err := db.Users().Create(ctx, database.NewUser{
-		Email:                 "a1@example.com",
-		Username:              "a1",
-		Password:              "p",
-		EmailVerificationCode: "c",
-	})
-	require.NoError(t, err)
-
-	nonAdmin, err := db.Users().Create(ctx, database.NewUser{
-		Email:                 "u1@example.com",
-		Username:              "u1",
-		Password:              "p",
-		EmailVerificationCode: "c",
-	})
-	require.NoError(t, err)
-
-	siteLevelService := &types.ExternalService{
+	extSvc := &types.ExternalService{
 		ID:          1,
 		Config:      extsvc.NewEmptyConfig(),
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "github.com - site",
 	}
-	err = db.ExternalServices().Upsert(ctx, siteLevelService)
-	require.NoError(t, err)
-
-	userService := &types.ExternalService{
-		ID:              2,
-		Config:          extsvc.NewEmptyConfig(),
-		Kind:            extsvc.KindGitHub,
-		DisplayName:     "github.com - user",
-		NamespaceUserID: nonAdmin.ID,
-	}
-	err = db.ExternalServices().Upsert(ctx, userService)
+	err := db.ExternalServices().Upsert(ctx, extSvc)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -77,26 +51,18 @@ func TestStatusMessages(t *testing.T) {
 		gitserverFailure map[string]bool
 		sourcerErr       error
 		res              []StatusMessage
-		user             *types.User
-		// maps repoName to external service
-		repoOwner map[api.RepoName]*types.ExternalService
-		err       string
+		err              string
 	}{
 		{
 			name:        "site-admin: all cloned",
 			cloneStatus: map[string]types.CloneStatus{"foobar": types.CloneStatusCloned},
 			repos:       []*types.Repo{{Name: "foobar"}},
-			user:        admin,
 			res:         nil,
 		},
 		{
 			name:        "site-admin: one repository not cloned",
 			repos:       []*types.Repo{{Name: "foobar"}},
-			user:        admin,
 			cloneStatus: map[string]types.CloneStatus{},
-			repoOwner: map[api.RepoName]*types.ExternalService{
-				"foobar": siteLevelService,
-			},
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
@@ -108,11 +74,7 @@ func TestStatusMessages(t *testing.T) {
 		{
 			name:        "site-admin: one repository cloning",
 			repos:       []*types.Repo{{Name: "foobar"}},
-			user:        admin,
 			cloneStatus: map[string]types.CloneStatus{"foobar": types.CloneStatusCloning},
-			repoOwner: map[api.RepoName]*types.ExternalService{
-				"foobar": siteLevelService,
-			},
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
@@ -124,12 +86,7 @@ func TestStatusMessages(t *testing.T) {
 		{
 			name:        "site-admin: one not cloned, one cloning",
 			repos:       []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
-			user:        admin,
 			cloneStatus: map[string]types.CloneStatus{"foobar": types.CloneStatusCloning, "barfoo": types.CloneStatusNotCloned},
-			repoOwner: map[api.RepoName]*types.ExternalService{
-				"foobar": siteLevelService,
-				"barfoo": siteLevelService,
-			},
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
@@ -148,7 +105,6 @@ func TestStatusMessages(t *testing.T) {
 				{Name: "repo-5"},
 				{Name: "repo-6"},
 			},
-			user: admin,
 			cloneStatus: map[string]types.CloneStatus{
 				"repo-1": types.CloneStatusCloning,
 				"repo-2": types.CloneStatusCloning,
@@ -156,10 +112,6 @@ func TestStatusMessages(t *testing.T) {
 				"repo-4": types.CloneStatusNotCloned,
 				"repo-5": types.CloneStatusCloned,
 				"repo-6": types.CloneStatusCloned,
-			},
-			repoOwner: map[api.RepoName]*types.ExternalService{
-				"foobar": siteLevelService,
-				"barfoo": siteLevelService,
 			},
 			res: []StatusMessage{
 				{
@@ -172,12 +124,7 @@ func TestStatusMessages(t *testing.T) {
 		{
 			name:        "site-admin: subset cloned",
 			repos:       []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
-			user:        admin,
 			cloneStatus: map[string]types.CloneStatus{"foobar": types.CloneStatusCloned},
-			repoOwner: map[api.RepoName]*types.ExternalService{
-				"foobar": siteLevelService,
-				"barfoo": siteLevelService,
-			},
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
@@ -187,25 +134,8 @@ func TestStatusMessages(t *testing.T) {
 			},
 		},
 		{
-			name:  "non-admins: only count their own non cloned repos",
-			repos: []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
-			repoOwner: map[api.RepoName]*types.ExternalService{
-				"foobar": userService,
-				"barfoo": siteLevelService,
-			},
-			user: nonAdmin,
-			res: []StatusMessage{
-				{
-					Cloning: &CloningProgress{
-						Message: "Some repositories cloning...",
-					},
-				},
-			},
-		},
-		{
 			name:  "site-admin: more cloned than stored",
 			repos: []*types.Repo{{Name: "foobar"}},
-			user:  admin,
 			cloneStatus: map[string]types.CloneStatus{
 				"foobar": types.CloneStatusCloned,
 				"barfoo": types.CloneStatusCloned,
@@ -215,15 +145,10 @@ func TestStatusMessages(t *testing.T) {
 		{
 			name:  "site-admin: cloned different than stored",
 			repos: []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
-			user:  admin,
 			cloneStatus: map[string]types.CloneStatus{
 				"one":   types.CloneStatusCloned,
 				"two":   types.CloneStatusCloned,
 				"three": types.CloneStatusCloned,
-			},
-			repoOwner: map[api.RepoName]*types.ExternalService{
-				"foobar": siteLevelService,
-				"barfoo": siteLevelService,
 			},
 			res: []StatusMessage{
 				{
@@ -236,16 +161,11 @@ func TestStatusMessages(t *testing.T) {
 		{
 			name:  "site-admin: one repo failed to sync",
 			repos: []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
-			user:  admin,
 			cloneStatus: map[string]types.CloneStatus{
 				"foobar": types.CloneStatusCloned,
 				"barfoo": types.CloneStatusCloned,
 			},
 			gitserverFailure: map[string]bool{"foobar": true},
-			repoOwner: map[api.RepoName]*types.ExternalService{
-				"foobar": siteLevelService,
-				"barfoo": siteLevelService,
-			},
 			res: []StatusMessage{
 				{
 					SyncError: &SyncError{
@@ -257,16 +177,11 @@ func TestStatusMessages(t *testing.T) {
 		{
 			name:  "site-admin: two repos failed to sync",
 			repos: []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
-			user:  admin,
 			cloneStatus: map[string]types.CloneStatus{
 				"foobar": types.CloneStatusCloned,
 				"barfoo": types.CloneStatusCloned,
 			},
 			gitserverFailure: map[string]bool{"foobar": true, "barfoo": true},
-			repoOwner: map[api.RepoName]*types.ExternalService{
-				"foobar": siteLevelService,
-				"barfoo": siteLevelService,
-			},
 			res: []StatusMessage{
 				{
 					SyncError: &SyncError{
@@ -277,13 +192,12 @@ func TestStatusMessages(t *testing.T) {
 		},
 		{
 			name:       "one external service syncer err",
-			user:       admin,
 			sourcerErr: errors.New("github is down"),
 			res: []StatusMessage{
 				{
 					ExternalServiceSyncError: &ExternalServiceSyncError{
 						Message:           "github is down",
-						ExternalServiceId: siteLevelService.ID,
+						ExternalServiceId: extSvc.ID,
 					},
 				},
 			},
@@ -342,25 +256,19 @@ func TestStatusMessages(t *testing.T) {
 			}
 
 			// Set up ownership of repos
-			if tc.repoOwner != nil {
-				for _, repo := range stored {
-					svc, ok := tc.repoOwner[repo.Name]
-					if !ok {
-						continue
-					}
-					q := sqlf.Sprintf(`
-						INSERT INTO external_service_repos(external_service_id, repo_id, user_id, clone_url)
-						VALUES (%s, %s, NULLIF(%s, 0), 'example.com')
-					`, svc.ID, repo.ID, svc.NamespaceUserID)
+			for _, repo := range stored {
+				q := sqlf.Sprintf(`
+						INSERT INTO external_service_repos(external_service_id, repo_id, clone_url)
+						VALUES (%s, %s, 'example.com')
+					`, extSvc.ID, repo.ID)
+				_, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+				require.NoError(t, err)
+
+				t.Cleanup(func() {
+					q := sqlf.Sprintf(`DELETE FROM external_service_repos WHERE external_service_id = %s`, extSvc.ID)
 					_, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 					require.NoError(t, err)
-
-					t.Cleanup(func() {
-						q := sqlf.Sprintf(`DELETE FROM external_service_repos WHERE external_service_id = %s`, svc.ID)
-						_, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
-						require.NoError(t, err)
-					})
-				}
+				})
 			}
 
 			clock := timeutil.NewFakeClock(time.Now(), 0)
@@ -372,18 +280,18 @@ func TestStatusMessages(t *testing.T) {
 
 			mockDB := database.NewMockDBFrom(db)
 			if tc.sourcerErr != nil {
-				sourcer := NewFakeSourcer(tc.sourcerErr, NewFakeSource(siteLevelService, nil))
+				sourcer := NewFakeSourcer(tc.sourcerErr, NewFakeSource(extSvc, nil))
 				syncer.Sourcer = sourcer
 
-				err = syncer.SyncExternalService(ctx, siteLevelService.ID, time.Millisecond)
+				err = syncer.SyncExternalService(ctx, extSvc.ID, time.Millisecond)
 				// In prod, SyncExternalService is kicked off by a worker queue. Any error
 				// returned will be stored in the external_service_sync_jobs table, so we fake
 				// that here.
 				if err != nil {
 					externalServices := database.NewMockExternalServiceStore()
-					externalServices.GetAffiliatedSyncErrorsFunc.SetDefaultReturn(
+					externalServices.GetLatestSyncErrorsFunc.SetDefaultReturn(
 						map[int64]string{
-							siteLevelService.ID: err.Error(),
+							extSvc.ID: err.Error(),
 						},
 						nil,
 					)
@@ -395,7 +303,7 @@ func TestStatusMessages(t *testing.T) {
 				tc.err = "<nil>"
 			}
 
-			res, err := FetchStatusMessages(ctx, mockDB, tc.user)
+			res, err := FetchStatusMessages(ctx, mockDB)
 			assert.Equal(t, tc.err, fmt.Sprint(err))
 			assert.Equal(t, tc.res, res)
 		})


### PR DESCRIPTION
Based on top of #41121 this changes the backend to not allow users to query status messages anymore. Simplifies a lot of code.

## Test plan

- New and old tests
