### PR TITLE
Remove GitHub and GitLab Enterprise from business tier

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { mdiInformation } from '@mdi/js'
 import * as H from 'history'
 
-import { ExternalServiceKind } from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useLocalStorage, Button, Link, Alert, H2, H3, Icon, Text } from '@sourcegraph/wildcard'
@@ -81,9 +80,13 @@ export const AddExternalServicesPage: React.FunctionComponent<
     }
 
     const licenseInfo = window.context.licenseInfo
-    let allowedCodeHosts: ExternalServiceKind[] | null = null
+    let allowedCodeHosts: AddExternalServiceOptions[] | null = null
     if (licenseInfo && licenseInfo.currentPlan === 'business-0') {
-        allowedCodeHosts = [ExternalServiceKind.GITHUB, ExternalServiceKind.GITLAB, ExternalServiceKind.BITBUCKETCLOUD]
+        allowedCodeHosts = [
+            codeHostExternalServices.github,
+            codeHostExternalServices.gitlabcom,
+            codeHostExternalServices.bitbucket,
+        ]
     }
 
     return (
@@ -141,7 +144,7 @@ export const AddExternalServicesPage: React.FunctionComponent<
                 </Alert>
             )}
             {Object.entries(codeHostExternalServices)
-                .filter(externalService => !allowedCodeHosts || allowedCodeHosts.includes(externalService[1].kind))
+                .filter(externalService => !allowedCodeHosts || allowedCodeHosts.includes(externalService[1]))
                 .map(([id, externalService]) => (
                     <div className={styles.addExternalServicesPageCard} key={id}>
                         <ExternalServiceCard to={getAddURL(id)} {...externalService} />
@@ -156,9 +159,7 @@ export const AddExternalServicesPage: React.FunctionComponent<
                         repositories from other code hosts.
                     </Text>
                     {Object.entries(codeHostExternalServices)
-                        .filter(
-                            externalService => allowedCodeHosts && !allowedCodeHosts.includes(externalService[1].kind)
-                        )
+                        .filter(externalService => allowedCodeHosts && !allowedCodeHosts.includes(externalService[1]))
                         .map(([id, externalService]) => (
                             <div className={styles.addExternalServicesPageCard} key={id}>
                                 <ExternalServiceCard


### PR DESCRIPTION
The initial implementation checked for `ExternalServiceKind.GITHUB`, not realising that this includes GitHub Enterprise. Same with GitLab. Now, instead, we check for the entire object.

Solves #41368 

This is merely a UI/UX thing, the backend would not have allowed the creation of those connections.

![image](https://user-images.githubusercontent.com/6427795/188821109-18cbd452-6751-44d7-b360-f7160adc9434.png)
## Test plan
Visual

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-41368-remove-gh-and-gl.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nedewizdln.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
