### PR TITLE
internal: remove forgotten print statements

### DIFF
--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -733,7 +733,6 @@ func (l *eventLogStore) countUniqueUsersBySQL(ctx context.Context, startDate, en
 	if len(conds) == 0 {
 		conds = []*sqlf.Query{sqlf.Sprintf("TRUE")}
 	}
-	fmt.Println(sqlf.Join(conds, ") AND ("))
 	q := sqlf.Sprintf(`SELECT COUNT(DISTINCT `+userIDQueryFragment+`)
 		FROM event_logs
 		WHERE (DATE(TIMEZONE('UTC'::text, timestamp)) >= %s) AND (DATE(TIMEZONE('UTC'::text, timestamp)) <= %s) AND (%s)`, startDate, endDate, sqlf.Join(conds, ") AND ("))

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -809,7 +809,6 @@ func (s *store) AddExecutionLogEntry(ctx context.Context, id int, entry workerut
 	if !ok {
 		debug, debugErr := s.fetchDebugInformationForJob(ctx, id)
 		if debugErr != nil {
-			println("foo", s.logger, "foo")
 			s.logger.Error("failed to fetch debug information for job",
 				log.Int("recordID", id),
 				log.Error(debugErr),


### PR DESCRIPTION
kept seeing
```
[       frontend] &{TRUE ) AND ( user_id > 0 OR anonymous_user_id <> 'backend' []}
```
for the past week and tracked the log down

also found a debugging print during my search and removed it

## Test plan

no logical impact.

monitored my local sg instance for a while and the message no longer pops up (no internal knowledge on how to explicitly trigger it)