### PR TITLE
authz: use FilePermissionsFunc for batch path operations

### DIFF
--- a/internal/authz/sub_repo_perms_test.go
+++ b/internal/authz/sub_repo_perms_test.go
@@ -164,11 +164,13 @@ func TestFilterActorPaths(t *testing.T) {
 	checker.EnabledFunc.SetDefaultHook(func() bool {
 		return true
 	})
-	checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content RepoContent) (Perms, error) {
-		if content.Path == "file1" {
-			return Read, nil
-		}
-		return None, nil
+	checker.FilePermissionsFuncFunc.SetDefaultHook(func(context.Context, int32, api.RepoName) (FilePermissionFunc, error) {
+		return func(path string) (Perms, error) {
+			if path == "file1" {
+				return Read, nil
+			}
+			return None, nil
+		}, nil
 	})
 
 	filtered, err := FilterActorPaths(ctx, checker, a, repo, testPaths)
@@ -289,13 +291,15 @@ func TestCanReadAllPaths(t *testing.T) {
 	checker.EnabledFunc.SetDefaultHook(func() bool {
 		return true
 	})
-	checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content RepoContent) (Perms, error) {
-		switch content.Path {
-		case "file1", "file2", "file3":
-			return Read, nil
-		default:
-			return None, nil
-		}
+	checker.FilePermissionsFuncFunc.SetDefaultHook(func(context.Context, int32, api.RepoName) (FilePermissionFunc, error) {
+		return func(path string) (Perms, error) {
+			switch path {
+			case "file1", "file2", "file3":
+				return Read, nil
+			default:
+				return None, nil
+			}
+		}, nil
 	})
 
 	ok, err := CanReadAllPaths(ctx, checker, repo, testPaths)

--- a/internal/search/job/jobutil/sub_repo_perms_job_test.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -35,6 +36,11 @@ func TestApplySubRepoFiltering(t *testing.T) {
 			}
 		}
 		return authz.Read, nil
+	})
+	checker.FilePermissionsFuncFunc.SetDefaultHook(func(ctx context.Context, userID int32, repo api.RepoName) (authz.FilePermissionFunc, error) {
+		return func(path string) (authz.Perms, error) {
+			return checker.Permissions(ctx, userID, authz.RepoContent{Repo: repo, Path: path})
+		}, nil
 	})
 
 	type args struct {


### PR DESCRIPTION
This introduces the use of FilePermissionsFunc in all places in authz were we check multiple paths for a repository. In particular FilterActorPaths and the helper canReadPaths. This doesn't help performance just yet since we haven't optimized FilePermissionsFunc, but in the next commit there should be a nice benchstat to ogle over.

Note: we now call actorSubRepoEnabled in FilterActorPaths. Previously this logic was done by the fact it was just a wrapper around ActorPermissions. But now we directly use the checker, so we need to introduce those actor checks here (they are already done by canReadPaths).

Additionally we add in metrics for these batch call sites, since FilePermissionsFunc will not record metrics. These metrics should be more useful and not be as large an overhead.

Test Plan: go test

Part of https://github.com/sourcegraph/sourcegraph/issues/41347

Stacked on https://github.com/sourcegraph/sourcegraph/pull/41433

plz-review-url: https://plz.review/review/11272
