### PR TITLE
search: highlight matching path ranges on content matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - A new look for Sourcegraph, previously in beta as "Simple UI", is now permanently enabled. [#41021](https://github.com/sourcegraph/sourcegraph/pull/41021)
 - A new [multi-version upgrade](https://docs.sourcegraph.com/admin/updates#multi-version-upgrades) process now allows Sourcegraph instances to upgrade more than a single minor version. Instances at version 3.20 or later can now jump directly to 4.0. [#40628](https://github.com/sourcegraph/sourcegraph/pull/40628)
+- Matching ranges in file paths are now highlighted for path results and content results. [#41296](https://github.com/sourcegraph/sourcegraph/pull/41296) [#41385](https://github.com/sourcegraph/sourcegraph/pull/41385)
 
 ### Changed
 

--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -193,7 +193,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
                 repoName={result.repository}
                 repoURL={repoAtRevisionURL}
                 filePath={result.path}
-                pathMatchRanges={result.type === 'path' ? result.pathMatches : []}
+                pathMatchRanges={'pathMatches' in result ? result.pathMatches : []}
                 fileURL={getFileMatchUrl(result)}
                 repoDisplayName={
                     props.repoDisplayName

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -45,6 +45,7 @@ export interface PathMatch {
 export interface ContentMatch {
     type: 'content'
     path: string
+    pathMatches?: Range[]
     repository: string
     repoStars?: number
     repoLastFetched?: string

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -389,6 +389,7 @@ func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Sear
 	contentEvent := &streamhttp.EventContentMatch{
 		Type:         streamhttp.ContentMatchType,
 		Path:         fm.Path,
+		PathMatches:  fromRanges(fm.PathMatches),
 		RepositoryID: int32(fm.Repo.ID),
 		Repository:   string(fm.Repo.Name),
 		Commit:       string(fm.CommitID),

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -20,6 +20,7 @@ type EventContentMatch struct {
 	Type MatchType `json:"type"`
 
 	Path            string           `json:"path"`
+	PathMatches     []Range          `json:"pathMatches,omitempty"`
 	RepositoryID    int32            `json:"repositoryID"`
 	Repository      string           `json:"repository"`
 	RepoStars       int              `json:"repoStars,omitempty"`


### PR DESCRIPTION
Stacked on #41297
Part of #18374

Per [feedback](https://github.com/sourcegraph/sourcegraph/pull/41296#pullrequestreview-1096559035), this PR adds file path highlighting to content matches.

![Screen Shot 2022-09-06 at 3 35 54 PM](https://user-images.githubusercontent.com/70350613/188733161-be109181-fbf0-4650-b04a-90e8183a04df.png)

## Test plan
Visually verify highlighting is occurring
CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
