### PR TITLE
Aggregation: Adjust aggregation url params

### DIFF
--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -191,10 +191,10 @@ describe('Search aggregation', () => {
             await delay(100)
 
             const aggregationCases = [
-                { mode: 'REPO', id: 'repo-aggregation-mode' },
-                { mode: 'PATH', id: 'file-aggregation-mode' },
-                { mode: 'AUTHOR', id: 'author-aggregation-mode' },
-                { mode: 'CAPTURE_GROUP', id: 'captureGroup-aggregation-mode' },
+                { mode: 'REPO', urlKey: 'repo', id: 'repo-aggregation-mode' },
+                { mode: 'PATH', urlKey: 'path', id: 'file-aggregation-mode' },
+                { mode: 'AUTHOR', urlKey: 'author', id: 'author-aggregation-mode' },
+                { mode: 'CAPTURE_GROUP', urlKey: 'group', id: 'captureGroup-aggregation-mode' },
             ]
 
             for (const testCase of aggregationCases) {
@@ -210,15 +210,13 @@ describe('Search aggregation', () => {
                     },
                     { timeout: 5000 },
                     `${origQuery}`,
-                    testCase.mode
+                    testCase.urlKey
                 )
             }
         })
 
         test('should open expanded full UI by default if UI mode is set in URL query param', async () => {
-            await driver.page.goto(
-                `${driver.sourcegraphBaseUrl}/search?q=${encodeURIComponent('insights(')}&groupByUI=searchPage`
-            )
+            await driver.page.goto(`${driver.sourcegraphBaseUrl}/search?q=${encodeURIComponent('insights(')}&expanded`)
 
             await driver.page.waitForSelector('[aria-label="Aggregation results panel"]')
         })
@@ -245,13 +243,13 @@ describe('Search aggregation', () => {
                     const url = new URL(document.location.href)
                     const query = url.searchParams.get('q')
                     const aggregationMode = url.searchParams.get('groupBy')
-                    const aggregationUIMode = url.searchParams.get('groupByUI')
+                    const aggregationUIMode = url.searchParams.get('expanded')
 
                     return (
                         query &&
                         query.trim() === expectedQuery &&
-                        aggregationMode === 'PATH' &&
-                        aggregationUIMode === 'searchPage'
+                        aggregationMode === 'path' &&
+                        aggregationUIMode === ''
                     )
                 },
                 { timeout: 5000 },
@@ -268,13 +266,13 @@ describe('Search aggregation', () => {
                     const url = new URL(document.location.href)
                     const query = url.searchParams.get('q')
                     const aggregationMode = url.searchParams.get('groupBy')
-                    const aggregationUIMode = url.searchParams.get('groupByUI')
+                    const aggregationUIMode = url.searchParams.get('expanded')
 
                     return (
                         query &&
                         query.trim() === expectedQuery &&
-                        aggregationMode === 'AUTHOR' &&
-                        aggregationUIMode === 'sidebar'
+                        aggregationMode === 'author' &&
+                        aggregationUIMode === null
                     )
                 },
                 { timeout: 5000 },

--- a/client/web/src/search/results/components/aggregation/constants.ts
+++ b/client/web/src/search/results/components/aggregation/constants.ts
@@ -3,4 +3,4 @@
  * type and UI modes.
  */
 export const AGGREGATION_MODE_URL_KEY = 'groupBy'
-export const AGGREGATION_UI_MODE_URL_KEY = 'groupByUI'
+export const AGGREGATION_UI_MODE_URL_KEY = 'expanded'


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/40868

## Test plan
- Make sure that URL has new aggregation values 
  - REPO → repo
  - PATH → path 
  - AUTHOR → author
  - CAPTURE_GROUP → group
- Make sure that when you run aggregation in sidebar panel ULR doesn't have any aggregation UI mode specific query param in URL 
- Make sure that when you run aggregatin in the full UI mode URL has `expanded=` query param 

## Why expanded has `=` at the end 
[WhatWG spec](https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams) says that query param always should have value (it's basically a key value pair) Since our hook uses `URLSearchParams` class we have to have a `=` at the end. We could change this logic and set param manually but working with search strings may be tricky (we can by accident remove something from the URL) 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-adjust-aggregation-url-params.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wizixptnqj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
