### PR TITLE
Fix aggregation cache across different ui modes

### DIFF
--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -330,7 +330,7 @@ describe('Search aggregation', () => {
 
             expect(variables).toStrictEqual({
                 mode: null,
-                limit: 10,
+                limit: 30,
                 skipAggregation: false,
                 patternType: 'standard',
                 query: `${origQuery} case:yes`,
@@ -343,7 +343,7 @@ describe('Search aggregation', () => {
 
             expect(variablesForFileMode).toStrictEqual({
                 mode: 'PATH',
-                limit: 10,
+                limit: 30,
                 skipAggregation: false,
                 patternType: 'standard',
                 query: `${origQuery} case:yes`,
@@ -356,7 +356,7 @@ describe('Search aggregation', () => {
 
             expect(variablesWithoutCaseSensitivity).toStrictEqual({
                 mode: 'PATH',
-                limit: 10,
+                limit: 30,
                 skipAggregation: false,
                 patternType: 'standard',
                 query: origQuery,

--- a/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
@@ -24,6 +24,8 @@ const LazyAggregationChart = lazyComponent<AggregationChartProps<SearchAggregati
 const MIN_X_TICK_ROTATION = 30
 const MAX_SHORT_LABEL_WIDTH = 8
 const MAX_LABEL_WIDTH = 16
+const MAX_BARS_FULL_MODE = 30
+const MAX_BARS_PREVIEW_MOD = 10
 
 const getName = (datum: SearchAggregationDatum): string => datum.label ?? ''
 const getValue = (datum: SearchAggregationDatum): number => datum.count
@@ -43,11 +45,11 @@ function getAggregationError(aggregation?: SearchAggregationResult): Error | und
     return
 }
 
-export function getAggregationData(aggregations: SearchAggregationResult, limit: number): SearchAggregationDatum[] {
+export function getAggregationData(aggregations: SearchAggregationResult, limit?: number): SearchAggregationDatum[] {
     switch (aggregations?.__typename) {
         case 'ExhaustiveSearchAggregationResult':
         case 'NonExhaustiveSearchAggregationResult':
-            return aggregations.groups.slice(0, limit)
+            return limit !== undefined ? aggregations.groups.slice(0, limit) : aggregations.groups
 
         default:
             return []
@@ -121,7 +123,7 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
         return null
     }
 
-    const maxBarsLimit = size === 'sm' ? 10 : 30
+    const maxBarsLimit = size === 'sm' ? MAX_BARS_PREVIEW_MOD : MAX_BARS_FULL_MODE
     const aggregationData = getAggregationData(data, maxBarsLimit)
     const missingCount = getOtherGroupCount(data, maxBarsLimit)
 
@@ -143,7 +145,7 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
             <Suspense>
                 <LazyAggregationChart
                     aria-label={ariaLabel}
-                    data={getAggregationData(data, maxBarsLimit)}
+                    data={aggregationData}
                     mode={mode}
                     minAngleXTick={size === 'md' ? 0 : MIN_X_TICK_ROTATION}
                     maxXLabelLength={size === 'md' ? MAX_LABEL_WIDTH : MAX_SHORT_LABEL_WIDTH}

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -50,9 +50,8 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
         query,
         patternType,
         aggregationMode,
-        limit: 30,
-        proactive: true,
         caseSensitive,
+        proactive: true,
     })
 
     const handleCollapseClick = (): void => {
@@ -141,7 +140,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
 
                 {data && (
                     <ul className={styles.listResult}>
-                        {getAggregationData(data.searchQueryAggregate.aggregations).map(datum => (
+                        {getAggregationData(data.searchQueryAggregate.aggregations, 30).map(datum => (
                             <li key={datum.label} className={styles.listResultItem}>
                                 <span>{datum.label}</span>
                                 <span>{datum.count}</span>

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -140,7 +140,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
 
                 {data && (
                     <ul className={styles.listResult}>
-                        {getAggregationData(data.searchQueryAggregate.aggregations, 30).map(datum => (
+                        {getAggregationData(data.searchQueryAggregate.aggregations).map(datum => (
                             <li key={datum.label} className={styles.listResultItem}>
                                 <span>{datum.label}</span>
                                 <span>{datum.count}</span>

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -205,9 +205,8 @@ interface SearchAggregationDataInput {
     query: string
     patternType: SearchPatternType
     aggregationMode: SearchAggregationMode | null
-    limit: number
-    proactive?: boolean
     caseSensitive: boolean
+    proactive?: boolean
 }
 
 interface AggregationState {
@@ -223,7 +222,7 @@ type SearchAggregationResults =
     | { data: GetSearchAggregationResult; loading: false; error: undefined }
 
 export const useSearchAggregationData = (input: SearchAggregationDataInput): SearchAggregationResults => {
-    const { query, patternType, aggregationMode, limit, proactive, caseSensitive } = input
+    const { query, patternType, aggregationMode, proactive, caseSensitive } = input
 
     const [, setAggregationMode] = useAggregationSearchMode()
     const [state, setState] = useState<AggregationState>(INITIAL_STATE)
@@ -240,7 +239,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
                 query: aggregationQuery,
                 patternType,
                 mode: aggregationMode,
-                limit,
+                limit: 30,
                 skipAggregation: aggregationMode === null && !proactive,
             },
 

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -55,7 +55,6 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         aggregationMode,
         proactive,
         caseSensitive,
-        limit: 10,
     })
 
     const handleBarLinkClick = (query: string, index: number): void => {


### PR DESCRIPTION
## Background

Prior to this PR sidebar aggregation chart and the full UI mode had different value for Aggregation group limit, (sidebar 10, full mode 30). Because of this cache didn't work well because different view required different amount of data and we had to fetch it. 

In this PR both view have the same limit (which is 30), based on @coury-clark feedback this doesn't do anything with resolver speed on the backed and it adds a proper cache on the frontend.


## Test plan
- Run any query that can have more than 30 aggregation groups
- Check that the sidebar displays only 10 bars
- Open the full UI mode
- It should be opened immediately without additional fetch call 
- Check that the addition group number was increased by 20


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-adjust-aggregation-limit.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lkkoonpicq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
