### PR TITLE
schema: go generate with go1.19

### DIFF
--- a/schema/gen.sh
+++ b/schema/gen.sh
@@ -14,10 +14,4 @@ schemas="$(ls -- *.schema.json | grep -v json-schema-draft)"
 # shellcheck disable=SC2086
 "$GOBIN"/go-jsonschema-compiler -o schema.go -pkg schema $schemas
 
-stringdata() {
-  # shellcheck disable=SC2039
-  target="${1/.schema.json/_stringdata.go}"
-  "$GOBIN"/stringdata -i "$1" -name "$2" -pkg schema -o "$target"
-}
-
 gofmt -s -w ./*.go

--- a/schema/stringdata.go
+++ b/schema/stringdata.go
@@ -3,81 +3,101 @@ package schema
 import _ "embed"
 
 // AWSCodeCommitSchemaJSON is the content of the file "aws_codecommit.schema.json".
+//
 //go:embed aws_codecommit.schema.json
 var AWSCodeCommitSchemaJSON string
 
 // BatchSpecSchemaJSON is the content of the file "batch_spec.schema.json".
+//
 //go:embed batch_spec.schema.json
 var BatchSpecSchemaJSON string
 
 // BitbucketCloudSchemaJSON is the content of the file "bitbucket_cloud.schema.json".
+//
 //go:embed bitbucket_cloud.schema.json
 var BitbucketCloudSchemaJSON string
 
 // BitbucketServerSchemaJSON is the content of the file "bitbucket_server.schema.json".
+//
 //go:embed bitbucket_server.schema.json
 var BitbucketServerSchemaJSON string
 
 // ChangesetSpecSchemaJSON is the content of the file "changeset_spec.schema.json".
+//
 //go:embed changeset_spec.schema.json
 var ChangesetSpecSchemaJSON string
 
 // GerritSchemaJSON is the content of the file "gerrit.schema.json".
+//
 //go:embed gerrit.schema.json
 var GerritSchemaJSON string
 
 // GitHubSchemaJSON is the content of the file "github.schema.json".
+//
 //go:embed github.schema.json
 var GitHubSchemaJSON string
 
 // GitLabSchemaJSON is the content of the file "gitlab.schema.json".
+//
 //go:embed gitlab.schema.json
 var GitLabSchemaJSON string
 
 // GitoliteSchemaJSON is the content of the file "gitolite.schema.json".
+//
 //go:embed gitolite.schema.json
 var GitoliteSchemaJSON string
 
 // GoModulesSchemaJSON is the content of the file "go-modules.schema.json".
+//
 //go:embed go-modules.schema.json
 var GoModulesSchemaJSON string
 
 // JVMPackagesSchemaJSON is the content of the file "jvm-packages.schema.json".
+//
 //go:embed jvm-packages.schema.json
 var JVMPackagesSchemaJSON string
 
 // NpmPackagesSchemaJSON is the content of the file "npm-packages.schema.json".
+//
 //go:embed npm-packages.schema.json
 var NpmPackagesSchemaJSON string
 
 // PythonPackagesSchemaJSON is the content of the file "python-packages.schema.json".
+//
 //go:embed python-packages.schema.json
 var PythonPackagesSchemaJSON string
 
 // RustPackagesSchemaJSON is the content of the file "python-packages.schema.json".
+//
 //go:embed rust-packages.schema.json
 var RustPackagesSchemaJSON string
 
 // OtherExternalServiceSchemaJSON is the content of the file "other_external_service.schema.json".
+//
 //go:embed other_external_service.schema.json
 var OtherExternalServiceSchemaJSON string
 
 // PerforceSchemaJSON is the content of the file "perforce.schema.json".
+//
 //go:embed perforce.schema.json
 var PerforceSchemaJSON string
 
 // PhabricatorSchemaJSON is the content of the file "phabricator.schema.json".
+//
 //go:embed phabricator.schema.json
 var PhabricatorSchemaJSON string
 
 // PagureSchemaJSON is the content of the file "pagure.schema.json".
+//
 //go:embed pagure.schema.json
 var PagureSchemaJSON string
 
 // SettingsSchemaJSON is the content of the file "settings.schema.json".
+//
 //go:embed settings.schema.json
 var SettingsSchemaJSON string
 
 // SiteSchemaJSON is the content of the file "site.schema.json".
+//
 //go:embed site.schema.json
 var SiteSchemaJSON string


### PR DESCRIPTION
gofmt in go1.19 adds an extra line in the comments for stringdata.go. This keeps popping up for me on my machine, so hoping this passes on CI.

Additionally removed the unused stringdata function in gen.sh

Test Plan: CI

