### PR TITLE
Reduce spacing in color picker input

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-color-input/FormColorInput.module.scss
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-color-input/FormColorInput.module.scss
@@ -62,7 +62,7 @@
 
     &__color-block {
         // stylelint-disable-next-line declaration-property-unit-allowed-list
-        margin-right: 11px;
+        margin-right: 10px;
     }
 
     &__custom-color {

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-color-input/FormColorInput.module.scss
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-color-input/FormColorInput.module.scss
@@ -61,7 +61,7 @@
     }
 
     &__color-block {
-        margin-right: 0.75rem;
+        margin-right: 11px;
     }
 
     &__custom-color {

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-color-input/FormColorInput.module.scss
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-color-input/FormColorInput.module.scss
@@ -61,6 +61,7 @@
     }
 
     &__color-block {
+        // stylelint-disable-next-line declaration-property-unit-allowed-list
         margin-right: 11px;
     }
 

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-color-input/FormColorInput.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-color-input/FormColorInput.tsx
@@ -60,3 +60,5 @@ export const FormColorInput: React.FunctionComponent<React.PropsWithChildren<For
         </fieldset>
     )
 })
+
+FormColorInput.displayName = 'FormColorInput'


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36698

Reduce padding between circle color pickers.

|Before|After|
|---|---|
|![PixelSnap 2022-09-14 at 11 00 18](https://user-images.githubusercontent.com/1855233/190204745-a5dcc362-50a7-4b16-9d93-cf3262fb58ba.png)|![PixelSnap 2022-09-14 at 11 04 10](https://user-images.githubusercontent.com/1855233/190205469-b9bbd82a-1f05-4312-8231-eeff59d80726.png)|

## Test plan

Open "Search Insight Creation Page" in storybook.
Color picker circles should all fit on one row.

## App preview:

- [Web](https://sg-web-insights-color-input-spacing.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-aaobmgwxmt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
