### PR TITLE
Notebook: Migrate share menu button to wildcard Menu component 

### DIFF
--- a/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
@@ -66,13 +66,7 @@ const ShareOptionComponent: React.FunctionComponent<
 }
 
 export const NotebookShareOptionsDropdown: FC<NotebookShareOptionsDropdownProps> = props => {
-    const {
-        isSourcegraphDotCom,
-        telemetryService,
-        authenticatedUser,
-        selectedShareOption,
-        onSelectShareOption
-    } = props
+    const { isSourcegraphDotCom, telemetryService, authenticatedUser, selectedShareOption, onSelectShareOption } = props
 
     const handleTriggerClick = (): void => {
         telemetryService.log('NotebookVisibilitySettingsDropdownToggled')
@@ -111,7 +105,7 @@ export const NotebookShareOptionsDropdown: FC<NotebookShareOptionsDropdownProps>
                 className={styles.button}
                 onClick={handleTriggerClick}
             >
-                { isOpen =>
+                {isOpen => (
                     <>
                         <span className="d-flex align-items-center">
                             <ShareOptionComponent {...selectedShareOption} isSourcegraphDotCom={isSourcegraphDotCom} />
@@ -124,7 +118,7 @@ export const NotebookShareOptionsDropdown: FC<NotebookShareOptionsDropdownProps>
                             )}
                         </span>
                     </>
-                }
+                )}
             </MenuButton>
 
             <MenuList>

--- a/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useMemo } from 'react'
 
-import { mdiLock, mdiWeb, mdiDomain, mdiChevronUp, mdiChevronDown } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp, mdiDomain, mdiLock, mdiWeb } from '@mdi/js'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Icon, Menu, MenuButton, MenuList, MenuItem } from '@sourcegraph/wildcard'
+import { Icon, Menu, MenuButton, MenuItem, MenuList } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { OrgAvatar } from '../../org/OrgAvatar'
@@ -121,7 +121,12 @@ export const NotebookShareOptionsDropdown: FC<NotebookShareOptionsDropdownProps>
                 )}
             </MenuButton>
 
-            <MenuList>
+            <MenuList
+                // Stop keydown event bubbling in order to prevent a global notebook keyboard
+                // navigation. Global notebook navigation breaks this menu keyboard navigation
+                // see https://github.com/sourcegraph/sourcegraph/pull/41654#issuecomment-1246672813
+                onKeyDown={event => event.stopPropagation()}
+            >
                 {shareOptions.map(option => (
                     <MenuItem
                         key={`${option.namespaceId}-${option.isPublic}`}

--- a/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
@@ -1,11 +1,9 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { FC, useMemo } from 'react'
 
 import { mdiLock, mdiWeb, mdiDomain, mdiChevronUp, mdiChevronDown } from '@mdi/js'
-// eslint-disable-next-line no-restricted-imports
-import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, Menu, MenuButton, MenuList, MenuItem } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { OrgAvatar } from '../../org/OrgAvatar'
@@ -67,14 +65,18 @@ const ShareOptionComponent: React.FunctionComponent<
     )
 }
 
-export const NotebookShareOptionsDropdown: React.FunctionComponent<
-    React.PropsWithChildren<NotebookShareOptionsDropdownProps>
-> = ({ isSourcegraphDotCom, telemetryService, authenticatedUser, selectedShareOption, onSelectShareOption }) => {
-    const [isOpen, setIsOpen] = useState(false)
-    const handleToggle = useCallback(() => {
+export const NotebookShareOptionsDropdown: FC<NotebookShareOptionsDropdownProps> = props => {
+    const {
+        isSourcegraphDotCom,
+        telemetryService,
+        authenticatedUser,
+        selectedShareOption,
+        onSelectShareOption
+    } = props
+
+    const handleTriggerClick = (): void => {
         telemetryService.log('NotebookVisibilitySettingsDropdownToggled')
-        setIsOpen(isOpen => !isOpen)
-    }, [telemetryService, setIsOpen])
+    }
 
     const shareOptions: ShareOption[] = useMemo(
         () => [
@@ -101,36 +103,42 @@ export const NotebookShareOptionsDropdown: React.FunctionComponent<
     )
 
     return (
-        <Dropdown isOpen={isOpen} toggle={handleToggle}>
-            <DropdownToggle
-                className={styles.button}
+        <Menu>
+            <MenuButton
                 outline={true}
                 variant="secondary"
                 data-testid="share-notebook-options-dropdown-toggle"
+                className={styles.button}
+                onClick={handleTriggerClick}
             >
-                <span className="d-flex align-items-center">
-                    <ShareOptionComponent {...selectedShareOption} isSourcegraphDotCom={isSourcegraphDotCom} />
-                </span>
-                <span className="ml-5">
-                    {isOpen ? (
-                        <Icon svgPath={mdiChevronUp} inline={false} aria-hidden={true} />
-                    ) : (
-                        <Icon svgPath={mdiChevronDown} inline={false} aria-hidden={true} />
-                    )}
-                </span>
-            </DropdownToggle>
-            <DropdownMenu>
+                { isOpen =>
+                    <>
+                        <span className="d-flex align-items-center">
+                            <ShareOptionComponent {...selectedShareOption} isSourcegraphDotCom={isSourcegraphDotCom} />
+                        </span>
+                        <span className="ml-5">
+                            {isOpen ? (
+                                <Icon svgPath={mdiChevronUp} inline={false} aria-hidden={true} />
+                            ) : (
+                                <Icon svgPath={mdiChevronDown} inline={false} aria-hidden={true} />
+                            )}
+                        </span>
+                    </>
+                }
+            </MenuButton>
+
+            <MenuList>
                 {shareOptions.map(option => (
-                    <DropdownItem
+                    <MenuItem
                         key={`${option.namespaceId}-${option.isPublic}`}
-                        className="d-flex align-items-center"
-                        onClick={() => onSelectShareOption(option)}
                         data-testid={`share-notebook-option-${option.namespaceName}-${option.isPublic}`}
+                        className="d-flex align-items-center"
+                        onSelect={() => onSelectShareOption(option)}
                     >
                         <ShareOptionComponent {...option} isSourcegraphDotCom={isSourcegraphDotCom} />
-                    </DropdownItem>
+                    </MenuItem>
                 ))}
-            </DropdownMenu>
-        </Dropdown>
+            </MenuList>
+        </Menu>
     )
 }

--- a/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.tsx
+++ b/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames'
 import {
     ButtonLink,
     ButtonLinkProps,
-    Button,
     ForwardReferenceComponent,
     MenuButton,
     MenuItem,
@@ -40,9 +39,9 @@ RepoHeaderActionButtonLink.displayName = 'RepoHeaderActionButtonLink'
 export const RepoHeaderActionDropdownToggle: React.FunctionComponent<
     React.PropsWithChildren<Pick<React.AriaAttributes, 'aria-label'>>
 > = ({ children, ...ariaAttributes }) => (
-    <Button as={MenuButton} className={styles.action} {...ariaAttributes}>
+    <MenuButton className={styles.action} {...ariaAttributes}>
         {children}
-    </Button>
+    </MenuButton>
 )
 
 export type RepoHeaderActionAnchorProps = Omit<ButtonLinkProps, 'as' | 'href'> & {

--- a/client/wildcard/src/components/Button/Button.tsx
+++ b/client/wildcard/src/components/Button/Button.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { useWildcardTheme } from '../../hooks/useWildcardTheme'
+import { useWildcardTheme } from '../../hooks'
 import { ForwardReferenceComponent } from '../../types'
 
 import { BUTTON_VARIANTS, BUTTON_SIZES, BUTTON_DISPLAY } from './constants'

--- a/client/wildcard/src/components/Form/Input/Input.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.tsx
@@ -6,7 +6,7 @@ import { useMergeRefs } from 'use-callback-ref'
 import { LoaderInput } from '@sourcegraph/branded/src/components/LoaderInput'
 
 import { Label } from '../..'
-import { useAutoFocus } from '../../../hooks/useAutoFocus'
+import { useAutoFocus } from '../../../hooks'
 import { ForwardReferenceComponent } from '../../../types'
 
 import styles from './Input.module.scss'

--- a/client/wildcard/src/components/Menu/MenuButton.tsx
+++ b/client/wildcard/src/components/Menu/MenuButton.tsx
@@ -1,13 +1,13 @@
-import React, { useMemo } from 'react'
+import React, { ReactNode, useMemo } from 'react'
 
 import { MenuButton as ReachMenuButton } from '@reach/menu-button'
 import { uniqueId } from 'lodash'
 
 import { ForwardReferenceComponent } from '../../types'
 import { Button, ButtonProps } from '../Button'
-import { PopoverTrigger } from '../Popover'
+import { PopoverTrigger, PopoverTriggerProps } from '../Popover'
 
-export type MenuButtonProps = Omit<ButtonProps, 'as'>
+export interface MenuButtonProps extends Omit<ButtonProps, 'as' | 'children'>, PopoverTriggerProps {}
 
 /**
  * Wraps a styled Wildcard `<Button />` component that can
@@ -23,12 +23,17 @@ export const MenuButton = React.forwardRef(({ children, id, ...props }, referenc
     // We unset aria-controls as it causes accessibility issues if the Menu is not yet rendered in the DOM.
     // aria-controls has low support across screen readers so this shouldn't be an issue: https://github.com/w3c/aria/issues/995
     return (
-        <ReachMenuButton ref={reference} as={PopoverTriggerButton} id={uniqueMenuId} {...props} aria-controls="">
-            {children}
+        <ReachMenuButton ref={reference} as={PopoverTriggerButton} id={uniqueMenuId} aria-controls="" {...props}>
+            {
+                // Cast to ReactNode since ReachMenuButton enforces its own children component which is a plain ReactNode
+                // But in our case children could be either ReactNode or render props since override component PopoverTrigger
+                // supports it.
+                children as ReactNode
+            }
         </ReachMenuButton>
     )
 }) as ForwardReferenceComponent<'button', MenuButtonProps>
 
 const PopoverTriggerButton = React.forwardRef((props, reference) => (
     <PopoverTrigger ref={reference} as={Button} {...props} />
-)) as ForwardReferenceComponent<'button', ButtonProps>
+)) as ForwardReferenceComponent<'button', ButtonProps & PopoverTriggerProps>

--- a/client/wildcard/src/components/Menu/MenuHeader.tsx
+++ b/client/wildcard/src/components/Menu/MenuHeader.tsx
@@ -13,7 +13,6 @@ export type MenuHeadingType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
  * A simple styled header component that can be used to
  * label sections of a `<Menu />` component.
  */
-
 export const MenuHeader = React.forwardRef(({ children, as: headerElement = 'h6', className, ...props }, reference) => (
     <Heading as={headerElement} ref={reference} {...props} className={classNames(styles.dropdownHeader, className)}>
         {children}

--- a/client/wildcard/src/components/Popover/components/PopoverTrigger.tsx
+++ b/client/wildcard/src/components/Popover/components/PopoverTrigger.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext } from 'react'
+import React, { forwardRef, ReactNode, useContext } from 'react'
 
 import { noop } from 'lodash'
 import { useCallbackRef, useMergeRefs } from 'use-callback-ref'
@@ -7,10 +7,12 @@ import { ForwardReferenceComponent } from '../../../types'
 import { PopoverContext } from '../contexts/internal-context'
 import { PopoverOpenEventReason } from '../Popover'
 
-interface PopoverTriggerProps {}
+export interface PopoverTriggerProps {
+    children?: ReactNode | ((isOpen: boolean) => ReactNode)
+}
 
 export const PopoverTrigger = forwardRef(function PopoverTrigger(props, reference) {
-    const { as: Component = 'button', onClick = noop, ...otherProps } = props
+    const { as: Component = 'button', onClick = noop, children, ...otherProps } = props
     const { setTargetElement, setOpen, isOpen } = useContext(PopoverContext)
 
     const callbackReference = useCallbackRef<HTMLButtonElement>(null, setTargetElement)
@@ -21,5 +23,9 @@ export const PopoverTrigger = forwardRef(function PopoverTrigger(props, referenc
         onClick(event)
     }
 
-    return <Component ref={mergedReference} onClick={handleClick} {...otherProps} />
+    return (
+        <Component ref={mergedReference} onClick={handleClick} {...otherProps}>
+            {typeof children === 'function' ? children(isOpen) : children}
+        </Component>
+    )
 }) as ForwardReferenceComponent<'button', PopoverTriggerProps>

--- a/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
+++ b/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
@@ -33,10 +33,11 @@ export const PopoverContent = forwardRef(function PopoverContent(props, referenc
         ...otherProps
     } = props
 
+    const { renderRoot } = useContext(PopoverRoot)
+
     const { isOpen: isOpenContext, targetElement: contextTargetElement, tailElement, anchor, setOpen } = useContext(
         PopoverContext
     )
-    const { renderRoot } = useContext(PopoverRoot)
 
     const targetElement = contextTargetElement ?? propertyTargetElement
     const [focusLock, setFocusLock] = useState(false)


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41632

## Background 

Prior to this PR `NotebookShareOptionsDropdown` used reactstrap Dropdown component for rendering share options dropdown menu. In order to remove reactstrap from the codebase this PR migrates this component to the wildcard Menu component UI. 

In order to migrate this component `NotebookShareOptionsDropdown` 
- MenuButton now supports render prop for rendering content conditionally based on open/closed internal state
- Because of reach-ui enforces prop-types check internally we had to add synthetic children prop to one of the internal MenuButton components (see this PR changes for more details) 

## Test plan
- Open any notebook
- Click Share action button 
- Check that share picker works as expected (as it works on the k8s or s2) 
- Check that in the console you don't have any error

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-migrate-reactstrap-in-notebooks.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jzbjfhdtho.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
