### PR TITLE
executor: double AWS_MAX_ATTEMPTS to 480

### DIFF
--- a/enterprise/cmd/executor/docker-mirror/build.sh
+++ b/enterprise/cmd/executor/docker-mirror/build.sh
@@ -26,7 +26,7 @@ export AWS_EXECUTOR_AMI_ACCESS_KEY=${AWS_EXECUTOR_AMI_ACCESS_KEY}
 export AWS_EXECUTOR_AMI_SECRET_KEY=${AWS_EXECUTOR_AMI_SECRET_KEY}
 # This should prevent some occurrences of Failed waiting for AMI failures:
 # https://austincloud.guru/2020/05/14/long-running-packer-builds-failing/
-export AWS_MAX_ATTEMPTS=240
+export AWS_MAX_ATTEMPTS=480
 export AWS_POLL_DELAY_SECONDS=5
 
 pushd "$TMR_WORKDIR" 1>/dev/null

--- a/enterprise/cmd/executor/vm-image/build.sh
+++ b/enterprise/cmd/executor/vm-image/build.sh
@@ -67,7 +67,7 @@ export AWS_EXECUTOR_AMI_ACCESS_KEY=${AWS_EXECUTOR_AMI_ACCESS_KEY}
 export AWS_EXECUTOR_AMI_SECRET_KEY=${AWS_EXECUTOR_AMI_SECRET_KEY}
 # This should prevent some occurrences of Failed waiting for AMI failures:
 # https://austincloud.guru/2020/05/14/long-running-packer-builds-failing/
-export AWS_MAX_ATTEMPTS=240
+export AWS_MAX_ATTEMPTS=480
 export AWS_POLL_DELAY_SECONDS=5
 
 pushd "$OUTPUT" 1>/dev/null


### PR DESCRIPTION
I am consistently getting `ResourceNotReady: exceeded wait attempts` in CI. The packer documentation suggests increasing this variable. So this is an attempt to make CI green on main again.

Full error for seen from packer:

```
Build 'aws' errored after 30 minutes 31 seconds: 1 error(s) occurred:

* Error waiting for AMI (ami-098b85ea8a63401ea) in region (us-east-2): Failed with ResourceNotReady error, which can have a variety of causes. For help troubleshooting, check our docs: https://www.packer.io/docs/builders/amazon.html#resourcenotready-error original error: ResourceNotReady: exceeded wait attempts
```

Test Plan: CI goes green on main.
