### PR TITLE
search: fix panic when requesting language stats

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -577,6 +577,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 		if err := json.Unmarshal(jsonRes, &stats); err != nil {
 			return nil, err
 		}
+		stats.logger = r.logger.Scoped("searchResultsStats", "provides status on search results")
 		stats.sr = r
 		return stats, nil
 	}


### PR DESCRIPTION
Conversion from log15 missed a case where the language stats were retrieved from cache causing the logger to be nil.

resolves https://github.com/sourcegraph/sourcegraph/issues/41511
## Test plan
Ran lang stats query multiple times from the api console to ensure I hit the cache and confirmed it no long caused a panic.
```graphql
query LangStatsInsightContent($query: String!) {
  search(query: $query) {
    results {
      limitHit
    }
    stats {
      languages {
        name
        totalLines
      }
    }
  }
}
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
