### PR TITLE
conf: redact src-cli version cache secrets when viewing configuration

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -212,6 +212,8 @@ var siteConfigSecrets = []struct {
 	{readPath: `gitHubApp.privateKey`, editPaths: []string{"gitHubApp", "privateKey"}},
 	{readPath: `gitHubApp.clientSecret`, editPaths: []string{"gitHubApp", "clientSecret"}},
 	{readPath: `auth\.unlockAccountLinkSigningKey`, editPaths: []string{"auth.unlockAccountLinkSigningKey"}},
+	{readPath: `dotcom.srcCliVersionCache.github.token`, editPaths: []string{"dotcom", "srcCliVersionCache", "github", "token"}},
+	{readPath: `dotcom.srcCliVersionCache.github.webhookSecret`, editPaths: []string{"dotcom", "srcCliVersionCache", "github", "webhookSecret"}},
 }
 
 // UnredactSecrets unredacts unchanged secrets back to their original value for

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -13,16 +13,18 @@ import (
 )
 
 const (
-	executorsAccessToken              = "executorsAccessToken"
-	authOpenIDClientSecret            = "authOpenIDClientSecret"
-	authGitHubClientSecret            = "authGitHubClientSecret"
-	authGitLabClientSecret            = "authGitLabClientSecret"
-	emailSMTPPassword                 = "emailSMTPPassword"
-	organizationInvitationsSigningKey = "organizationInvitationsSigningKey"
-	githubClientSecret                = "githubClientSecret"
-	dotcomGitHubAppCloudClientSecret  = "dotcomGitHubAppCloudClientSecret"
-	dotcomGitHubAppCloudPrivateKey    = "dotcomGitHubAppCloudPrivateKey"
-	authUnlockAccountLinkSigningKey   = "authUnlockAccountLinkSigningKey"
+	executorsAccessToken                        = "executorsAccessToken"
+	authOpenIDClientSecret                      = "authOpenIDClientSecret"
+	authGitHubClientSecret                      = "authGitHubClientSecret"
+	authGitLabClientSecret                      = "authGitLabClientSecret"
+	emailSMTPPassword                           = "emailSMTPPassword"
+	organizationInvitationsSigningKey           = "organizationInvitationsSigningKey"
+	githubClientSecret                          = "githubClientSecret"
+	dotcomGitHubAppCloudClientSecret            = "dotcomGitHubAppCloudClientSecret"
+	dotcomGitHubAppCloudPrivateKey              = "dotcomGitHubAppCloudPrivateKey"
+	authUnlockAccountLinkSigningKey             = "authUnlockAccountLinkSigningKey"
+	dotcomSrcCliVersionCacheGitHubToken         = "dotcomSrcCliVersionCacheGitHubToken"
+	dotcomSrcCliVersionCacheGitHubWebhookSecret = "dotcomSrcCliVersionCacheGitHubWebhookSecret"
 )
 
 func TestValidate(t *testing.T) {
@@ -152,6 +154,8 @@ func TestRedactSecrets(t *testing.T) {
 				githubClientSecret,
 				dotcomGitHubAppCloudClientSecret,
 				dotcomGitHubAppCloudPrivateKey,
+				dotcomSrcCliVersionCacheGitHubToken,
+				dotcomSrcCliVersionCacheGitHubWebhookSecret,
 				authUnlockAccountLinkSigningKey,
 			),
 		},
@@ -186,6 +190,8 @@ func TestUnredactSecrets(t *testing.T) {
 		githubClientSecret,
 		dotcomGitHubAppCloudClientSecret,
 		dotcomGitHubAppCloudPrivateKey,
+		dotcomSrcCliVersionCacheGitHubToken,
+		dotcomSrcCliVersionCacheGitHubWebhookSecret,
 		authUnlockAccountLinkSigningKey,
 	)
 
@@ -207,6 +213,8 @@ func TestUnredactSecrets(t *testing.T) {
 			redactedSecret,
 			redactedSecret,
 			redactedSecret,
+			redactedSecret,
+			redactedSecret,
 		)
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
 		require.NoError(t, err)
@@ -220,6 +228,8 @@ func TestUnredactSecrets(t *testing.T) {
 			githubClientSecret,
 			dotcomGitHubAppCloudClientSecret,
 			dotcomGitHubAppCloudPrivateKey,
+			dotcomSrcCliVersionCacheGitHubToken,
+			dotcomSrcCliVersionCacheGitHubWebhookSecret,
 			authUnlockAccountLinkSigningKey,
 		)
 		assert.Equal(t, want, unredactedSite)
@@ -230,6 +240,8 @@ func TestUnredactSecrets(t *testing.T) {
 		input := getTestSiteWithSecrets(
 			"new"+executorsAccessToken,
 			redactedSecret, "new"+authGitLabClientSecret, redactedSecret,
+			redactedSecret,
+			redactedSecret,
 			redactedSecret,
 			redactedSecret,
 			redactedSecret,
@@ -250,6 +262,8 @@ func TestUnredactSecrets(t *testing.T) {
 			githubClientSecret,
 			dotcomGitHubAppCloudClientSecret,
 			dotcomGitHubAppCloudPrivateKey,
+			dotcomSrcCliVersionCacheGitHubToken,
+			dotcomSrcCliVersionCacheGitHubWebhookSecret,
 			authUnlockAccountLinkSigningKey,
 			newEmail,
 		)
@@ -258,7 +272,7 @@ func TestUnredactSecrets(t *testing.T) {
 }
 
 func getTestSiteWithRedactedSecrets() string {
-	return getTestSiteWithSecrets(redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret)
+	return getTestSiteWithSecrets(redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret)
 }
 
 func getTestSiteWithSecrets(
@@ -268,6 +282,7 @@ func getTestSiteWithSecrets(
 	organizationInvitationsSigningKey,
 	githubClientSecret,
 	dotcomGitHubAppCloudClientSecret, dotcomGitHubAppCloudPrivateKey,
+	dotcomSrcCliVersionCacheGitHubToken, dotcomSrcCliVersionCacheGitHubWebhookSecret,
 	authUnlockAccountLinkSigningKey string,
 	optionalEdit ...string,
 ) string {
@@ -323,6 +338,12 @@ func getTestSiteWithSecrets(
     "githubApp.cloud": {
       "clientSecret": "%s",
       "privateKey": "%s"
+    },
+    "srcCliVersionCache": {
+      "github": {
+        "token": "%s",
+        "webhookSecret": "%s"
+      }
     }
   },
   "auth.unlockAccountLinkSigningKey": "%s",
@@ -334,6 +355,7 @@ func getTestSiteWithSecrets(
 		organizationInvitationsSigningKey,
 		githubClientSecret,
 		dotcomGitHubAppCloudClientSecret, dotcomGitHubAppCloudPrivateKey,
+		dotcomSrcCliVersionCacheGitHubToken, dotcomSrcCliVersionCacheGitHubWebhookSecret,
 		authUnlockAccountLinkSigningKey,
 	)
 


### PR DESCRIPTION
In practice, I'm not terribly concerned about this, since the token and webhook secrets don't actually provide access to anything secret, but this gives us more consistency with other parts of the site configuration that deal with secrets.

## Test plan

Tested locally in the site admin, and updated the relevant unit tests.