### PR TITLE
internal/trace: remove ENABLE_GRAFANA_CLOUD_TRACE_URL

### DIFF
--- a/internal/trace/url.go
+++ b/internal/trace/url.go
@@ -1,9 +1,6 @@
 package trace
 
 import (
-	"fmt"
-	"net/url"
-	"os"
 	"strings"
 	"text/template"
 
@@ -18,7 +15,8 @@ func URL(traceID string, querier conftypes.SiteConfigQuerier) string {
 	c := querier.SiteConfig()
 	tracing := c.ObservabilityTracing
 	if tracing == nil || tracing.UrlTemplate == "" {
-		return legacyTraceURL(traceID, c.ExternalURL)
+		// Default template
+		return strings.TrimSuffix(c.ExternalURL, "/") + "/-/debug/jaeger/trace/" + traceID
 	}
 
 	tpl, err := template.New("traceURL").Parse(tracing.UrlTemplate)
@@ -33,18 +31,4 @@ func URL(traceID string, querier conftypes.SiteConfigQuerier) string {
 		"ExternalURL": c.ExternalURL,
 	})
 	return sb.String()
-}
-
-// legacyTraceURL preserves the old trace URL generation behaviour if no template is
-// provided.
-func legacyTraceURL(traceID, externalURL string) string {
-	if os.Getenv("ENABLE_GRAFANA_CLOUD_TRACE_URL") != "true" {
-		// We proxy jaeger so we can construct URLs to traces.
-		return strings.TrimSuffix(externalURL, "/") + "/-/debug/jaeger/trace/" + traceID
-	}
-
-	return "https://sourcegraph.grafana.net/explore?orgId=1&left=" + url.QueryEscape(fmt.Sprintf(
-		`["now-1h","now","grafanacloud-sourcegraph-traces",{"query":"%s","queryType":"traceId"}]`,
-		traceID,
-	))
 }


### PR DESCRIPTION
The same behaviour can now be achieved with `observability.trace.urlTemplate`, e.g. in https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/17259:

```json
  "observability.tracing": {
    "type": "opentelemetry",
    "sampling": "selective",
    "urlTemplate": "https://sourcegraph.grafana.net/explore?orgId=1&left=[\"now-1h\",\"now\",\"grafanacloud-sourcegraph-traces\",{\"query\":\"{{ .TraceID }}\",\"queryType\":\"traceId\"}]"
  },
```

Do not merge until we roll out https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/17259

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested the above configuration locally