### PR TITLE
batches: remove GraphQL deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Quick links will no longer be shown on the homepage or search sidebar if the "Simple UI" toggle is enabled and will be removed entirely in a future release. The `quicklink` setting is now marked as deprecated. [#40750](https://github.com/sourcegraph/sourcegraph/pull/40750)
 - `file:contains()` has been removed from the list of valid predicates. `file:has.content()` and `file:contains.content()` remain, both of which work the same as `file:contains()` and are valid aliases of each other.
 - The single-container `sourcegraph/server` deployment no longer bundles a Jaeger instance. [#41244](https://github.com/sourcegraph/sourcegraph/pull/41244)
+- The following previously-deprecated fields have been removed from the Batch Changes GraphQL API: `GitBranchChangesetDescription.headRepository`, `BatchChange.initialApplier`, `BatchChange.specCreator`, `Changeset.publicationState`, `Changeset.reconcilerState`, `Changeset.externalState`.
 
 ## 3.43.1
 

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -507,7 +507,6 @@ type GitBranchChangesetDescriptionResolver interface {
 	BaseRef() string
 	BaseRev() string
 
-	HeadRepository() *RepositoryResolver
 	HeadRef() string
 
 	Title() string
@@ -631,11 +630,9 @@ type BatchChangeResolver interface {
 	Name() string
 	Description() *string
 	State() string
-	InitialApplier(ctx context.Context) (*UserResolver, error)
 	Creator(ctx context.Context) (*UserResolver, error)
 	LastApplier(ctx context.Context) (*UserResolver, error)
 	LastAppliedAt() *DateTime
-	SpecCreator(ctx context.Context) (*UserResolver, error)
 	ViewerCanAdminister(ctx context.Context) (bool, error)
 	URL(ctx context.Context) (string, error)
 	Namespace(ctx context.Context) (n NamespaceResolver, err error)
@@ -706,12 +703,6 @@ type ChangesetResolver interface {
 	CreatedAt() DateTime
 	UpdatedAt() DateTime
 	NextSyncAt(ctx context.Context) (*DateTime, error)
-	// PublicationState returns a value of type btypes.ChangesetPublicationState.
-	PublicationState() string
-	// ReconcilerState returns a value of type btypes.ReconcilerState.
-	ReconcilerState() string
-	// ExternalState returns a value of type *btypes.ChangesetExternalState.
-	ExternalState() *string
 	// State returns a value of type *btypes.ChangesetState.
 	State() string
 	BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -232,24 +232,6 @@ interface Changeset {
     ): BatchChangeConnection!
 
     """
-    The publication state of the changeset.
-    """
-    publicationState: ChangesetPublicationState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The reconciler state of the changeset.
-    """
-    reconcilerState: ChangesetReconcilerState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The external state of the changeset, or null when not yet published to the code host.
-    """
-    externalState: ChangesetExternalState
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
     The state of the changeset.
     """
     state: ChangesetState!
@@ -304,24 +286,6 @@ type HiddenExternalChangeset implements Node & Changeset {
         """
         viewerCanAdminister: Boolean
     ): BatchChangeConnection!
-
-    """
-    The publication state of the changeset.
-    """
-    publicationState: ChangesetPublicationState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The reconciler state of the changeset.
-    """
-    reconcilerState: ChangesetReconcilerState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The external state of the changeset, or null when not yet published to the code host.
-    """
-    externalState: ChangesetExternalState
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
 
     """
     The state of the changeset.
@@ -432,24 +396,6 @@ type ExternalChangeset implements Node & Changeset {
     or the changeset has not yet been published.
     """
     author: Person
-
-    """
-    The publication state of the changeset.
-    """
-    publicationState: ChangesetPublicationState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The reconciler state of the changeset.
-    """
-    reconcilerState: ChangesetReconcilerState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The external state of the changeset, or null when not yet published to the code host.
-    """
-    externalState: ChangesetExternalState
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
 
     """
     The state of the changeset.
@@ -925,14 +871,6 @@ type GitBranchChangesetDescription {
     For example: "4095572721c6234cd72013fd49dff4fb48f0f8a4"
     """
     baseRev: String!
-
-    """
-    The repository that contains the branch with this changeset's changes.
-    """
-    headRepository: Repository!
-        @deprecated(
-            reason: "Unused. Sourcegraph does not populate a full repository when creating a changeset on a fork. Use VisibleChangesetSpec.fork or ExternalChangeset.forkNamespace instead."
-        )
 
     """
     The full name of the Git ref that holds the changes proposed by this changeset. This ref will
@@ -2603,22 +2541,6 @@ type BatchChange implements Node {
     state: BatchChangeState!
 
     """
-    The user that created the initial spec. In an org, this will be different from the namespace, or null if the user was deleted.
-    """
-    specCreator: User
-        @deprecated(
-            reason: "Unused. This always incorrectly returned the current batch specs creator, not the intial one. This field is deprecated and will be removed in a future release."
-        )
-
-    """
-    The user who created the batch change initially by applying the spec for the first time, or null if the user was deleted.
-
-    This is an alias of BatchChange.creator.
-    """
-    initialApplier: User
-        @deprecated(reason: "Use creator instead. This field is deprecated and will be removed in a future release.")
-
-    """
     The user who created the batch change, or null if the user was deleted.
     """
     creator: User
@@ -2675,27 +2597,6 @@ type BatchChange implements Node {
         Opaque pagination cursor.
         """
         after: String
-        """
-        Only include changesets with any of the given reconciler states.
-        """
-        reconcilerState: [ChangesetReconcilerState!]
-            @deprecated(
-                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
-            )
-        """
-        Only include changesets with the given publication state.
-        """
-        publicationState: ChangesetPublicationState
-            @deprecated(
-                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
-            )
-        """
-        Only include changesets with the given external state.
-        """
-        externalState: ChangesetExternalState
-            @deprecated(
-                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
-            )
         """
         Only include changesets with the given state.
         """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
@@ -316,8 +316,7 @@ type ChangesetSpecDescription struct {
 	ExternalID     string
 	BaseRef        string
 
-	HeadRepository Repository
-	HeadRef        string
+	HeadRef string
 
 	Title string
 	Body  string

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -76,10 +76,6 @@ func (r *batchChangeResolver) State() string {
 	return state.ToGraphQL()
 }
 
-func (r *batchChangeResolver) InitialApplier(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	return r.Creator(ctx)
-}
-
 func (r *batchChangeResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
 	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DatabaseDB(), r.batchChange.CreatorID)
 	if errcode.IsNotFound(err) {
@@ -107,20 +103,6 @@ func (r *batchChangeResolver) LastAppliedAt() *graphqlbackend.DateTime {
 	}
 
 	return &graphqlbackend.DateTime{Time: r.batchChange.LastAppliedAt}
-}
-
-func (r *batchChangeResolver) SpecCreator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	spec, err := r.computeBatchSpec(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DatabaseDB(), spec.UserID)
-	if errcode.IsNotFound(err) {
-		return nil, nil
-	}
-
-	return user, err
 }
 
 func (r *batchChangeResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
@@ -78,7 +78,6 @@ func TestBatchChangeResolver(t *testing.T) {
 		Namespace:     apitest.UserOrg{ID: namespaceAPIID, Name: orgName},
 		Creator:       apiUser,
 		LastApplier:   apiUser,
-		SpecCreator:   apiUser,
 		LastAppliedAt: marshalDateTime(t, now),
 		URL:           fmt.Sprintf("/organizations/%s/batch-changes/%s", orgName, batchChange.Name),
 		CreatedAt:     marshalDateTime(t, now),
@@ -115,7 +114,6 @@ func TestBatchChangeResolver(t *testing.T) {
 
 	wantBatchChange.Creator = nil
 	wantBatchChange.LastApplier = nil
-	wantBatchChange.SpecCreator = nil
 
 	{
 		var response struct{ Node apitest.BatchChange }
@@ -259,7 +257,6 @@ query($batchChange: ID!){
       id, name, description, state
       creator { ...u }
       lastApplier    { ...u }
-      specCreator    { ...u }
       lastAppliedAt
       createdAt
       updatedAt
@@ -283,7 +280,6 @@ query($namespace: ID!, $name: String!){
     id, name, description, state
     creator { ...u }
     lastApplier    { ...u }
-    specCreator    { ...u }
     lastAppliedAt
     createdAt
     updatedAt

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -298,22 +298,6 @@ func (r *changesetResolver) getBranchSpecDescription(ctx context.Context) (*btyp
 	return spec, nil
 }
 
-func (r *changesetResolver) PublicationState() string {
-	return string(r.changeset.PublicationState)
-}
-
-func (r *changesetResolver) ReconcilerState() string {
-	return string(r.changeset.ReconcilerState)
-}
-
-func (r *changesetResolver) ExternalState() *string {
-	if !r.changeset.Published() {
-		return nil
-	}
-	state := string(r.changeset.ExternalState)
-	return &state
-}
-
 func (r *changesetResolver) State() string {
 	return string(r.changeset.State)
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -158,9 +158,6 @@ func (r *changesetDescriptionResolver) BaseRef() string {
 	return gitdomain.AbbreviateRef(r.spec.BaseRef)
 }
 func (r *changesetDescriptionResolver) BaseRev() string { return r.spec.BaseRev }
-func (r *changesetDescriptionResolver) HeadRepository() *graphqlbackend.RepositoryResolver {
-	return r.repoResolver
-}
 func (r *changesetDescriptionResolver) HeadRef() string {
 	return gitdomain.AbbreviateRef(r.spec.HeadRef)
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
@@ -91,12 +91,9 @@ func TestChangesetSpecResolver(t *testing.T) {
 						},
 						ExternalID: "",
 						BaseRef:    gitdomain.AbbreviateRef(spec.BaseRef),
-						HeadRepository: apitest.Repository{
-							ID: string(graphqlbackend.MarshalRepositoryID(spec.BaseRepoID)),
-						},
-						HeadRef: gitdomain.AbbreviateRef(spec.HeadRef),
-						Title:   spec.Title,
-						Body:    spec.Body,
+						HeadRef:    gitdomain.AbbreviateRef(spec.HeadRef),
+						Title:      spec.Title,
+						Body:       spec.Body,
 						Commits: []apitest.GitCommitDescription{
 							{
 								Author: apitest.Person{
@@ -146,12 +143,9 @@ func TestChangesetSpecResolver(t *testing.T) {
 						},
 						ExternalID: "",
 						BaseRef:    gitdomain.AbbreviateRef(spec.BaseRef),
-						HeadRepository: apitest.Repository{
-							ID: string(graphqlbackend.MarshalRepositoryID(spec.BaseRepoID)),
-						},
-						HeadRef: gitdomain.AbbreviateRef(spec.HeadRef),
-						Title:   spec.Title,
-						Body:    spec.Body,
+						HeadRef:    gitdomain.AbbreviateRef(spec.HeadRef),
+						Title:      spec.Title,
+						Body:       spec.Body,
 						Commits: []apitest.GitCommitDescription{
 							{
 								Author: apitest.Person{
@@ -201,12 +195,9 @@ func TestChangesetSpecResolver(t *testing.T) {
 						},
 						ExternalID: "",
 						BaseRef:    gitdomain.AbbreviateRef(spec.BaseRef),
-						HeadRepository: apitest.Repository{
-							ID: string(graphqlbackend.MarshalRepositoryID(spec.BaseRepoID)),
-						},
-						HeadRef: gitdomain.AbbreviateRef(spec.HeadRef),
-						Title:   spec.Title,
-						Body:    spec.Body,
+						HeadRef:    gitdomain.AbbreviateRef(spec.HeadRef),
+						Title:      spec.Title,
+						Body:       spec.Body,
 						Commits: []apitest.GitCommitDescription{
 							{
 								Author: apitest.Person{
@@ -312,9 +303,6 @@ query($id: ID!) {
           baseRef
           baseRev
 
-          headRepository {
-              id
-          }
           headRef
 
           title


### PR DESCRIPTION
I did a sweep of both the BC schema file as well as the OSS one. I've removed all fields obviously marked for deprecation in our area and looked for anything else that seemed out-of-date, redundant, or otherwise deprecation-worthy, but outside of those fields we had already marked as deprecated, nothing stood out to me. So, good job team? 🙂

I'm not 100% confident about what all to gut for `headRepository` and would appreciate a closer review of that by someone more familiar!
 
## Test plan

All our resolvers have unit test coverage so I'm relying on CI to inform me of any problems at this point.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
