### PR TITLE
licensing: make plan consts to have consistent naming

### DIFF
--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -2,30 +2,30 @@ package licensing
 
 // The list of plans.
 const (
-	// oldEnterpriseStarter is the old "Enterprise Starter" plan.
-	oldEnterpriseStarter Plan = "old-starter-0"
-	// oldEnterprise is the old "Enterprise" plan.
-	oldEnterprise Plan = "old-enterprise-0"
+	// PlanOldEnterpriseStarter is the old "Enterprise Starter" plan.
+	PlanOldEnterpriseStarter Plan = "old-starter-0"
+	// PlanOldEnterprise is the old "Enterprise" plan.
+	PlanOldEnterprise Plan = "old-enterprise-0"
 
 	// PlanTeam0 is the "Team" plan pre-4.0.
 	PlanTeam0 Plan = "team-0"
-	// enterprise0 is the "Enterprise" plan pre-4.0.
-	enterprise0 Plan = "enterprise-0"
+	// PlanEnterprise0 is the "Enterprise" plan pre-4.0.
+	PlanEnterprise0 Plan = "enterprise-0"
 
 	// PlanBusiness0 is the "Business" plan for 4.0.
 	PlanBusiness0 Plan = "business-0"
-	// enterprise1 is the "Enterprise" plan for 4.0.
-	enterprise1 Plan = "enterprise-1"
+	// PlanEnterprise1 is the "Enterprise" plan for 4.0.
+	PlanEnterprise1 Plan = "enterprise-1"
 )
 
 var allPlans = []Plan{
-	oldEnterpriseStarter,
-	oldEnterprise,
+	PlanOldEnterpriseStarter,
+	PlanOldEnterprise,
 	PlanTeam0,
-	enterprise0,
+	PlanEnterprise0,
 
 	PlanBusiness0,
-	enterprise1,
+	PlanEnterprise1,
 }
 
 // The list of features. For each feature, add a new const here and the checking logic in
@@ -77,8 +77,8 @@ const (
 
 // planFeatures defines the features that are enabled for each plan.
 var planFeatures = map[Plan][]Feature{
-	oldEnterpriseStarter: {},
-	oldEnterprise: {
+	PlanOldEnterpriseStarter: {},
+	PlanOldEnterprise: {
 		FeatureSSO,
 		FeatureACLs,
 		FeatureExplicitPermissionsAPI,
@@ -96,7 +96,7 @@ var planFeatures = map[Plan][]Feature{
 		FeatureExplicitPermissionsAPI,
 		FeatureSSO,
 	},
-	enterprise0: {
+	PlanEnterprise0: {
 		FeatureACLs,
 		FeatureExplicitPermissionsAPI,
 		FeatureSSO,
@@ -109,7 +109,7 @@ var planFeatures = map[Plan][]Feature{
 		FeatureCodeInsights,
 		FeatureSSO,
 	},
-	enterprise1: {
+	PlanEnterprise1: {
 		FeatureACLs,
 		FeatureCampaigns,
 		FeatureCodeInsights,

--- a/enterprise/internal/licensing/features_test.go
+++ b/enterprise/internal/licensing/features_test.go
@@ -26,15 +26,15 @@ func TestCheckFeature(t *testing.T) {
 
 		check(t, FeatureSSO, license("starter"), false)
 		check(t, FeatureSSO, license("starter", string(FeatureSSO)), true)
-		check(t, FeatureSSO, license(plan(oldEnterpriseStarter)), false)
-		check(t, FeatureSSO, license(plan(oldEnterprise)), true)
+		check(t, FeatureSSO, license(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureSSO, license(plan(PlanOldEnterprise)), true)
 		check(t, FeatureSSO, license(), true)
 
 		check(t, FeatureSSO, license(plan(PlanTeam0)), true)
-		check(t, FeatureSSO, license(plan(enterprise0)), true)
+		check(t, FeatureSSO, license(plan(PlanEnterprise0)), true)
 
 		check(t, FeatureSSO, license(plan(PlanBusiness0)), true)
-		check(t, FeatureSSO, license(plan(enterprise1)), true)
+		check(t, FeatureSSO, license(plan(PlanEnterprise1)), true)
 	})
 
 	t.Run(string(FeatureExplicitPermissionsAPI), func(t *testing.T) {
@@ -42,70 +42,70 @@ func TestCheckFeature(t *testing.T) {
 
 		check(t, FeatureExplicitPermissionsAPI, license("starter"), false)
 		check(t, FeatureExplicitPermissionsAPI, license("starter", string(FeatureExplicitPermissionsAPI)), true)
-		check(t, FeatureExplicitPermissionsAPI, license(plan(oldEnterpriseStarter)), false)
-		check(t, FeatureExplicitPermissionsAPI, license(plan(oldEnterprise)), true)
+		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanOldEnterprise)), true)
 		check(t, FeatureExplicitPermissionsAPI, license(), true)
 
 		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanTeam0)), true)
-		check(t, FeatureExplicitPermissionsAPI, license(plan(enterprise0)), true)
+		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanEnterprise0)), true)
 
 		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanBusiness0)), false)
-		check(t, FeatureExplicitPermissionsAPI, license(plan(enterprise1)), true)
+		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanEnterprise1)), true)
 	})
 
 	t.Run(string(FeatureACLs), func(t *testing.T) {
 		check(t, FeatureACLs, nil, false)
 
 		check(t, FeatureACLs, license("starter"), false)
-		check(t, FeatureACLs, license(plan(oldEnterpriseStarter)), false)
-		check(t, FeatureACLs, license(plan(oldEnterprise)), true)
+		check(t, FeatureACLs, license(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureACLs, license(plan(PlanOldEnterprise)), true)
 		check(t, FeatureACLs, license(), true)
 
 		check(t, FeatureACLs, license(plan(PlanTeam0)), true)
-		check(t, FeatureACLs, license(plan(enterprise0)), true)
-		check(t, FeatureACLs, license(plan(enterprise0), string(FeatureACLs)), true)
+		check(t, FeatureACLs, license(plan(PlanEnterprise0)), true)
+		check(t, FeatureACLs, license(plan(PlanEnterprise0), string(FeatureACLs)), true)
 
 		check(t, FeatureACLs, license(plan(PlanBusiness0)), true)
-		check(t, FeatureACLs, license(plan(enterprise1)), true)
+		check(t, FeatureACLs, license(plan(PlanEnterprise1)), true)
 	})
 
 	t.Run(string(FeatureExtensionRegistry), func(t *testing.T) {
 		check(t, FeatureExtensionRegistry, nil, false)
 
 		check(t, FeatureExtensionRegistry, license("starter"), false)
-		check(t, FeatureExtensionRegistry, license(plan(oldEnterpriseStarter)), false)
-		check(t, FeatureExtensionRegistry, license(plan(oldEnterprise)), true)
+		check(t, FeatureExtensionRegistry, license(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureExtensionRegistry, license(plan(PlanOldEnterprise)), true)
 		check(t, FeatureExtensionRegistry, license(), true)
 
 		check(t, FeatureExtensionRegistry, license(plan(PlanTeam0)), false)
-		check(t, FeatureExtensionRegistry, license(plan(enterprise0)), false)
-		check(t, FeatureExtensionRegistry, license(plan(enterprise0), string(FeatureExtensionRegistry)), true)
+		check(t, FeatureExtensionRegistry, license(plan(PlanEnterprise0)), false)
+		check(t, FeatureExtensionRegistry, license(plan(PlanEnterprise0), string(FeatureExtensionRegistry)), true)
 	})
 
 	t.Run(string(FeatureRemoteExtensionsAllowDisallow), func(t *testing.T) {
 		check(t, FeatureRemoteExtensionsAllowDisallow, nil, false)
 
 		check(t, FeatureRemoteExtensionsAllowDisallow, license("starter"), false)
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(oldEnterpriseStarter)), false)
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(oldEnterprise)), true)
+		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanOldEnterprise)), true)
 		check(t, FeatureRemoteExtensionsAllowDisallow, license(), true)
 
 		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanTeam0)), false)
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(enterprise0)), false)
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(enterprise0), string(FeatureRemoteExtensionsAllowDisallow)), true)
+		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanEnterprise0)), false)
+		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanEnterprise0), string(FeatureRemoteExtensionsAllowDisallow)), true)
 	})
 
 	t.Run(string(FeatureBranding), func(t *testing.T) {
 		check(t, FeatureBranding, nil, false)
 
 		check(t, FeatureBranding, license("starter"), false)
-		check(t, FeatureBranding, license(plan(oldEnterpriseStarter)), false)
-		check(t, FeatureBranding, license(plan(oldEnterprise)), true)
+		check(t, FeatureBranding, license(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureBranding, license(plan(PlanOldEnterprise)), true)
 		check(t, FeatureBranding, license(), true)
 
 		check(t, FeatureBranding, license(plan(PlanTeam0)), false)
-		check(t, FeatureBranding, license(plan(enterprise0)), false)
-		check(t, FeatureBranding, license(plan(enterprise0), string(FeatureBranding)), true)
+		check(t, FeatureBranding, license(plan(PlanEnterprise0)), false)
+		check(t, FeatureBranding, license(plan(PlanEnterprise0), string(FeatureBranding)), true)
 	})
 
 	testBatchChanges := func(feature Feature) func(*testing.T) {
@@ -113,16 +113,16 @@ func TestCheckFeature(t *testing.T) {
 			check(t, feature, nil, false)
 
 			check(t, feature, license("starter"), false)
-			check(t, feature, license(plan(oldEnterpriseStarter)), false)
-			check(t, feature, license(plan(oldEnterprise)), true)
+			check(t, feature, license(plan(PlanOldEnterpriseStarter)), false)
+			check(t, feature, license(plan(PlanOldEnterprise)), true)
 			check(t, feature, license(), true)
 
 			check(t, feature, license(plan(PlanTeam0)), false)
-			check(t, feature, license(plan(enterprise0)), false)
-			check(t, feature, license(plan(enterprise0), string(feature)), true)
+			check(t, feature, license(plan(PlanEnterprise0)), false)
+			check(t, feature, license(plan(PlanEnterprise0), string(feature)), true)
 
 			check(t, feature, license(plan(PlanBusiness0)), true)
-			check(t, feature, license(plan(enterprise1)), true)
+			check(t, feature, license(plan(PlanEnterprise1)), true)
 		}
 	}
 
@@ -135,16 +135,16 @@ func TestCheckFeature(t *testing.T) {
 			check(t, feature, nil, false)
 
 			check(t, feature, license("starter"), false)
-			check(t, feature, license(plan(oldEnterpriseStarter)), false)
-			check(t, feature, license(plan(oldEnterprise)), true)
+			check(t, feature, license(plan(PlanOldEnterpriseStarter)), false)
+			check(t, feature, license(plan(PlanOldEnterprise)), true)
 			check(t, feature, license(), true)
 
 			check(t, feature, license(plan(PlanTeam0)), false)
-			check(t, feature, license(plan(enterprise0)), false)
-			check(t, feature, license(plan(enterprise0), string(feature)), true)
+			check(t, feature, license(plan(PlanEnterprise0)), false)
+			check(t, feature, license(plan(PlanEnterprise0), string(feature)), true)
 
 			check(t, feature, license(plan(PlanBusiness0)), true)
-			check(t, feature, license(plan(enterprise1)), true)
+			check(t, feature, license(plan(PlanEnterprise1)), true)
 		}
 	}
 	// Code Insights
@@ -154,25 +154,25 @@ func TestCheckFeature(t *testing.T) {
 		check(t, FeatureMonitoring, nil, false)
 
 		check(t, FeatureMonitoring, license("starter"), false)
-		check(t, FeatureMonitoring, license(plan(oldEnterpriseStarter)), false)
-		check(t, FeatureMonitoring, license(plan(oldEnterprise)), true)
+		check(t, FeatureMonitoring, license(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureMonitoring, license(plan(PlanOldEnterprise)), true)
 		check(t, FeatureMonitoring, license(), true)
 
 		check(t, FeatureMonitoring, license(plan(PlanTeam0)), false)
-		check(t, FeatureMonitoring, license(plan(enterprise0)), false)
-		check(t, FeatureMonitoring, license(plan(enterprise0), string(FeatureMonitoring)), true)
+		check(t, FeatureMonitoring, license(plan(PlanEnterprise0)), false)
+		check(t, FeatureMonitoring, license(plan(PlanEnterprise0), string(FeatureMonitoring)), true)
 	})
 
 	t.Run(string(FeatureBackupAndRestore), func(t *testing.T) {
 		check(t, FeatureBackupAndRestore, nil, false)
 
 		check(t, FeatureBackupAndRestore, license("starter"), false)
-		check(t, FeatureBackupAndRestore, license(plan(oldEnterpriseStarter)), false)
-		check(t, FeatureBackupAndRestore, license(plan(oldEnterprise)), true)
+		check(t, FeatureBackupAndRestore, license(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureBackupAndRestore, license(plan(PlanOldEnterprise)), true)
 		check(t, FeatureBackupAndRestore, license(), true)
 
 		check(t, FeatureBackupAndRestore, license(plan(PlanTeam0)), false)
-		check(t, FeatureBackupAndRestore, license(plan(enterprise0)), false)
-		check(t, FeatureBackupAndRestore, license(plan(enterprise0), string(FeatureBackupAndRestore)), true)
+		check(t, FeatureBackupAndRestore, license(plan(PlanEnterprise0)), false)
+		check(t, FeatureBackupAndRestore, license(plan(PlanEnterprise0), string(FeatureBackupAndRestore)), true)
 	})
 }

--- a/enterprise/internal/licensing/plans.go
+++ b/enterprise/internal/licensing/plans.go
@@ -47,12 +47,12 @@ func (info *Info) Plan() Plan {
 
 		// Backcompat: support the old "starter" tag (which mapped to "Enterprise Starter").
 		if tag == "starter" {
-			return oldEnterpriseStarter
+			return PlanOldEnterpriseStarter
 		}
 	}
 
 	// Backcompat: no tags means it is the old "Enterprise" plan.
-	return oldEnterprise
+	return PlanOldEnterprise
 }
 
 // hasUnknownPlan returns an error if the plan is presented in the license tags

--- a/enterprise/internal/licensing/plans_test.go
+++ b/enterprise/internal/licensing/plans_test.go
@@ -36,15 +36,15 @@ func TestInfo_Plan(t *testing.T) {
 		{tags: []string{"foo", testPlan.tag()}, want: testPlan},
 		{tags: []string{"foo", testPlan.tag(), Plan("xyz").tag()}, want: testPlan},
 		{tags: []string{"foo", Plan("xyz").tag(), testPlan.tag()}, want: testPlan},
-		{tags: []string{"plan:old-starter-0"}, want: oldEnterpriseStarter},
-		{tags: []string{"plan:old-enterprise-0"}, want: oldEnterprise},
+		{tags: []string{"plan:old-starter-0"}, want: PlanOldEnterpriseStarter},
+		{tags: []string{"plan:old-enterprise-0"}, want: PlanOldEnterprise},
 		{tags: []string{"plan:team-0"}, want: PlanTeam0},
-		{tags: []string{"plan:enterprise-0"}, want: enterprise0},
-		{tags: []string{"plan:enterprise-1"}, want: enterprise1},
+		{tags: []string{"plan:enterprise-0"}, want: PlanEnterprise0},
+		{tags: []string{"plan:enterprise-1"}, want: PlanEnterprise1},
 		{tags: []string{"plan:business-0"}, want: PlanBusiness0},
-		{tags: []string{"starter"}, want: oldEnterpriseStarter},
-		{tags: []string{"foo"}, want: oldEnterprise},
-		{tags: []string{""}, want: oldEnterprise},
+		{tags: []string{"starter"}, want: PlanOldEnterpriseStarter},
+		{tags: []string{"foo"}, want: PlanOldEnterprise},
+		{tags: []string{""}, want: PlanOldEnterprise},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("tags: %v", test.tags), func(t *testing.T) {
@@ -63,10 +63,10 @@ func TestInfo_hasUnknownPlan(t *testing.T) {
 	}{
 		{tags: []string{""}},
 		{tags: []string{"foo"}},
-		{tags: []string{"foo", oldEnterpriseStarter.tag()}},
-		{tags: []string{"foo", oldEnterprise.tag()}},
+		{tags: []string{"foo", PlanOldEnterpriseStarter.tag()}},
+		{tags: []string{"foo", PlanOldEnterprise.tag()}},
 		{tags: []string{"foo", PlanTeam0.tag()}},
-		{tags: []string{"foo", enterprise0.tag()}},
+		{tags: []string{"foo", PlanEnterprise0.tag()}},
 		{tags: []string{"starter"}},
 
 		{tags: []string{"foo", "plan:xyz"}, wantErr: `The license has an unrecognizable plan in tag "plan:xyz", please contact Sourcegraph support.`},


### PR DESCRIPTION
We renamed and exposed two plans in https://github.com/sourcegraph/sourcegraph/pull/40980 but avoided renaming others to minimize the chance of merge conflict, now it is time to pay off this debt.

## Test plan

CI
