### PR TITLE
insights: aggregations reset the ui mode to sidebar when drilling into chart

### DIFF
--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -45,7 +45,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
     const { query, patternType, caseSensitive, onQuerySubmit, telemetryService, ...attributes } = props
 
     const [extendedTimeout, setExtendedTimeoutLocal] = useState(false)
-    const [, setAggregationUIMode] = useAggregationUIMode()
+    const [aggregationUIMode, setAggregationUIMode] = useAggregationUIMode()
     const [aggregationMode, setAggregationMode] = useAggregationSearchMode()
     const { data, error, loading } = useSearchAggregationData({
         query,
@@ -61,7 +61,14 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
         telemetryService.log(GroupResultsPing.CollapseFullViewPanel, { aggregationMode }, { aggregationMode })
     }
 
+    const resetUIMode = (): void => {
+        if (aggregationUIMode !== AggregationUIMode.Sidebar) {
+            setAggregationUIMode(AggregationUIMode.Sidebar)
+        }
+    }
+
     const handleBarLinkClick = (query: string, index: number): void => {
+        resetUIMode()
         onQuerySubmit(query)
         telemetryService.log(
             GroupResultsPing.ChartBarClick,


### PR DESCRIPTION
Updates the bar click logic to reset the current UI mode to Sidebar if it isn't already.   I avoided the pings because this is not a user taken.

resolves https://github.com/sourcegraph/sourcegraph/issues/41447
## Test plan
Expand the aggregation, then click a bar and see the aggregations return to the sidebar with updated search results.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cw-collapse-state.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wwsnhssudb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
