### PR TITLE
use theme background for get started card (Analytics)

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.module.scss
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.module.scss
@@ -64,7 +64,7 @@
 }
 
 .get-started-box {
-    background: var(--gray-01);
+    background: var(--color-bg-1);
     border: 1px solid var(--border-color-2);
     padding: 1rem;
     border-radius: 3px;


### PR DESCRIPTION
The newly added Get Started card on the Analytics Overview page isn't properly visible when in dark mode.

| Before  | After  |
|---|---|
| <img width="933" alt="CleanShot 2022-09-05 at 20 50 31@2x" src="https://user-images.githubusercontent.com/25608335/188507781-13ccd740-0461-4886-bd45-b12fd6fdfbb0.png">  | <img width="958" alt="CleanShot 2022-09-05 at 20 40 09@2x" src="https://user-images.githubusercontent.com/25608335/188507849-25c86e38-d0d7-47b7-a78b-bcc65970d313.png"> |
| | <img width="962" alt="CleanShot 2022-09-05 at 20 40 19@2x" src="https://user-images.githubusercontent.com/25608335/188507832-04c9d6b6-1870-4432-a0b0-1a0ffa407ed9.png"> |




## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Ensure the Analytics overview page is visible in dark mode.

## App preview:

- [Web](https://sg-web-bo-fix-get-started-background.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-agyvetctgo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
