### PR TITLE
schema: do not use 'sourcegraph' in urlTemplate example, add doc note about urlTemplate

### DIFF
--- a/doc/admin/observability/tracing.md
+++ b/doc/admin/observability/tracing.md
@@ -42,10 +42,14 @@ A link to the [exported trace](#tracing-backends) should be show up in the searc
 
 ![link to trace](https://user-images.githubusercontent.com/23356519/184953302-099bcb62-ccdb-4eed-be5d-801b7fe16d97.png)
 
+Note that getting a trace URL requires `urlTemplate` to be configured.
+
 ### Trace a GraphQL request
 
 To receive a traceID on a GraphQL request, include the header `X-Sourcegraph-Should-Trace: true` with the request.
 The response headers of the response will now include an `x-trace` entry, which will have a URL the [exported trace](#tracing-backends).
+
+Note that getting a trace URL requires `urlTemplate` to be configured.
 
 ## Tracing backends
 

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1239,7 +1239,7 @@
           "examples": [
             "https://ui.honeycomb.io/$ORG/environments/$DATASET/trace?trace_id={{ .TraceID }}",
             "https://console.cloud.google.com/traces/list?tid={{ .TraceID }}&project=$PROJECT",
-            "https://sourcegraph.grafana.net/explore?orgId=1&left=[\"now-1h\",\"now\",\"grafanacloud-sourcegraph-traces\",{\"query\":\"{{ .TraceID }}\",\"queryType\":\"traceId\"}]",
+            "https://$ORGANIZATION.grafana.net/explore?orgId=1&left=[\"now-1h\",\"now\",\"$DATASOURCE\",{\"query\":\"{{ .TraceID }}\",\"queryType\":\"traceId\"}]",
             "{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}"
           ]
         }


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a