### PR TITLE
Aggregation: Add bar index ping field

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1458,6 +1458,7 @@ type GroupResultPing struct {
 	AggregationMode *string
 	UIMode          *string
 	Count           *int32
+	BarIndex        *int32
 }
 
 type GroupResultExpandedViewPing struct {

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -400,6 +400,7 @@ func GetGroupResultsPing(ctx context.Context, db database.DB, pingName string) (
 			&groupResultsPing.Count,
 			&groupResultsPing.AggregationMode,
 			&groupResultsPing.UIMode,
+			&groupResultsPing.BarIndex,
 		); err != nil {
 			return nil, err
 		}
@@ -545,7 +546,7 @@ GROUP BY argument;
 `
 
 const getGroupResultsSql = `
-SELECT COUNT(*), argument::json->>'aggregationMode' as aggregationMode, argument::json->>'uiMode' as uiMode FROM event_logs
+SELECT COUNT(*), argument::json->>'aggregationMode' as aggregationMode, argument::json->>'uiMode' as uiMode, argument::json->>'index' as bar_index FROM event_logs
 WHERE name = $1::TEXT AND timestamp > DATE_TRUNC('week', $2::TIMESTAMP)
 GROUP BY argument;
 `


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/41510
Big query PR https://github.com/sourcegraph/analytics/pull/618

## Test plan
- Make sure that [`usagestats/code_insights.go`](https://github.com/sourcegraph/sourcegraph/compare/leo/bar-index-ping?expand=1#diff-9c7841c39d120483e325c7efd1b97b9c35bfeb1815f37379abc3ac1377fe522d) sends a proper `WeeklyGroupResultsChartBarClick` ping with bar index field

Set `"disableNonCriticalTelemetry"` to false in your dev-private settings. Change the [updatecheck delay](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/app/updatecheck/client.go?L719) to something shorter. Trigger some events, navigate to site pings. You'll see the pings with BarIndex will show it and the others won't 
