### PR TITLE
Update query to include case sensitive flag

### DIFF
--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -306,5 +306,53 @@ describe('Search aggregation', () => {
 
             expect(await editor.getValue()).toStrictEqual('insights repo:sourecegraph/about')
         })
+
+        test('should preserve case sensitive filter in a query', async () => {
+            const origQuery = 'context:global insights('
+
+            await driver.page.goto(
+                `${driver.sourcegraphBaseUrl}/search?q=${encodeURIComponent(origQuery)}&patternType=literal&case=yes`
+            )
+
+            const variables = await testContext.waitForGraphQLRequest(() => {}, 'GetSearchAggregation')
+
+            expect(variables).toStrictEqual({
+                mode: null,
+                limit: 10,
+                skipAggregation: false,
+                patternType: 'standard',
+                query: `${origQuery} case:yes`,
+            })
+
+            const variablesForFileMode = await testContext.waitForGraphQLRequest(async () => {
+                await driver.page.waitForSelector('[aria-label="Aggregation mode picker"]')
+                await driver.page.click('[data-testid="file-aggregation-mode"]')
+            }, 'GetSearchAggregation')
+
+            expect(variablesForFileMode).toStrictEqual({
+                mode: 'PATH',
+                limit: 10,
+                skipAggregation: false,
+                patternType: 'standard',
+                query: `${origQuery} case:yes`,
+            })
+
+            const editor = await createEditorAPI(driver, '[data-testid="searchbox"] .test-query-input')
+            await driver.page.waitForSelector('.test-case-sensitivity-toggle')
+            await editor.focus()
+            await driver.page.keyboard.type('test')
+            await driver.page.click('.test-case-sensitivity-toggle')
+
+            const variablesWithoutCaseSensitivity = await testContext.waitForGraphQLRequest(() => {},
+            'GetSearchAggregation')
+
+            expect(variablesWithoutCaseSensitivity).toStrictEqual({
+                mode: 'PATH',
+                limit: 10,
+                skipAggregation: false,
+                patternType: 'standard',
+                query: 'context:global insights(test',
+            })
+        })
     })
 })

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -299,6 +299,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                 aggregationUIMode={aggregationUIMode}
                 settingsCascade={props.settingsCascade}
                 telemetryService={props.telemetryService}
+                caseSensitive={caseSensitive}
                 className={classNames(styles.sidebar, showMobileSidebar && styles.sidebarShowMobile)}
                 onNavbarQueryChange={setQueryState}
                 onSearchSubmit={handleSidebarSearchSubmit}
@@ -315,6 +316,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                 <SearchAggregationResult
                     query={submittedURLQuery}
                     patternType={patternType}
+                    caseSensitive={caseSensitive}
                     aria-label="Aggregation results panel"
                     className={styles.contents}
                     onQuerySubmit={handleSearchAggregationBarClick}

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
@@ -102,6 +102,7 @@ export const SearchAggregationResultDemo: Story = () => (
                 <SearchAggregationResult
                     query=""
                     patternType={SearchPatternType.literal}
+                    caseSensitive={false}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
                     onQuerySubmit={noop}
                 />

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -31,6 +31,8 @@ interface SearchAggregationResultProps extends TelemetryProps, HTMLAttributes<HT
     /** Current search query pattern type. */
     patternType: SearchPatternType
 
+    caseSensitive: boolean
+
     /**
      * Emits whenever a user clicks one of aggregation chart segments (bars).
      * That should update the query and re-trigger search (but this should be connected
@@ -40,7 +42,7 @@ interface SearchAggregationResultProps extends TelemetryProps, HTMLAttributes<HT
 }
 
 export const SearchAggregationResult: FC<SearchAggregationResultProps> = props => {
-    const { query, patternType, onQuerySubmit, telemetryService, ...attributes } = props
+    const { query, patternType, caseSensitive, onQuerySubmit, telemetryService, ...attributes } = props
 
     const [, setAggregationUIMode] = useAggregationUIMode()
     const [aggregationMode, setAggregationMode] = useAggregationSearchMode()
@@ -50,6 +52,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
         aggregationMode,
         limit: 30,
         proactive: true,
+        caseSensitive,
     })
 
     const handleCollapseClick = (): void => {

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -207,6 +207,7 @@ interface SearchAggregationDataInput {
     aggregationMode: SearchAggregationMode | null
     limit: number
     proactive?: boolean
+    caseSensitive: boolean
 }
 
 type SearchAggregationResults =
@@ -215,7 +216,11 @@ type SearchAggregationResults =
     | { data: GetSearchAggregationResult; loading: false; error: undefined }
 
 export const useSearchAggregationData = (input: SearchAggregationDataInput): SearchAggregationResults => {
-    const { query, patternType, aggregationMode, limit, proactive } = input
+    const { query, patternType, aggregationMode, limit, proactive, caseSensitive } = input
+
+    // Search parses out the case argument, but backend needs it in the query
+    // Here we're checking the caseSensitive flag and adding it back to the query if it's true
+    const aggregationQuery = caseSensitive ? `${query} case:yes` : query
 
     const calculatedAggregationModeRef = useRef<SearchAggregationMode | null>(null)
     const [, setAggregationMode] = useAggregationSearchMode()
@@ -226,7 +231,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
         {
             fetchPolicy: 'cache-first',
             variables: {
-                query,
+                query: aggregationQuery,
                 patternType,
                 mode: aggregationMode,
                 limit,

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { gql, useQuery } from '@apollo/client'
 import { useHistory, useLocation } from 'react-router'
@@ -210,6 +210,13 @@ interface SearchAggregationDataInput {
     caseSensitive: boolean
 }
 
+interface AggregationState {
+    data: GetSearchAggregationResult | undefined
+    calculatedMode: SearchAggregationMode | null
+}
+
+const INITIAL_STATE: AggregationState = { calculatedMode: null, data: undefined }
+
 type SearchAggregationResults =
     | { data: undefined; loading: true; error: undefined }
     | { data: GetSearchAggregationResult | undefined; loading: false; error: Error }
@@ -218,14 +225,13 @@ type SearchAggregationResults =
 export const useSearchAggregationData = (input: SearchAggregationDataInput): SearchAggregationResults => {
     const { query, patternType, aggregationMode, limit, proactive, caseSensitive } = input
 
+    const [, setAggregationMode] = useAggregationSearchMode()
+    const [state, setState] = useState<AggregationState>(INITIAL_STATE)
+
     // Search parses out the case argument, but backend needs it in the query
     // Here we're checking the caseSensitive flag and adding it back to the query if it's true
     const aggregationQuery = caseSensitive ? `${query} case:yes` : query
 
-    const calculatedAggregationModeRef = useRef<SearchAggregationMode | null>(null)
-    const [, setAggregationMode] = useAggregationSearchMode()
-
-    const [data, setData] = useState<GetSearchAggregationResult | undefined>()
     const { error, loading } = useQuery<GetSearchAggregationResult, GetSearchAggregationVariables>(
         AGGREGATION_SEARCH_QUERY,
         {
@@ -242,10 +248,9 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
             // we got calculated aggregation mode from the BE. We should update
             // FE aggregationMode but this shouldn't trigger AGGREGATION_SEARCH_QUERY
             // fetching.
-            skip: aggregationMode !== null && calculatedAggregationModeRef.current === aggregationMode,
+            skip: aggregationMode !== null && state.calculatedMode === aggregationMode,
             onError: () => {
-                calculatedAggregationModeRef.current = null
-                setData(undefined)
+                setState({ calculatedMode: null, data: undefined })
             },
             onCompleted: data => {
                 const calculatedAggregationMode = getCalculatedAggregationMode(data)
@@ -265,13 +270,9 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
                     setAggregationMode(calculatedAggregationMode)
                 }
 
-                // Preserve calculated aggregation mode in order to use it for skipping
-                // extra API calls in useQuery "skip" field.
-                calculatedAggregationModeRef.current = calculatedAggregationMode
-
                 // skip: true resets data field in the useQuery hook, in order to use previously
                 // saved data we use useState to store data outside useQuery hook
-                setData(data)
+                setState({ data, calculatedMode: calculatedAggregationMode })
             },
         }
     )
@@ -279,7 +280,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
     useEffect(() => {
         // If query or pattern type have been changed we should "reset" our assumptions
         // about calculated aggregation mode and make another api call to determine it
-        calculatedAggregationModeRef.current = null
+        setState(state => ({ ...state, calculatedMode: null }))
     }, [query, patternType])
 
     if (loading) {
@@ -287,11 +288,11 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
     }
 
     if (error) {
-        return { data, error, loading: false }
+        return { data: state.data, error, loading: false }
     }
 
     return {
-        data: data as GetSearchAggregationResult,
+        data: state.data as GetSearchAggregationResult,
         error: undefined,
         loading: false,
     }

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -34,6 +34,8 @@ interface SearchAggregationsProps extends TelemetryProps {
     /** Whether to proactively load and display search aggregations */
     proactive: boolean
 
+    caseSensitive: boolean
+
     /**
      * Emits whenever a user clicks one of aggregation chart segments (bars).
      * That should update the query and re-trigger search (but this should be connected
@@ -43,7 +45,7 @@ interface SearchAggregationsProps extends TelemetryProps {
 }
 
 export const SearchAggregations: FC<SearchAggregationsProps> = props => {
-    const { query, patternType, proactive, telemetryService, onQuerySubmit } = props
+    const { query, patternType, proactive, caseSensitive, telemetryService, onQuerySubmit } = props
 
     const [, setAggregationUIMode] = useAggregationUIMode()
     const [aggregationMode, setAggregationMode] = useAggregationSearchMode()
@@ -52,6 +54,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
         patternType,
         aggregationMode,
         proactive,
+        caseSensitive,
         limit: 10,
     })
 

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, memo } from 'react'
 
 import { mdiArrowExpand } from '@mdi/js'
 
@@ -44,7 +44,7 @@ interface SearchAggregationsProps extends TelemetryProps {
     onQuerySubmit: (newQuery: string) => void
 }
 
-export const SearchAggregations: FC<SearchAggregationsProps> = props => {
+export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
     const { query, patternType, proactive, caseSensitive, telemetryService, onQuerySubmit } = props
 
     const [, setAggregationUIMode] = useAggregationUIMode()
@@ -141,4 +141,4 @@ export const SearchAggregations: FC<SearchAggregationsProps> = props => {
             )}
         </article>
     )
-}
+})

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
@@ -26,6 +26,7 @@ export default config
 const defaultProps: SearchFiltersSidebarProps = {
     liveQuery: '',
     submittedURLQuery: '',
+    caseSensitive: false,
     patternType: SearchPatternType.literal,
     onNavbarQueryChange: () => {},
     onSearchSubmit: () => {},

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -39,6 +39,7 @@ export interface SearchFiltersSidebarProps extends TelemetryProps, SettingsCasca
     filters?: Filter[]
     selectedSearchContextSpec?: string
     aggregationUIMode?: AggregationUIMode
+    caseSensitive: boolean
     onNavbarQueryChange: (queryState: QueryStateUpdate) => void
     onSearchSubmit: (updates: QueryUpdate[]) => void
 }
@@ -47,6 +48,7 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
     const {
         liveQuery,
         submittedURLQuery,
+        caseSensitive,
         patternType,
         filters,
         selectedSearchContextSpec,
@@ -111,6 +113,7 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
                         query={submittedURLQuery}
                         patternType={patternType}
                         proactive={!disableProactiveSearchAggregations}
+                        caseSensitive={caseSensitive}
                         telemetryService={telemetryService}
                         onQuerySubmit={handleAggregationBarLinkClick}
                     />

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -87,9 +87,12 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
         [telemetryService, onSearchSubmit]
     )
 
-    const handleAggregationBarLinkClick = (query: string): void => {
-        onSearchSubmit([{ type: 'replaceQuery', value: query }])
-    }
+    const handleAggregationBarLinkClick = useCallback(
+        (query: string): void => {
+            onSearchSubmit([{ type: 'replaceQuery', value: query }])
+        },
+        [onSearchSubmit]
+    )
 
     const handleGroupedByToggle = useCallback(
         (open: boolean): void => {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41120

Search removes `case:yes` from the query during passing. The backend needs it in the query. This PR adds it back if `caseSensitive` is true.

## Test plan

Note: When I was testing locally, at some point my case-sensitive flag got "saved". So if you start a new search make sure that the case-sensitive button is not highlighted if.

![Actual photo of the offender](https://user-images.githubusercontent.com/1855233/188038386-be7fe7ea-2e9b-4434-b351-776c603d3854.png)

Testing locally navigate here: https://sourcegraph.test:3443/search?q=context%3Aglobal+repo%3A%5Egithub%5C.com%2Fsourcegraph%2Fsourcegraph%24+file%3Aweb+file%3Acodeinsightsrouter++lang%3AtypeScript&patternType=standard&case=yes&groupBy=PATH&groupByUI=sidebar

Check the network tab in devtools and the `case:yes` should still be in the `query` variable.

It should not render a graph since there are no results for that search.

Navigate to https://sourcegraph.test:3443/search?q=context%3Aglobal+insights&patternType=standard&groupBy=REPO

Check the network tab in devtools and the `case:yes` should not be in the `query` variable.

It should render a graph since there are results for that search.

## App preview:

- [Web](https://sg-web-insights-respect-case-sensitive.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tpwmmhtmzr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

