### PR TITLE
HACK: Add syntax highlighting to reference panel

### DIFF
--- a/client/search-ui/src/components/CodeExcerpt.tsx
+++ b/client/search-ui/src/components/CodeExcerpt.tsx
@@ -20,6 +20,13 @@ import { Icon, Code } from '@sourcegraph/wildcard'
 
 import styles from './CodeExcerpt.module.scss'
 
+export interface Shape {
+    top?: number
+    left?: number
+    bottom?: number
+    right?: number
+}
+
 export interface FetchFileParameters {
     repoName: string
     commitID: string
@@ -48,6 +55,7 @@ interface Props extends Repo {
 
     viewerUpdates?: Observable<{ viewerId: ViewerId } & HoverContext>
     hoverifier?: Hoverifier<HoverContext, HoverMerged, ActionItemAction>
+    visibilityOffset?: Shape
     onCopy?: () => void
 }
 
@@ -99,7 +107,7 @@ const domFunctions: DOMFunctions = {
 }
 
 const makeTableHTML = (blobLines: string[]): string => '<table>' + blobLines.join('') + '</table>'
-const visibilitySensorOffset = { bottom: -500 }
+const DEFAULT_VISIBILITY_OFFSET: Shape = { bottom: -500 }
 
 /**
  * A code excerpt that displays syntax highlighting and match range highlighting.
@@ -113,6 +121,7 @@ export const CodeExcerpt: React.FunctionComponent<Props> = ({
     highlightRanges,
     viewerUpdates,
     hoverifier,
+    visibilityOffset = DEFAULT_VISIBILITY_OFFSET,
     className,
     onCopy,
 }) => {
@@ -207,7 +216,7 @@ export const CodeExcerpt: React.FunctionComponent<Props> = ({
     }, [hoverifier, tableContainerElements, viewerUpdates])
 
     return (
-        <VisibilitySensor onChange={setIsVisible} partialVisibility={true} offset={visibilitySensorOffset}>
+        <VisibilitySensor onChange={setIsVisible} partialVisibility={true} offset={visibilityOffset}>
             <Code
                 data-testid="code-excerpt"
                 onCopy={onCopy}

--- a/client/web/src/codeintel/ReferencesPanel.mocks.ts
+++ b/client/web/src/codeintel/ReferencesPanel.mocks.ts
@@ -170,6 +170,17 @@ function buildMockLocation({
     }
 }
 
+// Fake highlighting for lines 16 and 52 in diff/diff.go
+export const highlightedLinesDiffGo = [
+    ['<tr><td class="line" data-line="16"></td><td class="code">line 16</td></tr>'],
+    ['<tr><td class="line" data-line="52"></td><td class="code">line 52</td></tr>'],
+]
+
+// Fake highlighting for line 46 in cmd/go-diff/go-diff.go
+export const highlightedLinesGoDiffGo = [
+    ['<tr><td class="line" data-line="46"></td><td class="code">line 46</td></tr>'],
+]
+
 const MOCK_DEFINITIONS: LocationFields[] = [
     buildMockLocation({
         repo: 'github.com/sourcegraph/go-diff',
@@ -283,6 +294,7 @@ const HIGHLIGHTED_FILE_MOCK = {
                     highlight: {
                         aborted: false,
                         html: highlightedDiffFileContent,
+                        lsif: false,
                         __typename: 'HighlightedFile',
                     },
                     __typename: 'GitBlob',

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -94,6 +94,14 @@ $group-divider-height: 0.25rem;
 }
 
 .location {
+    display: flex;
+    flex-direction: column;
+    min-height: 18px;
+
+    &:not(:last-child) > button {
+        border-bottom: 1px solid var(--body-bg);
+    }
+
     button {
         padding-top: 0;
         padding-bottom: 0;
@@ -105,8 +113,9 @@ $group-divider-height: 0.25rem;
         // Avoid line number and filename getting put on different lines
         white-space: nowrap;
         padding-left: 0;
-        border: none;
         font-family: 'SF Mono', monospace;
+
+        border: none;
     }
 
     button:hover {
@@ -132,20 +141,18 @@ $group-divider-height: 0.25rem;
     }
 
     &--link {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
         color: inherit;
 
-        &--line-number {
-            font-family: 'SF Mono', monospace;
-            font-weight: 400;
-            color: var(--line-number-color);
-            min-width: 2.5rem;
-            text-align: right;
-            display: inline-block;
-            margin-right: 0.5rem;
+        &--code-excerpt {
+            flex: 1;
+            width: 100%;
 
-            font-style: normal;
-            font-size: 0.75rem;
-            line-height: 136%;
+            :global(.line) {
+                min-width: 2.5rem;
+            }
         }
     }
 }

--- a/client/web/src/codeintel/ReferencesPanel.test.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.test.tsx
@@ -1,21 +1,18 @@
 import { render, RenderResult, within, fireEvent } from '@testing-library/react'
 import * as H from 'history'
 import { EMPTY, NEVER, noop, of, Subscription } from 'rxjs'
-import { HoverThresholdProps } from 'src/repo/RepoContainer'
 
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
 import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src/api/util'
 import { ViewerId } from '@sourcegraph/shared/src/api/viewerTypes'
-import { Controller, ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { PlatformContext, PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { NOOP_TELEMETRY_SERVICE, TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Controller } from '@sourcegraph/shared/src/extensions/controller'
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider, waitForNextApolloResponse } from '@sourcegraph/shared/src/testing/apollo'
-import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import '@sourcegraph/shared/dev/mockReactVisibilitySensor'
 
-import { Location } from './location'
-import { getLineContent, ReferencesPanelWithMemoryRouter } from './ReferencesPanel'
-import { buildReferencePanelMocks } from './ReferencesPanel.mocks'
+import { ReferencesPanelProps, ReferencesPanelWithMemoryRouter } from './ReferencesPanel'
+import { buildReferencePanelMocks, highlightedLinesDiffGo, highlightedLinesGoDiffGo } from './ReferencesPanel.mocks'
 
 const NOOP_SETTINGS_CASCADE = {
     subjects: null,
@@ -46,12 +43,7 @@ const NOOP_EXTENSIONS_CONTROLLER: Controller = {
     unsubscribe: noop,
 }
 
-const defaultProps: SettingsCascadeProps &
-    PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'> &
-    TelemetryProps &
-    HoverThresholdProps &
-    ExtensionsControllerProps &
-    ThemeProps = {
+const defaultProps: Omit<ReferencesPanelProps, 'externalHistory' | 'externalLocation'> = {
     extensionsController: NOOP_EXTENSIONS_CONTROLLER,
     telemetryService: NOOP_TELEMETRY_SERVICE,
     settingsCascade: {
@@ -60,6 +52,16 @@ const defaultProps: SettingsCascadeProps &
     },
     platformContext: NOOP_PLATFORM_CONTEXT,
     isLightTheme: false,
+    fetchHighlightedFileLineRanges: args => {
+        if (args.filePath === 'cmd/go-diff/go-diff.go') {
+            return of(highlightedLinesGoDiffGo)
+        }
+        if (args.filePath === 'diff/diff.go') {
+            return of(highlightedLinesDiffGo)
+        }
+        console.error('attempt to fetch highlighted lines for file without mocks', args.filePath)
+        return of([])
+    },
 }
 
 describe('ReferencesPanel', () => {
@@ -88,16 +90,12 @@ describe('ReferencesPanel', () => {
 
         expect(result.getByText('Definitions')).toBeVisible()
 
-        const definitions = [['', 'string']]
+        // See MOCK_DEFINITIONS and highlightedLinesDiffGo/highlightedLinesGoDiffGo to see how these expectations here came to be
+        const definitions = ['line 16']
 
         const definitionsList = result.getByTestId('definitions')
         for (const line of definitions) {
-            for (const surrounding of line) {
-                if (surrounding === '') {
-                    continue
-                }
-                expect(within(definitionsList).getByText(surrounding)).toBeVisible()
-            }
+            expect(within(definitionsList).getByText(line)).toBeVisible()
         }
     })
 
@@ -106,20 +104,12 @@ describe('ReferencesPanel', () => {
 
         expect(result.getByText('References')).toBeVisible()
 
-        const references = [
-            ['', 'string'],
-            ['label = fmt.Sprintf("orig(%s) new(%s)", fdiff.', ', fdiff.NewName)'],
-            ['if err := printFileHeader(&buf, "--- ", d.', ', d.OrigTime); err != nil {'],
-        ]
+        // See MOCK_REFERENCES and highlightedLinesDiffGo/highlightedLinesGoDiffGo to see how these expectations here came to be
+        const references = ['line 46', 'line 16', 'line 52']
 
         const referencesList = result.getByTestId('references')
         for (const line of references) {
-            for (const surrounding of line) {
-                if (surrounding === '') {
-                    continue
-                }
-                expect(within(referencesList).getByText(surrounding)).toBeVisible()
-            }
+            expect(within(referencesList).getByText(line)).toBeVisible()
         }
     })
 
@@ -129,7 +119,7 @@ describe('ReferencesPanel', () => {
         const definitionsList = result.getByTestId('definitions')
         const referencesList = result.getByTestId('references')
 
-        const referenceButton = within(referencesList).getByRole('button', { name: '16: OrigName string' })
+        const referenceButton = within(referencesList).getByRole('button', { name: 'line 16' })
         const fullReferenceURL =
             '/github.com/sourcegraph/go-diff@9d1f353a285b3094bc33bdae277a19aedabe8b71/-/blob/diff/diff.go?L16:2-16:10'
         expect(referenceButton).toHaveAttribute('data-test-reference-url', fullReferenceURL)
@@ -141,7 +131,7 @@ describe('ReferencesPanel', () => {
         // Reference is marked as active
         expect(referenceButton.parentNode).toHaveClass('locationActive')
         // But we have the same in Definitions too, and that should be marked active too
-        const definitionButton = within(definitionsList).getByRole('button', { name: '16: OrigName string' })
+        const definitionButton = within(definitionsList).getByRole('button', { name: 'line 16' })
         expect(definitionButton.parentNode).toHaveClass('locationActive')
 
         // Expect "Loading" message
@@ -164,83 +154,5 @@ describe('ReferencesPanel', () => {
         // Assert the code view is rendered, by doing a partial match against its content
         const codeView = within(rightPane).getByRole('table')
         expect(codeView).toHaveTextContent('package diff import')
-    })
-})
-
-describe('getLineContent', () => {
-    const testFileLines = [
-        'package main',
-        '',
-        'import "fmt"',
-        '',
-        'type Animal interface {',
-        '\tSound() string',
-        '}',
-        '',
-        'var _ Animal = Cat{}',
-        '',
-        'type Cat struct{}',
-        '',
-        'func (c Cat) Sound() string { return "i am a cat" }',
-        '',
-        'type Dog struct{}',
-        '',
-        'func (d Dog) Sound() string { return "it is i, the dog" }',
-        '',
-        'func animalFarm() {',
-        '\tmakeSound(Cat{})',
-        '\tmakeSound(Dog{})',
-        '}',
-        '',
-        'func makeSound(a Animal) {',
-        '\tfmt.Printf("animal made a sound: %s", a.Sound())',
-        '',
-        '\tfoo := a',
-        '',
-        '\tfmt.Printf("another animal: %s", foo.Sound())',
-        '}',
-        '',
-    ]
-
-    it('returns pre/post and token of line', () => {
-        const location: Location = {
-            repo: 'a',
-            file: 'file',
-            commitID: 'f00b4r',
-            url: 'url',
-            precise: true,
-            content: '',
-            lines: testFileLines,
-            range: {
-                start: { line: 23, character: 5 },
-                end: { line: 23, character: 14 },
-            },
-        }
-
-        const content = getLineContent(location)
-        expect(content.prePostToken?.pre).toEqual('func ')
-        expect(content.prePostToken?.token).toEqual('makeSound')
-        expect(content.prePostToken?.post).toEqual('(a Animal) {')
-    })
-
-    it('handles token on multiple lines', () => {
-        const location: Location = {
-            repo: 'a',
-            file: 'file',
-            commitID: 'f00b4r',
-            url: 'url',
-            precise: true,
-            content: '',
-            lines: ['line0 start-of-tok', 'en-ends-here line1'],
-            range: {
-                start: { line: 0, character: 6 },
-                end: { line: 1, character: 12 },
-            },
-        }
-
-        const content = getLineContent(location)
-        expect(content.prePostToken?.pre).toEqual('line0 ')
-        expect(content.prePostToken?.token).toEqual('start-of-tok')
-        expect(content.prePostToken?.post).toEqual('')
     })
 })

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -5,6 +5,8 @@ import classNames from 'classnames'
 import * as H from 'history'
 import { capitalize } from 'lodash'
 import { MemoryRouter, useLocation } from 'react-router'
+import { Observable, of } from 'rxjs'
+import { map } from 'rxjs/operators'
 
 import { HoveredToken } from '@sourcegraph/codeintellify'
 import {
@@ -17,6 +19,7 @@ import {
 } from '@sourcegraph/common'
 import { Position } from '@sourcegraph/extension-api-classes'
 import { useQuery } from '@sourcegraph/http-client'
+import { CodeExcerpt, FetchFileParameters } from '@sourcegraph/search-ui'
 import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
 import { findLanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/languages'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
@@ -73,13 +76,18 @@ import styles from './ReferencesPanel.module.scss'
 
 type Token = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
 
-interface ReferencesPanelProps
+interface HighlightedFileLineRangesProps {
+    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
+}
+
+export interface ReferencesPanelProps
     extends SettingsCascadeProps,
         PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'>,
         TelemetryProps,
         HoverThresholdProps,
         ExtensionsControllerProps,
-        ThemeProps {
+        ThemeProps,
+        HighlightedFileLineRangesProps {
     /** Whether to show the first loaded reference in mini code view */
     jumpToFirst?: boolean
 
@@ -511,7 +519,11 @@ interface ActiveLocationProps {
     setActiveLocation: (reference: Location | undefined) => void
 }
 
-interface CollapsibleLocationListProps extends ActiveLocationProps, CollapseProps, SearchTokenProps {
+interface CollapsibleLocationListProps
+    extends ActiveLocationProps,
+        CollapseProps,
+        SearchTokenProps,
+        HighlightedFileLineRangesProps {
     name: string
     locations: Location[]
     filter: string | undefined
@@ -559,6 +571,7 @@ const CollapsibleLocationList: React.FunctionComponent<
                             navigateToUrl={props.navigateToUrl}
                             handleOpenChange={(id, isOpen) => props.handleOpenChange(props.name + id, isOpen)}
                             isOpen={id => props.isOpen(props.name + id)}
+                            fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
                         />
                     ) : (
                         <Text className="text-muted pl-2">
@@ -711,7 +724,11 @@ const SideBlob: React.FunctionComponent<React.PropsWithChildren<SideBlobProps>> 
     )
 }
 
-interface LocationsListProps extends ActiveLocationProps, CollapseProps, SearchTokenProps {
+interface LocationsListProps
+    extends ActiveLocationProps,
+        CollapseProps,
+        SearchTokenProps,
+        HighlightedFileLineRangesProps {
     locations: Location[]
     filter: string | undefined
     navigateToUrl: (url: string) => void
@@ -726,6 +743,7 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
     handleOpenChange,
     isOpen,
     searchToken,
+    fetchHighlightedFileLineRanges,
 }) => {
     const repoLocationGroups = useMemo(() => buildRepoLocationGroups(locations), [locations])
     const openByDefault = repoLocationGroups.length === 1
@@ -744,6 +762,7 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
                     navigateToUrl={navigateToUrl}
                     handleOpenChange={handleOpenChange}
                     isOpen={isOpen}
+                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                 />
             ))}
         </>
@@ -754,7 +773,8 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     React.PropsWithChildren<
         ActiveLocationProps &
             CollapseProps &
-            SearchTokenProps & {
+            SearchTokenProps &
+            HighlightedFileLineRangesProps & {
                 filter: string | undefined
                 navigateToUrl: (url: string) => void
                 repoLocationGroup: RepoLocationGroup
@@ -771,6 +791,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     isOpen,
     handleOpenChange,
     searchToken,
+    fetchHighlightedFileLineRanges,
 }) => {
     const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
 
@@ -804,6 +825,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                             handleOpenChange={(id, isOpen) => handleOpenChange(repoLocationGroup.repoName + id, isOpen)}
                             isOpen={id => isOpen(repoLocationGroup.repoName + id)}
                             navigateToUrl={navigateToUrl}
+                            fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                         />
                     ))}
                 </CollapsePanel>
@@ -816,13 +838,22 @@ const CollapsibleLocationGroup: React.FunctionComponent<
     React.PropsWithChildren<
         ActiveLocationProps &
             CollapseProps &
-            SearchTokenProps & {
+            SearchTokenProps &
+            HighlightedFileLineRangesProps & {
                 group: LocationGroup
                 filter: string | undefined
                 navigateToUrl: (url: string) => void
             }
     >
-> = ({ group, setActiveLocation, isActiveLocation, filter, isOpen, handleOpenChange }) => {
+> = ({
+    group,
+    setActiveLocation,
+    isActiveLocation,
+    filter,
+    isOpen,
+    handleOpenChange,
+    fetchHighlightedFileLineRanges,
+}) => {
     // On the first load, update the scroll position towards the active
     // location.  Without this behavior, the scroll position points at the top
     // of the reference panel when reloading the page or going back/forward in
@@ -833,10 +864,52 @@ const CollapsibleLocationGroup: React.FunctionComponent<
             activeLocationElement.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'center' })
         }
     }, [])
-
     let highlighted = [group.path]
     if (filter !== undefined) {
         highlighted = group.path.split(filter)
+    }
+
+    const { repo, commitID, file } = useMemo(() => group.locations[0], [group])
+    const ranges = useMemo(
+        () =>
+            group.locations.map(location => ({
+                startLine: location.range?.start.line ?? 0,
+                // TODO: off-by-one danger?
+                endLine: (location.range?.end.line ?? 0) + 1,
+            })),
+        [group.locations]
+    )
+
+    const fetchHighlightedFileRangeLines = useCallback(
+        (startLine: number, endLine: number): Observable<string[]> =>
+            fetchHighlightedFileLineRanges(
+                {
+                    repoName: repo,
+                    commitID,
+                    filePath: file,
+                    disableTimeout: false,
+                    format: HighlightResponseFormat.HTML_HIGHLIGHT,
+                    ranges,
+                },
+                false
+            ).pipe(
+                map(
+                    lines =>
+                        lines[ranges.findIndex(group => group.startLine === startLine && group.endLine === endLine + 1)]
+                )
+            ),
+        [fetchHighlightedFileLineRanges, repo, commitID, file, ranges]
+    )
+
+    const fetchPlainTextFileRangeLines = (location: Location): Observable<string[]> => {
+        const range = location.range
+        if (range !== undefined) {
+            const lineNumber = range.start.line + 1
+            const lineContent = location.lines[range.start.line]
+            const tableLine = `<tr><td class="line" data-line="${lineNumber}"></td><td class="code">${lineContent}</td></tr>`
+            return of([tableLine])
+        }
+        return of([])
     }
 
     const open = isOpen(group.path) ?? true
@@ -891,29 +964,6 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                             {group.locations.map(reference => {
                                 const className = isActiveLocation(reference) ? styles.locationActive : ''
 
-                                const locationLine = getLineContent(reference)
-                                const lineWithHighlightedToken = locationLine.prePostToken ? (
-                                    <>
-                                        {locationLine.prePostToken.pre === '' ? (
-                                            <></>
-                                        ) : (
-                                            <Code>{locationLine.prePostToken.pre}</Code>
-                                        )}
-                                        <mark className="p-0 selection-highlight sourcegraph-document-highlight">
-                                            <Code>{locationLine.prePostToken.token}</Code>
-                                        </mark>
-                                        {locationLine.prePostToken.post === '' ? (
-                                            <></>
-                                        ) : (
-                                            <Code>{locationLine.prePostToken.post}</Code>
-                                        )}
-                                    </>
-                                ) : locationLine.line ? (
-                                    <Code>{locationLine.line}</Code>
-                                ) : (
-                                    ''
-                                )
-
                                 return (
                                     <li
                                         key={reference.url}
@@ -927,11 +977,28 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                             data-test-reference-url={reference.url}
                                             className={styles.locationLink}
                                         >
-                                            <span className={styles.locationLinkLineNumber}>
-                                                {(reference.range?.start?.line ?? 0) + 1}
-                                                {': '}
-                                            </span>
-                                            {lineWithHighlightedToken}
+                                            <CodeExcerpt
+                                                className={styles.locationLinkCodeExcerpt}
+                                                commitID={reference.commitID}
+                                                filePath={reference.file}
+                                                repoName={reference.repo}
+                                                highlightRanges={[
+                                                    {
+                                                        line: reference.range?.start.line ?? 0,
+                                                        character: reference.range?.start.character ?? 0,
+                                                        highlightLength:
+                                                            (reference.range?.end.character ?? 0) -
+                                                            (reference.range?.start.character ?? 0),
+                                                    },
+                                                ]}
+                                                startLine={reference.range?.start.line ?? 0}
+                                                endLine={reference.range?.end.line ?? 0}
+                                                fetchHighlightedFileRangeLines={fetchHighlightedFileRangeLines}
+                                                visibilityOffset={{ bottom: 0 }}
+                                                fetchPlainTextFileRangeLines={(): Observable<string[]> =>
+                                                    fetchPlainTextFileRangeLines(reference)
+                                                }
+                                            />
                                         </Button>
                                     </li>
                                 )
@@ -942,38 +1009,6 @@ const CollapsibleLocationGroup: React.FunctionComponent<
             </div>
         </Collapse>
     )
-}
-
-interface LocationLine {
-    prePostToken?: { pre: string; token: string; post: string }
-    line?: string
-}
-
-export const getLineContent = (location: Location): LocationLine => {
-    const range = location.range
-    if (range !== undefined) {
-        const line = location.lines[range.start.line]
-
-        if (range.end.line === range.start.line) {
-            return {
-                prePostToken: {
-                    pre: line.slice(0, range.start.character).trimStart(),
-                    token: line.slice(range.start.character, range.end.character),
-                    post: line.slice(range.end.character),
-                },
-                line: line.trimStart(),
-            }
-        }
-        return {
-            prePostToken: {
-                pre: line.slice(0, range.start.character).trimStart(),
-                token: line.slice(range.start.character),
-                post: '',
-            },
-            line: line.trimStart(),
-        }
-    }
-    return {}
 }
 
 const LoadingCodeIntel: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -114,6 +114,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                                         context.repoHeaderContributionsLifecycleProps
                                     }
                                     onHandleFuzzyFinder={props.onHandleFuzzyFinder}
+                                    fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
                                 />
                             </TraceSpanProvider>
                         ) : resolvedRevision ? (

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -18,7 +18,7 @@ import {
     reactManualTracer,
 } from '@sourcegraph/observability-client'
 import { SearchContextProps } from '@sourcegraph/search'
-import { StreamingSearchResultsListProps } from '@sourcegraph/search-ui'
+import { FetchFileParameters, StreamingSearchResultsListProps } from '@sourcegraph/search-ui'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { HighlightResponseFormat, Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -85,6 +85,8 @@ interface BlobPageProps
     isSourcegraphDotCom: boolean
     repoID?: Scalars['ID']
     repoUrl?: string
+
+    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
 
 /**

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -14,6 +14,7 @@ import { ReferenceParameters, TextDocumentPositionParameters } from '@sourcegrap
 import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import { isErrorLike } from '@sourcegraph/common'
 import * as clientType from '@sourcegraph/extension-api-types'
+import { FetchFileParameters } from '@sourcegraph/search-ui'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { Activation, ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
@@ -42,6 +43,8 @@ interface Props
     repoID: Scalars['ID']
     repoName: string
     commitID: string
+
+    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
 
 export type BlobPanelTabID = 'info' | 'def' | 'references' | 'impl' | 'typedef' | 'history'
@@ -78,6 +81,7 @@ function useBlobPanelViews({
     isLightTheme,
     platformContext,
     telemetryService,
+    fetchHighlightedFileLineRanges,
 }: Props): void {
     const subscriptions = useMemo(() => new Subscription(), [])
 
@@ -264,6 +268,7 @@ function useBlobPanelViews({
                                     key="references"
                                     externalHistory={history}
                                     externalLocation={location}
+                                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                 />
                             ) : (
                                 <></>
@@ -284,6 +289,7 @@ function useBlobPanelViews({
             telemetryService,
             platformContext,
             extensionsController,
+            fetchHighlightedFileLineRanges,
         ])
     )
 


### PR DESCRIPTION
Hacked `<CodeExcerpt />` into `ReferencesPanel`.

See video:

https://user-images.githubusercontent.com/1185253/191068687-374222a7-44f5-4c5b-97f7-48e8006de701.mp4


## Bugs/TODOs:

* ~VisibilityDetector in `CodeExcerpt` didn't seem to work in ref panel. Had to turn it off~ -> @vovakulikov fixed that! Thank you.
* You can't select text in the results. Cursor changes but you can't select it.
* Lots of prop drilling to get to that highlighting function.
* Off-by-one errors probably.
* ~The `bottom: -500` offset for the visibility detector is independent of the height of the panel. What if someone resizes panel at runtime?~
* ~Since we load the highlights lazily, it can feel a bit weird when scrolling fast~ -> I changed it to show plain text first before falling back to syntax highlighting.

## Design questions

**EDIT:** I added a small border between results

<img width="1066" alt="screenshot_2022-09-09_15 33 30@2x" src="https://user-images.githubusercontent.com/1185253/189362115-5992dd77-c9e3-41fe-a0b5-83447f614954.png">


## Test plan

- N/A

## App preview:

- [Web](https://sg-web-mrn-refpanel-code-excerpt.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

