### PR TITLE
authz: cache prometheus metric lookup in subrepo

### DIFF
--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -161,11 +161,19 @@ var subRepoPermsPermissionsDuration = promauto.NewHistogramVec(prometheus.Histog
 	Help: "Time spent syncing",
 }, []string{"error"})
 
-// subRepoPermsCacheHit tracks the number of cache hits and misses for sub-repo permissions
-var subRepoPermsCacheHit = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "authz_sub_repo_perms_permissions_cache_count",
-	Help: "The number of sub-repo perms cache hits or misses",
-}, []string{"hit"})
+var (
+	metricSubRepoPermCacheHit  prometheus.Counter
+	metricSubRepoPermCacheMiss prometheus.Counter
+)
+
+func init() {
+	metric := promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "authz_sub_repo_perms_permissions_cache_count",
+		Help: "The number of sub-repo perms cache hits or misses",
+	}, []string{"hit"})
+	metricSubRepoPermCacheHit = metric.WithLabelValues("true")
+	metricSubRepoPermCacheMiss = metric.WithLabelValues("false")
+}
 
 // Permissions return the current permissions granted to the given user on the
 // given content. If sub-repo permissions are disabled, it is a no-op that return
@@ -249,10 +257,10 @@ func (s *SubRepoPermsClient) getCompiledRules(ctx context.Context, userID int32)
 	}
 
 	if ok && s.since(cached.timestamp) <= ttl {
-		subRepoPermsCacheHit.WithLabelValues("true").Inc()
+		metricSubRepoPermCacheHit.Inc()
 		return cached.rules, nil
 	}
-	subRepoPermsCacheHit.WithLabelValues("false").Inc()
+	metricSubRepoPermCacheMiss.Inc()
 
 	// Slow path on cache miss or expiry. Ensure that only one goroutine is doing the
 	// work


### PR DESCRIPTION
Viewing the profile the most expensive function is `getCompiledRules`. Surprisingly given the cache fast path, the slowest part of this function is in fact finding the prometheus metric given a list of labels. This minor change speeds up paths/s by 30%.

```
name                 old time/op  new time/op  delta
FilterActorPaths-32  3.75ms ± 7%  2.83ms ± 2%  -24.54%  (p=0.000 n=10+9)

name                 old paths/s  new paths/s  delta
FilterActorPaths-32   1.33M ± 7%   1.77M ± 3%  +32.37%  (p=0.000 n=10+9)
```


A deeper change is needed here where we cache most of the work here once per request, rather than doing it per file path. This requires a bit of refactoring, so just taking the quick wins from the benchmark first :)

Test Plan: go test
