### PR TITLE
ranking: flush result queue after X ms

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -91,7 +91,7 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 	// maxQueueDepth should be chosen as large as possible given the available
 	// resources.
 	if maxReorderDuration > 0 {
-		done := make(chan struct{}, 1)
+		done := make(chan struct{})
 		defer close(done)
 
 		go func() {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1538,8 +1538,8 @@ type QuickLink struct {
 
 // Ranking description: Experimental search result ranking options.
 type Ranking struct {
-	// MaxReorderDuration description: The maximum time in milliseconds we wait until we flush the results queue. The default is 50. 0 is unbounded. The larger the value the more stable the ranking and the higher the MEM pressure on frontend.
-	MaxReorderDuration *int `json:"maxReorderDuration,omitempty"`
+	// MaxReorderDurationMS description: The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.
+	MaxReorderDurationMS int `json:"maxReorderDurationMS,omitempty"`
 	// MaxReorderQueueSize description: The maximum number of search results that can be buffered to sort results. -1 is unbounded. The default is 24. Set this to small integers to limit latency increases from slow backends.
 	MaxReorderQueueSize *int `json:"maxReorderQueueSize,omitempty"`
 	// RepoScores description: a map of URI directories to numeric scores for specifying search result importance, like {"github.com": 500, "github.com/sourcegraph": 300, "github.com/sourcegraph/sourcegraph": 100}. Would rank "github.com/sourcegraph/sourcegraph" as 500+300+100=900, and "github.com/other/foo" as 500.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1538,6 +1538,8 @@ type QuickLink struct {
 
 // Ranking description: Experimental search result ranking options.
 type Ranking struct {
+	// MaxReorderDuration description: The maximum time in milliseconds we wait until we flush the results queue. The default is 50. 0 is unbounded. The larger the value the more stable the ranking and the higher the MEM pressure on frontend.
+	MaxReorderDuration *int `json:"maxReorderDuration,omitempty"`
 	// MaxReorderQueueSize description: The maximum number of search results that can be buffered to sort results. -1 is unbounded. The default is 24. Set this to small integers to limit latency increases from slow backends.
 	MaxReorderQueueSize *int `json:"maxReorderQueueSize,omitempty"`
 	// RepoScores description: a map of URI directories to numeric scores for specifying search result importance, like {"github.com": 500, "github.com/sourcegraph": 300, "github.com/sourcegraph/sourcegraph": 100}. Would rank "github.com/sourcegraph/sourcegraph" as 500+300+100=900, and "github.com/other/foo" as 500.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -491,12 +491,11 @@
               "group": "Search",
               "!go": { "pointer": true }
             },
-            "maxReorderDuration": {
+            "maxReorderDurationMS": {
               "description": "The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.",
               "type": "integer",
               "default": 0,
-              "group": "Search",
-              "!go": {"pointer":  true}
+              "group": "Search"
             }
           }
         },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -490,6 +490,13 @@
               "type": "integer",
               "group": "Search",
               "!go": { "pointer": true }
+            },
+            "maxReorderDuration": {
+              "description": "The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.",
+              "type": "integer",
+              "default": 0,
+              "group": "Search",
+              "!go": {"pointer":  true}
             }
           }
         },


### PR DESCRIPTION
We flush the result queue after maxReorderDuration ms. The default is 0
which maintains the current behavior.

For now this is just an experiment to better understand the dynamic of
the result queue.

Why?

So far we flush the queue if

(1) all pending results have lower priority, or
(2) the queue is full

For searches with very common terms, the result queue fills up quickly,
sometimes giving us not enough time to search some of the most popular,
larger repositories.

Example:
The shard size of golang/go is around 200mb. A search with common terms,
such as "http" and "get", yields results from a lot of repositories,
most of which are tiny. The result queue fills up before we finished
searching golang/go. Therefore results from golang/go frequently don't
show up if searches are too broad.

I confirmed this scenario by splitting golang/go in many smaller shards. 
Once the shards were smaller, their results showed up in Sourcegraph.
However, increasing the number of shards comes at a cost of MEM and DISK
for Zoekt.

Note: We could simply increase the queue length until results from golang/go
show up. However, setting a duration is a much more direct measure that
translates to a budget per Zoekt instance instead of to an overall
budget shared by all instances.

Experiments on .com indicate that a reasonable value for
maxReorderDuration could be around 50ms.

## Test plan
- existing tests
- the default setting is a NOP
- local testing, setting various values of maxReorderDuration

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
