### PR TITLE
Fix missing aggregation group tooltip copy

### DIFF
--- a/client/web/src/search/results/components/aggregation/components/aggregation-chart-card/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/components/aggregation-chart-card/AggregationChartCard.tsx
@@ -3,6 +3,7 @@ import { Suspense, HTMLAttributes, ReactElement, MouseEvent } from 'react'
 import { mdiPlay } from '@mdi/js'
 
 import { ErrorAlert, ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
+import { pluralize } from '@sourcegraph/common'
 import { NotAvailableReasonType, SearchAggregationMode } from '@sourcegraph/shared/src/graphql-operations'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Text, Link, Tooltip, Button, Icon } from '@sourcegraph/wildcard'
@@ -175,7 +176,11 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
 
                 {!!missingCount && (
                     <Tooltip
-                        content={`There are ${missingCount} more groups that were not included in this aggregation.`}
+                        content={`There ${pluralize('is', missingCount, 'are')} ${missingCount} more ${pluralize(
+                            'group',
+                            missingCount,
+                            'groups'
+                        )} not shown.`}
                     >
                         <Text size="small" className={styles.missingLabelCount}>
                             +{missingCount}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41291

## Test plan
- Make sure that aggregation missing group tooltip has right copy and right pluralized text

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
