### PR TITLE
Esbuild: Support HTTPS for `web-standalone`

### DIFF
--- a/client/web/dev/server/development.server.ts
+++ b/client/web/dev/server/development.server.ts
@@ -124,7 +124,7 @@ async function startEsbuildDevelopmentServer({
     const manifest = getManifest()
     const htmlPage = getHTMLPage(manifest)
 
-    await esbuildDevelopmentServer({ host: '0.0.0.0', port: SOURCEGRAPH_HTTPS_PORT }, app => {
+    await esbuildDevelopmentServer({ host: '0.0.0.0', port: SOURCEGRAPH_HTTP_PORT }, app => {
         app.use(createProxyMiddleware(proxyRoutes, proxyMiddlewareOptions))
         app.get(/.*/, (_request, response) => {
             response.send(htmlPage)


### PR DESCRIPTION
## Description

We already have Caddy setup on 3443, this just moves the http server to 3080 so Caddy works correctly and we don't get conflicting ports 

## Test plan

Tested locally with `DEV_WEB_BUILDER=esbuild sg start web-standalone`

## App preview:

- [Web](https://sg-web-tr-support-esbuild-https.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-eybifghjzu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
