### PR TITLE
sg: set license generation key for codeintel-worker

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -435,7 +435,9 @@ commands:
     cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-1" -pprof -rpc -listen "127.0.0.1:3071"
 
   codeintel-worker:
-    cmd: .bin/codeintel-worker
+    cmd: |
+      export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
+      .bin/codeintel-worker
     install: |
       if [ -n "$DELVE" ]; then
         export GCFLAGS='all=-N -l'


### PR DESCRIPTION
Set the `SOURCEGRAPH_LICENSE_GENERATION_KEY` for `codeintel-worker` to pass license key checking in dev instances.

## Test plan

n/a

---

Followup of https://github.com/sourcegraph/sourcegraph/pull/40826#issuecomment-1236765486