### PR TITLE
Add tests for LineChart component

### DIFF
--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
@@ -23,13 +23,13 @@ describe('LineChart', () => {
         })
 
         it('series with data', () => {
-            const { container } = renderChart(defaultArgs)
+            renderChart(defaultArgs)
 
             // Check number of series rendered
-            expect(container.querySelectorAll('.visx-linepath')).toHaveLength(totalSeries)
+            expect(screen.getAllByRole('listitem')).toHaveLength(totalSeries)
 
             // Check number of data points rendered
-            expect(container.querySelectorAll('circle.visx-glyph-dot')).toHaveLength(totalDataPoints)
+            expect(screen.getAllByRole(/(link|graphics-dataunit)/)).toHaveLength(totalDataPoints)
 
             // Spot check y axis labels
             expect(screen.getByLabelText(/tick axis 1 of 8. value: 8/i)).toBeInTheDocument()

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react'
+
+import { LineChart } from './LineChart'
+
+describe('LineChart', () => {
+    it('should render', () => {
+        render(<LineChart width={0} height={0} series={[]} />)
+    })
+})

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
@@ -1,9 +1,68 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { assert, stub } from 'sinon'
 
 import { LineChart } from './LineChart'
+import { FLAT_SERIES } from './story/mocks'
+
+const totalSeries = FLAT_SERIES.length
+const totalDataPoints = FLAT_SERIES.reduce((acc, series) => acc + series.data.length, 0)
+const defaultArgs: RenderChartArgs = { series: FLAT_SERIES }
+
+interface RenderChartArgs {
+    series: typeof FLAT_SERIES
+}
+const renderChart = ({ series }: RenderChartArgs) => render(<LineChart width={400} height={400} series={series} />)
 
 describe('LineChart', () => {
-    it('should render', () => {
-        render(<LineChart width={0} height={0} series={[]} />)
+    // Non exhaustive smoke tests to check that the chart renders correctly
+    // All other general rendering tests are covered by chromatic
+    describe('should render', () => {
+        it('empty series', () => {
+            renderChart({ ...defaultArgs, series: [] })
+        })
+
+        it('series with data', () => {
+            const { container } = renderChart(defaultArgs)
+
+            // Check number of series rendered
+            expect(container.querySelectorAll('.visx-linepath')).toHaveLength(totalSeries)
+
+            // Check number of data points rendered
+            expect(container.querySelectorAll('circle.visx-glyph-dot')).toHaveLength(totalDataPoints)
+
+            // Spot check y axis labels
+            expect(screen.getByLabelText(/tick axis 1 of 8. value: 8/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/tick axis 4 of 8. value: 20/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/tick axis 8 of 8. value: 36/i)).toBeInTheDocument()
+
+            // Spot check x axis labels
+            expect(screen.getByLabelText(/tick axis 1 of 8. value:.*jan 01/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/tick axis 4 of 8. value:.*oct 01/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/tick axis 8 of 8. value:.*oct 01/i)).toBeInTheDocument()
+        })
+    })
+
+    describe('should handle clicks', () => {
+        it('on a point', () => {
+            const openStub = stub(window, 'open')
+
+            renderChart(defaultArgs)
+
+            const [firstPoint, secondPoint, thirdPoint] = screen.getAllByRole('link', {
+                name: 'Click to view data point detail',
+            })
+
+            // Spot checking multiple points
+            // related issue https://github.com/sourcegraph/sourcegraph/issues/38304
+            userEvent.click(firstPoint)
+            userEvent.click(secondPoint)
+            userEvent.click(thirdPoint)
+
+            assert.alwaysCalledWith(openStub, 'https://google.com/search')
+            assert.calledThrice(openStub)
+
+            openStub.restore()
+        })
     })
 })

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -102,8 +102,8 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                 margin: {
                     top: 16,
                     right: 16,
-                    left: yAxisElement?.getBBox().width,
-                    bottom: xAxisReference?.getBBox().height,
+                    left: yAxisElement?.getBBox?.().width ?? 0,
+                    bottom: xAxisReference?.getBBox?.().height ?? 0,
                 },
             }),
         [yAxisElement, xAxisReference, outerWidth, outerHeight]

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -181,6 +181,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
             width={outerWidth}
             height={outerHeight}
             className={classNames(styles.root, className, { [styles.rootWithHoveredLinkPoint]: activePoint?.linkUrl })}
+            role="group"
             {...attributes}
             {...handlers}
         >
@@ -203,7 +204,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                 tickFormat={formatDateTick}
             />
 
-            <Group top={content.top} left={content.left}>
+            <Group top={content.top} left={content.left} role="list">
                 {stacked && <StackedArea dataSeries={activeSeries} xScale={xScale} yScale={yScale} />}
 
                 {activeSeries.map(line => (
@@ -220,6 +221,8 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                             hasActivePoint: !!activePoint,
                             isActive: activePoint?.seriesId === line.id,
                         })}
+                        aria-label={line.name}
+                        role="listitem"
                         onDatumClick={onDatumClick}
                         onDatumFocus={setActivePoint}
                     />

--- a/client/wildcard/src/components/Charts/core/components/MaybeLink.tsx
+++ b/client/wildcard/src/components/Charts/core/components/MaybeLink.tsx
@@ -17,5 +17,5 @@ export const MaybeLink: React.FunctionComponent<React.PropsWithChildren<MaybeLin
             {children}
         </Link>
     ) : (
-        (children as React.ReactElement)
+        <span {...props}>{children}</span>
     )

--- a/client/wildcard/src/components/Charts/core/components/MaybeLink.tsx
+++ b/client/wildcard/src/components/Charts/core/components/MaybeLink.tsx
@@ -10,12 +10,13 @@ interface MaybeLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 export const MaybeLink: React.FunctionComponent<React.PropsWithChildren<MaybeLinkProps>> = ({
     children,
     to,
+    role,
     ...props
 }) =>
     to ? (
-        <Link {...props} to={to}>
+        <Link {...props} to={to} role={role}>
             {children}
         </Link>
     ) : (
-        <span {...props}>{children}</span>
+        <g role={role}>{children}</g>
     )


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/38306

Add basic rendering smoke test.
Add click handling test.

Click test inspired by this issue: https://github.com/sourcegraph/sourcegraph/issues/38304

## Test plan

This test should pass

## App preview:

- [Web](https://sg-web-insights-line-chart-tests.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ijdyfvcusp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
