### PR TITLE
sg: ops, use docker API v2 endpoints

### DIFF
--- a/dev/sg/internal/docker/docker.go
+++ b/dev/sg/internal/docker/docker.go
@@ -91,7 +91,7 @@ func getStoreProvider(serverAddress string) (string, error) {
 		serverAddress == "https://docker.io" ||
 		serverAddress == "https://registry.hub.docker.com" ||
 		serverAddress == "https://index.docker.io/v2/" {
-		serverAddress = "https://index.docker.io/v1/"
+		serverAddress = "https://registry.hub.docker.com/v2"
 	}
 
 	homeDir, err := os.UserHomeDir()

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -139,7 +139,7 @@ func opsUpdateImage(ctx *cli.Context) error {
 		return flag.ErrHelp
 	}
 	dockerCredentials := &credentials.Credentials{
-		ServerURL: "https://index.docker.io/v1/",
+		ServerURL: "https://registry.hub.docker.com/v2",
 		Username:  opsUpdateImagesContainerRegistryUsernameFlag,
 		Secret:    opsUpdateImagesContainerRegistryPasswordFlag,
 	}


### PR DESCRIPTION
The internal calls were already using the V2 endpoint, but the auth still went through the v1 API. See https://www.docker.com/blog/docker-hub-v1-api-deprecation/#:~:text=Docker%20has%20planned%20to%20deprecate,repositories%20on%20September%205th%2C%202022. for the context. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Manually tested. 