### PR TITLE
search: closing parens terminate quoted patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Sourcegraph are documented in this file.
 - An issue where the saved search input box reports an invalid pattern type for `standard`, which is now valid. [#41068](https://github.com/sourcegraph/sourcegraph/pull/41068)
 - Fixed a bug where setting `"observability.tracing": {}` would disable tracing, when the intended behaviour is to default to tracing with `"sampling": "selective"` enabled by default. [#41242](https://github.com/sourcegraph/sourcegraph/pull/41242)
 - The performance, stability, and latency of search predicates like `repo:has.file()`, `repo:has.content()`, and `file:has.content()` have been dramatically improved. [#418](https://github.com/sourcegraph/zoekt/pull/418), [#40239](https://github.com/sourcegraph/sourcegraph/pull/40239), [#38988](https://github.com/sourcegraph/sourcegraph/pull/38988), [#39501](https://github.com/sourcegraph/sourcegraph/pull/39501)
+- A search query issue where quoted patterns inside parenthesized expressions would be interpreted incorrectly. [#41455](https://github.com/sourcegraph/sourcegraph/pull/41455)
 
 ### Removed
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -691,9 +691,9 @@ func (p *parser) parseQuoted(delimiter rune) (string, bool) {
 	}
 	p.pos += advance
 	if !p.done() {
-		if r, _ := utf8.DecodeRune([]byte{p.buf[p.pos]}); !unicode.IsSpace(r) {
+		if r, _ := utf8.DecodeRune([]byte{p.buf[p.pos]}); !unicode.IsSpace(r) && !p.match(RPAREN) {
 			p.pos = start // backtrack
-			// delimited value should be followed by whitespace
+			// delimited value should be followed by terminal (whitespace or closing paren).
 			return "", false
 		}
 	}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -781,4 +781,8 @@ func TestParseStandard(t *testing.T) {
 	t.Run("quoted patterns are still literal", func(t *testing.T) {
 		autogold.Equal(t, autogold.Raw(test(`"veneto"`)))
 	})
+
+	t.Run("parens around /.../", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test("(sancerre and /pouilly-fume/)")))
+	})
 }

--- a/internal/search/query/testdata/TestParseStandard/parens_around_/.../.golden
+++ b/internal/search/query/testdata/TestParseStandard/parens_around_/.../.golden
@@ -1,0 +1,40 @@
+[
+  {
+    "and": [
+      {
+        "value": "sancerre",
+        "negated": false,
+        "labels": [
+          "Literal"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 1
+          },
+          "end": {
+            "line": 0,
+            "column": 9
+          }
+        }
+      },
+      {
+        "value": "pouilly-fume",
+        "negated": false,
+        "labels": [
+          "Regexp"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 14
+          },
+          "end": {
+            "line": 0,
+            "column": 28
+          }
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Previously an expression like `(foo AND /bar/)` would treat the `/bar/` part as a literal instead of a regular expression in standard mode. This PR fixes it to treat `/bar/` as a regular expression.

---

<details>
<summary>Explanation, optional reading</summary>

This is because previous to standard mode, we didn't care whether any pattern is well-delineated (e.g., by `/.../` or `"..."`) since these terms were always literal. But when they _should_ be well-delineated (e.g., previously only in regex mode) we had a check that such a well-delineated pattern should be followed by a recognized terminal, in this case, whitespace. We check a "followed-by" condition because that lets us be resilient to lexing e.g., `/some/thing/` without the user needing to escape the inner `/`. But the "followed by a space" is insufficient: we also need to check a possible valid terminator `)` for a well-delineated regex in standard mode, before giving up and claiming the fallback case, that the pattern is a literal.

It would be nice to separate out the pure token lexing at some point (similar to frontend code) because of the hybrid literal/regexp complexity in standard mode, but this change is sufficient to cover the buggy behavior.

</details>

## Test plan
Added test
