### PR TITLE
search: Distinguish file content matches from path matches in the UI when `select:file` is present

### DIFF
--- a/client/search-ui/src/components/FileMatchChildren.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.tsx
@@ -361,7 +361,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             {/* Path */}
             {result.type === 'path' && (
                 <div className={styles.item} data-testid="file-match-children-item">
-                    <small>Path match</small>
+                    <small>{result.pathMatches ? 'Path match' : 'File content match'}</small>
                 </div>
             )}
 

--- a/client/search-ui/src/components/FileMatchChildren.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.tsx
@@ -361,7 +361,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             {/* Path */}
             {result.type === 'path' && (
                 <div className={styles.item} data-testid="file-match-children-item">
-                    <small>{result.pathMatches ? 'Path match' : 'File content match'}</small>
+                    <small>{result.pathMatches ? 'Path match' : 'File contains matching content'}</small>
                 </div>
             )}
 

--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -193,6 +193,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
                 repoName={result.repository}
                 repoURL={repoAtRevisionURL}
                 filePath={result.path}
+                pathMatchRanges={result.type === 'path' ? result.pathMatches : []}
                 fileURL={getFileMatchUrl(result)}
                 repoDisplayName={
                     props.repoDisplayName

--- a/client/search-ui/src/components/RepoFileLink.tsx
+++ b/client/search-ui/src/components/RepoFileLink.tsx
@@ -1,15 +1,18 @@
 import * as React from 'react'
+import { useEffect, useRef } from 'react'
 
 import classNames from 'classnames'
 
-import { appendSubtreeQueryParameter } from '@sourcegraph/common'
+import { appendSubtreeQueryParameter, highlightNode } from '@sourcegraph/common'
 import { displayRepoName, splitPath } from '@sourcegraph/shared/src/components/RepoLink'
+import { Range } from '@sourcegraph/shared/src/search/stream'
 import { Link } from '@sourcegraph/wildcard'
 
 interface Props {
     repoName: string
     repoURL: string
     filePath: string
+    pathMatchRanges?: Range[]
     fileURL: string
     repoDisplayName?: string
     className?: string
@@ -24,19 +27,35 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
     repoName,
     repoURL,
     filePath,
+    pathMatchRanges,
     fileURL,
     className,
 }) => {
     const [fileBase, fileName] = splitPath(filePath)
+    const containerElement = useRef<HTMLAnchorElement>(null)
 
-    return (
+    const repoFileLink = (): JSX.Element => (
         <div className={classNames(className)}>
             <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link>
             <span aria-hidden={true}> ›</span>{' '}
-            <Link to={appendSubtreeQueryParameter(fileURL)}>
+            <Link to={appendSubtreeQueryParameter(fileURL)} ref={containerElement}>
                 {fileBase ? `${fileBase}/` : null}
                 <strong>{fileName}</strong>
             </Link>
         </div>
     )
+
+    useEffect((): void => {
+        if (containerElement.current && pathMatchRanges && fileBase && fileName) {
+            for (const range of pathMatchRanges) {
+                highlightNode(
+                    containerElement.current as HTMLElement,
+                    range.start.column,
+                    range.end.column - range.start.column
+                )
+            }
+        }
+    }, [pathMatchRanges, fileBase, fileName, containerElement])
+
+    return repoFileLink()
 }

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -312,6 +312,7 @@ func fromPathMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Searche
 	pathEvent := &streamhttp.EventPathMatch{
 		Type:         streamhttp.PathMatchType,
 		Path:         fm.Path,
+		PathMatches:  fromRanges(fm.PathMatches),
 		Repository:   string(fm.Repo.Name),
 		RepositoryID: int32(fm.Repo.ID),
 		Commit:       string(fm.CommitID),

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -319,6 +319,11 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 					UseFullDeadline: useFullDeadline,
 					Features:        *searchInputs.Features,
 				}
+				if patternInfo.IsRegExp {
+					searcherJob.TextPatternRegexp = regexp.MustCompile(`(?i)` + patternInfo.Pattern)
+				} else {
+					searcherJob.TextPatternRegexp = regexp.MustCompile(`(?i)` + regexp.QuoteMeta(patternInfo.Pattern))
+				}
 
 				addJob(&repoPagerJob{
 					child:            &reposPartialJob{searcherJob},

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -317,10 +317,7 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 					Indexed:         false,
 					UseFullDeadline: useFullDeadline,
 					Features:        *searchInputs.Features,
-				}
-
-				if patternInfo.PatternMatchesPath {
-					searcherJob.PathRegexps = getPathRegexpsFromTextPatternInfo(patternInfo)
+					PathRegexps:     getPathRegexpsFromTextPatternInfo(patternInfo),
 				}
 
 				addJob(&repoPagerJob{
@@ -474,17 +471,19 @@ func getPathRegexpsFromTextPatternInfo(patternInfo *search.TextPatternInfo) (pat
 		}
 	}
 
-	if patternInfo.IsRegExp {
-		if patternInfo.IsCaseSensitive {
-			pathRegexps = append(pathRegexps, regexp.MustCompile(patternInfo.Pattern))
+	if patternInfo.PatternMatchesPath {
+		if patternInfo.IsRegExp {
+			if patternInfo.IsCaseSensitive {
+				pathRegexps = append(pathRegexps, regexp.MustCompile(patternInfo.Pattern))
+			} else {
+				pathRegexps = append(pathRegexps, regexp.MustCompile(`(?i)`+patternInfo.Pattern))
+			}
 		} else {
-			pathRegexps = append(pathRegexps, regexp.MustCompile(`(?i)`+patternInfo.Pattern))
-		}
-	} else {
-		if patternInfo.IsCaseSensitive {
-			pathRegexps = append(pathRegexps, regexp.MustCompile(regexp.QuoteMeta(patternInfo.Pattern)))
-		} else {
-			pathRegexps = append(pathRegexps, regexp.MustCompile(`(?i)`+regexp.QuoteMeta(patternInfo.Pattern)))
+			if patternInfo.IsCaseSensitive {
+				pathRegexps = append(pathRegexps, regexp.MustCompile(regexp.QuoteMeta(patternInfo.Pattern)))
+			} else {
+				pathRegexps = append(pathRegexps, regexp.MustCompile(`(?i)`+regexp.QuoteMeta(patternInfo.Pattern)))
+			}
 		}
 	}
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -1,7 +1,6 @@
 package jobutil
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -739,8 +738,6 @@ func zoektQueryPatternsAsRegexps(q zoektquery.Q) (res []*regexp.Regexp) {
 	case *zoektquery.Regexp:
 		res = append(res, regexp.MustCompile(`(?i)`+q.(*zoektquery.Regexp).Regexp.String()))
 	case *zoektquery.Substring:
-		item := regexp.MustCompile(`(?i)` + regexp.QuoteMeta(q.(*zoektquery.Substring).Pattern))
-		fmt.Println(item.String())
 		res = append(res, regexp.MustCompile(`(?i)`+regexp.QuoteMeta(q.(*zoektquery.Substring).Pattern)))
 	}
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -732,26 +732,26 @@ func (b *jobBuilder) newZoektSearch(typ search.IndexedRequestType) (job.Job, err
 }
 
 func zoektQueryPatternsAsRegexps(q zoektquery.Q) (res []*regexp.Regexp) {
-	switch q.(type) {
+	switch typedQ := q.(type) {
 	case *zoektquery.And:
-		for _, child := range q.(*zoektquery.And).Children {
+		for _, child := range typedQ.Children {
 			res = append(res, zoektQueryPatternsAsRegexps(child)...)
 		}
 	case *zoektquery.Or:
-		for _, child := range q.(*zoektquery.Or).Children {
+		for _, child := range typedQ.Children {
 			res = append(res, zoektQueryPatternsAsRegexps(child)...)
 		}
 	case *zoektquery.Regexp:
-		if q.(*zoektquery.Regexp).CaseSensitive {
-			res = append(res, regexp.MustCompile(q.(*zoektquery.Regexp).Regexp.String()))
+		if typedQ.CaseSensitive {
+			res = append(res, regexp.MustCompile(typedQ.Regexp.String()))
 		} else {
-			res = append(res, regexp.MustCompile(`(?i)`+q.(*zoektquery.Regexp).Regexp.String()))
+			res = append(res, regexp.MustCompile(`(?i)`+typedQ.Regexp.String()))
 		}
 	case *zoektquery.Substring:
-		if q.(*zoektquery.Substring).CaseSensitive {
-			res = append(res, regexp.MustCompile(regexp.QuoteMeta(q.(*zoektquery.Substring).Pattern)))
+		if typedQ.CaseSensitive {
+			res = append(res, regexp.MustCompile(regexp.QuoteMeta(typedQ.Pattern)))
 		} else {
-			res = append(res, regexp.MustCompile(`(?i)`+regexp.QuoteMeta(q.(*zoektquery.Substring).Pattern)))
+			res = append(res, regexp.MustCompile(`(?i)`+regexp.QuoteMeta(typedQ.Pattern)))
 		}
 	}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1216,9 +1216,7 @@ func TestZoektQueryPatternsAsRegexps(t *testing.T) {
 		{
 			name:  "respect case sensitivity setting",
 			input: &zoektquery.Substring{Pattern: "foo", CaseSensitive: true},
-			want: []*regexp.Regexp{
-				regexp.MustCompile(regexp.QuoteMeta("foo")),
-			},
+			want:  []*regexp.Regexp{regexp.MustCompile(regexp.QuoteMeta("foo"))},
 		},
 	}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1213,6 +1213,13 @@ func TestZoektQueryPatternsAsRegexps(t *testing.T) {
 				regexp.MustCompile(`(?i)` + zoektquery.Regexp{Regexp: &syntax.Regexp{Op: syntax.OpLiteral, Name: "python"}}.Regexp.String()),
 			},
 		},
+		{
+			name:  "respect case sensitivity setting",
+			input: &zoektquery.Substring{Pattern: "foo", CaseSensitive: true},
+			want: []*regexp.Regexp{
+				regexp.MustCompile(regexp.QuoteMeta("foo")),
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -6,11 +6,13 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"regexp/syntax"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/regexp"
 	"github.com/hexops/autogold"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
@@ -35,6 +37,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
+	zoektquery "github.com/sourcegraph/zoekt/query"
 )
 
 func TestNewPlanJob(t *testing.T) {
@@ -1148,6 +1151,76 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		{Repo: "foo", Commit: "mybranch", Path: "main.go"},
 	}
 	require.Equal(t, wantResultKeys, matchKeys)
+}
+
+func TestZoektQueryPatternsAsRegexps(t *testing.T) {
+	tests := []struct {
+		name  string
+		input zoektquery.Q
+		want  []*regexp.Regexp
+	}{
+		{
+			name:  "literal substring query",
+			input: &zoektquery.Substring{Pattern: "foobar"},
+			want:  []*regexp.Regexp{regexp.MustCompile(`(?i)foobar`)},
+		},
+		{
+			name:  "regex query",
+			input: &zoektquery.Regexp{Regexp: &syntax.Regexp{Op: syntax.OpLiteral, Name: "foobar"}},
+			want:  []*regexp.Regexp{regexp.MustCompile(`(?i)` + zoektquery.Regexp{Regexp: &syntax.Regexp{Op: syntax.OpLiteral, Name: "foobar"}}.Regexp.String())},
+		},
+		{
+			name: "and query",
+			input: zoektquery.NewAnd([]zoektquery.Q{
+				&zoektquery.Substring{Pattern: "foobar"},
+				&zoektquery.Substring{Pattern: "baz"},
+			}...),
+			want: []*regexp.Regexp{
+				regexp.MustCompile(`(?i)foobar`),
+				regexp.MustCompile(`(?i)baz`),
+			},
+		},
+		{
+			name: "or query",
+			input: zoektquery.NewOr([]zoektquery.Q{
+				&zoektquery.Substring{Pattern: "foobar"},
+				&zoektquery.Substring{Pattern: "baz"},
+			}...),
+			want: []*regexp.Regexp{
+				regexp.MustCompile(`(?i)foobar`),
+				regexp.MustCompile(`(?i)baz`),
+			},
+		},
+		{
+			name: "literal and regex",
+			input: zoektquery.NewAnd([]zoektquery.Q{
+				&zoektquery.Substring{Pattern: "foobar"},
+				&zoektquery.Regexp{Regexp: &syntax.Regexp{Op: syntax.OpLiteral, Name: "python"}},
+			}...),
+			want: []*regexp.Regexp{
+				regexp.MustCompile(`(?i)foobar`),
+				regexp.MustCompile(`(?i)` + zoektquery.Regexp{Regexp: &syntax.Regexp{Op: syntax.OpLiteral, Name: "python"}}.Regexp.String()),
+			},
+		},
+		{
+			name: "literal or regex",
+			input: zoektquery.NewOr([]zoektquery.Q{
+				&zoektquery.Substring{Pattern: "foobar"},
+				&zoektquery.Regexp{Regexp: &syntax.Regexp{Op: syntax.OpLiteral, Name: "python"}},
+			}...),
+			want: []*regexp.Regexp{
+				regexp.MustCompile(`(?i)foobar`),
+				regexp.MustCompile(`(?i)` + zoektquery.Regexp{Regexp: &syntax.Regexp{Op: syntax.OpLiteral, Name: "python"}}.Regexp.String()),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := zoektQueryPatternsAsRegexps(tc.input)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func makeRepositoryRevisions(repos ...string) []*search.RepositoryRevisions {

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -244,7 +244,7 @@ func convertMatches(repo types.MinimalRepo, commit api.CommitID, rev *string, se
 			})
 		}
 
-		pathMatches := make([]result.Range, 0, 3) // we don't expect a large number of path matches per file
+		pathMatches := make([]result.Range, 0, 1) // we don't expect a large number of path matches per file
 		if textPatternRegexp != nil {
 			pathSubmatches := textPatternRegexp.FindAllStringSubmatchIndex(fm.Path, -1)
 			if len(pathSubmatches) > 0 {

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -32,7 +32,7 @@ type TextSearchJob struct {
 	PatternInfo *search.TextPatternInfo
 	Repos       []*search.RepositoryRevisions // the set of repositories to search with searcher.
 
-	PathRegexps []*regexp.Regexp
+	PathRegexps []*regexp.Regexp // used for getting file path match ranges
 
 	// Indexed represents whether the set of repositories are indexed (used
 	// to communicate whether searcher should call Zoekt search on these

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -3,7 +3,9 @@ package searcher
 import (
 	"context"
 	"time"
+	"unicode/utf8"
 
+	"github.com/grafana/regexp"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
 	"golang.org/x/sync/errgroup"
@@ -29,6 +31,8 @@ var textSearchLimiter = mutablelimiter.New(32)
 type TextSearchJob struct {
 	PatternInfo *search.TextPatternInfo
 	Repos       []*search.RepositoryRevisions // the set of repositories to search with searcher.
+
+	TextPatternRegexp *regexp.Regexp
 
 	// Indexed represents whether the set of repositories are indexed (used
 	// to communicate whether searcher should call Zoekt search on these
@@ -199,7 +203,7 @@ func (s *TextSearchJob) searchFilesInRepo(
 
 	onMatches := func(searcherMatches []*protocol.FileMatch) {
 		stream.Send(streaming.SearchEvent{
-			Results: convertMatches(repo, commit, &rev, searcherMatches),
+			Results: convertMatches(repo, commit, &rev, searcherMatches, s.TextPatternRegexp),
 		})
 	}
 
@@ -207,7 +211,7 @@ func (s *TextSearchJob) searchFilesInRepo(
 }
 
 // convert converts a set of searcher matches into []result.Match
-func convertMatches(repo types.MinimalRepo, commit api.CommitID, rev *string, searcherMatches []*protocol.FileMatch) []result.Match {
+func convertMatches(repo types.MinimalRepo, commit api.CommitID, rev *string, searcherMatches []*protocol.FileMatch, textPatternRegexp *regexp.Regexp) []result.Match {
 	matches := make([]result.Match, 0, len(searcherMatches))
 	for _, fm := range searcherMatches {
 		chunkMatches := make(result.ChunkMatches, 0, len(fm.ChunkMatches))
@@ -240,6 +244,27 @@ func convertMatches(repo types.MinimalRepo, commit api.CommitID, rev *string, se
 			})
 		}
 
+		pathMatches := make([]result.Range, 0, 3) // we don't expect a large number of path matches per file
+		if textPatternRegexp != nil {
+			pathSubmatches := textPatternRegexp.FindAllStringSubmatchIndex(fm.Path, -1)
+			if len(pathSubmatches) > 0 {
+				for _, sm := range pathSubmatches {
+					pathMatches = append(pathMatches, result.Range{
+						Start: result.Location{
+							Offset: sm[0],
+							Line:   0,
+							Column: utf8.RuneCount([]byte(fm.Path[:sm[0]])),
+						},
+						End: result.Location{
+							Offset: sm[1],
+							Line:   0,
+							Column: utf8.RuneCount([]byte(fm.Path[:sm[1]])),
+						},
+					})
+				}
+			}
+		}
+
 		matches = append(matches, &result.FileMatch{
 			File: result.File{
 				Path:     fm.Path,
@@ -248,6 +273,7 @@ func convertMatches(repo types.MinimalRepo, commit api.CommitID, rev *string, se
 				InputRev: rev,
 			},
 			ChunkMatches: chunkMatches,
+			PathMatches:  pathMatches,
 			LimitHit:     fm.LimitHit,
 		})
 	}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -620,7 +620,7 @@ func zoektIndexedRepos(indexedSet map[uint32]*zoekt.MinimalRepoListEntry, revs [
 type RepoSubsetTextSearchJob struct {
 	Repos             *IndexedRepoRevs // the set of indexed repository revisions to search.
 	Query             zoektquery.Q
-	ZoektQueryRegexps []*regexp.Regexp
+	ZoektQueryRegexps []*regexp.Regexp // used for getting file path match ranges
 	Typ               search.IndexedRequestType
 	FileMatchLimit    int32
 	Select            filter.SelectPath
@@ -682,7 +682,7 @@ type GlobalTextSearchJob struct {
 	GlobalZoektQuery        *GlobalZoektQuery
 	ZoektArgs               *search.ZoektParameters
 	RepoOpts                search.RepoOptions
-	GlobalZoektQueryRegexps []*regexp.Regexp
+	GlobalZoektQueryRegexps []*regexp.Regexp // used for getting file path match ranges
 }
 
 func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -2,7 +2,6 @@ package zoekt
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -700,9 +699,6 @@ func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClient
 	userPrivateRepos := privateReposForActor(ctx, clients.Logger, clients.DB, t.RepoOpts)
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	t.ZoektArgs.Query = t.GlobalZoektQuery.Generate()
-
-	fmt.Printf("GlobalZoektQuery: %s\n", t.GlobalZoektQuery.Query.String())
-	fmt.Printf("GlobalZoektQuery.T: %T\n", t.GlobalZoektQuery.Query)
 
 	return nil, DoZoektSearchGlobal(ctx, clients.Zoekt, t.ZoektArgs, t.GlobalZoektQueryRegexps, stream)
 }

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -2,11 +2,13 @@ package zoekt
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/RoaringBitmap/roaring"
+	"github.com/grafana/regexp"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
@@ -239,7 +241,7 @@ func PartitionRepos(
 	return indexed, unindexed, nil
 }
 
-func DoZoektSearchGlobal(ctx context.Context, client zoekt.Streamer, args *search.ZoektParameters, c streaming.Sender) error {
+func DoZoektSearchGlobal(ctx context.Context, client zoekt.Streamer, args *search.ZoektParameters, zoektQueryRegexps []*regexp.Regexp, c streaming.Sender) error {
 	k := ResultCountFactor(0, args.FileMatchLimit, true)
 	searchOpts := SearchOpts(ctx, k, args.FileMatchLimit, args.Select)
 
@@ -261,7 +263,7 @@ func DoZoektSearchGlobal(ctx context.Context, client zoekt.Streamer, args *searc
 	}
 
 	return client.StreamSearch(ctx, args.Query, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
-		sendMatches(event, func(file *zoekt.FileMatch) (types.MinimalRepo, []string) {
+		sendMatches(event, zoektQueryRegexps, func(file *zoekt.FileMatch) (types.MinimalRepo, []string) {
 			repo := types.MinimalRepo{
 				ID:   api.RepoID(file.RepositoryID),
 				Name: api.RepoName(file.Repository),
@@ -272,7 +274,7 @@ func DoZoektSearchGlobal(ctx context.Context, client zoekt.Streamer, args *searc
 }
 
 // zoektSearch searches repositories using zoekt.
-func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, typ search.IndexedRequestType, client zoekt.Streamer, fileMatchLimit int32, selector filter.SelectPath, since func(t time.Time) time.Duration, c streaming.Sender) error {
+func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, zoektQueryRegexps []*regexp.Regexp, typ search.IndexedRequestType, client zoekt.Streamer, fileMatchLimit int32, selector filter.SelectPath, since func(t time.Time) time.Duration, c streaming.Sender) error {
 	if len(repos.RepoRevs) == 0 {
 		return nil
 	}
@@ -310,7 +312,7 @@ func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, ty
 	foundResults := atomic.Bool{}
 	err := client.StreamSearch(ctx, finalQuery, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 		foundResults.CAS(false, event.FileCount != 0 || event.MatchCount != 0)
-		sendMatches(event, repos.getRepoInputRev, typ, selector, c)
+		sendMatches(event, zoektQueryRegexps, repos.getRepoInputRev, typ, selector, c)
 	}))
 	if err != nil {
 		return err
@@ -330,7 +332,7 @@ func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, ty
 	return nil
 }
 
-func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ search.IndexedRequestType, selector filter.SelectPath, c streaming.Sender) {
+func sendMatches(event *zoekt.SearchResult, zoektQueryRegexps []*regexp.Regexp, getRepoInputRev repoRevFunc, typ search.IndexedRequestType, selector filter.SelectPath, c streaming.Sender) {
 	files := event.Files
 	limitHit := event.FilesSkipped+event.ShardsSkipped > 0
 
@@ -371,6 +373,11 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 			hms = zoektFileMatchToMultilineMatches(&file)
 		}
 
+		var pathMatches []result.Range
+		if len(zoektQueryRegexps) > 0 {
+			pathMatches = zoektFileMatchToPathMatchRanges(&file, zoektQueryRegexps)
+		}
+
 		for _, inputRev := range inputRevs {
 			inputRev := inputRev // copy so we can take the pointer
 
@@ -381,6 +388,7 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 			fm := result.FileMatch{
 				ChunkMatches: hms,
 				Symbols:      symbols,
+				PathMatches:  pathMatches,
 				File: result.File{
 					InputRev: &inputRev,
 					CommitID: api.CommitID(file.Version),
@@ -471,6 +479,32 @@ func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) result.ChunkMatches
 	}
 
 	return cms
+}
+
+func zoektFileMatchToPathMatchRanges(file *zoekt.FileMatch, zoektQueryRegexps []*regexp.Regexp) []result.Range {
+	pathMatchRanges := make([]result.Range, 0, 3) // we don't expect a large number of path matches for any given file
+
+	for _, re := range zoektQueryRegexps {
+		pathSubmatches := re.FindAllStringSubmatchIndex(file.FileName, -1)
+		if len(pathSubmatches) > 0 {
+			for _, sm := range pathSubmatches {
+				pathMatchRanges = append(pathMatchRanges, result.Range{
+					Start: result.Location{
+						Offset: sm[0],
+						Line:   0, // we can treat path matches as a single-line
+						Column: utf8.RuneCount([]byte(file.FileName[:sm[0]])),
+					},
+					End: result.Location{
+						Offset: sm[1],
+						Line:   0,
+						Column: utf8.RuneCount([]byte(file.FileName[:sm[1]])),
+					},
+				})
+			}
+		}
+	}
+
+	return pathMatchRanges
 }
 
 func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, file *zoekt.FileMatch) []*result.SymbolMatch {
@@ -592,12 +626,13 @@ func zoektIndexedRepos(indexedSet map[uint32]*zoekt.MinimalRepoListEntry, revs [
 }
 
 type RepoSubsetTextSearchJob struct {
-	Repos          *IndexedRepoRevs // the set of indexed repository revisions to search.
-	Query          zoektquery.Q
-	Typ            search.IndexedRequestType
-	FileMatchLimit int32
-	Select         filter.SelectPath
-	Since          func(time.Time) time.Duration `json:"-"` // since if non-nil will be used instead of time.Since. For tests
+	Repos             *IndexedRepoRevs // the set of indexed repository revisions to search.
+	Query             zoektquery.Q
+	ZoektQueryRegexps []*regexp.Regexp
+	Typ               search.IndexedRequestType
+	FileMatchLimit    int32
+	Select            filter.SelectPath
+	Since             func(time.Time) time.Duration `json:"-"` // since if non-nil will be used instead of time.Since. For tests
 }
 
 // ZoektSearch is a job that searches repositories using zoekt.
@@ -617,7 +652,7 @@ func (z *RepoSubsetTextSearchJob) Run(ctx context.Context, clients job.RuntimeCl
 		since = z.Since
 	}
 
-	return nil, zoektSearch(ctx, z.Repos, z.Query, z.Typ, clients.Zoekt, z.FileMatchLimit, z.Select, since, stream)
+	return nil, zoektSearch(ctx, z.Repos, z.Query, z.ZoektQueryRegexps, z.Typ, clients.Zoekt, z.FileMatchLimit, z.Select, since, stream)
 }
 
 func (*RepoSubsetTextSearchJob) Name() string {
@@ -652,9 +687,10 @@ func (*RepoSubsetTextSearchJob) Children() []job.Describer         { return nil 
 func (j *RepoSubsetTextSearchJob) MapChildren(job.MapFunc) job.Job { return j }
 
 type GlobalTextSearchJob struct {
-	GlobalZoektQuery *GlobalZoektQuery
-	ZoektArgs        *search.ZoektParameters
-	RepoOpts         search.RepoOptions
+	GlobalZoektQuery        *GlobalZoektQuery
+	ZoektArgs               *search.ZoektParameters
+	RepoOpts                search.RepoOptions
+	GlobalZoektQueryRegexps []*regexp.Regexp
 }
 
 func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
@@ -665,7 +701,10 @@ func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClient
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	t.ZoektArgs.Query = t.GlobalZoektQuery.Generate()
 
-	return nil, DoZoektSearchGlobal(ctx, clients.Zoekt, t.ZoektArgs, stream)
+	fmt.Printf("GlobalZoektQuery: %s\n", t.GlobalZoektQuery.Query.String())
+	fmt.Printf("GlobalZoektQuery.T: %T\n", t.GlobalZoektQuery.Query)
+
+	return nil, DoZoektSearchGlobal(ctx, clients.Zoekt, t.ZoektArgs, t.GlobalZoektQueryRegexps, stream)
 }
 
 func (*GlobalTextSearchJob) Name() string {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -481,7 +481,7 @@ func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) result.ChunkMatches
 }
 
 func zoektFileMatchToPathMatchRanges(file *zoekt.FileMatch, zoektQueryRegexps []*regexp.Regexp) []result.Range {
-	pathMatchRanges := make([]result.Range, 0, 3) // we don't expect a large number of path matches for any given file
+	pathMatchRanges := make([]result.Range, 0, 1) // we don't expect a large number of path matches for any given file
 
 	for _, re := range zoektQueryRegexps {
 		pathSubmatches := re.FindAllStringSubmatchIndex(file.FileName, -1)

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -42,7 +42,7 @@ func (z *SymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, s
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	err = zoektSearch(ctx, z.Repos, z.Query, search.SymbolRequest, clients.Zoekt, z.FileMatchLimit, z.Select, since, stream)
+	err = zoektSearch(ctx, z.Repos, z.Query, nil, search.SymbolRequest, clients.Zoekt, z.FileMatchLimit, z.Select, since, stream)
 	if err != nil {
 		tr.LogFields(log.Error(err))
 		// Only record error if we haven't timed out.
@@ -99,7 +99,7 @@ func (s *GlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	s.ZoektArgs.Query = s.GlobalZoektQuery.Generate()
 
 	// always search for symbols in indexed repositories when searching the repo universe.
-	err = DoZoektSearchGlobal(ctx, clients.Zoekt, s.ZoektArgs, stream)
+	err = DoZoektSearchGlobal(ctx, clients.Zoekt, s.ZoektArgs, nil, stream)
 	if err != nil {
 		tr.LogFields(log.Error(err))
 		// Only record error if we haven't timed out.


### PR DESCRIPTION
Stacked on #41296

`select:file` restricts result rendering to only show file paths. These results can be either:
1) A match on the literal file path string, or 
2) A file containing a content match, but not necessarily a match on the file path 

Regardless, `select:file` will cause all results to be converted to path matches.

Currently, we always label a result with "Path match" when it is rendered as a path match. This is confusing when a result is a content match that has been converted to a path match, because the label "Path match" implies that the file path itself contains a match, when this is not always the case. 

Now that path match ranges are available in the client, we can make the distinction between a "natural" path match and a "converted" path match in the UI in a way that's informative to users. 

Before:
![Screen Shot 2022-09-04 at 6 20 55 PM](https://user-images.githubusercontent.com/70350613/188337435-33043af4-f350-43ae-8e86-b49c14bf66b5.png)

After:
![Screen Shot 2022-09-06 at 11 43 08 AM](https://user-images.githubusercontent.com/70350613/188692726-45d98ca5-f81e-4b6c-876b-e8890bc09f75.png)

## Test plan
Visually confirm the change in the UI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
