### PR TITLE
search: text search jobs match repo name when `select:repo` is present

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -318,7 +318,7 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 					Indexed:            false,
 					UseFullDeadline:    useFullDeadline,
 					Features:           *searchInputs.Features,
-					TextPatternRegexps: getPathRegexpsFromTextPatternInfo(patternInfo, repoPatterns),
+					TextPatternRegexps: textPatternRegexps(patternInfo, repoPatterns),
 				}
 
 				addJob(&repoPagerJob{
@@ -466,7 +466,7 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 	return NewParallelJob(allJobs...), nil
 }
 
-func getPathRegexpsFromTextPatternInfo(patternInfo *search.TextPatternInfo, repoPatterns []string) (pathRegexps []*regexp.Regexp) {
+func textPatternRegexps(patternInfo *search.TextPatternInfo, repoPatterns []string) (pathRegexps []*regexp.Regexp) {
 	for _, pattern := range patternInfo.IncludePatterns {
 		if patternInfo.IsRegExp {
 			if patternInfo.IsCaseSensitive {

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -145,6 +145,7 @@ func (s *TextSearchJob) Fields(v job.Verbosity) (res []otlog.Field) {
 			otlog.Bool("useFullDeadline", s.UseFullDeadline),
 			trace.Scoped("patternInfo", s.PatternInfo.Fields()...),
 			otlog.Int("numRepos", len(s.Repos)),
+			otlog.Object("textPatternRegexps", s.TextPatternRegexps),
 		)
 		fallthrough
 	case job.VerbosityBasic:

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -658,6 +658,7 @@ func (z *RepoSubsetTextSearchJob) Fields(v job.Verbosity) (res []otlog.Field) {
 		res = append(res,
 			otlog.Int32("fileMatchLimit", z.FileMatchLimit),
 			trace.Stringer("select", z.Select),
+			otlog.Object("zoektQueryRegexps", z.ZoektQueryRegexps),
 		)
 		// z.Repos is nil for un-indexed search
 		if z.Repos != nil {
@@ -709,6 +710,7 @@ func (t *GlobalTextSearchJob) Fields(v job.Verbosity) (res []otlog.Field) {
 			trace.Stringer("select", t.ZoektArgs.Select),
 			trace.Printf("repoScope", "%q", t.GlobalZoektQuery.RepoScope),
 			otlog.Bool("includePrivate", t.GlobalZoektQuery.IncludePrivate),
+			otlog.Object("globalZoektQueryRegexps", t.GlobalZoektQueryRegexps),
 		)
 		fallthrough
 	case job.VerbosityBasic:

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -901,19 +901,17 @@ func TestZoektFileMatchToMultilineMatches(t *testing.T) {
 	}
 }
 
-func TestZoektFileMatchToPathMatchRanges(t *testing.T) {
+func TestZoektFileMatchFieldToMatchRanges(t *testing.T) {
 	zoektQueryRegexps := []*regexp.Regexp{regexp.MustCompile("python.*worker|stuff")}
 
 	cases := []struct {
 		name   string
-		input  *zoekt.FileMatch
+		input  string
 		output []result.Range
 	}{
 		{
-			name: "returns single path match range",
-			input: &zoekt.FileMatch{
-				FileName: "internal/python/foo/worker.py",
-			},
+			name:  "returns single match range",
+			input: "internal/python/foo/worker.py",
 			output: []result.Range{
 				{
 					Start: result.Location{Offset: 9, Line: 0, Column: 9},
@@ -922,10 +920,8 @@ func TestZoektFileMatchToPathMatchRanges(t *testing.T) {
 			},
 		},
 		{
-			name: "returns multiple path match ranges",
-			input: &zoekt.FileMatch{
-				FileName: "internal/python/foo/worker/src/dev/python_stuff.py",
-			},
+			name:  "returns multiple match ranges",
+			input: "internal/python/foo/worker/src/dev/python_stuff.py",
 			output: []result.Range{
 				{
 					Start: result.Location{Offset: 9, Line: 0, Column: 9},
@@ -941,7 +937,7 @@ func TestZoektFileMatchToPathMatchRanges(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := zoektFileMatchToPathMatchRanges(tc.input, zoektQueryRegexps)
+			got := zoektFileMatchFieldToMatchRanges(tc.input, zoektQueryRegexps)
 			require.Equal(t, tc.output, got)
 		})
 	}


### PR DESCRIPTION
This updates our text search jobs to get repo name match ranges when `select:repo` is present.

If part of a repository name matches a literal or a `repo:` pattern in a query, and `select:repo` is present, then the matching range of that repository name will be highlighted. See screenshot below:
![Screen Shot 2022-09-08 at 4 16 15 PM](https://user-images.githubusercontent.com/70350613/189227472-474f7619-cbeb-42fc-8450-166f17bdb589.png)

This seems intuitive from a user perspective. 

Additional examples:



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
