### PR TITLE
licensing: add documentation on how to generate a license key for testing and debugging

### DIFF
--- a/doc/dev/how-to/generate_license_key_for_testing.md
+++ b/doc/dev/how-to/generate_license_key_for_testing.md
@@ -1,0 +1,55 @@
+# How to generate a license key for testing and debugging
+
+During development, you can generate a license key locally to test and debug how some features, UI components, alerts, errors, and logs are (or will be) displayed to users depending on their purchased plan.
+
+The steps below are only for development and won't work in production. 
+
+1. Choose the plan you want to test:
+
+````
+old-starer-0     // the old Enterprise Starter plan.
+old-enterprise-0 // the old Enterprise plan.
+team-0           // the Team plan pre-4.0 (used for development).
+enterprise-0     // the Enterprise plan pre-4.0.
+business-0       // the Business plan for 4.0.
+enterprise-1     // the Enterprise plan for 4.0.
+````
+
+2. Run the following command from your terminal, from the `/sourcegraph` directory. Replace `business-0` with the name of any other plan that you want to test. This command will use the private key set on the `dev-private` repository in the `site-config.json` file, so you need to have a local clone of this repository.
+
+          go run ./enterprise/internal/license/generate-license.go -private-key ../dev-private/enterprise/dev/test-license-generation-key.pem -tags=plan:business-0 -users=10 -expires=8784h .
+
+3. Confirm that the license generated has the correct information. For the example above, the output was: 
+
+    ````
+    # License info (encoded and signed in license key)
+    {
+      "t": [
+       "plan:business-0"
+     ],
+     "u": 10,
+     "e": "2023-09-07T19:28:06Z"
+    }
+
+    # License key
+    <the license key> 
+    ````
+
+4. Copy and paste the new license key (just the block under "# License key") to the `site-config.json` file in your local clone of `dev-private.`
+
+````
+{
+  "auth.providers": [
+   {
+     "type": "builtin",
+     "allowSignup": true
+   }
+ ],
+ "licenseKey": "<paste here the newly generated license key> ",
+ // ... 
+}
+````
+
+5. Restart your local instance. 
+
+6. Go to the admin page and click on `Configuration > License` to confirm that the new license is active.

--- a/doc/dev/how-to/generate_license_key_for_testing.md
+++ b/doc/dev/how-to/generate_license_key_for_testing.md
@@ -4,18 +4,9 @@ During development, you can generate a license key locally to test and debug how
 
 The steps below are only for development and won't work in production. 
 
-1. Choose the plan you want to test:
+1. Choose the plan you want to test. Available options include `business-0` and `enterprise-1`, among others. You can see the whole list [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/internal/licensing/data.go?L3&subtree=true).
 
-````
-old-starer-0     // the old Enterprise Starter plan.
-old-enterprise-0 // the old Enterprise plan.
-team-0           // the Team plan pre-4.0 (used for development).
-enterprise-0     // the Enterprise plan pre-4.0.
-business-0       // the Business plan for 4.0.
-enterprise-1     // the Enterprise plan for 4.0.
-````
-
-2. Run the following command from your terminal, from the `/sourcegraph` directory. Replace `business-0` with the name of any other plan that you want to test. This command will use the private key set on the `dev-private` repository in the `site-config.json` file, so you need to have a local clone of this repository.
+2. Run the following command from your terminal in the root directory of the `/sourcegraph/sourcegraph` repository. Replace `business-0` with the name of any other plan that you want to test. This command will use the private key set on the `dev-private` repository in the `site-config.json` file, so you need to have a local clone of this repository.
 
           go run ./enterprise/internal/license/generate-license.go -private-key ../dev-private/enterprise/dev/test-license-generation-key.pem -tags=plan:business-0 -users=10 -expires=8784h .
 

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -167,6 +167,10 @@ Guides to help with troubleshooting, configuring test instances, debugging, and 
 - [Set up local monitoring development](how-to/monitoring_local_dev.md)
 - [Set up local OpenTelemetry development](how-to/otel_local_dev.md)
 
+### Plans and licenses
+
+- [How to generate a license key for testing and debugging](how-to/generate_license_key_for_testing.md)
+
 ### Documentation
 
 - [Developing the product documentation](how-to/documentation_implementation.md)


### PR DESCRIPTION
Part of #40064

This PR updates the docs with instructions for devs on how to generate a license key for testing and debugging locally.

## Test plan

Manually tested locally by checking the pages
- http://localhost:5080/dev#plans-and-licenses  to confirm that the new section "#Plans and licenses" was successfully created.
- http://localhost:5080/dev/how-to/generate_license_key_for_testing to confirm that new page was created.

<img width="1456" alt="Screen Shot 2022-09-06 at 14 12 43" src="https://user-images.githubusercontent.com/1552863/188739221-e6599e40-85f0-4676-b2f9-f4ea29c9a61a.png">
<img width="1365" alt="Screen Shot 2022-09-06 at 14 13 08" src="https://user-images.githubusercontent.com/1552863/188739239-09564be1-dd8a-427c-9db4-47b114a9e9f9.png">
