### PR TITLE
batches: maintain list state when deselecting a workspace

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { mdiClose } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
-import { useHistory } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
@@ -60,9 +59,9 @@ const MemoizedExecutionWorkspaces: React.FunctionComponent<
     queryBatchSpecWorkspaceStepFileDiffs,
     queryChangesetSpecFileDiffs,
 }) {
-    const history = useHistory()
+    const [isWorkspaceDetailsOpen, setIsWorkspaceDetailsOpen] = useState(false)
 
-    const deselectWorkspace = useCallback(() => history.push(batchSpec.executionURL), [batchSpec.executionURL, history])
+    const deselectWorkspace = useCallback(() => setIsWorkspaceDetailsOpen(true), [])
 
     const videoRef = useRef<HTMLVideoElement | null>(null)
     // Pause the execution animation loop when the batch spec stops executing.
@@ -80,12 +79,14 @@ const MemoizedExecutionWorkspaces: React.FunctionComponent<
                     batchSpecID={batchSpec.id}
                     selectedNode={selectedWorkspaceID}
                     executionURL={batchSpec.executionURL}
+                    isWorkspaceDetailsOpen={isWorkspaceDetailsOpen}
+                    setIsWorkspaceDetailsOpen={setIsWorkspaceDetailsOpen}
                 />
                 <Card className="w-100 overflow-auto flex-grow-1">
                     {/* This is necessary to prevent the margin collapse on `Card` */}
                     <div className="w-100">
                         <CardBody>
-                            {selectedWorkspaceID ? (
+                            {selectedWorkspaceID && !isWorkspaceDetailsOpen ? (
                                 <WorkspaceDetails
                                     id={selectedWorkspaceID}
                                     isLightTheme={isLightTheme}

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/Workspaces.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/Workspaces.story.tsx
@@ -34,7 +34,16 @@ export const WorkspacesStory: Story = () => (
     <WebStory>
         {props => (
             <MockedStoryProvider link={MOCKS}>
-                <Workspaces batchSpecID="1" selectedNode="workspace1" executionURL="" {...props} />
+                <Workspaces
+                    isWorkspaceDetailsOpen={false}
+                    setIsWorkspaceDetailsOpen={function (arg0: boolean): void {
+                        throw new Error('Function not implemented.')
+                    }}
+                    batchSpecID="1"
+                    selectedNode="workspace1"
+                    executionURL=""
+                    {...props}
+                />
             </MockedStoryProvider>
         )}
     </WebStory>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/Workspaces.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/Workspaces.tsx
@@ -15,12 +15,16 @@ export interface WorkspacesProps {
     selectedNode?: Scalars['ID']
     /** The URL path to the execution page this workspaces list is shown on. */
     executionURL: string
+    isWorkspaceDetailsOpen: boolean
+    setIsWorkspaceDetailsOpen: (arg0: boolean) => void
 }
 
 export const Workspaces: React.FunctionComponent<React.PropsWithChildren<WorkspacesProps>> = ({
     batchSpecID,
     selectedNode,
     executionURL,
+    isWorkspaceDetailsOpen,
+    setIsWorkspaceDetailsOpen,
 }) => {
     const [filters, setFilters] = useState<WorkspaceFilters>()
     const workspacesConnection = useWorkspacesListConnection(
@@ -38,6 +42,8 @@ export const Workspaces: React.FunctionComponent<React.PropsWithChildren<Workspa
                     workspacesConnection={workspacesConnection}
                     selectedNode={selectedNode}
                     executionURL={executionURL}
+                    isWorkspaceDetailsOpen={isWorkspaceDetailsOpen}
+                    setIsWorkspaceDetailsOpen={setIsWorkspaceDetailsOpen}
                 />
             </div>
         </div>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { useHistory } from 'react-router'
 
@@ -26,14 +26,27 @@ export interface WorkspacesListProps {
     selectedNode?: Scalars['ID']
     /** The URL path to the execution page this workspaces list is shown on. */
     executionURL: string
+    isWorkspaceDetailsOpen: boolean
+    setIsWorkspaceDetailsOpen: (state: boolean) => void
 }
 
 export const WorkspacesList: React.FunctionComponent<React.PropsWithChildren<WorkspacesListProps>> = ({
     workspacesConnection: { connection, error, loading, hasNextPage, fetchMore },
     selectedNode,
     executionURL,
+    isWorkspaceDetailsOpen,
+    setIsWorkspaceDetailsOpen,
 }) => {
     const history = useHistory()
+    const onSelected = useCallback(
+        (nodeId: string) => {
+            if (isWorkspaceDetailsOpen) {
+                setIsWorkspaceDetailsOpen(false)
+            }
+            history.push(`${executionURL}/execution/workspaces/${nodeId}`)
+        },
+        [isWorkspaceDetailsOpen, history, executionURL, setIsWorkspaceDetailsOpen]
+    )
 
     return (
         <ConnectionContainer>
@@ -44,7 +57,7 @@ export const WorkspacesList: React.FunctionComponent<React.PropsWithChildren<Wor
                         key={node.id}
                         workspace={node}
                         isSelected={node.id === selectedNode}
-                        onSelect={() => history.push(`${executionURL}/execution/workspaces/${node.id}`)}
+                        onSelect={() => onSelected(node.id)}
                     />
                 ))}
             </ConnectionList>


### PR DESCRIPTION
Closes #40520

Now when you deselect a workspace instead of re routing and losing params it will return to the default select workspace prompt and image

## Test plan
tested selecting and deselecting workspaces, as well as changing filter options

## App preview:

- [Web](https://sg-web-aa-maintain-workspace-state.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sttrudxtee.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
