### PR TITLE
autoindexing: Unify require and loadfile

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/lua/go.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/go.lua
@@ -2,7 +2,7 @@ local path = require "path"
 local patterns = require "sg.patterns"
 local recognizers = require "sg.recognizers"
 
-local shared = loadfile "shared.lua"()
+local shared = require("sg.autoindex.shared")
 
 local indexer = "sourcegraph/lsif-go:latest"
 

--- a/internal/codeintel/autoindexing/internal/inference/lua/recognizers.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/recognizers.lua
@@ -10,7 +10,7 @@ local languages = {
 
 local recognizers = {}
 for _, name in ipairs(languages) do
-  recognizers["sg." .. name] = loadfile(name .. ".lua")()
+  recognizers["sg." .. name] = require("sg.autoindex." .. name)
 end
 
 return recognizers

--- a/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
@@ -3,8 +3,8 @@ local path = require "path"
 local patterns = require "sg.patterns"
 local recognizers = require "sg.recognizers"
 
-local shared = loadfile "shared.lua"()
-local util = loadfile "util.lua"()
+local shared = require("sg.autoindex.shared")
+local util = require("sg.autoindex.util")
 
 local indexer = "sourcegraph/scip-typescript:autoindex"
 local typescript_nmusl_command =

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -204,8 +204,14 @@ func (s *Service) createSandbox(ctx context.Context) (_ *luasandbox.Sandbox, err
 	ctx, _, endObservation := s.operations.createSandbox.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
+	luaModules, err := luasandbox.LuaModulesFromFS(lua.Scripts, ".", "sg.autoindex")
+	if err != nil {
+		return nil, err
+	}
+
 	opts := luasandbox.CreateOptions{
-		Modules: defaultModules,
+		GoModules:  defaultModules,
+		LuaModules: luaModules,
 	}
 	sandbox, err := s.sandboxService.CreateSandbox(ctx, opts)
 	if err != nil {

--- a/internal/luasandbox/modules.go
+++ b/internal/luasandbox/modules.go
@@ -1,0 +1,79 @@
+package luasandbox
+
+import (
+	"embed"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed lua/*
+var luaRuntime embed.FS
+
+var DefaultLuaModules = map[string]string{}
+
+func init() {
+	modules, err := LuaModulesFromFS(luaRuntime, "lua", "")
+	if err != nil {
+		panic(fmt.Sprintf("error loading Lua runtime files: %s", err))
+	}
+
+	DefaultLuaModules = modules
+}
+
+func LuaModulesFromFS(fs embed.FS, dir, prefix string) (map[string]string, error) {
+	files, err := getAllFilepaths(fs, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	modules := make(map[string]string, len(files))
+	for _, file := range files {
+		f, err := fs.Open(file)
+		if err != nil {
+			return nil, err
+		}
+
+		contents, err := io.ReadAll(f)
+		if err != nil {
+			return nil, err
+		}
+
+		name := strings.Join(filepath.SplitList(strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))), ".")
+		if prefix != "" {
+			name = prefix + "." + name
+		}
+
+		modules[name] = string(contents)
+	}
+
+	return modules, nil
+}
+
+func getAllFilepaths(fs embed.FS, path string) (out []string, err error) {
+	if path == "" {
+		path = "."
+	}
+
+	entries, err := fs.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		path := filepath.Join(path, entry.Name())
+
+		if entry.IsDir() {
+			descendents, err := getAllFilepaths(fs, path)
+			if err != nil {
+				return nil, err
+			}
+
+			out = append(out, descendents...)
+		} else {
+			out = append(out, path)
+		}
+	}
+	return
+}

--- a/internal/luasandbox/sandbox_test.go
+++ b/internal/luasandbox/sandbox_test.go
@@ -103,7 +103,7 @@ func TestModule(t *testing.T) {
 	ctx := context.Background()
 
 	sandbox, err := newService(&observation.TestContext).CreateSandbox(ctx, CreateOptions{
-		Modules: map[string]lua.LGFunction{
+		GoModules: map[string]lua.LGFunction{
 			"testmod": util.CreateModule(api),
 		},
 	})

--- a/internal/luasandbox/service.go
+++ b/internal/luasandbox/service.go
@@ -6,6 +6,7 @@ import (
 	lua "github.com/yuin/gopher-lua"
 
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type Service struct {
@@ -21,12 +22,30 @@ func newService(
 }
 
 type CreateOptions struct {
-	Modules map[string]lua.LGFunction
+	GoModules map[string]lua.LGFunction
+
+	// LuaModules is map of require("$KEY") -> $VALUE that will be loaded
+	// in the lua sandbox state. This prevents subsequent executions from
+	// modifying (or peeking into) the state of any other recognizer.
+	LuaModules map[string]string
 }
 
 func (s *Service) CreateSandbox(ctx context.Context, opts CreateOptions) (_ *Sandbox, err error) {
 	_, _, endObservation := s.operations.createSandbox.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
+
+	// Default LuaModules to our runtime files
+	if opts.LuaModules == nil {
+		opts.LuaModules = map[string]string{}
+	}
+
+	for k, v := range DefaultLuaModules {
+		if _, ok := opts.LuaModules[k]; ok {
+			return nil, errors.Newf("a Lua module with the name %q already exists", k)
+		}
+
+		opts.LuaModules[k] = v
+	}
 
 	state := lua.NewState(lua.Options{
 		// Do not open libraries implicitly
@@ -41,7 +60,7 @@ func (s *Service) CreateSandbox(ctx context.Context, opts CreateOptions) (_ *San
 	}
 
 	// Preload caller-supplied modules
-	for name, loader := range opts.Modules {
+	for name, loader := range opts.GoModules {
 		state.PreloadModule(name, loader)
 	}
 
@@ -49,6 +68,29 @@ func (s *Service) CreateSandbox(ctx context.Context, opts CreateOptions) (_ *San
 	for _, name := range globalsToUnset {
 		state.SetGlobal(name, lua.LNil)
 	}
+
+	// Insert a new package loader into the Lua state to control `require("...")`
+	state.GetField(state.GetGlobal("package"), "loaders").(*lua.LTable).Insert(
+		1,
+		state.NewFunction(func(s *lua.LState) int {
+			contents, ok := opts.LuaModules[s.Get(-1).(lua.LString).String()]
+			if !ok {
+				// loaders return nil if they don't do anything
+				state.Push(lua.LNil)
+				return 1
+			}
+
+			val, err := state.LoadString(contents)
+			if err != nil {
+				state.RaiseError(err.Error())
+				return 0
+			}
+
+			// return loaded Lua chunk
+			state.Push(val)
+			return 1
+		}),
+	)
 
 	return &Sandbox{
 		state:      state,


### PR DESCRIPTION
Pulled from #36122 by @tjdevries. This PR removes `loadfile` from the Lua sandbox and allows for a more unified way to import code. Fixes #34295.

## Test plan

Existing unit tests.