### PR TITLE
search: simplify query generator control flow

### DIFF
--- a/internal/search/lucky/feeling_lucky_search_job.go
+++ b/internal/search/lucky/feeling_lucky_search_job.go
@@ -102,16 +102,8 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	generated := &alertobserver.ErrLuckyQueries{Type: luckyAlertType, ProposedQueries: []*search.QueryDescription{}}
 	var autoQ *autoQuery
 	for _, next := range f.generators {
-		for {
+		for next != nil {
 			autoQ, next = next()
-			if autoQ == nil {
-				if next == nil {
-					// No query and generator is exhausted.
-					break
-				}
-				continue
-			}
-
 			j := f.newGeneratedJob(autoQ)
 			if j == nil {
 				// Generated an invalid job with this query, just continue.
@@ -139,10 +131,6 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 			}
 
 			maxAlerter.Add(alert)
-
-			if next == nil {
-				break
-			}
 		}
 	}
 

--- a/internal/search/lucky/generator.go
+++ b/internal/search/lucky/generator.go
@@ -93,7 +93,7 @@ func NewGenerator(seed query.Basic, narrow, widen []rule) next {
 				// Base case: we exhausted the set of narrow
 				// rules (if any) and we've attempted every
 				// widen rule with the sets of narrow rules.
-				return func() (*autoQuery, next) { return nil, nil }
+				return nil
 			}
 
 			transform = append(transform, widen[w].transform...)

--- a/internal/search/lucky/generator_test.go
+++ b/internal/search/lucky/generator_test.go
@@ -39,21 +39,15 @@ func TestNewGenerator(t *testing.T) {
 func generateAll(g next, input string) []want {
 	var autoQ *autoQuery
 	generated := []want{}
-	for {
+	for g != nil {
 		autoQ, g = g()
-		if autoQ != nil {
-			generated = append(
-				generated,
-				want{
-					Description: autoQ.description,
-					Input:       input,
-					Query:       query.StringHuman(autoQ.query.ToParseTree()),
-				})
-		}
-
-		if g == nil {
-			break
-		}
+		generated = append(
+			generated,
+			want{
+				Description: autoQ.description,
+				Input:       input,
+				Query:       query.StringHuman(autoQ.query.ToParseTree()),
+			})
 	}
 	return generated
 }


### PR DESCRIPTION
Simplifies the base case value for the query generator, so the surrounding control flow simplifies to 

```go
g := NewGenerator(...)
for g != nil {
  autoQ, g = g()
  // stuff
}
```

(Rework of https://github.com/sourcegraph/sourcegraph/pull/38698)

## Test plan
Semantics-preserving, covered by tests.