### PR TITLE
Search: fix highlighting negated predicates

### DIFF
--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -951,7 +951,6 @@ const decorateRepoHasBody = (body: string, offset: number): DecoratedToken[] | u
     if (!matches) {
         return undefined
     }
-    console.log(matches)
 
     return [
         {

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -149,6 +149,10 @@ export const scanPredicate = (field: string, value: string): Predicate | undefin
     }
     const name = match[0]
     const path = name.split('.')
+    // Remove negation from the field for lookup
+    if (field[0] == '-') {
+        field = field.substring(1)
+    }
     field = resolveFieldAlias(field)
     const access = resolveAccess([field, ...path], PREDICATES)
     if (!access) {

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -150,8 +150,8 @@ export const scanPredicate = (field: string, value: string): Predicate | undefin
     const name = match[0]
     const path = name.split('.')
     // Remove negation from the field for lookup
-    if (field[0] == '-') {
-        field = field.substring(1)
+    if (field.startsWith('-')) {
+        field = field.slice(1)
     }
     field = resolveFieldAlias(field)
     const access = resolveAccess([field, ...path], PREDICATES)


### PR DESCRIPTION
Syntax highlighting of predicates currently fails. This fixes highlighting negated predicates. It makes no effort to disambiguate between which predicates support highlighting and which don't.

## Test plan

Manual testing.

Before:
<img width="265" alt="Screen Shot 2022-09-09 at 16 20 49" src="https://user-images.githubusercontent.com/12631702/189453692-7343e2aa-68bb-4620-bc37-d6134f6c7a31.png">

After:
<img width="291" alt="Screen Shot 2022-09-09 at 16 21 17" src="https://user-images.githubusercontent.com/12631702/189453694-97ab550d-7172-405c-9d2b-b61fd4aac921.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-negated-predicate-highlighting.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sftgidlpjx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
