### PR TITLE
Wildcard Popover: fix toggling open state on focus/blur with `focusLocked=true`

### DIFF
--- a/client/wildcard/src/components/Popover/story/Popover.story.tsx
+++ b/client/wildcard/src/components/Popover/story/Popover.story.tsx
@@ -378,7 +378,13 @@ export const WithControlledState: Story = () => {
                 </Button>
 
                 <Popover isOpen={open} onOpenChange={handleOpenChange}>
-                    <PopoverTrigger as={Button} variant="secondary" className={styles.target}>
+                    <PopoverTrigger
+                        as={Button}
+                        onFocus={() => setOpen(true)}
+                        onBlur={() => setOpen(false)}
+                        variant="secondary"
+                        className={styles.target}
+                    >
                         Target
                     </PopoverTrigger>
 


### PR DESCRIPTION
This PR is created for demo purpose only.

Page freezes when toggling popover open state in `PopoverTrigger` focus/blur handlers without `focusLocked=false` prop on `PopoverContent`.
Adding `focusLocked=false` prop to `PopoverContent` fixes the issue, but the buttons inside it can’t be focused with the keyboard anymore.

[Loom](https://www.loom.com/share/ddc316633aad438da1d8bf7a1aa5975a)

## Test plan
N/A
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-popover-issue.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

