### PR TITLE
otel-collector: bundle filelogreceiver

### DIFF
--- a/docker-images/opentelemetry-collector/builder.template.yaml
+++ b/docker-images/opentelemetry-collector/builder.template.yaml
@@ -25,6 +25,7 @@ receivers:
 
   # Contrib receivers - https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v$OTEL_COLLECTOR_VERSION"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v$OTEL_COLLECTOR_VERSION"
 
 extensions:
   # OpenTelemetry extensions - https://go.opentelemetry.io/collector/extension


### PR DESCRIPTION
Was quickly taking a look at how one might use OpenTelemetry collector for logging - [this example uses the filelog receiver on each agent](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml#L28), pointing the receiver at [mounted pod logs](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml#L102-L104) - might be worth exploring in relation to https://github.com/sourcegraph/sourcegraph/issues/37901

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes