### PR TITLE
doc/admin: link to deployment configuration from OpenTelemetry

### DIFF
--- a/doc/admin/deploy/docker-compose/operations.md
+++ b/doc/admin/deploy/docker-compose/operations.md
@@ -235,7 +235,9 @@ You can monitor the health of a deployment in several ways:
 - Using [`docker ps`](https://docs.docker.com/engine/reference/commandline/ps/) to check on the status of containers within the deployment (any tooling designed to work with Docker containers and/or Docker Compose will work too).
   - This requires direct access to your instance's host machine.
 
-## Tracing
+## OpenTelmeetry Collector
+
+Learn more about Sourcegraph's integrations with the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) in our [OpenTelemetry documentation](../../observability/opentelemetry.md).
 
 ### Configure a tracing backend
 

--- a/doc/admin/deploy/kubernetes/configure.md
+++ b/doc/admin/deploy/kubernetes/configure.md
@@ -517,7 +517,11 @@ spec:
             value: "<REDIS_STORE_DSN>"
 ```
 
-## Configure a tracing backend
+## OpenTelemetry Collector
+
+Learn more about Sourcegraph's integrations with the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) in our [OpenTelemetry documentation](../../observability/opentelemetry.md).
+
+### Configure a tracing backend
 
 Sourcegraph currently supports exporting tracing data to several backends. Refer to [OpenTelemetry](../../observability/opentelemetry.md) for detailed descriptions on how to configure your backend of choice.
 
@@ -527,7 +531,8 @@ By default, the collector is [configured to export trace data by logging](https:
 1. Modify [base/otel-collector/otel-collector.Deployment.yaml](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph@master/-/tree/base/otel-collector/otel-collector.Deployment.yaml). Update the `command` of the `otel-collector` container to point to the mounted config by changing the flag to `"--config=/etc/otel-collector/conf/config.yaml"`.
 1. Apply the edited `ConfigMap` and `Deployment` manifests.
 
-### Enable the bundled Jaeger deployment
+#### Enable the bundled Jaeger deployment
+
 If you do not currently have any tracing backend configured, you can enable Jaeger's [Collector](https://www.jaegertracing.io/docs/1.37/architecture/#collector) and [Query](https://www.jaegertracing.io/docs/1.37/architecture/#query) components by using the [Jaeger overlay](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph@master/-/tree/overlays/jaeger), which will also configure exporting trace data to this instance. Read the [Overlays](./kustomize.md#overlays) section below about overlays.
 
 ## Install without cluster-wide RBAC

--- a/doc/admin/observability/opentelemetry.md
+++ b/doc/admin/observability/opentelemetry.md
@@ -8,10 +8,17 @@ Sourcegraph exports OpenTelemetry data to a bundled [OpenTelemetry Collector](ht
 This service can be configured to ingest, process, and then export observability data to an observability backend of choice.
 This approach offers a great deal of flexibility.
 
+## Configuration
+
 Sourcegraph's OpenTelemetry Collector is deployed with a [custom image, `sourcegraph/opentelemetry-collector`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/opentelemetry-collector), and is configured with a configuration YAML file.
 By default, `sourcegraph/opentelemetry-collector` is configured to not do anything with the data it receives, but [exporters to various backends](#exporters) can be configured for each signal we currently support - **currently, only [traces data](#tracing) is supported**.
 
 Refer to the [documentation](https://opentelemetry.io/docs/collector/configuration/) for an in-depth explanation of the parts that compose a full collector pipeline.
+
+For more details on configuring the OpenTelemetry collector for your deployment method, refer to the deployment-specific guidance:
+
+- [Kubernetes (without Helm)](../deploy/kubernetes/configure.md#opentelemetry-collector)
+- [Docker Compose](../deploy/docker-compose/operations.md#opentelmeetry-collector)
 
 ## Tracing
 


### PR DESCRIPTION
Caught this over a quick proofread, links OpenTelemetry page to various deployment docs on getting it set up.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg run docsite`