### PR TITLE
gitserver: Disable colour for p4-fusion

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -70,6 +70,7 @@ func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.U
 			"--maxChanges", strconv.Itoa(s.FusionConfig.MaxChanges),
 			"--includeBinaries", strconv.FormatBool(s.FusionConfig.IncludeBinaries),
 			"--fsyncEnable", strconv.FormatBool(s.FusionConfig.FsyncEnable),
+			"--noColor", "true",
 		)
 	} else {
 		// Example: git p4 clone --bare --max-changes 1000 //Sourcegraph/@all /tmp/clone-584194180/.git
@@ -115,6 +116,7 @@ func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir
 			"--maxChanges", strconv.Itoa(s.FusionConfig.MaxChanges),
 			"--includeBinaries", strconv.FormatBool(s.FusionConfig.IncludeBinaries),
 			"--fsyncEnable", strconv.FormatBool(s.FusionConfig.FsyncEnable),
+			"--noColor", "true",
 		)
 	} else {
 		cmd = exec.CommandContext(ctx, "git", args...)


### PR DESCRIPTION
Now that we're using p4-fusion 1.11 by default we'll disabled colour by
default in our logs. We don't support the color codes in our UI and it
ends up causing the logs to be difficult to read.

## Test plan

None required, just passing an extra argument to p4-fusion