### PR TITLE
insights: aggregations disable click though on bars when it won't do anything.

### DIFF
--- a/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
@@ -31,7 +31,7 @@ const MAX_BARS_PREVIEW_MOD = 10
 
 const getName = (datum: SearchAggregationDatum): string => datum.label ?? ''
 const getValue = (datum: SearchAggregationDatum): number => datum.count
-const getLink = (datum: SearchAggregationDatum): string => datum.query ?? ''
+const getLink = (datum: SearchAggregationDatum): string | null => datum.query ?? null
 const getColor = (): string => 'var(--primary)'
 
 /**
@@ -155,7 +155,10 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
 
     const handleDatumLinkClick = (event: MouseEvent, datum: SearchAggregationDatum, index: number): void => {
         event.preventDefault()
-        onBarLinkClick?.(getLink(datum), index)
+        const link = getLink(datum)
+        if (link) {
+            onBarLinkClick?.(link, index)
+        }
     }
 
     return (

--- a/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/AggregationChartCard.tsx
@@ -31,7 +31,7 @@ const MAX_BARS_PREVIEW_MOD = 10
 
 const getName = (datum: SearchAggregationDatum): string => datum.label ?? ''
 const getValue = (datum: SearchAggregationDatum): number => datum.count
-const getLink = (datum: SearchAggregationDatum): string | null => datum.query ?? null
+const getLink = (datum: SearchAggregationDatum): string | undefined => datum.query ?? undefined
 const getColor = (): string => 'var(--primary)'
 
 /**


### PR DESCRIPTION
Changes the backend to only return a new search url if there are multiple groups OR the user is in capture group mode

Change the webapp to stop clicks if the new query isn't present.
## Test plan
tbd
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
