### PR TITLE
No-op extensions controller should mark initial extensions as loaded

### DIFF
--- a/client/shared/src/extensions/createNoopLoadedController.ts.ts
+++ b/client/shared/src/extensions/createNoopLoadedController.ts.ts
@@ -32,6 +32,9 @@ export function createNoopController(platformContext: PlatformContext): Controll
                 )
                 const extensionHostAPI = pretendRemote(createExtensionHostAPI(extensionHostState))
 
+                // We don't have to load any extensions so we are already done
+                extensionHostState.haveInitialExtensionsLoaded.next(true)
+
                 resolve(extensionHostAPI)
             })
         }),


### PR DESCRIPTION
This was an oversight when I created the no-op extensions controller that was discovered while I fixed tests for #41129.

When the no-op extensions controller is enabled, the actions sidebar is stuck in the loading state because the subscribeable is never updated. 

Since there are no extensions to load in this version, we can always mark them as loaded right away.

(cc @olafurpg this is called in a few places not just the extensions action sidebar so if you see something stuck in the loading state again, this might be the cause for it)

## Test plan

Extensions sidebar opens again:

![Screenshot 2022-09-05 at 11 52 30](https://user-images.githubusercontent.com/458591/188421912-96d7b2de-af9f-402a-9c05-455599642bde.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-noop-extension-loading.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-acoqaukgnf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
