### PR TITLE
Make clicking on repo and files expand them

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -777,7 +777,6 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     handleOpenChange,
     searchToken,
 }) => {
-    const repoUrl = `/${repoLocationGroup.repoName}`
     const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
 
     return (
@@ -792,16 +791,9 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                 >
                     <Icon aria-hidden="true" svgPath={open ? mdiChevronDown : mdiChevronRight} />
                     <small>
-                        <Link
-                            to={repoUrl}
-                            onClick={event => {
-                                event.preventDefault()
-                                navigateToUrl(repoUrl)
-                            }}
-                            className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}
-                        >
+                        <span className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}>
                             {displayRepoName(repoLocationGroup.repoName)}
-                        </Link>
+                        </span>
                     </small>
                 </CollapseHeader>
 
@@ -841,7 +833,6 @@ const CollapsibleLocationGroup: React.FunctionComponent<
         highlighted = group.path.split(filter)
     }
 
-    const fileUrl = group.locations[group.locations.length - 1].url.split('?')[0]
     const open = isOpen(group.path) ?? true
 
     return (
@@ -863,13 +854,8 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                     )}
                     <small className={styles.locationGroupHeaderFilename}>
                         <span>
-                            <Link
+                            <span
                                 aria-label={`File path ${group.path}`}
-                                to={fileUrl}
-                                onClick={event => {
-                                    event.preventDefault()
-                                    navigateToUrl(fileUrl)
-                                }}
                                 className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}
                             >
                                 {highlighted.length === 2 ? (
@@ -881,7 +867,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                 ) : (
                                     group.path
                                 )}{' '}
-                            </Link>
+                            </span>
                             <span className={classNames('ml-2 text-muted', styles.cardHeaderSmallText)}>
                                 ({group.locations.length}{' '}
                                 {pluralize('occurrence', group.locations.length, 'occurrences')})


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/issues/40904

![CleanShot 2022-09-07 at 16 42 15](https://user-images.githubusercontent.com/1387653/188996212-44ad05bc-5307-4235-a265-76e60b9c8f71.png)

## Test plan

Ran locally

## App preview:

- [Web](https://sg-web-repo-file-expandable.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lnslvrlxqw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
