### PR TITLE
Allow to cancel running external service sync jobs

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.module.scss
+++ b/client/web/src/components/externalServices/ExternalServicePage.module.scss
@@ -1,0 +1,5 @@
+.cancel-button {
+    margin-right: 0.5rem;
+    justify-content: flex-end;
+    align-self: flex-start;
+}

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -1,4 +1,5 @@
 import { DecoratorFn, Story, Meta } from '@storybook/react'
+import { subMinutes } from 'date-fns'
 import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
@@ -6,7 +7,7 @@ import { getDocumentNode } from '@sourcegraph/http-client'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
-import { ExternalServiceFields, ExternalServiceKind } from '../../graphql-operations'
+import { ExternalServiceFields, ExternalServiceKind, ExternalServiceSyncJobState } from '../../graphql-operations'
 import { WebStory } from '../WebStory'
 
 import { FETCH_EXTERNAL_SERVICE, queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs } from './backend'
@@ -51,9 +52,42 @@ const externalService = {
 
 const queryExternalServiceSyncJobs: typeof _queryExternalServiceSyncJobs = () =>
     of({
-        totalCount: 0,
+        totalCount: 3,
         pageInfo: { endCursor: null, hasNextPage: false },
-        nodes: [],
+        nodes: [
+            {
+                __typename: 'ExternalServiceSyncJob',
+                failureMessage: null,
+                startedAt: subMinutes(new Date(), 25).toISOString(),
+                finishedAt: null,
+                id: 'SYNCJOB1',
+                state: ExternalServiceSyncJobState.CANCELING,
+            },
+            {
+                __typename: 'ExternalServiceSyncJob',
+                failureMessage: null,
+                startedAt: subMinutes(new Date(), 25).toISOString(),
+                finishedAt: null,
+                id: 'SYNCJOB1',
+                state: ExternalServiceSyncJobState.PROCESSING,
+            },
+            {
+                __typename: 'ExternalServiceSyncJob',
+                failureMessage: 'Very bad error syncing with the code host.',
+                startedAt: subMinutes(new Date(), 25).toISOString(),
+                finishedAt: subMinutes(new Date(), 25).toISOString(),
+                id: 'SYNCJOB1',
+                state: ExternalServiceSyncJobState.FAILED,
+            },
+            {
+                __typename: 'ExternalServiceSyncJob',
+                failureMessage: null,
+                startedAt: subMinutes(new Date(), 25).toISOString(),
+                finishedAt: subMinutes(new Date(), 25).toISOString(),
+                id: 'SYNCJOB1',
+                state: ExternalServiceSyncJobState.COMPLETED,
+            },
+        ],
     })
 
 function newFetchMock(node: { __typename: 'ExternalService' } & ExternalServiceFields): WildcardMockLink {

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -52,7 +52,7 @@ const externalService = {
 
 const queryExternalServiceSyncJobs: typeof _queryExternalServiceSyncJobs = () =>
     of({
-        totalCount: 3,
+        totalCount: 4,
         pageInfo: { endCursor: null, hasNextPage: false },
         nodes: [
             {

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -3,7 +3,8 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react'
 import * as H from 'history'
 import { parse as parseJSONC } from 'jsonc-parser'
 import { Redirect, useHistory } from 'react-router'
-import { Observable, Subject } from 'rxjs'
+import { Subject } from 'rxjs'
+import { delay, repeatWhen } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { hasProperty } from '@sourcegraph/common'
@@ -20,6 +21,7 @@ import {
     ExternalServiceSyncJobConnectionFields,
     ExternalServiceResult,
     ExternalServiceVariables,
+    ExternalServiceSyncJobState,
 } from '../../graphql-operations'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../FilteredConnection'
 import { LoaderButton } from '../LoaderButton'
@@ -32,6 +34,7 @@ import {
     queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs,
     useUpdateExternalService,
     FETCH_EXTERNAL_SERVICE,
+    useCancelExternalServiceSync,
 } from './backend'
 import { ExternalServiceCard } from './ExternalServiceCard'
 import { ExternalServiceForm } from './ExternalServiceForm'
@@ -235,7 +238,7 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
 
 interface ExternalServiceSyncJobsListProps {
     externalServiceID: Scalars['ID']
-    updates: Observable<void>
+    updates: Subject<void>
 
     /** For testing only. */
     queryExternalServiceSyncJobs?: typeof _queryExternalServiceSyncJobs
@@ -251,7 +254,7 @@ const ExternalServiceSyncJobsList: React.FunctionComponent<ExternalServiceSyncJo
             queryExternalServiceSyncJobs({
                 first: args.first ?? null,
                 externalService: externalServiceID,
-            }),
+            }).pipe(repeatWhen(obs => obs.pipe(delay(1500)))),
         [externalServiceID, queryExternalServiceSyncJobs]
     )
 
@@ -272,7 +275,7 @@ const ExternalServiceSyncJobsList: React.FunctionComponent<ExternalServiceSyncJo
                 pluralNoun="sync jobs"
                 queryConnection={queryConnection}
                 nodeComponent={ExternalServiceSyncJobNode}
-                nodeComponentProps={{}}
+                nodeComponentProps={{ onUpdate: updates }}
                 hideSearch={true}
                 noSummaryIfAllNodesVisible={true}
                 history={history}
@@ -285,47 +288,79 @@ const ExternalServiceSyncJobsList: React.FunctionComponent<ExternalServiceSyncJo
 
 interface ExternalServiceSyncJobNodeProps {
     node: ExternalServiceSyncJobListFields
+    onUpdate: Subject<void>
 }
 
-const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJobNodeProps> = ({ node }) => (
-    <li className="list-group-item py-3">
-        <div className="d-flex align-items-center justify-content-between">
-            <div className="flex-shrink-0 mr-2">
-                <Badge>{node.state}</Badge>
-            </div>
-            <div className="flex-shrink-0">
-                {node.startedAt && (
-                    <>
-                        {node.finishedAt === null && <>Running since </>}
-                        {node.finishedAt !== null && <>Ran for </>}
-                        <Duration
-                            start={node.startedAt}
-                            end={node.finishedAt ?? undefined}
-                            stableWidth={false}
-                            className="d-inline"
-                        />
-                    </>
-                )}
-            </div>
-            <div className="text-right flex-grow-1">
-                <div>
-                    {node.startedAt === null && 'Not started yet'}
-                    {node.startedAt !== null && (
+const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJobNodeProps> = ({ node, onUpdate }) => {
+    const [
+        cancelExternalServiceSync,
+        { error: cancelSyncJobError, loading: cancelSyncJobLoading },
+    ] = useCancelExternalServiceSync()
+
+    const cancelJob = useCallback(
+        () =>
+            cancelExternalServiceSync({ variables: { id: node.id } }).then(() => {
+                onUpdate.next()
+                // Optimistically set state.
+                node.state = ExternalServiceSyncJobState.CANCELING
+            }),
+        [cancelExternalServiceSync, node, onUpdate]
+    )
+
+    return (
+        <li className="list-group-item py-3">
+            <div className="d-flex align-items-center justify-content-between">
+                <div className="flex-shrink-0 mr-2">
+                    <Badge>{node.state}</Badge>
+                </div>
+                <div className="flex-shrink-0">
+                    {node.startedAt && (
                         <>
-                            Started <Timestamp date={node.startedAt} />
+                            {node.finishedAt === null && <>Running since </>}
+                            {node.finishedAt !== null && <>Ran for </>}
+                            <Duration
+                                start={node.startedAt}
+                                end={node.finishedAt ?? undefined}
+                                stableWidth={false}
+                                className="d-inline"
+                            />
+                            {node.state === ExternalServiceSyncJobState.QUEUED ||
+                                (node.state === ExternalServiceSyncJobState.PROCESSING && (
+                                    <LoaderButton
+                                        label="Cancel"
+                                        alwaysShowLabel={true}
+                                        variant="danger"
+                                        outline={true}
+                                        size="sm"
+                                        onClick={cancelJob}
+                                        loading={cancelSyncJobLoading}
+                                        disabled={cancelSyncJobLoading}
+                                    />
+                                ))}
+                            {cancelSyncJobError && <ErrorAlert error={cancelSyncJobError} />}
                         </>
                     )}
                 </div>
-                <div>
-                    {node.finishedAt === null && 'Not finished yet'}
-                    {node.finishedAt !== null && (
-                        <>
-                            Finished <Timestamp date={node.finishedAt} />
-                        </>
-                    )}
+                <div className="text-right flex-grow-1">
+                    <div>
+                        {node.startedAt === null && 'Not started yet'}
+                        {node.startedAt !== null && (
+                            <>
+                                Started <Timestamp date={node.startedAt} />
+                            </>
+                        )}
+                    </div>
+                    <div>
+                        {node.finishedAt === null && 'Not finished yet'}
+                        {node.finishedAt !== null && (
+                            <>
+                                Finished <Timestamp date={node.finishedAt} />
+                            </>
+                        )}
+                    </div>
                 </div>
             </div>
-        </div>
-        {node.failureMessage && <ErrorAlert error={node.failureMessage} className="mt-2 mb-0" />}
-    </li>
-)
+            {node.failureMessage && <ErrorAlert error={node.failureMessage} className="mt-2 mb-0" />}
+        </li>
+    )
+}

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -41,6 +41,8 @@ import { ExternalServiceForm } from './ExternalServiceForm'
 import { defaultExternalServices, codeHostExternalServices } from './externalServices'
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 
+import styles from './ExternalServicePage.module.scss'
+
 interface Props extends TelemetryProps {
     externalServiceID: Scalars['ID']
     isLightTheme: boolean
@@ -313,7 +315,7 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                 <div className="flex-shrink-0 mr-2">
                     <Badge>{node.state}</Badge>
                 </div>
-                <div className="flex-shrink-0">
+                <div className="flex-shrink-0 flex-grow-1 mr-2">
                     {node.startedAt && (
                         <>
                             {node.finishedAt === null && <>Running since </>}
@@ -324,24 +326,28 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                                 stableWidth={false}
                                 className="d-inline"
                             />
-                            {node.state === ExternalServiceSyncJobState.QUEUED ||
-                                (node.state === ExternalServiceSyncJobState.PROCESSING && (
-                                    <LoaderButton
-                                        label="Cancel"
-                                        alwaysShowLabel={true}
-                                        variant="danger"
-                                        outline={true}
-                                        size="sm"
-                                        onClick={cancelJob}
-                                        loading={cancelSyncJobLoading}
-                                        disabled={cancelSyncJobLoading}
-                                    />
-                                ))}
                             {cancelSyncJobError && <ErrorAlert error={cancelSyncJobError} />}
                         </>
                     )}
                 </div>
-                <div className="text-right flex-grow-1">
+                {[
+                    ExternalServiceSyncJobState.QUEUED,
+                    ExternalServiceSyncJobState.PROCESSING,
+                    ExternalServiceSyncJobState.CANCELING,
+                ].includes(node.state) && (
+                    <LoaderButton
+                        label="Cancel"
+                        alwaysShowLabel={true}
+                        variant="danger"
+                        outline={true}
+                        size="sm"
+                        onClick={cancelJob}
+                        loading={cancelSyncJobLoading || node.state === ExternalServiceSyncJobState.CANCELING}
+                        disabled={cancelSyncJobLoading || node.state === ExternalServiceSyncJobState.CANCELING}
+                        className={styles.cancelButton}
+                    />
+                )}
+                <div className="text-right flex-shrink-0">
                     <div>
                         {node.startedAt === null && 'Not started yet'}
                         {node.startedAt !== null && (

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -25,6 +25,8 @@ import {
     ExternalServiceSyncJobsVariables,
     ExternalServiceSyncJobConnectionFields,
     ExternalServiceSyncJobsResult,
+    CancelExternalServiceSyncVariables,
+    CancelExternalServiceSyncResult,
 } from '../../graphql-operations'
 
 export const externalServiceFragment = gql`
@@ -260,6 +262,23 @@ export const SYNC_EXTERNAL_SERVICE = gql`
 
 export function useSyncExternalService(): MutationTuple<SyncExternalServiceResult, SyncExternalServiceVariables> {
     return useMutation<SyncExternalServiceResult, SyncExternalServiceVariables>(SYNC_EXTERNAL_SERVICE)
+}
+
+export const CANCEL_EXTERNAL_SERVICE_SYNC = gql`
+    mutation CancelExternalServiceSync($id: ID!) {
+        cancelExternalServiceSync(id: $id) {
+            alwaysNil
+        }
+    }
+`
+
+export function useCancelExternalServiceSync(): MutationTuple<
+    CancelExternalServiceSyncResult,
+    CancelExternalServiceSyncVariables
+> {
+    return useMutation<CancelExternalServiceSyncResult, CancelExternalServiceSyncVariables>(
+        CANCEL_EXTERNAL_SERVICE_SYNC
+    )
 }
 
 export const EXTERNAL_SERVICE_SYNC_JOBS = gql`

--- a/client/web/src/components/time/Duration.tsx
+++ b/client/web/src/components/time/Duration.tsx
@@ -57,7 +57,7 @@ export const Duration: React.FunctionComponent<React.PropsWithChildren<DurationP
     }, [end])
 
     return (
-        <div className={classNames({ [styles.stableWidth]: stableWidth }, className)} {...props}>
+        <div className={classNames('chromatic-ignore', { [styles.stableWidth]: stableWidth }, className)} {...props}>
             {stableWidth && (
                 // Set the width of the parent with a filler block of full-width digits,
                 // to prevent layout shift if the time changes.

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -324,11 +324,14 @@ func (r *externalServiceSyncJobResolver) ID() graphql.ID {
 }
 
 func (r *externalServiceSyncJobResolver) State() string {
+	if r.job.Cancel && r.job.State == "processing" {
+		return "CANCELING"
+	}
 	return strings.ToUpper(r.job.State)
 }
 
 func (r *externalServiceSyncJobResolver) FailureMessage() *string {
-	if r.job.FailureMessage == "" {
+	if r.job.FailureMessage == "" || r.job.Cancel {
 		return nil
 	}
 

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -503,7 +503,6 @@ func (r *schemaResolver) CancelExternalServiceSync(ctx context.Context, args *ca
 		return nil, err
 	}
 
-	// Enqueue a sync job for the external service, if none exists yet.
 	if err := r.db.ExternalServices().CancelSyncJob(ctx, esj.ID); err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -473,3 +473,40 @@ func (r *schemaResolver) SyncExternalService(ctx context.Context, args *syncExte
 
 	return &EmptyResponse{}, nil
 }
+
+type cancelExternalServiceSyncArgs struct {
+	ID graphql.ID
+}
+
+func (r *schemaResolver) CancelExternalServiceSync(ctx context.Context, args *cancelExternalServiceSyncArgs) (*EmptyResponse, error) {
+	start := time.Now()
+	var err error
+	var namespaceUserID, namespaceOrgID int32
+	defer reportExternalServiceDuration(start, Update, &err, &namespaceUserID, &namespaceOrgID)
+
+	id, err := unmarshalExternalServiceSyncJobID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	esj, err := r.db.ExternalServices().GetSyncJobByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	es, err := r.db.ExternalServices().GetByID(ctx, esj.ExternalServiceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 🚨 SECURITY: check access to external service.
+	if err = backend.CheckExternalServiceAccess(ctx, r.db, es.NamespaceUserID, es.NamespaceOrgID); err != nil {
+		return nil, err
+	}
+
+	// Enqueue a sync job for the external service, if none exists yet.
+	if err := r.db.ExternalServices().CancelSyncJob(ctx, esj.ID); err != nil {
+		return nil, err
+	}
+
+	return &EmptyResponse{}, nil
+}

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -14,6 +14,7 @@ import (
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 
 	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -22,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -1367,4 +1369,84 @@ func TestSyncExternalService_ContextTimeout(t *testing.T) {
 	if !strings.Contains(err.Error(), expected) {
 		t.Errorf("Expected error: %q, but got %v", expected, err)
 	}
+}
+
+func TestCancelExternalServiceSync(t *testing.T) {
+	externalServiceID := int64(1234)
+	syncJobID := int64(99)
+
+	externalServices := database.NewMockExternalServiceStore()
+	externalServices.GetByIDFunc.SetDefaultHook(func(_ context.Context, id int64) (*types.ExternalService, error) {
+		return &types.ExternalService{
+			ID:          externalServiceID,
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "my external service",
+			Config:      extsvc.NewUnencryptedConfig(`{}`),
+		}, nil
+	})
+
+	externalServices.GetSyncJobByIDFunc.SetDefaultHook(func(_ context.Context, id int64) (*types.ExternalServiceSyncJob, error) {
+		return &types.ExternalServiceSyncJob{
+			ID:                id,
+			State:             "processing",
+			QueuedAt:          timeutil.Now().Add(-5 * time.Minute),
+			StartedAt:         timeutil.Now(),
+			ExternalServiceID: externalServiceID,
+		}, nil
+	})
+
+	t.Run("as an admin with access to the external service", func(t *testing.T) {
+		users := database.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+
+		db := database.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
+		db.ExternalServicesFunc.SetDefaultReturn(externalServices)
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+		syncJobIDGraphQL := marshalExternalServiceSyncJobID(syncJobID)
+
+		RunTest(t, &Test{
+			Schema:         mustParseGraphQLSchema(t, db),
+			Query:          fmt.Sprintf(`mutation { cancelExternalServiceSync(id: %q) { alwaysNil } } `, syncJobIDGraphQL),
+			ExpectedResult: `{ "cancelExternalServiceSync": { "alwaysNil": null } }`,
+			Context:        ctx,
+		})
+
+		if callCount := len(externalServices.CancelSyncJobFunc.History()); callCount != 1 {
+			t.Errorf("unexpected handle call count. want=%d have=%d", 1, callCount)
+		} else if arg := externalServices.CancelSyncJobFunc.History()[0].Arg1; arg != syncJobID {
+			t.Errorf("unexpected sync job ID. want=%d have=%d", syncJobID, arg)
+		}
+	})
+
+	t.Run("as a user without access to the external service", func(t *testing.T) {
+		users := database.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: false}, nil)
+
+		db := database.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
+		db.ExternalServicesFunc.SetDefaultReturn(externalServices)
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+		syncJobIDGraphQL := marshalExternalServiceSyncJobID(syncJobID)
+
+		RunTest(t, &Test{
+			Schema:         mustParseGraphQLSchema(t, db),
+			Query:          fmt.Sprintf(`mutation { cancelExternalServiceSync(id: %q) { alwaysNil } } `, syncJobIDGraphQL),
+			ExpectedResult: `null`,
+			ExpectedErrors: []*gqlerrors.QueryError{
+				{
+					Path:          []any{"cancelExternalServiceSync"},
+					Message:       backend.ErrNoAccessExternalService.Error(),
+					ResolverError: backend.ErrNoAccessExternalService,
+				},
+			},
+			Context: ctx,
+		})
+
+		if callCount := len(externalServices.CancelSyncJobFunc.History()); callCount != 0 {
+			t.Errorf("unexpected handle call count. want=%d have=%d", 0, callCount)
+		}
+	})
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -770,6 +770,13 @@ type Mutation {
     syncExternalService(id: ID!): EmptyResponse!
 
     """
+    Cancels an external service sync job. Must be in queued or processing state.
+
+    Site-admin or owner of the external service only.
+    """
+    cancelExternalServiceSync(id: ID!): EmptyResponse!
+
+    """
     Associate a new key-value pair with a repo.
     """
     addRepoKeyValuePair(repo: ID!, key: String!, value: String): EmptyResponse!
@@ -2646,6 +2653,16 @@ enum ExternalServiceSyncJobState {
     Sync finished successfully.
     """
     COMPLETED
+
+    """
+    Sync job is being canceled.
+    """
+    CANCELING
+
+    """
+    Sync job has been canceled.
+    """
+    CANCELED
 }
 
 """

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -94,6 +94,10 @@ type ExternalServiceStore interface {
 	// CountSyncJobs counts all sync jobs.
 	CountSyncJobs(ctx context.Context, opt ExternalServicesGetSyncJobsOptions) (int64, error)
 
+	// CancelSyncJob cancels a given sync job. It returns an error when the job was not
+	// found or not in processing or queued state.
+	CancelSyncJob(ctx context.Context, id int64) error
+
 	// List returns external services under given namespace.
 	// If no namespace is given, it returns all external services.
 	//
@@ -1060,7 +1064,8 @@ SELECT
 	process_after,
 	num_resets,
 	external_service_id,
-	num_failures
+	num_failures,
+	cancel
 FROM
 	external_service_sync_jobs
 WHERE %s
@@ -1163,6 +1168,7 @@ func scanExternalServiceSyncJob(sc dbutil.Scanner, job *types.ExternalServiceSyn
 		&job.NumResets,
 		&dbutil.NullInt64{N: &job.ExternalServiceID},
 		&job.NumFailures,
+		&job.Cancel,
 	)
 }
 
@@ -1177,6 +1183,32 @@ LIMIT 1
 
 	lastError, _, err := basestore.ScanFirstNullString(e.Query(ctx, q))
 	return lastError, err
+}
+
+func (e *externalServiceStore) CancelSyncJob(ctx context.Context, id int64) error {
+	q := sqlf.Sprintf(`
+UPDATE
+	external_service_sync_jobs
+SET
+	cancel = TRUE
+WHERE
+	id = %s
+	AND
+	state IN ('queued', 'processing')
+`, id)
+
+	res, err := e.ExecResult(ctx, q)
+	if err != nil {
+		return err
+	}
+	af, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if af != 1 {
+		return &errSyncJobNotFound{id: id}
+	}
+	return nil
 }
 
 func (e *externalServiceStore) GetLatestSyncErrors(ctx context.Context) (map[int64]string, error) {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1193,7 +1193,7 @@ UPDATE
 SET
 	cancel = TRUE,
 	-- If the sync job is still queued, we directly abort, otherwise we keep the
-	-- state, so the worker can to teardown and, at some point, mark it failed itself.
+	-- state, so the worker can do teardown and, at some point, mark it failed itself.
 	state = CASE WHEN external_service_sync_jobs.state = 'processing' THEN external_service_sync_jobs.state ELSE 'canceled' END,
 	finished_at = CASE WHEN external_service_sync_jobs.state = 'processing' THEN external_service_sync_jobs.finished_at ELSE %s END
 WHERE

--- a/internal/extsvc/pagure/client.go
+++ b/internal/extsvc/pagure/client.go
@@ -94,7 +94,7 @@ func (c *Client) ListProjects(ctx context.Context, opts ListProjectsArgs) (*List
 
 	u := url.URL{Path: "api/0/projects", RawQuery: qs.Encode()}
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -222,6 +222,11 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 		// Admins normally add to end of lists, so end of list most likely has new repos
 		// => stream them first.
 		for i := len(s.config.Repos) - 1; i >= 0; i-- {
+			if err := ctx.Err(); err != nil {
+				ch <- batch{err: err}
+				break
+			}
+
 			name := s.config.Repos[i]
 			ps := strings.SplitN(name, "/", 2)
 			if len(ps) != 2 {

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -485,6 +485,7 @@ func (s *GitHubSource) paginate(ctx context.Context, results chan *githubResult,
 		}
 
 		if hasNext && cost > 0 {
+			// 0-duration sleep unless nearing rate limit exhaustion, or return if context has been canceled.
 			select {
 			case <-ctx.Done():
 				results <- &githubResult{err: ctx.Err()}
@@ -657,7 +658,7 @@ func (s *GitHubSource) listRepos(ctx context.Context, repos []string, results ch
 		results <- &githubResult{repo: repo}
 
 		select {
-		// 0-duration sleep unless nearing rate limit exhaustion
+		// 0-duration sleep unless nearing rate limit exhaustion, or return if context has been canceled.
 		case <-time.After(s.v3Client.RateLimitMonitor().RecommendedWaitForBackgroundOp(1)):
 		case <-ctx.Done():
 			results <- &githubResult{err: ctx.Err()}

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -1031,7 +1031,7 @@ func (s *GitHubSource) AffiliatedRepositories(ctx context.Context) ([]types.Code
 	for hasNextPage {
 		select {
 		case <-ctx.Done():
-			return nil, errors.Errorf("context canceled")
+			return nil, ctx.Err()
 		default:
 		}
 

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -82,7 +82,12 @@ func (s *GitoliteSource) ListRepos(ctx context.Context, results chan SourceResul
 	for _, r := range all {
 		repo := s.makeRepo(r)
 		if !s.excludes(r, repo) {
-			results <- SourceResult{Source: s, Repo: repo}
+			select {
+			case <-ctx.Done():
+				results <- SourceResult{Err: ctx.Err()}
+				return
+			case results <- SourceResult{Source: s, Repo: repo}:
+			}
 		}
 	}
 }

--- a/internal/repos/packages.go
+++ b/internal/repos/packages.go
@@ -56,6 +56,11 @@ func (s *PackagesSource) ListRepos(ctx context.Context, results chan SourceResul
 	handledPackages := make(map[reposource.PackageName]struct{})
 
 	for _, dep := range deps {
+		if err := ctx.Err(); err != nil {
+			results <- SourceResult{Source: s, Err: err}
+			return
+		}
+
 		if _, ok := handledPackages[dep.PackageSyntax()]; !ok {
 			_, err := getPackage(ctx, s.src, dep.PackageSyntax())
 			if err != nil {

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -47,6 +47,11 @@ func newPerforceSource(svc *types.ExternalService, c *schema.PerforceConnection)
 // configured in Sourcegraph via the external services configuration.
 func (s PerforceSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	for _, depot := range s.config.Depots {
+		// Tiny optimization: exit early if context has been canceled.
+		if err := ctx.Err(); err != nil {
+			results <- SourceResult{Source: s, Err: err}
+		}
+
 		results <- SourceResult{Source: s, Repo: s.makeRepo(depot)}
 	}
 }

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -50,6 +50,7 @@ func (s PerforceSource) ListRepos(ctx context.Context, results chan SourceResult
 		// Tiny optimization: exit early if context has been canceled.
 		if err := ctx.Err(); err != nil {
 			results <- SourceResult{Source: s, Err: err}
+			return
 		}
 
 		results <- SourceResult{Source: s, Repo: s.makeRepo(depot)}

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -70,6 +70,7 @@ func NewSyncWorker(ctx context.Context, logger log.Logger, dbHandle basestore.Tr
 		Name:              "repo_sync_worker",
 		NumHandlers:       opts.NumHandlers,
 		Interval:          opts.WorkerInterval,
+		CancelInterval:    5 * time.Second,
 		HeartbeatInterval: 15 * time.Second,
 		Metrics:           newWorkerMetrics(opts.PrometheusRegisterer),
 	})

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/repos/webhookworker"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -106,7 +107,7 @@ func (s *Syncer) Run(ctx context.Context, store Store, opts RunOptions) error {
 				s.Logger.Error("enqueuing sync jobs", log.Error(err))
 			}
 		}
-		sleep(ctx, opts.EnqueueInterval())
+		timeutil.SleepWithContext(ctx, opts.EnqueueInterval())
 	}
 
 	return ctx.Err()
@@ -125,14 +126,6 @@ func (s *syncHandler) Handle(ctx context.Context, logger log.Logger, record work
 	}
 
 	return s.syncer.SyncExternalService(ctx, sj.ExternalServiceID, s.minSyncInterval())
-}
-
-// sleep is a context aware time.Sleep
-func sleep(ctx context.Context, d time.Duration) {
-	select {
-	case <-ctx.Done():
-	case <-time.After(d):
-	}
 }
 
 // TriggerExternalServiceSync will enqueue a sync job for the supplied external

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -544,8 +544,10 @@ func (s *Syncer) SyncExternalService(
 		svc.NextSyncAt = now.Add(interval)
 		svc.LastSyncAt = now
 
-		// We only want to log this error, not return it
+		// We use context.Background() here because we want this update to
+		// succeed even if the job has been canceled.
 		if err := s.Store.ExternalServiceStore().Upsert(context.Background(), svc); err != nil {
+			// We only want to log this error, not return it
 			logger.Error("upserting external service", log.Error(err))
 		}
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -123,6 +123,10 @@ func (s *syncHandler) Handle(ctx context.Context, logger log.Logger, record work
 	if !ok {
 		return errors.Errorf("expected repos.SyncJob, got %T", record)
 	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(50 * time.Second):
+	}
 
 	return s.syncer.SyncExternalService(ctx, sj.ExternalServiceID, s.minSyncInterval())
 }

--- a/internal/timeutil/sleep.go
+++ b/internal/timeutil/sleep.go
@@ -1,0 +1,21 @@
+package timeutil
+
+import (
+	"context"
+	"time"
+)
+
+// SleepWithContext is time.Sleep but context-aware. If the given context is
+// canceled, it possibly returns before d has passed. It cleans up the
+// time.After goroutine.
+func SleepWithContext(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		// See documentation for t.Stop()
+		if !t.Stop() {
+			<-t.C
+		}
+	case <-t.C:
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -597,6 +597,7 @@ type ExternalServiceSyncJob struct {
 	NumResets         int
 	ExternalServiceID int64
 	NumFailures       int
+	Cancel            bool
 }
 
 // URN returns a unique resource identifier of this external service,


### PR DESCRIPTION
This PR makes use of dbworker cancellation which we recently added as a feature to allow to cancel a running external service sync, so customers don't need to shoot down their instance in case of misconfiguration (eg when syncing the entirety of github.com).

It also contains a couple of tweaks to honor context cancellation better in the sync jobs, so that we bail out early. Worker cancellation is async, and the UI handles that with a canceling state.

<img width="1153" alt="Screenshot 2022-09-23 at 12 55 39@2x" src="https://user-images.githubusercontent.com/19534377/191946295-1d17edef-cebb-41d6-945b-f7e724a1000e.png">

## Test plan

Added tests and verified locally that cancellation indeed works. 