### PR TITLE
Migrate StatusMessagesNavItem to be function component

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -378,7 +378,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
                     )}
                     {props.authenticatedUser?.siteAdmin && (
                         <NavAction>
-                            <StatusMessagesNavItem history={history} />
+                            <StatusMessagesNavItem />
                         </NavAction>
                     )}
                     {!props.authenticatedUser ? (

--- a/client/web/src/nav/StatusMessagesNavItem.mocks.ts
+++ b/client/web/src/nav/StatusMessagesNavItem.mocks.ts
@@ -1,0 +1,41 @@
+import { MockedResponse } from '@apollo/client/testing'
+
+import { getDocumentNode } from '@sourcegraph/http-client'
+
+import { StatusMessagesResult } from '../graphql-operations'
+
+import { STATUS_MESSAGES } from './StatusMessagesNavItemQueries'
+
+export const allStatusMessages: StatusMessagesResult['statusMessages'] = [
+    {
+        __typename: 'ExternalServiceSyncError',
+        message:
+            'This is a\nmulti line error message\nthat spans multiple lines and also is a bit long on some lines\nbut lets see',
+        externalService: {
+            id: 'RXh0ZXJuYWxTZXJ2aWNlOjE=',
+            displayName: 'GitHub PRODUCTION',
+            __typename: 'ExternalService',
+        },
+    },
+    {
+        __typename: 'SyncError',
+        message: '27 repositories could not be synced',
+    },
+    {
+        __typename: 'CloningProgress',
+        message: '477260 repositories enqueued for cloning. 11 repositories currently cloning...',
+    },
+]
+
+export const newStatusMessageMock = (
+    messages: StatusMessagesResult['statusMessages']
+): MockedResponse<StatusMessagesResult> => ({
+    request: {
+        query: getDocumentNode(STATUS_MESSAGES),
+    },
+    result: {
+        data: {
+            statusMessages: messages,
+        },
+    },
+})

--- a/client/web/src/nav/StatusMessagesNavItem.story.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.story.tsx
@@ -1,0 +1,44 @@
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+
+import { WebStory } from '../components/WebStory'
+
+import { StatusMessagesNavItem } from './StatusMessagesNavItem'
+import { allStatusMessages, newStatusMessageMock } from './StatusMessagesNavItem.mocks'
+
+const decorator: DecoratorFn = Story => <Story />
+
+const config: Meta = {
+    title: 'web/nav/StatusMessagesNavItem',
+    decorators: [decorator],
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
+}
+
+export default config
+
+export const NoMessages: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider mocks={[newStatusMessageMock([])]}>
+                <StatusMessagesNavItem disablePolling={true} />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+NoMessages.storyName = 'No messages'
+
+export const AllMessageTypes: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider mocks={[newStatusMessageMock(allStatusMessages)]}>
+                <StatusMessagesNavItem disablePolling={true} />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+AllMessageTypes.storyName = 'All message types'

--- a/client/web/src/nav/StatusMessagesNavItem.story.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.story.tsx
@@ -12,9 +12,6 @@ const decorator: DecoratorFn = Story => <Story />
 const config: Meta = {
     title: 'web/nav/StatusMessagesNavItem',
     decorators: [decorator],
-    parameters: {
-        chromatic: { disableSnapshot: false },
-    },
 }
 
 export default config

--- a/client/web/src/nav/StatusMessagesNavItem.test.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.test.tsx
@@ -1,75 +1,26 @@
-import { createMemoryHistory } from 'history'
-import { of, Observable } from 'rxjs'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
-
-import { StatusMessagesResult, StatusMessageFields } from '../graphql-operations'
-import { SourcegraphContext } from '../jscontext'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { StatusMessagesNavItem } from './StatusMessagesNavItem'
+import { allStatusMessages, newStatusMessageMock } from './StatusMessagesNavItem.mocks'
 
 describe('StatusMessagesNavItem', () => {
-    let oldContext: SourcegraphContext & Mocha.SuiteFunction
-
-    beforeEach(() => {
-        oldContext = window.context
-        window.context = {} as SourcegraphContext & Mocha.SuiteFunction
-    })
-    afterEach(() => {
-        window.context = oldContext
-    })
-
     test('no messages', () => {
-        const fetchMessages = (): Observable<StatusMessagesResult['statusMessages']> => of([])
         expect(
             renderWithBrandedContext(
-                <StatusMessagesNavItem fetchMessages={fetchMessages} history={createMemoryHistory()} />
+                <MockedTestProvider mocks={[newStatusMessageMock([])]}>
+                    <StatusMessagesNavItem disablePolling={true} />
+                </MockedTestProvider>
             ).asFragment()
         ).toMatchSnapshot()
     })
 
-    test('one CloningProgress message', () => {
-        const message: StatusMessageFields = {
-            type: 'CloningProgress',
-            message: 'Currently cloning repositories...',
-        }
-
-        const fetchMessages = () => of([message])
+    test('all messages', () => {
         expect(
             renderWithBrandedContext(
-                <StatusMessagesNavItem fetchMessages={fetchMessages} history={createMemoryHistory()} />
-            ).asFragment()
-        ).toMatchSnapshot()
-    })
-
-    test('one ExternalServiceSyncError message', () => {
-        const message: StatusMessageFields = {
-            type: 'ExternalServiceSyncError',
-            message: 'failed to list organization kubernetes repos: request returned status 404: Not Found',
-            externalService: {
-                id: 'abcd',
-                displayName: 'GitHub.com',
-            },
-        }
-
-        const fetchMessages = () => of([message])
-        expect(
-            renderWithBrandedContext(
-                <StatusMessagesNavItem fetchMessages={fetchMessages} history={createMemoryHistory()} />
-            ).asFragment()
-        ).toMatchSnapshot()
-    })
-
-    test('one SyncError message', () => {
-        const message: StatusMessageFields = {
-            type: 'SyncError',
-            message: 'syncer.sync.store.upsert-repos: pg: unique constraint foobar',
-        }
-
-        const fetchMessages = () => of([message])
-        expect(
-            renderWithBrandedContext(
-                <StatusMessagesNavItem fetchMessages={fetchMessages} history={createMemoryHistory()} />
+                <MockedTestProvider mocks={[newStatusMessageMock(allStatusMessages)]}>
+                    <StatusMessagesNavItem disablePolling={true} />
+                </MockedTestProvider>
             ).asFragment()
         ).toMatchSnapshot()
     })

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -1,15 +1,10 @@
-import React from 'react'
+import React, { useState, useMemo } from 'react'
 
 import { mdiInformation, mdiAlert, mdiSync, mdiCheckboxMarkedCircle } from '@mdi/js'
 import classNames from 'classnames'
-import * as H from 'history'
-import { isEqual } from 'lodash'
-import { Observable, Subscription } from 'rxjs'
-import { catchError, map, repeatWhen, delay, distinctUntilChanged } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { asError, ErrorLike, isErrorLike, repeatUntil } from '@sourcegraph/common'
-import { dataOrThrowErrors } from '@sourcegraph/http-client'
+import { useQuery } from '@sourcegraph/http-client'
 import {
     CloudAlertIconRefresh,
     CloudSyncIconRefresh,
@@ -28,22 +23,13 @@ import {
     Tooltip,
 } from '@sourcegraph/wildcard'
 
-import { requestGraphQL } from '../backend/graphql'
-import { CircleDashedIcon } from '../components/CircleDashedIcon'
 import { StatusMessagesResult } from '../graphql-operations'
 
 import { STATUS_MESSAGES } from './StatusMessagesNavItemQueries'
 
 import styles from './StatusMessagesNavItem.module.scss'
 
-function fetchAllStatusMessages(): Observable<StatusMessagesResult['statusMessages']> {
-    return requestGraphQL<StatusMessagesResult>(STATUS_MESSAGES).pipe(
-        map(dataOrThrowErrors),
-        map(data => data.statusMessages)
-    )
-}
-
-type EntryType = 'not-active' | 'progress' | 'warning' | 'success' | 'error'
+type EntryType = 'progress' | 'warning' | 'success' | 'error'
 
 interface StatusMessageEntryProps {
     message: string
@@ -56,60 +42,43 @@ interface StatusMessageEntryProps {
 }
 
 function entryIcon(entryType: EntryType): JSX.Element {
+    const sharedProps = { height: 14, width: 14, inline: false }
+
     switch (entryType) {
         case 'error':
             return (
                 <Icon
+                    {...sharedProps}
                     className={classNames('text-danger', styles.icon)}
                     svgPath={mdiInformation}
-                    inline={false}
                     aria-label="Error"
-                    height={14}
-                    width={14}
                 />
             )
         case 'warning':
             return (
                 <Icon
+                    {...sharedProps}
                     className={classNames('text-warning', styles.icon)}
                     svgPath={mdiAlert}
-                    inline={false}
                     aria-label="Warning"
-                    height={14}
-                    width={14}
                 />
             )
         case 'success':
             return (
                 <Icon
+                    {...sharedProps}
                     className={classNames('text-success', styles.icon)}
                     svgPath={mdiCheckboxMarkedCircle}
-                    inline={false}
                     aria-label="Success"
-                    height={14}
-                    width={14}
                 />
             )
         case 'progress':
             return (
                 <Icon
+                    {...sharedProps}
                     className={classNames('text-primary', styles.icon)}
                     svgPath={mdiSync}
-                    inline={false}
                     aria-label="In progress"
-                    height={14}
-                    width={14}
-                />
-            )
-        case 'not-active':
-            return (
-                <Icon
-                    className={classNames(styles.icon, styles.iconOff)}
-                    as={CircleDashedIcon}
-                    inline={false}
-                    aria-label="Not active"
-                    height={16}
-                    width={16}
                 />
             )
     }
@@ -141,180 +110,68 @@ const getBorderClassname = (entryType: EntryType): string => {
     }
 }
 
-const StatusMessagesNavItemEntry: React.FunctionComponent<React.PropsWithChildren<StatusMessageEntryProps>> = props => {
-    const onLinkClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
-        props.linkOnClick(event)
-    }
-
-    return (
-        <div key={props.message} className={styles.entry}>
-            <H4 className="d-flex align-items-center mb-0">
-                {entryIcon(props.entryType)}
-                {props.title ? props.title : 'Your repositories'}
-            </H4>
-            {props.entryType === 'not-active' ? (
-                <div className={classNames('status-messages-nav-item__entry-card border-0', styles.cardInactive)}>
-                    <Text className={classNames('text-muted', styles.message)}>{props.message}</Text>
-                    <Link className="text-primary" to={props.linkTo} onClick={onLinkClick}>
-                        {props.linkText}
-                    </Link>
-                </div>
-            ) : (
-                <div
-                    className={classNames(
-                        'status-messages-nav-item__entry-card',
-                        styles.cardActive,
-                        getBorderClassname(props.entryType)
-                    )}
-                >
-                    <Text className={classNames(styles.message, getMessageColor(props.entryType))}>
-                        {props.message}
-                    </Text>
-                    {props.messageHint && (
-                        <>
-                            <small className="text-muted d-inline-block mb-1">{props.messageHint}</small>
-                            <br />
-                        </>
-                    )}
-                    <Link className="text-primary" to={props.linkTo} onClick={onLinkClick}>
-                        {props.linkText}
-                    </Link>
-                </div>
+const StatusMessagesNavItemEntry: React.FunctionComponent<React.PropsWithChildren<StatusMessageEntryProps>> = props => (
+    <div key={props.message} className={styles.entry}>
+        <H4 className="d-flex align-items-center mb-0">
+            {entryIcon(props.entryType)}
+            {props.title ? props.title : 'Your repositories'}
+        </H4>
+        <div
+            className={classNames(
+                'status-messages-nav-item__entry-card',
+                styles.cardActive,
+                getBorderClassname(props.entryType)
             )}
+        >
+            <Text className={classNames(styles.message, getMessageColor(props.entryType))}>{props.message}</Text>
+            {props.messageHint && (
+                <>
+                    <small className="text-muted d-inline-block mb-1">{props.messageHint}</small>
+                    <br />
+                </>
+            )}
+            <Link className="text-primary" to={props.linkTo} onClick={props.linkOnClick}>
+                {props.linkText}
+            </Link>
         </div>
-    )
-}
+    </div>
+)
+
+const STATUS_MESSAGES_POLL_INTERVAL = 10000
 
 interface Props {
-    history: H.History
-    fetchMessages?: () => Observable<StatusMessagesResult['statusMessages']>
+    disablePolling?: boolean
 }
-
-type Messages = StatusMessagesResult['statusMessages']
-type MessagesOrError = Messages | ErrorLike
-
-interface State {
-    messagesOrError: MessagesOrError
-    isOpen: boolean
-}
-
-const REFRESH_INTERVAL_MS = 60000
-
 /**
  * Displays a status icon in the navbar reflecting the completion of backend
  * tasks such as repository cloning, and exposes a dropdown menu containing
  * more information on these tasks.
  */
-export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
-    private subscriptions = new Subscription()
+export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
+    const [isOpen, setIsOpen] = useState(false)
+    const toggleIsOpen = (): void => setIsOpen(old => !old)
 
-    public state: State = { isOpen: false, messagesOrError: [] }
+    const { data, error } = useQuery<StatusMessagesResult>(STATUS_MESSAGES, {
+        fetchPolicy: 'no-cache',
+        pollInterval:
+            props.disablePolling !== undefined && !props.disablePolling ? STATUS_MESSAGES_POLL_INTERVAL : undefined,
+    })
 
-    private toggleIsOpen = (): void => {
-        this.setState(previousState => ({ isOpen: !previousState.isOpen }))
-    }
-
-    public componentDidMount(): void {
-        this.subscriptions.add(
-            (this.props.fetchMessages ?? fetchAllStatusMessages)()
-                .pipe(
-                    catchError(error => [asError(error) as ErrorLike]),
-                    // Poll on REFRESH_INTERVAL_MS
-                    repeatUntil(messagesOrError => isErrorLike(messagesOrError), { delay: REFRESH_INTERVAL_MS }),
-                    repeatWhen(completions => completions.pipe(delay(REFRESH_INTERVAL_MS))),
-                    distinctUntilChanged(isEqual)
-                )
-                .subscribe(messagesOrError => {
-                    this.setState({ messagesOrError })
-                })
-        )
-    }
-
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
-
-    private renderMessage(messages: Messages): JSX.Element | JSX.Element[] {
-        const links = {
-            viewRepositories: '/site-admin/repositories',
-            manageRepositories: '/site-admin/external-services',
-            manageCodeHosts: '/site-admin/external-services',
-            getCodeHostLink: (id: string) => `/site-admin/external-services/${id}`,
-        }
-
-        // no status messages
-        if (messages.length === 0) {
-            return (
-                <StatusMessagesNavItemEntry
-                    key="up-to-date"
-                    message="Repositories available for search"
-                    linkTo={links.viewRepositories}
-                    linkText="View repositories"
-                    linkOnClick={this.toggleIsOpen}
-                    entryType="success"
-                />
-            )
-        }
-
-        return messages.map(status => {
-            switch (status.type) {
-                case 'CloningProgress':
-                    return (
-                        <StatusMessagesNavItemEntry
-                            key={status.message}
-                            message={status.message}
-                            messageHint="Your repositories may not be up-to-date."
-                            linkTo={links.viewRepositories}
-                            linkText="View status"
-                            linkOnClick={this.toggleIsOpen}
-                            entryType="progress"
-                        />
-                    )
-                case 'ExternalServiceSyncError':
-                    return (
-                        <StatusMessagesNavItemEntry
-                            key={status.externalService.id}
-                            message={`Can't connect to ${status.externalService.displayName}`}
-                            messageHint="Verify the code host configuration."
-                            linkTo={links.getCodeHostLink(status.externalService.id)}
-                            linkText="Manage code hosts"
-                            linkOnClick={this.toggleIsOpen}
-                            entryType="error"
-                        />
-                    )
-                case 'SyncError':
-                    return (
-                        <StatusMessagesNavItemEntry
-                            key={status.message}
-                            message={status.message}
-                            messageHint="Your repositories may not be up-to-date."
-                            linkTo={links.viewRepositories + '?status=failed-fetch'}
-                            linkText="Manage repositories"
-                            linkOnClick={this.toggleIsOpen}
-                            entryType="error"
-                        />
-                    )
-            }
-        })
-    }
-
-    private renderIcon(): JSX.Element | null {
-        if (isErrorLike(this.state.messagesOrError)) {
-            return (
-                <Tooltip content="Sorry, we couldn’t fetch notifications!">
-                    <Icon aria-label="Sorry, we couldn’t fetch notifications!" as={CloudAlertIconRefresh} size="md" />
-                </Tooltip>
-            )
+    const icon: JSX.Element | null = useMemo(() => {
+        if (!data) {
+            return null
         }
 
         let codeHostMessage
         let icon
         if (
-            this.state.messagesOrError.some(({ type }) => type === 'ExternalServiceSyncError' || type === 'SyncError')
+            data.statusMessages?.some(
+                ({ __typename: type }) => type === 'ExternalServiceSyncError' || type === 'SyncError'
+            )
         ) {
             codeHostMessage = 'Syncing repositories failed!'
             icon = CloudAlertIconRefresh
-        } else if (this.state.messagesOrError.some(({ type }) => type === 'CloningProgress')) {
+        } else if (data.statusMessages?.some(({ __typename: type }) => type === 'CloningProgress')) {
             codeHostMessage = 'Cloning repositories...'
             icon = CloudSyncIconRefresh
         } else {
@@ -323,43 +180,108 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
         }
 
         return (
-            <Tooltip content={this.state.isOpen ? undefined : codeHostMessage}>
-                <Icon
-                    as={icon}
-                    size="md"
-                    {...(this.state.isOpen ? { 'aria-hidden': true } : { 'aria-label': codeHostMessage })}
-                />
+            <Tooltip content={isOpen ? undefined : codeHostMessage}>
+                <Icon as={icon} size="md" {...(isOpen ? { 'aria-hidden': true } : { 'aria-label': codeHostMessage })} />
             </Tooltip>
         )
-    }
+    }, [data, isOpen])
 
-    public render(): JSX.Element | null {
+    const messages: JSX.Element | null = useMemo(() => {
+        if (!data) {
+            return null
+        }
+
+        // no status messages
+        if (data.statusMessages.length === 0) {
+            return (
+                <StatusMessagesNavItemEntry
+                    key="up-to-date"
+                    message="Repositories available for search"
+                    linkTo="/site-admin/repositories"
+                    linkText="View repositories"
+                    linkOnClick={toggleIsOpen}
+                    entryType="success"
+                />
+            )
+        }
+
         return (
-            <Popover isOpen={this.state.isOpen} onOpenChange={event => this.setState({ isOpen: event.isOpen })}>
-                <PopoverTrigger
-                    className="nav-link py-0 px-0 percy-hide chromatic-ignore"
-                    as={Button}
-                    variant="link"
-                    aria-label={this.state.isOpen ? 'Hide status messages' : 'Show status messages'}
-                >
-                    {this.renderIcon()}
-                </PopoverTrigger>
-
-                <PopoverContent position={Position.bottomEnd} className={classNames('p-0', styles.dropdownMenu)}>
-                    <div className={styles.dropdownMenuContent}>
-                        <small className={classNames('d-inline-block text-muted', styles.sync)}>Code sync status</small>
-                        {isErrorLike(this.state.messagesOrError) ? (
-                            <ErrorAlert
-                                className={styles.entry}
-                                prefix="Failed to load status messages"
-                                error={this.state.messagesOrError}
+            <>
+                {data.statusMessages.map(status => {
+                    if (status.__typename === 'CloningProgress') {
+                        return (
+                            <StatusMessagesNavItemEntry
+                                key={status.message}
+                                message={status.message}
+                                messageHint="Your repositories may not be up-to-date."
+                                linkTo="/site-admin/repositories"
+                                linkText="View status"
+                                linkOnClick={toggleIsOpen}
+                                entryType="progress"
                             />
-                        ) : (
-                            this.renderMessage(this.state.messagesOrError)
-                        )}
-                    </div>
-                </PopoverContent>
-            </Popover>
+                        )
+                    }
+                    if (status.__typename === 'ExternalServiceSyncError') {
+                        return (
+                            <StatusMessagesNavItemEntry
+                                key={status.message}
+                                message={`Can't connect to ${status.externalService.displayName}`}
+                                messageHint="Verify the code host configuration."
+                                linkTo={`/site-admin/external-services/${status.externalService.id}`}
+                                linkText="Manage code hosts"
+                                linkOnClick={toggleIsOpen}
+                                entryType="error"
+                            />
+                        )
+                    }
+                    if (status.__typename === 'SyncError') {
+                        return (
+                            <StatusMessagesNavItemEntry
+                                key={status.message}
+                                message={status.message}
+                                messageHint="Your repositories may not be up-to-date."
+                                linkTo="/site-admin/repositories?status=failed-fetch"
+                                linkText="Manage repositories"
+                                linkOnClick={toggleIsOpen}
+                                entryType="error"
+                            />
+                        )
+                    }
+                    return null
+                })}
+            </>
         )
-    }
+    }, [data])
+
+    return (
+        <Popover isOpen={isOpen} onOpenChange={event => setIsOpen(event.isOpen)}>
+            <PopoverTrigger
+                className="nav-link py-0 px-0 percy-hide chromatic-ignore"
+                as={Button}
+                variant="link"
+                aria-label={isOpen ? 'Hide status messages' : 'Show status messages'}
+            >
+                {error && (
+                    <Tooltip content="Sorry, we couldn’t fetch notifications!">
+                        <Icon
+                            aria-label="Sorry, we couldn’t fetch notifications!"
+                            as={CloudAlertIconRefresh}
+                            size="md"
+                        />
+                    </Tooltip>
+                )}
+                {icon}
+            </PopoverTrigger>
+
+            <PopoverContent position={Position.bottomEnd} className={classNames('p-0', styles.dropdownMenu)}>
+                <div className={styles.dropdownMenuContent}>
+                    <small className={classNames('d-inline-block text-muted', styles.sync)}>Code sync status</small>
+                    {error && (
+                        <ErrorAlert className={styles.entry} prefix="Failed to load status messages" error={error} />
+                    )}
+                    {messages}
+                </div>
+            </PopoverContent>
+        </Popover>
+    )
 }

--- a/client/web/src/nav/StatusMessagesNavItemQueries.ts
+++ b/client/web/src/nav/StatusMessagesNavItemQueries.ts
@@ -3,26 +3,26 @@ import { gql } from '@sourcegraph/http-client'
 export const STATUS_MESSAGES = gql`
     query StatusMessages {
         statusMessages {
-            ...StatusMessageFields
-        }
-    }
+            ... on CloningProgress {
+                __typename
 
-    fragment StatusMessageFields on StatusMessage {
-        type: __typename
+                message
+            }
 
-        ... on CloningProgress {
-            message
-        }
+            ... on SyncError {
+                __typename
 
-        ... on SyncError {
-            message
-        }
+                message
+            }
 
-        ... on ExternalServiceSyncError {
-            message
-            externalService {
-                id
-                displayName
+            ... on ExternalServiceSyncError {
+                __typename
+
+                message
+                externalService {
+                    id
+                    displayName
+                }
             }
         }
     }

--- a/client/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
@@ -1,177 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`StatusMessagesNavItem all messages 1`] = `
+<DocumentFragment>
+  <button
+    aria-label="Show status messages"
+    class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
+    type="button"
+  />
+</DocumentFragment>
+`;
+
 exports[`StatusMessagesNavItem no messages 1`] = `
 <DocumentFragment>
   <button
     aria-label="Show status messages"
     class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
     type="button"
-  >
-    <svg
-      aria-label="Repositories up-to-date"
-      class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-state="closed"
-      fill="currentColor"
-      height="24"
-      role="img"
-      viewBox="0 -4 20 20"
-      width="24"
-    >
-      <g>
-        <path
-          d="M14.4175 5.6859L14.6515 6.82244L16.1402 5.33371L16.1315 5.33301C15.5482 2.49967 13.0482 0.333008 9.96484 0.333008C7.54818 0.333008 5.46484 1.66634 4.46484 3.66634C1.88151 3.99967 -0.0351562 6.08301 -0.0351562 8.66634C-0.0351562 11.4163 2.21484 13.6663 4.96484 13.6663H10.273L8.52301 11.9163H4.96484C3.18134 11.9163 1.71484 10.4498 1.71484 8.66634C1.71484 7.00858 2.9321 5.62862 4.68879 5.40195L5.61324 5.28267L6.03009 4.44896C6.7313 3.04654 8.20576 2.08301 9.96484 2.08301C12.1965 2.08301 13.9973 3.64505 14.4175 5.6859Z"
-          fill="#798BAF"
-        />
-        <path
-          d="M9.74232 8.18541L8.50488 9.42285L12.7475 13.6655L19.8287 6.59486L18.5913 5.35742L12.7528 11.1959L9.74232 8.18541Z"
-          fill="#37B24D"
-        />
-      </g>
-      <defs>
-        <clippath
-          id="clip0"
-        >
-          <rect
-            fill="white"
-            height="20"
-            width="20"
-          />
-        </clippath>
-      </defs>
-    </svg>
-  </button>
-</DocumentFragment>
-`;
-
-exports[`StatusMessagesNavItem one CloningProgress message 1`] = `
-<DocumentFragment>
-  <button
-    aria-label="Show status messages"
-    class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
-    type="button"
-  >
-    <svg
-      aria-label="Cloning repositories..."
-      class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-state="closed"
-      fill="currentColor"
-      height="24"
-      role="img"
-      viewBox="0 0 20 20"
-      width="24"
-    >
-      <g>
-        <path
-          d="M13.7873 7.14774C12.9858 5.90993 11.5895 5.08203 9.96484 5.08203C8.20576 5.08203 6.7313 6.04556 6.03009 7.44799L5.61324 8.28169L4.68879 8.40098C2.9321 8.62765 1.71484 10.0076 1.71484 11.6654C1.71484 13.4489 3.18134 14.9154 4.96484 14.9154H10.3872V16.6654H4.96484C2.21484 16.6654 -0.0351562 14.4154 -0.0351562 11.6654C-0.0351562 9.08203 1.88151 6.9987 4.46484 6.66536C5.46484 4.66536 7.54818 3.33203 9.96484 3.33203C12.0727 3.33203 13.9079 4.34461 15.0445 5.89054L13.7873 7.14774Z"
-          fill="#798BAF"
-        />
-        <path
-          d="M12.6934 15.2025C11.353 13.8621 11.2692 11.684 12.4421 10.176L13.6149 11.4327C13.0285 12.1866 13.1961 13.3595 13.8663 14.0297C14.2851 14.3648 14.7878 14.6161 15.3742 14.6161V13.1081L17.7199 15.5376L15.3742 17.8833V16.2916C14.3689 16.2916 13.3636 15.8727 12.6934 15.2025Z"
-          fill="#5E6E8C"
-        />
-        <path
-          d="M13.8663 9.58962L16.2119 7.16016V8.75187C17.2172 8.75187 18.1388 9.17075 18.8927 9.75717C20.2331 11.0976 20.3169 13.2757 19.144 14.7836L17.9712 13.6108C18.5576 12.8568 18.3901 11.684 17.7199 11.0138C17.301 10.6787 16.7984 10.4274 16.2119 10.4274V11.9353L13.8663 9.58962Z"
-          fill="#5E6E8C"
-        />
-      </g>
-      <defs>
-        <clippath
-          id="clip0"
-        >
-          <rect
-            fill="white"
-            height="20"
-            width="20"
-          />
-        </clippath>
-      </defs>
-    </svg>
-  </button>
-</DocumentFragment>
-`;
-
-exports[`StatusMessagesNavItem one ExternalServiceSyncError message 1`] = `
-<DocumentFragment>
-  <button
-    aria-label="Show status messages"
-    class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
-    type="button"
-  >
-    <svg
-      aria-label="Syncing repositories failed!"
-      class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-state="closed"
-      fill="currentColor"
-      height="24"
-      role="img"
-      viewBox="0 0 20 20"
-      width="24"
-    >
-      <g>
-        <path
-          d="M15.3129 6.28624C14.2107 4.51968 12.2477 3.33203 9.96484 3.33203C7.54818 3.33203 5.46484 4.66536 4.46484 6.66536C1.88151 6.9987 -0.0351562 9.08203 -0.0351562 11.6654C-0.0351562 14.4154 2.21484 16.6654 4.96484 16.6654H9.32894L10.3379 14.9154H4.96484C3.18134 14.9154 1.71484 13.4489 1.71484 11.6654C1.71484 10.0076 2.9321 8.62765 4.68879 8.40098L5.61324 8.28169L6.03009 7.44799C6.7313 6.04556 8.20576 5.08203 9.96484 5.08203C11.9829 5.08203 13.6486 6.35936 14.2597 8.11301L15.3129 6.28624Z"
-          fill="#798BAF"
-        />
-        <path
-          d="M15.4749 9.62828C15.639 9.34396 16.0494 9.34396 16.2136 9.62828L19.9071 16.0256C20.0712 16.3099 19.866 16.6653 19.5377 16.6653H12.1508C11.8224 16.6653 11.6173 16.3099 11.7814 16.0256L15.4749 9.62828Z"
-          fill="#F59F00"
-        />
-      </g>
-      <defs>
-        <clippath
-          id="clip0"
-        >
-          <rect
-            fill="white"
-            height="20"
-            width="20"
-          />
-        </clippath>
-      </defs>
-    </svg>
-  </button>
-</DocumentFragment>
-`;
-
-exports[`StatusMessagesNavItem one SyncError message 1`] = `
-<DocumentFragment>
-  <button
-    aria-label="Show status messages"
-    class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
-    type="button"
-  >
-    <svg
-      aria-label="Syncing repositories failed!"
-      class="phabricator-icon mdi-icon mdi-icon iconInline iconInlineMd"
-      data-state="closed"
-      fill="currentColor"
-      height="24"
-      role="img"
-      viewBox="0 0 20 20"
-      width="24"
-    >
-      <g>
-        <path
-          d="M15.3129 6.28624C14.2107 4.51968 12.2477 3.33203 9.96484 3.33203C7.54818 3.33203 5.46484 4.66536 4.46484 6.66536C1.88151 6.9987 -0.0351562 9.08203 -0.0351562 11.6654C-0.0351562 14.4154 2.21484 16.6654 4.96484 16.6654H9.32894L10.3379 14.9154H4.96484C3.18134 14.9154 1.71484 13.4489 1.71484 11.6654C1.71484 10.0076 2.9321 8.62765 4.68879 8.40098L5.61324 8.28169L6.03009 7.44799C6.7313 6.04556 8.20576 5.08203 9.96484 5.08203C11.9829 5.08203 13.6486 6.35936 14.2597 8.11301L15.3129 6.28624Z"
-          fill="#798BAF"
-        />
-        <path
-          d="M15.4749 9.62828C15.639 9.34396 16.0494 9.34396 16.2136 9.62828L19.9071 16.0256C20.0712 16.3099 19.866 16.6653 19.5377 16.6653H12.1508C11.8224 16.6653 11.6173 16.3099 11.7814 16.0256L15.4749 9.62828Z"
-          fill="#F59F00"
-        />
-      </g>
-      <defs>
-        <clippath
-          id="clip0"
-        >
-          <rect
-            fill="white"
-            height="20"
-            width="20"
-          />
-        </clippath>
-      </defs>
-    </svg>
-  </button>
+  />
 </DocumentFragment>
 `;


### PR DESCRIPTION
This changes StatusMessagesNavItem from a class-based component to a
FunctionComponent.

It also reduces a lot of now-unneeded code, switches from RxJS to
`useQuery`, adds a storybook for easier testing.

## Test plan

- Tests
- Local manual testing

## App preview:

- [Web](https://sg-web-mrn-status-item-func-component.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-smyshdegbp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
