### PR TITLE
search: Update lingering usages of `repo:contains` in comments

### DIFF
--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -279,7 +279,7 @@ export const scanBalancedLiteral: Scanner<Literal> = (input, start) => {
 }
 
 /**
- * Scan predicate syntax like repo:contains(file:README.md). Predicate scanning
+ * Scan predicate syntax like repo:contains.file(path:README.md). Predicate scanning
  * takes precedence over other value scanners like scanBalancedLiteral.
  */
 export const scanPredicateValue = (input: string, start: number, field: Literal): ScanResult<Literal> => {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -340,9 +340,9 @@ func (p Parameters) IncludeExcludeValues(field string) (include, exclude []strin
 }
 
 // RepoHasFileContentArgs represents the args of any of the following predicates:
-// - repo:contains.file(f)
-// - repo:contains.content(c)
-// - repo:contains(file:f content:c)
+// - repo:contains.file(path:foo content:bar) || repo:has.file(path:foo content:bar)
+// - repo:contains.path(foo) || repo:has.path(foo)
+// - repo:contains.content(c) || repo:has.content(c)
 // - repohasfile:f
 type RepoHasFileContentArgs struct {
 	// At least one of these strings should be non-empty


### PR DESCRIPTION
Updating some stragglers in the wake of #39767
## Test plan
Just updating comments
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
