### PR TITLE
add pings for proactive mode

### DIFF
--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -53,6 +53,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
         caseSensitive,
         proactive: true,
         extendedTimeout,
+        telemetryService,
     })
 
     const handleCollapseClick = (): void => {

--- a/client/web/src/search/results/components/aggregation/pings.ts
+++ b/client/web/src/search/results/components/aggregation/pings.ts
@@ -13,4 +13,10 @@ export enum GroupResultsPing {
     ExpandFullViewPanel = 'GroupResultsExpandedViewOpen',
     CollapseFullViewPanel = 'GroupResultsExpandedViewCollapse',
     InfoIconHover = 'GroupResultsInfoIconHover',
+
+    // Proactive
+    ProactiveLimitHit = 'ProactiveLimitHit',
+    ProactiveLimitSuccess = 'ProactiveLimitSuccess',
+    ExplicitLimitHit = 'ExplicitLimitHit',
+    ExplicitLimitSuccess = 'ExplicitLimitSuccess',
 }

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -16,7 +16,6 @@ import {
     useSearchAggregationData,
     isNonExhaustiveAggregationResults,
     GroupResultsPing,
-    useAggregationLimitPing,
 } from '../components/aggregation'
 
 import styles from './SearchAggregations.module.scss'
@@ -59,9 +58,8 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         proactive,
         caseSensitive,
         extendedTimeout,
+        telemetryService,
     })
-
-    useAggregationLimitPing({ aggregationMode, data, extendedTimeout, proactive, telemetryService })
 
     // When query is updated reset extendedTimeout as per business rules
     useEffect(() => setExtendedTimeoutLocal(false), [query])

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -6,6 +6,7 @@ import { SearchAggregationMode, SearchPatternType } from '@sourcegraph/shared/sr
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon } from '@sourcegraph/wildcard'
 
+import { NotAvailableReasonType } from '../../../graphql-operations'
 import {
     AggregationChartCard,
     AggregationModeControls,
@@ -62,6 +63,30 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
 
     // When query is updated reset extendedTimeout as per business rules
     useEffect(() => setExtendedTimeoutLocal(false), [query])
+
+    useEffect(() => {
+        if (!proactive || loading || error || !data) {
+            return
+        }
+
+        const aggregation = data.searchQueryAggregate.aggregations
+        let pingType = GroupResultsPing.ProactiveLimitSuccess
+
+        if (aggregation?.__typename === 'SearchAggregationNotAvailable') {
+            if (aggregation.reasonType === NotAvailableReasonType.TIMEOUT_EXTENSION_AVAILABLE) {
+                pingType = GroupResultsPing.ProactiveLimitHit
+            }
+            if (aggregation.reasonType === NotAvailableReasonType.TIMEOUT_NO_EXTENSION_AVAILABLE) {
+                pingType = GroupResultsPing.ExplicitLimitHit
+            }
+        }
+
+        if (extendedTimeout) {
+            pingType = GroupResultsPing.ExplicitLimitSuccess
+        }
+
+        telemetryService.log(pingType, { aggregationMode, uiMode: 'sidebar' }, { aggregationMode, uiMode: 'sidebar' })
+    }, [aggregationMode, data, error, extendedTimeout, loading, proactive, telemetryService])
 
     const handleExtendTimeout = (): void => setExtendedTimeoutLocal(true)
 

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -103,11 +103,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         }
 
         if (pingType) {
-            telemetryService.log(
-                pingType,
-                { aggregationMode, uiMode: 'sidebar' },
-                { aggregationMode, uiMode: 'sidebar' }
-            )
+            telemetryService.log(pingType, { aggregationMode }, { aggregationMode })
         }
     }, [aggregationMode, data, error, extendedTimeout, loading, proactive, telemetryService])
 

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -66,7 +66,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
 
     useEffect(
         function proactiveModePings() {
-            if (!proactive || loading || error || !data.searchQueryAggregate.aggregations) {
+            if (loading || error || !data.searchQueryAggregate.aggregations) {
                 return
             }
 
@@ -80,18 +80,27 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
             let pingType
 
             if (aggregationUnavailable) {
-                if (aggregation.reasonType === NotAvailableReasonType.TIMEOUT_EXTENSION_AVAILABLE) {
+                const extensionAvailable = aggregation.reasonType === NotAvailableReasonType.TIMEOUT_EXTENSION_AVAILABLE
+                const noExtensionAvailable =
+                    aggregation.reasonType === NotAvailableReasonType.TIMEOUT_NO_EXTENSION_AVAILABLE
+
+                if (proactive && extensionAvailable) {
                     pingType = GroupResultsPing.ProactiveLimitHit
                 }
-                if (aggregation.reasonType === NotAvailableReasonType.TIMEOUT_NO_EXTENSION_AVAILABLE) {
+
+                if (noExtensionAvailable) {
                     pingType = GroupResultsPing.ExplicitLimitHit
                 }
             }
 
             if (aggregationAvailable) {
-                pingType = extendedTimeout
-                    ? GroupResultsPing.ExplicitLimitSuccess
-                    : GroupResultsPing.ProactiveLimitSuccess
+                if (proactive) {
+                    pingType = GroupResultsPing.ProactiveLimitSuccess
+                }
+
+                if (extendedTimeout) {
+                    pingType = GroupResultsPing.ExplicitLimitSuccess
+                }
             }
 
             if (pingType) {
@@ -198,3 +207,5 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         </article>
     )
 })
+
+SearchAggregations.displayName = 'SearchAggregations'

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1446,6 +1446,7 @@ type CodeInsightsUsageStatistics struct {
 	WeeklyGroupResultsChartBarClick                []GroupResultPing
 	WeeklyGroupResultsAggregationModeClicked       []GroupResultPing
 	WeeklyGroupResultsAggregationModeDisabledHover []GroupResultPing
+	WeeklyGroupResultsSearches                     []GroupResultSearchPing
 }
 
 type GroupResultPing struct {
@@ -1456,6 +1457,12 @@ type GroupResultPing struct {
 }
 
 type GroupResultExpandedViewPing struct {
+	AggregationMode *string
+	Count           *int32
+}
+
+type GroupResultSearchPing struct {
+	Name            PingName
 	AggregationMode *string
 	Count           *int32
 }

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -557,6 +557,12 @@ WHERE name = $1::TEXT AND timestamp > DATE_TRUNC('week', $2::TIMESTAMP)
 GROUP BY argument;
 `
 
+const getGroupResultSearchesSql = `
+SELECT COUNT(*), argument::json->>'aggregationMode' as aggregationMode FROM event_logs
+WHERE name = $1::TEXT AND timestamp > DATE_TRUNC('week', $2::TIMESTAMP)
+GROUP BY argument;
+`
+
 const InsightsTotalCountPingName = `INSIGHT_TOTAL_COUNTS`
 const InsightsTotalCountCriticalPingName = `INSIGHT_TOTAL_COUNT_CRITICAL`
 const InsightsIntervalCountsPingName = `INSIGHT_TIME_INTERVALS`

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -227,6 +227,21 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 	}
 	stats.WeeklyGroupResultsExpandedViewCollapse = weeklyGroupResultsExpandedViewCollapse
 
+	weeklyGroupResultsSearches, err := GetGroupResultsSearchesPings(
+		ctx,
+		db,
+		[]types.PingName{
+			"ProactiveLimitHit",
+			"ProactiveLimitSuccess",
+			"ExplicitLimitHit",
+			"ExplicitLimitSuccess",
+		},
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "WeeklyGroupResultsSearches")
+	}
+	stats.WeeklyGroupResultsSearches = weeklyGroupResultsSearches
+
 	return &stats, nil
 }
 
@@ -436,6 +451,40 @@ func GetGroupResultsExpandedViewPing(ctx context.Context, db database.DB, pingNa
 	return groupResultsExpandedViewPings, nil
 }
 
+func GetGroupResultsSearchesPings(ctx context.Context, db database.DB, pingNames []types.PingName) ([]types.GroupResultSearchPing, error) {
+	pings := []types.GroupResultSearchPing{}
+
+	for _, name := range pingNames {
+		rows, err := db.QueryContext(ctx, getGroupResultsSql, string(name), timeNow())
+		if err != nil {
+			return nil, err
+		}
+		err = func() error {
+			defer rows.Close()
+			var noop *string
+			for rows.Next() {
+				ping := types.GroupResultSearchPing{
+					Name: name,
+				}
+				if err := rows.Scan(
+					&ping.Count,
+					&ping.AggregationMode,
+					&noop,
+					&noop,
+				); err != nil {
+					return err
+				}
+				pings = append(pings, ping)
+			}
+			return nil
+		}()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return pings, nil
+}
+
 // WithAll adds multiple pings by name to this builder
 func (b *PingQueryBuilder) WithAll(pings []types.PingName) *PingQueryBuilder {
 	for _, p := range pings {
@@ -497,11 +546,6 @@ func creationPagesPingBuilder(timeSupplier func() time.Time) PingQueryBuilder {
 		"InsightGetStartedTemplateCopyClick",
 		"InsightGetStartedTemplateClick",
 		"InsightsGetStartedDocsClicks",
-
-		"ProactiveLimitHit",
-		"ProactiveLimitSuccess",
-		"ExplicitLimitHit",
-		"ExplicitLimitSuccess",
 	}
 
 	builder := NewPingBuilder(Week, timeSupplier)
@@ -553,12 +597,6 @@ GROUP BY argument;
 
 const getGroupResultsSql = `
 SELECT COUNT(*), argument::json->>'aggregationMode' as aggregationMode, argument::json->>'uiMode' as uiMode, argument::json->>'index' as bar_index FROM event_logs
-WHERE name = $1::TEXT AND timestamp > DATE_TRUNC('week', $2::TIMESTAMP)
-GROUP BY argument;
-`
-
-const getGroupResultSearchesSql = `
-SELECT COUNT(*), argument::json->>'aggregationMode' as aggregationMode FROM event_logs
 WHERE name = $1::TEXT AND timestamp > DATE_TRUNC('week', $2::TIMESTAMP)
 GROUP BY argument;
 `

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -497,6 +497,11 @@ func creationPagesPingBuilder(timeSupplier func() time.Time) PingQueryBuilder {
 		"InsightGetStartedTemplateCopyClick",
 		"InsightGetStartedTemplateClick",
 		"InsightsGetStartedDocsClicks",
+
+		"ProactiveLimitHit",
+		"ProactiveLimitSuccess",
+		"ExplicitLimitHit",
+		"ExplicitLimitSuccess",
 	}
 
 	builder := NewPingBuilder(Week, timeSupplier)

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -126,6 +126,7 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 	want.WeeklyGroupResultsChartBarClick = []types.GroupResultPing{}
 	want.WeeklyGroupResultsAggregationModeClicked = []types.GroupResultPing{}
 	want.WeeklyGroupResultsAggregationModeDisabledHover = []types.GroupResultPing{}
+	want.WeeklyGroupResultsSearches = []types.GroupResultSearchPing{}
 
 	if diff := cmp.Diff(want, have); diff != "" {
 		t.Fatal(diff)


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41033

Adds the following pings:

- ProactiveLimitHit
- ProactiveLimitSuccess
- ExplicitLimitHit
- ExplicitLimitSuccess

## Test plan

For all scenarios below, run a query and check the networking tab in dev tools.

Use this filter to narrow network requests: `/agg|log/`

Note: You will see multiple calls for `LogEvents`. It will be necessary to look through each of them to find the pings.

## Proactive Mode

Make sure the experimental features flag "proactiveSearchResultsAggregations" is set to `true`

### Scenario 1: No timeout hit

Run a search for `insights` This should return a value in less time than the 2-second default limit.

- Should see network request for `GetSearchAggregation`
- Network request payload for `LogEvents` should have `ProactiveLimitSuccess`

### Scenario 2: Timeout hit

Run a search for `insights type:diff` This should timeout at the 2-second default limit.

- Should see network request for `GetSearchAggregation`
- Network request payload for `LogEvents` should have `ProactiveLimitHit`

### Scenario 2.1: Timeout hit, extension success

Click the "Run aggregations" button on the chart skeleton

- Should see network request for `GetSearchAggregation`
- Network request payload for `LogEvents` should have `ExplicitLimitSuccess`

### Scenario 3: Timeout hit, extension limit hit

Run a search for `a type:diff count:all` This should timeout at the 2-second default limit.

- Should see network request for `GetSearchAggregation`
- Network request payload for `LogEvents` should have `ProactiveLimitSuccess`

Click the "Run aggregations" button on the chart skeleton

- Should see network request for `GetSearchAggregation`
- Network request payload for `LogEvents` should have `ExplicitLimitHit`

## Non-Proactive Mode

Make sure the experimental features flag "proactiveSearchResultsAggregations" is set to `false`

### Scenario 1: No timeout hit

Run a search for `insights`, then select `Repo`. This should return a value in less time than the 2-second default limit.

- Should see network request for `GetSearchAggregation`

### Scenario 2: Timeout hit

Run a search for `insights type:diff`, then select `Repo`. This should timeout at the 2-second default limit.

- Should see network request for `GetSearchAggregation`

### Scenario 2.1: Timeout hit, extension success

Click the "Run aggregations" button on the chart skeleton

- Should see network request for `GetSearchAggregation`
- Network request payload for `LogEvents` should have `ExplicitLimitSuccess`

### Scenario 3: Timeout hit, extension limit hit

Run a search for `a type:diff count:all`, then select `Repo` This should timeout at the 2-second default limit.

- Should see network request for `GetSearchAggregation`

Click the "Run aggregations" button on the chart skeleton

- Should see network request for `GetSearchAggregation`
- Network request payload for `LogEvents` should have `ExplicitLimitHit`

## App preview:

- [Web](https://sg-web-insights-proactive-pings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yfbgpmvbkf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

