### PR TITLE
Add tracking events for promoted extensions

### DIFF
--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -10,7 +10,6 @@ import {
     QueryState,
     SearchPatternType,
 } from '@sourcegraph/search'
-import type { TelemetryService } from '@sourcegraph/shared/out/src/telemetry/telemetryService'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import {
@@ -22,6 +21,7 @@ import {
 } from '@sourcegraph/shared/src/search/stream'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import { initializeSourcegraphSettings } from '../sourcegraphSettings'

--- a/client/jetbrains/webview/src/search/results/SearchResultList.story.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.story.tsx
@@ -5,7 +5,7 @@ import { subMonths } from 'date-fns'
 import { useDarkMode } from 'storybook-dark-mode'
 
 import { SymbolKind } from '@sourcegraph/search'
-import { SearchMatch } from '@sourcegraph/shared/out/src/search/stream'
+import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 import { usePrependStyles } from '@sourcegraph/storybook'
 
 import { applyTheme } from '..'

--- a/client/shared/src/api/client/search.ts
+++ b/client/shared/src/api/client/search.ts
@@ -23,7 +23,7 @@ export function transformSearchQuery({
     query: string
     extensionHostAPIPromise: null | Promise<Remote<FlatExtensionHostAPI>>
     enableGoImportsSearchQueryTransform: undefined | boolean
-    eventLogger: EventLogger
+    eventLogger: SharedEventLogger
 }): Observable<string> {
     // We apply any non-extension transform before we send the query to the
     // extensions since we want these to take presedence over the extensions.

--- a/client/shared/src/api/client/search.ts
+++ b/client/shared/src/api/client/search.ts
@@ -5,6 +5,7 @@ import { from, Observable, of, TimeoutError } from 'rxjs'
 import { catchError, filter, first, switchMap, timeout } from 'rxjs/operators'
 
 import { FlatExtensionHostAPI } from '../contract'
+import { SharedEventLogger } from '../sharedEventLogger'
 
 import { wrapRemoteObservable } from './api/common'
 
@@ -63,7 +64,7 @@ export function transformSearchQuery({
     )
 }
 
-function goImportsTransform(query: string, eventLogger: EventLogger): string {
+function goImportsTransform(query: string, eventLogger: SharedEventLogger): string {
     const goImportsRegex = /\bgo.imports:(\S*)/
     if (query.match(goImportsRegex)) {
         // Get package name
@@ -83,8 +84,4 @@ function goImportsTransform(query: string, eventLogger: EventLogger): string {
         return query.replace(goImportsRegex, finalRegex)
     }
     return query
-}
-
-interface EventLogger {
-    log: (eventLabel: string, eventProperties?: any) => void
 }

--- a/client/shared/src/api/sharedEventLogger.ts
+++ b/client/shared/src/api/sharedEventLogger.ts
@@ -1,0 +1,5 @@
+// An interface that we can depent on in the shared package which is implemented
+// by the event loggers.
+export interface SharedEventLogger {
+    log: (eventLabel: string, eventProperties?: any, publicArgument?: any) => void
+}

--- a/client/web/src/notebooks/notebook/index.ts
+++ b/client/web/src/notebooks/notebook/index.ts
@@ -18,6 +18,7 @@ import { UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 
 import { Block, BlockInit, BlockDependencies, BlockInput, BlockDirection, SymbolBlockInput } from '..'
 import { NotebookFields, SearchPatternType } from '../../graphql-operations'
+import { eventLogger } from '../../tracking/eventLogger'
 import { parseBrowserRepoURL } from '../../util/url'
 import { createNotebook } from '../backend'
 import { fetchSuggestions } from '../blocks/suggestions/suggestions'
@@ -161,6 +162,7 @@ export class Notebook {
                             query,
                             extensionHostAPIPromise: extensionHostAPI,
                             enableGoImportsSearchQueryTransform,
+                            eventLogger,
                         }),
                         {
                             version: LATEST_VERSION,

--- a/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
+++ b/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
@@ -4,11 +4,12 @@ import { useCallback, useEffect, useState } from 'react'
 import { Unsubscribable } from 'rxjs'
 
 import { isErrorLike } from '@sourcegraph/common'
-import { PlatformContext } from '@sourcegraph/shared/out/src/platform/context'
-import { SettingsCascadeOrError } from '@sourcegraph/shared/out/src/settings/settings'
+import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
+import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { Popover, PopoverContent, PopoverTrigger, Position } from '@sourcegraph/wildcard'
 
-import { SimpleActionItem } from '../../../shared/src/actions/SimpleActionItem'
+import { eventLogger } from '../tracking/eventLogger'
 
 import { getEditorSettingsErrorMessage } from './build-url'
 import type { EditorSettings } from './editor-settings'
@@ -99,13 +100,14 @@ export const OpenInEditorActionItem: React.FunctionComponent<OpenInEditorActionI
                             key={editor.id}
                             tooltip={`Open file in ${editor?.name}`}
                             iconURL={`${assetsRoot}/img/editors/${editor.id}.svg`}
-                            onClick={() =>
+                            onClick={() => {
+                                eventLogger.log('OpenInEditorClicked', { editor: editor.id }, { editor: editor.id })
                                 openCurrentUrlInEditor(
                                     settings?.openInEditor,
                                     props.platformContext.sourcegraphURL,
                                     index
                                 )
-                            }
+                            }}
                         />
                     )
             )}

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 
-import type { UIRangeSpec } from '@sourcegraph/shared/out/src/util/url'
+import type { UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 
 import type { EditorReplacements, EditorSettings } from './editor-settings'
 import { Editor, getEditor, supportedEditors } from './editors'

--- a/client/web/src/repo/actions/ToggleBlameAction.tsx
+++ b/client/web/src/repo/actions/ToggleBlameAction.tsx
@@ -6,6 +6,7 @@ import classNames from 'classnames'
 import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { useExperimentalFeatures } from '../../stores'
+import { eventLogger } from '../../tracking/eventLogger'
 import { useBlameVisibility } from '../blame/useBlameVisibility'
 import { RepoHeaderActionButtonLink, RepoHeaderActionMenuItem } from '../components/RepoHeaderActions'
 
@@ -25,7 +26,15 @@ export const ToggleBlameAction: React.FC<{ actionType?: 'nav' | 'dropdown'; file
 
     const descriptiveText = `${isBlameVisible ? 'Hide' : 'Show'} Git blame line annotations`
 
-    const toggleBlameState = useCallback(() => setIsBlameVisible(!isBlameVisible), [isBlameVisible, setIsBlameVisible])
+    const toggleBlameState = useCallback(() => {
+        if (isBlameVisible) {
+            setIsBlameVisible(false)
+            eventLogger.log('GitBlameDisabled')
+        } else {
+            setIsBlameVisible(true)
+            eventLogger.log('GitBlameEnabled')
+        }
+    }, [isBlameVisible, setIsBlameVisible])
 
     if (!extensionsAsCoreFeatures) {
         return null

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -174,7 +174,7 @@ export const BlameDecoration: React.FunctionComponent<{
                             target="_blank"
                             rel="noreferrer noopener"
                             className={styles.link}
-                            onClick={() => eventLogger.log('GitBlamePopupClicked')}
+                            onClick={logCommitClick}
                         >
                             {blameHunk.message}
                         </Link>
@@ -183,4 +183,8 @@ export const BlameDecoration: React.FunctionComponent<{
             </PopoverContent>
         </Popover>
     )
+}
+
+const logCommitClick = (): void => {
+    eventLogger.log('GitBlamePopupClicked', { target: 'commit' }, { target: 'commit' })
 }

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -16,6 +16,7 @@ import {
     useObservable,
 } from '@sourcegraph/wildcard'
 
+import { eventLogger } from '../../tracking/eventLogger'
 import { BlameHunk } from '../blame/useBlameHunks'
 
 import styles from './BlameDecoration.module.scss'
@@ -107,7 +108,10 @@ export const BlameDecoration: React.FunctionComponent<{
     onDeselect?: (line: number) => void
 }> = ({ line, blameHunk, onSelect, onDeselect }) => {
     const id = line?.toString() || ''
-    const onOpen = useCallback(() => onSelect?.(line), [onSelect, line])
+    const onOpen = useCallback(() => {
+        onSelect?.(line)
+        eventLogger.log('GitBlamePopupViewed')
+    }, [onSelect, line])
     const onClose = useCallback(() => onDeselect?.(line), [onDeselect, line])
     const { isOpen, open, close, closeWithTimeout, openWithTimeout } = usePopover({
         id,
@@ -170,6 +174,7 @@ export const BlameDecoration: React.FunctionComponent<{
                             target="_blank"
                             rel="noreferrer noopener"
                             className={styles.link}
+                            onClick={() => eventLogger.log('GitBlamePopupClicked')}
                         >
                             {blameHunk.message}
                         </Link>

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -23,6 +23,7 @@ import { LoadingSpinner, Button, useObservable } from '@sourcegraph/wildcard'
 import { PageTitle } from '../components/PageTitle'
 import { SearchPatternType } from '../graphql-operations'
 import { useExperimentalFeatures } from '../stores'
+import { eventLogger } from '../tracking/eventLogger'
 
 import { parseSearchURLQuery, parseSearchURLPatternType, SearchStreamingProps } from '.'
 
@@ -70,6 +71,7 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
             query,
             extensionHostAPIPromise: extensionHostAPI,
             enableGoImportsSearchQueryTransform,
+            eventLogger,
         })
     }, [props.location.search, extensionHostAPI, enableGoImportsSearchQueryTransform])
 

--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -14,6 +14,7 @@ import { useObservable } from '@sourcegraph/wildcard'
 
 import { SearchStreamingProps } from '..'
 import { useExperimentalFeatures } from '../../stores'
+import { eventLogger } from '../../tracking/eventLogger'
 
 interface CachedResults {
     results: AggregateStreamingSearchResults | undefined
@@ -54,6 +55,7 @@ export function useCachedSearchResults(
                 query,
                 extensionHostAPIPromise: extensionHostAPI,
                 enableGoImportsSearchQueryTransform,
+                eventLogger,
             }),
         [query, extensionHostAPI, enableGoImportsSearchQueryTransform]
     )

--- a/client/web/src/search/results/useExportSearchResultsQuery.ts
+++ b/client/web/src/search/results/useExportSearchResultsQuery.ts
@@ -7,6 +7,8 @@ import { SearchPatternTypeProps } from '@sourcegraph/search'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { IQuery, SearchResult } from '@sourcegraph/shared/src/schema'
 
+import { eventLogger } from '../../tracking/eventLogger'
+
 interface ExportSearchResultsConfig extends SearchPatternTypeProps, Pick<PlatformContext, 'sourcegraphURL'> {
     query: string
 }
@@ -142,6 +144,7 @@ export const useExportSearchResultsQuery: UseExportSearchResultsQuery = ({
             onCompleted: data => {
                 const results = data.search?.results.results
                 if (!results?.length || !results[0]) {
+                    eventLogger.log('SearchExportFailed')
                     throw new Error('No results to be exported.')
                 }
                 const content = searchResultsToFileContent(results, sourcegraphURL)
@@ -154,6 +157,7 @@ export const useExportSearchResultsQuery: UseExportSearchResultsQuery = ({
                 a.style.display = 'none'
                 a.download = downloadFilename
                 a.click()
+                eventLogger.log('SearchExportPerformed', { count: results.length }, { count: results.length })
 
                 // cleanup
                 a.remove()

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -4,6 +4,7 @@ import { catchError, map, publishReplay, refCount, take } from 'rxjs/operators'
 import * as uuid from 'uuid'
 
 import { isErrorLike, isFirefox } from '@sourcegraph/common'
+import { SharedEventLogger } from '@sourcegraph/shared/src/api/sharedEventLogger'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { UTMMarker } from '@sourcegraph/shared/src/tracking/utm'
 
@@ -65,7 +66,7 @@ const browserExtensionMessageReceived: Observable<{ platform?: string; version?:
     refCount()
 )
 
-export class EventLogger implements TelemetryService {
+export class EventLogger implements TelemetryService, SharedEventLogger {
     private hasStrippedQueryParameters = false
 
     private anonymousUserID = ''


### PR DESCRIPTION
Part of #40257

This PR adds tracking for the following migrated extensions:

- [x] Git blame
  - `GitBlameEnabled`
  - `GitBlameDisabled`
  - `GitBlamePopupViewed`
  - `GitBlamePopupClicked`
- [x] Search exports
  - `SearchExportPerformed`
  - `SearchExportFailed`
- [x] Go imports
  - `GoImportsSearchQueryTransformed`
- [x] Open in editor
  - `OpenInEditorClicked`

## Test plan

https://user-images.githubusercontent.com/458591/188446748-2344b65b-3cfc-4c89-989a-2428c326a9b8.mov

![Screenshot 2022-09-07 at 14 34 39](https://user-images.githubusercontent.com/458591/188879419-72330b9c-fe4c-412e-833e-4625a7236cc4.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-migrated-extensions-tracking.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-whacbdhsqm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
