### PR TITLE
insights: aggregations limit errors for mode availability queries

### DIFF
--- a/cmd/frontend/graphqlbackend/insights_aggregations.go
+++ b/cmd/frontend/graphqlbackend/insights_aggregations.go
@@ -18,7 +18,7 @@ type SearchQueryAggregateResolver interface {
 
 type AggregationModeAvailabilityResolver interface {
 	Mode() string //ENUM
-	Available() (bool, error)
+	Available() bool
 	ReasonUnavailable() (*string, error)
 }
 

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -255,13 +255,13 @@ func (r *aggregationModeAvailabilityResolver) Mode() string {
 	return string(r.mode)
 }
 
-func (r *aggregationModeAvailabilityResolver) Available() (bool, error) {
+func (r *aggregationModeAvailabilityResolver) Available() bool {
 	canAggregateByFunc := getAggregateBy(r.mode)
 	if canAggregateByFunc == nil {
-		return false, nil
+		return false
 	}
-	available, _, err := canAggregateByFunc(r.searchQuery, r.patternType)
-	return available, err
+	available, _, _ := canAggregateByFunc(r.searchQuery, r.patternType)
+	return available
 }
 
 func (r *aggregationModeAvailabilityResolver) ReasonUnavailable() (*string, error) {

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -260,7 +260,10 @@ func (r *aggregationModeAvailabilityResolver) Available() bool {
 	if canAggregateByFunc == nil {
 		return false
 	}
-	available, _, _ := canAggregateByFunc(r.searchQuery, r.patternType)
+	available, _, err := canAggregateByFunc(r.searchQuery, r.patternType)
+	if err != nil {
+		return false
+	}
 	return available
 }
 


### PR DESCRIPTION
Previously if the search query couldn't be parsed checking the availability of the aggregation mode would error.  This did not align with what happened when attempting to run the aggregation.  That would return a NotAvailable response with details that the search query was not valid.  This brings the mode availability in alignment.  In cases when it's not determined if the mode is supported `false` is the default.

It could still be possible for an array of errors to be returned if the query were to ask for the `reasonUnavailable` and that were to error for multiple modes.  I believe this is ok because those errors would be relevant to the specific mode and it is a nullable field.

resolves https://github.com/sourcegraph/sourcegraph/issues/40971

## Test plan
Query
```graphql
{
  searchQueryAggregate(query: "i++ patterntype:regexp",patternType:regexp) {
    modeAvailability {
      mode
      available
      reasonUnavailable
    }
  }
}
```

Response
```json
{
  "data": {
    "searchQueryAggregate": {     
      "modeAvailability": [
        {
          "__typename": "AggregationModeAvailability",
          "mode": "REPO",
          "available": false,
          "reasonUnavailable": "Grouping is disabled because the search query is not valid."
        },
        {
          "__typename": "AggregationModeAvailability",
          "mode": "PATH",
          "available": false,
          "reasonUnavailable": "Grouping is disabled because the search query is not valid."
        },
        {
          "__typename": "AggregationModeAvailability",
          "mode": "AUTHOR",
          "available": false,
          "reasonUnavailable": "Grouping is disabled because the search query is not valid."
        },
        {
          "__typename": "AggregationModeAvailability",
          "mode": "CAPTURE_GROUP",
          "available": false,
          "reasonUnavailable": "Grouping is disabled because the search query is not valid."
        }
      ],
      "__typename": "SearchQueryAggregate"
    }
  }
}

```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
