### PR TITLE
gitserver: include system certificates for git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The recommended [src-cli](https://github.com/sourcegraph/src-cli) version is now reported consistently. [#39468](https://github.com/sourcegraph/sourcegraph/issues/39468)
 - A performance issue affecting structural search causing results to not stream. It is much faster now. [#40872](https://github.com/sourcegraph/sourcegraph/pull/40872)
 - An issue where the saved search input box reports an invalid pattern type for `standard`, which is now valid. [#41068](https://github.com/sourcegraph/sourcegraph/pull/41068)
+- Git will now respect system certificate authorities when specifying `certificates` for the `tls.external` site configuration. [#38128](https://github.com/sourcegraph/sourcegraph/issues/38128)
 
 ### Removed
 

--- a/cmd/gitserver/server/internal/cacert/README.md
+++ b/cmd/gitserver/server/internal/cacert/README.md
@@ -1,0 +1,7 @@
+# cacert
+
+This package exists to expose the internal code in the stdlib x509 package related to loading system certificates. Not all operating systems expose the system root certificates, and instead rely on a system call. However, in linux you can load the system root certificates.
+
+To update run `update.bash`. It will copy the relevant code from your go installation and then patch it.
+
+Note: This does mean this won't work on darwin. So for example our code which depends on this package will not have system certificates to use in our development environments.

--- a/cmd/gitserver/server/internal/cacert/cacert.go
+++ b/cmd/gitserver/server/internal/cacert/cacert.go
@@ -1,0 +1,44 @@
+// package cacert is a subset of the stdlib x509 package, but including code
+// to expose the raw system certificates on linux.
+package cacert
+
+import "sync"
+
+var (
+	systemOnce  sync.Once
+	systemCerts [][]byte
+	systemErr   error
+)
+
+// System returns PEM encoded system certificates. Note: This function only
+// works on Linux. Other operating systems do not rely on PEM files at known
+// locations, instead they rely on system calls.
+func System() ([][]byte, error) {
+	systemOnce.Do(func() {
+		c, err := loadSystemRoots()
+		if err != nil {
+			systemErr = err
+			return
+		}
+		systemCerts = c.certs
+	})
+	return systemCerts, systemErr
+}
+
+// CertPool exists for interaction with x509. Do not use.
+type CertPool struct {
+	certs [][]byte
+}
+
+// CertPool exists for interaction with x509. Do not use.
+func NewCertPool() *CertPool {
+	return &CertPool{}
+}
+
+func (c *CertPool) AppendCertsFromPEM(data []byte) {
+	c.certs = append(c.certs, data)
+}
+
+func (c *CertPool) len() int {
+	return len(c.certs)
+}

--- a/cmd/gitserver/server/internal/cacert/cacert_test.go
+++ b/cmd/gitserver/server/internal/cacert/cacert_test.go
@@ -1,0 +1,32 @@
+package cacert_test
+
+import (
+	"crypto/x509"
+	"runtime"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/internal/cacert"
+)
+
+func TestSystem(t *testing.T) {
+	certs, err := cacert.System()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// We only have system certs on linux, which is fine since we deploy via
+	// docker using linux containers.
+	if runtime.GOOS != "linux" {
+		return
+	}
+	if len(certs) == 0 {
+		t.Fatal("expected system certificates")
+	}
+
+	pool := x509.NewCertPool()
+	for _, data := range certs {
+		ok := pool.AppendCertsFromPEM(data)
+		if !ok {
+			t.Fatalf("failed to parse system certificate:\n%s", string(data))
+		}
+	}
+}

--- a/cmd/gitserver/server/internal/cacert/package-rename.patch
+++ b/cmd/gitserver/server/internal/cacert/package-rename.patch
@@ -1,0 +1,42 @@
+Renames stdlib x509 package to cacert for update.bash
+
+diff --git a/cmd/gitserver/server/internal/cacert/root_linux.go b/cmd/gitserver/server/internal/cacert/root_linux.go
+index e32989b999..04024be2c9 100644
+--- a/cmd/gitserver/server/internal/cacert/root_linux.go
++++ b/cmd/gitserver/server/internal/cacert/root_linux.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-package x509
++package cacert
+ 
+ // Possible certificate files; stop after finding one.
+ var certFiles = []string{
+diff --git a/cmd/gitserver/server/internal/cacert/root_unix.go b/cmd/gitserver/server/internal/cacert/root_unix.go
+index aa54f891ca..dd85298ce0 100644
+--- a/cmd/gitserver/server/internal/cacert/root_unix.go
++++ b/cmd/gitserver/server/internal/cacert/root_unix.go
+@@ -2,9 +2,9 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build aix || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
++//go:build linux
+ 
+-package x509
++package cacert
+ 
+ import (
+ 	"io/fs"
+@@ -25,10 +25,6 @@ const (
+ 	certDirEnv = "SSL_CERT_DIR"
+ )
+ 
+-func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+-	return nil, nil
+-}
+-
+ func loadSystemRoots() (*CertPool, error) {
+ 	roots := NewCertPool()
+ 

--- a/cmd/gitserver/server/internal/cacert/root_linux.go
+++ b/cmd/gitserver/server/internal/cacert/root_linux.go
@@ -1,0 +1,22 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+	"/etc/pki/tls/cacert.pem",                           // OpenELEC
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+	"/etc/ssl/cert.pem",                                 // Alpine Linux
+}
+
+// Possible directories with certificate files; all will be read.
+var certDirectories = []string{
+	"/etc/ssl/certs",               // SLES10/SLES11, https://golang.org/issue/12139
+	"/etc/pki/tls/certs",           // Fedora/RHEL
+	"/system/etc/security/cacerts", // Android
+}

--- a/cmd/gitserver/server/internal/cacert/root_linux.go
+++ b/cmd/gitserver/server/internal/cacert/root_linux.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package x509
+package cacert
 
 // Possible certificate files; stop after finding one.
 var certFiles = []string{

--- a/cmd/gitserver/server/internal/cacert/root_other.go
+++ b/cmd/gitserver/server/internal/cacert/root_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package cacert
+
+// we intentionally only support linux and make it a noop on other operating
+// systems.
+func loadSystemRoots() (*CertPool, error) {
+	return &CertPool{}, nil
+}

--- a/cmd/gitserver/server/internal/cacert/root_unix.go
+++ b/cmd/gitserver/server/internal/cacert/root_unix.go
@@ -1,0 +1,108 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
+
+package x509
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// certFileEnv is the environment variable which identifies where to locate
+	// the SSL certificate file. If set this overrides the system default.
+	certFileEnv = "SSL_CERT_FILE"
+
+	// certDirEnv is the environment variable which identifies which directory
+	// to check for SSL certificate files. If set this overrides the system default.
+	// It is a colon separated list of directories.
+	// See https://www.openssl.org/docs/man1.0.2/man1/c_rehash.html.
+	certDirEnv = "SSL_CERT_DIR"
+)
+
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	return nil, nil
+}
+
+func loadSystemRoots() (*CertPool, error) {
+	roots := NewCertPool()
+
+	files := certFiles
+	if f := os.Getenv(certFileEnv); f != "" {
+		files = []string{f}
+	}
+
+	var firstErr error
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err == nil {
+			roots.AppendCertsFromPEM(data)
+			break
+		}
+		if firstErr == nil && !os.IsNotExist(err) {
+			firstErr = err
+		}
+	}
+
+	dirs := certDirectories
+	if d := os.Getenv(certDirEnv); d != "" {
+		// OpenSSL and BoringSSL both use ":" as the SSL_CERT_DIR separator.
+		// See:
+		//  * https://golang.org/issue/35325
+		//  * https://www.openssl.org/docs/man1.0.2/man1/c_rehash.html
+		dirs = strings.Split(d, ":")
+	}
+
+	for _, directory := range dirs {
+		fis, err := readUniqueDirectoryEntries(directory)
+		if err != nil {
+			if firstErr == nil && !os.IsNotExist(err) {
+				firstErr = err
+			}
+			continue
+		}
+		for _, fi := range fis {
+			data, err := os.ReadFile(directory + "/" + fi.Name())
+			if err == nil {
+				roots.AppendCertsFromPEM(data)
+			}
+		}
+	}
+
+	if roots.len() > 0 || firstErr == nil {
+		return roots, nil
+	}
+
+	return nil, firstErr
+}
+
+// readUniqueDirectoryEntries is like os.ReadDir but omits
+// symlinks that point within the directory.
+func readUniqueDirectoryEntries(dir string) ([]fs.DirEntry, error) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	uniq := files[:0]
+	for _, f := range files {
+		if !isSameDirSymlink(f, dir) {
+			uniq = append(uniq, f)
+		}
+	}
+	return uniq, nil
+}
+
+// isSameDirSymlink reports whether fi in dir is a symlink with a
+// target not containing a slash.
+func isSameDirSymlink(f fs.DirEntry, dir string) bool {
+	if f.Type()&fs.ModeSymlink == 0 {
+		return false
+	}
+	target, err := os.Readlink(filepath.Join(dir, f.Name()))
+	return err == nil && !strings.Contains(target, "/")
+}

--- a/cmd/gitserver/server/internal/cacert/root_unix.go
+++ b/cmd/gitserver/server/internal/cacert/root_unix.go
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build aix || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
+//go:build linux
 
-package x509
+package cacert
 
 import (
 	"io/fs"
@@ -24,10 +24,6 @@ const (
 	// See https://www.openssl.org/docs/man1.0.2/man1/c_rehash.html.
 	certDirEnv = "SSL_CERT_DIR"
 )
-
-func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
-	return nil, nil
-}
 
 func loadSystemRoots() (*CertPool, error) {
 	roots := NewCertPool()

--- a/cmd/gitserver/server/internal/cacert/update.bash
+++ b/cmd/gitserver/server/internal/cacert/update.bash
@@ -8,3 +8,5 @@ cp "$(go env GOROOT)/src/crypto/x509/root_linux.go" ./
 cp "$(go env GOROOT)/src/crypto/x509/root_unix.go" ./
 chmod +w root_linux.go
 chmod +w root_unix.go
+
+patch -p6 < package-rename.patch

--- a/cmd/gitserver/server/internal/cacert/update.bash
+++ b/cmd/gitserver/server/internal/cacert/update.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+set -eux -o pipefail
+
+cp "$(go env GOROOT)/src/crypto/x509/root_linux.go" ./
+cp "$(go env GOROOT)/src/crypto/x509/root_unix.go" ./
+chmod +w root_linux.go
+chmod +w root_unix.go

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/internal/cacert"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -121,6 +122,19 @@ func getTlsExternalDoNotInvoke() *tlsConfig {
 			b.WriteString(cert)
 			b.WriteString("\n")
 		}
+
+		// git will ignore the system certificates when specifying SSLCAInfo,
+		// so we additionally include the system certificates. Note: this only
+		// works on linux, see cacert package for more information.
+		root, err := cacert.System()
+		if err != nil {
+			logger.Error("failed to load system certificates for inclusion in SSLCAInfo. Git will now fail to speak to TLS services not not specified in your TlsExternal site configuration.", log.Error(err))
+		}
+		for _, cert := range root {
+			b.Write(cert)
+			b.WriteString("\n")
+		}
+
 		// We don't clean up the file since it has a process life time.
 		p, err := writeTempFile("gitserver*.crt", b.Bytes())
 		if err != nil {

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -40,6 +40,9 @@ func TestGetTlsExternal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		// We also include system certificates, so when comparing only compare
+		// the first 3 lines.
+		got = head(got, 3)
 
 		want := `foo
 bar
@@ -50,6 +53,19 @@ baz
 			t.Errorf("mismatch in contenst of SSLCAInfo file (-want +got):\n%s", diff)
 		}
 	})
+}
+
+// head will return the first n lines of data.
+func head(data []byte, n int) []byte {
+	for i, b := range data {
+		if b == '\n' {
+			n--
+			if n == 0 {
+				return data[:i+1]
+			}
+		}
+	}
+	return data
 }
 
 func TestConfigureRemoteGitCommand(t *testing.T) {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2148,7 +2148,7 @@ type SyntaxHighlightingLanguagePatterns struct {
 
 // TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
 type TlsExternal struct {
-	// Certificates description: TLS certificates to accept. This is only necessary if you are using self-signed certificates or an internal CA. Can be an internal CA certificate or a self-signed certificate. To get the certificate of a webserver run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh. NOTE: git will only respect these certificates and will ignore system certificates. Remember to include system certificates in this setting.
+	// Certificates description: TLS certificates to accept. This is only necessary if you are using self-signed certificates or an internal CA. Can be an internal CA certificate or a self-signed certificate. To get the certificate of a webserver run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh. NOTE: System Certificate Authorities are automatically included.
 	Certificates []string `json:"certificates,omitempty"`
 	// InsecureSkipVerify description: insecureSkipVerify controls whether a client verifies the server's certificate chain and host name.
 	// If InsecureSkipVerify is true, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -292,7 +292,7 @@
               "default": false
             },
             "certificates": {
-              "description": "TLS certificates to accept. This is only necessary if you are using self-signed certificates or an internal CA. Can be an internal CA certificate or a self-signed certificate. To get the certificate of a webserver run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh. NOTE: git will only respect these certificates and will ignore system certificates. Remember to include system certificates in this setting.",
+              "description": "TLS certificates to accept. This is only necessary if you are using self-signed certificates or an internal CA. Can be an internal CA certificate or a self-signed certificate. To get the certificate of a webserver run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh. NOTE: System Certificate Authorities are automatically included.",
               "type": "array",
               "items": {
                 "type": "string",


### PR DESCRIPTION
When specifying certificates for tls.external site configuration we adjust the TLS configuration for go and git. In the case of go we would respect both the certificates specified as well as the system certificate authorities. For git we would only respect the custom certificates. This lead to customers either including system certificates in the site configuration, or baking in the custom certificates into our docker images.

We now will include system certificates for git if running on linux. Given we deploy on Linux this is fine. It isn't possible to support all operating systems, since not all OSs expose certificates. For example darwin does not. This is also why the x509 package in go doesn't expose system certificates, since it can't do it cross platform.

As such we introduce the cacert package which is a modification the x509 to expose the system certificates on Linux.

Test Plan: modified unit tests to output the certificate, validated the certificate included the system certifications. Additionally validated the code did not error on non-linux systems.

Fixes https://github.com/sourcegraph/sourcegraph/issues/38128
Fixes https://github.com/sourcegraph/customer/issues/1136