### PR TITLE
sg: add -format flag to ci preview

### DIFF
--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"net/url"
 	"os"
@@ -201,6 +202,11 @@ sg ci build --help
 		Usage:   "Preview the pipeline that would be run against the currently checked out branch",
 		Flags: []cli.Flag{
 			&ciBranchFlag,
+			&cli.StringFlag{
+				Name:  "format",
+				Usage: "Output format for the preview, (valid values are 'markdown', 'json' and 'yaml' which will both output the raw pipeline in that format",
+				Value: "markdown",
+			},
 		},
 		Action: func(cmd *cli.Context) error {
 			std.Out.WriteLine(output.Styled(output.StyleSuggestion,
@@ -220,16 +226,39 @@ sg ci build --help
 				return err
 			}
 
-			previewCmd := usershell.Command(cmd.Context, "go run ./enterprise/dev/ci/gen-pipeline.go -preview").
-				Env(map[string]string{
-					"BUILDKITE_BRANCH":  target.target, // this must be a branch
-					"BUILDKITE_MESSAGE": message,
-				})
-			out, err := root.Run(previewCmd).String()
-			if err != nil {
-				return err
+			var previewCmd *sgrun.Command
+			env := map[string]string{
+				"BUILDKITE_BRANCH":  target.target, // this must be a branch
+				"BUILDKITE_MESSAGE": message,
 			}
-			return std.Out.WriteMarkdown(out)
+			switch cmd.String("format") {
+			case "markdown":
+				previewCmd = usershell.Command(cmd.Context, "go run ./enterprise/dev/ci/gen-pipeline.go -preview").
+					Env(env)
+				out, err := root.Run(previewCmd).String()
+				if err != nil {
+					return err
+				}
+				return std.Out.WriteMarkdown(out)
+			case "json":
+				previewCmd = usershell.Command(cmd.Context, "go run ./enterprise/dev/ci/gen-pipeline.go").
+					Env(env)
+				out, err := root.Run(previewCmd).String()
+				if err != nil {
+					return err
+				}
+				return std.Out.WriteCode("json", out)
+			case "yaml":
+				previewCmd = usershell.Command(cmd.Context, "go run ./enterprise/dev/ci/gen-pipeline.go -yaml").
+					Env(env)
+				out, err := root.Run(previewCmd).String()
+				if err != nil {
+					return err
+				}
+				return std.Out.WriteCode("yaml", out)
+			default:
+				return flag.ErrHelp
+			}
 		},
 	}, {
 		Name:    "status",


### PR DESCRIPTION
While debugging on some dependencies issues, I noticed we could avoid having to manually run the pipeline generator by adding `-format` to the `sg ci preview` command.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Manually tested. 