### PR TITLE
update link to tech docs from cloud docs page

### DIFF
--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -80,7 +80,7 @@ Your managed instance will be accessible over HTTPS/TLS, provide storage volumes
 
 If you decide for your manged instance to be public, we will provide security capabilities from Cloudflare such as WAF and rate-limiting. We will also provide a firewall to protect your instance from malicious traffic.
 
-It will be hosted in completely isolated Google Cloud infrastructure, with minimal access even within the Sourcegraph team, both for security and billing purposes. See our [employee handbook](https://handbook.sourcegraph.com/engineering/enablement/delivery/managed#technical-details) to learn more about the cloud architecture we use. Both your team and limited Sourcegraph personnel will have application-level administrator access to the instance.
+It will be hosted in completely isolated Google Cloud infrastructure, with minimal access even within the Sourcegraph team, both for security and billing purposes. See our [employee handbook](https://handbook.sourcegraph.com/departments/cloud/technical-docs/) to learn more about the cloud architecture we use. Both your team and limited Sourcegraph personnel will have application-level administrator access to the instance.
 
 Only essential Sourcegraph personnel will have access to the instance, server, code, and any other sensitive materials, such as tokens or keys. The employees or contractors with access would be bound by the same terms as Sourcegraph itself. Learn more in our [network security policies for Sourcegraph Cloud](https://about.sourcegraph.com/security) or [contact us](https://about.sourcegraph.com/contact/sales) with any questions/concerns.
 


### PR DESCRIPTION
reported by @Shinndig at https://sourcegraph.slack.com/archives/CNC4YAL1E/p1662536296261129?thread_ts=1662532052.349989&cid=CNC4YAL1E



## Test plan

Docs only.