### PR TITLE
Extension: Migrate Command list component to the wildcard

### DIFF
--- a/client/browser/src/shared/code-hosts/bitbucket/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/bitbucket/codeHost.tsx
@@ -272,7 +272,6 @@ export const bitbucketServerCodeHost: CodeHost = {
             styles.commandPalettePopover,
             'aui-dropdown2 aui-style-default aui-layer aui-dropdown2-in-header aui-alignment-element aui-alignment-side-bottom aui-alignment-snap-left aui-alignment-enabled aui-alignment-abutted aui-alignment-abutted-left aui-alignment-element-attached-top aui-alignment-element-attached-left aui-alignment-target-attached-bottom aui-alignment-target-attached-left'
         ),
-        popoverInnerClassName: 'aui-dropdown2-section',
         formClassName: 'aui',
         inputClassName: 'text',
         resultsContainerClassName: 'results',

--- a/client/browser/src/shared/code-hosts/github/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/github/codeHost.module.scss
@@ -24,9 +24,8 @@
 }
 
 .command-palette-popover {
-    border: 1px solid var(--color-border-default);
-    border-radius: 6px;
-    overflow: hidden;
+    --dropdown-border-color: var(--color-border-default);
+    --popover-border-radius: 6px;
 }
 
 .command-palette-action-item {

--- a/client/browser/src/shared/code-hosts/github/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/github/codeHost.module.scss
@@ -24,6 +24,7 @@
 }
 
 .command-palette-popover {
+    --dropdown-bg: var(--body-bg);
     --dropdown-border-color: var(--color-border-default);
     --popover-border-radius: 6px;
 }

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
@@ -5,6 +5,10 @@
 .command-list-popover {
     // The navbar has z-index 1000
     z-index: 1001 !important;
+    --dropdown-bg: #fff;
+    --dropdown-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+    --dropdown-border-color: #dbdbdb;
+    --popover-border-radius: 3px;
 }
 
 :global(.show) > .command-list-popover {

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
@@ -5,8 +5,9 @@
 .command-list-popover {
     // The navbar has z-index 1000
     z-index: 1001 !important;
-    --dropdown-bg: var(--gray-50, #fff);
-    --dropdown-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+
+    --dropdown-bg: var(--gray-50, #ffffff);
+    --dropdown-shadow: 0 2px 4px rgba(0, 0, 0, 10%);
     --dropdown-border-color: var(--border-color);
     --popover-border-radius: 3px;
 }

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
@@ -7,7 +7,7 @@
     z-index: 1001 !important;
     --dropdown-bg: var(--gray-50, #fff);
     --dropdown-shadow: 0 2px 4px rgb(0 0 0 / 10%);
-    --dropdown-border-color: #dbdbdb;
+    --dropdown-border-color: var(--border-color);
     --popover-border-radius: 3px;
 }
 

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
@@ -5,7 +5,7 @@
 .command-list-popover {
     // The navbar has z-index 1000
     z-index: 1001 !important;
-    --dropdown-bg: #fff;
+    --dropdown-bg: var(--gray-50, #fff);
     --dropdown-shadow: 0 2px 4px rgb(0 0 0 / 10%);
     --dropdown-border-color: #dbdbdb;
     --popover-border-radius: 3px;

--- a/client/browser/src/shared/code-hosts/shared/extensions.tsx
+++ b/client/browser/src/shared/code-hosts/shared/extensions.tsx
@@ -58,7 +58,7 @@ interface InjectProps
 interface RenderCommandPaletteProps
     extends TelemetryProps,
         InjectProps,
-        Pick<CommandListPopoverButtonProps, 'inputClassName' | 'popoverClassName' | 'popoverInnerClassName'> {
+        Pick<CommandListPopoverButtonProps, 'inputClassName' | 'popoverClassName'> {
     notificationClassNames: UnbrandedNotificationItemStyleProps['notificationItemClassNames']
 }
 
@@ -73,7 +73,6 @@ export const renderCommandPalette = ({
             <CommandListPopoverButton
                 {...props}
                 popoverClassName={classNames('command-list-popover', props.popoverClassName)}
-                popoverInnerClassName={props.popoverInnerClassName}
                 menu={ContributableMenu.CommandPalette}
                 extensionsController={extensionsController}
                 location={history.location}

--- a/client/shared/src/commandPalette/CommandList.module.scss
+++ b/client/shared/src/commandPalette/CommandList.module.scss
@@ -1,6 +1,5 @@
 .command-list {
     width: 24rem;
-    background-color: var(--body-bg);
 
     :global(.list-group) {
         max-height: 18.5rem;

--- a/client/shared/src/commandPalette/CommandList.tsx
+++ b/client/shared/src/commandPalette/CommandList.tsx
@@ -417,7 +417,9 @@ export const CommandListPopoverButton = forwardRef((props, ref) => {
                 ref={ref}
                 // Support legacy buttonElement prop since it's used in the different code hosts
                 // specifications
-                as={buttonElement ?? Component}
+                as={buttonElement as 'button' ?? Component}
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 variant={variant}
                 aria-label="Command list"
                 className={classNames(styles.popoverButton, buttonClassName, isOpen && buttonOpenClassName)}

--- a/client/shared/src/commandPalette/CommandList.tsx
+++ b/client/shared/src/commandPalette/CommandList.tsx
@@ -14,7 +14,6 @@ import { Key } from 'ts-key-enum'
 import { ContributableMenu, Contributions, Evaluated } from '@sourcegraph/client-api'
 import { memoizeObservable } from '@sourcegraph/common'
 import {
-    Button,
     ButtonProps,
     ForwardReferenceComponent,
     Icon,
@@ -379,7 +378,7 @@ export interface CommandListPopoverButtonProps
 
 export const CommandListPopoverButton = forwardRef((props, ref) => {
     const {
-        as: Component = Button,
+        as: Component = 'span',
         buttonElement,
         buttonClassName,
         buttonOpenClassName,

--- a/client/shared/src/commandPalette/CommandList.tsx
+++ b/client/shared/src/commandPalette/CommandList.tsx
@@ -6,9 +6,6 @@ import classNames from 'classnames'
 import { Remote } from 'comlink'
 import * as H from 'history'
 import { sortBy, uniq, uniqueId } from 'lodash'
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import TooltipPopoverWrapper from 'reactstrap/lib/TooltipPopoverWrapper'
 import { from, Subscription } from 'rxjs'
 import { filter, switchMap } from 'rxjs/operators'
 import stringScore from 'string-score'
@@ -16,7 +13,17 @@ import { Key } from 'ts-key-enum'
 
 import { ContributableMenu, Contributions, Evaluated } from '@sourcegraph/client-api'
 import { memoizeObservable } from '@sourcegraph/common'
-import { Button, ButtonProps, LoadingSpinner, Icon, Label, Input } from '@sourcegraph/wildcard'
+import {
+    ButtonProps,
+    LoadingSpinner,
+    Icon,
+    Label,
+    Input,
+    Popover,
+    PopoverTrigger,
+    PopoverContent,
+    Button
+} from '@sourcegraph/wildcard'
 
 import { ActionItem, ActionItemAction } from '../actions/ActionItem'
 import { wrapRemoteObservable } from '../api/client/api/common'
@@ -382,6 +389,7 @@ export const CommandListPopoverButton: React.FunctionComponent<
     ...props
 }) => {
     const [isOpen, setIsOpen] = useState(false)
+
     // Capture active element on open in order to restore focus on close.
     const originallyFocusedElement = useMemo(() => {
         if (isOpen && document.activeElement instanceof HTMLElement) {
@@ -394,6 +402,7 @@ export const CommandListPopoverButton: React.FunctionComponent<
         originallyFocusedElement?.focus()
         setIsOpen(false)
     }, [originallyFocusedElement])
+
     const toggleIsOpen = useCallback(() => {
         if (isOpen) {
             originallyFocusedElement?.focus()
@@ -406,38 +415,29 @@ export const CommandListPopoverButton: React.FunctionComponent<
     const MenuDropdownIcon = (): JSX.Element => (
         <Icon svgPath={isOpen ? mdiChevronUp : mdiChevronDown} aria-hidden={true} />
     )
+
     return (
-        <Button
-            as={buttonElement}
-            role="button"
-            id={id}
-            onClick={toggleIsOpen}
-            className={classNames(styles.popoverButton, buttonClassName, isOpen && buttonOpenClassName)}
-            variant={variant}
-            aria-label="Command list"
-        >
-            <Icon size="md" aria-hidden={true} svgPath={mdiConsole} />
-
-            {showCaret && <MenuDropdownIcon />}
-
-            {/* Need to use TooltipPopoverWrapper to apply classNames to inner element, see https://github.com/reactstrap/reactstrap/issues/1484 */}
-            <TooltipPopoverWrapper
-                isOpen={isOpen}
-                toggle={toggleIsOpen}
-                popperClassName={popoverClassName}
-                innerClassName={classNames('popover-inner', popoverInnerClassName)}
-                placement="bottom-end"
-                target={id}
-                trigger="legacy"
-                delay={0}
-                fade={false}
-                hideArrow={true}
+        <Popover isOpen={isOpen} onOpenChange={toggleIsOpen}>
+            <PopoverTrigger
+                as={Button}
+                id={id}
+                role="button"
+                aria-label="Command list"
+                variant={variant}
+                className={classNames(styles.popoverButton, buttonClassName, isOpen && buttonOpenClassName)}
+                onClick={toggleIsOpen}
             >
+                <Icon size="md" aria-hidden={true} svgPath={mdiConsole} />
+                {showCaret && <MenuDropdownIcon />}
+            </PopoverTrigger>
+
+            <PopoverContent>
                 <CommandList {...props} onSelect={close} />
-            </TooltipPopoverWrapper>
-            {keyboardShortcutForShow?.keybindings.map((keybinding, index) => (
-                <Shortcut key={index} {...keybinding} onMatch={toggleIsOpen} />
-            ))}
-        </Button>
+
+                {keyboardShortcutForShow?.keybindings.map((keybinding, index) => (
+                    <Shortcut key={index} {...keybinding} onMatch={toggleIsOpen} />
+                ))}
+            </PopoverContent>
+        </Popover>
     )
 }

--- a/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.tsx
+++ b/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.tsx
@@ -7,6 +7,7 @@ import {
     CommandListPopoverButtonProps,
 } from '@sourcegraph/shared/src/commandPalette/CommandList'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
+import { Button } from '@sourcegraph/wildcard'
 
 import styles from './WebCommandListPopoverButton.module.scss'
 
@@ -18,6 +19,7 @@ export const WebCommandListPopoverButton: React.FunctionComponent<
     return (
         <CommandListPopoverButton
             {...props}
+            as={Button}
             variant="link"
             buttonClassName={classNames('m-0 p-0', styles.button)}
             formClassName="form p-2 bg-1 border-bottom"

--- a/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.tsx
+++ b/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.tsx
@@ -20,15 +20,12 @@ export const WebCommandListPopoverButton: React.FunctionComponent<
             {...props}
             variant="link"
             buttonClassName={classNames('m-0 p-0', styles.button)}
-            popoverClassName="popover border-0"
-            popoverInnerClassName="rounded overflow-hidden"
             formClassName="form p-2 bg-1 border-bottom"
             inputClassName="form-control px-2 py-1"
             listClassName="list-group list-group-flush list-unstyled pt-1"
             actionItemClassName={classNames('list-group-item list-group-item-action p-2 border-0', styles.actionItem)}
             selectedActionItemClassName="active border-primary"
             noResultsClassName="list-group-item text-muted"
-            buttonElement="button"
             keyboardShortcutForShow={showCommandPaletteShortcut}
         />
     )


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41634

## Background
This PR migrates `CommandList.tsx` from reactstrap dropdown component to the wildcard Popover. 

## Test plan
- Make sure that the Extension command list panel works as it used to work prior to this PR 
- Check browser extension command list UI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-migrate-command-list.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cgndwzxtzr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
