### PR TITLE
Hide open in IDE button for logged out users

### DIFF
--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -253,7 +253,9 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
                 {source === 'blob' && (
                     <>
                         <ToggleBlameAction location={props.location} />
-                        <OpenInEditorActionItem platformContext={props.platformContext} />
+                        {window.context.isAuthenticatedUser && (
+                            <OpenInEditorActionItem platformContext={props.platformContext} />
+                        )}
                     </>
                 )}
 


### PR DESCRIPTION
Closes #41528

## Test plan

Validated that this hides the button when logged out and running dotcom mode:

![Screenshot 2022-09-09 at 13 58 40](https://user-images.githubusercontent.com/458591/189345203-924bf305-7b67-4c48-a3da-58069a7653ac.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-hide-open-in-ide-for-logged.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yjtfssuovk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
