### PR TITLE
ranking: introduce maxQueueMatchCount

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -279,9 +279,7 @@ func (q *resultQueue) Done(endpoint string) {
 	delete(q.endpointMaxPendingPriority, endpoint)
 }
 
-// FlushReady will send results which are greater than the
-// maxPendingPriority. Note: it will also send results if we exceed
-// maxQueueDepth.
+// FlushReady sends results that are ready to be sent.
 func (q *resultQueue) FlushReady(streamer zoekt.Sender) {
 	// we can send any results such that priority > maxPending. Need to
 	// calculate maxPending.

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -177,7 +177,7 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 func resultQueueSettingsFromConfig(siteConfig schema.SiteConfiguration) (maxQueueDepth int, maxReorderDuration time.Duration, maxQueueMatchCount int) {
 	// defaults
 	maxQueueDepth = 24
-	maxQueueMatchCount = 99999
+	maxQueueMatchCount = -1
 	maxReorderDuration = 0
 
 	if siteConfig.ExperimentalFeatures == nil || siteConfig.ExperimentalFeatures.Ranking == nil {
@@ -339,15 +339,11 @@ func (q *resultQueue) FlushAll(streamer zoekt.Sender) {
 }
 
 func (q *resultQueue) isFull() bool {
-	if q.maxQueueDepth < 0 {
-		return false
-	}
-
-	if q.queue.Len() > q.maxQueueDepth {
+	if q.maxQueueDepth >= 0 && q.queue.Len() > q.maxQueueDepth {
 		return true
 	}
 
-	if q.matchCount > q.maxMatchCount {
+	if q.maxMatchCount >= 0 && q.matchCount > q.maxMatchCount {
 		return true
 	}
 

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -321,9 +321,8 @@ func (q *resultQueue) FlushAll(streamer zoekt.Sender) {
 	}
 }
 
-// pop returns 1 search result from queue. The search result contains the
-// current aggregate stats. After the call to pop() the queue's aggregate stats
-// are reset.
+// pop returns 1 search result from q. The search result contains the current
+// aggregate stats. After the call to pop() we reset q's aggregate stats
 func (q *resultQueue) pop() *zoekt.SearchResult {
 	sr := heap.Pop(&q.queue).(*zoekt.SearchResult)
 	q.matchCount -= sr.MatchCount

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -305,7 +305,7 @@ func TestResultQueueSettingsFromConfig(t *testing.T) {
 			name:                   "defaults",
 			siteConfig:             schema.SiteConfiguration{},
 			wantMaxQueueDepth:      24,
-			wantMaxQueueMatchCount: 99999,
+			wantMaxQueueMatchCount: -1,
 		},
 		{
 			name: "MaxReorderDurationMS",
@@ -314,7 +314,7 @@ func TestResultQueueSettingsFromConfig(t *testing.T) {
 			}}},
 			wantMaxQueueDepth:      24,
 			wantMaxReorderDuration: 5 * time.Millisecond,
-			wantMaxQueueMatchCount: 99999,
+			wantMaxQueueMatchCount: -1,
 		},
 		{
 			name: "MaxReorderQueueSize",
@@ -322,7 +322,7 @@ func TestResultQueueSettingsFromConfig(t *testing.T) {
 				MaxReorderQueueSize: &queueDepth,
 			}}},
 			wantMaxQueueDepth:      96,
-			wantMaxQueueMatchCount: 99999,
+			wantMaxQueueMatchCount: -1,
 		},
 		{
 			name: "MaxQueueMatchCount",

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -292,17 +292,20 @@ func TestIgnoreDownEndpoints(t *testing.T) {
 
 func TestResultQueueSettingsFromConfig(t *testing.T) {
 	queueDepth := 96
+	maxQueueMatchCount := 100
 
 	cases := []struct {
 		name                   string
 		siteConfig             schema.SiteConfiguration
 		wantMaxQueueDepth      int
 		wantMaxReorderDuration time.Duration
+		wantMaxQueueMatchCount int
 	}{
 		{
-			name:              "defaults",
-			siteConfig:        schema.SiteConfiguration{},
-			wantMaxQueueDepth: 24,
+			name:                   "defaults",
+			siteConfig:             schema.SiteConfiguration{},
+			wantMaxQueueDepth:      24,
+			wantMaxQueueMatchCount: 99999,
 		},
 		{
 			name: "MaxReorderDurationMS",
@@ -311,20 +314,29 @@ func TestResultQueueSettingsFromConfig(t *testing.T) {
 			}}},
 			wantMaxQueueDepth:      24,
 			wantMaxReorderDuration: 5 * time.Millisecond,
+			wantMaxQueueMatchCount: 99999,
 		},
 		{
-
 			name: "MaxReorderQueueSize",
 			siteConfig: schema.SiteConfiguration{ExperimentalFeatures: &schema.ExperimentalFeatures{Ranking: &schema.Ranking{
 				MaxReorderQueueSize: &queueDepth,
 			}}},
-			wantMaxQueueDepth: 96,
+			wantMaxQueueDepth:      96,
+			wantMaxQueueMatchCount: 99999,
+		},
+		{
+			name: "MaxQueueMatchCount",
+			siteConfig: schema.SiteConfiguration{ExperimentalFeatures: &schema.ExperimentalFeatures{Ranking: &schema.Ranking{
+				MaxQueueMatchCount: &maxQueueMatchCount,
+			}}},
+			wantMaxQueueDepth:      24,
+			wantMaxQueueMatchCount: 100,
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			haveMaxQueueDepth, haveMaxReorderDuration := resultQueueSettingsFromConfig(tt.siteConfig)
+			haveMaxQueueDepth, haveMaxReorderDuration, haveMaxQueueMatchCount := resultQueueSettingsFromConfig(tt.siteConfig)
 
 			if haveMaxQueueDepth != tt.wantMaxQueueDepth {
 				t.Fatalf("want %d, got %d", tt.wantMaxQueueDepth, haveMaxQueueDepth)
@@ -332,6 +344,10 @@ func TestResultQueueSettingsFromConfig(t *testing.T) {
 
 			if haveMaxReorderDuration != tt.wantMaxReorderDuration {
 				t.Fatalf("want %d, got %d", tt.wantMaxReorderDuration, haveMaxReorderDuration)
+			}
+
+			if haveMaxQueueMatchCount != tt.wantMaxQueueMatchCount {
+				t.Fatalf("want %d, got %d", tt.wantMaxQueueMatchCount, haveMaxQueueMatchCount)
 			}
 		})
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1538,6 +1538,8 @@ type QuickLink struct {
 
 // Ranking description: Experimental search result ranking options.
 type Ranking struct {
+	// MaxQueueMatchCount description: The maximum number of matches that can be buffered to sort results. The default is 99999. This protects frontend against OOMs for queries with extremely high count of matches per repository.
+	MaxQueueMatchCount *int `json:"maxQueueMatchCount,omitempty"`
 	// MaxReorderDurationMS description: The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.
 	MaxReorderDurationMS int `json:"maxReorderDurationMS,omitempty"`
 	// MaxReorderQueueSize description: The maximum number of search results that can be buffered to sort results. -1 is unbounded. The default is 24. Set this to small integers to limit latency increases from slow backends.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1538,7 +1538,7 @@ type QuickLink struct {
 
 // Ranking description: Experimental search result ranking options.
 type Ranking struct {
-	// MaxQueueMatchCount description: The maximum number of matches that can be buffered to sort results. The default is 99999. This protects frontend against OOMs for queries with extremely high count of matches per repository.
+	// MaxQueueMatchCount description: The maximum number of matches that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs for queries with extremely high count of matches per repository.
 	MaxQueueMatchCount *int `json:"maxQueueMatchCount,omitempty"`
 	// MaxReorderDurationMS description: The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.
 	MaxReorderDurationMS int `json:"maxReorderDurationMS,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -492,8 +492,8 @@
               "!go": { "pointer": true }
             },
             "maxQueueMatchCount": {
-              "description": "The maximum number of matches that can be buffered to sort results. The default is 99999. This protects frontend against OOMs for queries with extremely high count of matches per repository.",
-              "default": 99999,
+              "description": "The maximum number of matches that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs for queries with extremely high count of matches per repository.",
+              "default": -1,
               "type": "integer",
               "group": "Search",
               "!go": { "pointer": true }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -491,6 +491,13 @@
               "group": "Search",
               "!go": { "pointer": true }
             },
+            "maxQueueMatchCount": {
+              "description": "The maximum number of matches that can be buffered to sort results. The default is 99999. This protects frontend against OOMs for queries with extremely high count of matches per repository.",
+              "default": 99999,
+              "type": "integer",
+              "group": "Search",
+              "!go": { "pointer": true }
+            },
             "maxReorderDurationMS": {
               "description": "The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.",
               "type": "integer",


### PR DESCRIPTION
the queue depth (IE number of search results) can be a poor measure to protect against OOMs because the number of matches per result varies a lot depending on the query.

Here we introduce another counter that can trigger a partial flush: `maxQueueMatchCount`. The goal is to set it high enough so that it doesn't trigger for reasonable queries, but low enough so that it protects the queue from extreme match counts.

To find a good value for `maxQueueMatchCount`, we add a new metric that tracks the maximum match count of the queue.

In the long run we might consider removing queue depth as a parameter and solely rely on match counts. 

## Test plan
- adapted unit tests
- default setting is a NOP
- local testing
  - trying various levels for `maxQueueMatchCount`
  - verify data in Prometheus
  - compared search statistics reported in the UI, main vs. PR  

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
