### PR TITLE
[SG-41358] `client/search-ui:` migration to graphql-operations

### DIFF
--- a/client/search-ui/src/components/CodeExcerpt.tsx
+++ b/client/search-ui/src/components/CodeExcerpt.tsx
@@ -10,11 +10,11 @@ import { catchError, filter } from 'rxjs/operators'
 import { HoverMerged } from '@sourcegraph/client-api'
 import { DOMFunctions, findPositionsFromEvents, Hoverifier } from '@sourcegraph/codeintellify'
 import { asError, ErrorLike, isDefined, isErrorLike, highlightNode } from '@sourcegraph/common'
+import { HighlightLineRange } from '@sourcegraph/search'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 import { ViewerId } from '@sourcegraph/shared/src/api/viewerTypes'
 import { HighlightResponseFormat } from '@sourcegraph/shared/src/graphql-operations'
 import { HoverContext } from '@sourcegraph/shared/src/hover/HoverOverlay.types'
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { Repo } from '@sourcegraph/shared/src/util/url'
 import { Icon, Code } from '@sourcegraph/wildcard'
 
@@ -25,7 +25,7 @@ export interface FetchFileParameters {
     commitID: string
     filePath: string
     disableTimeout?: boolean
-    ranges: GQL.IHighlightLineRange[]
+    ranges: HighlightLineRange[]
     format?: HighlightResponseFormat
 }
 

--- a/client/search-ui/src/components/FileMatchChildren.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.tsx
@@ -14,11 +14,11 @@ import {
     isErrorLike,
     toPositionOrRangeQueryParameter,
 } from '@sourcegraph/common'
+import { HighlightLineRange, HighlightResponseFormat } from '@sourcegraph/search'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 import { MatchGroup } from '@sourcegraph/shared/src/components/ranking/PerFileResultRanking'
 import { Controller as ExtensionsController } from '@sourcegraph/shared/src/extensions/controller'
 import { HoverContext } from '@sourcegraph/shared/src/hover/HoverOverlay.types'
-import { HighlightResponseFormat, IHighlightLineRange } from '@sourcegraph/shared/src/schema'
 import { ContentMatch, SymbolMatch, PathMatch, getFileMatchUrl } from '@sourcegraph/shared/src/search/stream'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { useCoreWorkflowImprovementsEnabled } from '@sourcegraph/shared/src/settings/useCoreWorkflowImprovementsEnabled'
@@ -162,7 +162,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
     const { result, grouped, fetchHighlightedFileLineRanges, telemetryService, extensionsController } = props
 
     const fetchFileRangeMatches = useCallback(
-        (args: { format?: HighlightResponseFormat; ranges: IHighlightLineRange[] }): Observable<string[][]> =>
+        (args: { format?: HighlightResponseFormat; ranges: HighlightLineRange[] }): Observable<string[][]> =>
             fetchHighlightedFileLineRanges(
                 {
                     repoName: result.repository,
@@ -183,7 +183,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             return fetchFileRangeMatches({
                 format: HighlightResponseFormat.HTML_HIGHLIGHT,
                 ranges: grouped.map(
-                    (group): IHighlightLineRange => ({
+                    (group): HighlightLineRange => ({
                         startLine: group.startLine,
                         endLine: group.endLine,
                     })
@@ -208,7 +208,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             fetchFileRangeMatches({
                 format: HighlightResponseFormat.HTML_PLAINTEXT,
                 ranges: grouped.map(
-                    (group): IHighlightLineRange => ({
+                    (group): HighlightLineRange => ({
                         startLine: group.startLine,
                         endLine: group.endLine,
                     })
@@ -232,7 +232,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             return fetchFileRangeMatches({
                 format: HighlightResponseFormat.HTML_HIGHLIGHT,
                 ranges: result.symbols.map(
-                    (symbol): IHighlightLineRange => ({
+                    (symbol): HighlightLineRange => ({
                         startLine: symbol.line - 1,
                         endLine: symbol.line,
                     })
@@ -263,7 +263,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             return fetchFileRangeMatches({
                 format: HighlightResponseFormat.HTML_PLAINTEXT,
                 ranges: result.symbols.map(
-                    (symbol): IHighlightLineRange => ({
+                    (symbol): HighlightLineRange => ({
                         startLine: symbol.line - 1,
                         endLine: symbol.line,
                     })

--- a/client/search-ui/src/input/MonacoQueryInput.story.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.story.tsx
@@ -1,7 +1,7 @@
 import { Meta, Story, DecoratorFn } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
-import { SearchPatternType } from '@sourcegraph/shared/src/schema'
+import { SearchPatternType } from '@sourcegraph/search'
 
 import { MonacoQueryInput, MonacoQueryInputProps } from './MonacoQueryInput'
 

--- a/client/search-ui/src/input/SearchBox.story.tsx
+++ b/client/search-ui/src/input/SearchBox.story.tsx
@@ -1,7 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
-import { SearchPatternType } from '@sourcegraph/shared/src/schema'
+import { SearchPatternType } from '@sourcegraph/search'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     mockFetchAutoDefinedSearchContexts,

--- a/client/search-ui/src/input/SearchContextMenu.test.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.test.tsx
@@ -6,8 +6,7 @@ import { DropdownMenu, UncontrolledDropdown } from 'reactstrap'
 import { Observable, of, throwError } from 'rxjs'
 import sinon from 'sinon'
 
-import { ListSearchContextsResult, SearchContextFields } from '@sourcegraph/search'
-import { ISearchContext } from '@sourcegraph/shared/src/schema'
+import { ListSearchContextsResult, SearchContextFields, SearchContextMinimalFields } from '@sourcegraph/search'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockIntersectionObserver } from '@sourcegraph/shared/src/testing/MockIntersectionObserver'
 import { mockGetUserSearchContextNamespaces } from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
@@ -49,7 +48,7 @@ const mockFetchAutoDefinedSearchContexts = () =>
             updatedAt: '2021-03-15T19:39:11Z',
             viewerCanManage: false,
         },
-    ] as ISearchContext[])
+    ] as SearchContextMinimalFields[])
 
 const mockFetchSearchContexts = ({ query }: { first: number; query?: string; after?: string }) => {
     const nodes = [
@@ -263,7 +262,7 @@ describe('SearchContextMenu', () => {
     })
 
     it('should default to empty array if fetching auto-defined contexts fails', () => {
-        const errorFetchAutoDefinedSearchContexts: () => Observable<ISearchContext[]> = () =>
+        const errorFetchAutoDefinedSearchContexts: () => Observable<SearchContextMinimalFields[]> = () =>
             throwError(new Error('unknown error'))
 
         render(

--- a/client/search-ui/src/input/SearchContextMenu.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.tsx
@@ -19,7 +19,6 @@ import { asError, isErrorLike } from '@sourcegraph/common'
 import { SearchContextInputProps, SearchContextMinimalFields } from '@sourcegraph/search'
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { ISearchContext } from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge, Button, useObservable, Icon, Input, ButtonLink, Tooltip } from '@sourcegraph/wildcard'
 
@@ -268,7 +267,7 @@ export const SearchContextMenu: React.FunctionComponent<React.PropsWithChildren<
     )
 
     // Merge auto-defined contexts and user-defined contexts
-    const filteredList = useMemo(() => filteredAutoDefinedSearchContexts.concat(searchContexts as ISearchContext[]), [
+    const filteredList = useMemo(() => filteredAutoDefinedSearchContexts.concat(searchContexts), [
         filteredAutoDefinedSearchContexts,
         searchContexts,
     ])

--- a/client/search-ui/src/input/toggles/Toggles.test.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react'
 
-import { SearchPatternType } from '@sourcegraph/shared/src/schema'
+import { SearchPatternType } from '@sourcegraph/search'
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { getFullQuery, Toggles } from './Toggles'

--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -10,8 +10,8 @@ import {
     SearchContextProps,
     SearchPatternTypeMutationProps,
     SubmitSearchProps,
+    SearchPatternType,
 } from '@sourcegraph/search'
-import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { findFilter, FilterKind } from '@sourcegraph/shared/src/search/query/query'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'

--- a/client/search-ui/src/input/useQueryIntelligence.ts
+++ b/client/search-ui/src/input/useQueryIntelligence.ts
@@ -4,7 +4,7 @@ import * as Monaco from 'monaco-editor'
 import { Observable } from 'rxjs'
 import * as uuid from 'uuid'
 
-import { SearchPatternType } from '@sourcegraph/shared/src/schema'
+import { SearchPatternType } from '@sourcegraph/search'
 import { Diagnostic, getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
 import { getProviders } from '@sourcegraph/shared/src/search/query/providers'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'


### PR DESCRIPTION
## Description
Migrate typing using from `schema.ts` to `graphql-oparations`

## Success criteria

1. All imports from `schema.ts` in the `client/search-ui` package are replaced with respective imports from `graphql-operations`.

## Ref
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/41358)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-41358)

## Test Plan
- Verify that all usage of `schema.ts` types has been migrated to their equivalent typing from `graphql-oparations.ts` file in `client/search-ui` package.

## App preview:

- [Web](https://sg-web-contractors-sg-41358.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cnlouonbag.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
