### PR TITLE
[SG-41230] New version available "Reload to update" button lost button styles (browser native button look)

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -340,10 +340,10 @@ export class SourcegraphWebApp extends React.Component<
 
         return (
             <ApolloProvider client={graphqlClient}>
-                <ErrorBoundary location={null}>
-                    <FeatureFlagsProvider>
-                        <ShortcutProvider>
-                            <WildcardThemeContext.Provider value={WILDCARD_THEME}>
+                <WildcardThemeContext.Provider value={WILDCARD_THEME}>
+                    <ErrorBoundary location={null}>
+                        <FeatureFlagsProvider>
+                            <ShortcutProvider>
                                 <TemporarySettingsProvider temporarySettingsStorage={temporarySettingsStorage}>
                                     <CoreWorkflowImprovementsEnabledProvider>
                                         <SearchResultsCacheProvider>
@@ -438,10 +438,10 @@ export class SourcegraphWebApp extends React.Component<
                                         </SearchResultsCacheProvider>
                                     </CoreWorkflowImprovementsEnabledProvider>
                                 </TemporarySettingsProvider>
-                            </WildcardThemeContext.Provider>
-                        </ShortcutProvider>
-                    </FeatureFlagsProvider>
-                </ErrorBoundary>
+                            </ShortcutProvider>
+                        </FeatureFlagsProvider>
+                    </ErrorBoundary>
+                </WildcardThemeContext.Provider>
             </ApolloProvider>
         )
     }


### PR DESCRIPTION
### Description
When the browser bundle is outdated and a request to load a chunk fails, a reload button is shown. As a regression, the `button` from `wildcard` component has lost its styling.

### Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/41230)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-41230)

### Test Plan
- Ensure that the reload button when the browser bundle is outdated has wildcard component button styling.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-contractors-sg-41230.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tcmdguffqp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
