### PR TITLE
Experiment: keep stack of definitions in ref panel

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -1,4 +1,4 @@
-$history-height: 2rem;
+$history-height: 1.8rem;
 
 .history {
     height: $history-height;

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -1,3 +1,11 @@
+$history-height: 2rem;
+
+.history {
+    height: $history-height;
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+
 $filter-input-height: 2.5rem;
 
 .filter {
@@ -225,7 +233,7 @@ $card-header-height: 1.5rem;
 
 // Lists of locations (definitions, references, implementations) on the left
 .location-lists {
-    height: calc(100% - #{$filter-input-height} - #{$card-header-height});
+    height: calc(100% - #{$history-height} - #{$filter-input-height} - #{$card-header-height});
     overflow: auto;
 }
 

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -89,7 +89,7 @@ interface ReferencesPanelProps
     externalLocation: H.Location
 
     tokensHistory?: TokenHistoryEntry[]
-    resetHistoryTo: (idx: number) => void
+    selectHistoryEntry: (idx: number) => void
 }
 
 interface TokenHistoryEntry {
@@ -101,7 +101,8 @@ export const ReferencesPanelWithMemoryRouter: React.FunctionComponent<
     React.PropsWithChildren<ReferencesPanelProps>
 > = props => {
     const [tokensHistory, setTokensHistory] = useState<TokenHistoryEntry[]>([])
-    const resetHistoryTo = (idx: number) => setTokensHistory(old => old.slice(0, idx))
+    const selectHistoryEntry = (idx: number) => setTokensHistory(old => old.slice(0, idx))
+
     useEffect(() => {
         setTokensHistory([])
     }, [props.externalLocation.pathname, props.externalLocation.search, props.externalLocation.hash])
@@ -113,7 +114,7 @@ export const ReferencesPanelWithMemoryRouter: React.FunctionComponent<
             key={`${props.externalLocation.pathname}${props.externalLocation.search}${props.externalLocation.hash}`}
             initialEntries={[props.externalLocation]}
         >
-            <ReferencesPanel {...props} tokensHistory={tokensHistory} resetHistoryTo={resetHistoryTo} />
+            <ReferencesPanel {...props} tokensHistory={tokensHistory} selectHistoryEntry={selectHistoryEntry} />
         </MemoryRouter>
     )
 }
@@ -175,8 +176,6 @@ export const RevisionResolvingReferencesList: React.FunctionComponent<
         <SearchTokenFindingReferencesList
             {...props}
             token={token}
-            tokens={props.tokensHistory ?? []}
-            setTokensHistory={props.resetHistoryTo}
             isFork={data.isFork}
             isArchived={data.isArchived}
             fileContent={data.fileContent}
@@ -189,8 +188,6 @@ interface ReferencesPanelPropsWithToken extends ReferencesPanelProps {
     isFork: boolean
     isArchived: boolean
     fileContent: string
-    tokens: TokenHistoryEntry[]
-    setTokensHistory: (idx: number) => void
 }
 
 const SearchTokenFindingReferencesList: React.FunctionComponent<
@@ -220,7 +217,6 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
         <ReferencesList
             {...props}
             token={props.token}
-            tokens={props.tokens}
             searchToken={tokenResult?.searchToken}
             spec={spec}
             fileContent={props.fileContent}
@@ -427,23 +423,22 @@ export const ReferencesList: React.FunctionComponent<
     return (
         <div className={classNames('align-items-stretch', styles.panel)}>
             <div className={classNames('px-0', styles.leftSubPanel)}>
-                <div className={classNames('d-flex justify-content-start mt-2', styles.history)}>
-                    {props.tokensHistory &&
-                        props.tokensHistory.map((entry, idx) => (
+                {props.tokensHistory && (
+                    <div className={classNames('d-flex justify-content-start mt-1', styles.history)}>
+                        {props.tokensHistory?.map((entry, idx) => (
                             <ButtonLink
                                 variant="secondary"
                                 size="sm"
                                 to={entry.location}
                                 key={entry.searchToken}
                                 className="mr-1"
-                                onClick={() => {
-                                    props.setTokensHistory(idx)
-                                }}
+                                onClick={() => props.selectHistoryEntry(idx)}
                             >
-                                {entry.searchToken}
+                                <Code>{entry.searchToken}</Code>
                             </ButtonLink>
                         ))}
-                </div>
+                    </div>
+                )}
                 <div className={classNames('d-flex justify-content-start ', styles.filter)}>
                     <small>
                         <Icon


### PR DESCRIPTION
1hr hack attempt to fix https://github.com/sourcegraph/sourcegraph/issues/30973. Lots of smaller issues here, obviously.


## Demo
https://user-images.githubusercontent.com/1185253/189112105-6d22772c-09b4-40f2-ac76-59d16ad21989.mp4


## Test plan

- manual testing but not all edge cases covered

## App preview:

- [Web](https://sg-web-mrn-ref-panel-history-stack.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

