### PR TITLE
frontend/otlpadapter: disable if client otel is disabled

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"go.uber.org/atomic"
 
 	sglog "github.com/sourcegraph/log"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/otlpenv"
 	srcprometheus "github.com/sourcegraph/sourcegraph/internal/src-prometheus"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 var (
@@ -270,6 +272,16 @@ func addJaeger(r *mux.Router, db database.DB) {
 	}
 }
 
+func clientOtelEnabled(s schema.SiteConfiguration) bool {
+	if s.ObservabilityClient == nil {
+		return false
+	}
+	if s.ObservabilityClient.OpenTelemetry == nil {
+		return false
+	}
+	return s.ObservabilityClient.OpenTelemetry.Endpoint != ""
+}
+
 // addOpenTelemetryProtocolAdapter registers handlers that forward OpenTelemetry protocol
 // (OTLP) requests in the http/json format to the configured backend.
 func addOpenTelemetryProtocolAdapter(r *mux.Router) {
@@ -280,6 +292,14 @@ func addOpenTelemetryProtocolAdapter(r *mux.Router) {
 		logger   = sglog.Scoped("otlpAdapter", "OpenTelemetry protocol adapter and forwarder").
 				With(sglog.String("endpoint", endpoint), sglog.String("protocol", string(protocol)))
 	)
+
+	// Clients can take a while to receive new site configuration - since this debug
+	// tunnel should only be receiving OpenTelemetry from clients, if client OTEL is
+	// disabled this tunnel should no-op.
+	clientEnabled := atomic.NewBool(clientOtelEnabled(conf.SiteConfig()))
+	conf.Watch(func() {
+		clientEnabled.Store(clientOtelEnabled(conf.SiteConfig()))
+	})
 
 	// If no endpoint is configured, we export a no-op handler
 	if endpoint == "" {
@@ -293,7 +313,7 @@ func addOpenTelemetryProtocolAdapter(r *mux.Router) {
 	}
 
 	// Register adapter endpoints
-	otlpadapter.Register(ctx, logger, protocol, endpoint, r)
+	otlpadapter.Register(ctx, logger, protocol, endpoint, r, clientEnabled)
 }
 
 // adminOnly is a HTTP middleware which only allows requests by admins.

--- a/cmd/frontend/internal/app/otlpadapter/adapter.go
+++ b/cmd/frontend/internal/app/otlpadapter/adapter.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"go.opentelemetry.io/collector/component"
+	"go.uber.org/atomic"
 
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/log"
@@ -43,6 +44,8 @@ type adaptedSignal struct {
 	// CreateAdapter creates the receiver for this signal that redirects to the
 	// appropriate exporter.
 	CreateAdapter func() (*signalAdapter, error)
+	// Enabled can be used to toggle whether the adapter should no-op.
+	Enabled *atomic.Bool
 }
 
 // Register attaches a route to the router that adapts requests on the `/otlp` path.
@@ -67,8 +70,24 @@ func (sig *adaptedSignal) Register(ctx context.Context, logger log.Logger, r *mu
 			req.URL.Host = receiverURL.Host
 			req.URL.Path = sig.PathPrefix
 		},
+		Transport: &roundTripper{
+			roundTrip: func(r *http.Request) (*http.Response, error) {
+				if !sig.Enabled.Load() {
+					return nil, errors.New("tunnel is disabled")
+				}
+				return http.DefaultClient.Transport.RoundTrip(r)
+			},
+		},
 		ErrorLog: std.NewLogger(adapterLogger, log.LevelWarn),
 	})
 
 	adapterLogger.Info("signal adapter registered")
+}
+
+type roundTripper struct {
+	roundTrip func(*http.Request) (*http.Response, error)
+}
+
+func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return r.roundTrip(req)
 }

--- a/cmd/frontend/internal/app/otlpadapter/register.go
+++ b/cmd/frontend/internal/app/otlpadapter/register.go
@@ -15,7 +15,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Register sets up adapter services and registers proxies on the router.
+// Register sets up adapter services and registers proxies on the router. enabled can be
+// provided to atomically toggle whether the signal endpoints are enabled serverside -
+// this is important because clients might not receive updated configuration for quite a
+// while, so we need to stop accepting incoming requests.
 func Register(ctx context.Context, logger log.Logger, protocol otlpenv.Protocol, endpoint string, r *mux.Router, enabled *atomic.Bool) {
 	// Build an OTLP exporter that exports directly to the desired protocol and endpoint
 	exporterFactory, signalExporterConfig, err := newExporter(protocol, endpoint)

--- a/cmd/frontend/internal/app/otlpadapter/register.go
+++ b/cmd/frontend/internal/app/otlpadapter/register.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	"github.com/sourcegraph/sourcegraph/internal/otlpenv"
@@ -15,7 +16,7 @@ import (
 )
 
 // Register sets up adapter services and registers proxies on the router.
-func Register(ctx context.Context, logger log.Logger, protocol otlpenv.Protocol, endpoint string, r *mux.Router) {
+func Register(ctx context.Context, logger log.Logger, protocol otlpenv.Protocol, endpoint string, r *mux.Router, enabled *atomic.Bool) {
 	// Build an OTLP exporter that exports directly to the desired protocol and endpoint
 	exporterFactory, signalExporterConfig, err := newExporter(protocol, endpoint)
 	if err != nil {
@@ -61,6 +62,7 @@ func Register(ctx context.Context, logger log.Logger, protocol otlpenv.Protocol,
 				}
 				return &signalAdapter{Exporter: exporter, Receiver: receiver}, nil
 			},
+			Enabled: enabled,
 		},
 		{
 			PathPrefix: "/v1/metrics",
@@ -75,6 +77,7 @@ func Register(ctx context.Context, logger log.Logger, protocol otlpenv.Protocol,
 				}
 				return &signalAdapter{Exporter: exporter, Receiver: receiver}, nil
 			},
+			Enabled: enabled,
 		},
 		{
 			PathPrefix: "/v1/logs",
@@ -89,6 +92,7 @@ func Register(ctx context.Context, logger log.Logger, protocol otlpenv.Protocol,
 				}
 				return &signalAdapter{Exporter: exporter, Receiver: receiver}, nil
 			},
+			Enabled: enabled,
 		},
 	}
 

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -257,6 +257,10 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 			switch {
 			case m.Code == http.StatusNotFound:
 				logger.Info(msg, fields...)
+			case m.Code == http.StatusNotAcceptable:
+				// Used for intentionally disabled endpoints
+				// https://www.rfc-editor.org/rfc/rfc9110.html#name-406-not-acceptable
+				logger.Debug(msg, fields...)
 			case m.Code == http.StatusUnauthorized:
 				logger.Warn(msg, fields...)
 			case m.Code >= http.StatusInternalServerError && requestErrorCause != nil:


### PR DESCRIPTION
Disabling clientside OTEL can take a long time to propagate correctly, since users must refresh their page to receive updated configuration. To remedy this, we also disable the serverside OTLP tunnel - currently only used for clientside OTEL - when clientside OTEL is disabled using [Status 406 Not Acceptable](https://www.rfc-editor.org/rfc/rfc9110.html#name-406-not-acceptable)

Safe for 4.0 since this is a small and safe addition to an experimental feature.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start`, enable `observability.client`

Test traces get pushed

disable `observability.client`, run a new search _without_ reloading the page:

<img width="397" alt="image" src="https://user-images.githubusercontent.com/23356519/189698638-3cc898bf-1147-4c20-889d-fc3a3b74f4a1.png">
