### PR TITLE
batches: maintain list state when deselecting a workspace

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
@@ -63,7 +63,7 @@ const MemoizedExecutionWorkspaces: React.FunctionComponent<
     const history = useHistory()
 
     const deselectWorkspace = useCallback(() => {
-        history.replace({ ...history.location, pathname: `${batchSpec.executionURL}/execution` })
+        history.push({ ...history.location, pathname: `${batchSpec.executionURL}/execution` })
     }, [batchSpec.executionURL, history])
 
     const videoRef = useRef<HTMLVideoElement | null>(null)

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
@@ -62,7 +62,9 @@ const MemoizedExecutionWorkspaces: React.FunctionComponent<
 }) {
     const history = useHistory()
 
-    const deselectWorkspace = useCallback(() => history.push(batchSpec.executionURL), [batchSpec.executionURL, history])
+    const deselectWorkspace = useCallback(() => {
+        history.replace({ ...history.location, pathname: `${batchSpec.executionURL}/execution` })
+    }, [batchSpec.executionURL, history])
 
     const videoRef = useRef<HTMLVideoElement | null>(null)
     // Pause the execution animation loop when the batch spec stops executing.

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesFilterRow.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesFilterRow.tsx
@@ -52,6 +52,9 @@ export const WorkspaceFilterRow: React.FunctionComponent<React.PropsWithChildren
         if (history.location.search !== searchParameters.toString()) {
             history.replace({ ...history.location, search: searchParameters.toString() })
         }
+
+        console.log(searchParameters.toString(), 'filter row')
+
         // Update the filters in the parent component.
         onFiltersChange({
             state: state || null,

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesFilterRow.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesFilterRow.tsx
@@ -53,8 +53,6 @@ export const WorkspaceFilterRow: React.FunctionComponent<React.PropsWithChildren
             history.replace({ ...history.location, search: searchParameters.toString() })
         }
 
-        console.log(searchParameters.toString(), 'filter row')
-
         // Update the filters in the parent component.
         onFiltersChange({
             state: state || null,

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesList.tsx
@@ -44,7 +44,12 @@ export const WorkspacesList: React.FunctionComponent<React.PropsWithChildren<Wor
                         key={node.id}
                         workspace={node}
                         isSelected={node.id === selectedNode}
-                        onSelect={() => history.push(`${executionURL}/execution/workspaces/${node.id}`)}
+                        onSelect={() =>
+                            history.replace({
+                                ...history.location,
+                                pathname: `${executionURL}/execution/workspaces/${node.id}`,
+                            })
+                        }
                     />
                 ))}
             </ConnectionList>


### PR DESCRIPTION
Closes #40520

This will fix a bug that would do a page redirect and lose any state or search in the filter row if a workspace was deselected.

https://user-images.githubusercontent.com/67931373/189354015-ea76cebf-1759-49d4-b72b-46f471e6de8c.mp4


## Test plan
tested selecting and deselecting workspaces, as well as changing filter options

## App preview:

- [Web](https://sg-web-aa-maintain-workspace-state2.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fntddnugav.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

