### PR TITLE
e2e/code-intel: skip flaky jump-to-def test

### DIFF
--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -518,7 +518,7 @@ describe('Repository component', () => {
             })
 
             describe('jump to definition', () => {
-                test('noops when on the definition', async () => {
+                test.skip('noops when on the definition', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +
                             '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d/-/blob/diff/parse.go?L29:6'

--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -518,6 +518,7 @@ describe('Repository component', () => {
             })
 
             describe('jump to definition', () => {
+                // https://github.com/sourcegraph/sourcegraph/issues/41555
                 test.skip('noops when on the definition', async () => {
                     await driver.page.goto(
                         sourcegraphBaseUrl +


### PR DESCRIPTION
This has failed 6 times recently on main: https://sourcegraph.grafana.net/goto/eofLKbG4z?orgId=1

https://github.com/sourcegraph/sourcegraph/issues/41555

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a

## App preview:

- [Web](https://sg-web-skip-flakey-j2d-test.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-groguiagov.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

