### PR TITLE
update kustomize to track deloy-sourcegraph

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -8,7 +8,7 @@ kubectl 1.21.7
 github-cli 2.0.0
 packer 1.8.3
 trivy 0.30.3
-kustomize 4.0.5
+kustomize 4.5.7
 awscli 2.4.7
 python system
 rust 1.62.0


### PR DESCRIPTION
fixes failing cluster qa tests

https://github.com/sourcegraph/deploy-sourcegraph/commit/f8f51d5b26aa1e9232c4cfb6e442d746684d3ab2

## Test plan

already passing in deploy-sourcegraph