### PR TITLE
insights: disable aggregation types that don't work

### DIFF
--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -72,15 +72,6 @@ func newEventMatch(event result.Match) *eventMatch {
 			Date:        match.Commit.Author.Date,
 			ResultCount: 1, //TODO(chwarwick): Verify that we want to count commits not matches in the commit
 		}
-	case *result.CommitDiffMatch:
-		return &eventMatch{
-			Repo:        string(match.Repo.Name),
-			RepoID:      int32(match.Repo.ID),
-			Author:      match.Commit.Author.Name,
-			Date:        match.Commit.Author.Date,
-			ResultCount: 1, //TODO(chwarwick): Verify that we want to count commits not matches in the commit
-		}
-
 	default:
 		return &eventMatch{}
 	}

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -327,10 +327,10 @@ func canAggregateByPath(searchQuery, patternType string) (bool, *notAvailableRea
 	}
 	parameters := querybuilder.ParametersFromQueryPlan(plan)
 	// cannot aggregate over:
-	// - searches by commit or repo
+	// - searches by commit, diff or repo
 	for _, parameter := range parameters {
 		if parameter.Field == query.FieldSelect || parameter.Field == query.FieldType {
-			if strings.EqualFold(parameter.Value, "commit") || strings.EqualFold(parameter.Value, "repo") {
+			if strings.EqualFold(parameter.Value, "commit") || strings.EqualFold(parameter.Value, "diff") || strings.EqualFold(parameter.Value, "repo") {
 				reason := fmt.Sprintf(fileUnsupportedFieldValueFmt,
 					parameter.Field, parameter.Value)
 				return false, &notAvailableReason{reason: reason, reasonType: types.INVALID_AGGREGATION_MODE_FOR_QUERY}, nil

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
@@ -99,6 +99,12 @@ func Test_canAggregateByPath(t *testing.T) {
 			canAggregate: false,
 		},
 		{
+			name:         "cannot aggregate for query with type:diff parameter",
+			query:        "insights type:diff",
+			reason:       fmt.Sprintf(fileUnsupportedFieldValueFmt, "type", "diff"),
+			canAggregate: false,
+		},
+		{
 			name:         "ensure type check is case insensitive ",
 			query:        "insights TYPE:commit",
 			reason:       fmt.Sprintf(fileUnsupportedFieldValueFmt, "type", "commit"),

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers_test.go
@@ -277,6 +277,27 @@ func Test_canAggregateByCaptureGroup(t *testing.T) {
 			patternType:  "regexp",
 			canAggregate: false,
 		},
+		{
+			name:         "cannot aggregate for query with type commit",
+			query:        "/func(\\w+)/ case:yes type:commit",
+			patternType:  "standard",
+			reason:       fmt.Sprintf(cgUnsupportedSelectFmt, "type", "commit"),
+			canAggregate: false,
+		},
+		{
+			name:         "cannot aggregate for query with type diff",
+			query:        "/func(\\w+)/ case:yes type:diff",
+			patternType:  "standard",
+			reason:       fmt.Sprintf(cgUnsupportedSelectFmt, "type", "diff"),
+			canAggregate: false,
+		},
+		{
+			name:         "cannot aggregate for query with select commit",
+			query:        "/func(\\w+)/ case:yes select:commit",
+			patternType:  "standard",
+			reason:       fmt.Sprintf(cgUnsupportedSelectFmt, "select", "commit"),
+			canAggregate: false,
+		},
 	}
 	suite := canAggregateBySuite{
 		canAggregateByFunc: canAggregateByCaptureGroup,


### PR DESCRIPTION
This disables FILE aggregation for diffs and capture group aggregations for diff and commit searches.

resolves https://github.com/sourcegraph/sourcegraph/issues/41208
## Test plan
unit tests added and pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
