### PR TITLE
Search: Remove unnecessary whitespace in case if we remove part of the string

### DIFF
--- a/client/common/src/util/strings.ts
+++ b/client/common/src/util/strings.ts
@@ -41,7 +41,7 @@ export function dedupeWhitespace(value: string): string {
 }
 
 /**
- * Checkes whether a given string is quoted.
+ * Checks whether a given string is quoted.
  *
  * @param value string to check against
  */
@@ -57,11 +57,5 @@ export function isQuoted(value: string): boolean {
  * @param replacement an optional replacement string
  */
 export function replaceRange(string: string, { start, end }: { start: number; end: number }, replacement = ''): string {
-    // We should preserve any original string whitespaces in case if we just replace,
-    // and we should remove whitespaces before removed part if we're removing from the string
-    const leftPart = replacement ? string.slice(0, start) : string.slice(0, start).trimEnd()
-
-    const rightPart = string.slice(end)
-
-    return leftPart + replacement + rightPart
+    return string.slice(0, start) + replacement + string.slice(end)
 }

--- a/client/common/src/util/strings.ts
+++ b/client/common/src/util/strings.ts
@@ -57,5 +57,11 @@ export function isQuoted(value: string): boolean {
  * @param replacement an optional replacement string
  */
 export function replaceRange(string: string, { start, end }: { start: number; end: number }, replacement = ''): string {
-    return string.slice(0, start) + replacement + string.slice(end)
+    // We should preserve any original string whitespaces in case if we just replace,
+    // and we should remove whitespaces before removed part if we're removing from the string
+    const leftPart = replacement ? string.slice(0, start) : string.slice(0, start).trimEnd()
+
+    const rightPart = string.slice(end)
+
+    return leftPart + replacement + rightPart
 }

--- a/client/shared/src/search/query/transformer.test.ts
+++ b/client/shared/src/search/query/transformer.test.ts
@@ -51,12 +51,12 @@ describe('omitFilter', () => {
 
     test('omit context filter from the end of the query', () => {
         const query = 'bar context:foo'
-        expect(omitFilter(query, getGlobalContextFilter(query))).toMatchInlineSnapshot('bar ')
+        expect(omitFilter(query, getGlobalContextFilter(query))).toMatchInlineSnapshot('bar')
     })
 
     test('omit context filter from the middle of the query', () => {
         const query = 'bar context:foo bar1'
-        expect(omitFilter(query, getGlobalContextFilter(query))).toMatchInlineSnapshot('bar  bar1')
+        expect(omitFilter(query, getGlobalContextFilter(query))).toMatchInlineSnapshot('bar bar1')
     })
 })
 

--- a/client/shared/src/search/query/transformer.ts
+++ b/client/shared/src/search/query/transformer.ts
@@ -12,8 +12,13 @@ export function appendContextFilter(query: string, searchContextSpec: string | u
         : query
 }
 
+/**
+ * Deletes the filter from a given query string by the filter's range.
+ */
 export function omitFilter(query: string, filter: Filter): string {
-    return replaceRange(query, filter.range).trimStart()
+    const { start, end } = filter.range
+
+    return `${query.slice(0, start).trimEnd()} ${query.slice(end).trimStart()}`.trim()
 }
 
 const succeedScan = (query: string): Token[] => {

--- a/client/shared/src/util/url.test.ts
+++ b/client/shared/src/util/url.test.ts
@@ -406,15 +406,15 @@ describe('buildSearchURLQuery', () => {
         ))
     it('appends the case parameter if `case:yes` exists in the query', () =>
         expect(buildSearchURLQuery('foo case:yes', SearchPatternType.standard, false, undefined)).toBe(
-            'q=foo+&patternType=standard&case=yes'
+            'q=foo&patternType=standard&case=yes'
         ))
     it('removes the case parameter if using a quoted value', () =>
         expect(buildSearchURLQuery('foo case:"yes"', SearchPatternType.standard, true, undefined)).toBe(
-            'q=foo+&patternType=standard&case=yes'
+            'q=foo&patternType=standard&case=yes'
         ))
     it('removes the case parameter case:no exists in the query and caseSensitive is true', () =>
         expect(buildSearchURLQuery('foo case:no', SearchPatternType.standard, true, undefined)).toBe(
-            'q=foo+&patternType=standard'
+            'q=foo&patternType=standard'
         ))
 })
 

--- a/client/web/src/search/index.test.tsx
+++ b/client/web/src/search/index.test.tsx
@@ -12,7 +12,7 @@ describe('search/index', () => {
         expect(
             parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+case:yes&patternType=standard&case=yes')
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph ',
+            query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: true,
         })
@@ -20,7 +20,7 @@ describe('search/index', () => {
         expect(
             parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+case:no&patternType=standard&case=yes')
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph ',
+            query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: false,
         })
@@ -28,13 +28,13 @@ describe('search/index', () => {
         expect(
             parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+patternType:regexp&patternType=literal&case=yes')
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph ',
+            query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.regexp,
             caseSensitive: true,
         })
 
         expect(parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+case:yes&patternType=standard')).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph ',
+            query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: true,
         })
@@ -44,7 +44,7 @@ describe('search/index', () => {
                 'q=TEST+repo:sourcegraph/sourcegraph+case:no+patternType:regexp&patternType=literal&case=yes'
             )
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph  ',
+            query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.regexp,
             caseSensitive: false,
         })
@@ -62,7 +62,7 @@ describe('search/index', () => {
                 appendCaseFilter: true,
             })
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph  case:yes',
+            query: 'TEST repo:sourcegraph/sourcegraph case:yes',
             patternType: SearchPatternType.standard,
             caseSensitive: true,
         })
@@ -72,7 +72,7 @@ describe('search/index', () => {
                 appendCaseFilter: true,
             })
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph ',
+            query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: false,
         })
@@ -82,7 +82,7 @@ describe('search/index', () => {
                 appendCaseFilter: true,
             })
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph  case:yes',
+            query: 'TEST repo:sourcegraph/sourcegraph case:yes',
             patternType: SearchPatternType.regexp,
             caseSensitive: true,
         })
@@ -92,7 +92,7 @@ describe('search/index', () => {
                 appendCaseFilter: true,
             })
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph  case:yes',
+            query: 'TEST repo:sourcegraph/sourcegraph case:yes',
             patternType: SearchPatternType.standard,
             caseSensitive: true,
         })
@@ -103,7 +103,7 @@ describe('search/index', () => {
                 { appendCaseFilter: true }
             )
         ).toStrictEqual({
-            query: 'TEST repo:sourcegraph/sourcegraph  ',
+            query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.regexp,
             caseSensitive: false,
         })

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -1,7 +1,7 @@
 import { escapeRegExp } from 'lodash'
 import { Observable } from 'rxjs'
 
-import { replaceRange } from '@sourcegraph/common'
+import { memoizeObservable } from '@sourcegraph/common'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { discreteValueAliases, escapeSpaces } from '@sourcegraph/shared/src/search/query/filters'
 import { stringHuman } from '@sourcegraph/shared/src/search/query/printer'
@@ -79,7 +79,7 @@ export function parseSearchURL(
     const globalPatternType = findFilter(queryInput, 'patterntype', FilterKind.Global)
     if (globalPatternType?.value && globalPatternType.value.type === 'literal') {
         // Any `patterntype:` filter in the query should override the patternType= URL query parameter if it exists.
-        queryInput = replaceRange(queryInput, globalPatternType.range)
+        queryInput = omitFilter(queryInput, globalPatternType)
         patternTypeInput = globalPatternType.value.value as SearchPatternType
     }
 
@@ -93,7 +93,7 @@ export function parseSearchURL(
     const globalCase = findFilter(query, 'case', FilterKind.Global)
     if (globalCase?.value && globalCase.value.type === 'literal') {
         // Any `case:` filter in the query should override the case= URL query parameter if it exists.
-        query = replaceRange(query, globalCase.range)
+        query = omitFilter(query, globalCase)
 
         if (discreteValueAliases.yes.includes(globalCase.value.value)) {
             caseSensitive = true

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -1,13 +1,13 @@
 import { escapeRegExp } from 'lodash'
 import { Observable } from 'rxjs'
 
-import { memoizeObservable } from '@sourcegraph/common'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { discreteValueAliases, escapeSpaces } from '@sourcegraph/shared/src/search/query/filters'
 import { stringHuman } from '@sourcegraph/shared/src/search/query/printer'
 import { findFilter, FilterKind } from '@sourcegraph/shared/src/search/query/query'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { createLiteral } from '@sourcegraph/shared/src/search/query/token'
+import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 
 /**


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41452

This PR removes unnecessary in case if we remove something from the query. We do it in a few cases. For example when we extract from the query filters that are supposed to be a part of UI (pattern type and case: filters)

**Prior to this PR:** 
 on the homepage we have `insights case:yes repo: sourcegraph/sourcegraph`
 on the search result page we have `insights  repo:sourcegraph/sourcegraph` (note that between search pattern `insights` and repo filter **there is an additional space**)
 
**In this PR** 
 on the homepage we have `insights case:yes repo: sourcegraph/sourcegraph`
 on the search result page we have `insights repo:sourcegraph/sourcegraph` Note that **there is only one space** between `insights` and repo filters

## Test plan
- Search any querh that has filters that are supposed to be remove from the query and become part of UI controls (like pattern type or case: filters) for example `insights case:yes patterntype:regex repo:sourcegraph/sourcegraph`
- On the search result page you should see that there are no whitespaces between parts that are still in the query (like `insights repo:sourcegraph/sourcegraph`, note that between search pattern and repo filter is no spaces) 
- Click different fitlers in the search sidebar panel like search types (find a symbol or search diffs), make sure that query is not currapted and still is valid after changing it through those filters. 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-replace-range.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-chpkmfarzg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
