### PR TITLE
search: Remove `file:contains()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - `CACHE_DIR` has been removed from the `sourcegraph-frontend` deployment. This required ephemeral storage which will no longer be needed. This variable (and corresponding filesystem mount) has been unused for many releases. [#38934](https://github.com/sourcegraph/sourcegraph/issues/38934)
 - Quick links will no longer be shown on the homepage or search sidebar if the "Simple UI" toggle is enabled and will be removed entirely in a future release. The `quicklink` setting is now marked as deprecated. [#40750](https://github.com/sourcegraph/sourcegraph/pull/40750)
+- `file:contains()` has been removed from the list of valid predicates. `file:has.content()` and `file:contains.content()` remain, both of which work the same as `file:contains()` and are valid aliases of each other.
 
 ## 3.43.1
 

--- a/client/shared/src/search/query/metrics.test.ts
+++ b/client/shared/src/search/query/metrics.test.ts
@@ -17,9 +17,9 @@ describe('collectMetrics', () => {
     })
 
     test('predicates', () => {
-        expect(collectMetrics('repo:contains.file(foo) r:contains(file:foo content:bar)')).toMatchInlineSnapshot(`
+        expect(collectMetrics('repo:contains.path(foo) r:contains.file(path:foo content:bar)')).toMatchInlineSnapshot(`
             {
-              "count_repo_contains": 1,
+              "count_repo_contains_path": 1,
               "count_repo_contains_file": 1
             }
         `)

--- a/client/shared/src/search/query/metrics.ts
+++ b/client/shared/src/search/query/metrics.ts
@@ -15,7 +15,7 @@ interface Metrics {
     count_select_symbol?: number
     count_select_commit_diff_added?: number
     count_select_commit_diff_removed?: number
-    count_repo_contains?: number
+    count_repo_contains_path?: number
     count_repo_contains_file?: number
     count_repo_contains_content?: number
     count_repo_contains_commit_after?: number
@@ -41,7 +41,7 @@ export const collectMetrics = (query: string): Metrics | undefined => {
     let count_select_symbol = 0
     let count_select_commit_diff_added = 0
     let count_select_commit_diff_removed = 0
-    let count_repo_contains = 0
+    let count_repo_contains_path = 0
     let count_repo_contains_file = 0
     let count_repo_contains_content = 0
     let count_repo_contains_commit_after = 0
@@ -121,8 +121,8 @@ export const collectMetrics = (query: string): Metrics | undefined => {
                             continue
                         }
                         switch (predicate.path.join('.')) {
-                            case 'contains':
-                                count_repo_contains += 1
+                            case 'contains.path':
+                                count_repo_contains_path += 1
                                 break
                             case 'contains.file':
                                 count_repo_contains_file += 1
@@ -164,7 +164,7 @@ export const collectMetrics = (query: string): Metrics | undefined => {
         count_select_commit_diff_added: nonzero(count_select_commit_diff_added),
         count_select_commit_diff_removed: nonzero(count_select_commit_diff_removed),
         // RFC 384: predicate usage
-        count_repo_contains: nonzero(count_repo_contains),
+        count_repo_contains_path: nonzero(count_repo_contains_path),
         count_repo_contains_file: nonzero(count_repo_contains_file),
         count_repo_contains_content: nonzero(count_repo_contains_content),
         count_repo_contains_commit_after: nonzero(count_repo_contains_commit_after),

--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -42,17 +42,25 @@ describe('scanPredicate', () => {
         )
     })
 
-    test('scan recognized file.contains syntax', () => {
-        expect(scanPredicate('file', 'contains(stuff)')).toMatchInlineSnapshot(
-            '{"path":["contains"],"parameters":"(stuff)"}'
+    test('scan recognized file:contains.content syntax', () => {
+        expect(scanPredicate('file', 'contains.content(stuff)')).toMatchInlineSnapshot(
+            '{"path":["contains","content"],"parameters":"(stuff)"}'
         )
+    })
+
+    test('scan invalid repo:contains() syntax', () => {
+        expect(scanPredicate('repo', 'contains(content:stuff)')).toMatchInlineSnapshot('invalid')
+    })
+
+    test('scan invalid file:contains() syntax', () => {
+        expect(scanPredicate('file', 'contains(stuff')).toMatchInlineSnapshot('invalid')
     })
 })
 
 describe('resolveAccess', () => {
     test('resolves partial access tree', () => {
-        expect(resolveAccess(['repo', 'contains'], PREDICATES)).toMatchInlineSnapshot(
-            '[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]'
+        expect(resolveAccess(['repo'], PREDICATES)).toMatchInlineSnapshot(
+            '[{"name":"contains","fields":[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]},{"name":"has","fields":[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]},{"name":"description"},{"name":"tag"}]}]'
         )
     })
 
@@ -66,5 +74,9 @@ describe('resolveAccess', () => {
 
     test('undefind path', () => {
         expect(resolveAccess(['OCOTILLO', 'contains', 'file'], PREDICATES)).toMatchInlineSnapshot('invalid')
+    })
+
+    test('invalid predicate syntax', () => {
+        expect(resolveAccess(['repo', 'contains'], PREDICATES)).toMatchInlineSnapshot('invalid')
     })
 })

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -69,6 +69,12 @@ export const resolveAccess = (path: string[], tree: Access[]): Access[] | undefi
     if (path.length === 0) {
         return tree
     }
+
+    // repo:contains() and file:contains() are not supported
+    if (path.length === 1 && path[0] === 'contains') {
+        return undefined
+    }
+
     const subtree = tree.find(value => value.name === path[0])
     if (!subtree) {
         return undefined

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1324,7 +1324,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name: `file contains content predicate type diff`,
 				// matches .travis.yml and in the last commit that added after_success, but not in previous commits
-				query:  `type:diff repo:go-diff file:contains(after_success)`,
+				query:  `type:diff repo:go-diff file:contains.content(after_success)`,
 				counts: counts{Commit: 1},
 			},
 			{

--- a/doc/code_insights/explanations/automatically_generated_data_series.md
+++ b/doc/code_insights/explanations/automatically_generated_data_series.md
@@ -38,7 +38,7 @@ This type of Code Insight only supports capture groups in the main query string.
 
 ### No multiline matches (<3.43)
 
-On Sourcegraph instances on earlier versions than 3.43, you can only use a single-line regular expression. This means that `^` and `$` characters are still valid but needing to match on a `\n` is not. As a potential workaround to get more granularity, you can still use `file:contains()` and other [search predicates](https://docs.sourcegraph.com/code_search/reference/language#built-in-file-predicate). 
+On Sourcegraph instances on earlier versions than 3.43, you can only use a single-line regular expression. This means that `^` and `$` characters are still valid but needing to match on a `\n` is not. As a potential workaround to get more granularity, you can still use `file:has.content()` and other [search predicates](https://docs.sourcegraph.com/code_search/reference/language#built-in-file-predicate). 
 
 ### No combinations of capture groups 
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -176,7 +176,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 
 	basicJob := NewParallelJob(children...)
 
-	{ // Apply file:contains() post-filter
+	{ // Apply file:contains.content() post-filter
 		if len(fileContainsPatterns) > 0 {
 			basicJob = NewFileContainsFilterJob(fileContainsPatterns, originalQuery.Pattern, b.IsCaseSensitive(), basicJob)
 		}

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -39,7 +39,6 @@ var DefaultPredicateRegistry = PredicateRegistry{
 	FieldFile: {
 		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
 		"has.content":      func() Predicate { return &FileContainsContentPredicate{} },
-		"contains":         func() Predicate { return &FileContainsContentPredicate{} },
 		"has.owner":        func() Predicate { return &FileHasOwnerPredicate{} },
 	},
 }

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -10,11 +10,11 @@ import (
 
 type Predicate interface {
 	// Field is the name of the field that the predicate applies to.
-	// For example, with `file:contains()`, Field returns "file".
+	// For example, with `repo:contains.file`, Field returns "repo".
 	Field() string
 
 	// Name is the name of the predicate.
-	// For example, with `file:contains()`, Name returns "contains".
+	// For example, with `repo:contains.file`, Name returns "contains.file".
 	Name() string
 
 	// ParseParams parses the contents of the predicate arguments


### PR DESCRIPTION
Straggler from #39767

Removes `file:contains()` from list of valid predicates, in line with `repo:contains()` no longer being a valid predicate.

Removes query syntax highlighting for `file:contains()` and `repo:contains()` to visually indicate these queries will not be interpreted as predicates.

Updates examples used in comments and docs

Updates metrics collection to track updated predicates

![Screen Shot 2022-09-01 at 3 15 54 PM](https://user-images.githubusercontent.com/70350613/188004131-8964bb03-9802-4645-b289-60606351b9a7.png)


## Test plan
Added and updated unit tests
Backend integration tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
