### PR TITLE
site admin repos page: display byte size of repositories

### DIFF
--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -145,6 +145,7 @@ const mirrorRepositoryInfoFieldsFragment = gql`
         cloneInProgress
         updatedAt
         lastError
+        byteSize
     }
 `
 

--- a/client/web/src/site-admin/components/RepoMirrorInfo.tsx
+++ b/client/web/src/site-admin/components/RepoMirrorInfo.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { mdiCloudOutline } from '@mdi/js'
+import prettyBytes from 'pretty-bytes'
 
 import { Icon, LoadingSpinner, Text, Tooltip } from '@sourcegraph/wildcard'
 
@@ -31,7 +32,7 @@ export const RepoMirrorInfo: React.FunctionComponent<
                     <>Not yet synced from code host.</>
                 ) : (
                     <>
-                        Last synced <Timestamp date={mirrorInfo.updatedAt} />.
+                        Last synced <Timestamp date={mirrorInfo.updatedAt} />. Size: {prettyBytes(mirrorInfo.byteSize)}.
                     </>
                 )}
             </small>

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -158,6 +158,15 @@ func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*DateTime
 	return &DateTime{Time: info.LastFetched}, nil
 }
 
+func (r *repositoryMirrorInfoResolver) ByteSize(ctx context.Context) (int32, error) {
+	info, err := r.computeGitserverRepo(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return int32(info.RepoSizeBytes), nil
+}
+
 func (r *repositoryMirrorInfoResolver) UpdateSchedule(ctx context.Context) (*updateScheduleResolver, error) {
 	info, err := r.repoUpdateSchedulerInfo(ctx)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2992,6 +2992,10 @@ type MirrorRepositoryInfo {
     The last error message, if any, returned when fetching or cloning the repo
     """
     lastError: String
+    """
+    The byte size of the repo.
+    """
+    byteSize: Int!
 }
 
 """


### PR DESCRIPTION
This one's for @mike-r-mclaughlin.

We're fetching the `gitserver_repos` row anyway, so we might as well display that data too :)

## Screenshot

![image](https://user-images.githubusercontent.com/1185253/189389005-d6684efb-00c6-4dad-a449-c7f762b2faf5.png)

## Test plan

- Tested manually locally
- Existing tests