### PR TITLE
otel: bundle probabilistic sampling processor

### DIFF
--- a/docker-images/opentelemetry-collector/builder.template.yaml
+++ b/docker-images/opentelemetry-collector/builder.template.yaml
@@ -33,3 +33,6 @@ extensions:
 
   # Contrib extensions - https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v$OTEL_COLLECTOR_VERSION
+
+processors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v$OTEL_COLLECTOR_VERSION

--- a/docker-images/opentelemetry-collector/configs/jaeger.yaml
+++ b/docker-images/opentelemetry-collector/configs/jaeger.yaml
@@ -23,9 +23,15 @@ extensions:
   zpages:
    endpoint: "localhost:55679"
 
+# processors:
+#   probabilistic_sampler:
+#     hash_seed: 22
+#     sampling_percentage: 15.3
+
 service:
   extensions: [health_check,zpages]
   pipelines:
     traces:
       receivers: [otlp]
       exporters: [jaeger]
+      # processors: [probabilistic_sampler]

--- a/docker-images/opentelemetry-collector/configs/jaeger.yaml
+++ b/docker-images/opentelemetry-collector/configs/jaeger.yaml
@@ -23,15 +23,9 @@ extensions:
   zpages:
    endpoint: "localhost:55679"
 
-# processors:
-#   probabilistic_sampler:
-#     hash_seed: 22
-#     sampling_percentage: 15.3
-
 service:
   extensions: [health_check,zpages]
   pipelines:
     traces:
       receivers: [otlp]
       exporters: [jaeger]
-      # processors: [probabilistic_sampler]


### PR DESCRIPTION
This PR add the probabilistic sampling processor to our otel collector packaged image. This allows customers to enable probabilistic sampling without having to rebuild the docker image of the collector on their own. 

Part of #40813 and #37958

⚠️ It is to be noted that if enabled, the sampling processor completely disregard `selective` tracing at this stage. See #41177 for the issue tracking this. 

Fixes https://github.com/sourcegraph/sourcegraph/pull/41176

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Ran the collector locally with the configuration that is presently commented. Traces will be discarded until they get picked by the processor. We get complete traces of courses, no spans are missing. 