### PR TITLE
insights: aggregations only capture the match's content if needed for the group type

### DIFF
--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -241,9 +241,6 @@ func (r *searchAggregationResults) Send(event streaming.SearchEvent) {
 					r.tabulator(nil, err)
 					continue
 				}
-				if groups == nil {
-					continue
-				}
 				current, _ := combined[groupKey]
 				combined[groupKey] = current + count
 			}

--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -40,24 +40,18 @@ type MatchKey struct {
 }
 
 func countRepo(r result.Match) (map[MatchKey]int, error) {
-	resultCount := r.ResultCount()
-	switch r.(type) {
-	case *result.CommitMatch:
-		resultCount = 1
-	}
 	if r.RepoName().Name != "" {
 		return map[MatchKey]int{{
 			RepoID: int32(r.RepoName().ID),
 			Repo:   string(r.RepoName().Name),
 			Group:  string(r.RepoName().Name),
-		}: resultCount}, nil
+		}: r.ResultCount()}, nil
 	}
 	return nil, nil
 }
 
 func countLang(r result.Match) (map[MatchKey]int, error) {
 	var lang string
-	resultCount := r.ResultCount()
 	switch match := r.(type) {
 	case *result.FileMatch:
 		lang, _ = enry.GetLanguageByExtension(match.Path)
@@ -68,14 +62,13 @@ func countLang(r result.Match) (map[MatchKey]int, error) {
 			RepoID: int32(r.RepoName().ID),
 			Repo:   string(r.RepoName().Name),
 			Group:  lang,
-		}: resultCount}, nil
+		}: r.ResultCount()}, nil
 	}
 	return nil, nil
 }
 
 func countPath(r result.Match) (map[MatchKey]int, error) {
 	var path string
-	resultCount := r.ResultCount()
 	switch match := r.(type) {
 	case *result.FileMatch:
 		path = match.Path
@@ -86,7 +79,7 @@ func countPath(r result.Match) (map[MatchKey]int, error) {
 			RepoID: int32(r.RepoName().ID),
 			Repo:   string(r.RepoName().Name),
 			Group:  path,
-		}: resultCount}, nil
+		}: r.ResultCount()}, nil
 	}
 	return nil, nil
 }
@@ -103,7 +96,7 @@ func countAuthor(r result.Match) (map[MatchKey]int, error) {
 			RepoID: int32(r.RepoName().ID),
 			Repo:   string(r.RepoName().Name),
 			Group:  author,
-		}: 1}, nil
+		}: r.ResultCount()}, nil
 	}
 	return nil, nil
 }

--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -49,7 +49,11 @@ func newEventMatch(event result.Match, contentNeeded bool) *eventMatch {
 	switch match := event.(type) {
 	case *result.FileMatch:
 		lang, _ := enry.GetLanguageByExtension(match.Path)
-		content := make([]string, 0, len(match.ChunkMatches))
+		var capacity int
+		if contentNeeded {
+			capacity = len(match.ChunkMatches)
+		}
+		content := make([]string, 0, capacity)
 		if contentNeeded {
 			if len(match.ChunkMatches) > 0 { // This File match with the subtype of text results
 				for _, cm := range match.ChunkMatches {

--- a/enterprise/internal/insights/aggregation/aggregation_test.go
+++ b/enterprise/internal/insights/aggregation/aggregation_test.go
@@ -99,6 +99,18 @@ func commitMatch(repo, author string, date time.Time, repoID, numRanges int32, c
 			Message:   gitdomain.Message(content),
 		},
 		Repo: internaltypes.MinimalRepo{Name: api.RepoName(repo), ID: api.RepoID(repoID)},
+		MessagePreview: &result.MatchedString{
+			Content: content,
+			MatchedRanges: result.Ranges{
+				{
+					Start: result.Location{Line: 1, Offset: 0, Column: 1},
+					End:   result.Location{Line: 1, Offset: 1, Column: 1},
+				},
+				{
+					Start: result.Location{Line: 2, Offset: 0, Column: 1},
+					End:   result.Location{Line: 2, Offset: 1, Column: 1},
+				}},
+		},
 	}
 }
 
@@ -176,7 +188,7 @@ func TestRepoAggregation(t *testing.T) {
 					commitMatch("myRepo", "Author A", sampleDate, 1, 2, "a"),
 					commitMatch("myRepo", "Author B", sampleDate, 1, 2, "b"),
 				}},
-			autogold.Want("Count repos on commit matches", map[string]int{"myRepo": 2}),
+			autogold.Want("Count repos on commit matches", map[string]int{"myRepo": 4}),
 		},
 		{
 			types.REPO_AGGREGATION_MODE,
@@ -213,7 +225,7 @@ func TestRepoAggregation(t *testing.T) {
 					diffMatch("myRepo", "author-a", 1),
 					diffMatch("myRepo", "author-b", 1),
 				}},
-			autogold.Want("Count repos on diff matches", map[string]int{"myRepo": 2}),
+			autogold.Want("Count repos on diff matches", map[string]int{"myRepo": 4}),
 		},
 		{
 			types.REPO_AGGREGATION_MODE,
@@ -222,7 +234,7 @@ func TestRepoAggregation(t *testing.T) {
 					diffMatch("myRepo", "author-a", 1),
 					diffMatch("myRepo2", "author-b", 2),
 				}},
-			autogold.Want("Count multiple repos on diff matches", map[string]int{"myRepo": 1, "myRepo2": 1}),
+			autogold.Want("Count multiple repos on diff matches", map[string]int{"myRepo": 2, "myRepo2": 2}),
 		},
 	}
 	for _, tc := range testCases {
@@ -274,7 +286,7 @@ func TestAuthorAggregation(t *testing.T) {
 					commitMatch("repoB", "Author C", sampleDate, 2, 2, "a"),
 				},
 			},
-			autogold.Want("counts by author", map[string]int{"Author A": 1, "Author B": 2, "Author C": 1}),
+			autogold.Want("counts by author", map[string]int{"Author A": 2, "Author B": 4, "Author C": 2}),
 		},
 		{
 			types.AUTHOR_AGGREGATION_MODE,
@@ -284,7 +296,7 @@ func TestAuthorAggregation(t *testing.T) {
 					diffMatch("myRepo2", "author-a", 2),
 					diffMatch("myRepo2", "author-b", 2),
 				}},
-			autogold.Want("Count authors on diff matches", map[string]int{"author-a": 2, "author-b": 1}),
+			autogold.Want("Count authors on diff matches", map[string]int{"author-a": 4, "author-b": 2}),
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Most of the group by types don't need the content of the match just metadata, this change ignores the matches content except when doing capture group matches which rely on it.
## Test plan
existing unit test coverage 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
