### PR TITLE
search: remove nodes value annotation

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -655,7 +655,7 @@ func space(patterns []Pattern) []Node {
 //
 // The callback parameter defines how the function concatenates patterns. The
 // return value of callback is substituted in-place in the tree.
-func substituteConcat(callback func([]Pattern) []Node) func(nodes []Node) []Node {
+func substituteConcat(callback func([]Pattern) []Node) func([]Node) []Node {
 	isPattern := func(node Node) bool {
 		if pattern, ok := node.(Pattern); ok && !pattern.Negated {
 			return true


### PR DESCRIPTION
Prep for other things, noticed this `nodes` value isn't referenced for anything and made things a bit confusing.

## Test plan
Semantics-preserving
