### PR TITLE
conf: cache getMode

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -54,7 +54,19 @@ const (
 	modeEmpty
 )
 
+var (
+	cachedModeOnce sync.Once
+	cachedMode     configurationMode
+)
+
 func getMode() configurationMode {
+	cachedModeOnce.Do(func() {
+		cachedMode = getModeUncached()
+	})
+	return cachedMode
+}
+
+func getModeUncached() configurationMode {
 	mode := os.Getenv("CONFIGURATION_MODE")
 
 	switch mode {


### PR DESCRIPTION
getMode() is called everytime we call conf.Get(). The getMode implementation calls os.Getenv which requires a system call. However, the result of getMode will never change over the lifetime of a process. So we can cache its result and avoid the system call.

This was noticed while benchmarking sub repository permissions. Currently the code for that calls conf.Get() per file in a repository. This can be changed, but what it did show this performance issue. Here is the impact on that benchmark:

```
name                 old time/op  new time/op   delta
FilterActorPaths-32  52.4ms ± 7%    3.9ms ±10%    -92.60%  (p=0.000 n=10+10)

name                 old paths/s  new paths/s   delta
FilterActorPaths-32   95.7k ± 8%  1294.0k ±11%  +1251.45%  (p=0.000 n=10+10)
```

Benchmark is here https://github.com/sourcegraph/sourcegraph/pull/41257

Test Plan: go test
