### PR TITLE
search: Dedup logic to strip code host from repository name

### DIFF
--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { highlightNode } from '@sourcegraph/common'
-import {codeHostSubstrLength, displayRepoName} from '@sourcegraph/shared/src/components/RepoLink'
+import { codeHostSubstrLength, displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { Icon, Link } from '@sourcegraph/wildcard'

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { highlightNode } from '@sourcegraph/common'
-import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
+import {codeHostSubstrLength, displayRepoName} from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { Icon, Link } from '@sourcegraph/wildcard'
@@ -125,11 +125,11 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     )
 
     useEffect((): void => {
-        if (repoNameElement.current && result.repositoryMatches) {
+        if (repoNameElement.current && result.repository && result.repositoryMatches) {
             for (const range of result.repositoryMatches) {
                 highlightNode(
                     repoNameElement.current as HTMLElement,
-                    range.start.column,
+                    range.start.column - codeHostSubstrLength(result.repository),
                     range.end.column - range.start.column
                 )
             }

--- a/client/shared/src/components/RepoLink.tsx
+++ b/client/shared/src/components/RepoLink.tsx
@@ -14,6 +14,18 @@ export function displayRepoName(repoName: string): string {
 }
 
 /**
+ * Returns the number of characters in the code host portion of the repository name
+ * (e.g. "github.com/sourcegraph/sourcegraph") returns 11, the length of "github.com/"
+ */
+export function codeHostSubstrLength(repoName: string): number {
+    const parts = repoName.split('/')
+    if (parts.length >= 3 && parts[0].includes('.')) {
+        return parts[0].length + 1 // add 1 to account for the trailing '/' in the code host name
+    }
+    return 0
+}
+
+/**
  * Splits the repository name into the dir and base components.
  */
 export function splitPath(path: string): [string, string] {

--- a/internal/search/job/jobutil/repos.go
+++ b/internal/search/job/jobutil/repos.go
@@ -2,7 +2,6 @@ package jobutil
 
 import (
 	"context"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/grafana/regexp"
@@ -143,29 +142,19 @@ func repoRevsToRepoMatches(repos []*search.RepositoryRevisions, repoNameRegexps 
 }
 
 func repoMatchRanges(repoName string, repoNameRegexps []*regexp.Regexp) (res []result.Range) {
-	// Remove code host from repo name (e.g. remove "github.com/")
-	// The code host is removed from the repo name before being displayed in the client (see function `displayRepoName()`)
-	// so this is needed to ensure the repo name match ranges are highlighted correctly in the client.
-	// This is not ideal, but works for now.
-	parts := strings.Split(repoName, "/")
-	if len(parts) >= 3 && strings.Contains(parts[0], ".") {
-		parts = parts[1:]
-	}
-	simplifiedRepoName := strings.Join(parts, "/")
-
 	for _, repoNameRe := range repoNameRegexps {
-		submatches := repoNameRe.FindAllStringSubmatchIndex(simplifiedRepoName, -1)
+		submatches := repoNameRe.FindAllStringSubmatchIndex(repoName, -1)
 		for _, sm := range submatches {
 			res = append(res, result.Range{
 				Start: result.Location{
 					Offset: sm[0],
 					Line:   0, // we can treat repo names as single-line
-					Column: utf8.RuneCountInString(simplifiedRepoName[:sm[0]]),
+					Column: utf8.RuneCountInString(repoName[:sm[0]]),
 				},
 				End: result.Location{
 					Offset: sm[1],
 					Line:   0,
-					Column: utf8.RuneCountInString(simplifiedRepoName[:sm[1]]),
+					Column: utf8.RuneCountInString(repoName[:sm[1]]),
 				},
 			})
 		}

--- a/internal/search/job/jobutil/repos_test.go
+++ b/internal/search/job/jobutil/repos_test.go
@@ -221,24 +221,6 @@ func TestRepoMatchRanges(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:  "strips code host from repo name before matching",
-			input: "github.com/paramore/riot/tracklist/4-misery-business/5-when-it-rains",
-			want: []result.Range{
-				{
-					Start: result.Location{
-						Offset: 26,
-						Line:   0,
-						Column: 26,
-					},
-					End: result.Location{
-						Offset: 41,
-						Line:   0,
-						Column: 41,
-					},
-				},
-			},
-		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Fixes #41476

- Add helper function `codeHostSubstrLength()` that counts the number of characters in the code host prefix portion of a repository name, e.g. "github.com/" 
- Use the return value from this function to ensure the start position passed to `highlightNode()` is still correct after the code host is removed from the text displayed in the HTML element 
- Remove duplicated code from search backend which was previously added to ensure results from backend were sending the correct ranges for repo name highlighting



## Test plan
Manually verify things work the same as they did before
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
