### PR TITLE
search: Clean up description matching code

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -455,22 +455,12 @@ func fromRepository(rm *result.RepoMatch, repoCache map[api.RepoID]*types.Search
 	}
 
 	repoEvent := &streamhttp.EventRepoMatch{
-		Type:              streamhttp.RepoMatchType,
-		RepositoryID:      int32(rm.ID),
-		Repository:        string(rm.Name),
-		RepositoryMatches: fromRanges(rm.RepoNameMatches),
-		Branches:          branches,
-	}
-
-	if len(rm.DescriptionMatches) > 0 {
-		dms := make([]streamhttp.Range, 0, len(rm.DescriptionMatches))
-		for _, matchRange := range rm.DescriptionMatches {
-			dms = append(dms, streamhttp.Range{
-				Start: fromLocation(matchRange.Start),
-				End:   fromLocation(matchRange.End),
-			})
-		}
-		repoEvent.DescriptionMatches = dms
+		Type:               streamhttp.RepoMatchType,
+		RepositoryID:       int32(rm.ID),
+		Repository:         string(rm.Name),
+		RepositoryMatches:  fromRanges(rm.RepoNameMatches),
+		Branches:           branches,
+		DescriptionMatches: fromRanges(rm.DescriptionMatches),
 	}
 
 	if r, ok := repoCache[rm.ID]; ok {

--- a/internal/search/job/jobutil/repos.go
+++ b/internal/search/job/jobutil/repos.go
@@ -84,12 +84,12 @@ func (s *RepoSearchJob) descriptionMatchRanges(repoDescriptions map[api.RepoID]s
 					Start: result.Location{
 						Offset: sm[0],
 						Line:   0,
-						Column: utf8.RuneCount([]byte(repoDescription[:sm[0]])),
+						Column: utf8.RuneCountInString(repoDescription[:sm[0]]),
 					},
 					End: result.Location{
 						Offset: sm[1],
 						Line:   0,
-						Column: utf8.RuneCount([]byte(repoDescription[:sm[1]])),
+						Column: utf8.RuneCountInString(repoDescription[:sm[1]]),
 					},
 				})
 			}


### PR DESCRIPTION
Use `utf8.RuneCountInString()` to avoid extra allocation. Use helper method `fromRanges()` in `frontend` to populate event struct field `DescriptionMatches`.



## Test plan
Semantics-preserving
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
