### PR TITLE
log: lower level for enqueuing errors on repo-updater

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -142,7 +142,7 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 	}
 	result, status, err := s.enqueueRepoUpdate(r.Context(), &req)
 	if err != nil {
-		s.Logger.Error("enqueueRepoUpdate failed", log.String("req", fmt.Sprint(req)), log.Error(err))
+		s.Logger.Warn("enqueueRepoUpdate failed", log.String("req", fmt.Sprint(req)), log.Error(err))
 		s.respond(w, status, err)
 		return
 	}


### PR DESCRIPTION
Following-up to https://sourcegraph.slack.com/archives/C02EDAQAJQZ/p1662124359938039, this PR lowers the loglevel for errors coming from the repo-updater. This is a very noisy error that is spamming Sentry quite a lot.

I'm unsure if we shouldn't do so more precise matching or not, whoever takes a look please take a look at this :) 


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Log level change, extremely minor change. 
