### PR TITLE
[Admin Analytics] update default extensions mins saved

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
@@ -138,14 +138,14 @@ export const AnalyticsExtensionsPage: React.FunctionComponent<RouteComponentProp
                 },
                 {
                     label: 'JetBrains IDE plugin',
-                    minPerItem: 1.5,
+                    minPerItem: 5,
                     value: jetbrains.summary.totalCount,
                     description:
                         "Searches from JetBrains IDEs across all of your company's code without locally cloning repositories or complex scripting.",
                 },
                 {
                     label: 'VS Code IDE extension',
-                    minPerItem: 3,
+                    minPerItem: 5,
                     value: vscode.summary.totalCount,
                     description:
                         "Searches from VS Code across all of your company's code without locally cloning repositories or complex scripting.",


### PR DESCRIPTION
closes https://sourcegraph.slack.com/archives/C03JNPY7V3L/p1662470406464039?thread_ts=1662466640.458559&cid=C03JNPY7V3L

Update default minutes saved per event for JetBrains and VS Code extensions to 5. 

## Test plan

<img width="951" alt="image" src="https://user-images.githubusercontent.com/22571395/188708399-843dae4d-b1b7-4f84-930d-f963e61a3acb.png">

## App preview:

- [Web](https://sg-web-naman-admin-analytics-ext-update.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wgnojbnsuu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
