### PR TITLE
Performance: Reduce layout shift on blob page

### DIFF
--- a/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.module.scss
+++ b/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.module.scss
@@ -4,16 +4,18 @@
 
 .braindot {
     position: relative;
+    margin-right: 0.625rem;
+    padding: 0.25rem;
 }
 
 .braindot::after {
     content: '';
     position: absolute;
     bottom: 0.2rem;
-    right: 0.25rem;
+    right: -0.25rem;
     border-radius: 1rem;
-    width: 0.75rem;
-    height: 0.75rem;
+    width: 0.65rem;
+    height: 0.65rem;
     border: 2px solid var(--body-bg);
 }
 


### PR DESCRIPTION
## Description

When testing some of our improved performance changes, I noticed that we have a layout shift when the code intelligence "brain" badge loads. The badge is a little too big compared to the other icons, so it pushes everything downwards once it loads.

This PR makes some minor UI changes so that it is aligned with the rest of the badges, and does not cause a layout shift

| BEFORE             |  AFTER |
:-------------------------:|:-------------------------:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/9516420/189181879-7505259d-23b4-4b96-86dd-f477aeb11502.png"> | <img width="372" alt="image" src="https://user-images.githubusercontent.com/9516420/189181684-7c23ae5e-fc81-4ed2-9640-9812af1af869.png">

## Test plan

Tested locally for error badges, success badges and no status

## App preview:

- [Web](https://sg-web-tr-perf-badge-layout-shift.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-utcgpzgnvs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
