### PR TITLE
[SG-35755] Wildcard button: text in disabled buttons is too bright in dark mode

### DIFF
--- a/client/wildcard/src/components/Button/Button.module.scss
+++ b/client/wildcard/src/components/Button/Button.module.scss
@@ -141,7 +141,8 @@
     $light-color-variant,
     $dark-color-variant,
     $text-color: var(--light-text),
-    $disabled-text-color: var(--light-text)
+    $light-disabled-text-color: var(--light-text),
+    $dark-disabled-text-color: var(--text-disabled)
 ) {
     .btn-#{$name} {
         color: $text-color;
@@ -153,7 +154,12 @@
             opacity: 1;
             background-color: $light-color-variant;
             border-color: $light-color-variant;
-            color: $disabled-text-color;
+            :global(.theme-light) & {
+                color: $light-disabled-text-color;
+            }
+            :global(.theme-dark) & {
+                color: $dark-disabled-text-color;
+            }
         }
 
         &:not(:disabled):not(:global(.disabled)) {
@@ -266,7 +272,8 @@
     $name: 'primary',
     $base-color: var(--primary),
     $light-color-variant: var(--primary-2),
-    $dark-color-variant: var(--primary-3)
+    $dark-color-variant: var(--primary-3),
+    $dark-disabled-text-color: rgba(var(--text-light), 0.6)
 );
 
 @include button-variant(
@@ -276,7 +283,8 @@
     $dark-color-variant: var(--secondary-3),
     // Use darker text colors for contrast
     $text-color: var(--body-color),
-    $disabled-text-color: var(--text-disabled)
+    $light-disabled-text-color: var(--text-disabled),
+    $dark-disabled-text-color: var(--text-muted)
 );
 
 @include button-variant(
@@ -300,7 +308,8 @@
     $dark-color-variant: var(--warning-3),
     // Use darker text colors for contrast
     $text-color: var(--dark-text),
-    $disabled-text-color: var(--text-disabled)
+    $light-disabled-text-color: var(--text-muted),
+    $dark-disabled-text-color: var(--text-muted)
 );
 
 @include button-variant(
@@ -310,14 +319,16 @@
     $dark-color-variant: var(--info-3),
     // Use darker text colors for contrast
     $text-color: var(--dark-text),
-    $disabled-text-color: var(--text-disabled)
+    $light-disabled-text-color: var(--text-muted),
+    $dark-disabled-text-color: var(--text-muted)
 );
 
 @include button-variant(
     $name: 'merged',
     $base-color: var(--merged),
     $light-color-variant: var(--merged-2),
-    $dark-color-variant: var(--merged-3)
+    $dark-color-variant: var(--merged-3),
+    $dark-disabled-text-color: var(--light-text)
 );
 
 :global(.theme-dark),


### PR DESCRIPTION
### Description
In `dark mode`, the text color in `disabled` buttons is too bright in `primary`, `success`, and `danger`. 
Using **gray** text would make it clearer that the button is disabled.

### Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35755)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35755)

### Success Criteria
The disabled button styles in the dark mode are updated to reflect the latest changes in [Figma mockups](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/%E2%9C%B3%EF%B8%8F-Wildcard-Design-System?node-id=908%3A2513).

### Test Plan
- Compare the disabled button states of the `primary`, `success`, and `danger` on the local storybook and remote storybook to ensure it meets the success criteria.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-contractors-sg-35755.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ibttjkgeye.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
