### PR TITLE
Aggregation: Fix aggregation cache invalidation when case sensitivity has changed

### DIFF
--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -349,21 +349,17 @@ describe('Search aggregation', () => {
                 query: `${origQuery} case:yes`,
             })
 
-            const editor = await createEditorAPI(driver, '[data-testid="searchbox"] .test-query-input')
-            await driver.page.waitForSelector('.test-case-sensitivity-toggle')
-            await editor.focus()
-            await driver.page.keyboard.type('test')
-            await driver.page.click('.test-case-sensitivity-toggle')
-
-            const variablesWithoutCaseSensitivity = await testContext.waitForGraphQLRequest(() => {},
-            'GetSearchAggregation')
+            const variablesWithoutCaseSensitivity = await testContext.waitForGraphQLRequest(
+                async () => driver.page.click('.test-case-sensitivity-toggle'),
+                'GetSearchAggregation'
+            )
 
             expect(variablesWithoutCaseSensitivity).toStrictEqual({
                 mode: 'PATH',
                 limit: 10,
                 skipAggregation: false,
                 patternType: 'standard',
-                query: 'context:global insights(test',
+                query: origQuery,
             })
         })
     })

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -281,7 +281,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
         // If query or pattern type have been changed we should "reset" our assumptions
         // about calculated aggregation mode and make another api call to determine it
         setState(state => ({ ...state, calculatedMode: null }))
-    }, [query, patternType])
+    }, [aggregationQuery, patternType])
 
     if (loading) {
         return { data: undefined, error: undefined, loading: true }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41346

## Test plan
- Search anything that has different results with case:yes/case:no filters
- See aggregation result in the sidebar
- Toggle case sensitivity settings in the search box input
- See that aggregation cache has been invalidated and you see loading state and the most recent aggregation data 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-case-sensetivity-cache.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-oqzpiwouaw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
