### PR TITLE
[SG-40295] Extract bootstrap style import @import 'bootstrap/scss/function', @import 'bootstrap/scss/mixins'

### DIFF
--- a/client/branded/src/global-styles/base.scss
+++ b/client/branded/src/global-styles/base.scss
@@ -55,12 +55,8 @@ $custom-select-feedback-icon-size: 0;
 $enable-transitions: false;
 
 /* stylelint-disable @sourcegraph/no-restricted-imports */
-// Apply static variables before Bootstrap imports.
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins';
-
-/* stylelint-enable @sourcegraph/no-restricted-imports */
+@import './functions.scss';
+@import './mixins.scss';
 @import './reboot';
 @import './utilities';
 @import 'wildcard/src/global-styles/breakpoints';

--- a/client/branded/src/global-styles/base.scss
+++ b/client/branded/src/global-styles/base.scss
@@ -54,7 +54,6 @@ $custom-select-feedback-icon-size: 0;
 // Disable all Bootstrap transitions
 $enable-transitions: false;
 
-/* stylelint-disable @sourcegraph/no-restricted-imports */
 @import './functions.scss';
 @import './mixins.scss';
 @import './reboot';

--- a/client/branded/src/global-styles/functions.scss
+++ b/client/branded/src/global-styles/functions.scss
@@ -1,0 +1,19 @@
+// Minimum breakpoint width. Null for the smallest (first) breakpoint.
+//
+//    >> breakpoint-min(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    576px
+@function breakpoint-min($name, $breakpoints: $grid-breakpoints) {
+    $min: map-get($breakpoints, $name);
+    @return if($min != 0, $min, null);
+}
+
+// Returns a blank string if smallest breakpoint, otherwise returns the name with a dash in front.
+// Useful for making responsive utilities.
+//
+//    >> breakpoint-infix(xs, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    ""  (Returns a blank string)
+//    >> breakpoint-infix(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    "-sm"
+@function breakpoint-infix($name, $breakpoints: $grid-breakpoints) {
+    @return if(breakpoint-min($name, $breakpoints) == null, '', '-#{$name}');
+}

--- a/client/branded/src/global-styles/grid.scss
+++ b/client/branded/src/global-styles/grid.scss
@@ -1,18 +1,6 @@
 $grid-row-columns: 6;
 $grid-columns: 12;
 
-// Grid breakpoints
-//
-// Define the minimum dimensions at which your layout will change,
-// adapting to different screen sizes, for use in media queries.
-$grid-breakpoints: (
-    xs: 0,
-    sm: 576px,
-    md: 768px,
-    lg: 992px,
-    xl: 1200px,
-);
-
 :root {
     --grid-gutter-width: 1.5rem;
 }

--- a/client/branded/src/global-styles/mixins.scss
+++ b/client/branded/src/global-styles/mixins.scss
@@ -1,0 +1,21 @@
+// stylelint-disable declaration-no-important
+
+// Typography
+@mixin text-emphasis-variant($parent, $color) {
+    #{$parent} {
+        color: $color !important;
+    }
+}
+
+// Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
+// Makes the @content apply to the given breakpoint and wider.
+@mixin media-breakpoint-up($name, $breakpoints: $grid-breakpoints) {
+    $min: breakpoint-min($name, $breakpoints);
+    @if $min {
+        @media (min-width: $min) {
+            @content;
+        }
+    } @else {
+        @content;
+    }
+}

--- a/client/branded/src/global-styles/typography.scss
+++ b/client/branded/src/global-styles/typography.scss
@@ -170,7 +170,7 @@ label.text-uppercase small,
 .theme-light,
 .theme-dark {
     @each $color, $value in $theme-colors {
-        @include text-emphasis-variant('.text-#{$color}', $value, true);
+        @include text-emphasis-variant('.text-#{$color}', $value);
     }
 }
 

--- a/client/branded/src/global-styles/variables.scss
+++ b/client/branded/src/global-styles/variables.scss
@@ -26,6 +26,18 @@ $sizes: (
     auto: auto,
 );
 
+// Grid breakpoints
+//
+// Define the minimum dimensions at which your layout will change,
+// adapting to different screen sizes, for use in media queries.
+$grid-breakpoints: (
+    xs: 0,
+    sm: 576px,
+    md: 768px,
+    lg: 992px,
+    xl: 1200px,
+);
+
 :root {
     --font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
         sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';

--- a/client/browser/src/app.scss
+++ b/client/browser/src/app.scss
@@ -31,7 +31,6 @@ $line-height-base: (20/14);
     }
 }
 
-/* stylelint-disable @sourcegraph/no-restricted-imports */
 @import '../../branded/src/global-styles/functions.scss';
 @import '../../branded/src/global-styles/variables.scss';
 @import '../../branded/src/global-styles/mixins.scss';

--- a/client/browser/src/app.scss
+++ b/client/browser/src/app.scss
@@ -32,10 +32,9 @@ $line-height-base: (20/14);
 }
 
 /* stylelint-disable @sourcegraph/no-restricted-imports */
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins';
-/* stylelint-enable @sourcegraph/no-restricted-imports */
+@import '../../branded/src/global-styles/functions.scss';
+@import '../../branded/src/global-styles/variables.scss';
+@import '../../branded/src/global-styles/mixins.scss';
 @import '../../branded/src/global-styles/utilities/text';
 @import '../../branded/src/global-styles/utilities/screenreaders';
 @import '../../shared/src/global-styles/icons';


### PR DESCRIPTION
### Description
We depend on Bootstrap styles in our global styles a lot. But we don't plan to move forward with Bootstrap because we're working on our design system called Wildcard. To ease the transition to our styles and gain more control over visual changes, we want to move Bootstrap styles that we need into our codebase and eventually drop Bootstrap dependency.

### Refs
[Parent Issue](https://github.com/sourcegraph/sourcegraph/issues/29200)
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/40295)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-40295)

### Test Plan
- All imports mentioned above are removed and there is no UI Changes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-contractors-sg-40295.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cinfegcxhw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
