### PR TITLE
Enable extension registry list for code intel extension to unblock native code host integration

### DIFF
--- a/cmd/frontend/registry/api/gating.go
+++ b/cmd/frontend/registry/api/gating.go
@@ -6,6 +6,48 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// This list is different from the builtinExtensions since it only includes code
+// intel extensions.
+var codeIntelExtensions = map[string]bool{
+	"sourcegraph/apex":       true,
+	"sourcegraph/clojure":    true,
+	"sourcegraph/cobol":      true,
+	"sourcegraph/cpp":        true,
+	"sourcegraph/csharp":     true,
+	"sourcegraph/cuda":       true,
+	"sourcegraph/dart":       true,
+	"sourcegraph/elixir":     true,
+	"sourcegraph/erlang":     true,
+	"sourcegraph/go":         true,
+	"sourcegraph/graphql":    true,
+	"sourcegraph/groovy":     true,
+	"sourcegraph/haskell":    true,
+	"sourcegraph/java":       true,
+	"sourcegraph/jsonnet":    true,
+	"sourcegraph/kotlin":     true,
+	"sourcegraph/lisp":       true,
+	"sourcegraph/lua":        true,
+	"sourcegraph/ocaml":      true,
+	"sourcegraph/pascal":     true,
+	"sourcegraph/perl":       true,
+	"sourcegraph/php":        true,
+	"sourcegraph/powershell": true,
+	"sourcegraph/protobuf":   true,
+	"sourcegraph/python":     true,
+	"sourcegraph/r":          true,
+	"sourcegraph/ruby":       true,
+	"sourcegraph/rust":       true,
+	"sourcegraph/scala":      true,
+	"sourcegraph/shell":      true,
+	"sourcegraph/starlark":   true,
+	"sourcegraph/swift":      true,
+	"sourcegraph/tcl":        true,
+	"sourcegraph/thrift":     true,
+	"sourcegraph/typescript": true,
+	"sourcegraph/verilog":    true,
+	"sourcegraph/vhdl":       true,
+}
+
 func ExtensionRegistryReadEnabled() error {
 	// We need to allow read access to the extension registry of sourcegraph.com to allow instances
 	// on older versions to fetch extensions.
@@ -14,6 +56,31 @@ func ExtensionRegistryReadEnabled() error {
 	}
 
 	return ExtensionRegistryWriteEnabled()
+}
+
+// The extensions list query (`extensionRegistry.extensions`) will be called by the native
+// integration, a deployment method where we do not have control over updating the client.
+//
+// An example for this is the GitLab native integration that ships with GitLab releases.
+// When enabled, it will make a GraphQL query to Sourcegraph to get a list of valid
+// extensions.
+//
+// Since we want to support code navigation in the native integrations after 4.0, we are
+// special-casing this API and make it return only code intel legacy extensions.
+//
+// Since the dotcom instance will be connected to from instances before 4.0, we'll need
+// to keep the behavior of being able to list all extensions there.
+//
+// This method returns nil if all extensions are allowed to be listed.
+func ExtensionRegistryListAllowedExtension() map[string]bool {
+	err := ExtensionRegistryReadEnabled()
+
+	if err != nil {
+		return codeIntelExtensions
+	} else {
+		// nil means all extensions are allowed
+		return nil
+	}
 }
 
 func ExtensionRegistryWriteEnabled() error {


### PR DESCRIPTION
Closes #41039

The extensions list query (`extensionRegistry.extensions`) is called by the native code host integrations, a deployment method where we do not have control over updating the client.

An example for this is the GitLab native integration that ships with GitLab releases. When enabled, it will make a GraphQL query to the Sourcegraph instance to get a list of valid extensions and where to download the extension code.

Since we want to support code navigation in the native integrations after 4.0, this PR is about special-casing the list API and make it return only code intel legacy extensions post 4.0.

Any non-air-gapped instances will then return the list of legacy code intel extensions and point the download URL to sourcegraph.com where we need to keep the extension registry around regardless (for pre 4.0 instances).

## Air gapped instances

Air gapped instances are special here since they would require not only to list the extension but also read access to the individual extension (since they are not hosted on dotcom but on their local extension registry). **I think the best way is to break those instances and require them to `enableLegacyExtensions` if they want to move forward with native code host integrations.** Here's my reasoning for this:

- In order for air gapped instances to load legacy extensions, they need to manually create extensions in their extension registry. This is not possible anymore on 4.0 by default and the guides will make it clear to enable legacy extensions for this to work.
- The extension registry is also locked down completely on 4.0 by default, so it's not possible to read the extension source code. This is also consistent with the overall extension deprecation messaging.

If we were to apply a similar workaround we would have to undo almost all 4.0 deprecations of the extension registry which seems to undo a lot of the efforts. Hence I am fine with it breaking (especially since it would not show errors on the native code host side). 

We could have a guide article ready that goes into more depth here.

cc @ryankscott @muratsu @jjinnii 

## Outdated browser extensions

There's a nice side effect with this change. Any outdated browser extensions (i.e those that were not updated before the Sourcegraph instance was moved to 4.0) will also benefit from this change and not break anymore.

## Test plan

### Code navigation works with the GitLab native code integration

![Screenshot 2022-09-09 at 11 55 08](https://user-images.githubusercontent.com/458591/189327672-8aaf59f0-fc26-4e89-a71e-e0ee7da24c53.png)

### Does not load git extras extension

Since git-extras is the only extension that is enabled by default but should not enable post 4.0, we expect the native code host integration to _not load these extension_. I verified that this is the case:

![Screenshot 2022-09-09 at 11 55 05](https://user-images.githubusercontent.com/458591/189327822-b923e5b6-e246-4274-a078-e9cdf5d61576.png)

### I also tested that with `enableLegacyExtensions` turned `true`, all extensions are loaded  ✅

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

