### PR TITLE
upgrade: Add doc clarifications

### DIFF
--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -18,7 +18,8 @@ Administration is usually handled by site administrators are the admins responsi
 
 ## [Upgrade Sourcegraph](updates/index.md)
 
-> NOTE: The Sourcegraph 4.0 [`migrator`](./how-to/manual_database_migrations) can now perform upgrades across multiple versions on any instance 3.20 or later.
+> NOTE: The Sourcegraph 4.0 [`migrator`](./how-to/manual_database_migrations.md) can now perform upgrades across 
+multiple versions on any instance 3.20 or later.
 
 - [Upgrade Sourcegraph](updates/index.md)
   - [Single-minor-version "standard" upgrades](updates/index.md#standard-upgrades)

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -18,11 +18,16 @@ Administration is usually handled by site administrators are the admins responsi
 
 ## [Upgrade Sourcegraph](updates/index.md)
 
+> NOTE: The Sourcegraph 4.0 [`migrator`](./how-to/manual_database_migrations) can now perform upgrades across multiple versions on any instance 3.20 or later.
+
 - [Upgrade Sourcegraph](updates/index.md)
-  - [Update notes for Sourcegraph with Docker Compose](updates/docker_compose.md)
-  - [Update notes for Sourcegraph with Kubernetes](updates/kubernetes.md)
-  - [Update notes for single-container Sourcegraph with Docker](updates/server.md)
-  - [Update notes for pure-docker custom deployments](updates/pure_docker.md)
+  - [Single-minor-version "standard" upgrades](updates/index.md#standard-upgrades)
+  - [Multi-version upgrades](updates/index.md#multi-version-upgrades)
+- [Upgrade notes](updates/index.md#update-notes) (by distribution method):
+  - [Sourcegraph with Docker Compose](updates/docker_compose.md)
+  - [Sourcegraph with Kubernetes](updates/kubernetes.md)
+  - [Single-container Sourcegraph with Docker](updates/server.md)
+  - [Pure-docker custom deployments](updates/pure_docker.md)
 - [Migration guides](migration/index.md)
 - [Upgrading PostgreSQL](postgres.md#upgrading-postgresql)
 

--- a/doc/admin/updates/index.md
+++ b/doc/admin/updates/index.md
@@ -20,7 +20,7 @@ Also [check the status out-of-band migrations](../how-to/unfinished_migration.md
 
 ### Multi-version upgrades
 
-A **multi-version** upgrade moves an instance multiple minor versions ahead. We currently support jumping from `v3.20` to any future version.
+A **multi-version** upgrade moves an instance multiple minor versions ahead. We currently support jumping from `v3.20` to any future version (using a version of the `migrator` at least as new as the target version).
 
 This upgrade process involves spinning down the active instance (incurring a definite downtime period), running a migration utility on the database, and spinning up the infrastructure for the new target instance. This migration utility performs both schema migrations, as well as data migrations that generally happen slowly in the background over several versions.
 


### PR DESCRIPTION
Some edits to the admin docs index page and a clarification to which version of migrator to use.

## Test plan

N/A.