### PR TITLE
Aggregation: Fix sidebar aggregation label rotation

### DIFF
--- a/client/web/src/search/results/components/aggregation/AggregationChart.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChart.tsx
@@ -25,11 +25,12 @@ type SharedBarProps<Datum> = Omit<BarChartProps<Datum>, PredefinedBarProps>
 
 export interface AggregationChartProps<Datum> extends SharedBarProps<Datum> {
     mode?: SearchAggregationMode | null
+    minAngleXTick: number
     maxXLabelLength: number
 }
 
 export function AggregationChart<Datum>(props: AggregationChartProps<Datum>): ReactElement {
-    const { mode, maxXLabelLength, className, ...attributes } = props
+    const { mode, minAngleXTick, maxXLabelLength, className, ...attributes } = props
 
     const getTruncatedXLabel = useMemo(() => getTruncationFormatter(mode, maxXLabelLength), [mode, maxXLabelLength])
 
@@ -40,9 +41,10 @@ export function AggregationChart<Datum>(props: AggregationChartProps<Datum>): Re
                     {...attributes}
                     width={parent.width}
                     height={parent.height}
+                    hideXTicks={true}
                     pixelsPerYTick={20}
                     pixelsPerXTick={20}
-                    hideXTicks={true}
+                    minAngleXTick={minAngleXTick}
                     maxAngleXTick={45}
                     getScaleXTicks={getXScaleTicks}
                     getTruncatedXTick={getTruncatedXLabel}

--- a/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
@@ -18,6 +18,11 @@ const LazyAggregationChart = lazyComponent<AggregationChartProps<SearchAggregati
     'AggregationChart'
 )
 
+/** Set custom value for minimal rotation angle for X ticks in sidebar UI panel mode. */
+const MIN_X_TICK_ROTATION = 30
+const MAX_SHORT_LABEL_WIDTH = 8
+const MAX_LABEL_WIDTH = 16
+
 const getName = (datum: SearchAggregationDatum): string => datum.label ?? ''
 const getValue = (datum: SearchAggregationDatum): number => datum.count
 const getColor = (datum: SearchAggregationDatum): string => (datum.label ? 'var(--primary)' : 'var(--text-muted)')
@@ -136,7 +141,8 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
                     aria-label={ariaLabel}
                     data={getAggregationData(data)}
                     mode={mode}
-                    maxXLabelLength={size === 'md' ? WIDE_LABEL_WIDTH : SHORT_LABEL_WIDTH}
+                    minAngleXTick={size === 'md' ? 0 : MIN_X_TICK_ROTATION}
+                    maxXLabelLength={size === 'md' ? MAX_LABEL_WIDTH : MAX_SHORT_LABEL_WIDTH}
                     getDatumValue={getValue}
                     getDatumColor={getColor}
                     getDatumName={getName}
@@ -177,9 +183,6 @@ const DataLayoutContainer = forwardRef((props, ref) => {
         />
     )
 }) as ForwardReferenceComponent<'div', DataLayoutContainerProps>
-
-const SHORT_LABEL_WIDTH = 8
-const WIDE_LABEL_WIDTH = 16
 
 const BAR_VALUES_FULL_UI = [95, 88, 83, 70, 65, 45, 35, 30, 30, 30, 30, 27, 27, 27, 27, 24, 10, 10, 10, 10, 10]
 const BAR_VALUES_SIDEBAR_UI = [95, 80, 75, 70, 68, 68, 55, 40, 38, 33, 30, 25, 15, 7]

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -22,6 +22,7 @@ export interface BarChartProps<Datum> extends CategoricalLikeChart<Datum>, SVGPr
     pixelsPerYTick?: number
     pixelsPerXTick?: number
     hideXTicks?: boolean
+    minAngleXTick?: number
     maxAngleXTick?: number
     getScaleXTicks?: <T>(options: GetScaleTicksOptions) => T[]
     getTruncatedXTick?: (formattedTick: string) => string
@@ -38,6 +39,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         pixelsPerYTick,
         pixelsPerXTick,
         hideXTicks,
+        minAngleXTick,
         maxAngleXTick,
         stacked = false,
         getDatumHover,
@@ -90,6 +92,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
             <SvgAxisLeft pixelsPerTick={pixelsPerYTick} />
             <SvgAxisBottom
                 pixelsPerTick={pixelsPerXTick}
+                minRotateAngle={minAngleXTick}
                 maxRotateAngle={maxAngleXTick}
                 hideTicks={hideXTicks}
                 getTruncatedTick={getTruncatedXTick}

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
@@ -149,15 +149,16 @@ export const reverseTruncatedTick = (tick: string): string => (tick.length >= 15
 interface SvgAxisBottomProps<Tick> {
     tickFormat?: (tick: Tick) => string
     pixelsPerTick?: number
+    minRotateAngle?: number
     maxRotateAngle?: number
     hideTicks?: boolean
     getTruncatedTick?: (formattedTick: string) => string
     getScaleTicks?: <T>(options: GetScaleTicksOptions) => T[]
 }
-
 export function SvgAxisBottom<Tick = string>(props: SvgAxisBottomProps<Tick>): ReactElement {
     const {
         pixelsPerTick = 0,
+        minRotateAngle = 0,
         maxRotateAngle = 45,
         tickFormat = defaultToString,
         getTruncatedTick = defaultTruncatedTick,
@@ -183,14 +184,15 @@ export function SvgAxisBottom<Tick = string>(props: SvgAxisBottomProps<Tick>): R
         }
 
         return getMaxTickWidth(axisGroup, ticks.map(tickFormat))
-    }, [ticks, tickFormat])
+    }, [tickFormat, ticks])
 
     const getXTickProps = (props: TickRendererProps): TickProps => {
+        // TODO: Improve rotation math see https://github.com/sourcegraph/sourcegraph/issues/41310
         const measuredSize = ticks.length * maxWidth
         const fontSize = 12 // 0.75rem
         const rotate =
             upperRangeBound < measuredSize
-                ? maxRotateAngle * Math.min(1, (measuredSize / upperRangeBound - 0.8) / 2)
+                ? Math.max(maxRotateAngle * Math.min(1, (measuredSize / upperRangeBound - 0.8) / 2), minRotateAngle)
                 : 0
 
         if (rotate) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41191

## Background
This PR simply adds min X label rotation angle for the sidebar aggregation chart. This solution may not cover all possible cases but this should cover most of them. This problem with labels rotation will be fully addressed in a follow up issue here https://github.com/sourcegraph/sourcegraph/issues/41310

| Before | After |
| ------------- | ------------- |
| ![](https://user-images.githubusercontent.com/29406849/187917340-96d18abc-d2ff-445e-803c-4db10a623743.png) | <img width="242" alt="Screenshot 2022-09-05 at 14 18 39" src="https://user-images.githubusercontent.com/18492575/188438718-05a2df46-bc5d-4401-ac2c-6cb12ea88bb1.png">  |

## Test plan
- Serve sg locally 
- Check [`TODO[(](\w+)[)] count:all`](https://sourcegraph.sourcegraph.com/search?q=context%3Aglobal+TODO%5B%28%5D%28%5Cw%2B%29%5B%29%5D+count%3Aall&patternType=regexp&groupBy=group) query 
- Make sure that label rotation works correctly with different aggregation datasets 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-sidebar-aggregation-label.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xijotzlict.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
