### PR TITLE
insights: add aggregation pings documentation

### DIFF
--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -11,6 +11,24 @@ We keep this docs page up to date because pings are a vital component of our pro
 
 ## Metrics
 
+<!-- 
+TEMPLATE 
+
+**Type:** FE/BE event
+
+**Intended purpose:** Why does this ping exist?
+
+**Functional implementation:** When does this event fire?
+
+**Other considerations:**
+
+- Aggregation: Frequency
+- Event Code:
+  - Link to a Sourcegraph search of this event code name
+- **Version added:** 
+- **Version(s) broken:** (only add if required, link to fix PR)
+-->
+
 ### Additions count, edits count, and removals count 
 
 **Type:** FE event
@@ -327,3 +345,21 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 - Event Code: [InsightsPerDashboard](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+InsightsPerDashboard&patternType=literal)
 - **Version added:** 3.38
 <!-- - **Version(s) broken:**  -->
+
+## Search Results Aggregations Metrics
+
+### 
+
+**Type:** FE/BE event
+
+**Intended purpose:** Why does this ping exist?
+
+**Functional implementation:** When does this event fire?
+
+**Other considerations:**
+
+- Aggregation: Frequency
+- Event Code:
+  - Link to a Sourcegraph search of this event code name
+- **Version added:**
+- **Version(s) broken:** (only add if required)

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -4,13 +4,6 @@ Code Insights pings allow us to quantitatively measure the usage and success of 
 
 We keep this docs page up to date because pings are a vital component of our product knowledge and prioritization process, and a broken or incorrect ping impacts 3-5 months of data (because that's how long a fix takes to propagate).
 
-## Terminology
-
-- **FE event** - log events that we send by calling standard telemetry service on the frontend. These pings live only in the `event_logs` table. These typically represent user actions, such as hovers.
-- **BE capture** - pings that our BE sends to the ping store by checking/selecting data from database tables. Our backend periodically sends these pings to the `event_logs` table. These typically represent absolute counts across the entire instance. 
-
-## Metrics
-
 <!-- 
 TEMPLATE 
 
@@ -20,14 +13,20 @@ TEMPLATE
 
 **Functional implementation:** When does this event fire?
 
-**Other considerations:**
+**Other considerations:** Anything worth noting.
 
-- Aggregation: Frequency
-- Event Code:
-  - Link to a Sourcegraph search of this event code name
+- Aggregation: e.g. total, weekly
+- Event Code: link to a Sourcegraph search of this event code name
 - **Version added:** (link to PR)
 - **Version(s) broken:** (only add if required, link to fix PR)
 -->
+
+## Terminology
+
+- **FE event** - log events that we send by calling standard telemetry service on the frontend. These pings live only in the `event_logs` table. These typically represent user actions, such as hovers.
+- **BE capture** - pings that our BE sends to the ping store by checking/selecting data from database tables. Our backend periodically sends these pings to the `event_logs` table. These typically represent absolute counts across the entire instance. 
+
+## Metrics
 
 ### Additions count, edits count, and removals count 
 

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -25,7 +25,7 @@ TEMPLATE
 - Aggregation: Frequency
 - Event Code:
   - Link to a Sourcegraph search of this event code name
-- **Version added:** 
+- **Version added:** (link to PR)
 - **Version(s) broken:** (only add if required, link to fix PR)
 -->
 
@@ -348,18 +348,33 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 
 ## Search Results Aggregations Metrics
 
-### 
+### Information icon hover
 
-**Type:** FE/BE event
+**Type:** FE event
 
-**Intended purpose:** Why does this ping exist?
+**Intended purpose:** To track interest in the feature.
 
-**Functional implementation:** When does this event fire?
+**Functional implementation:** This ping works by firing a telemetry evente on the client when a user hovers over the information icon.
 
-**Other considerations:**
+- Aggregation: Weekly
+- Event Codes: [WeeklyGroupResultsInfoIconHover](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsInfoIconHover&patternType=lucky)
+- **Version added:** 4.0 ([#40977](https://github.com/sourcegraph/sourcegraph/pull/40977))
 
-- Aggregation: Frequency
-- Event Code:
-  - Link to a Sourcegraph search of this event code name
-- **Version added:**
-- **Version(s) broken:** (only add if required)
+
+### Sidebar and expanded view events
+
+**Type:** FE event
+
+**Intended purpose:** To track how users are using the different aggregation UI modes.
+
+**Functional implementation:** These pings work by firing telemetry events on the client when a user expands or collapses the sidebar or full view panel.
+
+**Other considerations**: For the full UI mode events we record which aggregation mode was toggled.
+
+- Aggregation: Weekly
+- Event Codes:
+  - [WeeklyGroupResultsOpenSection](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsOpenSection&patternType=lucky)
+  - [WeeklyGroupResultsCollapseSection](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsCollapseSection&patternType=lucky)
+  - [WeeklyGroupResultsExpandedViewOpen](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsExpandedViewOpen&patternType=lucky)
+  - [WeeklyGroupResultsExpandedViewCollapse](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsExpandedViewCollapse&patternType=lucky)
+- **Version added:** 4.0 ([#40977](https://github.com/sourcegraph/sourcegraph/pull/40977))

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -348,7 +348,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 
 ## Search Results Aggregations Metrics
 
-### Information icon hover
+### Information icon hovers
 
 **Type:** FE event
 
@@ -357,7 +357,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 **Functional implementation:** This ping works by firing a telemetry evente on the client when a user hovers over the information icon.
 
 - Aggregation: Weekly
-- Event Codes: [WeeklyGroupResultsInfoIconHover](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsInfoIconHover&patternType=lucky)
+- Event Code: [WeeklyGroupResultsInfoIconHover](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsInfoIconHover&patternType=lucky)
 - **Version added:** 4.0 ([#40977](https://github.com/sourcegraph/sourcegraph/pull/40977))
 
 
@@ -377,4 +377,20 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
   - [WeeklyGroupResultsCollapseSection](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsCollapseSection&patternType=lucky)
   - [WeeklyGroupResultsExpandedViewOpen](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsExpandedViewOpen&patternType=lucky)
   - [WeeklyGroupResultsExpandedViewCollapse](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsExpandedViewCollapse&patternType=lucky)
+- **Version added:** 4.0 ([#40977](https://github.com/sourcegraph/sourcegraph/pull/40977))
+
+### Aggregation modes clicks and hovers
+
+**Type:** FE event
+
+**Intended purpose:** To track aggregation mode usage and interest.
+
+**Functional implementation:** These pings work by firing telemetry events on the client when a user clicks on a mode or hovers over a disabled mode.
+
+**Other considerations:** The ping also includes data on which UI mode the user was.
+
+- Aggregation: Weekly
+- Event Codes: 
+  - [WeeklyGroupResultsAggregationModeClicked](https://sourcegraph.com/search?q=context:%40sourcegraph/all+WeeklyGroupResultsAggregationModeClicked%7CGroupAggregationModeClicked&patternType=regexp)
+  - [WeeklyGroupResultsAggregationModeDisabledHover](https://sourcegraph.com/search?q=context:%40sourcegraph/all+WeeklyGroupResultsAggregationModeDisabledHover%7CGroupAggregationModeDisabledHover&patternType=regexp)
 - **Version added:** 4.0 ([#40977](https://github.com/sourcegraph/sourcegraph/pull/40977))

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -105,7 +105,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 **Other considerations:** As we add new insights pages it's important to make sure we're adding pages to this counter. 
 
 - Aggregation: By week 
-- Event Code: [ViewInsights](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+ViewInsights&patternType=regexp), [StandaloneInsightPageViewed](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+StandaloneInsightPageViewed&patternType=regexp),
+- Event Code: [ViewInsights](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+ViewInsights&patternType=regexp), [StandaloneInsightPageViewed](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+StandaloneInsightPageViewed&patternType=regexp)
 - PRs: [#17805](https://github.com/sourcegraph/sourcegraph/pull/17805/files)
 - **Version Added:** 3.25
 - **Version(s) broken:** 3.25-3.26 (not weekly)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/20070/files)), 3.30 (broken when switching to dashboard pages, didn't track dashboard views)([fix PR](https://github.com/sourcegraph/sourcegraph/pull/24129/files))
@@ -346,7 +346,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 - **Version added:** 3.38
 <!-- - **Version(s) broken:**  -->
 
-## Search Results Aggregations Metrics
+## Search results aggregations metrics
 
 ### Information icon hovers
 
@@ -356,7 +356,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 
 **Functional implementation:** This ping works by firing a telemetry evente on the client when a user hovers over the information icon.
 
-- Aggregation: Weekly
+- Aggregation: weekly
 - Event Code: [WeeklyGroupResultsInfoIconHover](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsInfoIconHover&patternType=lucky)
 - **Version added:** 4.0 ([#40977](https://github.com/sourcegraph/sourcegraph/pull/40977))
 
@@ -369,9 +369,9 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 
 **Functional implementation:** These pings work by firing telemetry events on the client when a user expands or collapses the sidebar or full view panel.
 
-**Other considerations**: For the full UI mode events we record which aggregation mode was toggled.
+**Other considerations**: For the expanded UI mode events we record which aggregation mode was toggled.
 
-- Aggregation: Weekly
+- Aggregation: weekly
 - Event Codes:
   - [WeeklyGroupResultsOpenSection](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsOpenSection&patternType=lucky)
   - [WeeklyGroupResultsCollapseSection](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsCollapseSection&patternType=lucky)
@@ -387,10 +387,26 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 
 **Functional implementation:** These pings work by firing telemetry events on the client when a user clicks on a mode or hovers over a disabled mode.
 
-**Other considerations:** The ping also includes data on which UI mode the user was.
+**Other considerations:** The ping also includes data for current UI mode.
 
-- Aggregation: Weekly
+- Aggregation: weekly
 - Event Codes: 
   - [WeeklyGroupResultsAggregationModeClicked](https://sourcegraph.com/search?q=context:%40sourcegraph/all+WeeklyGroupResultsAggregationModeClicked%7CGroupAggregationModeClicked&patternType=regexp)
   - [WeeklyGroupResultsAggregationModeDisabledHover](https://sourcegraph.com/search?q=context:%40sourcegraph/all+WeeklyGroupResultsAggregationModeDisabledHover%7CGroupAggregationModeDisabledHover&patternType=regexp)
+- **Version added:** 4.0 ([#40977](https://github.com/sourcegraph/sourcegraph/pull/40977))
+
+### Aggregation chart clicks and hovers 
+
+**Type:** FE event
+
+**Intended purpose:** To track if users are hovering over results and clicking through.
+
+**Functional implementation:** These pings work by firing telemetry events on the client when a user hovers or clicks on a result.
+
+**Other considerations:** The ping also includes data for the current UI mode and aggregation mode.
+
+- Aggregation: weekly
+- Event Codes:
+  - [WeeklyGroupResultsChartBarClick](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsChartBarClick&patternType=regexp)
+  - [WeeklyGroupResultsChartBarHover](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsChartBarHover&patternType=regexp)
 - **Version added:** 4.0 ([#40977](https://github.com/sourcegraph/sourcegraph/pull/40977))


### PR DESCRIPTION
part of #41237 (we need to add proactive mode pings too) 

## Test plan

Checked docsite locally and `sg lint docs`