### PR TITLE
monitoring: render error as plain output, use dev format for logger

### DIFF
--- a/monitoring/main.go
+++ b/monitoring/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
-	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
@@ -28,8 +27,14 @@ func optsFromEnv() monitoring.GenerateOptions {
 }
 
 func main() {
-	// Use standard Sourcegraph logging options and flags.
-	logging.Init()
+	// Configure logger
+	if _, set := os.LookupEnv(log.EnvDevelopment); !set {
+		os.Setenv(log.EnvDevelopment, "true")
+	}
+	if _, set := os.LookupEnv(log.EnvLogFormat); !set {
+		os.Setenv(log.EnvLogFormat, "console")
+	}
+
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),
@@ -62,7 +67,10 @@ func main() {
 		definitions.CodeIntelPolicies(),
 		definitions.Telemetry(),
 	); err != nil {
-		logger.Fatal(err.Error())
+		// Dump error as plain output for readability.
+		println(err.Error())
+
+		logger.Fatal("Error encountered")
 	}
 }
 


### PR DESCRIPTION
Logger error output is quite bad to read, since the returned error can span dozens of error entries (the generator generally collates all validation errors before returning). Since it's usually a human reading the output, instead we render the error directly before using `logger.Fatal` (to ensure we sync the logger before exiting). In a similar spirit we also ensure that the log configuration is geared towards human-readability by default.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

run the generator with some errors to get readable output.