### PR TITLE
internal/observation: add OpenTelemetry APIs, deprecated OpenTracing APIs

### DIFF
--- a/internal/observation/fields.go
+++ b/internal/observation/fields.go
@@ -2,6 +2,7 @@ package observation
 
 import (
 	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
 	"github.com/sourcegraph/log"
@@ -18,6 +19,22 @@ func toLogFields(otFields []otlog.Field) []log.Field {
 		default:
 			// Allow usage of zap.Any here for ease of interop.
 			fields[i] = zap.Any(field.Key(), value)
+		}
+	}
+	return fields
+}
+
+func attributesToLogFields(attributes []attribute.KeyValue) []log.Field {
+	fields := make([]log.Field, len(attributes))
+	for i, field := range attributes {
+		switch value := field.Value.AsInterface().(type) {
+		case error:
+			// Special handling for errors, since we have a custom error field implementation
+			fields[i] = log.NamedError(string(field.Key), value)
+
+		default:
+			// Allow usage of zap.Any here for ease of interop.
+			fields[i] = zap.Any(string(field.Key), value)
 		}
 	}
 	return fields


### PR DESCRIPTION
We want to encourage using OpenTelemetry event names as well as the new attributes API in general.

Setting label `i-acknowledge-this-goes-into-4.0` because this is only an internal API change that is very similar to existing APIs, and introduces no usages.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

tests pass