### PR TITLE
search: highlight repository matches in RepoSearchJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - A new look for Sourcegraph, previously in beta as "Simple UI", is now permanently enabled. [#41021](https://github.com/sourcegraph/sourcegraph/pull/41021)
 - A new [multi-version upgrade](https://docs.sourcegraph.com/admin/updates#multi-version-upgrades) process now allows Sourcegraph instances to upgrade more than a single minor version. Instances at version 3.20 or later can now jump directly to 4.0. [#40628](https://github.com/sourcegraph/sourcegraph/pull/40628)
-- Matching ranges in file paths are now highlighted for path results and content results. [#41296](https://github.com/sourcegraph/sourcegraph/pull/41296) [#41385](https://github.com/sourcegraph/sourcegraph/pull/41385)
+- Matching ranges in file paths are now highlighted for path results and content results. Matching paths in repository names are now highlighted for repository results. [#41296](https://github.com/sourcegraph/sourcegraph/pull/41296) [#41385](https://github.com/sourcegraph/sourcegraph/pull/41385) [#41470](https://github.com/sourcegraph/sourcegraph/pull/41470)
 - Aggregations by repository, file, author, and capture group are now provided for search results. [#39643](https://github.com/sourcegraph/sourcegraph/issues/39643)
 
 ### Changed

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -33,7 +33,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     index,
 }) => {
     const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
-    const containerElement = useRef<HTMLDivElement>(null)
+    const repoDescriptionElement = useRef<HTMLDivElement>(null)
+    const repoNameElement = useRef<HTMLAnchorElement>(null)
 
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
@@ -44,7 +45,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                     coreWorkflowImprovementsEnabled && styles.mutedRepoFileLink
                 )}
             >
-                <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
+                <Link to={getRepoMatchUrl(result)} ref={repoNameElement}>{displayRepoName(getRepoMatchLabel(result))}</Link>
             </span>
         </div>
     )
@@ -108,7 +109,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                         <div className={styles.dividerVertical} />
                         <div>
                             <small>
-                                <em ref={containerElement}>
+                                <em ref={repoDescriptionElement}>
                                     {result.description.length > REPO_DESCRIPTION_CHAR_LIMIT
                                         ? result.description.slice(0, REPO_DESCRIPTION_CHAR_LIMIT) + ' ...'
                                         : result.description}
@@ -122,16 +123,26 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     )
 
     useEffect((): void => {
-        if (containerElement.current && result.descriptionMatches) {
-            for (const range of result.descriptionMatches) {
+        if (repoNameElement.current && result.repositoryMatches) {
+            for (const range of result.repositoryMatches) {
                 highlightNode(
-                    containerElement.current as HTMLElement,
+                    repoNameElement.current as HTMLElement,
                     range.start.column,
                     range.end.column - range.start.column
                 )
             }
         }
-    }, [result.description, result.descriptionMatches, containerElement])
+
+        if (repoDescriptionElement.current && result.descriptionMatches) {
+            for (const range of result.descriptionMatches) {
+                highlightNode(
+                    repoDescriptionElement.current as HTMLElement,
+                    range.start.column,
+                    range.end.column - range.start.column
+                )
+            }
+        }
+    }, [result, result.repositoryMatches, repoNameElement, result.description, result.descriptionMatches, repoDescriptionElement])
 
     return (
         <ResultContainer

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -45,7 +45,9 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                     coreWorkflowImprovementsEnabled && styles.mutedRepoFileLink
                 )}
             >
-                <Link to={getRepoMatchUrl(result)} ref={repoNameElement}>{displayRepoName(getRepoMatchLabel(result))}</Link>
+                <Link to={getRepoMatchUrl(result)} ref={repoNameElement}>
+                    {displayRepoName(getRepoMatchLabel(result))}
+                </Link>
             </span>
         </div>
     )
@@ -142,7 +144,14 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                 )
             }
         }
-    }, [result, result.repositoryMatches, repoNameElement, result.description, result.descriptionMatches, repoDescriptionElement])
+    }, [
+        result,
+        result.repositoryMatches,
+        repoNameElement,
+        result.description,
+        result.descriptionMatches,
+        repoDescriptionElement,
+    ])
 
     return (
         <ResultContainer

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -131,6 +131,7 @@ export interface CommitMatch {
 export interface RepositoryMatch {
     type: 'repo'
     repository: string
+    repositoryMatches?: Range[]
     repoStars?: number
     repoLastFetched?: string
     description?: string

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -455,10 +455,11 @@ func fromRepository(rm *result.RepoMatch, repoCache map[api.RepoID]*types.Search
 	}
 
 	repoEvent := &streamhttp.EventRepoMatch{
-		Type:         streamhttp.RepoMatchType,
-		RepositoryID: int32(rm.ID),
-		Repository:   string(rm.Name),
-		Branches:     branches,
+		Type:              streamhttp.RepoMatchType,
+		RepositoryID:      int32(rm.ID),
+		Repository:        string(rm.Name),
+		RepositoryMatches: fromRanges(rm.RepoNameMatches),
+		Branches:          branches,
 	}
 
 	if len(rm.DescriptionMatches) > 0 {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -445,9 +445,10 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 					repoNamePatterns := make([]*regexp.Regexp, 0, len(repoOptions.RepoFilters))
 					for _, repoFilter := range repoOptions.RepoFilters {
 						if repoOptions.CaseSensitiveRepoFilters {
-							repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(regexp.QuoteMeta(repoFilter)))
+							// escaping regexp meta characters in literal patterns is handled by call to PatternString() above
+							repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(repoFilter))
 						} else {
-							repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(`(?i)`+regexp.QuoteMeta(repoFilter)))
+							repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(`(?i)`+repoFilter))
 						}
 					}
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -442,9 +442,19 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 						descriptionPatterns = append(descriptionPatterns, regexp.MustCompile(`(?is)`+pat))
 					}
 
+					repoNamePatterns := make([]*regexp.Regexp, 0, len(repoOptions.RepoFilters))
+					for _, repoFilter := range repoOptions.RepoFilters {
+						if repoOptions.CaseSensitiveRepoFilters {
+							repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(regexp.QuoteMeta(repoFilter)))
+						} else {
+							repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(`(?i)`+regexp.QuoteMeta(repoFilter)))
+						}
+					}
+
 					addJob(&RepoSearchJob{
 						RepoOpts:            repoOptions,
 						DescriptionPatterns: descriptionPatterns,
+						RepoNamePatterns:    repoNamePatterns,
 					})
 				}
 			}

--- a/internal/search/job/jobutil/repos.go
+++ b/internal/search/job/jobutil/repos.go
@@ -2,6 +2,7 @@ package jobutil
 
 import (
 	"context"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/grafana/regexp"
@@ -21,6 +22,7 @@ import (
 type RepoSearchJob struct {
 	RepoOpts            search.RepoOptions
 	DescriptionPatterns []*regexp.Regexp
+	RepoNamePatterns    []*regexp.Regexp // used for getting repo name match ranges
 }
 
 func (s *RepoSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
@@ -41,7 +43,7 @@ func (s *RepoSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 		}
 
 		stream.Send(streaming.SearchEvent{
-			Results: repoRevsToRepoMatches(page.RepoRevs, descriptionMatches),
+			Results: repoRevsToRepoMatches(page.RepoRevs, s.RepoNamePatterns, descriptionMatches),
 		})
 
 		return nil
@@ -117,14 +119,50 @@ func (s *RepoSearchJob) Fields(v job.Verbosity) (res []log.Field) {
 func (s *RepoSearchJob) Children() []job.Describer       { return nil }
 func (s *RepoSearchJob) MapChildren(job.MapFunc) job.Job { return s }
 
-func repoRevsToRepoMatches(repos []*search.RepositoryRevisions, descriptionMatches map[api.RepoID][]result.Range) []result.Match {
+func repoRevsToRepoMatches(repos []*search.RepositoryRevisions, repoNameRegexps []*regexp.Regexp, descriptionMatches map[api.RepoID][]result.Range) []result.Match {
 	matches := make([]result.Match, 0, len(repos))
+
+	// Remove code host from repo name (e.g. remove "github.com/")
+	// The code host is removed from the repo name before being displayed in the client (see function `displayRepoName()`)
+	// so this is needed to ensure the repo name match ranges are highlighted correctly in the client.
+	// This is not ideal, but works for now.
+	simplifyRepoName := func(repoName string) string {
+		parts := strings.Split(repoName, "/")
+		if len(parts) >= 3 && strings.Contains(parts[0], ".") {
+			parts = parts[1:]
+		}
+		return strings.Join(parts, "/")
+	}
+
 	for _, r := range repos {
+		var repoNameMatches []result.Range
+		simplifiedRepoName := simplifyRepoName(string(r.Repo.Name))
+
+		// Find repo name match ranges
+		for _, repoNameRe := range repoNameRegexps {
+			submatches := repoNameRe.FindAllStringSubmatchIndex(simplifiedRepoName, -1)
+			for _, sm := range submatches {
+				repoNameMatches = append(repoNameMatches, result.Range{
+					Start: result.Location{
+						Offset: sm[0],
+						Line:   0, // we can treat repo names as single-line
+						Column: utf8.RuneCountInString(simplifiedRepoName[:sm[0]]),
+					},
+					End: result.Location{
+						Offset: sm[1],
+						Line:   0,
+						Column: utf8.RuneCountInString(simplifiedRepoName[:sm[1]]),
+					},
+				})
+			}
+		}
+
 		for _, rev := range r.Revs {
 			rm := result.RepoMatch{
-				Name: r.Repo.Name,
-				ID:   r.Repo.ID,
-				Rev:  rev,
+				Name:            r.Repo.Name,
+				ID:              r.Repo.ID,
+				Rev:             rev,
+				RepoNameMatches: repoNameMatches,
 			}
 			if ranges, ok := descriptionMatches[r.Repo.ID]; ok {
 				rm.DescriptionMatches = ranges

--- a/internal/search/job/jobutil/repos_test.go
+++ b/internal/search/job/jobutil/repos_test.go
@@ -1,6 +1,7 @@
 package jobutil
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -157,6 +158,93 @@ func Test_descriptionMatchRanges(t *testing.T) {
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("unexpected results (-want +got)\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestRepoMatchRanges(t *testing.T) {
+	repoNameRegexps := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)(?:misery).*?(?:business)`),
+		regexp.MustCompile(`(?i)(?:brick).*?(?:by).*?(?:boring).*?(?:brick)`),
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  []result.Range
+	}{
+		{
+			name:  "single repo name match range",
+			input: "2007/riot/misery-business",
+			want: []result.Range{
+				{
+					Start: result.Location{
+						Offset: 10,
+						Line:   0,
+						Column: 10,
+					},
+					End: result.Location{
+						Offset: 25,
+						Line:   0,
+						Column: 25,
+					},
+				},
+			},
+		},
+		{
+			name:  "multiple match ranges",
+			input: "greatest-hits/miseryBusiness/crushcrushcrush/brickByBoringBrick",
+			want: []result.Range{
+				{
+					Start: result.Location{
+						Offset: 14,
+						Line:   0,
+						Column: 14,
+					},
+					End: result.Location{
+						Offset: 28,
+						Line:   0,
+						Column: 28,
+					},
+				},
+				{
+					Start: result.Location{
+						Offset: 45,
+						Line:   0,
+						Column: 45,
+					},
+					End: result.Location{
+						Offset: 63,
+						Line:   0,
+						Column: 63,
+					},
+				},
+			},
+		},
+		{
+			name:  "strips code host from repo name before matching",
+			input: "github.com/paramore/riot/tracklist/4-misery-business/5-when-it-rains",
+			want: []result.Range{
+				{
+					Start: result.Location{
+						Offset: 26,
+						Line:   0,
+						Column: 26,
+					},
+					End: result.Location{
+						Offset: 41,
+						Line:   0,
+						Column: 41,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := repoMatchRanges(tc.input, repoNameRegexps)
+			require.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/search/job/jobutil/repos_test.go
+++ b/internal/search/job/jobutil/repos_test.go
@@ -1,11 +1,11 @@
 package jobutil
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"

--- a/internal/search/result/merger.go
+++ b/internal/search/result/merger.go
@@ -82,6 +82,8 @@ func (lm *merger) addMatch(m Match, source int) Match {
 		prev.match.(*FileMatch).AppendMatches(v)
 	case *CommitMatch:
 		prev.match.(*CommitMatch).AppendMatches(v)
+	case *RepoMatch:
+		prev.match.(*RepoMatch).AppendMatches(v)
 	}
 
 	// Mark the key as seen by this source

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -16,6 +16,7 @@ type RepoMatch struct {
 	Rev string
 
 	DescriptionMatches []Range
+	RepoNameMatches    []Range
 }
 
 func (r RepoMatch) RepoName() types.MinimalRepo {

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -52,9 +52,7 @@ func (r *RepoMatch) URL() *url.URL {
 }
 
 func (r *RepoMatch) AppendMatches(src *RepoMatch) {
-	if len(r.RepoNameMatches) > 0 && len(src.RepoNameMatches) > 0 {
-		r.RepoNameMatches = append(r.RepoNameMatches, src.RepoNameMatches...)
-	}
+	r.RepoNameMatches = append(r.RepoNameMatches, src.RepoNameMatches...)
 }
 
 func (r *RepoMatch) Key() Key {

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -51,6 +51,12 @@ func (r *RepoMatch) URL() *url.URL {
 	return &url.URL{Path: path}
 }
 
+func (r *RepoMatch) AppendMatches(src *RepoMatch) {
+	if len(r.RepoNameMatches) > 0 && len(src.RepoNameMatches) > 0 {
+		r.RepoNameMatches = append(r.RepoNameMatches, src.RepoNameMatches...)
+	}
+}
+
 func (r *RepoMatch) Key() Key {
 	return Key{
 		TypeRank: rankRepoMatch,

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -97,6 +97,7 @@ type EventRepoMatch struct {
 
 	RepositoryID       int32              `json:"repositoryID"`
 	Repository         string             `json:"repository"`
+	RepositoryMatches  []Range            `json:"repositoryMatches,omitempty"`
 	Branches           []string           `json:"branches,omitempty"`
 	RepoStars          int                `json:"repoStars,omitempty"`
 	RepoLastFetched    *time.Time         `json:"repoLastFetched,omitempty"`


### PR DESCRIPTION
Part of #18374

As part of `RepoSearchJob` execution, get the ranges of the repo name that match any of `RepoOpts.RepoFilters`, and return those ranges to the client to be highlighted on repository match results.

![Screen Shot 2022-09-07 at 4 37 17 PM](https://user-images.githubusercontent.com/70350613/188986877-815b7274-d397-4a64-bf39-42e5bc4a9807.png)

![Screen Shot 2022-09-07 at 4 37 46 PM](https://user-images.githubusercontent.com/70350613/188986974-ae4c6a0e-e003-4e84-9a10-3022c14b1fb9.png)

![Screen Shot 2022-09-07 at 4 39 30 PM](https://user-images.githubusercontent.com/70350613/188987349-2da31abe-410c-4f1c-b54e-fb49f6e5a37c.png)

## Test plan
Added unit test
Manual testing to feel good about the addition
CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
