### PR TITLE
Aggregation: Fix bar index calculation

### DIFF
--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
@@ -176,7 +176,7 @@ function getActiveBar<Datum>(input: GetActiveBarInput<Datum>): ActiveBarTuple<Da
     const isOneDatumCategory = category.data.length === 1
 
     if (isOneDatumCategory) {
-        return [category.data[0], category, 0]
+        return [category.data[0], category, categoryPossibleIndex]
     }
 
     const invertCategories = scaleBandInvert(xCategoriesScale)


### PR DESCRIPTION

## Test plan
- Click on any bar on the chart
- You should see that in the `GroupResultsChartBarClick ` FE event log, we have a proper index value (prior to this PR, it was always 0)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-aggregation-index-ping.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wltkyjlpgx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
