### PR TITLE
monitoring: migrate log15 to sourcegraph/log

### DIFF
--- a/monitoring/main.go
+++ b/monitoring/main.go
@@ -36,17 +36,11 @@ func main() {
 		Name:       env.MyName,
 		Version:    version.Version(),
 		InstanceID: hostname.Get(),
-	}, log.NewSentrySinkWith(
-		log.SentrySink{
-			ClientOptions: sentry.ClientOptions{SampleRate: 0.2},
-		},
-	)) // Experimental: DevX is observing how sampling affects the errors signal
+	})
 	defer liblog.Sync()
 
-	conf.Init()
-	go conf.Watch(liblog.Update(conf.GetLogSinks))
 
-	logger := log.Scoped("dashboard-generator", "generates monitoring dashboards")
+	logger := log.Scoped("monitoring-generator", "generates monitoring dashboards")
 
 	// Runs the monitoring generator. Ensure that any dashboards created or removed are
 	// updated in the arguments here as required.

--- a/monitoring/main.go
+++ b/monitoring/main.go
@@ -6,10 +6,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/getsentry/sentry-go"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
@@ -38,7 +36,6 @@ func main() {
 		InstanceID: hostname.Get(),
 	})
 	defer liblog.Sync()
-
 
 	logger := log.Scoped("monitoring-generator", "generates monitoring dashboards")
 

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -118,7 +118,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 
 	// Reload all Prometheus rules
 	if opts.PrometheusDir != "" && opts.Reload {
-		rlog := logger.Scoped("prometheus", "reloading prometheus instances")
+		rlog := logger.Scoped("prometheus", "reloading prometheus instance")
 		// Reload all Prometheus rules
 		rlog.Debug("Reloading Prometheus instance", log.String("instance", localPrometheusURL))
 		resp, err := http.Post(localPrometheusURL+"/-/reload", "", nil)

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -62,7 +62,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 	// Generate output for all dashboards
 	for _, dashboard := range dashboards {
 		// Logger for dashboard
-		clog := dlog.With(log.String("dashboard", dashboard.Name), log.String("grafana", localGrafanaURL))
+		clog := dlog.With(log.String("dashboard", dashboard.Name), log.String("instance", localGrafanaURL))
 		// Prepare Grafana assets
 		if opts.GrafanaDir != "" {
 			clog.Debug("Rendering Grafana assets")

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -58,7 +58,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 	if validationErrors != nil {
 		return errors.Wrap(validationErrors, "Validation failed")
 	}
-	dlog := logger.Scoped("dashboards", "dashboard generation")
+	dlog := logger.Scoped("grafana", "grafana dashboard generation")
 	// Generate output for all dashboards
 	for _, dashboard := range dashboards {
 		// Logger for dashboard
@@ -117,7 +117,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 
 	// Reload all Prometheus rules
 	if opts.PrometheusDir != "" && opts.Reload {
-		rlog := logger.Scoped("prometheus", "reloading prometheus instance").With(log.String("instance", localPrometheusURL))
+		rlog := logger.Scoped("prometheus", "prometheus alerts generation").With(log.String("instance", localPrometheusURL))
 		// Reload all Prometheus rules
 		rlog.Debug("Reloading Prometheus instance")
 		resp, err := http.Post(localPrometheusURL+"/-/reload", "", nil)

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -58,12 +58,11 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 	if validationErrors != nil {
 		return errors.Wrap(validationErrors, "Validation failed")
 	}
-
+	dlog := logger.Scoped("dashboards", "dashboard generation")
 	// Generate output for all dashboards
 	for _, dashboard := range dashboards {
 		// Logger for dashboard
-		clog := logger.Scoped(dashboard.Name, "name of the dashboard").With(log.String("instance", localGrafanaURL))
-
+		clog := dlog.With(log.String("dashboard", dashboard.Name), log.String("grafana", localGrafanaURL))
 		// Prepare Grafana assets
 		if opts.GrafanaDir != "" {
 			clog.Debug("Rendering Grafana assets")

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -62,7 +62,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 	// Generate output for all dashboards
 	for _, dashboard := range dashboards {
 		// Logger for dashboard
-		clog := logger.Scoped(dashboard.Name, "name of the dashboard")
+		clog := logger.Scoped(dashboard.Name, "name of the dashboard").With(log.String("instance", localGrafanaURL))
 
 		// Prepare Grafana assets
 		if opts.GrafanaDir != "" {
@@ -91,7 +91,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				if err != nil {
 					return errors.Wrapf(err, "Could not reload Grafana instance for dashboard %q", dashboard.Title)
 				} else {
-					clog.Info("Reloaded Grafana instance", log.String("instance", localGrafanaURL))
+					clog.Info("Reloaded Grafana instance")
 				}
 			}
 		}
@@ -118,9 +118,9 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 
 	// Reload all Prometheus rules
 	if opts.PrometheusDir != "" && opts.Reload {
-		rlog := logger.Scoped("prometheus", "reloading prometheus instance")
+		rlog := logger.Scoped("prometheus", "reloading prometheus instance").With(log.String("instance", localPrometheusURL))
 		// Reload all Prometheus rules
-		rlog.Debug("Reloading Prometheus instance", log.String("instance", localPrometheusURL))
+		rlog.Debug("Reloading Prometheus instance")
 		resp, err := http.Post(localPrometheusURL+"/-/reload", "", nil)
 		if err != nil {
 			return errors.Wrapf(err, "Could not reload Prometheus at %q", localPrometheusURL)
@@ -129,7 +129,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 			if resp.StatusCode != 200 {
 				return errors.Newf("Unexpected status code %d while reloading Prometheus rules", resp.StatusCode)
 			}
-			rlog.Info("Reloaded Prometheus instance", log.String("instance", localPrometheusURL))
+			rlog.Info("Reloaded Prometheus instance")
 		}
 	}
 

--- a/monitoring/monitoring/prune.go
+++ b/monitoring/monitoring/prune.go
@@ -16,7 +16,7 @@ func pruneAssets(logger log.Logger, filelist []string, grafanaDir, promDir strin
 	if grafanaDir != "" {
 		logger.Info("Pruning Grafana assets", log.String("dir", grafanaDir))
 		err := filepath.Walk(grafanaDir, func(path string, info fs.FileInfo, err error) error {
-			plog := logger.Scoped("path", path)
+			plog := logger.With(log.String("path", path))
 			if err != nil {
 				plog.Debug("Unable to access file, ignoring")
 				return nil
@@ -44,7 +44,7 @@ func pruneAssets(logger log.Logger, filelist []string, grafanaDir, promDir strin
 	if promDir != "" {
 		logger.Info("Pruning Prometheus assets", log.String("dir", promDir))
 		err := filepath.Walk(promDir, func(path string, info fs.FileInfo, err error) error {
-			plog := logger.Scoped("path", path)
+			plog := logger.With(log.String("path", path))
 			if err != nil {
 				plog.Debug("Unable to access file, ignoring")
 				return nil

--- a/monitoring/monitoring/prune.go
+++ b/monitoring/monitoring/prune.go
@@ -6,17 +6,17 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func pruneAssets(logger log15.Logger, filelist []string, grafanaDir, promDir string) error {
+func pruneAssets(logger log.Logger, filelist []string, grafanaDir, promDir string) error {
 	// Prune Grafana assets
 	if grafanaDir != "" {
-		logger.Info("Pruning Grafana assets", "dir", grafanaDir)
+		logger.Info("Pruning Grafana assets", log.String("dir", grafanaDir))
 		err := filepath.Walk(grafanaDir, func(path string, info fs.FileInfo, err error) error {
-			plog := logger.New("path", path)
+			plog := logger.Scoped("path", path)
 			if err != nil {
 				plog.Debug("Unable to access file, ignoring")
 				return nil
@@ -32,7 +32,7 @@ func pruneAssets(logger log15.Logger, filelist []string, grafanaDir, promDir str
 					return nil
 				}
 			}
-			logger.Info("Removing dangling Grafana asset", path)
+			logger.Info("Removing dangling Grafana asset", log.String("path", path))
 			return os.Remove(path)
 		})
 		if err != nil {
@@ -42,9 +42,9 @@ func pruneAssets(logger log15.Logger, filelist []string, grafanaDir, promDir str
 
 	// Prune Prometheus assets
 	if promDir != "" {
-		logger.Info("Pruning Prometheus assets", "dir", promDir)
+		logger.Info("Pruning Prometheus assets", log.String("dir", promDir))
 		err := filepath.Walk(promDir, func(path string, info fs.FileInfo, err error) error {
-			plog := logger.New("path", path)
+			plog := logger.Scoped("path", path)
 			if err != nil {
 				plog.Debug("Unable to access file, ignoring")
 				return nil
@@ -61,7 +61,7 @@ func pruneAssets(logger log15.Logger, filelist []string, grafanaDir, promDir str
 					return nil
 				}
 			}
-			logger.Info("Removing dangling Prometheus asset", path)
+			logger.Info("Removing dangling Prometheus asset", log.String("path", path))
 			return os.Remove(path)
 		})
 		if err != nil {


### PR DESCRIPTION
migrate the log15 usage in the monitoring package to use sourcegraph/log
## Test plan
sg start monitoring 
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/78464298/188241560-44659b4c-5252-4d2e-9ea4-e44743d920a8.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
