### PR TITLE
otel: enable SQLCommenter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -456,7 +456,7 @@ replace (
 // or issues with specific versions.
 replace (
 	// Forked until PR is merged upstream TODO @jhchabran
-	github.com/XSAM/otelsql => github.com/sourcegraph/otelsql v0.0.0-20220825134523-e3712953a6a5
+	github.com/XSAM/otelsql => github.com/sourcegraph/otelsql v0.0.0-20220905085252-74375c884fff
 	// Pending: https://github.com/ghodss/yaml/pull/65
 	github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
 	// Pending: Renamed to github.com/google/gnostic. Transitive deps still use the old name (kubernetes/kubernetes).

--- a/go.sum
+++ b/go.sum
@@ -2070,8 +2070,8 @@ github.com/sourcegraph/log v0.0.0-20220901143117-fc0516a694c9 h1:JjFyvx9hCD5+Jpu
 github.com/sourcegraph/log v0.0.0-20220901143117-fc0516a694c9/go.mod h1:UxiwB6C3xk3xOySJpW1R0MDUyfGuJRFS5Z8C+SA5p2I=
 github.com/sourcegraph/oauth2 v0.0.0-20210825125341-77c1d99ece3c h1:HGa4iJr6MGKnB5qbU7tI511NdGuHUHnNCqP67G6KmfE=
 github.com/sourcegraph/oauth2 v0.0.0-20210825125341-77c1d99ece3c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-github.com/sourcegraph/otelsql v0.0.0-20220825134523-e3712953a6a5 h1:gv92/ctwOCyj13tV94TX/FYXrHNdZMmGYc46AdLnmzM=
-github.com/sourcegraph/otelsql v0.0.0-20220825134523-e3712953a6a5/go.mod h1:AfMs/2M3s2GnTKqPBnX5pwNPDxmXCt0poaM8efznH7Q=
+github.com/sourcegraph/otelsql v0.0.0-20220905085252-74375c884fff h1:u/Lf5xLBDYfRjyeGk8+zUqXrWwRzMIwFbhqKPIWo79Q=
+github.com/sourcegraph/otelsql v0.0.0-20220905085252-74375c884fff/go.mod h1:DpO7NCSeqQdr23nU0yapjR3jGx2OdO/PihPRG+/PV0Y=
 github.com/sourcegraph/run v0.9.0 h1:mj4pwBqCB+5qEaTp+rhauh5ubYI8n/icOkeiLTCT9Xg=
 github.com/sourcegraph/run v0.9.0/go.mod h1:j6Do38ccF+w/rSWgOuu4Ou/eOIDiU6pC87BZmq0DXDY=
 github.com/sourcegraph/scip v0.1.0 h1:kTs0CJaLQvcRZjg+HpGrcJPNX2Tx31+d6szWio3ZOkQ=

--- a/internal/database/dbconn/open.go
+++ b/internal/database/dbconn/open.go
@@ -212,6 +212,7 @@ func open(cfg *pgx.ConnConfig) (*sql.DB, error) {
 		"postgres-proxy",
 		stdlib.RegisterConnConfig(cfg),
 		otelsql.WithTracerProvider(otel.GetTracerProvider()),
+		otelsql.WithSQLCommenter(true),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{
 			OmitConnResetSession: true,
 			ArgumentOptions: otelsql.ArgumentOptions{


### PR DESCRIPTION
SQLCommenter annotates queries send to the database with trace
annotations which enable to link Database level spans back to
application traces.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Found 

```
/*uber-trace-id='c235da8e44b09e2388a4a234cb69dd5a%3Ac3aa2f6720039660%3A0%3A1',ot-tracer-traceid='88a4a234cb69dd5a',ot-tracer-spanid='c3aa2f6720039660',ot-tracer-sampled='true',traceparent='00-c235da8e44b09e2388a4a234cb69dd5a-c3aa2f6720039660-01'*/
```