### PR TITLE
status messages: add a tail to the popover

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -15,6 +15,7 @@ import {
     Link,
     Popover,
     PopoverContent,
+    PopoverTail,
     PopoverTrigger,
     Position,
     Icon,
@@ -277,7 +278,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                 {icon}
             </PopoverTrigger>
 
-            <PopoverContent position={Position.bottomEnd} className={classNames('p-0', styles.dropdownMenu)}>
+            <PopoverContent position={Position.bottom} className={classNames('p-0', styles.dropdownMenu)}>
                 <div className={styles.dropdownMenuContent}>
                     <small className={classNames('d-inline-block text-muted', styles.sync)}>Status</small>
                     {error && (
@@ -286,6 +287,8 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                     {messages}
                 </div>
             </PopoverContent>
+
+            <PopoverTail />
         </Popover>
     )
 }


### PR DESCRIPTION
Great suggestion by @vovakulikov.

## Screenshot

<img width="460" alt="screenshot_2022-09-05_15 29 44@2x" src="https://user-images.githubusercontent.com/1185253/188461117-e3077f7d-7bf4-4aba-b5e0-9d6245d88c6d.png">

## Test plan

- Manual testing

## App preview:

- [Web](https://sg-web-mrn-status-messages-tail.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pphhrxihlt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
