### PR TITLE
insights: add logging into aggregations resolver

### DIFF
--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -124,7 +124,7 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 
 	countingFunc, err := aggregation.GetCountFuncForMode(r.searchQuery, r.patternType, aggregationMode)
 	if err != nil {
-		r.getLogger().Error("no aggregation count func for mode", log.String("mode", string(aggregationMode)), log.Error(err))
+		r.getLogger().Error("no aggregation counting function for mode", log.String("mode", string(aggregationMode)), log.Error(err))
 		return &searchAggregationResultResolver{
 			resolver: newSearchAggregationNotAvailableResolver(
 				notAvailableReason{reason: unknowAggregationModeMsg, reasonType: types.ERROR_OCCURRED},

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -88,7 +88,7 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	}
 	// It should not be possible for the getNotAvailableReason to return an err without giving a reason but leaving a fallback here incase.
 	if err != nil {
-		r.getLogger().Warn("unable to determine why aggregation not possible", log.String("mode", string(aggregationMode)), log.Error(err))
+		r.getLogger().Warn("unable to determine why aggregation is unavailable", log.String("mode", string(aggregationMode)), log.Error(err))
 		return nil, err
 	}
 

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/aggregation"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/querybuilder"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/streaming"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
@@ -48,6 +49,14 @@ type searchAggregateResolver struct {
 
 	searchQuery string
 	patternType string
+	logger      log.Logger
+}
+
+func (r *searchAggregateResolver) getLogger() log.Logger {
+	if r.logger == nil {
+		r.logger = log.Scoped("searchAggregations", "")
+	}
+	return r.logger
 }
 
 func (r *searchAggregateResolver) ModeAvailability(ctx context.Context) []graphqlbackend.AggregationModeAvailabilityResolver {
@@ -79,6 +88,7 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	}
 	// It should not be possible for the getNotAvailableReason to return an err without giving a reason but leaving a fallback here incase.
 	if err != nil {
+		r.getLogger().Warn("unable to determine why aggregation not possible", log.String("mode", string(aggregationMode)), log.Error(err))
 		return nil, err
 	}
 
@@ -91,6 +101,7 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	// This includes a timeout in the search that is a second longer than the context we will cancel as a fail safe
 	modifiedQuery, err := querybuilder.AggregationQuery(querybuilder.BasicQuery(r.searchQuery), searchTimelimit+1)
 	if err != nil {
+		r.getLogger().Info("unable to build aggregation query", log.Error(err))
 		return &searchAggregationResultResolver{
 			resolver: newSearchAggregationNotAvailableResolver(notAvailableReason{reason: unableToModifyQueryMsg, reasonType: types.ERROR_OCCURRED}, aggregationMode),
 		}, nil
@@ -104,6 +115,7 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	tabulationErrors := []error{}
 	tabulationFunc := func(amr *aggregation.AggregationMatchResult, err error) {
 		if err != nil {
+			r.getLogger().Error("unable to aggregate results", log.Error(err))
 			tabulationErrors = append(tabulationErrors, err)
 			return
 		}
@@ -112,6 +124,7 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 
 	countingFunc, err := aggregation.GetCountFuncForMode(r.searchQuery, r.patternType, aggregationMode)
 	if err != nil {
+		r.getLogger().Error("no aggregation count func for mode", log.String("mode", string(aggregationMode)), log.Error(err))
 		return &searchAggregationResultResolver{
 			resolver: newSearchAggregationNotAvailableResolver(
 				notAvailableReason{reason: unknowAggregationModeMsg, reasonType: types.ERROR_OCCURRED},
@@ -127,12 +140,14 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	alert, err := searchClient.Search(requestContext, string(modifiedQuery), &r.patternType, searchResultsAggregator)
 	if err != nil || requestContext.Err() != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(requestContext.Err(), context.DeadlineExceeded) {
+			r.getLogger().Info("aggregation search did not complete in time", log.String("mode", string(aggregationMode)), log.Bool("extendedTimeout", args.ExtendedTimeout))
 			reasonType := types.TIMEOUT_EXTENSION_AVAILABLE
 			if args.ExtendedTimeout {
 				reasonType = types.TIMEOUT_NO_EXTENSION_AVAILABLE
 			}
 			return &searchAggregationResultResolver{resolver: newSearchAggregationNotAvailableResolver(notAvailableReason{reason: generalTimeoutMsg, reasonType: reasonType}, aggregationMode)}, nil
 		} else {
+			r.getLogger().Error("unable to run aggregation search", log.String("mode", string(aggregationMode)), log.Error(err))
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Adds logging to leave a trail when aggregations fail in expected or unexpected ways to aid with debugging.
## Test plan
Run an aggregation ensure it still works.
Run a global diff query to see aggregation timeout and see log message.
```
INFO searchAggregations resolvers/aggregates_resolvers.go:143 aggregation search did not complete in time {"mode": "AUTHOR", "extendedTimeout": false}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
