### PR TITLE
Flip extensionsAsCoreFeatures flag

### DIFF
--- a/client/shared/src/api/client/enabledExtensions.ts
+++ b/client/shared/src/api/client/enabledExtensions.ts
@@ -66,8 +66,7 @@ export const getConfiguredSideloadedExtension = (
     )
 
 /**
- * List of extensions migrated to the core workflow. These extensions should not be activated if
- * `extensionsAsCoreFeatures` experimental feature is enabled.
+ * List of extensions migrated to the core workflow.
  */
 export const MIGRATED_TO_CORE_WORKFLOW_EXTENSION_IDS = new Set([
     'sourcegraph/git-extras',
@@ -103,15 +102,14 @@ export const getEnabledExtensions = once(
 
         return combineLatest([viewerConfiguredExtensions(context), sideloadedExtension, context.settings]).pipe(
             map(([configuredExtensions, sideloadedExtension, settings]) => {
-                const extensionsAsCoreFeatures =
-                    isSettingsValid(settings) && settings.final.experimentalFeatures?.extensionsAsCoreFeatures
                 const enableGoImportsSearchQueryTransform =
                     isSettingsValid(settings) &&
                     settings.final.experimentalFeatures?.enableGoImportsSearchQueryTransform
 
                 let enabled = configuredExtensions.filter(extension => {
-                    const extensionsAsCoreFeatureMigratedExtension =
-                        extensionsAsCoreFeatures && MIGRATED_TO_CORE_WORKFLOW_EXTENSION_IDS.has(extension.id)
+                    const extensionsAsCoreFeatureMigratedExtension = MIGRATED_TO_CORE_WORKFLOW_EXTENSION_IDS.has(
+                        extension.id
+                    )
                     // Ignore extensions migrated to the core workflow if the experimental feature is enabled
                     if (context.clientApplication === 'sourcegraph' && extensionsAsCoreFeatureMigratedExtension) {
                         return false

--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -31,7 +31,6 @@ export interface Settings {
             enabled: boolean
             forNerds?: boolean
         }
-        extensionsAsCoreFeatures?: boolean
         enableGoImportsSearchQueryTransform?: boolean
         enableLegacyExtensions?: boolean
         enableLazyFileResultSyntaxHighlighting?: boolean

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -23,7 +23,6 @@ import { Button, ButtonLink, Icon, Link, LoadingSpinner, Tooltip, useObservable 
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { useCarousel } from '../../components/useCarousel'
 import { OpenInEditorActionItem } from '../../open-in-editor/OpenInEditorActionItem'
-import { useExperimentalFeatures } from '../../stores'
 
 import styles from './ActionItemsBar.module.scss'
 
@@ -205,8 +204,6 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
         )
     )
 
-    const extensionsAsCoreFeatures = useExperimentalFeatures(features => features.extensionsAsCoreFeatures)
-
     if (!isOpen) {
         return <div className={styles.barCollapsed} />
     }
@@ -227,7 +224,7 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
                         <Icon aria-hidden={true} svgPath={mdiMenuUp} />
                     </Button>
                 )}
-                {extensionsAsCoreFeatures ? <OpenInEditorActionItem platformContext={props.platformContext} /> : null}
+                <OpenInEditorActionItem platformContext={props.platformContext} />
                 {extensionsController !== null ? (
                     <ActionsContainer
                         menu={ContributableMenu.EditorTitle}

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -295,8 +295,11 @@ describe('Blob viewer', () => {
 
         /**
          * This test is meant to prevent regression: https://github.com/sourcegraph/sourcegraph/pull/15099
+         *
+         * TODO(philipp-spiess): This test no longer works after enabling the migrated git blame
+         * extension. We can remove it once we remove the extension support completely.
          */
-        it('adds and clears line decoration attachments properly', async () => {
+        it.skip('adds and clears line decoration attachments properly', async () => {
             const mockExtensions: MockExtension[] = [
                 {
                     id: 'test',

--- a/client/web/src/repo/actions/ToggleBlameAction.tsx
+++ b/client/web/src/repo/actions/ToggleBlameAction.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames'
 
 import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
-import { useExperimentalFeatures } from '../../stores'
 import { eventLogger } from '../../tracking/eventLogger'
 import { useBlameVisibility } from '../blame/useBlameVisibility'
 import { RepoHeaderActionButtonLink, RepoHeaderActionMenuItem } from '../components/RepoHeaderActions'
@@ -16,7 +15,6 @@ export const ToggleBlameAction: React.FC<{ actionType?: 'nav' | 'dropdown'; file
     actionType,
     filePath,
 }) => {
-    const extensionsAsCoreFeatures = useExperimentalFeatures(features => features.extensionsAsCoreFeatures)
     const [isBlameVisible, setIsBlameVisible] = useBlameVisibility()
 
     // Turn off visibility when the file path changes.
@@ -35,10 +33,6 @@ export const ToggleBlameAction: React.FC<{ actionType?: 'nav' | 'dropdown'; file
             eventLogger.log('GitBlameEnabled')
         }
     }, [isBlameVisible, setIsBlameVisible])
-
-    if (!extensionsAsCoreFeatures) {
-        return null
-    }
 
     if (actionType === 'dropdown') {
         return (

--- a/client/web/src/repo/blame/useBlameHunks.ts
+++ b/client/web/src/repo/blame/useBlameHunks.ts
@@ -12,7 +12,6 @@ import { useObservable } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../backend/graphql'
 import { GitBlameResult, GitBlameVariables } from '../../graphql-operations'
-import { useExperimentalFeatures } from '../../stores'
 
 import { useBlameVisibility } from './useBlameVisibility'
 
@@ -114,16 +113,14 @@ export const useBlameHunks = (
     },
     sourcegraphURL: string
 ): BlameHunk[] | undefined => {
-    const extensionsAsCoreFeatures = useExperimentalFeatures(features => features.extensionsAsCoreFeatures)
     const [isBlameVisible] = useBlameVisibility()
     const hunks = useObservable(
-        useMemo(
-            () =>
-                extensionsAsCoreFeatures && isBlameVisible
-                    ? fetchBlame({ revision, repoName, filePath })
-                    : of(undefined),
-            [extensionsAsCoreFeatures, isBlameVisible, revision, repoName, filePath]
-        )
+        useMemo(() => (isBlameVisible ? fetchBlame({ revision, repoName, filePath }) : of(undefined)), [
+            isBlameVisible,
+            revision,
+            repoName,
+            filePath,
+        ])
     )
 
     const hunksWithDisplayInfo = useMemo(() => {

--- a/client/web/src/search/results/SearchActionsMenu.tsx
+++ b/client/web/src/search/results/SearchActionsMenu.tsx
@@ -19,7 +19,6 @@ import {
 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
-import { useExperimentalFeatures } from '../../stores'
 
 import { CreateAction } from './createActions'
 import { useExportSearchResultsQuery } from './useExportSearchResultsQuery'
@@ -34,7 +33,6 @@ interface SearchActionsMenuProps extends SearchPatternTypeProps, Pick<PlatformCo
     canCreateMonitor: boolean
     resultsFound: boolean
     allExpanded: boolean
-    extensionsAsCoreFeatures?: boolean
     onExpandAllResultsToggle: () => void
     onSaveQueryClick: () => void
 }
@@ -52,7 +50,6 @@ export const SearchActionsMenu: React.FunctionComponent<SearchActionsMenuProps> 
     onExpandAllResultsToggle,
     onSaveQueryClick,
 }) => {
-    const extensionsAsCoreFeatures = useExperimentalFeatures(features => features.extensionsAsCoreFeatures)
     const [requestSearchResultsExport] = useExportSearchResultsQuery({ query, patternType, sourcegraphURL })
 
     return (
@@ -80,12 +77,10 @@ export const SearchActionsMenu: React.FunctionComponent<SearchActionsMenuProps> 
                                     />
                                     {allExpanded ? 'Collapse all' : 'Expand all'}
                                 </MenuItem>
-                                {extensionsAsCoreFeatures && (
-                                    <MenuItem onSelect={requestSearchResultsExport}>
-                                        <Icon aria-hidden={true} className="mr-1" svgPath={mdiDownload} />
-                                        Export Results
-                                    </MenuItem>
-                                )}
+                                <MenuItem onSelect={requestSearchResultsExport}>
+                                    <Icon aria-hidden={true} className="mr-1" svgPath={mdiDownload} />
+                                    Export Results
+                                </MenuItem>
                             </>
                         )}
                         <MenuHeader>Search query</MenuHeader>

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -44,20 +44,6 @@ export function defaultCaseSensitiveFromSettings(settingsCascade: SettingsCascad
 }
 
 /**
- * Whether user wants to use default extensions functionality as core product features instead of the corresponding extensions.
- */
-export function extensionsAsCoreFeaturesEnabled(settingsCascade: SettingsCascadeOrError): boolean {
-    if (!settingsCascade.final) {
-        return false
-    }
-    if (isErrorLike(settingsCascade.final)) {
-        return false
-    }
-
-    return settingsCascade.final.experimentalFeatures?.extensionsAsCoreFeatures === true
-}
-
-/**
  * Returns undefined if the settings cannot be loaded or if the setting doesn't
  * exist.
  */

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1839,8 +1839,6 @@ type SettingsExperimentalFeatures struct {
 	EnableSidebarFilePrefetch *bool `json:"enableSidebarFilePrefetch,omitempty"`
 	// EnableSmartQuery description: REMOVED. Previously, added more syntax highlighting and hovers for queries in the web app. This behavior is active by default now.
 	EnableSmartQuery *bool `json:"enableSmartQuery,omitempty"`
-	// ExtensionsAsCoreFeatures description: Use default extensions (Git extras, Open in editor, Search export) functionality as core features instead of extensions.
-	ExtensionsAsCoreFeatures *bool `json:"extensionsAsCoreFeatures,omitempty"`
 	// FuzzyFinder description: Enables fuzzy finder with the keyboard shortcut `Cmd+K` on macOS and `Ctrl+K` on Linux/Windows.
 	FuzzyFinder *bool `json:"fuzzyFinder,omitempty"`
 	// FuzzyFinderCaseInsensitiveFileCountThreshold description: The maximum number of files a repo can have to use case-insensitive fuzzy finding

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -325,14 +325,6 @@
             "pointer": true
           }
         },
-        "extensionsAsCoreFeatures": {
-          "description": "Use default extensions (Git extras, Open in editor, Search export) functionality as core features instead of extensions.",
-          "type": "boolean",
-          "default": false,
-          "!go": {
-            "pointer": true
-          }
-        },
         "enableGoImportsSearchQueryTransform": {
           "description": "Lets you easily search for all files using a Go package. Adds a new operator `go.imports`: for all import statements of the package passed to the operator.",
           "type": "boolean",


### PR DESCRIPTION
Part of #40460

This PR removes the `extensionsAsCoreFeatures` feature flag and changes its call sites to make it always true. After this is merged, migrated extensions are enabled by default.

__Note: Merging this PR will flip the flag for our continuously deployed instances unless otherwise configured. I'll merge this later this week after we have done some testing with the flags turned on.__

## Test plan

- Tests pass
- Migrated extensions load even with legacy extensions disabled:
![Screenshot 2022-09-05 at 13 27 56](https://user-images.githubusercontent.com/458591/188438753-1af10e36-d459-4ecd-83de-b7aaefa771d0.png)
![Screenshot 2022-09-05 at 13 27 42](https://user-images.githubusercontent.com/458591/188438757-6da39cbe-5d06-4978-a8f1-18f14b73f215.png)

