### PR TITLE
simple ui: add back search reference panel (again)

### DIFF
--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -163,18 +163,16 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
                 </SearchSidebarSection>
             )}
 
-            {!coreWorkflowImprovementsEnabled && (
-                <SearchSidebarSection
-                    sectionId={SectionID.SEARCH_REFERENCE}
-                    header="Search reference"
-                    showSearch={true}
-                    // search reference should always preserve the filter
-                    // (false is just an arbitrary but static value)
-                    clearSearchOnChange={false}
-                >
-                    {getSearchReferenceFactory({ telemetryService, setQueryState: onNavbarQueryChange })}
-                </SearchSidebarSection>
-            )}
+            <SearchSidebarSection
+                sectionId={SectionID.SEARCH_REFERENCE}
+                header="Search reference"
+                showSearch={true}
+                // search reference should always preserve the filter
+                // (false is just an arbitrary but static value)
+                clearSearchOnChange={false}
+            >
+                {getSearchReferenceFactory({ telemetryService, setQueryState: onNavbarQueryChange })}
+            </SearchSidebarSection>
 
             <SearchSidebarSection sectionId={SectionID.SEARCH_SNIPPETS} header="Search snippets">
                 {getSearchSnippetLinks(settingsCascade, onSnippetClicked)}


### PR DESCRIPTION
Closes #40998 (again)
The original PR, #41005, was broken due to a merge conflict from a large refactor done on the sidebar.

(review with "hide whitespace" enabled)

## Test plan

Verify that the reference panel is shown whether Simple UI is on or off.

## App preview:

- [Web](https://sg-web-jp-searchreferenceagain.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uuvdzstvqc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
