### PR TITLE
executors: Bump sourcegraph/ignite to 0.10.4

### DIFF
--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex -o nounset -o pipefail
 
-export IGNITE_VERSION=v0.10.1
+export IGNITE_VERSION=v0.10.4
 export CNI_VERSION=v0.9.1
 export RUNTIME_IMAGE="sourcegraph/ignite:${IGNITE_VERSION}"
 export KERNEL_IMAGE="sourcegraph/ignite-kernel:5.10.135-amd64"


### PR DESCRIPTION
## Test plan

This ran on k8s before so it should be good.