### PR TITLE
GraphQL repositories: allow TotalCount for cloned/uncloned/cloneStatus

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -70,6 +70,7 @@ func (args *repositoryArgs) toReposListOptions() (database.ReposListOptions, err
 
 		opt.Cursors = append(opt.Cursors, &cursor)
 	}
+	args.Set(&opt.LimitOffset)
 
 	if args.CloneStatus != nil {
 		opt.CloneStatus = types.ParseCloneStatusFromGraphQL(*args.CloneStatus)

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -568,65 +568,91 @@ func TestRepositories_Integration(t *testing.T) {
 	}
 	ctx = actor.WithActor(ctx, actor.FromUser(admin.ID))
 
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		wantRepos:      []string{"repo1", "repo2", "repo3", "repo4", "repo5", "repo6"},
-		wantTotalCount: 6,
-	})
+	tests := []repositoriesQueryTest{
+		// no args
+		{
+			wantRepos:      []string{"repo1", "repo2", "repo3", "repo4", "repo5", "repo6"},
+			wantTotalCount: 6,
+		},
+		// first
+		{
+			args:           "first: 2",
+			wantRepos:      []string{"repo1", "repo2"},
+			wantTotalCount: 6,
+		},
+		// cloned
+		{
+			// cloned only says whether to "Include cloned repositories.", it doesn't exclude non-cloned.
+			args:           "cloned: true",
+			wantRepos:      []string{"repo1", "repo2", "repo3", "repo4", "repo5", "repo6"},
+			wantTotalCount: 6,
+		},
+		{
+			args:           "cloned: false",
+			wantRepos:      []string{"repo1", "repo2", "repo3", "repo4"},
+			wantTotalCount: 4,
+		},
+		{
+			args:           "cloned: false, first: 2",
+			wantRepos:      []string{"repo1", "repo2"},
+			wantTotalCount: 4,
+		},
+		// notCloned
+		{
+			args:           "notCloned: true",
+			wantRepos:      []string{"repo1", "repo2", "repo3", "repo4", "repo5", "repo6"},
+			wantTotalCount: 6,
+		},
+		{
+			args:           "notCloned: false",
+			wantRepos:      []string{"repo5", "repo6"},
+			wantTotalCount: 2,
+		},
+		// failedFetch
+		{
+			args:           "failedFetch: true",
+			wantRepos:      []string{"repo2", "repo4", "repo6"},
+			wantTotalCount: 3,
+		},
+		{
+			args:           "failedFetch: true, first: 2",
+			wantRepos:      []string{"repo2", "repo4"},
+			wantTotalCount: 3,
+		},
+		{
+			args:           "failedFetch: false",
+			wantRepos:      []string{"repo1", "repo2", "repo3", "repo4", "repo5", "repo6"},
+			wantTotalCount: 6,
+		},
+		// cloneStatus
+		{
+			args:           "cloneStatus:NOT_CLONED",
+			wantRepos:      []string{"repo1", "repo2"},
+			wantTotalCount: 2,
+		},
+		{
+			args:           "cloneStatus:CLONING",
+			wantRepos:      []string{"repo3", "repo4"},
+			wantTotalCount: 2,
+		},
+		{
+			args:           "cloneStatus:CLONED",
+			wantRepos:      []string{"repo5", "repo6"},
+			wantTotalCount: 2,
+		},
+		{
+			args:           "cloneStatus:NOT_CLONED, first: 1",
+			wantRepos:      []string{"repo1"},
+			wantTotalCount: 2,
+		},
+	}
 
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		// cloned only says whether to "Include cloned repositories.", it doesn't exclude non-cloned.
-		args:           "cloned: true",
-		wantRepos:      []string{"repo1", "repo2", "repo3", "repo4", "repo5", "repo6"},
-		wantTotalCount: 6,
-	})
+	for _, tt := range tests {
+		t.Run(tt.args, func(t *testing.T) {
+			runRepositoriesQuery(t, ctx, schema, tt)
+		})
+	}
 
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:           "cloned: false",
-		wantRepos:      []string{"repo1", "repo2", "repo3", "repo4"},
-		wantTotalCount: 4,
-	})
-
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:           "notCloned: true",
-		wantRepos:      []string{"repo1", "repo2", "repo3", "repo4", "repo5", "repo6"},
-		wantTotalCount: 6,
-	})
-
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:           "notCloned: false",
-		wantRepos:      []string{"repo5", "repo6"},
-		wantTotalCount: 2,
-	})
-
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:           "failedFetch: true",
-		wantRepos:      []string{"repo2", "repo4", "repo6"},
-		wantTotalCount: 3,
-	})
-
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:           "failedFetch: false",
-		wantRepos:      []string{"repo1", "repo2", "repo3", "repo4", "repo5", "repo6"},
-		wantTotalCount: 6,
-	})
-
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:           "cloneStatus:NOT_CLONED",
-		wantRepos:      []string{"repo1", "repo2"},
-		wantTotalCount: 2,
-	})
-
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:           "cloneStatus:CLONING",
-		wantRepos:      []string{"repo3", "repo4"},
-		wantTotalCount: 2,
-	})
-
-	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:           "cloneStatus:CLONED",
-		wantRepos:      []string{"repo5", "repo6"},
-		wantTotalCount: 2,
-	})
 }
 
 type repositoriesQueryTest struct {

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -581,10 +581,9 @@ func TestRepositories_Integration(t *testing.T) {
 	})
 
 	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:      "cloned: false",
-		wantRepos: []string{"repo1", "repo2", "repo3", "repo4"},
-		// Right now we don't produce a totalCount if "cloned: false" is used
-		wantNoTotalCount: true,
+		args:           "cloned: false",
+		wantRepos:      []string{"repo1", "repo2", "repo3", "repo4"},
+		wantTotalCount: 4,
 	})
 
 	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
@@ -594,10 +593,9 @@ func TestRepositories_Integration(t *testing.T) {
 	})
 
 	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:      "notCloned: false",
-		wantRepos: []string{"repo5", "repo6"},
-		// Right now we don't produce a totalCount if "notCloned" is used
-		wantNoTotalCount: true,
+		args:           "notCloned: false",
+		wantRepos:      []string{"repo5", "repo6"},
+		wantTotalCount: 2,
 	})
 
 	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
@@ -613,24 +611,21 @@ func TestRepositories_Integration(t *testing.T) {
 	})
 
 	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:      "cloneStatus:NOT_CLONED",
-		wantRepos: []string{"repo1", "repo2"},
-		// Right now we don't produce a totalCount if "cloneStatus" is used
-		wantNoTotalCount: true,
+		args:           "cloneStatus:NOT_CLONED",
+		wantRepos:      []string{"repo1", "repo2"},
+		wantTotalCount: 2,
 	})
 
 	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:      "cloneStatus:CLONING",
-		wantRepos: []string{"repo3", "repo4"},
-		// Right now we don't produce a totalCount if "cloneStatus" is used
-		wantNoTotalCount: true,
+		args:           "cloneStatus:CLONING",
+		wantRepos:      []string{"repo3", "repo4"},
+		wantTotalCount: 2,
 	})
 
 	runRepositoriesQuery(t, ctx, schema, repositoriesQueryTest{
-		args:      "cloneStatus:CLONED",
-		wantRepos: []string{"repo5", "repo6"},
-		// Right now we don't produce a totalCount if "cloneStatus" is used
-		wantNoTotalCount: true,
+		args:           "cloneStatus:CLONED",
+		wantRepos:      []string{"repo5", "repo6"},
+		wantTotalCount: 2,
 	})
 }
 


### PR DESCRIPTION
Since we now have `gitserver_repos` table and can do this with a join, I don't see a big reason for why we can't do this, especially since we already allow it for `failedFetch`.

This addresses parts of https://github.com/sourcegraph/sourcegraph/issues/39980

## Test plan

- Existing and new tests
