### PR TITLE
search ui: fix symbol search snapshot test

### DIFF
--- a/client/search-ui/src/components/FileMatchChildren.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.tsx
@@ -385,21 +385,20 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             {((coreWorkflowImprovementsEnabled && result.type === 'symbol' && result.symbols) || []).map(symbol => (
                 <div
                     key={`symbol:${symbol.name}${String(symbol.containerName)}${symbol.url}`}
-                    className={styles.symbol}
+                    className={classNames('test-file-match-children-item', styles.symbol)}
+                    data-href={symbol.url}
+                    role="link"
+                    tabIndex={0}
+                    onClick={navigateToFile}
+                    onMouseUp={navigateToFileOnMiddleMouseButtonClick}
+                    onKeyDown={navigateToFile}
                 >
                     <div className="mr-2 flex-shrink-0">
                         <SymbolTag kind={symbol.kind} />
                     </div>
-                    <div
-                        className={styles.symbolCodeExcerpt}
-                        data-href={symbol.url}
-                        onClick={navigateToFile}
-                        onMouseUp={navigateToFileOnMiddleMouseButtonClick}
-                        onKeyDown={navigateToFile}
-                        role="link"
-                        tabIndex={0}
-                    >
+                    <div className={styles.symbolCodeExcerpt}>
                         <CodeExcerpt
+                            className="a11y-ignore"
                             repoName={result.repository}
                             commitID={result.commit || ''}
                             filePath={result.path}

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -477,6 +477,7 @@ describe('Search', () => {
         test('symbol results', async () => {
             testContext.overrideGraphQL({
                 ...commonSearchGraphQLResults,
+                ...highlightFileResult,
             })
             testContext.overrideSearchStreamEvents(symbolSearchStreamEvents)
 


### PR DESCRIPTION
Fixes a failing Percy snapshot test for symbol search.
Also fixes a small bug where clicking on the symbol's padding wouldn't navigate to the file.

## Test plan

Verify Percy snapshot tests now pass.

## App preview:

- [Web](https://sg-web-jp-fixsymbolsnapshot.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sauugvgjow.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
