### PR TITLE
auth: remove flake from TestLockoutStore

### DIFF
--- a/cmd/frontend/internal/auth/userpasswd/lockout_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout_test.go
@@ -122,7 +122,6 @@ func TestLockoutStore(t *testing.T) {
 	})
 
 	t.Run("generates an expected jwt token", func(t *testing.T) {
-		expiryTime := time.Now().Add(5 * time.Minute)
 		rcache.SetupForTest(t)
 
 		s := NewLockoutStore(2, time.Minute, time.Second)
@@ -154,10 +153,20 @@ func TestLockoutStore(t *testing.T) {
 		if !ok {
 			t.Fatalf("parsed JWT claims not ok")
 		}
-		if claims.Subject != "1" || claims.ExpiresAt == nil || *claims.ExpiresAt != *jwt.NewNumericDate(expiryTime) {
+
+		if claims.Subject != "1" || claims.ExpiresAt == nil {
 			t.Fatalf("claims from JWT do not match expectations %v", claims)
 		}
 
+		// if GenerateUnlockAccountURL runs within a different second
+		// (jwt.TimePrecision) to the next line, our want will be different
+		// than the claims ExpiresAt. Additionally CI can be busy, so lets add
+		// a decent amount of fudge to this (10s).
+		want := time.Now().Add(5 * time.Minute).Truncate(jwt.TimePrecision)
+		got := *&claims.ExpiresAt.Time
+		if want.Sub(got).Abs() > 10*time.Second {
+			t.Fatalf("unexpected ExpiresAt time:\ngot:  %s\nwant: %s", got, want)
+		}
 	})
 
 	t.Run("correctly verifies unlock account token", func(t *testing.T) {


### PR DESCRIPTION
This test flaked on me just one too many times, so here is a fix :) The root cause is if expected expiryTime is generated within a different second of GenerateUnlockAccountURL we will get an unexpected ExpiresAt. This commit adjusts the test to instead allow any expiry time within 10s of our expectation.

Test Plan: go test
