### PR TITLE
executors: Fix diff check for executor vm

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -50,6 +50,10 @@ The default run type.
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
+- Pipeline for `ExecutorVMImage` changes:
+  - **Metadata**: Pipeline metadata
+  - Upload build trace
+
 - Pipeline for `ExecutorDockerRegistryMirror` changes:
   - **Metadata**: Pipeline metadata
   - Upload build trace

--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -18,6 +18,7 @@ const (
 	DatabaseSchema
 	Docs
 	Dockerfiles
+	ExecutorVMImage
 	ExecutorDockerRegistryMirror
 	CIScripts
 	Terraform
@@ -131,6 +132,11 @@ func ParseDiff(files []string) (diff Diff) {
 			diff |= ExecutorDockerRegistryMirror
 		}
 
+		// Affects executor VM image
+		if strings.HasPrefix(p, "docker-images/executor-vm/") {
+			diff |= ExecutorVMImage
+		}
+
 		// Affects CI scripts
 		if strings.HasPrefix(p, "enterprise/dev/ci/scripts") {
 			diff |= CIScripts
@@ -187,6 +193,8 @@ func (d Diff) String() string {
 		return "Dockerfiles"
 	case ExecutorDockerRegistryMirror:
 		return "ExecutorDockerRegistryMirror"
+	case ExecutorVMImage:
+		return "ExecutorVMImage"
 	case CIScripts:
 		return "CIScripts"
 	case Terraform:

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -249,7 +249,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			imageBuildOps.Append(buildCandidateDockerImage(dockerImage, c.Version, c.candidateImageTag(), uploadSourcemaps))
 		}
 		// Executor VM image
-		skipHashCompare := c.MessageFlags.SkipHashCompare || c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease)
+		skipHashCompare := c.MessageFlags.SkipHashCompare || c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorVMImage)
 		if c.RunType.Is(runtype.MainDryRun, runtype.MainBranch, runtype.ReleaseBranch, runtype.TaggedRelease) {
 			imageBuildOps.Append(buildExecutor(c, skipHashCompare))
 			if c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {


### PR DESCRIPTION
This lived in the executor dir before, but now it wouldn't trigger an executor build. This should fix it.

## Test plan

Verified the CI pipeline looks correct.