### PR TITLE
Tooltip: Add additional documentation around component triggers

### DIFF
--- a/client/wildcard/src/components/Tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.tsx
@@ -6,7 +6,11 @@ import { isEmpty } from 'lodash'
 import styles from './Tooltip.module.scss'
 
 export interface TooltipProps {
-    /** A single child element that will trigger the Tooltip to open on hover. */
+    /**
+     * A single child element/component that will trigger the Tooltip to open on hover.
+     *
+     * **Note:** If you are using a component, it **must** be able to receive and attach a ref (React.forwardRef).
+     **/
     children: React.ReactElement
     /** The text that will be displayed in the Tooltip. If `null`, no Tooltip will be rendered, allowing for Tooltips to be shown conditionally. */
     content: string | null | undefined


### PR DESCRIPTION
## Description

Make it clearer that `children` (the tooltip trigger) must use `forwardRef`.

As part of https://github.com/sourcegraph/sourcegraph/issues/32362, we should look at ensuring that tooltip triggers are a restricted set of interactive elements that we can use to reduce any accidental incorrect usage

## Test plan

N/A - Docs only change

## App preview:

- [Web](https://sg-web-tr-tooltip-docs.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zkscdjrjvq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
