### PR TITLE
remove deprecated logViewEvent method

### DIFF
--- a/client/web/src/api/ApiConsole.tsx
+++ b/client/web/src/api/ApiConsole.tsx
@@ -88,7 +88,7 @@ export class ApiConsole extends React.PureComponent<Props, State> {
     }
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('ApiConsole')
+        eventLogger.logPageView('ApiConsole')
 
         // Update the browser URL bar when query/variables/operation name are
         // changed so that the page can be easily shared.

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -71,7 +71,7 @@ export const PostSignUpPage: FunctionComponent<React.PropsWithChildren<PostSignU
     const goToSearch = (): void => navigate(getReturnTo(location))
 
     useEffect(() => {
-        eventLogger.logViewEvent(getPostSignUpEvent())
+        eventLogger.logPageView(getPostSignUpEvent())
     }, [])
 
     if (debug && !didUserFinishWelcomeFlow) {

--- a/client/web/src/auth/ResetPasswordPage.tsx
+++ b/client/web/src/auth/ResetPasswordPage.tsx
@@ -260,7 +260,7 @@ export const ResetPasswordPage: React.FunctionComponent<ResetPasswordPageProps> 
     const location = useLocation()
 
     React.useEffect(() => {
-        eventLogger.logViewEvent('ResetPassword', false)
+        eventLogger.logPageView('ResetPassword', false)
     }, [])
 
     let body: JSX.Element

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -30,7 +30,7 @@ interface SignInPageProps {
 }
 
 export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInPageProps>> = props => {
-    useEffect(() => eventLogger.logViewEvent('SignIn', null, false))
+    useEffect(() => eventLogger.logPageView('SignIn', null, false))
 
     const location = useLocation()
     const [error, setError] = useState<Error | null>(null)

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -47,7 +47,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
     const returnTo = getReturnTo(location)
 
     useEffect(() => {
-        eventLogger.logViewEvent('SignUp', null, false)
+        eventLogger.logPageView('SignUp', null, false)
 
         if (invitedBy !== null) {
             const parameters = {

--- a/client/web/src/enterprise/batches/global/DotcomGettingStartedPage.tsx
+++ b/client/web/src/enterprise/batches/global/DotcomGettingStartedPage.tsx
@@ -20,7 +20,7 @@ export interface DotcomGettingStartedPageProps {
 export const DotcomGettingStartedPage: React.FunctionComponent<
     React.PropsWithChildren<DotcomGettingStartedPageProps>
 > = () => {
-    useEffect(() => eventLogger.logViewEvent('BatchChangesCloudLandingPage'), [])
+    useEffect(() => eventLogger.logPageView('BatchChangesCloudLandingPage'), [])
 
     return (
         <Page>

--- a/client/web/src/enterprise/executors/ExecutorsListPage.tsx
+++ b/client/web/src/enterprise/executors/ExecutorsListPage.tsx
@@ -50,7 +50,7 @@ export const ExecutorsListPage: FunctionComponent<React.PropsWithChildren<Execut
     queryExecutors = defaultQueryExecutors,
     ...props
 }) => {
-    useEffect(() => eventLogger.logViewEvent('ExecutorsList'))
+    useEffect(() => eventLogger.logPageView('ExecutorsList'))
 
     const history = useHistory()
 

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
@@ -85,7 +85,7 @@ export const RegistryExtensionManagePage = withAuthenticatedUser(
         private subscriptions = new Subscription()
 
         public componentDidMount(): void {
-            eventLogger.logViewEvent('RegistryExtensionManage')
+            eventLogger.logPageView('RegistryExtensionManage')
 
             this.subscriptions.add(
                 this.submits

--- a/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
+++ b/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
@@ -57,7 +57,7 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
         private subscriptions = new Subscription()
 
         public componentDidMount(): void {
-            eventLogger.logViewEvent('ExtensionRegistryCreateExtension')
+            eventLogger.logPageView('ExtensionRegistryCreateExtension')
 
             this.subscriptions.add(
                 concat(

--- a/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -24,7 +24,7 @@ export interface RepoSettingsPermissionsPageProps {
 export const RepoSettingsPermissionsPage: React.FunctionComponent<
     React.PropsWithChildren<RepoSettingsPermissionsPageProps>
 > = ({ repo, history }) => {
-    useEffect(() => eventLogger.logViewEvent('RepoSettingsPermissions'))
+    useEffect(() => eventLogger.logPageView('RepoSettingsPermissions'))
     const permissionsInfo = useObservable(useMemo(() => repoPermissionsInfo(repo.id), [repo.id]))
 
     if (permissionsInfo === undefined) {

--- a/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
@@ -73,7 +73,7 @@ class FilteredAuthProviderConnection extends FilteredConnection<GQL.IAuthProvide
  */
 export class SiteAdminAuthenticationProvidersPage extends React.Component<Props> {
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SiteAdminAuthentication')
+        eventLogger.logPageView('SiteAdminAuthentication')
     }
 
     public render(): JSX.Element | null {

--- a/client/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
@@ -42,7 +42,7 @@ export class SiteAdminExternalAccountsPage extends React.Component<Props> {
     private externalAccountUpdates = new Subject<void>()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SiteAdminExternalAccounts')
+        eventLogger.logPageView('SiteAdminExternalAccounts')
     }
 
     public componentWillUnmount(): void {

--- a/client/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
@@ -22,7 +22,7 @@ export const SiteAdminLsifUploadPage: FunctionComponent<React.PropsWithChildren<
         params: { id },
     },
 }) => {
-    useEffect(() => eventLogger.logViewEvent('SiteAdminLsifUpload'))
+    useEffect(() => eventLogger.logPageView('SiteAdminLsifUpload'))
 
     const uploadOrError = useObservable(
         useMemo(() => fetchLsifUpload({ id }).pipe(catchError((error): [ErrorLike] => [asError(error)])), [id])

--- a/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -175,7 +175,7 @@ export class SiteAdminRegistryExtensionsPage extends React.PureComponent<Props> 
     private updates = new Subject<void>()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SiteAdminRegistryExtensions')
+        eventLogger.logPageView('SiteAdminRegistryExtensions')
     }
 
     public render(): JSX.Element | null {

--- a/client/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomersPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomersPage.tsx
@@ -60,7 +60,7 @@ class FilteredSiteAdminCustomerConnection extends FilteredConnection<
  * Displays a list of customers associated with user accounts on Sourcegraph.com.
  */
 export const SiteAdminProductCustomersPage: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
-    useEffect(() => eventLogger.logViewEvent('SiteAdminProductCustomers'), [])
+    useEffect(() => eventLogger.logPageView('SiteAdminProductCustomers'), [])
 
     const updates = useMemo(() => new Subject<void>(), [])
     const onUserUpdate = useCallback(() => updates.next(), [updates])

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -127,7 +127,7 @@ export const SiteAdminCreateProductSubscriptionPage: React.FunctionComponent<
     React.PropsWithChildren<Props>
 > = props => {
     useEffect(() => {
-        eventLogger.logViewEvent('SiteAdminCreateProductSubscription')
+        eventLogger.logPageView('SiteAdminCreateProductSubscription')
     })
     return (
         <div className="site-admin-create-product-subscription-page">

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicensesPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicensesPage.tsx
@@ -34,7 +34,7 @@ export const SiteAdminProductLicensesPage: React.FunctionComponent<React.PropsWi
     history,
     location,
 }) => {
-    useEffect(() => eventLogger.logViewEvent('SiteAdminProductLicenses'), [])
+    useEffect(() => eventLogger.logPageView('SiteAdminProductLicenses'), [])
 
     const nodeProps: Pick<SiteAdminProductLicenseNodeProps, 'showSubscription'> = {
         showSubscription: true,

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -71,7 +71,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
     _queryProductSubscription = queryProductSubscription,
     _queryProductLicenses = queryProductLicenses,
 }) => {
-    useEffect(() => eventLogger.logViewEvent('SiteAdminProductSubscription'), [])
+    useEffect(() => eventLogger.logPageView('SiteAdminProductSubscription'), [])
 
     const [showGenerate, setShowGenerate] = useState<boolean>(false)
 

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
@@ -35,7 +35,7 @@ export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<React.Pr
     history,
     location,
 }) => {
-    useEffect(() => eventLogger.logViewEvent('SiteAdminProductSubscriptions'), [])
+    useEffect(() => eventLogger.logPageView('SiteAdminProductSubscriptions'), [])
     return (
         <div className="site-admin-product-subscriptions-page">
             <PageTitle title="Product subscriptions" />

--- a/client/web/src/enterprise/site-admin/productSubscription/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/productSubscription/SiteAdminProductSubscriptionPage.tsx
@@ -13,7 +13,7 @@ import { ProductSubscriptionStatus } from './ProductSubscriptionStatus'
 export const SiteAdminProductSubscriptionPage: React.FunctionComponent<
     React.PropsWithChildren<RouteComponentProps>
 > = props => {
-    useEffect(() => eventLogger.logViewEvent('SiteAdminProductSubscription'), [])
+    useEffect(() => eventLogger.logPageView('SiteAdminProductSubscription'), [])
 
     return (
         <div className="site-admin-product-subscription-page">

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
@@ -43,7 +43,7 @@ export const UserSubscriptionsEditProductSubscriptionPage: React.FunctionCompone
     isLightTheme,
     _queryProductSubscription = queryProductSubscription,
 }) => {
-    useEffect(() => eventLogger.logViewEvent('UserSubscriptionsEditProductSubscription'), [])
+    useEffect(() => eventLogger.logPageView('UserSubscriptionsEditProductSubscription'), [])
 
     /**
      * The product subscription, or loading, or an error.

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsNewProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsNewProductSubscriptionPage.tsx
@@ -45,7 +45,7 @@ export const UserSubscriptionsNewProductSubscriptionPage: React.FunctionComponen
     history,
     isLightTheme,
 }) => {
-    useEffect(() => eventLogger.logViewEvent('UserSubscriptionsNewProductSubscription'), [])
+    useEffect(() => eventLogger.logPageView('UserSubscriptionsNewProductSubscription'), [])
 
     /**
      * The result of creating the paid product subscription: undefined when complete or not started yet,

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -43,7 +43,7 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<R
     },
     _queryProductSubscription = queryProductSubscription,
 }) => {
-    useEffect(() => eventLogger.logViewEvent('UserSubscriptionsProductSubscription'), [])
+    useEffect(() => eventLogger.logPageView('UserSubscriptionsProductSubscription'), [])
 
     /**
      * The product subscription, or loading, or an error.

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
@@ -37,7 +37,7 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
     React.PropsWithChildren<Props>
 > = props => {
     useEffect(() => {
-        eventLogger.logViewEvent('UserSubscriptionsProductSubscriptions')
+        eventLogger.logPageView('UserSubscriptionsProductSubscriptions')
     }, [])
 
     const queryLicenses = useCallback(

--- a/client/web/src/enterprise/user/settings/UserSettingsExternalAccountsPage.tsx
+++ b/client/web/src/enterprise/user/settings/UserSettingsExternalAccountsPage.tsx
@@ -38,7 +38,7 @@ export class UserSettingsExternalAccountsPage extends React.Component<Props> {
     private externalAccountUpdates = new Subject<void>()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('UserSettingsExternalAccounts')
+        eventLogger.logPageView('UserSettingsExternalAccounts')
     }
 
     public componentWillUnmount(): void {

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -23,7 +23,7 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<
         history: H.History
     }>
 > = ({ user, history }) => {
-    useEffect(() => eventLogger.logViewEvent('UserSettingsPermissions'))
+    useEffect(() => eventLogger.logPageView('UserSettingsPermissions'))
     const permissionsInfo = useObservable(useMemo(() => userPermissionsInfo(user.id), [user.id]))
 
     if (permissionsInfo === undefined) {

--- a/client/web/src/extensions/ExtensionRegistry.tsx
+++ b/client/web/src/extensions/ExtensionRegistry.tsx
@@ -117,7 +117,7 @@ export type ConfiguredExtensionCache = Map<string, MinimalConfiguredRegistryExte
 
 /** A page that displays overview information about the available extensions. */
 export const ExtensionRegistry: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
-    useEffect(() => eventLogger.logViewEvent('ExtensionsOverview'), [])
+    useEffect(() => eventLogger.logPageView('ExtensionsOverview'), [])
 
     const { history, location, settingsCascade, platformContext, authenticatedUser } = props
 

--- a/client/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
@@ -151,7 +151,7 @@ function toContributionsGroups(manifest: ExtensionManifest): ContributionGroup[]
 /** A page that displays an extension's contributions. */
 export class RegistryExtensionContributionsPage extends React.PureComponent<Props> {
     public componentDidMount(): void {
-        eventLogger.logViewEvent('RegistryExtensionContributions')
+        eventLogger.logPageView('RegistryExtensionContributions')
     }
 
     public render(): JSX.Element | null {

--- a/client/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
@@ -66,7 +66,7 @@ export class RegistryExtensionManifestPage extends React.PureComponent<Props, St
     public state: State = { viewMode: RegistryExtensionManifestPage.getViewMode() }
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('RegistryExtensionManifest')
+        eventLogger.logPageView('RegistryExtensionManifest')
     }
 
     public render(): JSX.Element | null {

--- a/client/web/src/marketing/page/SurveyPage.tsx
+++ b/client/web/src/marketing/page/SurveyPage.tsx
@@ -31,7 +31,7 @@ export const SurveyPage: React.FunctionComponent<React.PropsWithChildren<SurveyP
     const score = props.forceScore || matchParameters.score
 
     useEffect(() => {
-        eventLogger.logViewEvent('Survey')
+        eventLogger.logPageView('Survey')
     }, [])
 
     if (score === 'thanks') {

--- a/client/web/src/org/area/OrgInvitationPageLegacy.tsx
+++ b/client/web/src/org/area/OrgInvitationPageLegacy.tsx
@@ -54,7 +54,7 @@ export const OrgInvitationPageLegacy = withAuthenticatedUser(
         private subscriptions = new Subscription()
 
         public componentDidMount(): void {
-            eventLogger.logViewEvent('OrgInvitation')
+            eventLogger.logPageView('OrgInvitation')
 
             const orgChanges = this.componentUpdates.pipe(
                 distinctUntilKeyChanged('org'),

--- a/client/web/src/org/new/NewOrganizationPage.tsx
+++ b/client/web/src/org/new/NewOrganizationPage.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 export const NewOrganizationPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ history }) => {
     useEffect(() => {
-        eventLogger.logViewEvent('NewOrg')
+        eventLogger.logPageView('NewOrg')
     }, [])
     const [loading, setLoading] = useState<boolean | Error>(false)
     const [name, setName] = useState<string>('')

--- a/client/web/src/org/settings/members-v1/OrgSettingsMembersPage.tsx
+++ b/client/web/src/org/settings/members-v1/OrgSettingsMembersPage.tsx
@@ -181,7 +181,7 @@ export class OrgSettingsMembersPage extends React.PureComponent<Props, State> {
     }
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('OrgMembers')
+        eventLogger.logPageView('OrgMembers')
 
         this.subscriptions.add(
             this.componentUpdates

--- a/client/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
+++ b/client/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
@@ -22,7 +22,7 @@ export const OrgSettingsProfilePage: React.FunctionComponent<React.PropsWithChil
     onOrganizationUpdate,
 }) => {
     useEffect(() => {
-        eventLogger.logViewEvent('OrgSettingsProfile')
+        eventLogger.logPageView('OrgSettingsProfile')
     }, [org.id])
 
     const [displayName, setDisplayName] = useState<string>(org.displayName ?? '')

--- a/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.tsx
+++ b/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.tsx
@@ -69,7 +69,7 @@ export const RepositoriesPopover: React.FunctionComponent<React.PropsWithChildre
     const query = useDebounce(searchValue, 200)
 
     useEffect(() => {
-        eventLogger.logViewEvent('RepositoriesPopover')
+        eventLogger.logPageView('RepositoriesPopover')
         telemetryService.log('RepositoriesPopover')
     }, [telemetryService])
 

--- a/client/web/src/repo/RepositoryNotFoundPage.tsx
+++ b/client/web/src/repo/RepositoryNotFoundPage.tsx
@@ -47,7 +47,7 @@ export class RepositoryNotFoundPage extends React.PureComponent<Props, State> {
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('RepositoryError')
+        eventLogger.logPageView('RepositoryError')
 
         // Show/hide add.
         this.subscriptions.add(

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
@@ -90,7 +90,7 @@ export const RevisionsPopover: React.FunctionComponent<React.PropsWithChildren<R
     const { getPathFromRevision = replaceRevisionInURL } = props
 
     useEffect(() => {
-        eventLogger.logViewEvent('RevisionsPopover')
+        eventLogger.logPageView('RevisionsPopover')
     }, [])
 
     const [tabIndex, setTabIndex] = useLocalStorage(LAST_TAB_STORAGE_KEY, 0)

--- a/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
@@ -16,7 +16,7 @@ interface Props extends RepositoryBranchesAreaPageProps, RouteComponentProps<{}>
 /** A page that shows all of a repository's branches. */
 export class RepositoryBranchesAllPage extends React.PureComponent<Props> {
     public componentDidMount(): void {
-        eventLogger.logViewEvent('RepositoryBranchesAll')
+        eventLogger.logPageView('RepositoryBranchesAll')
     }
 
     public render(): JSX.Element | null {

--- a/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
@@ -88,7 +88,7 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('RepositoryBranchesOverview')
+        eventLogger.logPageView('RepositoryBranchesOverview')
 
         this.subscriptions.add(
             this.componentUpdates

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -128,7 +128,7 @@ export const RepositoryCommitsPage: React.FunctionComponent<React.PropsWithChild
     ...props
 }) => {
     useEffect(() => {
-        eventLogger.logViewEvent('RepositoryCommits')
+        eventLogger.logPageView('RepositoryCommits')
     }, [])
 
     useBreadcrumb(useMemo(() => ({ key: 'commits', element: <>Commits</> }), []))

--- a/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -106,7 +106,7 @@ export class RepositoryCompareOverviewPage extends React.PureComponent<Props, St
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('RepositoryCompareOverview')
+        eventLogger.logPageView('RepositoryCompareOverview')
 
         this.subscriptions.add(
             this.componentUpdates

--- a/client/web/src/repo/releases/RepositoryReleasesTagsPage.tsx
+++ b/client/web/src/repo/releases/RepositoryReleasesTagsPage.tsx
@@ -31,7 +31,7 @@ export const RepositoryReleasesTagsPage: React.FunctionComponent<React.PropsWith
     queryGitReferences: queryGitReferences = queryGitReferencesFromBackend,
 }) => {
     useEffect(() => {
-        eventLogger.logViewEvent('RepositoryReleasesTags')
+        eventLogger.logPageView('RepositoryReleasesTags')
     }, [])
 
     const queryTags = useCallback(

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -158,7 +158,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('RepoSettingsIndex')
+        eventLogger.logPageView('RepoSettingsIndex')
 
         this.subscriptions.add(
             this.updates

--- a/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -292,7 +292,7 @@ export class RepoSettingsMirrorPage extends React.PureComponent<
     }
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('RepoSettingsMirror')
+        eventLogger.logPageView('RepoSettingsMirror')
 
         this.subscriptions.add(
             this.repoUpdates.pipe(switchMap(() => fetchSettingsAreaRepository(this.props.repo.name))).subscribe(

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -48,7 +48,7 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
     }
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('RepoSettings')
+        eventLogger.logPageView('RepoSettings')
 
         this.subscriptions.add(
             this.repoUpdates.pipe(switchMap(() => fetchSettingsAreaRepository(this.props.repo.name))).subscribe(

--- a/client/web/src/savedSearches/SavedSearchCreateForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchCreateForm.tsx
@@ -68,7 +68,7 @@ export class SavedSearchCreateForm extends React.Component<Props, State> {
                     }
                 })
         )
-        eventLogger.logViewEvent('NewSavedSearchPage')
+        eventLogger.logPageView('NewSavedSearchPage')
     }
 
     public render(): JSX.Element | null {

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -144,7 +144,7 @@ export class SavedSearchListPage extends React.Component<Props, State> {
                 )
                 .subscribe(newState => this.setState(newState as State))
         )
-        eventLogger.logViewEvent('SavedSearchListPage')
+        eventLogger.logPageView('SavedSearchListPage')
     }
 
     public render(): JSX.Element | null {

--- a/client/web/src/savedSearches/SavedSearchUpdateForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchUpdateForm.tsx
@@ -102,7 +102,7 @@ export class SavedSearchUpdateForm extends React.Component<Props, State> {
 
         this.componentUpdates.next(this.props)
 
-        eventLogger.logViewEvent('UpdateSavedSearchPage')
+        eventLogger.logPageView('UpdateSavedSearchPage')
     }
 
     public render(): JSX.Element | null {

--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -83,7 +83,7 @@ export class SettingsArea extends React.Component<Props, State> {
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent(`Settings${this.props.subject.__typename}`)
+        eventLogger.logPageView(`Settings${this.props.subject.__typename}`)
         // Load settings.
         this.subscriptions.add(
             combineLatest([

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/index.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/index.tsx
@@ -388,7 +388,7 @@ export class SiteAdminAllUsersPage extends React.Component<Props, State> {
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SiteAdminAllUsers')
+        eventLogger.logPageView('SiteAdminAllUsers')
     }
 
     public componentWillUnmount(): void {

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -231,7 +231,7 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SiteAdminConfiguration')
+        eventLogger.logPageView('SiteAdminConfiguration')
 
         this.subscriptions.add(
             this.remoteRefreshes.pipe(mergeMap(() => fetchSite())).subscribe(

--- a/client/web/src/site-admin/SiteAdminCreateUserPage.tsx
+++ b/client/web/src/site-admin/SiteAdminCreateUserPage.tsx
@@ -48,7 +48,7 @@ export class SiteAdminCreateUserPage extends React.Component<RouteComponentProps
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SiteAdminCreateUser')
+        eventLogger.logPageView('SiteAdminCreateUser')
 
         this.subscriptions.add(
             this.submits

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -35,7 +35,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
         )
     )
     useEffect(() => {
-        eventLogger.logViewEvent('SiteAdminPings')
+        eventLogger.logPageView('SiteAdminPings')
     }, [])
 
     const nonCriticalTelemetryDisabled = window.context.site.disableNonCriticalTelemetry === true

--- a/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
@@ -290,7 +290,7 @@ export const SiteAdminSurveyResponsesPage: React.FunctionComponent<React.PropsWi
     const [persistedTabIndex, setPersistedTabIndex] = useLocalStorage(LAST_TAB_STORAGE_KEY, 0)
 
     useEffect(() => {
-        eventLogger.logViewEvent('SiteAdminSurveyResponses')
+        eventLogger.logPageView('SiteAdminSurveyResponses')
     }, [])
 
     return (

--- a/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -225,7 +225,7 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
     }
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('SiteAdminUsageStatistics')
+        eventLogger.logPageView('SiteAdminUsageStatistics')
 
         this.subscriptions.add(
             fetchSiteUsageStatistics().subscribe(

--- a/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
+++ b/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
@@ -118,7 +118,7 @@ export const SiteAdminOverviewPage: React.FunctionComponent<React.PropsWithChild
     _fetchWeeklyActiveUsers = fetchWeeklyActiveUsers,
 }) => {
     useEffect(() => {
-        eventLogger.logViewEvent('SiteAdminOverview')
+        eventLogger.logPageView('SiteAdminOverview')
     }, [])
 
     const info = useObservable(

--- a/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
@@ -48,7 +48,7 @@ export class UserSettingsPasswordPage extends React.Component<Props, State> {
     }
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('UserSettingsPassword')
+        eventLogger.logPageView('UserSettingsPassword')
         this.subscriptions.add(
             this.submits
                 .pipe(

--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -174,7 +174,7 @@ export class UserSettingsSecurityPage extends React.Component<Props, State> {
     }
 
     public componentDidMount(): void {
-        eventLogger.logViewEvent('UserSettingsPassword')
+        eventLogger.logPageView('UserSettingsPassword')
         this.fetchAccounts()
     }
 

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -60,7 +60,7 @@ export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<P
     const flags = useObservable(siteFlags)
 
     useEffect(() => {
-        eventLogger.logViewEvent('UserSettingsEmails')
+        eventLogger.logPageView('UserSettingsEmails')
     }, [])
 
     useEffect(() => {

--- a/client/web/src/user/settings/openBetaOrgs/OrganizationsList.tsx
+++ b/client/web/src/user/settings/openBetaOrgs/OrganizationsList.tsx
@@ -73,9 +73,9 @@ const refreshOrganizationList = (): void => {
     refreshAuthenticatedUser()
         .toPromise()
         .then(() => {
-            eventLogger.logViewEvent('OrganizationsList')
+            eventLogger.logPageView('OrganizationsList')
         })
-        .catch(() => eventLogger.logViewEvent('ErrorOrgListLoading'))
+        .catch(() => eventLogger.logPageView('ErrorOrgListLoading'))
 }
 
 export const OrganizationsListPage: React.FunctionComponent<React.PropsWithChildren<OrganizationsListProps>> = ({

--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
@@ -34,7 +34,7 @@ export const UserSettingsProfilePage: React.FunctionComponent<React.PropsWithChi
     user,
     ...props
 }) => {
-    useEffect(() => eventLogger.logViewEvent('UserProfile'), [])
+    useEffect(() => eventLogger.logPageView('UserProfile'), [])
 
     return (
         <div>


### PR DESCRIPTION
We make use of the deprecated [`logViewEvent`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/client/web/src/tracking/eventLogger.ts?L120%3A1-132%3A6=&utm_source=VSCode-2.2.9) in a number of places, this PR replaces the deprecated method with `logPageView`.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Ensure events are still logged.

## App preview:

- [Web](https://sg-web-bo-switch-deprecated-eventlogger.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pygsiqkyqw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
