### PR TITLE
search ui: tweak text color of highlighted terms in search result header

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -151,6 +151,7 @@ $theme-colors: (
     --mark-bg: #f8e688;
     --merged-4: #eee9fd;
     --text-muted: var(--gray-07);
+    --text-muted-highlighted: #566880; // --text-muted with higher contrast when shown on a --mark-bg background
     --link-color: var(--primary);
     --link-color-2: #0766cc;
     --link-active-color: #0c7bf0;
@@ -246,6 +247,7 @@ $theme-colors: (
     --mark-bg: #7a341e;
     --merged-4: #1f0a5c;
     --text-muted: var(--gray-06);
+    --text-muted-highlighted: #a9b9da; // --text-muted with higher contrast when shown on a --mark-bg background
     --link-color: #4393e7;
     --link-color-2: #70b0f3;
     --link-active-color: #489ffa;

--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -200,10 +200,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
                         ? `${props.repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
                         : undefined
                 }
-                className={classNames(
-                    styles.titleInner,
-                    coreWorkflowImprovementsEnabled && result.type !== 'path' && styles.mutedRepoFileLink
-                )}
+                className={classNames(styles.titleInner, coreWorkflowImprovementsEnabled && styles.mutedRepoFileLink)}
             />
         ),
         allExpanded: props.allExpanded,

--- a/client/search-ui/src/components/ResultContainer.module.scss
+++ b/client/search-ui/src/components/ResultContainer.module.scss
@@ -53,6 +53,10 @@
     &-description {
         line-height: (14/11);
     }
+
+    :global(.match-highlight) {
+        color: var(--text-muted-highlighted);
+    }
 }
 
 .toggle-matches-container {


### PR DESCRIPTION
Closes #41378

Tweaks the text color of highlighted terms in the search result header to meet contrast requirements, based on [this Figma](https://www.figma.com/file/DmIlwMDNaJ5TBa6FYnR6WK/Search-match-highlight-background-color-has-insufficient-text-contrast?node-id=2%3A24).

Also makes all result types have the same gray link color (previously path results only had a blue link color).

## Test plan

Verify both dark and light mode of highlighted items in the search result header passes WCAG 2.1 AA contrast requirements.
![image](https://user-images.githubusercontent.com/206864/189187136-b0280dc0-f878-44a5-ae7f-00f6dd162687.png)
![image](https://user-images.githubusercontent.com/206864/189187208-3f364022-d357-48c9-8ae6-24036b0ccd6c.png)


## Screenshots

| | Light mode | Dark Mode |
|-|-|-|
| Repo result | ![image](https://user-images.githubusercontent.com/206864/189186451-bd4f3602-6f53-4255-a5f9-1215062fc835.png) | ![image](https://user-images.githubusercontent.com/206864/189186520-aceb5231-8fac-49b8-8a98-58131d3808b8.png) |
| Path result | ![image](https://user-images.githubusercontent.com/206864/189186671-bc8e4276-fbf4-4613-8648-b550c34e72ca.png) | ![image](https://user-images.githubusercontent.com/206864/189186634-66e5faf8-46a1-4111-a4db-08f34b9ac98d.png) |
| Content result | ![image](https://user-images.githubusercontent.com/206864/189186852-0a928b27-763b-4a62-93b3-a56742c282c3.png) | ![image](https://user-images.githubusercontent.com/206864/189186919-8ab30bcf-f455-4a21-925d-96d8f912d4b7.png) |



## App preview:

- [Web](https://sg-web-jp-resulthighlightcolor.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wsoxmfubws.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
