### PR TITLE
doc: align on opentelemetry docs naming

### DIFF
--- a/doc/admin/deploy/docker-compose/operations.md
+++ b/doc/admin/deploy/docker-compose/operations.md
@@ -235,7 +235,7 @@ You can monitor the health of a deployment in several ways:
 - Using [`docker ps`](https://docs.docker.com/engine/reference/commandline/ps/) to check on the status of containers within the deployment (any tooling designed to work with Docker containers and/or Docker Compose will work too).
   - This requires direct access to your instance's host machine.
 
-## OpenTelmeetry Collector
+## OpenTelemetry Collector
 
 Learn more about Sourcegraph's integrations with the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) in our [OpenTelemetry documentation](../../observability/opentelemetry.md).
 

--- a/doc/admin/observability/opentelemetry.md
+++ b/doc/admin/observability/opentelemetry.md
@@ -18,7 +18,7 @@ Refer to the [documentation](https://opentelemetry.io/docs/collector/configurati
 For more details on configuring the OpenTelemetry collector for your deployment method, refer to the deployment-specific guidance:
 
 - [Kubernetes (without Helm)](../deploy/kubernetes/configure.md#opentelemetry-collector)
-- [Docker Compose](../deploy/docker-compose/operations.md#opentelmeetry-collector)
+- [Docker Compose](../deploy/docker-compose/operations.md#opentelemetry-collector)
 
 ## Tracing
 

--- a/doc/dev/background-information/observability/index.md
+++ b/doc/dev/background-information/observability/index.md
@@ -26,7 +26,7 @@ Observability at Sourcegraph includes:
 - [How to find monitoring](../../how-to/find_monitoring.md)
 - [How to add monitoring](../../how-to/add_monitoring.md)
 - [Set up local monitoring development](../../how-to/monitoring_local_dev.md)
-- [Set up local OpenTelemetry development](../../how-to/otel_local_dev.md)
+- [Set up local OpenTelemetry development](../../how-to/opentelemetry_local_dev.md)
 
 ## Components
 

--- a/doc/dev/how-to/add_observability.md
+++ b/doc/dev/how-to/add_observability.md
@@ -6,7 +6,7 @@ If you're not ready to migrate completely to `internal/observation`, you can con
 - [How to add logging](add_logging.md)
 - [How to add monitoring](add_monitoring.md)
 - [Set up local monitoring development](monitoring_local_dev.md)
-- [Set up local OpenTelemetry development](otel_local_dev.md)
+- [Set up local OpenTelemetry development](opentelemetry_local_dev.md)
 
 > NOTE: For how to *use* Sourcegraph's observability and an overview of our observability features, refer to the [observability for site administrators documentation](../../admin/observability/index.md).
 

--- a/doc/dev/how-to/monitoring_local_dev.md
+++ b/doc/dev/how-to/monitoring_local_dev.md
@@ -4,7 +4,7 @@ This guide documents how to spin up and develop Sourcegraph's monitoring stack l
 Sourcegraph employees should also refer to the [handbook's monitoring section](https://handbook.sourcegraph.com/engineering/observability/monitoring) for Sourcegraph-specific documentation.
 The [developing observability page](../background-information/observability/index.md) contains relevant documentation as well, including background about the components listed here.
 
-> NOTE: For how to *use* Sourcegraph's observability and an overview of our observability features, refer to the [observability for site administrators documentation](index.md).
+> NOTE: For how to *use* Sourcegraph's observability and an overview of our observability features, refer to the [observability for site administrators documentation](../../admin/observability/index.md).
 
 ## Running monitoring components
 

--- a/doc/dev/how-to/opentelemetry_local_dev.md
+++ b/doc/dev/how-to/opentelemetry_local_dev.md
@@ -1,8 +1,8 @@
 # Set up local Sourcegraph OpenTelemetry development
 
-> WARNING: OpenTelemetry support is a work in progress, and so are these docs!
-
 General OpenTelemetry export configuration is done via environment variables according to the [official configuration options specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options).
+
+> NOTE: For how to *use* Sourcegraph's OpenTelemetry integrations, refer to the [OpenTelemetry for site administrators documentation](../../admin/observability/opentelemetry.md).
 
 ## Collector
 

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -165,7 +165,7 @@ Guides to help with troubleshooting, configuring test instances, debugging, and 
 - [How to find monitoring](how-to/find_monitoring.md)
 - [How to add monitoring](how-to/add_monitoring.md)
 - [Set up local monitoring development](how-to/monitoring_local_dev.md)
-- [Set up local OpenTelemetry development](how-to/otel_local_dev.md)
+- [Set up local OpenTelemetry development](how-to/opentelemetry_local_dev.md)
 
 ### Documentation
 


### PR DESCRIPTION
- fix spelling issue
- rename `otel_local_dev` to `opentelemetry_local_dev` and add backlink similar to the monitoring dev docs
- fix backlink in monitoring dev docs

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes