### PR TITLE
Performance: Avoid refetching blob when commitID changes

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -184,7 +184,6 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                                 html: blob.highlight.html ?? '',
                                 repoName,
                                 revision,
-                                commitID,
                                 filePath,
                                 mode,
                                 // Properties used in `BlobPage` but not `Blob`
@@ -198,7 +197,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                         })
                     )
             )
-        }, [commitID, enableLazyBlobSyntaxHighlighting, filePath, mode, repoName, revision, span])
+        }, [enableLazyBlobSyntaxHighlighting, filePath, mode, repoName, revision, span])
     )
 
     // Bundle latest blob with all other file info to pass to `Blob`
@@ -244,7 +243,6 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                             lsif: blob.highlight.lsif ?? '',
                             repoName,
                             revision,
-                            commitID,
                             filePath,
                             mode,
                             // Properties used in `BlobPage` but not `Blob`
@@ -255,7 +253,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                     }),
                     catchError((error): [ErrorLike] => [asError(error)])
                 ),
-            [repoName, revision, commitID, filePath, mode, enableCodeMirror]
+            [repoName, revision, filePath, mode, enableCodeMirror]
         )
     )
 


### PR DESCRIPTION
## Description

We already make an exception for this [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/repo/blob/BlobPage.tsx?L479&utm_source=VSCode-2.2.9), we just need to remove it from the `useMemo` as we only use it to enhance `blobInfo`

## Test plan

Tested locally

## App preview:

- [Web](https://sg-web-tr-blob-refetch-bug.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dcoifkgqrm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
