### PR TITLE
search: emit query input for lucky tests

### DIFF
--- a/internal/search/lucky/generator_test.go
+++ b/internal/search/lucky/generator_test.go
@@ -10,6 +10,7 @@ import (
 
 type want struct {
 	Description string
+	Input       string
 	Query       string
 }
 
@@ -18,7 +19,7 @@ func TestNewGenerator(t *testing.T) {
 		q, _ := query.ParseStandard(input)
 		b, _ := query.ToBasicQuery(q)
 		g := NewGenerator(b, rulesNarrow, rulesWiden)
-		result, _ := json.MarshalIndent(generateAll(g), "", "  ")
+		result, _ := json.MarshalIndent(generateAll(g, input), "", "  ")
 		return string(result)
 	}
 
@@ -35,7 +36,7 @@ func TestNewGenerator(t *testing.T) {
 	}
 }
 
-func generateAll(g next) []want {
+func generateAll(g next, input string) []want {
 	var autoQ *autoQuery
 	generated := []want{}
 	for {
@@ -45,6 +46,7 @@ func generateAll(g next) []want {
 				generated,
 				want{
 					Description: autoQ.description,
+					Input:       input,
 					Query:       query.StringHuman(autoQ.query.ToParseTree()),
 				})
 		}

--- a/internal/search/lucky/testdata/TestNewGenerator/rule_application#01.golden
+++ b/internal/search/lucky/testdata/TestNewGenerator/rule_application#01.golden
@@ -1,14 +1,17 @@
 [
   {
     "Description": "apply search type for pattern ⚬ apply language filter for pattern",
+    "Input": "go commit yikes derp",
     "Query": "type:commit lang:Go yikes derp"
   },
   {
     "Description": "apply search type for pattern",
+    "Input": "go commit yikes derp",
     "Query": "type:commit go yikes derp"
   },
   {
     "Description": "apply language filter for pattern",
+    "Input": "go commit yikes derp",
     "Query": "lang:Go commit yikes derp"
   }
 ]

--- a/internal/search/lucky/testdata/TestNewGenerator/rule_application#02.golden
+++ b/internal/search/lucky/testdata/TestNewGenerator/rule_application#02.golden
@@ -1,6 +1,7 @@
 [
   {
     "Description": "AND patterns together",
+    "Input": "go commit yikes derp",
     "Query": "(go AND commit AND yikes AND derp)"
   }
 ]

--- a/internal/search/lucky/testdata/TestNewGenerator/rule_application.golden
+++ b/internal/search/lucky/testdata/TestNewGenerator/rule_application.golden
@@ -1,30 +1,37 @@
 [
   {
     "Description": "apply search type for pattern ⚬ apply language filter for pattern",
+    "Input": "go commit yikes derp",
     "Query": "type:commit lang:Go yikes derp"
   },
   {
     "Description": "apply search type for pattern",
+    "Input": "go commit yikes derp",
     "Query": "type:commit go yikes derp"
   },
   {
     "Description": "apply language filter for pattern",
+    "Input": "go commit yikes derp",
     "Query": "lang:Go commit yikes derp"
   },
   {
     "Description": "apply search type for pattern ⚬ apply language filter for pattern ⚬ AND patterns together",
+    "Input": "go commit yikes derp",
     "Query": "type:commit lang:Go (yikes AND derp)"
   },
   {
     "Description": "apply search type for pattern ⚬ AND patterns together",
+    "Input": "go commit yikes derp",
     "Query": "type:commit (go AND yikes AND derp)"
   },
   {
     "Description": "apply language filter for pattern ⚬ AND patterns together",
+    "Input": "go commit yikes derp",
     "Query": "lang:Go (commit AND yikes AND derp)"
   },
   {
     "Description": "AND patterns together",
+    "Input": "go commit yikes derp",
     "Query": "(go AND commit AND yikes AND derp)"
   }
 ]


### PR DESCRIPTION
As in title. Prep to make it easy to compare input/output (planning to remove lucky deduplication)

## Test plan
Updates tests, semantics-preserving.
