### PR TITLE
Increase the temporary increase

### DIFF
--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -14,7 +14,7 @@ const config = {
        * Primary cause is due to multiple ongoing migrations that mean we are duplicating similar dependencies.
        * Issue to track: https://github.com/sourcegraph/sourcegraph/issues/37845
        */
-      maxSize: '425kb',
+      maxSize: '450kb',
       compression: 'none',
     },
     {


### PR DESCRIPTION
Fixes the bundle size increase due to https://github.com/sourcegraph/sourcegraph/pull/41412/files

This is the quick and dirty fix but we should follow up and make the admin routes lazy loaded (no way they should be in the app bundle) I guess?

## Test plan

Tests pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-scripts-app-bundle-js.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lgpejkqyec.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
