### PR TITLE
search: Add field for storing path match ranges

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -34,6 +34,7 @@ export type SearchMatch = ContentMatch | RepositoryMatch | CommitMatch | SymbolM
 export interface PathMatch {
     type: 'path'
     path: string
+    pathMatches?: Range[]
     repository: string
     repoStars?: number
     repoLastFetched?: string

--- a/internal/search/job/jobutil/select_test.go
+++ b/internal/search/job/jobutil/select_test.go
@@ -48,11 +48,13 @@ func TestWithSelect(t *testing.T) {
   {
     "Path": "pokeman/",
     "ChunkMatches": null,
+    "PathMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/",
     "ChunkMatches": null,
+    "PathMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("file.directory"))
@@ -61,16 +63,19 @@ func TestWithSelect(t *testing.T) {
   {
     "Path": "pokeman/charmandar",
     "ChunkMatches": null,
+    "PathMatches": null,
     "LimitHit": false
   },
   {
     "Path": "pokeman/bulbosaur",
     "ChunkMatches": null,
+    "PathMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/ummm",
     "ChunkMatches": null,
+    "PathMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("file"))
@@ -124,6 +129,7 @@ func TestWithSelect(t *testing.T) {
         ]
       }
     ],
+    "PathMatches": null,
     "LimitHit": false
   },
   {
@@ -152,6 +158,7 @@ func TestWithSelect(t *testing.T) {
         ]
       }
     ],
+    "PathMatches": null,
     "LimitHit": false
   },
   {
@@ -180,6 +187,7 @@ func TestWithSelect(t *testing.T) {
         ]
       }
     ],
+    "PathMatches": null,
     "LimitHit": false
   },
   {
@@ -208,6 +216,7 @@ func TestWithSelect(t *testing.T) {
         ]
       }
     ],
+    "PathMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("content"))

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -39,12 +39,13 @@ func (f *File) URL() *url.URL {
 // FileMatch represents either:
 // - A collection of symbol results (len(Symbols) > 0)
 // - A collection of text content results (len(LineMatches) > 0)
-// - A result representing the whole file (len(Symbols) == 0 && len(LineMatches) == 0)
+// - A result representing the whole file (len(PathMatches) > 0 && len(Symbols) == 0 && len(LineMatches) == 0)
 type FileMatch struct {
 	File
 
 	ChunkMatches ChunkMatches
 	Symbols      []*SymbolMatch `json:"-"`
+	PathMatches  []Range
 
 	LimitHit bool
 }

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -39,7 +39,7 @@ func (f *File) URL() *url.URL {
 // FileMatch represents either:
 // - A collection of symbol results (len(Symbols) > 0)
 // - A collection of text content results (len(LineMatches) > 0)
-// - A result representing the whole file (len(PathMatches) > 0 && len(Symbols) == 0 && len(LineMatches) == 0)
+// - A result representing the whole file (len(Symbols) == 0 && len(LineMatches) == 0)
 type FileMatch struct {
 	File
 

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -42,6 +42,7 @@ type EventPathMatch struct {
 	Type MatchType `json:"type"`
 
 	Path            string     `json:"path"`
+	PathMatches     []Range    `json:"pathMatches,omitempty"`
 	RepositoryID    int32      `json:"repositoryID"`
 	Repository      string     `json:"repository"`
 	RepoStars       int        `json:"repoStars,omitempty"`


### PR DESCRIPTION
This just adds a field to `EventPathMatch` and `result.FileMatch` in the backend, and to the `PathMatch` interface in the frontend. This field will store path match ranges. Preparation for adding path match highlighting.


## Test plan
Just adding a field to a few types
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
