### PR TITLE
frontend: set logger for editorRequest

### DIFF
--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -225,6 +225,7 @@ func parseEditorRequest(db database.DB, q url.Values) (*editorRequest, error) {
 		version:           q.Get("version"),
 		utmProductName:    q.Get("utm_product_name"),
 		utmProductVersion: q.Get("utm_product_name"),
+		logger:            log.Scoped("editor", "requests from editors."),
 	}
 	if v.editor == "" {
 		return nil, errors.New("expected URL parameter missing: editor=$EDITOR_NAME")


### PR DESCRIPTION
We started using logger in June, but never set the logger (meaning we could panic if logging). However, we just got our first report of a panic, so I assume it is hard to hit the code path which logs.

Test Plan: go test
