### PR TITLE
insights: stop aggregation counting if the context is canceled

### DIFF
--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -244,6 +244,8 @@ func (r *searchAggregationResults) Send(event streaming.SearchEvent) {
 	for _, match := range event.Results {
 		select {
 		case <-r.ctx.Done():
+			// let the tabulator an error occured.
+			r.tabulator(nil, r.ctx.Err())
 			return
 		default:
 			groups, err := r.countFunc(match)

--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -245,7 +245,8 @@ func (r *searchAggregationResults) Send(event streaming.SearchEvent) {
 		select {
 		case <-r.ctx.Done():
 			// let the tabulator an error occured.
-			r.tabulator(nil, r.ctx.Err())
+			err := errors.Wrap(r.ctx.Err(), "tabulation terminated context is done")
+			r.tabulator(nil, err)
 			return
 		default:
 			groups, err := r.countFunc(match)

--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -208,8 +208,9 @@ func GetCountFuncForMode(query, patternType string, mode types.SearchAggregation
 	return modeCountFunc, nil
 }
 
-func NewSearchResultsAggregatorWithProgress(ctx context.Context, tabulator AggregationTabulator, countFunc AggregationCountFunc, db database.DB) SearchResultsAggregator {
+func NewSearchResultsAggregatorWithContext(ctx context.Context, tabulator AggregationTabulator, countFunc AggregationCountFunc, db database.DB) SearchResultsAggregator {
 	return &searchAggregationResults{
+		ctx:       ctx,
 		tabulator: tabulator,
 		countFunc: countFunc,
 		progress: client.ProgressAggregator{
@@ -221,6 +222,7 @@ func NewSearchResultsAggregatorWithProgress(ctx context.Context, tabulator Aggre
 }
 
 type searchAggregationResults struct {
+	ctx       context.Context
 	tabulator AggregationTabulator
 	countFunc AggregationCountFunc
 	progress  client.ProgressAggregator
@@ -240,19 +242,25 @@ func (r *searchAggregationResults) Send(event streaming.SearchEvent) {
 	r.progress.Update(event)
 	combined := map[MatchKey]int{}
 	for _, match := range event.Results {
-		groups, err := r.countFunc(match)
-		for groupKey, count := range groups {
-			// delegate error handling to the passed in tabulator
-			if err != nil {
-				r.tabulator(nil, err)
-				continue
+		select {
+		case <-r.ctx.Done():
+			return
+		default:
+			groups, err := r.countFunc(match)
+			for groupKey, count := range groups {
+				// delegate error handling to the passed in tabulator
+				if err != nil {
+					r.tabulator(nil, err)
+					continue
+				}
+				if groups == nil {
+					continue
+				}
+				current, _ := combined[groupKey]
+				combined[groupKey] = current + count
 			}
-			if groups == nil {
-				continue
-			}
-			current, _ := combined[groupKey]
-			combined[groupKey] = current + count
 		}
+
 	}
 	for key, count := range combined {
 		r.tabulator(&AggregationMatchResult{Key: key, Count: count}, nil)

--- a/enterprise/internal/insights/aggregation/aggregation_test.go
+++ b/enterprise/internal/insights/aggregation/aggregation_test.go
@@ -1,6 +1,7 @@
 package aggregation
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -14,8 +15,9 @@ import (
 	internaltypes "github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func newTestSearchResultsAggregator(tabulator AggregationTabulator, countFunc AggregationCountFunc) SearchResultsAggregator {
+func newTestSearchResultsAggregator(ctx context.Context, tabulator AggregationTabulator, countFunc AggregationCountFunc) SearchResultsAggregator {
 	return &searchAggregationResults{
+		ctx:       ctx,
 		tabulator: tabulator,
 		countFunc: countFunc,
 	}
@@ -225,7 +227,7 @@ func TestRepoAggregation(t *testing.T) {
 		t.Run(tc.want.Name(), func(t *testing.T) {
 			aggregator := testAggregator{results: make(map[string]int)}
 			countFunc, _ := GetCountFuncForMode("", "", tc.mode)
-			sra := newTestSearchResultsAggregator(aggregator.AddResult, countFunc)
+			sra := newTestSearchResultsAggregator(context.Background(), aggregator.AddResult, countFunc)
 			sra.Send(tc.searchEvent)
 			tc.want.Equal(t, aggregator.results)
 		})
@@ -287,7 +289,7 @@ func TestAuthorAggregation(t *testing.T) {
 		t.Run(tc.want.Name(), func(t *testing.T) {
 			aggregator := testAggregator{results: make(map[string]int)}
 			countFunc, _ := GetCountFuncForMode("", "", tc.mode)
-			sra := newTestSearchResultsAggregator(aggregator.AddResult, countFunc)
+			sra := newTestSearchResultsAggregator(context.Background(), aggregator.AddResult, countFunc)
 			sra.Send(tc.searchEvent)
 			tc.want.Equal(t, aggregator.results)
 		})
@@ -384,7 +386,7 @@ func TestPathAggregation(t *testing.T) {
 		t.Run(tc.want.Name(), func(t *testing.T) {
 			aggregator := testAggregator{results: make(map[string]int)}
 			countFunc, _ := GetCountFuncForMode("", "", tc.mode)
-			sra := newTestSearchResultsAggregator(aggregator.AddResult, countFunc)
+			sra := newTestSearchResultsAggregator(context.Background(), aggregator.AddResult, countFunc)
 			sra.Send(tc.searchEvent)
 			tc.want.Equal(t, aggregator.results)
 		})
@@ -577,7 +579,46 @@ func TestCaptureGroupAggregation(t *testing.T) {
 				t.Errorf("expected test not to error, got %v", err)
 				t.FailNow()
 			}
-			sra := newTestSearchResultsAggregator(aggregator.AddResult, countFunc)
+			sra := newTestSearchResultsAggregator(context.Background(), aggregator.AddResult, countFunc)
+			sra.Send(tc.searchEvent)
+			tc.want.Equal(t, aggregator.results)
+		})
+	}
+}
+
+func TestAggregationCancelation(t *testing.T) {
+
+	testCases := []struct {
+		mode        types.SearchAggregationMode
+		searchEvent streaming.SearchEvent
+		query       string
+		want        autogold.Value
+	}{
+		{
+			types.CAPTURE_GROUP_AGGREGATION_MODE,
+			streaming.SearchEvent{
+				Results: []result.Match{
+					contentMatch("myRepo", "file.go", 1, "python2.7 python3.9"),
+					contentMatch("myRepo2", "file2.go", 2, "python2.7 python3.9"),
+				},
+			},
+			`python([0-9]\.[0-9])`,
+			autogold.Want("aggregator stops counting if context canceled", map[string]int{"2.7": 2, "3.9": 2}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.want.Name(), func(t *testing.T) {
+			aggregator := testAggregator{results: make(map[string]int)}
+			countFunc, err := GetCountFuncForMode(tc.query, "regexp", tc.mode)
+			if err != nil {
+				t.Errorf("expected test not to error, got %v", err)
+				t.FailNow()
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			sra := newTestSearchResultsAggregator(ctx, aggregator.AddResult, countFunc)
+			sra.Send(tc.searchEvent)
+			cancel()
 			sra.Send(tc.searchEvent)
 			tc.want.Equal(t, aggregator.results)
 		})

--- a/enterprise/internal/insights/aggregation/aggregation_test.go
+++ b/enterprise/internal/insights/aggregation/aggregation_test.go
@@ -25,10 +25,12 @@ func newTestSearchResultsAggregator(ctx context.Context, tabulator AggregationTa
 
 type testAggregator struct {
 	results map[string]int
+	errors  []error
 }
 
 func (r *testAggregator) AddResult(result *AggregationMatchResult, err error) {
 	if err != nil {
+		r.errors = append(r.errors, err)
 		return
 	}
 	current, _ := r.results[result.Key.Group]
@@ -621,6 +623,9 @@ func TestAggregationCancelation(t *testing.T) {
 			cancel()
 			sra.Send(tc.searchEvent)
 			tc.want.Equal(t, aggregator.results)
+			if len(aggregator.errors) != 1 {
+				t.Errorf("context cancel should be captured as an error")
+			}
 		})
 	}
 }

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -122,7 +122,7 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	requestContext, cancelReqContext := context.WithTimeout(ctx, time.Second*time.Duration(searchTimelimit))
 	defer cancelReqContext()
 	searchClient := streaming.NewInsightsSearchClient(r.postgresDB)
-	searchResultsAggregator := aggregation.NewSearchResultsAggregatorWithProgress(ctx, tabulationFunc, countingFunc, r.postgresDB)
+	searchResultsAggregator := aggregation.NewSearchResultsAggregatorWithContext(requestContext, tabulationFunc, countingFunc, r.postgresDB)
 
 	alert, err := searchClient.Search(requestContext, string(modifiedQuery), &r.patternType, searchResultsAggregator)
 	if err != nil || requestContext.Err() != nil {


### PR DESCRIPTION
In searches that generate many matches it was possible for the request to extend beyond the context cancelation because it was processing a backlog of search events.  The request would eventually be marked as a timeout so this processing was wasteful.  This adds a check to exit early from the counting process if the context is already canceled.
## Test plan
Unit tests added.
Manually verify with long running searches.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
