### PR TITLE
Add first integration tests for `repositories()` GraphQL query

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1255,7 +1255,7 @@ type Query {
         """
         notIndexed: Boolean = true
         """
-        Include repositories that have encountered errors when cloning or fetching
+        Include only repositories that have encountered errors when cloning or fetching
         """
         failedFetch: Boolean = false
         """


### PR DESCRIPTION
Before I refactor the argument handling and (hopefully) the `TotalCount` stuff I want to add some integration tests to document the behaviour and make sure it works - without a mocked out database and through the whole stack.

## Test plan

- These are the tests
