### PR TITLE
otlp: treat OTEL_EXPORTER_OTLP_ENDPOINT='' as OpenTelemetry being disabled

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -286,7 +286,7 @@ func addOpenTelemetryProtocolAdapter(r *mux.Router) {
 		logger.Error("unable to parse OTLP export target")
 
 		r.PathPrefix("/otlp").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, `OpenTelemetry protocol tunnel: please configure an exporter endpoint with OTEL_EXPORTER_OTLP_HTTP_JSON_ENDPOINT, or OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_PROTOCOL=http/json`)
+			fmt.Fprintf(w, `OpenTelemetry protocol tunnel: please configure an exporter endpoint with OTEL_EXPORTER_OTLP_ENDPOINT`)
 			w.WriteHeader(http.StatusNotFound)
 		})
 		return

--- a/internal/otlpenv/otlpenv.go
+++ b/internal/otlpenv/otlpenv.go
@@ -25,6 +25,9 @@ const defaultGRPCCollectorEndpoint = "http://127.0.0.1:4317"
 // GetEndpoint returns the root collector endpoint, NOT per-signal endpoints. We do not
 // yet support per-signal endpoints.
 //
+// If an empty value is returned, then OTEL_EXPORTER_OTLP_ENDPOINT has explicitly been set
+// to an empty string, and callers should consider OpenTelemetry to be disabled.
+//
 // See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options
 func GetEndpoint() string {
 	return getWithDefault(defaultGRPCCollectorEndpoint,

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -193,7 +193,7 @@ func newTracer(logger log.Logger, opts *options) (opentracing.Tracer, oteltrace.
 	case Jaeger, openTracing:
 		exporter, err = exporters.NewJaegerExporter()
 	case OpenTelemetry:
-		exporter, err = exporters.NewOTelCollectorExporter(context.Background(), logger)
+		exporter, err = exporters.NewOTLPExporter(context.Background(), logger)
 	}
 
 	if err != nil || exporter == nil {


### PR DESCRIPTION
We need a mechanism to disable OpenTelemetry by default even if it is enabled by default (#41242), most notably for `sourcegraph/server` (https://github.com/sourcegraph/sourcegraph/pull/41244)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`OTEL_EXPORTER_OTLP_ENDPOINT='' sg start`

```
[         worker] WARN tracer tracer/tracer.go:163 failed to initialize tracer {"tracerType": "opentelemetry", "debug": false, "error": "please configure an exporter endpoint with OTEL_EXPORTER_OTLP_ENDPOINT"}
```