### PR TITLE
capture metrics for search aggregations

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -4077,6 +4077,160 @@ Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="s
 
 <br />
 
+### Frontend: Search aggregations: proactive and expanded search aggregations
+
+#### frontend: insights_aggregations_total
+
+<p class="subtitle">Aggregate search aggregations operations every 5m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103000` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+
+</details>
+
+<br />
+
+#### frontend: insights_aggregations_99th_percentile_duration
+
+<p class="subtitle">Aggregate successful search aggregations operation duration distribution over 5m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103001` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum  by (le)(rate(src_insights_aggregations_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+
+</details>
+
+<br />
+
+#### frontend: insights_aggregations_errors_total
+
+<p class="subtitle">Aggregate search aggregations operation errors every 5m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103002` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+
+</details>
+
+<br />
+
+#### frontend: insights_aggregations_error_rate
+
+<p class="subtitle">Aggregate search aggregations operation error rate over 5m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103003` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+
+</details>
+
+<br />
+
+#### frontend: insights_aggregations_total
+
+<p class="subtitle">Search aggregations operations every 5m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103010` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (op,extended_mode)(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+
+</details>
+
+<br />
+
+#### frontend: insights_aggregations_99th_percentile_duration
+
+<p class="subtitle">99th percentile successful search aggregations operation duration over 5m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103011` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.99, sum  by (le,op,extended_mode)(rate(src_insights_aggregations_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+
+</details>
+
+<br />
+
+#### frontend: insights_aggregations_errors_total
+
+<p class="subtitle">Search aggregations operation errors every 5m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103012` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (op,extended_mode)(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+
+</details>
+
+<br />
+
+#### frontend: insights_aggregations_error_rate
+
+<p class="subtitle">Search aggregations operation error rate over 5m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103013` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (op,extended_mode)(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op,extended_mode)(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op,extended_mode)(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+
+</details>
+
+<br />
+
 ## Git Server
 
 <p class="subtitle">Stores, manages, and operates Git repositories.</p>

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -41,7 +41,7 @@ func IsEnabled() bool {
 
 // Init initializes the given enterpriseServices to include the required resolvers for insights.
 func Init(ctx context.Context, postgres database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
-	enterpriseServices.InsightsAggregationResolver = resolvers.NewAggregationResolver(postgres)
+	enterpriseServices.InsightsAggregationResolver = resolvers.NewAggregationResolver(postgres, observationContext)
 
 	if !IsEnabled() {
 		if deploy.IsDeployTypeSingleDockerContainer(deploy.Type()) {

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -3,8 +3,11 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 
@@ -52,6 +55,7 @@ type searchAggregateResolver struct {
 	searchQuery string
 	patternType string
 	logger      log.Logger
+	operations  *aggregationsOperations
 }
 
 func (r *searchAggregateResolver) getLogger() log.Logger {
@@ -69,7 +73,16 @@ func (r *searchAggregateResolver) ModeAvailability(ctx context.Context) []graphq
 	return resolvers
 }
 
-func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphqlbackend.AggregationsArgs) (graphqlbackend.SearchAggregationResultResolver, error) {
+func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphqlbackend.AggregationsArgs) (_ graphqlbackend.SearchAggregationResultResolver, err error) {
+	var aggregationMode types.SearchAggregationMode
+
+	ctx, _, endObservation := r.operations.aggregations.With(ctx, &err, observation.Args{
+		MetricLabelValues: []string{strconv.FormatBool(args.ExtendedTimeout)},
+	})
+	defer func() {
+		endObservation(1, observation.Args{MetricLabelValues: []string{string(aggregationMode)}})
+	}()
+
 	// Steps:
 	// 1. - If no mode get the default mode
 	// 2. - Validate mode is supported (if in default mode this is done in that step)
@@ -77,7 +90,6 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 	// 3. - Run Search
 	// 4. - Check search for errors/alerts
 	// 5 -  Generate correct resolver pass search results if valid
-	var aggregationMode types.SearchAggregationMode
 	if args.Mode == nil {
 		aggregationMode = getDefaultAggregationMode(r.searchQuery, r.patternType)
 	} else {

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -903,6 +903,7 @@ func Frontend() *monitoring.Dashboard {
 					},
 				},
 			},
+			shared.CodeInsights.NewSearchAggregationsGroup(containerName),
 		},
 	}
 }

--- a/monitoring/definitions/shared/codeinsights.go
+++ b/monitoring/definitions/shared/codeinsights.go
@@ -115,3 +115,30 @@ func (codeInsights) NewInsightsQueryRunnerStoreGroup(containerName string) monit
 		},
 	})
 }
+
+func (codeInsights) NewSearchAggregationsGroup(containerName string) monitoring.Group {
+	return Observation.NewGroup(containerName, monitoring.ObservableOwnerCodeInsights, ObservationGroupOptions{
+		GroupConstructorOptions: GroupConstructorOptions{
+			ObservableConstructorOptions: ObservableConstructorOptions{
+				MetricNameRoot:        "insights_aggregations",
+				MetricDescriptionRoot: "search aggregations",
+				By:                    []string{"op", "extended_mode"},
+			},
+			Namespace:       "search aggregations",
+			DescriptionRoot: "proactive and expanded search aggregations",
+			Hidden:          true,
+		},
+		SharedObservationGroupOptions: SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+		Aggregate: &SharedObservationGroupOptions{
+			Total:     NoAlertsOption("none"),
+			Duration:  NoAlertsOption("none"),
+			Errors:    NoAlertsOption("none"),
+			ErrorRate: NoAlertsOption("none"),
+		},
+	})
+}


### PR DESCRIPTION
Some basic metrics + a dashboard for search aggregations. Not enabling any alerts, because we have absolutely no idea what normal usage would look like.

## Test plan

<img width="1432" alt="CleanShot 2022-09-09 at 13 24 20@2x" src="https://user-images.githubusercontent.com/5090588/189439275-22215b03-a26c-4041-aa63-0c862bf43404.png">
<img width="1434" alt="CleanShot 2022-09-09 at 13 39 21@2x" src="https://user-images.githubusercontent.com/5090588/189439280-1ca59c27-a704-4a20-991c-59d6daffd695.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
