### PR TITLE
Fix wrong use of loop variables in parallel tests

### DIFF
--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -164,6 +164,7 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 			},
 		},
 	} {
+		test := test // capture range variable
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			db := NewDB(logger, dbtest.NewDB(logger, t))

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -499,6 +499,7 @@ func TestUsers_GetByUsernames(t *testing.T) {
 
 func TestUsers_Delete(t *testing.T) {
 	for name, hard := range map[string]bool{"soft": false, "hard": true} {
+		hard := hard // capture range variable
 		t.Run(name, func(t *testing.T) {
 			if testing.Short() {
 				t.Skip()

--- a/internal/workerutil/worker_test.go
+++ b/internal/workerutil/worker_test.go
@@ -155,6 +155,7 @@ func TestWorkerConcurrent(t *testing.T) {
 	for numHandlers := 1; numHandlers < NumTestRecords; numHandlers++ {
 		name := fmt.Sprintf("numHandlers=%d", numHandlers)
 
+		numHandlers := numHandlers // capture range variable
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This commit fixes occurrences of a loop variable being incorrectly captured in parallel tests. To work around this problem, we create a local copy of the range variable before the parallel test, as suggested in the documentation of the `testing` package:

https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks

Issues were found using the `loopvarcapture` linter.

## Test plan

This change doesn't add new code to be tested, only expands what is currently tested.
