### PR TITLE
user-management: exclude non-active-user-events from "events_count" aggregation

### DIFF
--- a/internal/eventlogger/event_logger.go
+++ b/internal/eventlogger/event_logger.go
@@ -19,6 +19,23 @@ type TelemetryRequest struct {
 	PublicArgument json.RawMessage
 }
 
+var NonActiveUserEvents = []string{
+	"ViewSignIn",
+	"ViewSignUp",
+	"SignOutAttempted",
+	"SignOutFailed",
+	"SignOutSucceeded",
+	"SignInAttempted",
+	"SignInFailed",
+	"SignInSucceeded",
+	"PasswordResetRequested",
+	"PasswordRandomized",
+	"PasswordChanged",
+	"EmailVerified",
+	"ExternalAuthSignupFailed",
+	"ExternalAuthSignupSucceeded",
+}
+
 // LogEvent sends a payload representing an event to the api/telemetry endpoint.
 //
 // This method should be invoked after the frontend service has started. It is

--- a/internal/eventlogger/event_logger.go
+++ b/internal/eventlogger/event_logger.go
@@ -19,6 +19,8 @@ type TelemetryRequest struct {
 	PublicArgument json.RawMessage
 }
 
+// List of events that don't meet the criteria of "active" usage of Sourcegraph.
+// These are mostly actions taken by signed-out users.
 var NonActiveUserEvents = []string{
 	"ViewSignIn",
 	"ViewSignUp",

--- a/internal/users/update_aggregated_stats_job.go
+++ b/internal/users/update_aggregated_stats_job.go
@@ -3,11 +3,13 @@ package users
 import (
 	"context"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/eventlogger"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
@@ -24,7 +26,7 @@ var (
 				user_id,
 				MAX(timestamp) AS last_active_at,
 				-- count billable only events for each user
-				COUNT(*) FILTER (WHERE name NOT IN ('ViewSignIn', 'ViewResetPassword')) AS events_count
+				COUNT(*) FILTER (WHERE name NOT IN ('` + strings.Join(eventlogger.NonActiveUserEvents, "','") + `')) AS events_count
 			FROM
 				event_logs
 			GROUP BY


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41250.

## Test plan
- Check the diff

OR

- Delete all rows from `aggregated_user_statistics` table
- `sg start`
- wait ~5 minutes for user statistics aggregation job to start/finish
- Open http://localhost:3080/site-admin/users
- Check that the "Events" and "Last Active" columns are populated with data
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
