### PR TITLE
gitserver: adjust logger usage

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -188,7 +188,7 @@ func main() {
 		logger.Warn("error performing initial site level rate limit sync", log.Error(err))
 	}
 
-	go syncRateLimiters(ctx, externalServiceStore, rateLimitSyncerLimitPerSecond)
+	go syncRateLimiters(ctx, logger, externalServiceStore, rateLimitSyncerLimitPerSecond)
 	go debugserver.NewServerRoutine(ready).Start()
 	go gitserver.Janitor(janitorInterval)
 	go gitserver.SyncRepoState(syncRepoStateInterval, syncRepoStateBatchSize, syncRepoStateUpdatePerSecond)
@@ -527,10 +527,10 @@ func syncSiteLevelExternalServiceRateLimiters(ctx context.Context, store databas
 
 // Sync rate limiters from config. Since we don't have a trigger that watches for
 // changes to rate limits we'll run this periodically in the background.
-func syncRateLimiters(ctx context.Context, store database.ExternalServiceStore, perSecond int) {
+func syncRateLimiters(ctx context.Context, logger log.Logger, store database.ExternalServiceStore, perSecond int) {
 	backoff := 5 * time.Second
 	batchSize := 50
-	logger := log.Scoped("syncRateLimiters", "sync rate limiters from config")
+	logger = logger.Scoped("syncRateLimiters", "sync rate limiters from config")
 
 	// perSecond should be spread across all gitserver instances and we want to wait
 	// until we know about at least one instance.

--- a/cmd/gitserver/server/commands.go
+++ b/cmd/gitserver/server/commands.go
@@ -11,11 +11,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )
 
-func handleGetObject(getObject gitdomain.GetObjectFunc) func(w http.ResponseWriter, r *http.Request) {
+func handleGetObject(logger log.Logger, getObject gitdomain.GetObjectFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req protocol.GetObjectRequest
-		logger := log.Scoped("handleGetObject", "handles get object")
-
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "decoding body", http.StatusBadRequest)
 			logger.Error("decoding body", log.Error(err))

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -44,6 +44,13 @@ func (s *Server) handleCreateCommitFromPatch(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
+	logger := s.Logger.Scoped("createCommitFromPatch", "").
+		With(
+			log.String("repo", string(req.Repo)),
+			log.String("baseCommit", string(req.BaseCommit)),
+			log.String("targetRef", req.TargetRef),
+		)
+
 	var resp protocol.CreateCommitFromPatchResponse
 
 	repo := string(protocol.NormalizeRepo(req.Repo))
@@ -70,7 +77,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	}
 
 	if err != nil {
-		s.Logger.Error("Failed to get remote URL", log.String("ref", ref), log.Error(err))
+		logger.Error("Failed to get remote URL", log.Error(err))
 		resp.SetError(repo, "", "", errors.Wrap(err, "repoRemoteURL"))
 		return http.StatusInternalServerError, resp
 	}
@@ -92,7 +99,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 		resp.SetError(repo, "", "", errors.Wrap(err, "gitserver: make tmp repo"))
 		return http.StatusInternalServerError, resp
 	}
-	defer cleanUpTmpRepo(tmpRepoDir)
+	defer cleanUpTmpRepo(logger, tmpRepoDir)
 
 	argsToString := func(args []string) string {
 		return strings.Join(args, " ")
@@ -104,7 +111,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 		t := time.Now()
 		out, err := runWith(ctx, cmd, true, nil)
 
-		logger := s.Logger.With(
+		logger := logger.With(
 			log.String("prefix", prefix),
 			log.String("command", argsToString(cmd.Args)),
 			log.Duration("duration", time.Since(t)),
@@ -115,7 +122,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 			resp.SetError(repo, argsToString(cmd.Args), string(out), errors.Wrap(err, "gitserver: "+reason))
 			logger.Warn("command failed", log.Error(err))
 		} else {
-			s.Logger.Info("command ran successfully")
+			logger.Info("command ran successfully")
 		}
 		return out, err
 	}
@@ -123,7 +130,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	if req.UniqueRef {
 		refs, err := repoRemoteRefs(ctx, remoteURL, ref)
 		if err != nil {
-			s.Logger.Error("Failed to get remote refs", log.String("ref", ref), log.Error(err))
+			logger.Error("Failed to get remote refs", log.Error(err))
 			resp.SetError(repo, "", "", errors.Wrap(err, "repoRemoteRefs"))
 			return http.StatusInternalServerError, resp
 		}
@@ -164,9 +171,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Env = append(os.Environ(), tmpGitPathEnv, altObjectsEnv)
 
 	if out, err := run(cmd, "basing staging on base rev"); err != nil {
-		s.Logger.Error("Failed to base the temporary repo on the base revision.",
-			log.String("ref", ref),
-			log.String("base", string(req.BaseCommit)),
+		logger.Error("Failed to base the temporary repo on the base revision",
 			log.String("output", string(out)),
 		)
 		return http.StatusInternalServerError, resp
@@ -179,7 +184,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Stdin = strings.NewReader(req.Patch)
 
 	if out, err := run(cmd, "applying patch"); err != nil {
-		s.Logger.Error("Failed to apply patch.", log.String("ref", ref), log.String("output", string(out)))
+		logger.Error("Failed to apply patch", log.String("output", string(out)))
 		return http.StatusInternalServerError, resp
 	}
 
@@ -218,7 +223,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	}...)
 
 	if out, err := run(cmd, "committing patch"); err != nil {
-		s.Logger.Error("Failed to commit patch.", log.String("ref", ref), log.String("output", string(out)))
+		logger.Error("Failed to commit patch.", log.String("output", string(out)))
 		return http.StatusInternalServerError, resp
 	}
 
@@ -292,7 +297,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 		}
 
 		if out, err = run(cmd, "pushing ref"); err != nil {
-			s.Logger.Error("Failed to push", log.String("ref", ref), log.String("commit", cmtHash), log.String("output", string(out)))
+			logger.Error("Failed to push", log.String("commit", cmtHash), log.String("output", string(out)))
 			return http.StatusInternalServerError, resp
 		}
 	}
@@ -303,16 +308,15 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Dir = repoGitDir
 
 	if out, err = run(cmd, "creating ref"); err != nil {
-		s.Logger.Error("Failed to create ref for commit.", log.String("ref", ref), log.String("commit", cmtHash), log.String("output", string(out)))
+		logger.Error("Failed to create ref for commit.", log.String("commit", cmtHash), log.String("output", string(out)))
 		return http.StatusInternalServerError, resp
 	}
 
 	return http.StatusOK, resp
 }
 
-func cleanUpTmpRepo(path string) {
+func cleanUpTmpRepo(logger log.Logger, path string) {
 	err := os.RemoveAll(path)
-	logger := log.Scoped("cleanUpTmpRepo", "cleans up temp Repo")
 	if err != nil {
 		logger.Warn("unable to clean up tmp repo", log.String("path", path), log.Error(err))
 	}

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -279,7 +279,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 			// it in the background.
 			// This is used to pass the private key to be used when pushing to the remote,
 			// without the need to store it on the disk.
-			agent, err := newSSHAgent([]byte(req.Push.PrivateKey), []byte(req.Push.Passphrase))
+			agent, err := newSSHAgent(logger, []byte(req.Push.PrivateKey), []byte(req.Push.Passphrase))
 			if err != nil {
 				resp.SetError(repo, "", "", errors.Wrap(err, "gitserver: error creating ssh-agent"))
 				return http.StatusInternalServerError, resp

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1688,7 +1688,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	stderrN = stderrW.n
 
 	stderr := stderrBuf.String()
-	checkMaybeCorruptRepo(req.Repo, dir, stderr)
+	checkMaybeCorruptRepo(s.Logger, req.Repo, dir, stderr)
 
 	// write trailer
 	w.Header().Set("X-Exec-Error", errorString(execErr))

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -399,10 +399,9 @@ var logUnflushableResponseWriterOnce sync.Once
 // must call Close to free the resources created by the writer.
 //
 // If w does not support flushing, it returns nil.
-func newFlushingResponseWriter(w http.ResponseWriter) *flushingResponseWriter {
+func newFlushingResponseWriter(logger log.Logger, w http.ResponseWriter) *flushingResponseWriter {
 	// We panic if we don't implement the needed interfaces.
 	flusher := hackilyGetHTTPFlusher(w)
-	logger := log.Scoped("flushingResponseWriter", "")
 	if flusher == nil {
 		logUnflushableResponseWriterOnce.Do(func() {
 			logger.Warn("unable to flush HTTP response bodies - Diff search performance and completeness will be affected",

--- a/cmd/gitserver/server/ssh_agent.go
+++ b/cmd/gitserver/server/ssh_agent.go
@@ -28,7 +28,7 @@ type sshAgent struct {
 }
 
 // newSSHAgent takes a private key and it's passphrase and returns an `sshAgent`.
-func newSSHAgent(raw, passphrase []byte) (*sshAgent, error) {
+func newSSHAgent(logger log.Logger, raw, passphrase []byte) (*sshAgent, error) {
 	// This does error if the passphrase is invalid, so we get immediate
 	// feedback here if we screw up.
 	key, err := ssh.ParseRawPrivateKeyWithPassphrase(raw, passphrase)
@@ -57,7 +57,7 @@ func newSSHAgent(raw, passphrase []byte) (*sshAgent, error) {
 
 	// Set up the type we're going to return.
 	a := &sshAgent{
-		logger:  log.Scoped("sshAgent", "speaks the ssh-agent protocol and can be used by gitserver"),
+		logger:  logger.Scoped("sshAgent", "speaks the ssh-agent protocol and can be used by gitserver"),
 		l:       l,
 		sock:    socketName,
 		keyring: keyring,

--- a/cmd/gitserver/server/ssh_agent_test.go
+++ b/cmd/gitserver/server/ssh_agent_test.go
@@ -7,6 +7,8 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -19,7 +21,7 @@ func TestSSHAgent(t *testing.T) {
 	}
 
 	// Spawn the agent using the keypair from above.
-	a, err := newSSHAgent([]byte(keypair.PrivateKey), []byte(keypair.Passphrase))
+	a, err := newSSHAgent(logtest.Scoped(t), []byte(keypair.PrivateKey), []byte(keypair.Passphrase))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gitserver/server/vcs_syncer_go_modules.go
+++ b/cmd/gitserver/server/vcs_syncer_go_modules.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"path"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"golang.org/x/mod/module"
 	modzip "golang.org/x/mod/zip"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/log"
 


### PR DESCRIPTION
Was reviewing Sentry errors, came across a missed sub-logger usage and some unnecessary `log.Scoped` usage from the gitstart migration 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

tests pass