### PR TITLE
executorqueue: use logtest in tests

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -140,7 +139,7 @@ func TestTransformRecord(t *testing.T) {
 		// Set the no cache flag on the batch spec.
 		batchSpec.NoCache = true
 
-		job, err := transformRecord(context.Background(), log.Scoped("test", "test logger"), store, workspaceExecutionJob)
+		job, err := transformRecord(context.Background(), logtest.Scoped(t), store, workspaceExecutionJob)
 		if err != nil {
 			t.Fatalf("unexpected error transforming record: %s", err)
 		}


### PR DESCRIPTION
Spotted this in a code insight, `logtest` offers some additional features in tests: https://docs.sourcegraph.com/dev/how-to/add_logging#testing-usage

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a