### PR TITLE
search docs: collapsible regex mode section

### DIFF
--- a/doc/code_search/reference/queries.md
+++ b/doc/code_search/reference/queries.md
@@ -51,10 +51,10 @@ Standard search matches literal patterns exactly, including puncutation like quo
 
 Matching is case-_insensitive_ (toggle the <span class="toggle-container"><img class="toggle" src=../img/case.png alt="case"></span> button to change).
 
-### Dedicated regular expression search
+<details>
+  <summary><strong>Dedicated regular expression search with <span class="toggle-container"><img class="toggle" src=../img/regex.png alt="regular expression"></span></strong></summary>
 
-Clicking the <span class="toggle-container"><img class="toggle"
-src=../img/regex.png alt="regular expression"></span> toggle interprets _all_
+Clicking the <span class="toggle-container"><img class="toggle" src=../img/regex.png alt="regular expression"></span> toggle interprets _all_
 search patterns as regular expressions.
 
 **Note.** You can achieve the same regular expression searches in the [default Standard mode](#standard-search-default) by enclosing patterns in `/.../`, so
@@ -70,7 +70,7 @@ exactly".
 | [`"foo bar"`](https://sourcegraph.com/search?q=%27foo+bar%27&patternType=regexp) | Match the _string literal_ `foo bar`. Quoting strings in this mode are interpreted exactly, except that special characters like `"` and `\` may be escaped, and whitespace escape sequences like `\n` are interpreted normally. |
 
 As in Standard search, we support [RE2 syntax](https://golang.org/s/re2syntax). Matching is case-_insensitive_ (toggle the <span class="toggle-container"><img class="toggle" src=../img/case.png alt="case"></span> button to change).
-
+</details>
 
 ### Structural search
 


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/41289

This is **a concept** idea to make the doc explanation of regex mode quirks collapsible, please leave thoughts.

Reason: ["Regular expression mode"](https://docs.sourcegraph.com/code_search/reference/queries#regular-expression-search) is largely superseded by supporting `/.../` syntax in standard mode, and the docs take up a lot of space to basically explain the very quirky behaviors associated with it. I think we can do with something to make it less prominent. 



https://user-images.githubusercontent.com/888624/188237211-3ab68229-d65b-463b-b867-d04ca2bb9e00.mp4

# Test plan
Docs