### PR TITLE
Aggregation: fix aggregation section rendering

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchFilterSection.tsx
+++ b/client/search-ui/src/results/sidebar/SearchFilterSection.tsx
@@ -20,6 +20,8 @@ export interface SearchFilterSectionProps {
     onToggle?: (id: string, open: boolean) => void
     startCollapsed?: boolean
 
+    forcedRender?: boolean
+
     /**
      * Shown when the built-in search doesn't find any results.
      */
@@ -58,6 +60,7 @@ export const SearchFilterSection: FC<SearchFilterSectionProps> = memo(props => {
         children = [],
         className,
         showSearch = false,
+        forcedRender = true,
         onToggle,
         startCollapsed,
         minItems = 0,
@@ -163,7 +166,7 @@ export const SearchFilterSection: FC<SearchFilterSectionProps> = memo(props => {
                     />
                 </CollapseHeader>
 
-                <CollapsePanel>
+                <CollapsePanel forcedRender={forcedRender}>
                     <div
                         className={classNames(
                             'pb-4',

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -112,6 +112,10 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
                 <SearchSidebarSection
                     sectionId={SectionID.GROUPED_BY}
                     header={<CustomAggregationHeading telemetryService={props.telemetryService} />}
+                    // SearchAggregations content contains component that makes a few API network requests
+                    // in order to prevent these calls if this section is collapsed we turn off force render
+                    // for collapse section component
+                    forcedRender={false}
                     onToggle={handleGroupedByToggle}
                 >
                     <SearchAggregations

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
@@ -176,7 +176,7 @@ function getActiveBar<Datum>(input: GetActiveBarInput<Datum>): ActiveBarTuple<Da
     const isOneDatumCategory = category.data.length === 1
 
     if (isOneDatumCategory) {
-        return [category.data[0], category, 0]
+        return [category.data[0], category, categoryPossibleIndex]
     }
 
     const invertCategories = scaleBandInvert(xCategoriesScale)

--- a/client/wildcard/src/components/Collapse/Collapse.story.tsx
+++ b/client/wildcard/src/components/Collapse/Collapse.story.tsx
@@ -95,6 +95,31 @@ export const Simple: Story = () => {
                     </>
                 )}
             </Collapse>
+
+            <H2 className="my-3">Without forced CollapsePanel rendering</H2>
+            <Collapse>
+                {({ isOpen }) => (
+                    <>
+                        <CollapseHeader
+                            as={Button}
+                            aria-label={isOpen ? 'Expand' : 'Collapse'}
+                            outline={true}
+                            variant="secondary"
+                            className="w-50"
+                        >
+                            Collapsable
+                            <Icon
+                                aria-hidden={true}
+                                svgPath={isOpen ? mdiChevronDown : mdiChevronLeft}
+                                className="mr-1"
+                            />
+                        </CollapseHeader>
+                        <CollapsePanel forcedRender={false} className="w-50">
+                            <Input placeholder="testing this one" />
+                        </CollapsePanel>
+                    </>
+                )}
+            </Collapse>
         </div>
     )
 }

--- a/client/wildcard/src/components/Collapse/Collapse.tsx
+++ b/client/wildcard/src/components/Collapse/Collapse.tsx
@@ -110,11 +110,22 @@ export const CollapseHeader = React.forwardRef(function CollapseHeader(props, re
     )
 }) as ForwardReferenceComponent<'button', CollapseHeaderProps>
 
-export const CollapsePanel = React.forwardRef(function CollapsePanel(
-    { children, className, as: Component = 'div', ...attributes },
-    reference
-) {
+interface CollapsePanelProps {
+    forcedRender?: boolean
+}
+
+export const CollapsePanel = React.forwardRef(function CollapsePanel(props, reference) {
+    const { forcedRender = true, children, className, as: Component = 'div', ...attributes } = props
     const { isOpen } = useContext(CollapseContext)
+
+    // When we enforce rendering we always render a DOM element and hide it with
+    // display: none CSS rule, on other cases when we explicitly say forcedRender={false}
+    // we render/not render DOM element based on isOpen state
+    const shouldRender = forcedRender ? true : isOpen
+
+    if (!shouldRender) {
+        return null
+    }
 
     return (
         <Component
@@ -125,4 +136,4 @@ export const CollapsePanel = React.forwardRef(function CollapsePanel(
             {children}
         </Component>
     )
-}) as ForwardReferenceComponent<'div'>
+}) as ForwardReferenceComponent<'div', CollapsePanelProps>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41469

## Background
Since the sidebar section uses the collapse section from the wildcard package, these sections are always rendered in the DOM, and the collapse section UI works in a way where it always renders section content and based on the open state, it sets `display: none` styles. Because of this, we always have components in the react tree, and therefore, these components can make network requests (which are based on the render tree) 

This PR introduces a new prop setting for the collapse component that allows to turn off render enforcing in consumer and therefore doesn't have collapse content in the react call tree. This helps for the aggregation UI because we don't make any network requests if the section is collapsed. 

## Test plan
- Open the search result page 
- Make sure that you can see aggregation data if the panel is open
- Close the aggregation panel in the sidebar and refresh the page
- Make sure that you don't have any network requests about aggregation when this panel is closed

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
