### PR TITLE
insights: add a result count limit for proactive aggregations

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -39,12 +39,12 @@ func withDefaults(inputQuery BasicQuery, defaults searchquery.Parameters) (Basic
 
 // AggregationQuery takes an existing query and adds a count:all and timeout:[timeoutSeconds]s
 // If a count or timeout parameter already exist in the query they will be updated.
-func AggregationQuery(inputQuery BasicQuery, timeoutSeconds int) (BasicQuery, error) {
+func AggregationQuery(inputQuery BasicQuery, timeoutSeconds int, count string) (BasicQuery, error) {
 
 	upsertParams := searchquery.Parameters{
 		{
 			Field:      searchquery.FieldCount,
-			Value:      "all",
+			Value:      count,
 			Negated:    false,
 			Annotation: searchquery.Annotation{},
 		},

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -432,28 +432,38 @@ func TestAggregationQuery(t *testing.T) {
 	tests := []struct {
 		name       string
 		inputQuery string
+		count      string
 		want       autogold.Value
 	}{
 		{
 			inputQuery: `test`,
+			count:      "all",
 			want:       autogold.Want("basic query", BasicQuery("count:all timeout:2s test")),
 		},
 		{
 			inputQuery: `(repo:^github\.com/sourcegraph/sourcegraph$ test) OR (repo:^github\.com/sourcegraph/sourcegraph$ todo)`,
+			count:      "all",
 			want:       autogold.Want("multiplan query", BasicQuery("(repo:^github\\.com/sourcegraph/sourcegraph$ count:all timeout:2s test OR repo:^github\\.com/sourcegraph/sourcegraph$ count:all timeout:2s todo)")),
 		},
 		{
 			inputQuery: `(repo:^github\.com/sourcegraph/sourcegraph$ test) OR (repo:^github\.com/sourcegraph/sourcegraph$ todo) count:2000`,
+			count:      "all",
 			want:       autogold.Want("multiplan query overwrite", BasicQuery("(repo:^github\\.com/sourcegraph/sourcegraph$ count:all timeout:2s test OR repo:^github\\.com/sourcegraph/sourcegraph$ count:all timeout:2s todo)")),
 		},
 		{
 			inputQuery: `test count:1000`,
+			count:      "all",
 			want:       autogold.Want("overwrite existing", BasicQuery("count:all timeout:2s test")),
+		},
+		{
+			inputQuery: `test count:1000`,
+			count:      "50000",
+			want:       autogold.Want("overwrite existing", BasicQuery("count:50000 timeout:2s test")),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.want.Name(), func(t *testing.T) {
-			got, _ := AggregationQuery(BasicQuery(test.inputQuery), 2)
+			got, _ := AggregationQuery(BasicQuery(test.inputQuery), 2, test.count)
 			test.want.Equal(t, got)
 
 		})

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -236,6 +236,8 @@ func searchSuccessful(alert *search.Alert, tabulationErrors []error, shardTimeou
 		return false, notAvailableReason{reason: shardTimeoutMsg, reasonType: reasonType}
 	}
 
+	// This is a protective feature to limit the number of results proactive aggregations could process
+	// It behaves like a timeout so the user has an option to re-run with the extended timeout that has no result limit
 	if !runningWithExtendedTimeout && resultLimitHit {
 		return false, notAvailableReason{reason: proactiveResultLimitMsg, reasonType: types.TIMEOUT_EXTENSION_AVAILABLE}
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2060,6 +2060,8 @@ type SiteConfiguration struct {
 	HtmlHeadTop string `json:"htmlHeadTop,omitempty"`
 	// InsightsAggregationsBufferSize description: The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend
 	InsightsAggregationsBufferSize int `json:"insights.aggregations.bufferSize,omitempty"`
+	// InsightsAggregationsProactiveResultLimit description: The maximum number of results a proactive search aggregation can accept before stopping
+	InsightsAggregationsProactiveResultLimit int `json:"insights.aggregations.proactiveResultLimit,omitempty"`
 	// InsightsCommitIndexerInterval description: The interval (in minutes) at which the insights commit indexer will check for new commits.
 	InsightsCommitIndexerInterval int `json:"insights.commit.indexer.interval,omitempty"`
 	// InsightsCommitIndexerWindowDuration description: The number of days of commits the insights commit indexer will pull during each request (0 is no limit).

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1851,6 +1851,8 @@ type SettingsExperimentalFeatures struct {
 	HomepageUserInvitation *bool `json:"homepageUserInvitation,omitempty"`
 	// ProactiveSearchResultsAggregations description: Search results aggregations are triggered automatically with a search.
 	ProactiveSearchResultsAggregations *bool `json:"proactiveSearchResultsAggregations,omitempty"`
+	// ProactiveSearchResultsAggregationsLimit description: Limits the number of results requested for proactive search aggregations.
+	ProactiveSearchResultsAggregationsLimit int `json:"proactiveSearchResultsAggregationsLimit,omitempty"`
 	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts
 	SearchContextsQuery *bool `json:"searchContextsQuery,omitempty"`
 	// SearchResultsAggregations description: Display aggregations for your search results on the search screen.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1851,8 +1851,6 @@ type SettingsExperimentalFeatures struct {
 	HomepageUserInvitation *bool `json:"homepageUserInvitation,omitempty"`
 	// ProactiveSearchResultsAggregations description: Search results aggregations are triggered automatically with a search.
 	ProactiveSearchResultsAggregations *bool `json:"proactiveSearchResultsAggregations,omitempty"`
-	// ProactiveSearchResultsAggregationsLimit description: Limits the number of results requested for proactive search aggregations.
-	ProactiveSearchResultsAggregationsLimit int `json:"proactiveSearchResultsAggregationsLimit,omitempty"`
 	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts
 	SearchContextsQuery *bool `json:"searchContextsQuery,omitempty"`
 	// SearchResultsAggregations description: Display aggregations for your search results on the search screen.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -404,6 +404,13 @@
           "!go": {
             "pointer": true
           }
+        },
+        "proactiveSearchResultsAggregationsLimit": {
+          "description": "Limits the number of results requested for proactive search aggregations.",
+          "type": "integer",
+          "default": 50000,
+          "minimum": 500,
+          "maximum": 250000
         }
       },
       "group": "Experimental"

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -404,13 +404,6 @@
           "!go": {
             "pointer": true
           }
-        },
-        "proactiveSearchResultsAggregationsLimit": {
-          "description": "Limits the number of results requested for proactive search aggregations.",
-          "type": "integer",
-          "default": 50000,
-          "minimum": 500,
-          "maximum": 250000
         }
       },
       "group": "Experimental"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1392,6 +1392,12 @@
       "group": "CodeInsights",
       "default": 500
     },
+    "insights.aggregations.proactiveResultLimit": {
+      "description": "The maximum number of results a proactive search aggregation can accept before stopping",
+      "type": "integer",
+      "group": "CodeInsights",
+      "default": 50000
+    },
     "htmlHeadTop": {
       "description": "HTML to inject at the top of the `<head>` element on each page, for analytics scripts",
       "type": "string",


### PR DESCRIPTION
Adds a limit to results allowed for proactive aggregations default 50k.  It treats hitting this limit the same as a timeout so that the user can re-run the aggregation with the extended timeout which also removes the result limit.


## Test plan
54k results within 2 seconds but no aggregation present - but user can run if desired
<img width="1671" alt="Screen Shot 2022-09-09 at 2 01 18 PM" src="https://user-images.githubusercontent.com/6098507/189418769-eb3268b6-0fd9-43a9-b477-4f4dfefd16b1.png">

Less than 50k results within 2 seconds - aggregation present
<img width="1676" alt="Screen Shot 2022-09-09 at 2 02 30 PM" src="https://user-images.githubusercontent.com/6098507/189418926-d5852129-5acd-4093-afc5-4714ee17e9ca.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
