### PR TITLE
insights: rename aggregations settings

### DIFF
--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -179,7 +179,7 @@ describe('Search aggregation', () => {
                                 latestSettings: {
                                     id: 0,
                                     contents: JSON.stringify({
-                                        experimentalFeatures: { enableSearchResultsAggregations: true },
+                                        experimentalFeatures: { searchResultsAggregations: true },
                                     }),
                                 },
                             },

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -64,11 +64,9 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
 
     // Settings
     const [coreWorkflowImprovementsEnabled] = useCoreWorkflowImprovementsEnabled()
-    const enableSearchAggregations = useExperimentalFeatures(
-        features => features.enableSearchResultsAggregations ?? false
-    )
-    const disableProactiveSearchAggregations = useExperimentalFeatures(
-        features => features.disableProactiveSearchAggregations ?? false
+    const enableSearchAggregations = useExperimentalFeatures(features => features.searchResultsAggregations ?? false)
+    const proactiveSearchAggregations = useExperimentalFeatures(
+        features => features.proactiveSearchResultsAggregations ?? true
     )
     const [, setSelectedTab] = useTemporarySetting('search.sidebar.selectedTab', 'filters')
 
@@ -119,7 +117,7 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
                     <SearchAggregations
                         query={submittedURLQuery}
                         patternType={patternType}
-                        proactive={!disableProactiveSearchAggregations}
+                        proactive={proactiveSearchAggregations}
                         caseSensitive={caseSensitive}
                         telemetryService={telemetryService}
                         onQuerySubmit={handleAggregationBarLinkClick}

--- a/doc/code_insights/explanations/search_results_aggregations.md
+++ b/doc/code_insights/explanations/search_results_aggregations.md
@@ -19,9 +19,9 @@ We may continue adding new aggregation categories, like date and code host, base
 
 ## Feature visibility
 
-You can turn the aggregations on with the experimental feature setting: `enableSearchResultsAggregations`
+You can turn the aggregations on with the experimental feature setting: `searchResultsAggregations`
 
-You can turn off just the proactive aggregations with the setting: `disableProactiveSearchAggregations`
+You can turn off just the proactive aggregations by setting `proactiveSearchResultsAggregations` to `false`.
 
 ## Drilldowns 
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1815,8 +1815,6 @@ type SettingsExperimentalFeatures struct {
 	CoolCodeIntel *bool `json:"coolCodeIntel,omitempty"`
 	// CopyQueryButton description: DEPRECATED: This feature is now permanently enabled. Enables displaying the copy query button in the search bar when hovering over the global navigation bar.
 	CopyQueryButton *bool `json:"copyQueryButton,omitempty"`
-	// DisableProactiveSearchAggregations description: Search results aggregations are not triggered automatically with a search.
-	DisableProactiveSearchAggregations *bool `json:"disableProactiveSearchAggregations,omitempty"`
 	// Editor description: Specifies which (code) editor to use for query and text input
 	Editor *string `json:"editor,omitempty"`
 	// EnableCodeMirrorFileView description: Uses CodeMirror to display files. In this first iteration not all features of the current file view are available.
@@ -1831,8 +1829,6 @@ type SettingsExperimentalFeatures struct {
 	EnableLazyFileResultSyntaxHighlighting *bool `json:"enableLazyFileResultSyntaxHighlighting,omitempty"`
 	// EnableMergedFileSymbolSidebar description: Enables the new file sidebar experience with merged file and symbol entries.
 	EnableMergedFileSymbolSidebar *bool `json:"enableMergedFileSymbolSidebar,omitempty"`
-	// EnableSearchResultsAggregations description: Display aggregations for your search results on the search screen.
-	EnableSearchResultsAggregations *bool `json:"enableSearchResultsAggregations,omitempty"`
 	// EnableSearchStack description: REMOVED: This feature can now be enabled/disabled via the notepad button on the notebooks list page.
 	EnableSearchStack *bool `json:"enableSearchStack,omitempty"`
 	// EnableSidebarFilePrefetch description: Pre-fetch plaintext file revisions from sidebar on hover.
@@ -1851,8 +1847,12 @@ type SettingsExperimentalFeatures struct {
 	HomePanelsComputeSuggestions bool `json:"homePanelsComputeSuggestions,omitempty"`
 	// HomepageUserInvitation description: Shows a panel to invite collaborators to Sourcegraph on home page.
 	HomepageUserInvitation *bool `json:"homepageUserInvitation,omitempty"`
+	// ProactiveSearchResultsAggregations description: Search results aggregations are not triggered automatically with a search.
+	ProactiveSearchResultsAggregations *bool `json:"proactiveSearchResultsAggregations,omitempty"`
 	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts
 	SearchContextsQuery *bool `json:"searchContextsQuery,omitempty"`
+	// SearchResultsAggregations description: Display aggregations for your search results on the search screen.
+	SearchResultsAggregations *bool `json:"searchResultsAggregations,omitempty"`
 	// SearchStats description: Enables a button on the search results page that shows language statistics about the results for a search query.
 	SearchStats *bool `json:"searchStats,omitempty"`
 	// SearchStreaming description: DEPRECATED: This feature is now permanently enabled. Enables streaming search support.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1847,7 +1847,7 @@ type SettingsExperimentalFeatures struct {
 	HomePanelsComputeSuggestions bool `json:"homePanelsComputeSuggestions,omitempty"`
 	// HomepageUserInvitation description: Shows a panel to invite collaborators to Sourcegraph on home page.
 	HomepageUserInvitation *bool `json:"homepageUserInvitation,omitempty"`
-	// ProactiveSearchResultsAggregations description: Search results aggregations are not triggered automatically with a search.
+	// ProactiveSearchResultsAggregations description: Search results aggregations are triggered automatically with a search.
 	ProactiveSearchResultsAggregations *bool `json:"proactiveSearchResultsAggregations,omitempty"`
 	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts
 	SearchContextsQuery *bool `json:"searchContextsQuery,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -389,7 +389,7 @@
             "pointer": true
           }
         },
-        "enableSearchResultsAggregations": {
+        "searchResultsAggregations": {
           "description": "Display aggregations for your search results on the search screen.",
           "type": "boolean",
           "default": "false",
@@ -397,10 +397,10 @@
             "pointer": true
           }
         },
-        "disableProactiveSearchAggregations": {
+        "proactiveSearchResultsAggregations": {
           "description": "Search results aggregations are not triggered automatically with a search.",
           "type": "boolean",
-          "default": "false",
+          "default": "true",
           "!go": {
             "pointer": true
           }

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -392,7 +392,7 @@
         "searchResultsAggregations": {
           "description": "Display aggregations for your search results on the search screen.",
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "!go": {
             "pointer": true
           }
@@ -400,7 +400,7 @@
         "proactiveSearchResultsAggregations": {
           "description": "Search results aggregations are triggered automatically with a search.",
           "type": "boolean",
-          "default": "false",
+          "default": true,
           "!go": {
             "pointer": true
           }

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -398,7 +398,7 @@
           }
         },
         "proactiveSearchResultsAggregations": {
-          "description": "Search results aggregations are not triggered automatically with a search.",
+          "description": "Search results aggregations are triggered automatically with a search.",
           "type": "boolean",
           "default": "true",
           "!go": {

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -400,7 +400,7 @@
         "proactiveSearchResultsAggregations": {
           "description": "Search results aggregations are triggered automatically with a search.",
           "type": "boolean",
-          "default": "true",
+          "default": "false",
           "!go": {
             "pointer": true
           }


### PR DESCRIPTION
not to use enable/disable wording

## Test plan

Ran `sg start enterprise-codeinsights` and tested different combinations of settings