### PR TITLE
dev/sg: introduce linter against OpenTracing usages

### DIFF
--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -99,3 +99,26 @@ func lintLoggingLibraries() *linter {
 		HelpText: "Learn more about logging and why some libraries are banned: https://docs.sourcegraph.com/dev/how-to/add_logging",
 	})
 }
+
+func lintTracingLibraries() *linter {
+	return newUsageLinter(usageLinterOptions{
+		Target: "**/*.go",
+		BannedUsages: []string{
+			// No OpenTracing
+			`"github.com/opentracing/opentracing-go"`,
+			// No OpenTracing util library
+			`"github.com/sourcegraph/sourcegraph/internal/trace/ot"`,
+		},
+		AllowedFiles: []string{
+			// Banned imports will match on the linter here
+			"dev/sg/linters",
+			// Adapters here
+			"internal/tracer",
+		},
+		ErrorFunc: func(bannedImport string) error {
+			return errors.Newf(`banned usage of '%s': use "go.opentelemetry.io/otel/trace" instead`,
+				bannedImport)
+		},
+		HelpText: "OpenTracing interop with OpenTelemetry is set up, but the libraries are deprecated - use OpenTelemetry directly instead: https://go.opentelemetry.io/otel/trace",
+	})
+}

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -42,6 +42,7 @@ var Targets = []Target{
 			noLocalHost,
 			lintGoDirectives(),
 			lintLoggingLibraries(),
+			lintTracingLibraries(),
 			goModGuards(),
 			lintSGExit(),
 		},


### PR DESCRIPTION
Based on https://github.com/sourcegraph/sourcegraph/pull/40949#issuecomment-1232949300 there are major issues with context propagation in OpenTracing even with the OpenTracing to OpenTelemetry bridge set up. To expedite migration and prevent further usage, we add a simple linter that just targets imports for now - this can later be expanded to ban new API usages as well.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes