### PR TITLE
ci: ensure namespace is always deleted

### DIFF
--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -13,6 +13,9 @@ export NAMESPACE="cluster-ci-$BUILDKITE_BUILD_NUMBER-$BUILDKITE_JOB_ID"
 
 # Capture information about the state of the test cluster
 function cluster_capture_state() {
+  # Get some more verbobe information about what is running.
+  set -x
+
   echo "--- dump diagnostics"
   # Get overview of all pods
   kubectl get pods
@@ -22,6 +25,8 @@ function cluster_capture_state() {
 
   # Get logs for some deployments
   kubectl logs deployment/sourcegraph-frontend --all-containers >"$root_dir/frontend_logs.log" 2>&1
+
+  set +x
 }
 
 # Cleanup the cluster

--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -26,7 +26,7 @@ function cluster_capture_state() {
 
 # Cleanup the cluster
 function cluster_cleanup() {
-  cluster_capture_state
+  cluster_capture_state || true
   kubectl delete namespace "$NAMESPACE"
 }
 


### PR DESCRIPTION
This test has been leaving resources on the CI cluster because the `cluster_capture_state` function will exit  immediately if any of the commands do not return 0. This means the script will exit and the namespace, and resources in it are never cleaned up. 

It's possible we are still not allowing enough time but this runs "most" of the time without issue so I suspect there is some other flake here that might need looking into. The `kubectl describe` command exiting 1 and not finding resources indicates  sourcegraph hasn't been deployed correctly, or at all but then it leaves resources around after. 

I'll follow that up. 

The following builds all left the namespace and some or all resources. 

https://buildkite.com/sourcegraph/sourcegraph/builds/170432
https://buildkite.com/sourcegraph/sourcegraph/builds/170413
https://buildkite.com/sourcegraph/sourcegraph/builds/170402
https://buildkite.com/sourcegraph/sourcegraph/builds/170400
https://buildkite.com/sourcegraph/sourcegraph/builds/170383
https://buildkite.com/sourcegraph/sourcegraph/builds/170383
https://buildkite.com/sourcegraph/sourcegraph/builds/170369
https://buildkite.com/sourcegraph/sourcegraph/builds/170368
https://buildkite.com/sourcegraph/sourcegraph/builds/170364
https://buildkite.com/sourcegraph/sourcegraph/builds/169467
https://buildkite.com/sourcegraph/sourcegraph/builds/168180
https://buildkite.com/sourcegraph/sourcegraph/builds/168173
https://buildkite.com/sourcegraph/sourcegraph/builds/168044
https://buildkite.com/sourcegraph/sourcegraph/builds/168042
https://buildkite.com/sourcegraph/sourcegraph/builds/168023

## Test plan

Always returns true, so this won't stop any other functionality. 