### PR TITLE
sg: improve `sg` web testsuites

### DIFF
--- a/dev/sg/sg_tests.go
+++ b/dev/sg/sg_tests.go
@@ -29,7 +29,7 @@ var testCommand = &cli.Command{
 sg test backend
 sg test backend-integration
 sg test client
-sg test client-e2e
+sg test web-e2e
 
 # List available test suites:
 sg test -help

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -113,6 +113,7 @@ Available commands in `sg.config.yaml`:
 * storybook
 * symbols
 * syntax-highlighter
+* web-integration-build: Build web application for integration tests
 * web-standalone-http-prod: Standalone web frontend (production) with API proxy to a configurable URL
 * web-standalone-http: Standalone web frontend (dev) with API proxy to a configurable URL
 * web: Enterprise version of the web app
@@ -312,8 +313,9 @@ Available testsuites in `sg.config.yaml`:
 * client
 * docsite
 * web-e2e
-* web-regression
 * web-integration
+* web-integration:debug
+* web-regression
 
 ```sh
 # Run different test suites:

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -310,9 +310,9 @@ Available testsuites in `sg.config.yaml`:
 * bext-e2e
 * bext-integration
 * client
-* client-e2e
-* client-regression
 * docsite
+* web-e2e
+* web-regression
 * web-integration
 
 ```sh
@@ -320,7 +320,7 @@ Available testsuites in `sg.config.yaml`:
 $ sg test backend
 $ sg test backend-integration
 $ sg test client
-$ sg test client-e2e
+$ sg test web-e2e
 
 # List available test suites:
 $ sg test -help

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -199,21 +199,20 @@ The integration test suite for the webapp can be found in [`web/src/integration`
 
 Test coverage from integration tests is tracked in [Codecov](https://codecov.io/gh/sourcegraph/sourcegraph) under the flag `integration`.
 
-#### Running client integration tests
+#### Running integration tests
 
 To run integration tests for the web app:
 
-1. Run `INTEGRATION_TESTS=true yarn watch-web` in the repository root in a separate terminal to watch files and build a JavaScript bundle. You can also launch it as the VS Code task "Watch web app".
-    - Alternatively, `INTEGRATION_TESTS=true yarn build-web` will only build a bundle once.
-1. If you need to test Enterprise features such as Batch Changes, set `ENTERPRISE=1` when building.
-1. Run `yarn test-integration` in the repository root to run the tests.
+1. Run `INTEGRATION_TESTS=true ENTERPRISE=1 yarn watch-web` in the repository root in a separate terminal to watch files and build a JavaScript bundle. You can also launch it as the VS Code task "Watch web app".
+    - Alternatively, `sg run web-integration-build` will only build a bundle once.
+1. Run `sg test web-integration` in the repository root to run the tests.
 
 A Sourcegraph instance does not need to be running, because all backend interactions are stubbed.
 
 To run a specific web app integration test in the debug mode:
 
 1. Run `sg start web-standalone` in the repository root to start serving the development version of the application.
-2. Run `yarn test-integration:debug PATH_TO_THE_TEST_FILE_TO_DEBUG`. With that command, the server is only used to serve `index.html` and client bundle assets, but the API responses should be mocked as usual.
+2. Run `sg test web-integration:debug PATH_TO_THE_TEST_FILE_TO_DEBUG`. With that command, the server is only used to serve `index.html` and client bundle assets, but the API responses should be mocked as usual.
 
 See the above sections for more details on how to debug the tests, which applies to both integration and end-to-end tests.
 
@@ -279,7 +278,7 @@ TAG=insiders sg run server
 In the repository root:
 
 ```
-GH_TOKEN=XXX sg test client-e2e
+GH_TOKEN=XXX sg test web-e2e
 ```
 
 You can find the `GH_TOKEN` value in the shared 1Password vault under `BUILDKITE_GITHUBDOTCOM_TOKEN`.
@@ -288,7 +287,7 @@ If you have access to CI secrets via the `gcloud` CLI, the `GH_TOKEN` value will
 If you run the test suite against an existing server image:
 
 ```
-SOURCEGRAPH_BASE_URL=http://localhost:7080 GH_TOKEN=XXX sg test client-e2e
+SOURCEGRAPH_BASE_URL=http://localhost:7080 GH_TOKEN=XXX sg test web-e2e
 ```
 
 This will open Chromium, add a code host, clone repositories, and execute the e2e tests.
@@ -301,13 +300,13 @@ This will open Chromium, add a code host, clone repositories, and execute the e2
 4. Run in the repository root:
 
 ```
-GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test client-regression
+GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test web-regression
 ```
 
 And if you're running the test suite against an existing server image:
 
 ```
-SOURCEGRAPH_BASE_URL=http://localhost:7080 GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test client-regression
+SOURCEGRAPH_BASE_URL=http://localhost:7080 GITHUB_TOKEN=XXX SOURCEGRAPH_SUDO_TOKEN=YYY sg test web-regression
 ```
 
 Also, you can also run tests selectively with a command like `yarn run test:regression:search` in the `client/web` directory, which runs the tests for search functionality.

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -360,6 +360,13 @@ commands:
       WEBPACK_SERVE_INDEX: true
       SOURCEGRAPH_API_URL: https://k8s.sgdev.org
 
+  web-integration-build:
+    description: Build web application for integration tests
+    cmd: yarn workspace @sourcegraph/web run build
+    env:
+      ENTERPRISE: 1
+      INTEGRATION_TESTS: true
+
   docsite:
     description: Docsite instance serving the docs
     cmd: .bin/docsite_${DOCSITE_VERSION} -config doc/docsite.json serve -http=localhost:5080
@@ -977,9 +984,6 @@ tests:
       EMAIL: 'joe@sourcegraph.com'
       PASSWORD: '12345'
 
-  web-integration:
-    cmd: yarn test-integration
-
   bext:
     cmd: yarn workspace @sourcegraph/browser test
 
@@ -997,14 +1001,18 @@ tests:
   client:
     cmd: yarn run jest --testPathIgnorePatterns end-to-end regression integration storybook
 
-  client-e2e:
+  docsite:
+    cmd: .bin/docsite_${DOCSITE_VERSION} check ./doc
+    env:
+      DOCSITE_VERSION: v1.8.7 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)
+
+  web-e2e:
     preamble: |
       A Sourcegraph isntance must be already running for these tests to work, most
       commonly with: `sg start enterprise-e2e`
 
       See more details: https://docs.sourcegraph.com/dev/how-to/testing#running-end-to-end-tests
-    cmd: |
-      yarn run test-e2e
+    cmd: yarn run test-e2e
     env:
       TEST_USER_EMAIL: test@sourcegraph.com
       TEST_USER_PASSWORD: supersecurepassword
@@ -1016,22 +1024,34 @@ tests:
         project: 'sourcegraph-ci'
         name: 'BUILDKITE_GITHUBDOTCOM_TOKEN'
 
-  client-regression:
+  web-regression:
     preamble: |
       A Sourcegraph instance must be already running for these tests to work, most
       commonly with: `sg start enterprise-e2e`
 
       See more details: https://docs.sourcegraph.com/dev/how-to/testing#running-regression-tests
 
-    cmd: |
-      yarn run test-regression
+    cmd: yarn run test-regression
     env:
       SOURCEGRAPH_SUDO_USER: test
       SOURCEGRAPH_BASE_URL: https://sourcegraph.test:3443
       TEST_USER_PASSWORD: supersecurepassword
       BROWSER: chrome
 
-  docsite:
-    cmd: .bin/docsite_${DOCSITE_VERSION} check ./doc
-    env:
-      DOCSITE_VERSION: v1.8.7 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)
+  web-integration:
+    preamble: |
+      A web application should be built for these tests to work, most
+      commonly with: `sg run web-integration-build`
+
+      See more details: https://docs.sourcegraph.com/dev/how-to/testing#running-integration-tests
+
+    cmd: yarn run test-integration
+
+  web-integration:debug:
+    preamble: |
+      A Sourcegraph instance must be already running for these tests to work, most
+      commonly with: `sg start web-standalone`
+
+      See more details: https://docs.sourcegraph.com/dev/how-to/testing#running-integration-tests
+
+    cmd: yarn run test-integration:debug


### PR DESCRIPTION
## Context

1. Make `sg test web-*` commands more consistent.
2. Improve respective docs.

## Test plan

Ensure that all `sg test web-*` commands work properly.

1. `sg test web-e2e`
2. `sg test web-regression`
3. `sg test web-integration`
4. `sg test web-integration:debug` 
