### PR TITLE
licensing: fix setup for creating license keys locally and for testing features in a local instance

### DIFF
--- a/enterprise/internal/license/generate-license.go
+++ b/enterprise/internal/license/generate-license.go
@@ -68,7 +68,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	licenseKey, err := license.GenerateSignedKey(info, privateKey)
+	licenseKey, _, err := license.GenerateSignedKey(info, privateKey)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -249,7 +249,9 @@ commands:
       - cmd/repo-updater
 
   repo-updater:
-    cmd: .bin/repo-updater
+    cmd: |
+      export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
+      .bin/repo-updater
     install: |
       if [ -n "$DELVE" ]; then
         export GCFLAGS='all=-N -l'


### PR DESCRIPTION
This PR fixes the setup for generating license keys locally,  so we can manually test, in a local instance, if a feature are available or not depending on the plan used.

Documentation on how to generate a license key locally and how to test a new feature will be added in the next PR.

## Test plan

Manually tested that we can successfully generated a license key with the following steps

1. `  go run ./enterprise/internal/license/generate-license.go -private-key ../dev-private/enterprise/dev/test-license-generation-key.pem -tags=plan:team-0 -users=10 -expires=8784h . ` (You can replace the `team-0` with other plans) 

2. added the new license key to our dev-private site configuration; restarted SG.
3. when the repo-updater called  `licensing.Check(licensing.FeatureACLs)` (in [perms_syncer.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go?L1365&subtree=true)), the 
`crypto/rsa: verification error` wasn't displayed anymore and all worked as expected.

