### PR TITLE
Fix flaky cancel worker jobs test

### DIFF
--- a/internal/workerutil/worker_test.go
+++ b/internal/workerutil/worker_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/derision-test/glock"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log"
 
@@ -498,8 +497,6 @@ func TestWorkerMaxActiveTime(t *testing.T) {
 }
 
 func TestWorkerCancelJobs(t *testing.T) {
-	t.Skip("Disabled because it's flaky. See: https://github.com/sourcegraph/sourcegraph/issues/39749")
-
 	recordID := 42
 	store := NewMockStore()
 	// Return one record from dequeue.
@@ -536,9 +533,9 @@ func TestWorkerCancelJobs(t *testing.T) {
 		return ctx.Err()
 	}
 
-	var canceledJobsCalled bool
+	canceledJobsCalled := make(chan struct{})
 	store.CanceledJobsFunc.SetDefaultHook(func(c context.Context, i []int) ([]int, error) {
-		canceledJobsCalled = true
+		close(canceledJobsCalled)
 		// Cancel all jobs.
 		return i, nil
 	})
@@ -554,18 +551,25 @@ func TestWorkerCancelJobs(t *testing.T) {
 	})
 
 	// Wait until a job has been dequeued.
-	<-dequeued
+	select {
+	case <-dequeued:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for Dequeue call")
+	}
 	// Trigger a fetchCanceledJobs call.
-	cancelClock.Advance(time.Second)
-
+	cancelClock.BlockingAdvance(time.Second)
+	// Wait for cancelled jobs to be called.
+	select {
+	case <-canceledJobsCalled:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for CanceledJobs call")
+	}
 	// Expect that markFailed is called eventually.
 	select {
 	case <-markedFailedCalled:
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for markFailed call")
 	}
-
-	assert.True(t, canceledJobsCalled, "CanceledJobs not called")
 }
 
 func TestWorkerDeadline(t *testing.T) {


### PR DESCRIPTION
Sometimes the .After wasn't called when we advanced the clock, leading to it waiting from that point in time. BlockingAdvance waits for an .After handler to attach.

Closes https://github.com/sourcegraph/sourcegraph/issues/39749

## Test plan

Verified it never flakes anymore:
```
go test ./internal/workerutil -run=TestWorkerCancelJobs -count=1000000
ok      github.com/sourcegraph/sourcegraph/internal/workerutil  39.729s
```