### PR TITLE
dev/sg: rename cloud to dotcom in sg live

### DIFF
--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -19,9 +19,9 @@ type environment struct {
 }
 
 var environments = []environment{
-	{Name: "cloud", URL: "https://sourcegraph.com"},
-	{Name: "k8s", URL: "https://k8s.sgdev.org"},
 	{Name: "s2", URL: "https://sourcegraph.sourcegraph.com"},
+	{Name: "dotcom", URL: "https://sourcegraph.com"},
+	{Name: "k8s", URL: "https://k8s.sgdev.org"},
 }
 
 func environmentNames() []string {

--- a/dev/sg/sg_live.go
+++ b/dev/sg/sg_live.go
@@ -18,9 +18,9 @@ var liveCommand = &cli.Command{
 	Usage:     "Reports which version of Sourcegraph is currently live in the given environment",
 	UsageText: `
 # See which version is deployed on a preset environment
-sg live cloud
-sg live k8s
 sg live s2
+sg live dotcom
+sg live k8s
 
 # See which version is deployed on a custom environment
 sg live https://demo.sourcegraph.com
@@ -68,7 +68,7 @@ func liveExec(ctx *cli.Context) error {
 			e = environment{Name: customURL.Host, URL: customURL.String()}
 		} else {
 			std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: Environment %q not found, or is not a valid URL :(", args[0]))
-			return flag.ErrHelp
+			return NewEmptyExitErr(1)
 		}
 	}
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1105,15 +1105,15 @@ Prints the Sourcegraph version deployed to the given environment.
 
 Available preset environments:
 
-* cloud
-* k8s
 * s2
+* dotcom
+* k8s
 
 ```sh
 # See which version is deployed on a preset environment
-$ sg live cloud
-$ sg live k8s
 $ sg live s2
+$ sg live dotcom
+$ sg live k8s
 
 # See which version is deployed on a custom environment
 $ sg live https://demo.sourcegraph.com


### PR DESCRIPTION
We've come full circle, Cloud refers to something else now

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go run ./dev/sg live dotcom`