### PR TITLE
Restrict imports from any `out/` directories

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,10 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
             message:
               'Imports from package internals are banned. Add relevant export to the entry point of the package to import it from the outside world.',
           },
+          {
+            group: ['**/out/*'],
+            message: 'Please don\'t import stuff from the \'out\' directory. It’s generated code. Remove the \'out/\' part and you should be good go to.',
+          },
         ],
       },
     ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,7 +94,8 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
           },
           {
             group: ['**/out/*'],
-            message: 'Please don\'t import stuff from the \'out\' directory. It’s generated code. Remove the \'out/\' part and you should be good go to.',
+            message:
+              "Please don't import stuff from the 'out' directory. It’s generated code. Remove the 'out/' part and you should be good go to.",
           },
         ],
       },

--- a/client/build-config/src/esbuild/monacoPlugin.ts
+++ b/client/build-config/src/esbuild/monacoPlugin.ts
@@ -1,7 +1,9 @@
 import path from 'path'
 
 import * as esbuild from 'esbuild'
+// eslint-disable-next-line no-restricted-imports
 import { EditorFeature, featuresArr } from 'monaco-editor-webpack-plugin/out/features'
+// eslint-disable-next-line no-restricted-imports
 import { EditorLanguage, languagesArr } from 'monaco-editor-webpack-plugin/out/languages'
 
 import { MONACO_LANGUAGES_AND_FEATURES } from '@sourcegraph/build-config'


### PR DESCRIPTION
This should do the trick.

To be on the safe side, I’ve only applied the rule to our main repo rather than adding it to https://github.com/sourcegraph/eslint-config

## Test plan

Test cases and results:

These throw the correct error message:
`import type { anything } from '@sourcegraph/shared/out/src/auth/xxx'`
`import type { anything } from '@sourcegraph/shared/out/src/auth'`
`import type { anything } from '@sourcegraph/shared/out/src'`

These are not marked as problematic:
`import type { anything } from '@sourcegraph/shared/src/auth'`
`import type { anything } from '@sourcegraph/shared/out'`

## App preview:

- [Web](https://sg-web-dv-restrict-imports-from-out-dir.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bokvhibyfx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
