### PR TITLE
insights: lock aggregation updates

### DIFF
--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -3,6 +3,7 @@ package aggregation
 import (
 	"context"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/go-enry/go-enry/v2"
@@ -226,6 +227,8 @@ type searchAggregationResults struct {
 	tabulator AggregationTabulator
 	countFunc AggregationCountFunc
 	progress  client.ProgressAggregator
+
+	mu sync.Mutex
 }
 
 func (r *searchAggregationResults) ShardTimeoutOccurred() bool {
@@ -239,6 +242,9 @@ func (r *searchAggregationResults) ShardTimeoutOccurred() bool {
 }
 
 func (r *searchAggregationResults) Send(event streaming.SearchEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	r.progress.Update(event)
 	combined := map[MatchKey]int{}
 	for _, match := range event.Results {

--- a/enterprise/internal/insights/aggregation/limited_aggregator.go
+++ b/enterprise/internal/insights/aggregation/limited_aggregator.go
@@ -17,6 +17,8 @@ func NewLimitedAggregator(bufferSize int) LimitedAggregator {
 	}
 }
 
+// limitedAggregator is not thread safe and uses no locks over the map of results when performing reads/writes.
+// Use it accordingly.
 type limitedAggregator struct {
 	resultBufferSize int
 	smallestResult   *Aggregate


### PR DESCRIPTION
closes #41423 

we think that we didn't notice this unsafe behaviour sooner because we expected `type:commit` queries to time out, and commit search triggers a search of each repo in a separate go routine which would have triggered this concurrent access

## Test plan

Ran a `type:commit` query locally and observed it worked rather than panicked the whole instance

Also tested the sync lock on a lower level in [another branch](https://github.com/sourcegraph/sourcegraph/compare/leo/panic-test?expand=1) with `go test -race`

we went with the safety of a lock at the higher level function (to also align with search's implementation)