### PR TITLE
Reset aggregation mode on drill-down

### DIFF
--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -67,6 +67,11 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
     }
 
     const handleBarLinkClick = (query: string, index: number): void => {
+        // Clearing the aggregation mode on drill down would provide a better experience
+        // in most cases and preserve the desired behavior of the capture group search
+        // when the original query had multiple capture groups
+        setAggregationMode(null)
+
         resetUIMode()
         onQuerySubmit(query)
         telemetryService.log(

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 
 import { gql, useQuery } from '@apollo/client'
 import { useHistory, useLocation } from 'react-router'
@@ -280,7 +280,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
         }
     )
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         // If query, pattern type or extendedTimeout have been changed we should "reset" our assumptions
         // about calculated aggregation mode and make another api call to determine it
         setState(state => ({ ...state, calculatedMode: null }))

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -66,6 +66,11 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
     const handleExtendTimeout = (): void => setExtendedTimeoutLocal(true)
 
     const handleBarLinkClick = (query: string, index: number): void => {
+        // Clearing the aggregation mode on drill down would provide a better experience
+        // in most cases and preserve the desired behavior of the capture group search
+        // when the original query had multiple capture groups
+        setAggregationMode(null)
+
         onQuerySubmit(query)
         telemetryService.log(
             GroupResultsPing.ChartBarClick,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41133

## Background

https://user-images.githubusercontent.com/18492575/189377995-b1b607f2-7bc7-4bb7-8f8a-628f1c11af71.mov

## Test plan
- Search anything that you could see aggregation chart (for example: `file:go\.mod$ go\s*(\d\.\d+) patterntype:regexp`) it will produce capture group aggregation
- Try to click one of the bars on the chart (drill down to some particular value)
- You should see that the aggregation mode has been reset, and BE calculates a new aggregation mode based on the new query (changed after you clicked one of the bars)
- Make sure that history buttons back/forward work correctly and restore a proper state for the aggregation mode



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
