### PR TITLE
log15 migration: migrate use of log15 in auth package to use sourcegraph/log

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githuboauth/main_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/main_test.go
@@ -5,13 +5,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
 )
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if !testing.Verbose() {
-		log15.Root().SetHandler(log15.DiscardHandler())
+		logtest.InitWithLevel(m, log.LevelNone)
 	}
 	os.Exit(m.Run())
 }

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/middleware.go
@@ -3,6 +3,8 @@ package githuboauth
 import (
 	"net/http"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -18,13 +20,13 @@ func init() {
 	})
 }
 
-func Middleware(db database.DB) *auth.Middleware {
+func Middleware(logger log.Logger, db database.DB) *auth.Middleware {
 	return &auth.Middleware{
 		API: func(next http.Handler) http.Handler {
-			return oauth.NewHandler(db, extsvc.TypeGitHub, authPrefix, true, next)
+			return oauth.NewHandler(logger.Scoped("githuboauth.api", "api handler for github oauth authentication"), db, extsvc.TypeGitHub, authPrefix, true, next)
 		},
 		App: func(next http.Handler) http.Handler {
-			return oauth.NewHandler(db, extsvc.TypeGitHub, authPrefix, false, next)
+			return oauth.NewHandler(logger.Scoped("githuboauth.app", "app handler for github oauth authentication"), db, extsvc.TypeGitHub, authPrefix, false, next)
 		},
 	}
 }

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
@@ -40,8 +40,8 @@ func TestMiddleware(t *testing.T) {
 		_, _ = w.Write([]byte("got through"))
 	})
 	authedHandler := http.NewServeMux()
-	authedHandler.Handle("/.api/", Middleware(nil).API(h))
-	authedHandler.Handle("/", Middleware(nil).App(h))
+	authedHandler.Handle("/.api/", Middleware(logger, nil).API(h))
+	authedHandler.Handle("/", Middleware(logger, nil).App(h))
 
 	mockGitHubCom := newMockProvider(t, db, "githubcomclient", "githubcomsecret", "https://github.com/")
 	mockGHE := newMockProvider(t, db, "githubenterpriseclient", "githubenterprisesecret", "https://mycompany.com/")

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
@@ -38,7 +38,7 @@ func parseProvider(logger log.Logger, p *schema.GitHubAuthProvider, db database.
 	}
 	codeHost := extsvc.NewCodeHost(parsedURL, extsvc.TypeGitHub)
 
-	return oauth.NewProvider(oauth.ProviderOp{
+	return oauth.NewProvider(logger, oauth.ProviderOp{
 		AuthPrefix: authPrefix,
 		OAuth2Config: func(extraScopes ...string) oauth2.Config {
 			return oauth2.Config{
@@ -62,6 +62,7 @@ func parseProvider(logger log.Logger, p *schema.GitHubAuthProvider, db database.
 			return github.CallbackHandler(
 				&oauth2Cfg,
 				oauth.SessionIssuer(logger, db, &sessionIssuerHelper{
+					logger:       logger.Scoped("sessionIssuerHelper", "helper that handles interaction with github oauth"),
 					CodeHost:     codeHost,
 					db:           db,
 					clientID:     p.ClientID,

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -294,6 +296,7 @@ func TestSessionIssuerHelper_GetOrCreateUser(t *testing.T) {
 
 				ctx := githublogin.WithUser(context.Background(), ci.ghUser)
 				s := &sessionIssuerHelper{
+					logger:       logtest.Scoped(t),
 					CodeHost:     codeHost,
 					clientID:     clientID,
 					allowSignup:  ci.allowSignup,
@@ -363,6 +366,7 @@ func TestSessionIssuerHelper_SignupMatchesSecondaryAccount(t *testing.T) {
 
 	ctx := githublogin.WithUser(context.Background(), ghUser)
 	s := &sessionIssuerHelper{
+		logger:      logtest.Scoped(t),
 		CodeHost:    codeHost,
 		clientID:    clientID,
 		allowSignup: true,
@@ -394,6 +398,7 @@ func TestVerifyUserOrgs_UserHasMoreThan100Orgs(t *testing.T) {
 	}()
 
 	s := &sessionIssuerHelper{
+		logger:       logtest.Scoped(t),
 		CodeHost:     nil,
 		clientID:     "clientID",
 		allowSignup:  true,
@@ -426,7 +431,7 @@ func createCodeHostConnectionHelper(t *testing.T, serviceExists bool) {
 
 	ctx := context.Background()
 	db := database.NewMockDB()
-	s := &sessionIssuerHelper{db: db}
+	s := &sessionIssuerHelper{logger: logtest.Scoped(t), db: db}
 	t.Run("Unauthenticated request", func(t *testing.T) {
 		_, _, err := s.CreateCodeHostConnection(ctx, nil, "")
 		assert.Error(t, err)

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware.go
@@ -3,6 +3,8 @@ package gitlaboauth
 import (
 	"net/http"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -18,13 +20,13 @@ func init() {
 	})
 }
 
-func Middleware(db database.DB) *auth.Middleware {
+func Middleware(logger log.Logger, db database.DB) *auth.Middleware {
 	return &auth.Middleware{
 		API: func(next http.Handler) http.Handler {
-			return oauth.NewHandler(db, extsvc.TypeGitLab, authPrefix, true, next)
+			return oauth.NewHandler(logger.Scoped("gitlaboauth.api", "api handler for gitlab oauth authentication"), db, extsvc.TypeGitLab, authPrefix, true, next)
 		},
 		App: func(next http.Handler) http.Handler {
-			return oauth.NewHandler(db, extsvc.TypeGitLab, authPrefix, false, next)
+			return oauth.NewHandler(logger.Scoped("gitlaboauth.app", "app handlier for gitlab oauth authentication"), db, extsvc.TypeGitLab, authPrefix, false, next)
 		},
 	}
 }

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -44,8 +44,8 @@ func TestMiddleware(t *testing.T) {
 		}
 	})
 	authedHandler := http.NewServeMux()
-	authedHandler.Handle("/.api/", Middleware(nil).API(h))
-	authedHandler.Handle("/", Middleware(nil).App(h))
+	authedHandler.Handle("/.api/", Middleware(logger, nil).API(h))
+	authedHandler.Handle("/", Middleware(logger, nil).App(h))
 
 	mockGitLabCom := newMockProvider(t, db, "gitlab-com-client", "gitlab-com-secret", "https://gitlab.com/")
 	mockPrivateGitLab := newMockProvider(t, db, "gitlab-private-instance-client", "github-private-instance-secret", "https://mycompany.com/")

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -31,7 +31,7 @@ func parseProvider(logger log.Logger, db database.DB, callbackURL string, p *sch
 	}
 	codeHost := extsvc.NewCodeHost(parsedURL, extsvc.TypeGitLab)
 
-	return oauth.NewProvider(oauth.ProviderOp{
+	return oauth.NewProvider(logger, oauth.ProviderOp{
 		AuthPrefix: authPrefix,
 		OAuth2Config: func(extraScopes ...string) oauth2.Config {
 			return oauth2.Config{

--- a/enterprise/cmd/frontend/internal/auth/httpheader/config.go
+++ b/enterprise/cmd/frontend/internal/auth/httpheader/config.go
@@ -10,6 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+const pkgName = "httpheader"
+
 // getProviderConfig returns the HTTP header auth provider config. At most 1 can be specified in
 // site config; if there is more than 1, it returns multiple == true (which the caller should handle
 // by returning an error and refusing to proceed with auth).
@@ -25,12 +27,10 @@ func getProviderConfig() (pc *schema.HTTPHeaderAuthProvider, multiple bool) {
 	return pc, false
 }
 
-const pkgName = "httpheader"
-
-func Init() {
+func Init(logger log.Logger) {
 	conf.ContributeValidator(validateConfig)
 
-	logger := log.Scoped(pkgName, "HTTP header authentication config watch")
+	logger = log.Scoped(pkgName, "HTTP header authentication config watch")
 	go func() {
 		conf.Watch(func() {
 			newPC, _ := getProviderConfig()

--- a/enterprise/cmd/frontend/internal/auth/httpheader/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/httpheader/middleware_test.go
@@ -28,7 +28,7 @@ func TestMiddleware(t *testing.T) {
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
-	handler := middleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := middleware(logger, db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		actor := actor.FromContext(r.Context())
 		if actor.IsAuthenticated() {
 			fmt.Fprintf(w, "user %v", actor.UID)
@@ -199,7 +199,7 @@ func TestMiddleware_stripPrefix(t *testing.T) {
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
-	handler := middleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := middleware(logger, db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		actor := actor.FromContext(r.Context())
 		if actor.IsAuthenticated() {
 			fmt.Fprintf(w, "user %v", actor.UID)

--- a/enterprise/cmd/frontend/internal/auth/init.go
+++ b/enterprise/cmd/frontend/internal/auth/init.go
@@ -35,7 +35,7 @@ func Init(logger log.Logger, db database.DB) {
 	// Register enterprise auth middleware
 	auth.RegisterMiddlewares(
 		openidconnect.Middleware(db),
-		saml.Middleware(db),
+		saml.Middleware(logger, db),
 		httpheader.Middleware(db),
 		githuboauth.Middleware(db),
 		gitlaboauth.Middleware(db),

--- a/enterprise/cmd/frontend/internal/auth/init.go
+++ b/enterprise/cmd/frontend/internal/auth/init.go
@@ -25,19 +25,19 @@ import (
 // Init must be called by the frontend to initialize the auth middlewares.
 func Init(logger log.Logger, db database.DB) {
 	logger = logger.Scoped("auth", "provides enterprise authentication middleware")
-	openidconnect.Init()
-	saml.Init()
-	httpheader.Init()
+	openidconnect.Init(logger)
+	saml.Init(logger)
+	httpheader.Init(logger)
 	githuboauth.Init(logger, db)
 	gitlaboauth.Init(logger, db)
 
 	// Register enterprise auth middleware
 	auth.RegisterMiddlewares(
-		openidconnect.Middleware(db),
+		openidconnect.Middleware(logger, db),
 		saml.Middleware(logger, db),
-		httpheader.Middleware(db),
-		githuboauth.Middleware(db),
-		gitlaboauth.Middleware(db),
+		httpheader.Middleware(logger, db),
+		githuboauth.Middleware(logger, db),
+		gitlaboauth.Middleware(logger, db),
 	)
 	// Register app-level sign-out handler
 	app.RegisterSSOSignOutHandler(ssoSignOutHandler(logger))

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -34,7 +34,7 @@ import (
 )
 
 func NewHandler(logger log.Logger, db database.DB, serviceType, authPrefix string, isAPIHandler bool, next http.Handler) http.Handler {
-	logger = log.Scoped("oauthFlowHandler", "handles oauth authentication flow")
+	logger = logger.Scoped("oauthFlowHandler", "handles oauth authentication flow")
 	oauthFlowHandler := http.StripPrefix(authPrefix, newOAuthFlowHandler(logger, db, serviceType))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Delegate to the auth flow handler

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -37,7 +37,7 @@ type SessionIssuerHelper interface {
 }
 
 func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, sessionKey string) http.Handler {
-	logger = logger.Scoped("SessionIssuer", "validates a token and then sets up a session")
+	logger = logger.Scoped("SessionIssuerHandler", "http handler that validates a token and then sets up a session")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
@@ -52,11 +52,11 @@ func handleGetProvider(ctx context.Context, logger log.Logger, w http.ResponseWr
 	return p, false
 }
 
-func Init() {
+func Init(logger log.Logger) {
 	conf.ContributeValidator(validateConfig)
 
 	const pkgName = "openidconnect"
-	logger := log.Scoped(pkgName, "OpenID Connect config watch")
+	logger = logger.Scoped(pkgName, "OpenID Connect config watch")
 	go func() {
 		conf.Watch(func() {
 

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -95,7 +95,7 @@ func handleOpenIDConnectAuth(logger log.Logger, db database.DB, w http.ResponseW
 	// anything else anyway; there's no point in showing them a signin screen with just a single
 	// signin option.
 	if ps := providers.Providers(); len(ps) == 1 && ps[0].Config().Openidconnect != nil && !isAPIRequest {
-		p, handled := handleGetProvider(r.Context(), w, ps[0].ConfigID().ID)
+		p, handled := handleGetProvider(r.Context(), logger, w, ps[0].ConfigID().ID)
 		if handled {
 			return
 		}
@@ -119,7 +119,7 @@ func authHandler(logger log.Logger, db database.DB) func(w http.ResponseWriter, 
 		switch strings.TrimPrefix(r.URL.Path, authPrefix) {
 		case "/login":
 			// Endpoint that starts the Authentication Request Code Flow.
-			p, handled := handleGetProvider(r.Context(), w, r.URL.Query().Get("pc"))
+			p, handled := handleGetProvider(r.Context(), logger, w, r.URL.Query().Get("pc"))
 			if handled {
 				return
 			}
@@ -167,7 +167,7 @@ func authHandler(logger log.Logger, db database.DB) func(w http.ResponseWriter, 
 			}
 			// 🚨 SECURITY: TODO(sqs): Do we need to check state.CSRFToken?
 
-			p, handled := handleGetProvider(r.Context(), w, state.ProviderID)
+			p, handled := handleGetProvider(r.Context(), logger, w, state.ProviderID)
 			if handled {
 				return
 			}

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -10,8 +10,9 @@ import (
 	"time"
 
 	"github.com/gorilla/csrf"
-	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
@@ -49,16 +50,16 @@ type userClaims struct {
 // a new session and session cookie. The expiration of the session is the expiration of the OIDC ID Token.
 //
 // 🚨 SECURITY
-func Middleware(db database.DB) *auth.Middleware {
+func Middleware(logger log.Logger, db database.DB) *auth.Middleware {
 	return &auth.Middleware{
 		API: func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				handleOpenIDConnectAuth(db, w, r, next, true)
+				handleOpenIDConnectAuth(logger.Scoped("openidconnect.api", "OpenID Connect authentication middleware"), db, w, r, next, true)
 			})
 		},
 		App: func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				handleOpenIDConnectAuth(db, w, r, next, false)
+				handleOpenIDConnectAuth(logger.Scoped("openidconnect.app", "OpenID Connect authentication middleware"), db, w, r, next, false)
 			})
 		},
 	}
@@ -66,7 +67,7 @@ func Middleware(db database.DB) *auth.Middleware {
 
 // handleOpenIDConnectAuth performs OpenID Connect authentication (if configured) for HTTP requests,
 // both API requests and non-API requests.
-func handleOpenIDConnectAuth(db database.DB, w http.ResponseWriter, r *http.Request, next http.Handler, isAPIRequest bool) {
+func handleOpenIDConnectAuth(logger log.Logger, db database.DB, w http.ResponseWriter, r *http.Request, next http.Handler, isAPIRequest bool) {
 	// Fixup URL path. We use "/.auth/callback" as the redirect URI for OpenID Connect, but the rest
 	// of this middleware's handlers expect paths of "/.auth/openidconnect/...", so add the
 	// "openidconnect" path component. We can't change the redirect URI because it is hardcoded in
@@ -78,7 +79,7 @@ func handleOpenIDConnectAuth(db database.DB, w http.ResponseWriter, r *http.Requ
 
 	// Delegate to the OpenID Connect auth handler.
 	if !isAPIRequest && strings.HasPrefix(r.URL.Path, authPrefix+"/") {
-		authHandler(db)(w, r)
+		authHandler(logger, db)(w, r)
 		return
 	}
 
@@ -112,7 +113,8 @@ var mockVerifyIDToken func(rawIDToken string) *oidc.IDToken
 // (http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth) on the Relying Party's end.
 //
 // 🚨 SECURITY
-func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
+func authHandler(logger log.Logger, db database.DB) func(w http.ResponseWriter, r *http.Request) {
+	logger = log.Scoped("authHandler", "handles the OIDC authentication code flow")
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimPrefix(r.URL.Path, authPrefix) {
 		case "/login":
@@ -129,7 +131,7 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 			if authError := r.URL.Query().Get("error"); authError != "" {
 				errorDesc := r.URL.Query().Get("error_description")
-				log15.Error("OpenID Connect auth provider returned error to callback.", "error", authError, "description", errorDesc)
+				logger.Error("OpenID Connect auth provider returned error to callback.", log.String("error", authError), log.String("description", errorDesc))
 				http.Error(w, fmt.Sprintf("Authentication failed. Try signing in again (and clearing cookies for the current site). The authentication provider reported the following problems.\n\n%s\n\n%s", authError, errorDesc), http.StatusUnauthorized)
 				return
 			}
@@ -142,16 +144,16 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			}
 			stateCookie, err := r.Cookie(stateCookieName)
 			if err == http.ErrNoCookie {
-				log15.Error("OpenID Connect auth failed: no state cookie found (possible request forgery).")
+				logger.Error("OpenID Connect auth failed: no state cookie found (possible request forgery).")
 				http.Error(w, fmt.Sprintf("Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: no OpenID Connect state cookie found (possible request forgery, or more than %s elapsed since you started the authentication process).", stateCookieTimeout), http.StatusBadRequest)
 				return
 			} else if err != nil {
-				log15.Error("OpenID Connect auth failed: could not read state cookie (possible request forgery).", "error", err)
+				logger.Error("OpenID Connect auth failed: could not read state cookie (possible request forgery).", log.Error(err))
 				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: invalid OpenID Connect state cookie.", http.StatusInternalServerError)
 				return
 			}
 			if stateCookie.Value != stateParam {
-				log15.Error("OpenID Connect auth failed: state cookie mismatch (possible request forgery).")
+				logger.Error("OpenID Connect auth failed: state cookie mismatch (possible request forgery).")
 				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: OpenID Connect state parameter did not match the expected value (possible request forgery).", http.StatusBadRequest)
 				return
 			}
@@ -159,7 +161,7 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			// Decode state param value
 			var state authnState
 			if err := state.Decode(stateParam); err != nil {
-				log15.Error("OpenID Connect auth failed: state parameter was malformed.", "error", err)
+				logger.Error("OpenID Connect auth failed: state parameter was malformed.", log.Error(err))
 				http.Error(w, "Authentication failed. OpenID Connect state parameter was malformed.", http.StatusBadRequest)
 				return
 			}
@@ -174,7 +176,7 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			// Exchange the code for an access token. See http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest.
 			oauth2Token, err := p.oauth2Config().Exchange(ctx, r.URL.Query().Get("code"))
 			if err != nil {
-				log15.Error("OpenID Connect auth failed: failed to obtain access token from OP.", "error", err)
+				logger.Error("OpenID Connect auth failed: failed to obtain access token from OP.", log.Error(err))
 				http.Error(w, "Authentication failed. Try signing in again. The error was: unable to obtain access token from issuer.", http.StatusUnauthorized)
 				return
 			}
@@ -182,7 +184,7 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			// Extract the ID Token from the Access Token. See http://openid.net/specs/openid-connect-core-1_0.html#TokenResponse.
 			rawIDToken, ok := oauth2Token.Extra("id_token").(string)
 			if !ok {
-				log15.Error("OpenID Connect auth failed: the issuer's authorization response did not contain an ID token.")
+				logger.Error("OpenID Connect auth failed: the issuer's authorization response did not contain an ID token.")
 				http.Error(w, "Authentication failed. Try signing in again. The error was: the issuer's authorization response did not contain an ID token.", http.StatusUnauthorized)
 				return
 			}
@@ -194,7 +196,7 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			} else {
 				idToken, err = verifier.Verify(ctx, rawIDToken)
 				if err != nil {
-					log15.Error("OpenID Connect auth failed: the ID token verification failed.", "error", err)
+					logger.Error("OpenID Connect auth failed: the ID token verification failed.", log.Error(err))
 					http.Error(w, "Authentication failed. Try signing in again. The error was: OpenID Connect ID token could not be verified.", http.StatusUnauthorized)
 					return
 				}
@@ -204,38 +206,38 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			// We set the nonce to be the same as the state in the Authentication Request state, so we check for equality
 			// here.
 			if idToken.Nonce != stateParam {
-				log15.Error("OpenID Connect auth failed: nonce is incorrect (possible replay attach).")
+				logger.Error("OpenID Connect auth failed: nonce is incorrect (possible replay attach).")
 				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: OpenID Connect nonce is incorrect (possible replay attack).", http.StatusUnauthorized)
 				return
 			}
 
 			userInfo, err := p.oidc.UserInfo(ctx, oauth2.StaticTokenSource(oauth2Token))
 			if err != nil {
-				log15.Error("Failed to get userinfo", "error", err)
+				logger.Error("Failed to get userinfo", log.Error(err))
 				http.Error(w, "Failed to get userinfo: "+err.Error(), http.StatusInternalServerError)
 				return
 			}
 
 			if p.config.RequireEmailDomain != "" && !strings.HasSuffix(userInfo.Email, "@"+p.config.RequireEmailDomain) {
-				log15.Error("OpenID Connect auth failed: user's email is not from allowed domain.", "userEmail", userInfo.Email, "requireEmailDomain", p.config.RequireEmailDomain)
+				logger.Error("OpenID Connect auth failed: user's email is not from allowed domain.", log.String("userEmail", userInfo.Email), log.String("requireEmailDomain", p.config.RequireEmailDomain))
 				http.Error(w, fmt.Sprintf("Authentication failed. Only users in %q are allowed.", p.config.RequireEmailDomain), http.StatusUnauthorized)
 				return
 			}
 
 			var claims userClaims
 			if err := userInfo.Claims(&claims); err != nil {
-				log15.Warn("OpenID Connect auth: could not parse userInfo claims.", "error", err)
+				logger.Warn("OpenID Connect auth: could not parse userInfo claims.", log.Error(err))
 			}
 			actr, safeErrMsg, err := getOrCreateUser(ctx, db, p, idToken, userInfo, &claims)
 			if err != nil {
-				log15.Error("OpenID Connect auth failed: error looking up OpenID-authenticated user.", "error", err, "userErr", safeErrMsg)
+				logger.Error("OpenID Connect auth failed: error looking up OpenID-authenticated user.", log.Error(err), log.String("userErr", safeErrMsg))
 				http.Error(w, safeErrMsg, http.StatusInternalServerError)
 				return
 			}
 
 			user, err := db.Users().GetByID(r.Context(), actr.UID)
 			if err != nil {
-				log15.Error("OpenID Connect auth failed: error retrieving user from database.", "error", err)
+				logger.Error("OpenID Connect auth failed: error retrieving user from database.", log.Error(err))
 				http.Error(w, "Failed to retrieve user: "+err.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -252,7 +254,7 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			// 	exp = time.Until(idToken.Expiry)
 			// }
 			if err := session.SetActor(w, r, actr, exp, user.CreatedAt); err != nil {
-				log15.Error("OpenID Connect auth failed: could not initiate session.", "error", err)
+				logger.Error("OpenID Connect auth failed: could not initiate session.", log.Error(err))
 				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not initiate session.", http.StatusInternalServerError)
 				return
 			}
@@ -265,7 +267,7 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			if err := session.SetData(w, r, sessionKey, data); err != nil {
 				// It's not fatal if this fails. It just means we won't be able to sign the user out of
 				// the OP.
-				log15.Warn("Failed to set OpenID Connect session data. The session is still secure, but Sourcegraph will be unable to revoke the user's token or redirect the user to the end-session endpoint after the user signs out of Sourcegraph.", "error", err)
+				logger.Warn("Failed to set OpenID Connect session data. The session is still secure, but Sourcegraph will be unable to revoke the user's token or redirect the user to the end-session endpoint after the user signs out of Sourcegraph.", log.Error(err))
 			}
 
 			// 🚨 SECURITY: Call auth.SafeRedirectURL to avoid an open-redirect vuln.

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/coreos/go-oidc"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
@@ -162,10 +164,11 @@ func TestMiddleware(t *testing.T) {
 
 	const mockUserID = 123
 
+	logger := logtest.Scoped(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	authedHandler := http.NewServeMux()
-	authedHandler.Handle("/.api/", Middleware(db).API(h))
-	authedHandler.Handle("/", Middleware(db).App(h))
+	authedHandler.Handle("/.api/", Middleware(logger, db).API(h))
+	authedHandler.Handle("/", Middleware(logger, db).App(h))
 
 	doRequest := func(method, urlStr, body string, cookies []*http.Cookie, authed bool) *http.Response {
 		req := httptest.NewRequest(method, urlStr, bytes.NewBufferString(body))
@@ -339,7 +342,7 @@ func TestMiddleware_NoOpenRedirect(t *testing.T) {
 	db.UsersFunc.SetDefaultReturn(users)
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	authedHandler := Middleware(db).App(h)
+	authedHandler := Middleware(logtest.Scoped(t), db).App(h)
 
 	doRequest := func(method, urlStr, body string, cookies []*http.Cookie) *http.Response {
 		req := httptest.NewRequest(method, urlStr, bytes.NewBufferString(body))

--- a/enterprise/cmd/frontend/internal/auth/saml/config.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/config.go
@@ -58,19 +58,19 @@ func handleGetProvider(ctx context.Context, logger log.Logger, w http.ResponseWr
 		return nil, true
 	}
 	if err := p.Refresh(ctx); err != nil {
-        configID := p.ConfigID()
-		logger.Error("Error getting SAML auth provider", log.Object("configID", log.String("id", configID.ID), log.String("type", configID.Type), log.Error(err))
+		configID := p.ConfigID()
+		logger.Error("Error getting SAML auth provider", log.Object("configID", log.String("id", configID.ID), log.String("type", configID.Type)), log.Error(err))
 		http.Error(w, "Unexpected error getting SAML authentication provider. This may indicate that the SAML IdP does not exist. Ask a site admin to check the server \"frontend\" logs for \"Error getting SAML auth provider\".", http.StatusInternalServerError)
 		return nil, true
 	}
 	return p, false
 }
 
-func Init() {
+func Init(logger log.Logger) {
 	conf.ContributeValidator(validateConfig)
 
 	const pkgName = "saml"
-	logger := log.Scoped(pkgName, "SAML config watch")
+	logger = logger.Scoped(pkgName, "SAML config watch")
 	go func() {
 		conf.Watch(func() {
 

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
@@ -144,7 +143,7 @@ func samlSPHandler(logger log.Logger, db database.DB) func(w http.ResponseWriter
 			}
 
 			if !allowSignin(p, info.groups) {
-				log15.Warn("Error authorizing SAML-authenticated user.", "AccountID", info.spec.AccountID, "Expected groups", p.config.AllowGroups, "Got", info.groups)
+				logger.Warn("Error authorizing SAML-authenticated user.", log.String("AccountID", info.spec.AccountID), log.Strings("Expected groups", p.config.AllowGroups), log.Strings("Got", info.groups))
 				http.Error(w, "Error authorizing SAML-authenticated user. The user does not belong to one of the configured groups.", http.StatusForbidden)
 				return
 			}
@@ -251,11 +250,11 @@ func buildAuthURLRedirect(p *provider, relayState relayState) (string, error) {
 // login flows.
 //
 // SAML overloads the term "RelayState".
-// * In the SP-initiated login flow, it is an opaque value originated from the SP and reflected
-//   back in the AuthnResponse. The Sourcegraph SP uses the base64-encoded JSON of this struct as
-//   the RelayState.
-// * In the IdP-initiated login flow, the RelayState can be any arbitrary hint, but in practice
-//   is the desired post-login redirect URL in plain text.
+//   - In the SP-initiated login flow, it is an opaque value originated from the SP and reflected
+//     back in the AuthnResponse. The Sourcegraph SP uses the base64-encoded JSON of this struct as
+//     the RelayState.
+//   - In the IdP-initiated login flow, the RelayState can be any arbitrary hint, but in practice
+//     is the desired post-login redirect URL in plain text.
 type relayState struct {
 	ProviderID  string `json:"k"`
 	ReturnToURL string `json:"r"`

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -220,13 +220,13 @@ func samlSPHandler(logger log.Logger, db database.DB) func(w http.ResponseWriter
 	}
 }
 
-func redirectToAuthURL(w http.ResponseWriter, r *http.Request, p *provider, returnToURL string) {
+func redirectToAuthURL(logger log.Logger, w http.ResponseWriter, r *http.Request, p *provider, returnToURL string) {
 	authURL, err := buildAuthURLRedirect(p, relayState{
 		ProviderID:  p.ConfigID().ID,
 		ReturnToURL: auth.SafeRedirectURL(returnToURL),
 	})
 	if err != nil {
-		log15.Error("Failed to build SAML auth URL.", "err", err)
+		logger.Error("Failed to build SAML auth URL.", logger.String("error", err))
 		http.Error(w, "Unexpected error in SAML authentication provider.", http.StatusInternalServerError)
 		return
 	}

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlidp"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
@@ -218,12 +220,12 @@ func TestMiddleware(t *testing.T) {
 
 	// Set up the test handler.
 	authedHandler := http.NewServeMux()
-	authedHandler.Handle("/.api/", Middleware(db).API(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	authedHandler.Handle("/.api/", Middleware(logtest.Scoped(t), db).API(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if uid := actor.FromContext(r.Context()).UID; uid != mockedUserID && uid != 0 {
 			t.Errorf("got actor UID %d, want %d", uid, mockedUserID)
 		}
 	})))
-	authedHandler.Handle("/", Middleware(db).App(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	authedHandler.Handle("/", Middleware(logtest.Scoped(t), db).App(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/":
 			_, _ = w.Write([]byte("This is the home"))


### PR DESCRIPTION
This migrates all auth modules to use sourcegraph/log instead of log15

## Test plan
unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
