### PR TITLE
Analytics: Fix user analytics bar chart colours

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.module.scss
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.module.scss
@@ -1,0 +1,15 @@
+.bar-chart {
+    // Default initial bar color values
+    --bar-color: var(--oc-blue-2);
+    --bar-fade-color: var(--oc-blue-1);
+
+    :global(.theme-dark) & {
+        --bar-color: var(--oc-blue-5);
+        --bar-fade-color: var(--oc-blue-9);
+    }
+
+    :global(.theme-light) & {
+        --bar-color: var(--oc-blue-2);
+        --bar-fade-color: var(--oc-blue-1);
+    }
+}

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.module.scss
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.module.scss
@@ -4,8 +4,8 @@
     --bar-fade-color: var(--oc-blue-1);
 
     :global(.theme-dark) & {
-        --bar-color: var(--oc-blue-5);
-        --bar-fade-color: var(--oc-blue-9);
+        --bar-color: var(--oc-blue-3);
+        --bar-fade-color: rgba(var(--oc-blue-2-rgb), 0.55);
     }
 
     :global(.theme-light) & {

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
@@ -680,6 +680,6 @@ const USER_ANALYTICS_QUERY_MOCK: MockedResponse<UsersStatisticsResult> = {
 
 export const AnalyticsUsersPageExample: Story = () => (
     <MockedTestProvider mocks={[USER_ANALYTICS_QUERY_MOCK]}>
-        <AnalyticsUsersPage />
+        <AnalyticsUsersPage history={{} as any} location={{} as any} match={{} as any} />
     </MockedTestProvider>
 )

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
@@ -1,7 +1,7 @@
 import { MockedResponse } from '@apollo/client/testing'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
-import { getDocumentNode } from '@sourcegraph/http-client/out/src'
+import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
@@ -1,0 +1,685 @@
+import { MockedResponse } from '@apollo/client/testing'
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+
+import { getDocumentNode } from '@sourcegraph/http-client/out/src'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+
+import { WebStory } from '../../../components/WebStory'
+import { UsersStatisticsResult } from '../../../graphql-operations'
+
+import { USERS_STATISTICS } from './queries'
+
+import { AnalyticsUsersPage } from './index'
+
+const decorator: DecoratorFn = story => <WebStory>{() => <div className="p-3 container">{story()}</div>}</WebStory>
+
+const config: Meta = {
+    title: 'web/site-admin/analytics/AnalyticsUsersPage',
+    decorators: [decorator],
+}
+
+export default config
+
+const USER_ANALYTICS_QUERY_MOCK: MockedResponse<UsersStatisticsResult> = {
+    request: {
+        query: getDocumentNode(USERS_STATISTICS),
+        variables: {
+            dateRange: 'LAST_THREE_MONTHS',
+            grouping: 'WEEKLY',
+        },
+    },
+    result: {
+        data: {
+            site: {
+                analytics: {
+                    users: {
+                        summary: {
+                            avgDAU: 16717,
+                            avgWAU: 99778,
+                            avgMAU: 380389,
+                            __typename: 'AnalyticsUsersSummaryResult',
+                        },
+                        activity: {
+                            nodes: [
+                                {
+                                    date: '2022-09-05T00:00:00Z',
+                                    count: 1679289,
+                                    registeredUsers: 1148,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-08-29T00:00:00Z',
+                                    count: 2017644,
+                                    registeredUsers: 1280,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-08-22T00:00:00Z',
+                                    count: 2022434,
+                                    registeredUsers: 1313,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-08-15T00:00:00Z',
+                                    count: 2118379,
+                                    registeredUsers: 1338,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-08-08T00:00:00Z',
+                                    count: 2092362,
+                                    registeredUsers: 1383,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-08-01T00:00:00Z',
+                                    count: 2155192,
+                                    registeredUsers: 1502,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-07-25T00:00:00Z',
+                                    count: 1896399,
+                                    registeredUsers: 1492,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-07-18T00:00:00Z',
+                                    count: 1897174,
+                                    registeredUsers: 1672,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-07-11T00:00:00Z',
+                                    count: 1847606,
+                                    registeredUsers: 1746,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-07-04T00:00:00Z',
+                                    count: 1817582,
+                                    registeredUsers: 1797,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-06-27T00:00:00Z',
+                                    count: 1808359,
+                                    registeredUsers: 1914,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-06-20T00:00:00Z',
+                                    count: 2014862,
+                                    registeredUsers: 2091,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                                {
+                                    date: '2022-06-13T00:00:00Z',
+                                    count: 1967790,
+                                    registeredUsers: 2109,
+                                    __typename: 'AnalyticsStatItemNode',
+                                },
+                            ],
+                            summary: {
+                                totalCount: 25888117,
+                                totalRegisteredUsers: 6663,
+                                __typename: 'AnalyticsStatItemSummary',
+                            },
+                            __typename: 'AnalyticsStatItem',
+                        },
+                        frequencies: [
+                            {
+                                daysUsed: 1,
+                                frequency: 928939,
+                                percentage: 0.8690111238857171,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 2,
+                                frequency: 76622,
+                                percentage: 0.07167894806265149,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 3,
+                                frequency: 24992,
+                                percentage: 0.02337971170136235,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 4,
+                                frequency: 10372,
+                                percentage: 0.009702879712169106,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 5,
+                                frequency: 5773,
+                                percentage: 0.005400571208865431,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 6,
+                                frequency: 3714,
+                                percentage: 0.0034744017789236463,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 7,
+                                frequency: 2754,
+                                percentage: 0.0025763334677317506,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 8,
+                                frequency: 2126,
+                                percentage: 0.0019888471141603858,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 9,
+                                frequency: 1723,
+                                percentage: 0.001611845521024621,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 10,
+                                frequency: 1376,
+                                percentage: 0.0012872312460417172,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 11,
+                                frequency: 1173,
+                                percentage: 0.0010973272177375976,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 12,
+                                frequency: 1029,
+                                percentage: 0.0009626169710588131,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 13,
+                                frequency: 841,
+                                percentage: 0.0007867452601170669,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 14,
+                                frequency: 737,
+                                percentage: 0.0006894545264046116,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 15,
+                                frequency: 653,
+                                percentage: 0.0006108735491753207,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 16,
+                                frequency: 567,
+                                percentage: 0.0005304215962977134,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 17,
+                                frequency: 494,
+                                percentage: 0.000462130985134163,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 18,
+                                frequency: 472,
+                                percentage: 0.00044155025300268204,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 19,
+                                frequency: 414,
+                                percentage: 0.000387291959201505,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 20,
+                                frequency: 355,
+                                percentage: 0.00033209817757616977,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 21,
+                                frequency: 346,
+                                percentage: 0.0003236787871587457,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 22,
+                                frequency: 317,
+                                percentage: 0.0002965496402581572,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 23,
+                                frequency: 241,
+                                percentage: 0.00022545256562213215,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 24,
+                                frequency: 209,
+                                percentage: 0.00019551695524906896,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 25,
+                                frequency: 232,
+                                percentage: 0.00021703317520470813,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 26,
+                                frequency: 199,
+                                percentage: 0.0001861620770074867,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 27,
+                                frequency: 181,
+                                percentage: 0.00016932329617263867,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 28,
+                                frequency: 162,
+                                percentage: 0.0001515490275136324,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 29,
+                                frequency: 131,
+                                percentage: 0.00012254890496472744,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 30,
+                                frequency: 123,
+                                percentage: 0.00011506500237146163,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 31,
+                                frequency: 126,
+                                percentage: 0.00011787146584393631,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 32,
+                                frequency: 119,
+                                percentage: 0.00011132305107482874,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 33,
+                                frequency: 119,
+                                percentage: 0.00011132305107482874,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 34,
+                                frequency: 104,
+                                percentage: 0.00009729073371245536,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 35,
+                                frequency: 88,
+                                percentage: 0.00008232292852592377,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 36,
+                                frequency: 85,
+                                percentage: 0.0000795164650534491,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 37,
+                                frequency: 67,
+                                percentage: 0.00006267768421860106,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 38,
+                                frequency: 58,
+                                percentage: 0.00005425829380117703,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 39,
+                                frequency: 64,
+                                percentage: 0.00005987122074612638,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 40,
+                                frequency: 67,
+                                percentage: 0.00006267768421860106,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 41,
+                                frequency: 55,
+                                percentage: 0.00005145183032870236,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 42,
+                                frequency: 59,
+                                percentage: 0.000055193781625335255,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 43,
+                                frequency: 56,
+                                percentage: 0.00005238731815286058,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 44,
+                                frequency: 38,
+                                percentage: 0.00003554853731801254,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 45,
+                                frequency: 54,
+                                percentage: 0.00005051634250454413,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 46,
+                                frequency: 32,
+                                percentage: 0.00002993561037306319,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 47,
+                                frequency: 33,
+                                percentage: 0.000030871098197221414,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 48,
+                                frequency: 47,
+                                percentage: 0.000043967927735436557,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 49,
+                                frequency: 34,
+                                percentage: 0.000031806586021379636,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 50,
+                                frequency: 33,
+                                percentage: 0.000030871098197221414,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 51,
+                                frequency: 33,
+                                percentage: 0.000030871098197221414,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 52,
+                                frequency: 27,
+                                percentage: 0.000025258171252272065,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 53,
+                                frequency: 22,
+                                percentage: 0.000020580732131480942,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 54,
+                                frequency: 21,
+                                percentage: 0.000019645244307322716,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 55,
+                                frequency: 18,
+                                percentage: 0.000016838780834848044,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 56,
+                                frequency: 27,
+                                percentage: 0.000025258171252272065,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 57,
+                                frequency: 14,
+                                percentage: 0.000013096829538215145,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 58,
+                                frequency: 16,
+                                percentage: 0.000014967805186531595,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 59,
+                                frequency: 16,
+                                percentage: 0.000014967805186531595,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 60,
+                                frequency: 15,
+                                percentage: 0.00001403231736237337,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 61,
+                                frequency: 20,
+                                percentage: 0.000018709756483164494,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 62,
+                                frequency: 16,
+                                percentage: 0.000014967805186531595,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 63,
+                                frequency: 9,
+                                percentage: 0.000008419390417424022,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 64,
+                                frequency: 6,
+                                percentage: 0.000005612926944949348,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 65,
+                                frequency: 7,
+                                percentage: 0.000006548414769107573,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 66,
+                                frequency: 8,
+                                percentage: 0.000007483902593265797,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 67,
+                                frequency: 4,
+                                percentage: 0.0000037419512966328986,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 68,
+                                frequency: 9,
+                                percentage: 0.000008419390417424022,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 69,
+                                frequency: 6,
+                                percentage: 0.000005612926944949348,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 70,
+                                frequency: 8,
+                                percentage: 0.000007483902593265797,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 71,
+                                frequency: 7,
+                                percentage: 0.000006548414769107573,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 72,
+                                frequency: 7,
+                                percentage: 0.000006548414769107573,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 73,
+                                frequency: 3,
+                                percentage: 0.000002806463472474674,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 74,
+                                frequency: 4,
+                                percentage: 0.0000037419512966328986,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 75,
+                                frequency: 6,
+                                percentage: 0.000005612926944949348,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 76,
+                                frequency: 3,
+                                percentage: 0.000002806463472474674,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 77,
+                                frequency: 2,
+                                percentage: 0.0000018709756483164493,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 78,
+                                frequency: 3,
+                                percentage: 0.000002806463472474674,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 79,
+                                frequency: 6,
+                                percentage: 0.000005612926944949348,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 80,
+                                frequency: 3,
+                                percentage: 0.000002806463472474674,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 82,
+                                frequency: 1,
+                                percentage: 9.354878241582247e-7,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 83,
+                                frequency: 1,
+                                percentage: 9.354878241582247e-7,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 84,
+                                frequency: 1,
+                                percentage: 9.354878241582247e-7,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 85,
+                                frequency: 1,
+                                percentage: 9.354878241582247e-7,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 88,
+                                frequency: 1,
+                                percentage: 9.354878241582247e-7,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 89,
+                                frequency: 1,
+                                percentage: 9.354878241582247e-7,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 90,
+                                frequency: 3,
+                                percentage: 0.000002806463472474674,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                            {
+                                daysUsed: 93,
+                                frequency: 1,
+                                percentage: 9.354878241582247e-7,
+                                __typename: 'AnalyticsUsersFrequencyItem',
+                            },
+                        ],
+                        __typename: 'AnalyticsUsersResult',
+                    },
+                    __typename: 'Analytics',
+                },
+                productSubscription: {
+                    license: {
+                        userCount: 999999,
+                        __typename: 'ProductLicenseInfo',
+                    },
+                    __typename: 'ProductSubscriptionStatus',
+                },
+                __typename: 'Site',
+            },
+            users: {
+                totalCount: 49036,
+                __typename: 'UserConnection',
+            },
+        },
+    },
+}
+
+export const AnalyticsUsersPageExample: Story = () => (
+    <MockedTestProvider mocks={[USER_ANALYTICS_QUERY_MOCK]}>
+        <AnalyticsUsersPage />
+    </MockedTestProvider>
+)

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo, useEffect } from 'react'
+import { useMemo, useEffect, FC } from 'react'
 
 import classNames from 'classnames'
 import { startCase } from 'lodash'
+import { RouteComponentProps } from 'react-router'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { AlertType } from '@sourcegraph/shared/src/graphql-operations'
@@ -22,7 +23,7 @@ import { USERS_STATISTICS } from './queries'
 
 import styles from './AnalyticsUsersPage.module.scss'
 
-export const AnalyticsUsersPage: React.FunctionComponent<{}> = () => {
+export const AnalyticsUsersPage: FC<RouteComponentProps> = () => {
     const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Users', aggregation: 'registeredUsers' })
     const { data, error, loading } = useQuery<UsersStatisticsResult, UsersStatisticsVariables>(USERS_STATISTICS, {
         variables: {

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useEffect } from 'react'
 
 import classNames from 'classnames'
 import { startCase } from 'lodash'
-import { RouteComponentProps } from 'react-router'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { AlertType } from '@sourcegraph/shared/src/graphql-operations'
@@ -21,7 +20,9 @@ import { StandardDatum, FrequencyDatum, buildFrequencyDatum } from '../utils'
 
 import { USERS_STATISTICS } from './queries'
 
-export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>> = () => {
+import styles from './AnalyticsUsersPage.module.scss'
+
+export const AnalyticsUsersPage: React.FunctionComponent<{}> = () => {
     const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Users', aggregation: 'registeredUsers' })
     const { data, error, loading } = useQuery<UsersStatisticsResult, UsersStatisticsVariables>(USERS_STATISTICS, {
         variables: {
@@ -163,9 +164,9 @@ export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>
                     {summary && (
                         <ChartContainer
                             title="Average user activity by period"
-                            className="mb-5"
                             labelX="Average DAU/WAU/MAU"
                             labelY="Unique users"
+                            className={classNames(styles.barChart, 'mb-5')}
                         >
                             {width => (
                                 <BarChart
@@ -174,26 +175,29 @@ export const AnalyticsUsersPage: React.FunctionComponent<RouteComponentProps<{}>
                                     data={summary}
                                     getDatumName={datum => datum.label}
                                     getDatumValue={datum => datum.value}
-                                    getDatumColor={() => 'var(--oc-blue-2)'}
+                                    getDatumColor={() => 'var(--bar-color)'}
+                                    getDatumFadeColor={() => 'var(--bar-fade-color)'}
                                 />
                             )}
                         </ChartContainer>
                     )}
                     {frequencies && (
                         <ChartContainer
-                            className="mb-5"
                             title="Frequency of use"
                             labelX="Days used"
                             labelY="Unique users"
+                            className={classNames(styles.barChart, 'mb-5')}
                         >
                             {width => (
                                 <BarChart
                                     width={isWideScreen ? 540 : width}
                                     height={300}
                                     data={frequencies}
+                                    pixelsPerXTick={20}
                                     getDatumName={datum => datum.label}
                                     getDatumValue={datum => datum.value}
-                                    getDatumColor={() => 'var(--oc-blue-2)'}
+                                    getDatumColor={() => 'var(--bar-color)'}
+                                    getDatumFadeColor={() => 'var(--bar-fade-color)'}
                                 />
                             )}
                         </ChartContainer>

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.story.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.story.tsx
@@ -80,6 +80,7 @@ export const BarChartDemo: Story = () => (
         <GroupedBarExample />
         <StackedBarExample />
         <ManyBarsExample />
+        <CustomDimmedColor />
     </main>
 )
 
@@ -299,5 +300,27 @@ const ManyBarsExample = () => (
                 )}
             </ParentSize>
         </ResizableBox>
+    </section>
+)
+
+const CustomDimmedColor = () => (
+    <section style={{ flexBasis: 0 }}>
+        <H2>Dimmed colors</H2>
+
+        <Text style={{ maxWidth: 400, minWidth: 400 }}>
+            You can specify any dimmed colors for the non-active bars. (see bar chart README.md for more details about
+            chart colours.
+        </Text>
+
+        <BarChart
+            width={400}
+            height={400}
+            data={LANGUAGE_USAGE_DATA}
+            getDatumName={getName}
+            getDatumValue={getValue}
+            getDatumColor={getColor}
+            getDatumFadeColor={() => 'var(--blue)'}
+            getDatumLink={getLink}
+        />
     </section>
 )

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -28,6 +28,7 @@ export interface BarChartProps<Datum> extends CategoricalLikeChart<Datum>, SVGPr
     getScaleXTicks?: <T>(options: GetScaleTicksOptions) => T[]
     getTruncatedXTick?: (formattedTick: string) => string
     getCategory?: (datum: Datum) => string | undefined
+    getDatumFadeColor?: (datum: Datum) => string
 
     onDatumHover?: (datum: Datum) => void
 }
@@ -50,6 +51,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         getDatumName,
         getDatumValue,
         getDatumColor,
+        getDatumFadeColor,
         getDatumLink = DEFAULT_LINK_GETTER,
         getCategory = getDatumName,
         onDatumLinkClick,
@@ -118,6 +120,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
                         getDatumName={getDatumName}
                         getDatumValue={getDatumValue}
                         getDatumColor={getDatumColor}
+                        getDatumFadeColor={getDatumFadeColor}
                         getDatumLink={getDatumLink}
                         onBarClick={handleBarClick}
                         onBarHover={onDatumHover}

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
@@ -28,6 +28,7 @@ interface BarChartContentProps<Datum> extends SVGProps<SVGGElement> {
     getDatumValue: (datum: Datum) => number
     getDatumHover?: (datum: Datum) => string
     getDatumColor: (datum: Datum) => string | undefined
+    getDatumFadeColor?: (datum: Datum) => string
     getDatumLink: (datum: Datum) => string | undefined | null
     onBarClick: (event: MouseEvent, datum: Datum, index: number) => void
     onBarHover?: (datum: Datum) => void
@@ -47,6 +48,7 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
         getDatumName,
         getDatumValue,
         getDatumColor,
+        getDatumFadeColor,
         getDatumLink,
         onBarClick,
         onBarHover,
@@ -93,6 +95,7 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
                     getDatumName={getDatumName}
                     getDatumValue={getDatumValue}
                     getDatumColor={getDatumColor}
+                    getDatumFadeColor={getDatumFadeColor}
                     getDatumLink={getDatumLink}
                     height={+height}
                     width={+width}

--- a/client/wildcard/src/components/Charts/components/bar-chart/README.md
+++ b/client/wildcard/src/components/Charts/components/bar-chart/README.md
@@ -16,14 +16,14 @@ component it has a few UI features that are already implemented inside the compo
 
 ## Colors
 
-By default, the bar chart requires `getDatumColor` prop that should specify colours for bars (groups)
-on the chart. When we hover one of the bar, we should dim all other bars on the chart. For that, we
-use CSS filters algorithm that tries to convert the current colour (the one that we got from the `getDatumColor` prop)
-and make it dimmed. This algorithm allows you to have a proper dimmed colors in case when you don't have
-a clear defined colors for your chart (for example code insight can have any color that user defines in the creation UI,
-and we can't have all color combination for insights chart, we need to calculate colors dynamically) However, this
-algorithm doesn't work well in all cases. Sometimes when you're using bright colours it may produce low-contrast colors.
+By default, the bar chart requires the `getDatumColor` prop that should specify colors for bars (groups)
+on the chart. When we hover one of the bars, we should dim all other bars on the chart. For that, we
+use a CSS filters algorithm that tries to convert the current color (the one that we got from the `getDatumColor` prop)
+and make it dimmed. This algorithm allows you to have proper dimmed colors when you don't have
+clear defined colors for your chart (for example, code insight can have any color that the user defines in the creation UI,
+and we can't have all color combinations for insights chart, we need to calculate colors dynamically) However, this
+algorithm doesn't work well in all cases. Sometimes when you're using bright colors, it may produce low-contrast colors.
 
-In order to solve this problem, if you need to use bright colours on the chart, and you want to get control
-over active/non-active colors you can specify colours for the bar non-active state manually with `getDatumFadeColor` prop.
-If you set this prop, this turns off a generic color algorithm for non-active bars and takes provided from you colour.
+To solve this problem, if you need to use bright colors on the chart, and you want to get control
+over active/non-active colors, you can specify colors for the bar non-active state manually with `getDatumFadeColor` prop.
+If you set this prop, this turns off the generic color algorithm for non-active bars and takes the color provided by you.

--- a/client/wildcard/src/components/Charts/components/bar-chart/README.md
+++ b/client/wildcard/src/components/Charts/components/bar-chart/README.md
@@ -1,6 +1,6 @@
 # Bar Chart
 
-The bar chart is one of the pre-built high-level data visualization components. Since it's pre-built
+The bar chart is one of the pre-built high-level data visualization components. Since it's a pre-built
 component it has a few UI features that are already implemented inside the component.
 
 - **Data grouping**. A bar chart can render data in different modes,

--- a/client/wildcard/src/components/Charts/components/bar-chart/README.md
+++ b/client/wildcard/src/components/Charts/components/bar-chart/README.md
@@ -1,0 +1,29 @@
+# Bar Chart
+
+The bar chart is one of the pre-built high-level data visualization components. Since it's pre-built
+component it has a few UI features that are already implemented inside the component.
+
+- **Data grouping**. A bar chart can render data in different modes,
+  - Plain list of bars (groups)
+  - Grouped by categories' data. In this mode, you can group your bars with
+    different categories (see Grouped bar chart demo in the bar chart storybook)
+  - Stacked bars
+- **Smart axis components**. Smart axes adjust label UI based on chart size. Small charts
+  rotate their labels in order to avoid visual collisions between labels
+- **Smart active/non-active bar colors**. The bar chart has a smart colour calculation
+  algorithm that produces dimmed colours as you hover one of the bars (it has a limitation though,
+  see the section about colours below)
+
+## Colors
+
+By default, the bar chart requires `getDatumColor` prop that should specify colours for bars (groups)
+on the chart. When we hover one of the bar, we should dim all other bars on the chart. For that, we
+use CSS filters algorithm that tries to convert the current colour (the one that we got from the `getDatumColor` prop)
+and make it dimmed. This algorithm allows you to have a proper dimmed colors in case when you don't have
+a clear defined colors for your chart (for example code insight can have any color that user defines in the creation UI,
+and we can't have all color combination for insights chart, we need to calculate colors dynamically) However, this
+algorithm doesn't work well in all cases. Sometimes when you're using bright colours it may produce low-contrast colors.
+
+In order to solve this problem, if you need to use bright colours on the chart, and you want to get control
+over active/non-active colors you can specify colours for the bar non-active state manually with `getDatumFadeColor` prop.
+If you set this prop, this turns off a generic color algorithm for non-active bars and takes provided from you colour.

--- a/client/wildcard/src/components/Charts/components/bar-chart/README.md
+++ b/client/wildcard/src/components/Charts/components/bar-chart/README.md
@@ -10,9 +10,9 @@ component it has a few UI features that are already implemented inside the compo
   - Stacked bars
 - **Smart axis components**. Smart axes adjust label UI based on chart size. Small charts
   rotate their labels in order to avoid visual collisions between labels
-- **Smart active/non-active bar colors**. The bar chart has a smart colour calculation
-  algorithm that produces dimmed colours as you hover one of the bars (it has a limitation though,
-  see the section about colours below)
+- **Smart active/non-active bar colors**. The bar chart has a smart color calculation
+  algorithm that produces dimmed colors as you hover one of the bars (it has a limitation though,
+  see the section about colors below)
 
 ## Colors
 

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.module.scss
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.module.scss
@@ -1,8 +1,4 @@
 .bar {
-    &--active {
-        filter: brightness(110%);
-    }
-
     // Based on the current bar fill color fade version of this color
     // for non active bars
     &--fade {

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/TooltipContent.tsx
@@ -24,7 +24,7 @@ export function BarTooltipContent<Datum>(props: BarTooltipContentProps<Datum>): 
     // Handle a special case when we don't have any multiple datum per group
     if (category.data.length === 1) {
         const datum = category.data[0]
-        const name = getDatumName(datum)
+        const name = getName(datum)
         const value = getDatumValue(datum)
 
         return (
@@ -38,7 +38,7 @@ export function BarTooltipContent<Datum>(props: BarTooltipContentProps<Datum>): 
     // Handle a special case when we don't have any multiple datum per group
     if (category.data.length === 1) {
         const datum = category.data[0]
-        const name = getDatumName(datum)
+        const name = getName(datum)
         const value = getDatumValue(datum)
 
         return (


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41614

## Background

This PR adjusts colors for light and dark themes. Prior to this PR in the light versions chart colours algorithm were producing wrong set of colors for the bright color that we use on the user analytics page. In this PR we use manually set colors for the dark and light theme. See table below

| Theme | Before | After |
| ----- | ----- | ----- |
| Light  | <img width="597" alt="Screenshot 2022-09-11 at 12 25 39" src="https://user-images.githubusercontent.com/18492575/189520565-4ee30666-70ac-465c-9bd0-e1ed2c52e12e.png"> | <img width="585" alt="Screenshot 2022-09-11 at 12 24 46" src="https://user-images.githubusercontent.com/18492575/189520553-3173139d-afe4-46cc-826b-e3e0b7573887.png"> |
| Dark | <img width="581" alt="Screenshot 2022-09-11 at 12 26 25" src="https://user-images.githubusercontent.com/18492575/189520593-bb37a025-f254-4afb-ad34-ef6d9c661f4f.png"> | <img width="578" alt="Screenshot 2022-09-11 at 12 30 24" src="https://user-images.githubusercontent.com/18492575/189520735-7f9c6515-25a0-4651-9693-a93b9846f5a3.png"> |

## Test plan
- Make sure that bar chart colours look good in both light and dark themes
- Make sure that active/non-acitve (dimmed) bars also look good in both themes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-user-analytics-charts.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hcgqwumdxd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
