### PR TITLE
Aggregation: Fix squished aggregation chart

### DIFF
--- a/client/web/src/search/results/components/aggregation/AggregationChart.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChart.tsx
@@ -86,7 +86,7 @@ const getXScaleTicks = <T,>(options: GetScaleTicksOptions): T[] => {
         filteredTicks = filteredTicks.filter((tick, index) => index % 2 === 0)
     }
 
-    return filteredTicks
+    return filteredTicks.map(tick => tick.trim()).filter(tick => !!tick)
 }
 
 const getTruncatedTick = (maxLength: number) => (tick: string): string =>

--- a/client/web/src/search/results/components/aggregation/AggregationChart.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChart.tsx
@@ -86,7 +86,7 @@ const getXScaleTicks = <T,>(options: GetScaleTicksOptions): T[] => {
         filteredTicks = filteredTicks.filter((tick, index) => index % 2 === 0)
     }
 
-    return filteredTicks.map(tick => tick.trim()).filter(tick => !!tick)
+    return filteredTicks
 }
 
 const getTruncatedTick = (maxLength: number) => (tick: string): string =>

--- a/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
@@ -25,8 +25,8 @@ const MAX_LABEL_WIDTH = 16
 
 const getName = (datum: SearchAggregationDatum): string => datum.label ?? ''
 const getValue = (datum: SearchAggregationDatum): number => datum.count
-const getColor = (datum: SearchAggregationDatum): string => (datum.label ? 'var(--primary)' : 'var(--text-muted)')
 const getLink = (datum: SearchAggregationDatum): string => datum.query ?? ''
+const getColor = (): string => 'var(--primary)'
 
 /**
  * Nested aggregation results types from {@link AGGREGATION_SEARCH_QUERY} GQL query

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
@@ -15,6 +15,9 @@ import { SearchAggregationResult } from './SearchAggregationResult'
 
 const config: Meta = {
     title: 'web/search/results/SearchAggregationResult',
+    parameters: {
+        chromatic: { disableSnapshots: false },
+    },
 }
 
 export default config
@@ -25,8 +28,9 @@ const SEARCH_AGGREGATION_MOCK: MockedResponse<GetSearchAggregationResult> = {
         variables: {
             query: '',
             patternType: 'literal',
-            mode: 'REPO',
+            mode: null,
             limit: 30,
+            skipAggregation: false,
         },
     },
     result: {
@@ -34,33 +38,73 @@ const SEARCH_AGGREGATION_MOCK: MockedResponse<GetSearchAggregationResult> = {
             searchQueryAggregate: {
                 __typename: 'SearchQueryAggregate',
                 aggregations: {
-                    __typename: 'ExhaustiveSearchAggregationResult',
-                    mode: SearchAggregationMode.REPO,
-                    otherGroupCount: 100,
+                    __typename: 'NonExhaustiveSearchAggregationResult',
+                    mode: SearchAggregationMode.CAPTURE_GROUP,
+                    approximateOtherGroupCount: 776,
                     groups: [
                         {
                             __typename: 'AggregationGroup',
-                            label: 'sourcegraph/sourcegraph',
-                            count: 100,
-                            query: 'context:global insights repo:sourcegraph/sourcegraph',
+                            label: ': ',
+                            count: 232,
+                            query: 'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?:: )string/',
                         },
                         {
                             __typename: 'AggregationGroup',
-                            label: 'sourcegraph/about',
-                            count: 80,
-                            query: 'context:global insights repo:sourecegraph/about',
+                            label: ' ',
+                            count: 215,
+                            query: 'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?: )string/',
                         },
                         {
                             __typename: 'AggregationGroup',
-                            label: 'sourcegraph/search-insight',
-                            count: 60,
-                            query: 'context:global insights repo:sourecegraph/search-insight',
+                            label: '',
+                            count: 68,
+                            query: 'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?:)string/',
                         },
                         {
                             __typename: 'AggregationGroup',
-                            label: 'sourcegraph/lang-stats',
-                            count: 40,
-                            query: 'context:global insights repo:sourecegraph/lang-stats',
+                            label: '?: ',
+                            count: 43,
+                            query: 'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?:\\?: )string/',
+                        },
+                        {
+                            __typename: 'AggregationGroup',
+                            label: 'ExampleFrom',
+                            count: 38,
+                            query:
+                                'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?:ExampleFrom)string/',
+                        },
+                        {
+                            __typename: 'AggregationGroup',
+                            label: '       ',
+                            count: 26,
+                            query:
+                                'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?:       )string/',
+                        },
+                        {
+                            __typename: 'AggregationGroup',
+                            label: ', summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []',
+                            count: 15,
+                            query:
+                                'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?:, summaryQuery, err := makeEventLogsQueries\\(s\\.DateRange, s\\.Grouping, \\[\\])string/',
+                        },
+                        {
+                            __typename: 'AggregationGroup',
+                            label: '.',
+                            count: 11,
+                            query: 'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?:\\.)string/',
+                        },
+                        {
+                            __typename: 'AggregationGroup',
+                            label: '  ',
+                            count: 10,
+                            query: 'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?:  )string/',
+                        },
+                        {
+                            __typename: 'AggregationGroup',
+                            label: 'Parameters: map[string][]',
+                            count: 8,
+                            query:
+                                'context:global repo:^github\\.com/sourcegraph/sourcegraph$ /query(?:Parameters: map\\[string\\]\\[\\])string/',
                         },
                     ],
                 },

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
@@ -196,7 +196,7 @@ export function SvgAxisBottom<Tick = string>(props: SvgAxisBottomProps<Tick>): R
                 : 0
 
         if (rotate) {
-            const xCoord = hideTicks ? props.x - fontSize / 2 : props.x
+            const xCoord = props.x
             const yCoord = hideTicks ? props.y - fontSize / 2 : props.y
 
             return {

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
@@ -191,17 +191,22 @@ export function SvgAxisBottom<Tick = string>(props: SvgAxisBottomProps<Tick>): R
         const measuredSize = ticks.length * maxWidth
         const fontSize = 12 // 0.75rem
         const rotate =
-            upperRangeBound < measuredSize
+            upperRangeBound <= measuredSize
                 ? Math.max(maxRotateAngle * Math.min(1, (measuredSize / upperRangeBound - 0.8) / 2), minRotateAngle)
                 : 0
 
         if (rotate) {
+            const xCoord = hideTicks ? props.x - fontSize / 2 : props.x
+            const yCoord = hideTicks ? props.y - fontSize / 2 : props.y
+
             return {
                 ...props,
+                x: xCoord,
+                y: yCoord,
                 // Truncate ticks only if we rotate them, this means truncate labels only
                 // when they overlap
                 getTruncatedTick,
-                transform: `rotate(${rotate}, ${props.x + fontSize / 2} ${props.y - fontSize / 2})`,
+                transform: `rotate(${rotate}, ${xCoord} ${yCoord})`,
                 textAnchor: 'start',
             }
         }

--- a/client/wildcard/src/components/Charts/core/components/axis/Tick.tsx
+++ b/client/wildcard/src/components/Charts/core/components/axis/Tick.tsx
@@ -22,7 +22,7 @@ export const Tick: FC<TickProps> = props => {
         ...tickLabelProps
     } = props
 
-    // Formatted and truanted tick value
+    // Formatted and truncated tick value
     const tickValue = getTruncatedTick ? getTruncatedTick(formattedValue) : formattedValue
 
     // Empty tick value breaks the tick axis container measurement

--- a/client/wildcard/src/components/Charts/core/components/axis/Tick.tsx
+++ b/client/wildcard/src/components/Charts/core/components/axis/Tick.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 import { TickRendererProps } from '@visx/axis'
 import { Group } from '@visx/group'
-import { Text, TextProps } from '@visx/text'
+import { TextProps } from '@visx/text'
 import classNames from 'classnames'
 
 import styles from './Tick.module.scss'
@@ -13,7 +13,22 @@ export interface TickProps extends TickRendererProps {
 
 /** Tick component displays tick label for each axis line of chart. */
 export const Tick: FC<TickProps> = props => {
-    const { formattedValue = '', 'aria-label': ariaLabel, className, getTruncatedTick, ...tickLabelProps } = props
+    const {
+        children,
+        formattedValue = '',
+        className,
+        'aria-label': ariaLabel,
+        getTruncatedTick,
+        ...tickLabelProps
+    } = props
+
+    // Formatted and truanted tick value
+    const tickValue = getTruncatedTick ? getTruncatedTick(formattedValue) : formattedValue
+
+    // Empty tick value breaks the tick axis container measurement
+    // And therefore breaks the whole chart content calculation
+    // see https://github.com/sourcegraph/sourcegraph/issues/41158
+    const sanitizedTickValue = tickValue.trim() === '' ? '&nbsp;' : tickValue
 
     // Hack with Group + Text (aria hidden)
     // Because the Text component renders text inside svg element and text element with tspan
@@ -23,9 +38,12 @@ export const Tick: FC<TickProps> = props => {
     return (
         // eslint-disable-next-line jsx-a11y/aria-role
         <Group role="text" aria-label={ariaLabel}>
-            <Text aria-hidden={true} className={classNames(styles.tick, className)} {...(tickLabelProps as TextProps)}>
-                {getTruncatedTick ? getTruncatedTick(formattedValue) : formattedValue}
-            </Text>
+            <text
+                aria-hidden={true}
+                className={classNames(styles.tick, className)}
+                {...(tickLabelProps as TextProps)}
+                dangerouslySetInnerHTML={{ __html: sanitizedTickValue }}
+            />
         </Group>
     )
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41158
## Background
We know now that there is some strange behaviour about empty line measurement in SVG. If SVG text has no child or text content then measurement is corrupted and it breaks the chart layout calculation. This bug doesn't exist in Firefox for example, in Safari it appears but chart isn't squished completely (just a little) and only Chrome breaks the chart entirely.

This PR replaces empty SVG text elements textContent with whitespaces. This fixes problem in all three major browsers. 

## Test plan
- Run this query ` query(.*)string repo:^github\.com/sourcegraph/sourcegraph$ ` on sourcegraph.sourcegraph.com staging (or locally) 
- Make sure that chart looks fine with groups that returns this query. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-squished-aggregation-chart.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vfeiwaixzx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
