### PR TITLE
Add audit.Log API to the system

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -15,7 +15,7 @@ import (
 // action - caller supplied, free form (log message)
 // entity - caller supplied, free form (should describe the component that's being audited)
 // context - any additional logging fields (log.Field)
-func Log(logger log.Logger, ctx context.Context, record *Record) {
+func Log(ctx context.Context, logger log.Logger, record *Record) {
 	var fields []log.Field
 	fields = append(fields, log.String("audit", "true"))
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -15,18 +15,27 @@ import (
 func Log(ctx context.Context, logger log.Logger, record Record) {
 	var fields []log.Field
 
-	act := actor.FromContext(ctx)
 	client := requestclient.FromContext(ctx)
 
 	fields = append(fields, log.Object("audit",
 		log.String("entity", record.Entity),
 		log.Object("actor",
-			log.String("actorUID", act.UIDString()),
+			log.String("actorUID", actorId(actor.FromContext(ctx))),
 			log.String("ip", ip(client)),
 			log.String("X-Forwarded-For", forwardedFor(client)))))
 	fields = append(fields, record.Fields...)
 
 	logger.Info(record.Action, fields...)
+}
+
+func actorId(act *actor.Actor) string {
+	if act.UID > 0 {
+		return act.UIDString()
+	}
+	if act.AnonymousUID != "" {
+		return act.AnonymousUID
+	}
+	return "unknown"
 }
 
 func ip(client *requestclient.Client) string {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -10,11 +10,8 @@ import (
 )
 
 // Log creates an INFO log statement that will be a part of the audit log.
-// The audit log records comply with the following design: an actor takes an action on an entity within a context
-// actor - obtained from the context
-// action - caller supplied, free form (log message)
-// entity - caller supplied, free form (should describe the component that's being audited)
-// context - any additional logging fields (log.Field)
+// The audit log records comply with the following design: an actor takes an action on an entity within a context.
+// Refer to Record struct to see details about individual components.
 func Log(ctx context.Context, logger log.Logger, record *Record) {
 	var fields []log.Field
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,56 @@
+package audit
+
+import (
+	"context"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/requestclient"
+)
+
+// Log creates an INFO log statement that will be a part of the audit log.
+// The audit log records comply with the following design: an actor takes an action on an entity within a context
+// actor - obtained from the context
+// action - caller supplied, free form (log message)
+// entity - caller supplied, free form (should describe the component that's being audited)
+// context - any additional logging fields (log.Field)
+func Log(logger log.Logger, ctx context.Context, record *Record) {
+	var fields []log.Field
+	fields = append(fields, log.String("audit", "true"))
+
+	act := actor.FromContext(ctx)
+	client := requestclient.FromContext(ctx)
+
+	fields = append(fields, log.Object("audit.actor",
+		log.String("actorUID", act.UIDString()),
+		log.String("ip", ip(client)),
+		log.String("X-Forwarded-For", forwardedFor(client))))
+	fields = append(fields, log.String("audit.entity", record.Entity))
+	fields = append(fields, record.Fields...)
+
+	logger.Info(record.Action, fields...)
+}
+
+func ip(client *requestclient.Client) string {
+	if client == nil {
+		return "unknown"
+	}
+	return client.IP
+}
+
+func forwardedFor(client *requestclient.Client) string {
+	if client == nil {
+		return "unknown"
+	}
+	return client.ForwardedFor
+}
+
+type Record struct {
+	// The audited entity name
+	Entity string
+	// The audit action taking place
+	Action string
+	// Additional context relevant to the action
+	Fields []log.Field
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -47,10 +47,10 @@ func forwardedFor(client *requestclient.Client) string {
 }
 
 type Record struct {
-	// Entity is the audited entity name
+	// Entity is the name of the audited entity
 	Entity string
-	// Action is he audit action taking place
+	// Action describes the state change relevant to the audit log
 	Action string
-	// Fields hold any additional context relevant to the action
+	// Fields hold any additional context relevant to the Action
 	Fields []log.Field
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -12,7 +12,7 @@ import (
 // Log creates an INFO log statement that will be a part of the audit log.
 // The audit log records comply with the following design: an actor takes an action on an entity within a context.
 // Refer to Record struct to see details about individual components.
-func Log(ctx context.Context, logger log.Logger, record *Record) {
+func Log(ctx context.Context, logger log.Logger, record Record) {
 	var fields []log.Field
 
 	act := actor.FromContext(ctx)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -47,10 +47,10 @@ func forwardedFor(client *requestclient.Client) string {
 }
 
 type Record struct {
-	// The audited entity name
+	// Entity is the audited entity name
 	Entity string
-	// The audit action taking place
+	// Action is he audit action taking place
 	Action string
-	// Additional context relevant to the action
+	// Fields hold any additional context relevant to the action
 	Fields []log.Field
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -17,16 +17,16 @@ import (
 // context - any additional logging fields (log.Field)
 func Log(ctx context.Context, logger log.Logger, record *Record) {
 	var fields []log.Field
-	fields = append(fields, log.String("audit", "true"))
 
 	act := actor.FromContext(ctx)
 	client := requestclient.FromContext(ctx)
 
-	fields = append(fields, log.Object("audit.actor",
-		log.String("actorUID", act.UIDString()),
-		log.String("ip", ip(client)),
-		log.String("X-Forwarded-For", forwardedFor(client))))
-	fields = append(fields, log.String("audit.entity", record.Entity))
+	fields = append(fields, log.Object("audit",
+		log.String("entity", record.Entity),
+		log.Object("actor",
+			log.String("actorUID", act.UIDString()),
+			log.String("ip", ip(client)),
+			log.String("X-Forwarded-For", forwardedFor(client)))))
 	fields = append(fields, record.Fields...)
 
 	logger.Info(record.Action, fields...)

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -27,12 +27,13 @@ func TestLog(t *testing.T) {
 			},
 			additionalContext: []log.Field{log.String("additional", "stuff")},
 			expectedEntry: map[string]interface{}{
-				"audit":        "true",
-				"audit.entity": "test entity",
-				"audit.actor": map[string]interface{}{
-					"actorUID":        "1",
-					"ip":              "192.168.0.1",
-					"X-Forwarded-For": "192.168.0.1",
+				"audit": map[string]interface{}{
+					"entity": "test entity",
+					"actor": map[string]interface{}{
+						"actorUID":        "1",
+						"ip":              "192.168.0.1",
+						"X-Forwarded-For": "192.168.0.1",
+					},
 				},
 				"additional": "stuff",
 			},
@@ -42,12 +43,13 @@ func TestLog(t *testing.T) {
 			client:            nil,
 			additionalContext: []log.Field{log.String("additional", "stuff")},
 			expectedEntry: map[string]interface{}{
-				"audit":        "true",
-				"audit.entity": "test entity",
-				"audit.actor": map[string]interface{}{
-					"actorUID":        "1",
-					"ip":              "unknown",
-					"X-Forwarded-For": "unknown",
+				"audit": map[string]interface{}{
+					"entity": "test entity",
+					"actor": map[string]interface{}{
+						"actorUID":        "1",
+						"ip":              "unknown",
+						"X-Forwarded-For": "unknown",
+					},
 				},
 				"additional": "stuff",
 			},
@@ -60,12 +62,13 @@ func TestLog(t *testing.T) {
 			},
 			additionalContext: nil,
 			expectedEntry: map[string]interface{}{
-				"audit":        "true",
-				"audit.entity": "test entity",
-				"audit.actor": map[string]interface{}{
-					"actorUID":        "1",
-					"ip":              "192.168.0.1",
-					"X-Forwarded-For": "192.168.0.1",
+				"audit": map[string]interface{}{
+					"entity": "test entity",
+					"actor": map[string]interface{}{
+						"actorUID":        "1",
+						"ip":              "192.168.0.1",
+						"X-Forwarded-For": "192.168.0.1",
+					},
 				},
 			},
 		},

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestLog(t *testing.T) {
-	ctx := context.Background()
-	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})
-
 	testCases := []struct {
 		name              string
 		client            *requestclient.Client

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,102 @@
+package audit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/requestclient"
+)
+
+func TestLog(t *testing.T) {
+	ctx := context.Background()
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})
+
+	testCases := []struct {
+		name              string
+		client            *requestclient.Client
+		additionalContext []log.Field
+		expectedEntry     map[string]interface{}
+	}{
+		{
+			name: "fully populated audit data",
+			client: &requestclient.Client{
+				IP:           "192.168.0.1",
+				ForwardedFor: "192.168.0.1",
+			},
+			additionalContext: []log.Field{log.String("additional", "stuff")},
+			expectedEntry: map[string]interface{}{
+				"audit":        "true",
+				"audit.entity": "test entity",
+				"audit.actor": map[string]interface{}{
+					"actorUID":        "1",
+					"ip":              "192.168.0.1",
+					"X-Forwarded-For": "192.168.0.1",
+				},
+				"additional": "stuff",
+			},
+		},
+		{
+			name:              "missing client info",
+			client:            nil,
+			additionalContext: []log.Field{log.String("additional", "stuff")},
+			expectedEntry: map[string]interface{}{
+				"audit":        "true",
+				"audit.entity": "test entity",
+				"audit.actor": map[string]interface{}{
+					"actorUID":        "1",
+					"ip":              "unknown",
+					"X-Forwarded-For": "unknown",
+				},
+				"additional": "stuff",
+			},
+		},
+		{
+			name: "no additional context",
+			client: &requestclient.Client{
+				IP:           "192.168.0.1",
+				ForwardedFor: "192.168.0.1",
+			},
+			additionalContext: nil,
+			expectedEntry: map[string]interface{}{
+				"audit":        "true",
+				"audit.entity": "test entity",
+				"audit.actor": map[string]interface{}{
+					"actorUID":        "1",
+					"ip":              "192.168.0.1",
+					"X-Forwarded-For": "192.168.0.1",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})
+			ctx = requestclient.WithClient(ctx, tc.client)
+
+			fields := &Record{
+				Entity: "test entity",
+				Action: "test audit action",
+				Fields: tc.additionalContext,
+			}
+
+			logger, exportLogs := logtest.Captured(t)
+
+			Log(logger, ctx, fields)
+
+			logs := exportLogs()
+			if len(logs) != 1 {
+				t.Fatal("expected to capture one log exactly")
+			}
+
+			assert.Equal(t, "test audit action", logs[0].Message)
+			assert.Equal(t, tc.expectedEntry, logs[0].Fields)
+		})
+	}
+}

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -85,7 +85,7 @@ func TestLog(t *testing.T) {
 
 			logger, exportLogs := logtest.Captured(t)
 
-			Log(logger, ctx, fields)
+			Log(ctx, logger, fields)
 
 			logs := exportLogs()
 			if len(logs) != 1 {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -80,7 +80,7 @@ func TestLog(t *testing.T) {
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})
 			ctx = requestclient.WithClient(ctx, tc.client)
 
-			fields := &Record{
+			fields := Record{
 				Entity: "test entity",
 				Action: "test audit action",
 				Fields: tc.additionalContext,

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -34,7 +34,6 @@ import (
 	"github.com/sourcegraph/go-rendezvous"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/audit"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -1211,13 +1210,6 @@ func (c *clientImplementor) GetObject(ctx context.Context, repo api.RepoName, ob
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	auditFields := &audit.Record{
-		Entity: "gitserver",
-		Action: "get gitserver object",
-		Fields: []sglog.Field{sglog.String("additional", "stuff")},
-	}
-	audit.Log(c.logger, ctx, auditFields)
 
 	if resp.StatusCode != http.StatusOK {
 		c.logger.Warn("reading gitserver get-object response", sglog.Error(err))

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sourcegraph/go-rendezvous"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/audit"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -1210,6 +1211,13 @@ func (c *clientImplementor) GetObject(ctx context.Context, repo api.RepoName, ob
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	auditFields := &audit.Record{
+		Entity: "gitserver",
+		Action: "get gitserver object",
+		Fields: []sglog.Field{sglog.String("additional", "stuff")},
+	}
+	audit.Log(c.logger, ctx, auditFields)
 
 	if resp.StatusCode != http.StatusOK {
 		c.logger.Warn("reading gitserver get-object response", sglog.Error(err))


### PR DESCRIPTION
## Description

This introduces a new `audit.Log()` API to the system that will be used for appending entries to the audit log (WIP).

For more details, see the following:
- [RFC 732](https://docs.google.com/document/d/12x09FhwKz4hS-r__kPqn8k5pcnhJ_Iy3DHt7p6OKQcY/edit)
- [RFC 734](https://docs.google.com/document/d/1tv1wNxfqtg4qfJ6jhbd9rFMIt1JCEjGEFzvV5j_i-sI/edit#heading=h.trqab8y0kufp)

The new `Log` call delegates to `log.Logger`'s `INFO` call internally, and it enriches the standard INFO log statement with a few extra fields:

```json
{
  "SeverityText": "INFO",
  "Timestamp": 1662548864785662000,
  "InstrumentationScope": "NewClient",
  "Caller": "audit/audit.go:28",
  "Function": "github.com/sourcegraph/sourcegraph/internal/audit.Log",
  "Body": "get gitserver object",
  "Resource": {
    "service.name": "frontend",
    "service.version": "0.0.0+dev",
    "service.instance.id": "Michals-MacBook-Pro.local"
  },
  "Attributes": {
    "audit": {
      "entity": "gitserver",
      "actor": {
        "actorUID": "1",
        "ip": "127.0.0.1",
        "X-Forwarded-For": "127.0.0.1, 127.0.0.1"
      }
    },
    "additional": "stuff"
  }
}
```

We can filter the audit log statements by the presence of the `audit` attribute in the `Attributes` map.

Sample usage:

```
	record := audit.Record{
		Entity: "gitserver",
		Action: "get gitserver object",
		Fields: []sglog.Field{sglog.String("additional", "stuff")},
	}
	audit.Log(c.logger, ctx, record)

```

### Design

- audit log builds on top of our existing logging so that we don't need to think twice about using yet another library along our standard logging, and instrumentation libraries
- an audit log entry should read like: "**an actor takes an action on entity**"; see the [Godoc snippet](https://github.com/sourcegraph/sourcegraph/pull/41345/files#diff-fc56f9872288b6e7bfb24f645467134436b803fcdcaa254e9949ec45e2dd1d92R14) for how they're computed

### Other options considered

Adding `Audit` method to the `log.Logger` interface, see the PR https://github.com/sourcegraph/log/pull/36

We'll likely close the PR above in favor of this one.

### Next steps

- transform gitserver access logs to audit calls
- transform graphql request logs to audit calls
- tee security events inserts to audit calls

## Test plan

- automated unit tests
- manual testing @localhost 
- will be more widely adopted later
