### PR TITLE
Revert "search: Restructure "sync query from URL" logic (#41459)"

### DIFF
--- a/client/web/src/Layout.test.tsx
+++ b/client/web/src/Layout.test.tsx
@@ -1,0 +1,133 @@
+import { render } from '@testing-library/react'
+import { createBrowserHistory } from 'history'
+import { BrowserRouter } from 'react-router-dom'
+import { CompatRouter } from 'react-router-dom-v5-compat'
+import { NEVER } from 'rxjs'
+
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import { extensionsController } from '@sourcegraph/shared/src/testing/searchTestHelpers'
+
+import { SearchPatternType } from './graphql-operations'
+import { Layout, LayoutProps } from './Layout'
+import { useNavbarQueryState } from './stores'
+
+jest.mock('./theme', () => ({
+    useThemeProps: () => ({
+        isLightTheme: true,
+        themePreference: 'system',
+        onThemePreferenceChange: () => {},
+    }),
+}))
+
+describe('Layout', () => {
+    const defaultProps: LayoutProps = ({
+        // Parsed query components
+        patternType: SearchPatternType.standard,
+        setPatternType: () => {},
+        caseSensitive: false,
+        setCaseSensitivity: () => {},
+
+        // Other minimum props required to render
+        routes: [],
+        navbarSearchQueryState: { query: '' },
+        onNavbarQueryChange: () => {},
+        settingsCascade: {
+            subjects: null,
+            final: null,
+        },
+        keyboardShortcuts: [],
+        extensionsController,
+        platformContext: { settings: NEVER },
+    } as unknown) as LayoutProps
+
+    const origContext = window.context
+    beforeEach(() => {
+        const root = document.createElement('div')
+        root.id = 'root'
+        document.body.append(root)
+        window.context = {
+            enableLegacyExtensions: true,
+        } as any
+    })
+
+    afterEach(() => {
+        document.querySelector('#root')?.remove()
+        window.context = origContext
+    })
+
+    it('should update patternType if different between URL and context', () => {
+        const history = createBrowserHistory()
+        history.replace({ search: 'q=r:golang/oauth2+test+f:travis&patternType=regexp' })
+
+        useNavbarQueryState.setState({ searchPatternType: SearchPatternType.standard })
+
+        render(
+            <MockedTestProvider>
+                <BrowserRouter>
+                    <CompatRouter>
+                        <Layout {...defaultProps} history={history} location={history.location} />
+                    </CompatRouter>
+                </BrowserRouter>
+            </MockedTestProvider>
+        )
+
+        expect(useNavbarQueryState.getState().searchPatternType).toBe(SearchPatternType.regexp)
+    })
+
+    it('should not update patternType if query is empty', () => {
+        const history = createBrowserHistory()
+        history.replace({ search: 'q=&patternType=regexp' })
+
+        useNavbarQueryState.setState({ searchPatternType: SearchPatternType.standard })
+
+        render(
+            <MockedTestProvider>
+                <BrowserRouter>
+                    <CompatRouter>
+                        <Layout {...defaultProps} history={history} location={history.location} />
+                    </CompatRouter>
+                </BrowserRouter>
+            </MockedTestProvider>
+        )
+
+        expect(useNavbarQueryState.getState().searchPatternType).toBe(SearchPatternType.standard)
+    })
+
+    it('should update caseSensitive if different between URL and context', () => {
+        const history = createBrowserHistory()
+        history.replace({ search: 'q=r:golang/oauth2+test+f:travis case:yes' })
+
+        useNavbarQueryState.setState({ searchCaseSensitivity: false })
+
+        render(
+            <MockedTestProvider>
+                <BrowserRouter>
+                    <CompatRouter>
+                        <Layout {...defaultProps} history={history} location={history.location} />
+                    </CompatRouter>
+                </BrowserRouter>
+            </MockedTestProvider>
+        )
+
+        expect(useNavbarQueryState.getState().searchCaseSensitivity).toBe(true)
+    })
+
+    it('should not update caseSensitive if query is empty', () => {
+        const history = createBrowserHistory()
+        history.replace({ search: 'q=case:yes' })
+
+        useNavbarQueryState.setState({ searchCaseSensitivity: false })
+
+        render(
+            <MockedTestProvider>
+                <BrowserRouter>
+                    <CompatRouter>
+                        <Layout {...defaultProps} history={history} location={history.location} />
+                    </CompatRouter>
+                </BrowserRouter>
+            </MockedTestProvider>
+        )
+
+        expect(useNavbarQueryState.getState().searchCaseSensitivity).toBe(false)
+    })
+})

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useEffect, useState } from 'react'
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Shortcut } from '@slimsag/react-shortcuts'
 import classNames from 'classnames'
@@ -15,6 +15,7 @@ import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/u
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
+import { getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -51,10 +52,11 @@ import { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
 import { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
 import { LayoutRouteProps, LayoutRouteComponentProps } from './routes'
 import { PageRoutes, EnterprisePageRoutes } from './routes.constants'
-import { parseSearchURLQuery, HomePanelsProps, SearchStreamingProps } from './search'
+import { parseSearchURLQuery, HomePanelsProps, SearchStreamingProps, parseSearchURL } from './search'
 import { NotepadContainer } from './search/Notepad'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
+import { setQueryStateFromURL } from './stores'
 import { useThemeProps } from './theme'
 import { UserAreaRoute } from './user/area/UserArea'
 import { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
@@ -146,6 +148,24 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
             setIsFuzzyFinderVisible(false)
         }
     }, [isRepositoryRelatedPage, isFuzzyFinderVisible])
+
+    // Update patternType, caseSensitivity, and selectedSearchContextSpec based on current URL
+    const { history, selectedSearchContextSpec, location, setSelectedSearchContextSpec } = props
+
+    useEffect(() => setQueryStateFromURL(location.search), [location.search])
+
+    const { query = '' } = useMemo(() => parseSearchURL(location.search), [location.search])
+
+    const searchContextSpec = useMemo(() => getGlobalSearchContextFilter(query)?.spec, [query])
+
+    useEffect(() => {
+        // Only override filters from URL if there is a search query
+        if (query) {
+            if (searchContextSpec && searchContextSpec !== selectedSearchContextSpec) {
+                setSelectedSearchContextSpec(searchContextSpec)
+            }
+        }
+    }, [history, selectedSearchContextSpec, query, setSelectedSearchContextSpec, searchContextSpec])
 
     const communitySearchContextPaths = communitySearchContextsRoutes.map(route => route.path)
     const isCommunitySearchContextPage = communitySearchContextPaths.includes(props.location.pathname)

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -10,7 +10,7 @@ import { Route, Router } from 'react-router'
 import { CompatRouter } from 'react-router-dom-v5-compat'
 import { ScrollManager } from 'react-scroll-manager'
 import { combineLatest, from, Subscription, fromEvent, of, Subject, Observable } from 'rxjs'
-import { distinctUntilChanged, first, map, startWith, switchMap } from 'rxjs/operators'
+import { distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
 import * as uuid from 'uuid'
 
 import { GraphQLClient, HTTPStatusError } from '@sourcegraph/http-client'
@@ -77,20 +77,18 @@ import { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
 import { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
 import { LayoutRouteProps } from './routes'
 import { PageRoutes } from './routes.constants'
-import { parseSearchURL, getQueryStateFromLocation } from './search'
+import { parseSearchURL } from './search'
 import { SearchResultsCacheProvider } from './search/results/SearchResultsCacheProvider'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import { CodeHostScopeProvider } from './site/CodeHostScopeAlerts/CodeHostScopeProvider'
 import {
     setQueryStateFromSettings,
+    setQueryStateFromURL,
     setExperimentalFeaturesFromSettings,
     getExperimentalFeatures,
     useNavbarQueryState,
-    observeStore,
-    useExperimentalFeatures,
 } from './stores'
-import { setQueryStateFromURL } from './stores/navbarSearchQueryState'
 import { eventLogger } from './tracking/eventLogger'
 import { withActivation } from './tracking/withActivation'
 import { UserAreaRoute } from './user/area/UserArea'
@@ -215,6 +213,8 @@ export class SourcegraphWebApp extends React.Component<
             )
         }
 
+        setQueryStateFromURL(window.location.search)
+
         this.state = {
             settingsCascade: EMPTY_SETTINGS_CASCADE,
             viewerSubject: siteSubjectNoAdmin(),
@@ -299,37 +299,6 @@ export class SourcegraphWebApp extends React.Component<
         this.setWorkspaceSearchContext(this.state.selectedSearchContextSpec).catch(error => {
             console.error('Error sending search context to extensions!', error)
         })
-
-        // Update search query state whenever the URL changes
-        this.subscriptions.add(
-            getQueryStateFromLocation({
-                location: observeLocation(history).pipe(startWith(history.location)),
-                showSearchContext: observeStore(useExperimentalFeatures).pipe(
-                    // We use true here because search contexts are enabled by
-                    // default
-                    map(([features]) => features.showSearchContext ?? true),
-                    startWith(true),
-                    distinctUntilChanged()
-                ),
-                isSearchContextAvailable: (searchContext: string) =>
-                    this.props.searchContextsEnabled
-                        ? isSearchContextSpecAvailable({ spec: searchContext, platformContext: this.platformContext })
-                              .pipe(first())
-                              .toPromise()
-                        : Promise.resolve(false),
-            }).subscribe(({ parsedSearchURL, searchContextSpec, processedQuery }) => {
-                // Only override filters from URL if there is a search query
-                if (
-                    parsedSearchURL.query &&
-                    searchContextSpec &&
-                    searchContextSpec !== this.state.selectedSearchContextSpec
-                ) {
-                    this.setSelectedSearchContextSpec(searchContextSpec)
-                }
-
-                setQueryStateFromURL(parsedSearchURL, processedQuery)
-            })
-        )
 
         this.userRepositoriesUpdates.next()
     }

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -6,19 +6,31 @@ import BarChartIcon from 'mdi-react/BarChartIcon'
 import BookOutlineIcon from 'mdi-react/BookOutlineIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import PuzzleOutlineIcon from 'mdi-react/PuzzleOutlineIcon'
+import { of } from 'rxjs'
+import { startWith } from 'rxjs/operators'
 
 import { ContributableMenu } from '@sourcegraph/client-api'
 import { isErrorLike } from '@sourcegraph/common'
-import { SearchContextInputProps } from '@sourcegraph/search'
+import { SearchContextInputProps, isSearchContextSpecAvailable } from '@sourcegraph/search'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
+import { getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
+import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { buildGetStartedURL } from '@sourcegraph/shared/src/util/url'
-import { Button, Link, FeedbackPrompt, ButtonLink, PopoverTrigger, useWindowSize } from '@sourcegraph/wildcard'
+import {
+    useObservable,
+    Button,
+    Link,
+    FeedbackPrompt,
+    ButtonLink,
+    PopoverTrigger,
+    useWindowSize,
+} from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { BatchChangesProps } from '../batches'
@@ -152,6 +164,27 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
     // Workaround: can't put this in optional parameter value because of https://github.com/babel/babel/issues/11166
     branding = branding ?? window.context?.branding
 
+    const query = useNavbarQueryState(state => state.searchQueryFromURL)
+
+    const globalSearchContextSpec = useMemo(() => getGlobalSearchContextFilter(query), [query])
+
+    const isSearchContextAvailable = useObservable(
+        useMemo(
+            () =>
+                globalSearchContextSpec && searchContextsEnabled
+                    ? // While we wait for the result of the `isSearchContextSpecAvailable` call, we assume the context is available
+                      // to prevent flashing and moving content in the query bar. This optimizes for the most common use case where
+                      // user selects a search context from the dropdown.
+                      // See https://github.com/sourcegraph/sourcegraph/issues/19918 for more info.
+                      isSearchContextSpecAvailable({
+                          spec: globalSearchContextSpec.spec,
+                          platformContext: props.platformContext,
+                      }).pipe(startWith(true))
+                    : of(false),
+            [globalSearchContextSpec, searchContextsEnabled, props.platformContext]
+        )
+    )
+
     const routeMatch = useRoutesMatch(props.routes)
     const { handleSubmitFeedback } = useHandleSubmitFeedback({
         routeMatch,
@@ -170,7 +203,27 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
             onNavbarQueryChange({ query: '' })
             return
         }
-    }, [showSearchBox, onNavbarQueryChange])
+        // Do nothing if there is no query in the URL
+        if (!query) {
+            return
+        }
+
+        // If a global search context spec is available to the user, we omit it from the
+        // query and move it to the search contexts dropdown
+        const finalQuery =
+            globalSearchContextSpec && isSearchContextAvailable && showSearchContext
+                ? omitFilter(query, globalSearchContextSpec.filter)
+                : query
+
+        onNavbarQueryChange({ query: finalQuery })
+    }, [
+        showSearchBox,
+        onNavbarQueryChange,
+        query,
+        globalSearchContextSpec,
+        isSearchContextAvailable,
+        showSearchContext,
+    ])
 
     const navbarReference = useRef<HTMLDivElement | null>(null)
     const navLinkVariant = useCalculatedNavLinkVariant(navbarReference, props.activation, props.authenticatedUser)

--- a/client/web/src/search/index.test.tsx
+++ b/client/web/src/search/index.test.tsx
@@ -1,13 +1,6 @@
-import { createBrowserHistory, History, Location } from 'history'
-import { of, Subscription, Observable } from 'rxjs'
-import { first, startWith, tap, last } from 'rxjs/operators'
-
-import { resetAllMemoizationCaches } from '@sourcegraph/common'
-
 import { SearchPatternType } from '../graphql-operations'
-import { observeLocation } from '../util/location'
 
-import { parseSearchURL, repoFilterForRepoRevision, getQueryStateFromLocation } from '.'
+import { parseSearchURL, repoFilterForRepoRevision } from '.'
 
 expect.addSnapshotSerializer({
     serialize: value => JSON.stringify(value),
@@ -150,99 +143,5 @@ describe('repoFilterForRepoRevision escapes values with spaces', () => {
         expect(repoFilterForRepoRevision('7 is my final answer', false)).toMatchInlineSnapshot(
             '"^7\\\\ is\\\\ my\\\\ final\\\\ answer$"'
         )
-    })
-})
-
-describe('updateQueryStateFromURL', () => {
-    let subscription: Subscription
-
-    beforeEach(() => {
-        subscription = new Subscription()
-    })
-
-    afterEach(() => {
-        subscription.unsubscribe()
-        // Ugly implementation detail
-        resetAllMemoizationCaches()
-    })
-
-    function createHistoryObservable(search: string): [Observable<Location>, History] {
-        const history = createBrowserHistory()
-        history.replace({ search })
-
-        return [observeLocation(history).pipe(startWith(history.location)), history]
-    }
-
-    const isSearchContextAvailable = () => Promise.resolve(true)
-    const showSearchContext = of(false)
-
-    describe('search context', () => {
-        it('should extract the search context from the query', () => {
-            const [location] = createHistoryObservable('q=context:me+test')
-
-            return getQueryStateFromLocation({
-                location: location.pipe(first()),
-                isSearchContextAvailable,
-                showSearchContext,
-            })
-                .pipe(
-                    last(),
-                    tap(({ searchContextSpec }) => {
-                        expect(searchContextSpec).toEqual('me')
-                    })
-                )
-                .toPromise()
-        })
-
-        it('remove the context filter from the URL if search contexts are enabled and available', () => {
-            const [location] = createHistoryObservable('q=context:me+test')
-
-            return getQueryStateFromLocation({
-                location: location.pipe(first()),
-                isSearchContextAvailable: () => Promise.resolve(true),
-                showSearchContext: of(true),
-            })
-                .pipe(
-                    last(),
-                    tap(({ processedQuery }) => {
-                        expect(processedQuery).toBe('test')
-                    })
-                )
-                .toPromise()
-        })
-
-        it('should not remove the context filter from the URL if search context is not available', () => {
-            const [location] = createHistoryObservable('q=context:me+test')
-
-            return getQueryStateFromLocation({
-                location: location.pipe(first()),
-                showSearchContext: of(true),
-                isSearchContextAvailable: () => Promise.resolve(false),
-            })
-                .pipe(
-                    last(),
-                    tap(({ processedQuery }) => {
-                        expect(processedQuery).toBe('context:me test')
-                    })
-                )
-                .toPromise()
-        })
-
-        it('should not remove the context filter from the URL if search contexts are disabled', () => {
-            const [location] = createHistoryObservable('q=context:me+test')
-
-            return getQueryStateFromLocation({
-                location: location.pipe(first()),
-                showSearchContext: of(false),
-                isSearchContextAvailable: () => Promise.resolve(true),
-            })
-                .pipe(
-                    last(),
-                    tap(({ processedQuery }) => {
-                        expect(processedQuery).toBe('context:me test')
-                    })
-                )
-                .toPromise()
-        })
     })
 })

--- a/client/web/src/stores/index.ts
+++ b/client/web/src/stores/index.ts
@@ -9,11 +9,9 @@
  * everything that should be in here is already in here.
  */
 
-import { Observable } from 'rxjs'
-import { UseBoundStore } from 'zustand'
-
 export {
     useNavbarQueryState,
+    setQueryStateFromURL,
     setQueryStateFromSettings,
     setSearchPatternType,
     setSearchCaseSensitivity,
@@ -25,14 +23,3 @@ export {
     setExperimentalFeaturesFromSettings,
 } from './experimentalFeatures'
 export { useNotepadState, useNotepad } from './notepad'
-
-/**
- * observeStore converts a zustand store to an observable. The observable emits
- * the same values as the store's subscribe method, i.e. the current and the
- * previous state.
- */
-export function observeStore<T extends object>(store: UseBoundStore<T>): Observable<[T, T]> {
-    return new Observable(subscription =>
-        store.subscribe((current, previous) => subscription.next([current, previous]))
-    )
-}

--- a/client/web/src/stores/navbarSearchQueryState.test.ts
+++ b/client/web/src/stores/navbarSearchQueryState.test.ts
@@ -1,7 +1,5 @@
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 
-import { parseSearchURL } from '../search'
-
 import { setQueryStateFromSettings, setQueryStateFromURL, useNavbarQueryState } from './navbarSearchQueryState'
 
 describe('navbar query state', () => {
@@ -30,54 +28,28 @@ describe('navbar query state', () => {
     })
 
     describe('set state from URL', () => {
-        it('sets the query from URL', () => {
-            setQueryStateFromURL(parseSearchURL('q=test'))
-
-            expect(useNavbarQueryState.getState().queryState).toHaveProperty('query', 'test')
-        })
-
-        it('prefers query parameter over parsed query', () => {
-            setQueryStateFromURL(parseSearchURL('q=test'), 'testparameter')
-
-            expect(useNavbarQueryState.getState().queryState).toHaveProperty('query', 'testparameter')
-        })
-
-        it('sets the search pattern from URL parameter', () => {
-            setQueryStateFromURL(parseSearchURL('q=context:global+&patternType=regexp'))
+        it('sets the search pattern from URL parementer', () => {
+            setQueryStateFromURL('q=context:global+&patternType=regexp')
 
             expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
         })
 
         it('sets the search pattern from filter', () => {
-            setQueryStateFromURL(parseSearchURL('q=context:global+patterntype:regexp'))
+            setQueryStateFromURL('q=context:global+&patternType=regexp')
 
             expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
         })
 
-        it('should not set patternType if query is empty', () => {
-            useNavbarQueryState.setState({ searchPatternType: SearchPatternType.standard })
-            setQueryStateFromURL(parseSearchURL('q=patterntype:regexp'))
-
-            expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.standard)
-        })
-
         it('sets case sensitivity from filter', () => {
-            setQueryStateFromURL(parseSearchURL('q=context:global+case:yes'))
+            setQueryStateFromURL('q=context:global+case:yes')
 
             expect(useNavbarQueryState.getState()).toHaveProperty('searchCaseSensitivity', true)
         })
 
-        it('sets case sensitivity from URL parameter', () => {
-            setQueryStateFromURL(parseSearchURL('q=context:global+&case=yes'))
+        it('sets case sensitivity from URL paramster', () => {
+            setQueryStateFromURL('q=context:global+&case=yes')
 
             expect(useNavbarQueryState.getState()).toHaveProperty('searchCaseSensitivity', true)
-        })
-
-        it('should not update caseSensitive from filter if query is empty', () => {
-            useNavbarQueryState.setState({ searchCaseSensitivity: false })
-            setQueryStateFromURL(parseSearchURL('q=case:yes'))
-
-            expect(useNavbarQueryState.getState().searchCaseSensitivity).toBe(false)
         })
     })
 
@@ -92,13 +64,12 @@ describe('navbar query state', () => {
                     'search.defaultPatternType': SearchPatternType.structural,
                 },
             })
-            setQueryStateFromURL(parseSearchURL('q=context:global+&patternType=regexp'))
+            setQueryStateFromURL('q=context:global+&patternType=regexp')
 
             expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
         })
-
         it('prefers user settings over settings from empty URL', () => {
-            setQueryStateFromURL(parseSearchURL(''))
+            setQueryStateFromURL('')
             setQueryStateFromSettings({
                 subjects: [],
                 final: {
@@ -110,7 +81,7 @@ describe('navbar query state', () => {
         })
 
         it('does not prefer user settings over settings from URL', () => {
-            setQueryStateFromURL(parseSearchURL('q=context:global+&patternType=regexp'))
+            setQueryStateFromURL('q=context:global+&patternType=regexp')
             setQueryStateFromSettings({
                 subjects: [],
                 final: {

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -16,7 +16,7 @@ import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { Settings, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 
-import { ParsedSearchURL } from '../search'
+import { parseSearchURL } from '../search'
 import { submitSearch } from '../search/helpers'
 import { defaultCaseSensitiveFromSettings, defaultPatternTypeFromSettings } from '../util/settings'
 
@@ -59,13 +59,9 @@ export function setSearchCaseSensitivity(searchCaseSensitivity: boolean): void {
 }
 
 /**
- * Update or initialize query state related data from URL search parameters.
- *
- * @param parsedSearchURL contains the information extracted from a URL
- * @param query can be used to specify the query to use when it differs from
- * the one contained in the URL (e.g. when the context:... filter got removed)
+ * Update or initialize query state related data from URL search parameters
  */
-export function setQueryStateFromURL(parsedSearchURL: ParsedSearchURL, query = parsedSearchURL.query ?? ''): void {
+export function setQueryStateFromURL(urlParameters: string): void {
     if (useNavbarQueryState.getState().parametersSource > InitialParametersSource.URL) {
         return
     }
@@ -74,11 +70,11 @@ export function setQueryStateFromURL(parsedSearchURL: ParsedSearchURL, query = p
     const newState: Partial<
         Pick<
             NavbarQueryState,
-            'queryState' | 'searchPatternType' | 'searchCaseSensitivity' | 'searchQueryFromURL' | 'parametersSource'
+            'searchPatternType' | 'searchCaseSensitivity' | 'searchQueryFromURL' | 'parametersSource'
         >
-    > = {
-        queryState: { query },
-    }
+    > = {}
+
+    const parsedSearchURL = parseSearchURL(urlParameters)
 
     if (parsedSearchURL.query) {
         // Only update flags if the URL contains a search query.


### PR DESCRIPTION
This reverts commit 5d198e4a02b95db9810852fd3034e0d3de6140cc.

https://buildkite.com/sourcegraph/sourcegraph/builds/172011#01831de0-4b87-4c49-80ce-41f18e76f484

Fixes broken e2e tests cc @fkling 

## Test plan

Green tests on CI