### PR TITLE
log: lower log level for some less important auth errors

### DIFF
--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -211,7 +211,7 @@ func handleSignUp(logger log.Logger, db database.DB, w http.ResponseWriter, r *h
 	// Write the session cookie
 	a := &actor.Actor{UID: usr.ID}
 	if err := session.SetActor(w, r, a, 0, usr.CreatedAt); err != nil {
-		httpLogAndError(logger, w, "Could not create new user session", http.StatusInternalServerError, log.Error(err))
+		httpLogError(logger, log.LevelError, w, "Could not create new user session", http.StatusInternalServerError, log.Error(err))
 	}
 
 	// Track user data
@@ -283,7 +283,7 @@ func HandleSignIn(logger log.Logger, db database.DB, store LockoutStore) http.Ha
 		// Validate user. Allow login by both email and username (for convenience).
 		u, err := getByEmailOrUsername(ctx, db, creds.Email)
 		if err != nil {
-			httpLogAndError(logger, w, "Authentication failed", http.StatusUnauthorized, log.Error(err))
+			httpLogError(logger, log.LevelWarn, w, "Authentication failed", http.StatusUnauthorized, log.Error(err))
 			return
 		}
 		user = *u
@@ -307,18 +307,18 @@ func HandleSignIn(logger log.Logger, db database.DB, store LockoutStore) http.Ha
 				}
 			}()
 
-			httpLogAndError(logger, w, fmt.Sprintf("Account has been locked out due to %q", reason), http.StatusUnprocessableEntity)
+			httpLogError(logger, log.LevelError, w, fmt.Sprintf("Account has been locked out due to %q", reason), http.StatusUnprocessableEntity)
 			return
 		}
 
 		// 🚨 SECURITY: check password
 		correct, err := db.Users().IsPassword(ctx, user.ID, creds.Password)
 		if err != nil {
-			httpLogAndError(logger, w, "Error checking password", http.StatusInternalServerError, log.Error(err))
+			httpLogError(logger, log.LevelError, w, "Error checking password", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 		if !correct {
-			httpLogAndError(logger, w, "Authentication failed", http.StatusUnauthorized)
+			httpLogError(logger, log.LevelWarn, w, "Authentication failed", http.StatusUnauthorized)
 			return
 		}
 
@@ -327,7 +327,7 @@ func HandleSignIn(logger log.Logger, db database.DB, store LockoutStore) http.Ha
 			UID: user.ID,
 		}
 		if err := session.SetActor(w, r, &actor, 0, user.CreatedAt); err != nil {
-			httpLogAndError(logger, w, "Could not create new user session", http.StatusInternalServerError, log.Error(err))
+			httpLogError(logger, log.LevelError, w, "Could not create new user session", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 
@@ -365,7 +365,7 @@ func HandleUnlockAccount(logger log.Logger, _ database.DB, store LockoutStore) h
 			if error != nil {
 				err = error.Error()
 			}
-			httpLogAndError(logger, w, err, http.StatusUnauthorized)
+			httpLogError(logger, log.LevelWarn, w, err, http.StatusUnauthorized)
 			return
 		}
 	}
@@ -418,7 +418,7 @@ func HandleCheckUsernameTaken(logger log.Logger, db database.DB) http.HandlerFun
 			return
 		}
 		if err != nil {
-			httpLogAndError(logger, w, "Error checking username uniqueness", http.StatusInternalServerError, log.Error(err))
+			httpLogError(logger, log.LevelError, w, "Error checking username uniqueness", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 
@@ -426,7 +426,18 @@ func HandleCheckUsernameTaken(logger log.Logger, db database.DB) http.HandlerFun
 	}
 }
 
-func httpLogAndError(logger log.Logger, w http.ResponseWriter, msg string, code int, errArgs ...log.Field) {
-	logger.Error(msg, errArgs...)
+func httpLogError(logger log.Logger, level log.Level, w http.ResponseWriter, msg string, code int, errArgs ...log.Field) {
+	switch level {
+	case log.LevelInfo:
+		logger.Info(msg, errArgs...)
+	case log.LevelWarn:
+		logger.Warn(msg, errArgs...)
+	case log.LevelDebug:
+		logger.Debug(msg, errArgs...)
+	case log.LevelError:
+		logger.Error(msg, errArgs...)
+	default:
+		logger.Error(msg, errArgs...)
+	}
 	http.Error(w, msg, code)
 }

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -46,7 +46,7 @@ func HandleResetPasswordInit(logger log.Logger, db database.DB) http.HandlerFunc
 			return
 		}
 		if !conf.CanSendEmail() {
-			httpLogAndError(logger, w, "Unable to reset password because email sending is not configured on this site", http.StatusNotFound)
+			httpLogError(logger, log.LevelError, w, "Unable to reset password because email sending is not configured on this site", http.StatusNotFound)
 			return
 		}
 
@@ -55,12 +55,12 @@ func HandleResetPasswordInit(logger log.Logger, db database.DB) http.HandlerFunc
 			Email string `json:"email"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&formData); err != nil {
-			httpLogAndError(logger, w, "Could not decode password reset request body", http.StatusBadRequest, log.Error(err))
+			httpLogError(logger, log.LevelError, w, "Could not decode password reset request body", http.StatusBadRequest, log.Error(err))
 			return
 		}
 
 		if formData.Email == "" {
-			httpLogAndError(logger, w, "No email specified in password reset request", http.StatusBadRequest)
+			httpLogError(logger, log.LevelWarn, w, "No email specified in password reset request", http.StatusBadRequest)
 			return
 		}
 
@@ -69,22 +69,22 @@ func HandleResetPasswordInit(logger log.Logger, db database.DB) http.HandlerFunc
 			// 🚨 SECURITY: We don't show an error message when the user is not found
 			// as to not leak the existence of a given e-mail address in the database.
 			if !errcode.IsNotFound(err) {
-				httpLogAndError(logger, w, "Failed to lookup user", http.StatusInternalServerError)
+				httpLogError(logger, log.LevelWarn, w, "Failed to lookup user", http.StatusInternalServerError)
 			}
 			return
 		}
 
 		resetURL, err := backend.MakePasswordResetURL(ctx, db, usr.ID)
 		if err == database.ErrPasswordResetRateLimit {
-			httpLogAndError(logger, w, "Too many password reset requests. Try again in a few minutes.", http.StatusTooManyRequests, log.Error(err))
+			httpLogError(logger, log.LevelWarn, w, "Too many password reset requests. Try again in a few minutes.", http.StatusTooManyRequests, log.Error(err))
 			return
 		} else if err != nil {
-			httpLogAndError(logger, w, "Could not reset password", http.StatusBadRequest, log.Error(err))
+			httpLogError(logger, log.LevelError, w, "Could not reset password", http.StatusBadRequest, log.Error(err))
 			return
 		}
 
 		if err := SendResetPasswordURLEmail(r.Context(), formData.Email, usr.Username, resetURL); err != nil {
-			httpLogAndError(logger, w, "Could not send reset password email", http.StatusInternalServerError, log.Error(err))
+			httpLogError(logger, log.LevelError, w, "Could not send reset password email", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 		database.LogPasswordEvent(ctx, db, r, database.SecurityEventNamPasswordResetRequested, usr.ID)
@@ -185,7 +185,7 @@ func HandleResetPasswordCode(logger log.Logger, db database.DB) http.HandlerFunc
 			Password string `json:"password"` // new password
 		}
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-			httpLogAndError(logger, w, "Password reset with code: could not decode request body", http.StatusBadGateway, log.Error(err))
+			httpLogError(logger, log.LevelError, w, "Password reset with code: could not decode request body", http.StatusBadGateway, log.Error(err))
 			return
 		}
 
@@ -196,7 +196,7 @@ func HandleResetPasswordCode(logger log.Logger, db database.DB) http.HandlerFunc
 
 		success, err := db.Users().SetPassword(ctx, params.UserID, params.Code, params.Password)
 		if err != nil {
-			httpLogAndError(logger, w, "Unexpected error", http.StatusInternalServerError, log.Error(err))
+			httpLogError(logger, log.LevelError, w, "Unexpected error", http.StatusInternalServerError, log.Error(err))
 			return
 		}
 


### PR DESCRIPTION
Was looking at Sentry for S2 and noticed a few error reports that should not be reported in the first place. 

Avoid reporting errors caused by the most common incorrect user inputs. 

@ryanslade I mentioned you because it seems you edited those recently. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Log level changes, CI should catch errors. 
