### PR TITLE
searcher: factor out newSearchableFilter

### DIFF
--- a/cmd/searcher/internal/search/filter.go
+++ b/cmd/searcher/internal/search/filter.go
@@ -4,13 +4,17 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"hash"
+	"io"
 	"strings"
 
+	"github.com/bmatcuk/doublestar"
 	"github.com/sourcegraph/zoekt/ignore"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // NewFilter calls gitserver to retrieve the ignore-file. If the file doesn't
@@ -38,4 +42,67 @@ func NewFilter(ctx context.Context, db database.DB, repo api.RepoName, commit ap
 		}
 		return ig.Match(header.Name)
 	}, nil
+}
+
+func newSearchableFilter(c *schema.SiteConfiguration) *searchableFilter {
+	return &searchableFilter{
+		SearchLargeFiles: c.SearchLargeFiles,
+	}
+}
+
+// searchableFilter contains logic for what should and should not be stored in
+// the store.
+type searchableFilter struct {
+	// CommitIgnore filters out files that should not appear at all based on
+	// the commit. This does not contribute to HashKey and is only set once we
+	// start fetching the archive. This is since it is part of the state of
+	// the commit, and not derivable from the request.
+	//
+	// See NewFilter function above.
+	CommitIgnore FilterFunc
+
+	// SearchLargeFiles is a list of globs for files were we do not respect
+	// fileSizeMax. It comes from the site configuration search.largeFiles.
+	SearchLargeFiles []string
+}
+
+// Ignore returns true if the file should not appear at all when searched. IE
+// is excluded for both filename and content searches.
+//
+// Note: This function relies on CommitIgnore being set by NewFilter. Not
+// calling NewFilter indicates a bug and as such will panic.
+func (f *searchableFilter) Ignore(hdr *tar.Header) bool {
+	return f.CommitIgnore(hdr)
+}
+
+// SkipContent returns true if we should not include the content of the file
+// in the search. This means you can still find the file by filename, but not
+// by its contents.
+func (f *searchableFilter) SkipContent(hdr *tar.Header) bool {
+	// We do not search the content of large files unless they are
+	// allowed.
+	if hdr.Size <= maxFileSize {
+		return false
+	}
+
+	for _, pattern := range f.SearchLargeFiles {
+		pattern = strings.TrimSpace(pattern)
+		if m, _ := doublestar.Match(pattern, hdr.Name); m {
+			return false
+		}
+	}
+
+	return true
+}
+
+// HashKey will write the input of the filter to h.
+//
+// This is used as part of the key of what is stored on disk, such that if the
+// configuration changes we invalidated the cache.
+func (f *searchableFilter) HashKey(h hash.Hash) {
+	_, _ = io.WriteString(h, "\x00SearchLargeFiles")
+	for _, p := range f.SearchLargeFiles {
+		_, _ = h.Write([]byte{0})
+		_, _ = io.WriteString(h, p)
+	}
 }


### PR DESCRIPTION
The logic in store was getting a bit hard to reason about, so this commit introduces a struct which is responsible for deciding if something is ignored or skipped. We make it clearer what it means to ignore vs skip. Additionally this will be the place to extend logic as we introduce more complicated business rules here.

I plan to use this for introducing a ignore site config after 4.0.

Test Plan: go test