### PR TITLE
admin-analytics: refactor overview page to load gradually

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/DevTimeSaved.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/DevTimeSaved.tsx
@@ -38,7 +38,11 @@ export const DevTimeSaved: React.FunctionComponent<DevTimeSavedProps> = ({ showA
     }
 
     if (loading || !data) {
-        return <LoadingSpinner />
+        return (
+            <div className="d-flex justify-content-center">
+                <LoadingSpinner />
+            </div>
+        )
     }
 
     const { search, codeIntel, batchChanges, notebooks, extensions, users } = data.site.analytics

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/DevTimeSaved.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/DevTimeSaved.tsx
@@ -1,0 +1,267 @@
+import React from 'react'
+
+import { mdiMagnify, mdiSitemap, mdiBookOutline, mdiPuzzleOutline } from '@mdi/js'
+import classNames from 'classnames'
+
+import { useQuery } from '@sourcegraph/http-client'
+import { H2, H3, Text, LoadingSpinner, Link, Icon } from '@sourcegraph/wildcard'
+
+import { BatchChangesIconNav } from '../../../batches/icons'
+import {
+    OverviewDevTimeSavedResult,
+    OverviewDevTimeSavedVariables,
+    AnalyticsDateRange,
+} from '../../../graphql-operations'
+import { ValueLegendItem } from '../components/ValueLegendList'
+import { formatNumber } from '../utils'
+
+import { OVERVIEW_DEV_TIME_SAVED } from './queries'
+
+import styles from './index.module.scss'
+
+interface DevTimeSavedProps {
+    showAnnualProjection?: boolean
+    dateRange: AnalyticsDateRange
+}
+export const DevTimeSaved: React.FunctionComponent<DevTimeSavedProps> = ({ showAnnualProjection, dateRange }) => {
+    const { data, error, loading } = useQuery<OverviewDevTimeSavedResult, OverviewDevTimeSavedVariables>(
+        OVERVIEW_DEV_TIME_SAVED,
+        {
+            variables: {
+                dateRange,
+            },
+        }
+    )
+
+    if (error) {
+        throw error
+    }
+
+    if (loading || !data) {
+        return <LoadingSpinner />
+    }
+
+    const { search, codeIntel, batchChanges, notebooks, extensions, users } = data.site.analytics
+
+    const totalSearchEvents = search.searches.summary.totalCount + search.fileViews.summary.totalCount
+
+    const totalSearchHoursSaved =
+        (totalSearchEvents * 0.75 * 0.5 + totalSearchEvents * 0.22 * 5 + totalSearchEvents * 0.03 * 120) / 60
+
+    const totalCodeIntelEvents =
+        codeIntel.definitionClicks.summary.totalCount + codeIntel.referenceClicks.summary.totalCount
+    const totalCodeIntelHoverEvents =
+        codeIntel.searchBasedEvents.summary.totalCount + codeIntel.preciseEvents.summary.totalCount
+
+    const totalCodeIntelHoursSaved =
+        (codeIntel.inAppEvents.summary.totalCount * 0.5 +
+            codeIntel.codeHostEvents.summary.totalCount * 1.5 +
+            Math.floor(
+                (codeIntel.crossRepoEvents.summary.totalCount * totalCodeIntelEvents * 3) / totalCodeIntelHoverEvents ||
+                    0
+            ) +
+            Math.floor(
+                (codeIntel.preciseEvents.summary.totalCount * totalCodeIntelEvents) / totalCodeIntelHoverEvents || 0
+            )) /
+        60
+
+    const totalBatchChangesEvents = batchChanges.changesetsMerged.summary.totalCount
+    const totalBatchChangesHoursSaved = (totalBatchChangesEvents * 15) / 60
+
+    const totalNotebooksEvents = notebooks.views.summary.totalCount
+    const totalNotebooksHoursSaved = (totalNotebooksEvents * 5) / 60
+
+    const totalExtensionsEvents =
+        extensions.vscode.summary.totalCount +
+        extensions.jetbrains.summary.totalCount +
+        extensions.browser.summary.totalCount
+
+    const totalExtensionsHoursSaved =
+        (extensions.vscode.summary.totalCount * 3 +
+            extensions.jetbrains.summary.totalCount * 1.5 +
+            extensions.browser.summary.totalCount * 0.5) /
+        60
+
+    const totalEvents =
+        totalSearchEvents +
+        totalCodeIntelEvents +
+        totalBatchChangesEvents +
+        totalNotebooksEvents +
+        totalExtensionsEvents
+
+    const totalHoursSaved =
+        totalSearchHoursSaved +
+        totalCodeIntelHoursSaved +
+        totalBatchChangesHoursSaved +
+        totalNotebooksHoursSaved +
+        totalExtensionsHoursSaved
+
+    const projectedHoursSaved = (() => {
+        if (dateRange === AnalyticsDateRange.LAST_WEEK) {
+            return totalHoursSaved * 52
+        }
+        if (dateRange === AnalyticsDateRange.LAST_MONTH) {
+            return totalHoursSaved * 12
+        }
+        if (dateRange === AnalyticsDateRange.LAST_THREE_MONTHS) {
+            return (totalHoursSaved * 12) / 3
+        }
+        return totalHoursSaved
+    })()
+
+    return (
+        <div>
+            <H3 className="mb-3">Developer time saved</H3>
+            <div className={classNames(styles.statsBox, 'p-4 mb-3')}>
+                <div className="d-flex">
+                    <ValueLegendItem
+                        value={users.activity.summary.totalRegisteredUsers}
+                        className={classNames('flex-1', styles.borderRight)}
+                        description="Active Users"
+                        color="var(--body-color)"
+                        tooltip="Currently registered users using the application in the selected timeframe."
+                    />
+                    <ValueLegendItem
+                        value={totalEvents}
+                        className={classNames('flex-1', styles.borderRight)}
+                        description="Events"
+                        color="var(--body-color)"
+                        tooltip="Total number of actions performed in the selected timeframe."
+                    />
+                    <ValueLegendItem
+                        value={totalHoursSaved}
+                        className="flex-1"
+                        description="Hours saved"
+                        color="var(--purple)"
+                        tooltip="Total number of hours saved in the selected timeframe."
+                    />
+                </div>
+                {showAnnualProjection && (
+                    <div className="d-flex flex-column align-items-center mt-4">
+                        <H2>
+                            Annual projection:{' '}
+                            <span className={styles.purple}>{formatNumber(projectedHoursSaved)} hours</span> saved*
+                        </H2>
+                        <Text as="span" className="text-muted">
+                            * Based on{' '}
+                            {dateRange === AnalyticsDateRange.LAST_THREE_MONTHS
+                                ? 'last 3 months'
+                                : dateRange === AnalyticsDateRange.LAST_MONTH
+                                ? 'last month'
+                                : 'last week'}{' '}
+                            of data
+                        </Text>
+                    </div>
+                )}
+            </div>
+            <H3 className={classNames('my-3 pb-2', styles.border)}>Hours by feature</H3>
+            <table className={styles.hoursTable}>
+                <thead>
+                    <tr>
+                        <Text as="th" className="text-muted text-left">
+                            EVENT TYPE
+                        </Text>
+                        <Text as="th" className="text-muted">
+                            EVENTS
+                        </Text>
+                        <Text as="th" className="text-muted">
+                            HOURS SAVED
+                        </Text>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td className="text-left">
+                            <Link to="/site-admin/analytics/search">
+                                <Text as="span" className="d-flex align-items-center">
+                                    <Icon svgPath={mdiMagnify} size="md" aria-label="Code Search" className="mr-1" />
+                                    Search
+                                </Text>
+                            </Link>
+                        </td>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalSearchEvents)}
+                        </Text>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalSearchHoursSaved)}
+                        </Text>
+                    </tr>
+                    <tr>
+                        <td className="text-left">
+                            <Link to="/site-admin/analytics/code-intel">
+                                <Text as="span" className="d-flex align-items-center">
+                                    <Icon
+                                        svgPath={mdiSitemap}
+                                        size="md"
+                                        aria-label="Code Navigation"
+                                        className="mr-1"
+                                    />
+                                    Code Navigation
+                                </Text>
+                            </Link>
+                        </td>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalCodeIntelEvents)}
+                        </Text>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalCodeIntelHoursSaved)}
+                        </Text>
+                    </tr>
+                    <tr>
+                        <td className="text-left">
+                            <Link to="/site-admin/analytics/batch-changes">
+                                <Text as="span" className="d-flex align-items-center">
+                                    <BatchChangesIconNav className="mr-1" />
+                                    Batch Changes
+                                </Text>
+                            </Link>
+                        </td>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalBatchChangesEvents)}
+                        </Text>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalBatchChangesHoursSaved)}
+                        </Text>
+                    </tr>
+                    <tr>
+                        <td className="text-left">
+                            <Link to="/site-admin/analytics/notebooks">
+                                <Text as="span" className="d-flex align-items-center">
+                                    <Icon svgPath={mdiBookOutline} size="md" aria-label="Notebooks" className="mr-1" />
+                                    Notebooks
+                                </Text>
+                            </Link>
+                        </td>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalNotebooksEvents)}
+                        </Text>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalNotebooksHoursSaved)}
+                        </Text>
+                    </tr>
+                    <tr>
+                        <td className="text-left">
+                            <Link to="/site-admin/analytics/extensions">
+                                <Text as="span" className="d-flex align-items-center">
+                                    <Icon
+                                        svgPath={mdiPuzzleOutline}
+                                        size="md"
+                                        aria-label="Extensions"
+                                        className="mr-1"
+                                    />
+                                    Extensions
+                                </Text>
+                            </Link>
+                        </td>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalExtensionsEvents)}
+                        </Text>
+                        <Text as="td" weight="bold">
+                            {formatNumber(totalExtensionsHoursSaved)}
+                        </Text>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    )
+}

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -1,36 +1,24 @@
 import React, { useState, useEffect } from 'react'
 
-import {
-    mdiCheck,
-    mdiClose,
-    mdiAccount,
-    mdiSourceRepository,
-    mdiCommentOutline,
-    mdiArrowRight,
-    mdiMagnify,
-    mdiSitemap,
-    mdiBookOutline,
-    mdiPuzzleOutline,
-} from '@mdi/js'
+import { mdiCheck, mdiClose, mdiAccount, mdiSourceRepository, mdiCommentOutline, mdiArrowRight } from '@mdi/js'
 import classNames from 'classnames'
 import format from 'date-fns/format'
 import * as H from 'history'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
-import { Card, H2, H3, H4, Text, LoadingSpinner, Link, AnchorLink, Icon } from '@sourcegraph/wildcard'
+import { Card, H2, H3, H4, Text, LoadingSpinner, AnchorLink, Icon } from '@sourcegraph/wildcard'
 
-import { BatchChangesIconNav } from '../../../batches/icons'
 import { dismissAlert, isAlertDismissed } from '../../../components/DismissibleAlert'
-import { OverviewStatisticsResult, OverviewStatisticsVariables, AnalyticsDateRange } from '../../../graphql-operations'
+import { ErrorBoundary } from '../../../components/ErrorBoundary'
+import { OverviewStatisticsResult, OverviewStatisticsVariables } from '../../../graphql-operations'
 import { formatRelativeExpirationDate, isProductLicenseExpired } from '../../../productSubscription/helpers'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { HorizontalSelect } from '../components/HorizontalSelect'
-import { ValueLegendItem } from '../components/ValueLegendList'
-import { useChartFilters } from '../useChartFilters'
-import { formatNumber } from '../utils'
 
+import { useChartFilters } from '../useChartFilters'
+import { DevTimeSaved } from './DevTimeSaved'
 import { OVERVIEW_STATISTICS } from './queries'
 import { Sidebar } from './Sidebar'
 
@@ -47,11 +35,7 @@ export const AnalyticsOverviewPage: React.FunctionComponent<IProps> = ({ activat
     const [showGetStarted, setShowGetStarted] = useState(!isAlertDismissed(GET_STARTED_ALERT_KEY))
     const { data, error, loading } = useQuery<OverviewStatisticsResult, OverviewStatisticsVariables>(
         OVERVIEW_STATISTICS,
-        {
-            variables: {
-                dateRange: dateRange.value,
-            },
-        }
+        {}
     )
     useEffect(() => {
         eventLogger.logPageView('AdminAnalyticsOverview')
@@ -65,76 +49,8 @@ export const AnalyticsOverviewPage: React.FunctionComponent<IProps> = ({ activat
         return <LoadingSpinner />
     }
 
-    const { analytics, productSubscription } = data.site
+    const { productSubscription } = data.site
     const licenseExpiresAt = productSubscription.license ? new Date(productSubscription.license.expiresAt) : null
-
-    const totalSearchEvents =
-        analytics.search.searches.summary.totalCount + analytics.search.fileViews.summary.totalCount
-
-    const totalSearchHoursSaved =
-        (totalSearchEvents * 0.75 * 0.5 + totalSearchEvents * 0.22 * 5 + totalSearchEvents * 0.03 * 120) / 60
-
-    const totalCodeIntelEvents =
-        analytics.codeIntel.definitionClicks.summary.totalCount + analytics.codeIntel.referenceClicks.summary.totalCount
-    const totalCodeIntelHoverEvents =
-        analytics.codeIntel.searchBasedEvents.summary.totalCount + analytics.codeIntel.preciseEvents.summary.totalCount
-
-    const totalCodeIntelHoursSaved =
-        (analytics.codeIntel.inAppEvents.summary.totalCount * 0.5 +
-            analytics.codeIntel.codeHostEvents.summary.totalCount * 1.5 +
-            Math.floor(
-                (analytics.codeIntel.crossRepoEvents.summary.totalCount * totalCodeIntelEvents * 3) /
-                    totalCodeIntelHoverEvents || 0
-            ) +
-            Math.floor(
-                (analytics.codeIntel.preciseEvents.summary.totalCount * totalCodeIntelEvents) /
-                    totalCodeIntelHoverEvents || 0
-            )) /
-        60
-
-    const totalBatchChangesEvents = analytics.batchChanges.changesetsMerged.summary.totalCount
-    const totalBatchChangesHoursSaved = (totalBatchChangesEvents * 15) / 60
-
-    const totalNotebooksEvents = analytics.notebooks.views.summary.totalCount
-    const totalNotebooksHoursSaved = (totalNotebooksEvents * 5) / 60
-
-    const totalExtensionsEvents =
-        analytics.extensions.vscode.summary.totalCount +
-        analytics.extensions.jetbrains.summary.totalCount +
-        analytics.extensions.browser.summary.totalCount
-
-    const totalExtensionsHoursSaved =
-        (analytics.extensions.vscode.summary.totalCount * 3 +
-            analytics.extensions.jetbrains.summary.totalCount * 1.5 +
-            analytics.extensions.browser.summary.totalCount * 0.5) /
-        60
-
-    const totalEvents =
-        totalSearchEvents +
-        totalCodeIntelEvents +
-        totalBatchChangesEvents +
-        totalNotebooksEvents +
-        totalExtensionsEvents
-
-    const totalHoursSaved =
-        totalSearchHoursSaved +
-        totalCodeIntelHoursSaved +
-        totalBatchChangesHoursSaved +
-        totalNotebooksHoursSaved +
-        totalExtensionsHoursSaved
-
-    const projectedHoursSaved = (() => {
-        if (dateRange.value === AnalyticsDateRange.LAST_WEEK) {
-            return totalHoursSaved * 52
-        }
-        if (dateRange.value === AnalyticsDateRange.LAST_MONTH) {
-            return totalHoursSaved * 12
-        }
-        if (dateRange.value === AnalyticsDateRange.LAST_THREE_MONTHS) {
-            return (totalHoursSaved * 12) / 3
-        }
-        return totalHoursSaved
-    })()
 
     return (
         <>
@@ -238,168 +154,12 @@ export const AnalyticsOverviewPage: React.FunctionComponent<IProps> = ({ activat
                 )}
                 <div className={classNames('d-flex mt-3', styles.padded)}>
                     <div className={styles.main}>
-                        <H3 className="mb-3">Developer time saved</H3>
-                        <div className={classNames(styles.statsBox, 'p-4 mb-3')}>
-                            <div className="d-flex">
-                                <ValueLegendItem
-                                    value={data.site.analytics.users.activity.summary.totalRegisteredUsers}
-                                    className={classNames('flex-1', styles.borderRight)}
-                                    description="Active Users"
-                                    color="var(--body-color)"
-                                    tooltip="Currently registered users using the application in the selected timeframe."
-                                />
-                                <ValueLegendItem
-                                    value={totalEvents}
-                                    className={classNames('flex-1', styles.borderRight)}
-                                    description="Events"
-                                    color="var(--body-color)"
-                                    tooltip="Total number of actions performed in the selected timeframe."
-                                />
-                                <ValueLegendItem
-                                    value={totalHoursSaved}
-                                    className="flex-1"
-                                    description="Hours saved"
-                                    color="var(--purple)"
-                                    tooltip="Total number of hours saved in the selected timeframe."
-                                />
-                            </div>
-                            {data.users.totalCount > 1 && (
-                                <div className="d-flex flex-column align-items-center mt-4">
-                                    <H2>
-                                        Annual projection:{' '}
-                                        <span className={styles.purple}>{formatNumber(projectedHoursSaved)} hours</span>{' '}
-                                        saved*
-                                    </H2>
-                                    <Text as="span" className="text-muted">
-                                        * Based on{' '}
-                                        {dateRange.value === AnalyticsDateRange.LAST_THREE_MONTHS
-                                            ? 'last 3 months'
-                                            : dateRange.value === AnalyticsDateRange.LAST_MONTH
-                                            ? 'last month'
-                                            : 'last week'}{' '}
-                                        of data
-                                    </Text>
-                                </div>
-                            )}
-                        </div>
-                        <H3 className={classNames('my-3 pb-2', styles.border)}>Hours by feature</H3>
-                        <table className={styles.hoursTable}>
-                            <thead>
-                                <tr>
-                                    <Text as="th" className="text-muted text-left">
-                                        EVENT TYPE
-                                    </Text>
-                                    <Text as="th" className="text-muted">
-                                        EVENTS
-                                    </Text>
-                                    <Text as="th" className="text-muted">
-                                        HOURS SAVED
-                                    </Text>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td className="text-left">
-                                        <Link to="/site-admin/analytics/search">
-                                            <Text as="span" className="d-flex align-items-center">
-                                                <Icon
-                                                    svgPath={mdiMagnify}
-                                                    size="md"
-                                                    aria-label="Code Search"
-                                                    className="mr-1"
-                                                />
-                                                Search
-                                            </Text>
-                                        </Link>
-                                    </td>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalSearchEvents)}
-                                    </Text>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalSearchHoursSaved)}
-                                    </Text>
-                                </tr>
-                                <tr>
-                                    <td className="text-left">
-                                        <Link to="/site-admin/analytics/code-intel">
-                                            <Text as="span" className="d-flex align-items-center">
-                                                <Icon
-                                                    svgPath={mdiSitemap}
-                                                    size="md"
-                                                    aria-label="Code Navigation"
-                                                    className="mr-1"
-                                                />
-                                                Code Navigation
-                                            </Text>
-                                        </Link>
-                                    </td>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalCodeIntelEvents)}
-                                    </Text>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalCodeIntelHoursSaved)}
-                                    </Text>
-                                </tr>
-                                <tr>
-                                    <td className="text-left">
-                                        <Link to="/site-admin/analytics/batch-changes">
-                                            <Text as="span" className="d-flex align-items-center">
-                                                <BatchChangesIconNav className="mr-1" />
-                                                Batch Changes
-                                            </Text>
-                                        </Link>
-                                    </td>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalBatchChangesEvents)}
-                                    </Text>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalBatchChangesHoursSaved)}
-                                    </Text>
-                                </tr>
-                                <tr>
-                                    <td className="text-left">
-                                        <Link to="/site-admin/analytics/notebooks">
-                                            <Text as="span" className="d-flex align-items-center">
-                                                <Icon
-                                                    svgPath={mdiBookOutline}
-                                                    size="md"
-                                                    aria-label="Notebooks"
-                                                    className="mr-1"
-                                                />
-                                                Notebooks
-                                            </Text>
-                                        </Link>
-                                    </td>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalNotebooksEvents)}
-                                    </Text>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalNotebooksHoursSaved)}
-                                    </Text>
-                                </tr>
-                                <tr>
-                                    <td className="text-left">
-                                        <Link to="/site-admin/analytics/extensions">
-                                            <Text as="span" className="d-flex align-items-center">
-                                                <Icon
-                                                    svgPath={mdiPuzzleOutline}
-                                                    size="md"
-                                                    aria-label="Extensions"
-                                                    className="mr-1"
-                                                />
-                                                Extensions
-                                            </Text>
-                                        </Link>
-                                    </td>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalExtensionsEvents)}
-                                    </Text>
-                                    <Text as="td" weight="bold">
-                                        {formatNumber(totalExtensionsHoursSaved)}
-                                    </Text>
-                                </tr>
-                            </tbody>
-                        </table>
+                        <ErrorBoundary location={null}>
+                            <DevTimeSaved
+                                showAnnualProjection={data.users.totalCount > 1}
+                                dateRange={dateRange.value}
+                            />
+                        </ErrorBoundary>
                     </div>
                     <div className={styles.sidebar}>
                         <Sidebar

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -16,8 +16,8 @@ import { formatRelativeExpirationDate, isProductLicenseExpired } from '../../../
 import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { HorizontalSelect } from '../components/HorizontalSelect'
-
 import { useChartFilters } from '../useChartFilters'
+
 import { DevTimeSaved } from './DevTimeSaved'
 import { OVERVIEW_STATISTICS } from './queries'
 import { Sidebar } from './Sidebar'

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/queries.ts
@@ -1,7 +1,7 @@
 import { gql } from '@sourcegraph/http-client'
 
 export const OVERVIEW_STATISTICS = gql`
-    query OverviewStatistics($dateRange: AnalyticsDateRange!) {
+    query OverviewStatistics {
         site {
             productVersion
             productSubscription {
@@ -12,6 +12,31 @@ export const OVERVIEW_STATISTICS = gql`
                     expiresAt
                 }
             }
+            adminUsers: users(siteAdmin: true, deletedAt: { empty: true }) {
+                totalCount
+            }
+        }
+        users {
+            totalCount
+        }
+        repositories {
+            totalCount(precise: true)
+        }
+        repositoryStats {
+            gitDirBytes
+            indexedLinesCount
+        }
+        surveyResponses {
+            totalCount
+            averageScore
+            netPromoterScore
+        }
+    }
+`
+
+export const OVERVIEW_DEV_TIME_SAVED = gql`
+    query OverviewDevTimeSaved($dateRange: AnalyticsDateRange!) {
+        site {
             analytics {
                 search(dateRange: $dateRange, grouping: WEEKLY) {
                     searches {
@@ -101,24 +126,6 @@ export const OVERVIEW_STATISTICS = gql`
                     }
                 }
             }
-            adminUsers: users(siteAdmin: true, deletedAt: { empty: true }) {
-                totalCount
-            }
-        }
-        users {
-            totalCount
-        }
-        repositories {
-            totalCount(precise: true)
-        }
-        repositoryStats {
-            gitDirBytes
-            indexedLinesCount
-        }
-        surveyResponses {
-            totalCount
-            averageScore
-            netPromoterScore
         }
     }
 `


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41443.

This PR splits the `Analytics / Overview` > `Dev Time Saved` section (the most query heavy) into a separate component that fetches data on its own, thus not blocking other page sections from loading.

## Test plan
- `sg start`
- Open http://localhost:3080/site-admin
- Check that page loads gradually and without any errors

## Screenshot
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/6717049/189304840-7e22e652-0bcb-4854-a92d-db2967f079de.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-refactor-admin-analytics.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bkohzpyoov.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
