### PR TITLE
log15 migration: use sourcgraph/log instead log15 for licensing logging

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_expiration_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_expiration_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/derision-test/glock"
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -76,7 +78,7 @@ func TestCheckForUpcomingLicenseExpirations(t *testing.T) {
 	})
 
 	client := &fakeSlackClient{}
-	checkForUpcomingLicenseExpirations(db, clock, client)
+	checkForUpcomingLicenseExpirations(logtest.Scoped(t), db, clock, client)
 
 	wantPayloads := []*slack.Payload{
 		{Text: "The license for user `alice` <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/e9450fb2-87c7-47ae-a713-a376c4618faa|will expire *in the next 24 hours*> :rotating_light:"},

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -39,7 +39,7 @@ func Init(ctx context.Context, db database.DB, conf conftypes.UnifiedWatchable, 
 	// services when the max is reached.
 	database.BeforeCreateExternalService = enforcement.NewBeforeCreateExternalServiceHook()
 
-	logger := log.Scoped("licensing.int", "initialize licensing enforcement")
+	logger := log.Scoped("licensing", "licensing enforcement")
 	hooks.GetLicenseInfo = func(isSiteAdmin bool) *hooks.LicenseInfo {
 		if !isSiteAdmin {
 			return nil
@@ -152,7 +152,7 @@ func Init(ctx context.Context, db database.DB, conf conftypes.UnifiedWatchable, 
 	})
 	if envvar.SourcegraphDotComMode() {
 		goroutine.Go(func() {
-			productsubscription.StartCheckForUpcomingLicenseExpirations(db)
+			productsubscription.StartCheckForUpcomingLicenseExpirations(logger, db)
 		})
 	}
 


### PR DESCRIPTION
Migrate use of log15 logger to use sourcegraph/log

## Test plan
Unit Tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
