### PR TITLE
Search backend: allow negating `repo:has.commit.after()`

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1226,9 +1226,19 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Repo: 1},
 			},
 			{
+				name:   `repo does not have commit after`,
+				query:  `repo:go-diff -repo:contains.commit.after(10 years ago)`,
+				counts: counts{Repo: 0},
+			},
+			{
 				name:   `repo has commit after no results`,
 				query:  `repo:go-diff repo:contains.commit.after(1 second ago)`,
 				counts: counts{Repo: 0},
+			},
+			{
+				name:   `repo does not has commit after some results`,
+				query:  `repo:go-diff -repo:contains.commit.after(1 second ago)`,
+				counts: counts{Repo: 1},
 			},
 			{
 				name:   `unscoped repo has commit after no results`,

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -943,7 +943,7 @@ func isGlobal(op search.RepoOptions) bool {
 
 	// repo:has.commit.after() is handled during the repo resolution step,
 	// and we cannot depend on Zoekt for this information.
-	if op.CommitAfter != "" {
+	if op.CommitAfter != nil {
 		return false
 	}
 

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -225,14 +225,12 @@ func (f *RepoContainsPathPredicate) Name() string  { return "contains.path" }
 
 type RepoContainsCommitAfterPredicate struct {
 	TimeRef string
+	Negated bool
 }
 
 func (f *RepoContainsCommitAfterPredicate) Unmarshal(params string, negated bool) error {
-	if negated {
-		return &NegatedPredicateError{f.Field() + ":" + f.Name()}
-	}
-
 	f.TimeRef = params
+	f.Negated = negated
 	return nil
 }
 

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -393,18 +393,30 @@ func (p Parameters) FileContainsContent() (include []string) {
 	return include
 }
 
-func (p Parameters) RepoContainsCommitAfter() (value string) {
-	nodes := toNodes(p)
+type RepoHasCommitAfterArgs struct {
+	TimeRef string
+	Negated bool
+}
 
+func (p Parameters) RepoContainsCommitAfter() (res *RepoHasCommitAfterArgs) {
 	// Look for values of repohascommitafter:
-	value = p.FindValue(FieldRepoHasCommitAfter)
-
-	// Look for values of repo:contains.commit.after()
-	VisitTypedPredicate(nodes, func(pred *RepoContainsCommitAfterPredicate) {
-		value = pred.TimeRef
+	p.FindParameter(FieldRepoHasCommitAfter, func(value string, negated bool, annotation Annotation) {
+		res = &RepoHasCommitAfterArgs{
+			TimeRef: value,
+			Negated: negated,
+		}
 	})
 
-	return value
+	// Look for values of repo:contains.commit.after()
+	nodes := toNodes(p)
+	VisitTypedPredicate(nodes, func(pred *RepoContainsCommitAfterPredicate) {
+		res = &RepoHasCommitAfterArgs{
+			TimeRef: pred.TimeRef,
+			Negated: pred.Negated,
+		}
+	})
+
+	return res
 }
 
 type RepoKVPFilter struct {

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -706,13 +706,13 @@ func TestRepoHasCommitAfter(t *testing.T) {
 	cases := []struct {
 		name        string
 		nameFilter  string
-		commitAfter string
+		commitAfter *query.RepoHasCommitAfterArgs
 		expected    []*search.RepositoryRevisions
 		err         error
 	}{{
 		name:        "no filters",
 		nameFilter:  ".*",
-		commitAfter: "",
+		commitAfter: nil,
 		expected: []*search.RepositoryRevisions{
 			mkHead(repoA),
 			mkHead(repoB),
@@ -721,26 +721,32 @@ func TestRepoHasCommitAfter(t *testing.T) {
 		},
 		err: nil,
 	}, {
-		name:        "commit after",
-		nameFilter:  ".*",
-		commitAfter: "yesterday",
+		name:       "commit after",
+		nameFilter: ".*",
+		commitAfter: &query.RepoHasCommitAfterArgs{
+			TimeRef: "yesterday",
+		},
 		expected: []*search.RepositoryRevisions{
 			mkHead(repoA),
 			mkHead(repoB),
 		},
 		err: nil,
 	}, {
-		name:        "err commit after",
-		nameFilter:  "repoD",
-		commitAfter: "yesterday",
-		expected:    nil,
-		err:         ErrNoResolvedRepos,
+		name:       "err commit after",
+		nameFilter: "repoD",
+		commitAfter: &query.RepoHasCommitAfterArgs{
+			TimeRef: "yesterday",
+		},
+		expected: nil,
+		err:      ErrNoResolvedRepos,
 	}, {
-		name:        "no commit after",
-		nameFilter:  "repoC",
-		commitAfter: "yesterday",
-		expected:    nil,
-		err:         ErrNoResolvedRepos,
+		name:       "no commit after",
+		nameFilter: "repoC",
+		commitAfter: &query.RepoHasCommitAfterArgs{
+			TimeRef: "yesterday",
+		},
+		expected: nil,
+		err:      ErrNoResolvedRepos,
 	}}
 
 	for _, tc := range cases {

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -364,7 +364,7 @@ type RepoOptions struct {
 	CaseSensitiveRepoFilters bool
 	SearchContextSpec        string
 
-	CommitAfter string
+	CommitAfter *query.RepoHasCommitAfterArgs
 	Visibility  query.RepoVisibility
 	Limit       int
 	Cursors     []*types.Cursor
@@ -410,8 +410,9 @@ func (op *RepoOptions) Tags() []otlog.Field {
 	if op.SearchContextSpec != "" {
 		add(otlog.String("searchContextSpec", op.SearchContextSpec))
 	}
-	if op.CommitAfter != "" {
-		add(otlog.String("commitAfter", op.CommitAfter))
+	if op.CommitAfter != nil {
+		add(otlog.String("commitAfter.time", op.CommitAfter.TimeRef))
+		add(otlog.Bool("commitAfter.negated", op.CommitAfter.Negated))
 	}
 	if op.Visibility != query.Any {
 		add(otlog.String("visibility", string(op.Visibility)))

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -498,7 +498,9 @@ func (op *RepoOptions) String() string {
 		fmt.Fprintf(&b, "DescriptionPatterns: %q\n", op.DescriptionPatterns)
 	}
 
-	fmt.Fprintf(&b, "CommitAfter: %s\n", op.CommitAfter)
+	if op.CommitAfter != nil {
+		fmt.Fprintf(&b, "CommitAfter: %s\n", op.CommitAfter.TimeRef)
+	}
 	fmt.Fprintf(&b, "Visibility: %s\n", string(op.Visibility))
 
 	if op.UseIndex != query.Yes {


### PR DESCRIPTION
As in title. Resurrected this from the pre-offsite push on predicates. 

The basics:
- Pass `RepoHasCommitAfterArgs` through the backend instead of just a possibly-empty string containing the time.
- Add `Negated` field to `RepoHasCommitAfterArgs`.

## Test plan

New integration tests, manual testing. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
