### PR TITLE
batches: fix broken tooltips

### DIFF
--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -15,7 +15,6 @@ import {
     MenuDivider,
     H4,
     Text,
-    Tooltip,
     Icon,
 } from '@sourcegraph/wildcard'
 
@@ -48,7 +47,6 @@ export interface Props {
     disabled?: boolean
     onLabel?: (label: string | undefined) => void
     placeholder?: string
-    tooltip?: string
 }
 
 export const DropdownButton: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
@@ -57,7 +55,6 @@ export const DropdownButton: React.FunctionComponent<React.PropsWithChildren<Pro
     disabled,
     onLabel,
     placeholder = 'Select action',
-    tooltip,
 }) => {
     const [isDisabled, setIsDisabled] = useState(!!disabled)
 
@@ -133,16 +130,14 @@ export const DropdownButton: React.FunctionComponent<React.PropsWithChildren<Pro
             {renderedElement}
             <Menu>
                 <ButtonGroup>
-                    <Tooltip content={tooltip}>
-                        <Button
-                            className="text-nowrap"
-                            onClick={onTriggerAction}
-                            disabled={isDisabled || actions.length === 0 || selectedAction === undefined}
-                            variant="primary"
-                        >
-                            {label}
-                        </Button>
-                    </Tooltip>
+                    <Button
+                        className="text-nowrap"
+                        onClick={onTriggerAction}
+                        disabled={isDisabled || actions.length === 0 || selectedAction === undefined}
+                        variant="primary"
+                    >
+                        {label}
+                    </Button>
                     {actions.length > 1 && (
                         <MenuButton variant="primary" className={styles.dropdownButton}>
                             <Icon svgPath={mdiChevronDown} inline={false} aria-hidden={true} />

--- a/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { uniqBy, upperFirst } from 'lodash'
 import { NavLink as RouterLink } from 'react-router-dom'
 
-import { Button, Tooltip } from '@sourcegraph/wildcard'
+import { Button } from '@sourcegraph/wildcard'
 
 import styles from './TabBar.module.scss'
 
@@ -14,7 +14,6 @@ export type TabKey = typeof TAB_KEYS[number]
 export interface TabsConfig {
     key: TabKey
     isEnabled: boolean
-    disabledTooltip?: string
     handler?: { type: 'link' } | { type: 'button'; onClick: () => void }
 }
 
@@ -47,7 +46,7 @@ export const TabBar: React.FunctionComponent<React.PropsWithChildren<TabBarProps
     const fullTabsConfig = useMemo<TabsConfig[]>(() => uniqBy([...tabsConfig, ...DEFAULT_TABS], 'key'), [tabsConfig])
     return (
         <ul className={classNames('nav nav-tabs', styles.navList, className)}>
-            {fullTabsConfig.map(({ key, isEnabled, disabledTooltip, handler }, index) => {
+            {fullTabsConfig.map(({ key, isEnabled, handler }, index) => {
                 const tabName = getTabName(key, index)
 
                 return (
@@ -57,19 +56,13 @@ export const TabBar: React.FunctionComponent<React.PropsWithChildren<TabBarProps
                                 {tabName}
                             </span>
                         ) : !isEnabled ? (
-                            <Tooltip content={disabledTooltip}>
-                                <span
-                                    aria-disabled="true"
-                                    className={classNames(
-                                        'nav-link text-muted',
-                                        styles.navLinkDisabled,
-                                        styles.navLink
-                                    )}
-                                    data-tab-content={tabName}
-                                >
-                                    {tabName}
-                                </span>
-                            </Tooltip>
+                            <span
+                                aria-disabled="true"
+                                className={classNames('nav-link text-muted', styles.navLinkDisabled, styles.navLink)}
+                                data-tab-content={tabName}
+                            >
+                                {tabName}
+                            </span>
                         ) : !handler ? (
                             <span
                                 aria-disabled="true"

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -331,6 +331,7 @@ export const mockWorkspace = (
 export const QUEUED_WORKSPACE = mockWorkspace(1, {
     state: BatchSpecWorkspaceState.QUEUED,
     placeInQueue: 2,
+    placeInGlobalQueue: 4,
     startedAt: null,
     finishedAt: null,
     diffStat: null,

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/StepStateIcon.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/StepStateIcon.tsx
@@ -41,7 +41,9 @@ export const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<Step
     return (
         <div className="d-flex flex-shrink-0">
             <Tooltip content={label} placement="bottom">
-                <Icon className={classNameVariant} aria-label={label} as={IconElement} />
+                <span>
+                    <Icon className={classNameVariant} aria-label={label} as={IconElement} />
+                </span>
             </Tooltip>
         </div>
     )

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.tsx
@@ -34,11 +34,13 @@ export const WorkspaceStateIcon: React.FunctionComponent<React.PropsWithChildren
         case BatchSpecWorkspaceState.PROCESSING:
             return (
                 <Tooltip content="This workspace is currently executing.">
-                    <Icon
-                        aria-label="This workspace is currently executing."
-                        className={className}
-                        as={LoadingSpinner}
-                    />
+                    <span>
+                        <Icon
+                            aria-label="This workspace is currently executing."
+                            className={className}
+                            as={LoadingSpinner}
+                        />
+                    </span>
                 </Tooltip>
             )
         case BatchSpecWorkspaceState.SKIPPED:

--- a/client/web/src/enterprise/batches/preview/list/GitBranchChangesetDescriptionInfo.tsx
+++ b/client/web/src/enterprise/batches/preview/list/GitBranchChangesetDescriptionInfo.tsx
@@ -45,7 +45,9 @@ export const GitBranchChangesetDescriptionInfo: React.FunctionComponent<React.Pr
                         >
                             <div className="d-flex flex-column align-items-center mr-3">
                                 <Tooltip content={formatPersonName(previousCommit.author)}>
-                                    <UserAvatar inline={true} className="mb-1" user={previousCommit.author} />
+                                    <span>
+                                        <UserAvatar inline={true} className="mb-1" user={previousCommit.author} />
+                                    </span>
                                 </Tooltip>{' '}
                                 <PersonLink person={previousCommit.author} className="font-weight-bold text-nowrap" />
                             </div>
@@ -64,7 +66,9 @@ export const GitBranchChangesetDescriptionInfo: React.FunctionComponent<React.Pr
                 )}
             <div className="d-flex flex-column align-items-center mr-3">
                 <Tooltip content={formatPersonName(commit.author)}>
-                    <UserAvatar inline={true} className="mb-1" user={commit.author} />
+                    <span>
+                        <UserAvatar inline={true} className="mb-1" user={commit.author} />
+                    </span>
                 </Tooltip>{' '}
                 <PersonLink person={commit.author} className="font-weight-bold text-nowrap" />
             </div>


### PR DESCRIPTION
This is the result of the tooltip sweep in #41030. In short, there were three places where tooltips were broken in the Batch Changes UI; all of these have been addressed by wrapping the icon in `<span>`, which prevents the error by providing `<Tooltip>` with a real DOM component as the child element. None of these cases are trivially ported to use `svgPath` — two use `LoadingSpinner`, which needs the styles attached to the element for the animation to work, and one uses `UserAvatar`, which probably doesn't even have an SVG path that makes sense.

I've also removed tooltip props from two components that no longer need them, and fixed a bad mock I spotted while I was in the storybook.

I've chosen not to add any `defaultOpen={true}` attributes to stories for now, as I think we should probably consider this more carefully in the context of our overall approach to snapshots. (I would argue that we should run all snapshots with and without tooltips showing, but I can hear the dollar signs from here.)

Closes #41030.

## Test plan

Tested both in the live UI and in the storybook.

## App preview:

- [Web](https://sg-web-aharvey-batch-tooltip-sweep.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-opjkvvrqtd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
