### PR TITLE
VSCode: Migrate dropdown button cta component to the wildcard

### DIFF
--- a/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
+++ b/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
@@ -2,11 +2,9 @@ import React, { useCallback, useEffect, useState } from 'react'
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
-// eslint-disable-next-line no-restricted-imports
-import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button } from '@sourcegraph/wildcard'
+import { Button, Popover, PopoverTrigger, PopoverContent } from '@sourcegraph/wildcard'
 
 import { WebviewPageProps } from '../../platform/context'
 
@@ -70,19 +68,17 @@ export const ButtonDropdownCta: React.FunctionComponent<React.PropsWithChildren<
     }
 
     return (
-        <ButtonDropdown className="menu-nav-item" direction="down" isOpen={isDropdownOpen} toggle={toggleDropdownOpen}>
-            <Button
-                as={DropdownToggle}
+        <Popover isOpen={isDropdownOpen} onOpenChange={toggleDropdownOpen}>
+            <PopoverTrigger
+                as={Button}
                 variant="secondary"
                 outline={true}
                 size="sm"
                 className={classNames('text-decoration-none', className, styles.toggle)}
-                nav={true}
-                caret={false}
             >
                 {button}
-            </Button>
-            <DropdownMenu right={true} className={styles.container}>
+            </PopoverTrigger>
+            <PopoverContent className={styles.container}>
                 <div className="d-flex mb-3">
                     <div className="d-flex align-items-center mr-3">
                         <div className={styles.icon}>{icon}</div>
@@ -97,7 +93,7 @@ export const ButtonDropdownCta: React.FunctionComponent<React.PropsWithChildren<
                 <VSCodeButton type="button" onClick={onClick} autofocus={true}>
                     Sign up for Sourcegraph
                 </VSCodeButton>
-            </DropdownMenu>
-        </ButtonDropdown>
+            </PopoverContent>
+        </Popover>
     )
 }

--- a/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
+++ b/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
@@ -4,7 +4,7 @@ import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Popover, PopoverTrigger, PopoverContent } from '@sourcegraph/wildcard'
+import { Button, Popover, PopoverContent, PopoverTrigger, Position } from '@sourcegraph/wildcard'
 
 import { WebviewPageProps } from '../../platform/context'
 
@@ -78,7 +78,7 @@ export const ButtonDropdownCta: React.FunctionComponent<React.PropsWithChildren<
             >
                 {button}
             </PopoverTrigger>
-            <PopoverContent className={styles.container}>
+            <PopoverContent className={styles.container} position={Position.bottomEnd}>
                 <div className="d-flex mb-3">
                     <div className="d-flex align-items-center mr-3">
                         <div className={styles.icon}>{icon}</div>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41635

## Background
This PR simply removes reactstrap component from the `ButtonDropdownCta` and brings Popover-like components instead (in order to remove reactstrap eventually) 

## Test plan
- Make sure that the `ButtonDropdownCta` looks ok in the vs code browser extension 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-migrate-cta-button-dropdown.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yluvmcaaqy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
