### PR TITLE
batches: increase aggressiveness of GitLab minimum version site alert

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -395,8 +395,8 @@ func gitlabVersionAlert(args AlertFuncArgs) []*Alert {
 			log15.Debug("Detected GitLab instance running a version below 12.0.0", "version", chv.Version)
 
 			return []*Alert{{
-				TypeValue:    AlertTypeWarning,
-				MessageValue: "Warning: One or more of your code hosts is running a version of GitLab below 12.0. Sourcegraph will no longer support GitLab < 12.0 in the next major version. Please upgrade your GitLab instance(s) before upgrading Sourcegraph to version 4.0.",
+				TypeValue:    AlertTypeError,
+				MessageValue: "One or more of your code hosts is running a version of GitLab below 12.0, which is not supported by Sourcegraph. Please upgrade your GitLab instance(s) to prevent disruption.",
 			}}
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/40290.

Just changes the contents and type of the site alert.

![image](https://user-images.githubusercontent.com/8942601/188685311-f47b6301-4fee-4992-a601-fad76ff71133.png)

## Test plan

Triggered and verified alert contents locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
