### PR TITLE
Access manager: Migrate user autocomplete UI to the wildcard combobox

### DIFF
--- a/client/web/src/org/members/InviteMemberModal.tsx
+++ b/client/web/src/org/members/InviteMemberModal.tsx
@@ -169,7 +169,7 @@ export const InviteMemberModalHandler: React.FunctionComponent<
         }
     }, [setModalOpened, orgId, eventLoggerEventName])
 
-    const onCloseIviteModal = useCallback(() => {
+    const onCloseInviteModal = useCallback(() => {
         setModalOpened(false)
     }, [setModalOpened])
 
@@ -184,7 +184,7 @@ export const InviteMemberModalHandler: React.FunctionComponent<
                     orgId={orgId}
                     orgName={orgName}
                     onInviteSent={onInviteSent}
-                    onDismiss={onCloseIviteModal}
+                    onDismiss={onCloseInviteModal}
                     showBetaBanner={showBetaBanner}
                 />
             )}

--- a/client/web/src/org/members/SearchUserAutocomplete.module.scss
+++ b/client/web/src/org/members/SearchUserAutocomplete.module.scss
@@ -4,11 +4,6 @@
 }
 
 .suggestions-container {
-    width: 100%;
-    padding: 0.25rem 0;
-    border-radius: 5px;
-    box-shadow: 0 4px 16px -6px rgba(36, 41, 54, 0.2);
-    background-color: var(--color-bg-1);
     overflow: auto;
     max-height: 18rem;
 }

--- a/client/web/src/org/members/SearchUserAutocomplete.module.scss
+++ b/client/web/src/org/members/SearchUserAutocomplete.module.scss
@@ -13,76 +13,28 @@
     align-items: center;
     padding: 0.25rem 1rem;
 
-    &--error {
-        color: var(--danger) !important;
-    }
-
-    &-name {
-        width: 10rem;
-        margin-right: 0.25rem;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        flex-shrink: 0;
+    &[data-highlighted] {
+        .user-name {
+            color: inherit;
+        }
     }
 
     &-description {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        flex-grow: 1;
-        font-size: 0.75rem;
-    }
-
-    &:not(:active) {
-        > .item-description {
-            color: var(--text-muted);
-        }
-    }
-
-    &--selected {
-        background-color: var(--color-bg-3);
-    }
-
-    &--highlighted {
-        font-weight: 700;
-    }
-
-    &:hover,
-    &:active,
-    &:focus {
-        /* Override default focus styles */
-        box-shadow: none;
-        outline: none;
-
-        background-color: var(--primary);
-        color: var(--light-text) !important;
-
-        > .item-description {
-            color: var(--light-text);
-        }
-
-        .user-name {
-            color: var(--light-text) !important;
-        }
-    }
-
-    &:hover,
-    &:active,
-    &:focus,
-    &--selected {
-        /* Badge-secondary variant for improved contrast when background color changes */
-        > .item-default {
-            background-color: var(--color-bg-1);
-            border-color: var(--color-bg-1);
-        }
+        display: flex;
+        flex-direction: column;
     }
 }
 
 .empty-results {
+    display: flex;
+    flex-direction: column;
     padding: 0 1rem;
-    cursor: default;
 }
 
 .user-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     gap: 0.5rem;
     height: 2rem;
 }
@@ -107,5 +59,9 @@
 }
 
 .user-name {
+    color: var(--text-muted);
+}
+
+.user-description {
     color: var(--text-muted);
 }

--- a/client/web/src/org/members/SearchUserAutocomplete.tsx
+++ b/client/web/src/org/members/SearchUserAutocomplete.tsx
@@ -1,20 +1,92 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react'
 
 import { useLazyQuery } from '@apollo/client'
 import classNames from 'classnames'
 import { debounce } from 'lodash'
-// eslint-disable-next-line no-restricted-imports
-import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 
-import { Input, Tooltip } from '@sourcegraph/wildcard'
+import { Tooltip, Combobox, ComboboxInput, ComboboxPopover, ComboboxList, ComboboxOption } from '@sourcegraph/wildcard'
 
 import { AutocompleteMembersSearchResult, AutocompleteMembersSearchVariables, Maybe } from '../../graphql-operations'
-import { eventLogger } from '../../tracking/eventLogger'
 import { UserAvatar } from '../../user/UserAvatar'
 
 import { SEARCH_USERS_AUTOCOMPLETE_QUERY } from './gqlQueries'
 
 import styles from './SearchUserAutocomplete.module.scss'
+
+const MIN_SEARCH_LENGTH = 3
+const EMAIL_PATTERN = new RegExp(/^[\w!#$%&'*+./=?^`{|}~-]+@[A-Z_a-z]+?\.[A-Za-z]{2,3}$/)
+
+interface AutocompleteSearchUsersProps {
+    disabled?: boolean
+    onValueChanged: (value: string, isEmail: boolean) => void
+    orgId: string
+}
+
+export const AutocompleteSearchUsers: FC<AutocompleteSearchUsersProps> = props => {
+    const { disabled, onValueChanged, orgId } = props
+
+    const [userNameOrEmail, setUsernameOrEmail] = useState('')
+
+    const [getUsers, { loading, data, error }] = useLazyQuery<
+        AutocompleteMembersSearchResult,
+        AutocompleteMembersSearchVariables
+    >(SEARCH_USERS_AUTOCOMPLETE_QUERY, {
+        variables: { organization: orgId, query: userNameOrEmail },
+    })
+
+    useEffect(() => {
+        onValueChanged(userNameOrEmail, EMAIL_PATTERN.test(userNameOrEmail))
+    }, [onValueChanged, userNameOrEmail])
+
+    const searchUsers = useCallback(
+        (query: string): void => {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            getUsers({ variables: { query, organization: orgId } })
+        },
+        [getUsers, orgId]
+    )
+
+    const debounceGetUsers = useRef(debounce(searchUsers, 250, { leading: false }))
+
+    const onUsernameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
+        const newValue = event.currentTarget.value
+
+        setUsernameOrEmail(newValue)
+
+        if (!EMAIL_PATTERN.test(newValue) && newValue.length >= MIN_SEARCH_LENGTH) {
+            debounceGetUsers.current(newValue)
+        }
+    }, [])
+
+    const results = (data
+        ? data.autocompleteMembersSearch.map(usr => ({ ...usr })).sort(item => (item.inOrg ? 1 : -1))
+        : []) as IUserItem[]
+
+    const resultsEnabled = !EMAIL_PATTERN.test(userNameOrEmail) && !error && userNameOrEmail.length >= MIN_SEARCH_LENGTH
+    const renderResults = resultsEnabled && results.length > 0
+    const renderNoMatch = resultsEnabled && !loading && results.length === 0
+
+    return (
+        <Combobox className={styles.inputContainer} onSelect={setUsernameOrEmail}>
+            <ComboboxInput
+                autocomplete={false}
+                label="Email address or username"
+                title="Email address or username"
+                autoFocus={true}
+                disabled={disabled}
+                status={loading ? 'loading' : error ? 'error' : undefined}
+                onChange={onUsernameChange}
+            />
+
+            <ComboboxPopover className={styles.suggestionsContainer}>
+                <ComboboxList>
+                    {renderResults && results.map(usr => <UserResultItem key={usr.id} user={usr} />)}
+                    {renderNoMatch && <EmptyResultsItem userNameOrEmail={userNameOrEmail} />}
+                </ComboboxList>
+            </ComboboxPopover>
+        </Combobox>
+    )
+}
 
 interface IUserItem {
     id: string
@@ -24,40 +96,20 @@ interface IUserItem {
     avatarURL: Maybe<string>
 }
 
-interface AutocompleteSearchUsersProps {
-    disabled?: boolean
-    onValueChanged: (value: string, isEmail: boolean) => void
-    orgId: string
+interface UserResultItemProps {
+    user: IUserItem
 }
 
-const UserResultItem: React.FunctionComponent<
-    React.PropsWithChildren<{
-        onSelectUser: (user: IUserItem) => void
-        onKeyDown: (key: string, index: number) => void
-        index: number
-        user: IUserItem
-    }>
-> = ({ user, onSelectUser, onKeyDown, index }) => {
-    const selectUser = useCallback(() => {
-        onSelectUser(user)
-    }, [onSelectUser, user])
-
-    const keyDown = useCallback(
-        (event: React.KeyboardEvent) => {
-            onKeyDown(event.key, index)
-        },
-        [onKeyDown, index]
-    )
+const UserResultItem: FC<UserResultItemProps> = props => {
+    const { user } = props
 
     return (
-        <DropdownItem
+        <ComboboxOption
+            value={user.displayName ?? user.username}
             data-testid="search-context-menu-item"
             data-res-user-id={user.id}
-            className={styles.item}
-            onClick={selectUser}
-            role="menuitem"
             disabled={user.inOrg}
-            onKeyDown={keyDown}
+            className={styles.item}
         >
             <div className={classNames('d-flex align-items-center justify-content-between', styles.userContainer)}>
                 <div className={styles.avatarContainer}>
@@ -77,165 +129,23 @@ const UserResultItem: React.FunctionComponent<
                     {user.inOrg && <small className="text-muted">Already in this organization</small>}
                 </div>
             </div>
-        </DropdownItem>
+        </ComboboxOption>
     )
 }
 
-const EmptyResultsItem: React.FunctionComponent<
-    React.PropsWithChildren<{
-        userNameOrEmail: string
-    }>
-> = ({ userNameOrEmail }) => (
-    <DropdownItem data-testid="search-context-menu-item" role="menuitem">
-        <div className={classNames('d-flex', 'flex-column', styles.emptyResults)}>
-            <span>
-                <small>
-                    <strong>{`Nobody found with the username “${userNameOrEmail}”`}</strong>
-                </small>
-            </span>
-            <span className="text-muted">
-                <small>Try sending invite via email instead</small>
-            </span>
-        </div>
-    </DropdownItem>
+const EmptyResultsItem: FC<{ userNameOrEmail: string }> = ({ userNameOrEmail }) => (
+    <div
+        data-testid="search-context-menu-item"
+        role="menuitem"
+        className={classNames('d-flex', 'flex-column', styles.emptyResults)}
+    >
+        <span>
+            <small>
+                <strong>{`Nobody found with the username “${userNameOrEmail}”`}</strong>
+            </small>
+        </span>
+        <span className="text-muted">
+            <small>Try sending invite via email instead</small>
+        </span>
+    </div>
 )
-
-const getUserSearchResultItem = (userId: string): HTMLButtonElement | null =>
-    document.querySelector(`[data-res-user-id="${userId}"]`)
-
-export const AutocompleteSearchUsers: React.FunctionComponent<
-    React.PropsWithChildren<AutocompleteSearchUsersProps>
-> = props => {
-    const { disabled, onValueChanged, orgId } = props
-    const MinSearchLength = 3
-    const emailPattern = useRef(new RegExp(/^[\w!#$%&'*+./=?^`{|}~-]+@[A-Z_a-z]+?\.[A-Za-z]{2,3}$/))
-    const [userNameOrEmail, setUsernameOrEmail] = useState('')
-    const [isEmail, setIsEmail] = useState<boolean>(false)
-    const inputReference = useRef<HTMLInputElement | null>(null)
-    const [openResults, setOpenResults] = useState<boolean>(true)
-
-    const [getUsers, { loading, data, error }] = useLazyQuery<
-        AutocompleteMembersSearchResult,
-        AutocompleteMembersSearchVariables
-    >(SEARCH_USERS_AUTOCOMPLETE_QUERY, {
-        variables: { organization: orgId, query: userNameOrEmail },
-    })
-
-    const results = (data
-        ? data.autocompleteMembersSearch.map(usr => ({ ...usr })).sort(item => (item.inOrg ? 1 : -1))
-        : []) as IUserItem[]
-
-    const firstResult = results.length > 0 ? results[0] : undefined
-    const resultsEnabled = !isEmail && !error && userNameOrEmail.length >= MinSearchLength && openResults
-    const renderResults = resultsEnabled && results.length > 0
-    const renderNoMatch = resultsEnabled && results.length === 0
-
-    useEffect(() => {
-        onValueChanged(userNameOrEmail, isEmail)
-    }, [onValueChanged, isEmail, userNameOrEmail])
-
-    const searchUsers = useCallback(
-        (query: string): void => {
-            setOpenResults(true)
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            getUsers({ variables: { query, organization: orgId } })
-        },
-        [getUsers, orgId]
-    )
-
-    const debounceGetUsers = useRef(debounce(searchUsers, 250, { leading: false }))
-
-    const focusInputElement = (): void => {
-        inputReference.current?.focus()
-    }
-
-    const onUsernameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
-        const newValue = event.currentTarget.value
-        const isEmail = emailPattern.current.test(newValue)
-        setIsEmail(isEmail)
-        setUsernameOrEmail(newValue)
-        if (!isEmail && newValue.length >= MinSearchLength) {
-            debounceGetUsers.current(newValue)
-        }
-    }, [])
-
-    const onInputKeyDown = useCallback(
-        (event: React.KeyboardEvent) => {
-            if (firstResult && event.key === 'ArrowDown') {
-                event.stopPropagation()
-                event.preventDefault()
-                getUserSearchResultItem(firstResult.id)?.focus()
-            } else if (event.key === 'Escape') {
-                setOpenResults(false)
-                event.stopPropagation()
-            }
-        },
-        [firstResult]
-    )
-
-    const onSelectUser = useCallback(
-        (user: IUserItem) => {
-            eventLogger.log(
-                'InviteAutocompleteUserSelected',
-                { organizationId: orgId, user: user.username },
-                { organizationId: orgId }
-            )
-            setOpenResults(false)
-            setUsernameOrEmail(user.username)
-        },
-        [orgId]
-    )
-
-    const onMenuKeyDown = useCallback((event: React.KeyboardEvent): void => {
-        if (event.key === 'Escape') {
-            setOpenResults(false)
-            event.stopPropagation()
-            event.preventDefault()
-            focusInputElement()
-        }
-    }, [])
-
-    const toggleOpen = useCallback(() => {
-        setOpenResults(false)
-    }, [])
-
-    const onResultItemKeydown = useCallback((key: string, index: number) => {
-        if (index === 0 && key === 'ArrowUp') {
-            window.requestAnimationFrame(() => focusInputElement())
-        }
-    }, [])
-
-    return (
-        <div className={styles.inputContainer} onKeyDown={onMenuKeyDown} tabIndex={-1} role="menu">
-            <Dropdown isOpen={resultsEnabled} toggle={toggleOpen}>
-                <DropdownToggle tag="div" data-toggle="dropdown">
-                    <Input
-                        autoFocus={true}
-                        ref={inputReference}
-                        value={userNameOrEmail}
-                        label="Email address or username"
-                        title="Email address or username"
-                        onChange={onUsernameChange}
-                        onKeyDown={onInputKeyDown}
-                        aria-expanded={renderResults ? 'true' : 'false'}
-                        disabled={disabled}
-                        status={loading ? 'loading' : error ? 'error' : undefined}
-                    />
-                </DropdownToggle>
-                <DropdownMenu className={styles.suggestionsContainer}>
-                    {renderResults &&
-                        results.map((usr, index) => (
-                            <UserResultItem
-                                key={usr.id}
-                                index={index}
-                                user={usr}
-                                onSelectUser={onSelectUser}
-                                onKeyDown={onResultItemKeydown}
-                            />
-                        ))}
-                    {renderNoMatch && <EmptyResultsItem userNameOrEmail={userNameOrEmail} />}
-                </DropdownMenu>
-            </Dropdown>
-        </div>
-    )
-}

--- a/client/web/src/org/members/SearchUserAutocomplete.tsx
+++ b/client/web/src/org/members/SearchUserAutocomplete.tsx
@@ -133,7 +133,11 @@ const UserResultItem: FC<UserResultItemProps> = props => {
     )
 }
 
-const EmptyResultsItem: FC<{ userNameOrEmail: string }> = ({ userNameOrEmail }) => (
+interface EmptyResultsItemProps {
+  userNameOrEmail: string
+}
+
+const EmptyResultsItem: FC<EmptyResultsItemProps> = ({ userNameOrEmail }) => (
     <div
         data-testid="search-context-menu-item"
         role="menuitem"

--- a/client/wildcard/src/components/Combobox/Combobox.module.scss
+++ b/client/wildcard/src/components/Combobox/Combobox.module.scss
@@ -39,6 +39,12 @@
     }
 }
 
+.item {
+    &--disabled {
+        cursor: not-allowed;
+    }
+}
+
 .group {
     margin-top: 0.25rem;
 }

--- a/client/wildcard/src/components/Combobox/Combobox.tsx
+++ b/client/wildcard/src/components/Combobox/Combobox.tsx
@@ -10,7 +10,9 @@ import {
     ComboboxList as ReachComboboxList,
     ComboboxListProps as ReachComboboxListProps,
     ComboboxOption as ReachComboboxOption,
+    ComboboxOptionProps as ReachComboboxOptionProps,
     ComboboxOptionText as ReachComboboxOptionText,
+    useComboboxOptionContext,
 } from '@reach/combobox'
 import classNames from 'classnames'
 import { useMergeRefs } from 'use-callback-ref'
@@ -88,7 +90,7 @@ export const ComboboxPopover = forwardRef<HTMLDivElement, ComboboxPopoverProps>(
 
     // If we don't have registered input element we should not
     // render anything about combobox suggestions (popover content)
-    if (!inputRef) {
+    if (!inputRef || !isExpanded) {
         return null
     }
 
@@ -99,7 +101,7 @@ export const ComboboxPopover = forwardRef<HTMLDivElement, ComboboxPopoverProps>(
             // compared to reach-ui Popover logic. (it support content size changes, different render
             // strategies and so on, see Popover doc for more details)
             as={PopoverContent}
-            isOpen={isExpanded}
+            isOpen={true}
             targetElement={inputRef}
             // Suppress TS problem about position prop. ReachComboboxPopover and PopoverContent both
             // have position props with different interfaces. Since we swap component rendering with `as`
@@ -145,5 +147,27 @@ export const ComboboxOptionGroup = forwardRef((props, ref) => {
     )
 }) as ForwardReferenceComponent<'div', ComboboxOptionGroupProps>
 
-export { ReachComboboxOption as ComboboxOption }
+interface ComboboxOptionProps extends ReachComboboxOptionProps {
+    disabled?: boolean
+}
+
+export const ComboboxOption = forwardRef((props, ref) => {
+    const { disabled, children, ...attributes } = props
+    const context = useComboboxOptionContext()
+
+    if (disabled) {
+        return (
+            <li ref={ref} {...attributes}>
+                {typeof children === 'function' ? children(context) : children}
+            </li>
+        )
+    }
+
+    return (
+        <ReachComboboxOption ref={ref} {...attributes}>
+            {children}
+        </ReachComboboxOption>
+    )
+}) as ForwardReferenceComponent<'li', ComboboxOptionProps>
+
 export { ReachComboboxOptionText as ComboboxOptionText }

--- a/client/wildcard/src/components/Combobox/Combobox.tsx
+++ b/client/wildcard/src/components/Combobox/Combobox.tsx
@@ -90,6 +90,8 @@ export const ComboboxPopover = forwardRef<HTMLDivElement, ComboboxPopoverProps>(
 
     // If we don't have registered input element we should not
     // render anything about combobox suggestions (popover content)
+    // And if we have closed state we shouldn't render anything about ReachComboboxPopover
+    // (by default even if combobox is closed it renders empty block with border 1px line)
     if (!inputRef || !isExpanded) {
         return null
     }
@@ -152,19 +154,24 @@ interface ComboboxOptionProps extends ReachComboboxOptionProps {
 }
 
 export const ComboboxOption = forwardRef((props, ref) => {
-    const { disabled, children, ...attributes } = props
+    const { value, disabled, children, className, ...attributes } = props
     const context = useComboboxOptionContext()
 
     if (disabled) {
         return (
-            <li ref={ref} {...attributes}>
-                {typeof children === 'function' ? children(context) : children}
+            <li
+                ref={ref}
+                data-option-disabled={true}
+                className={classNames(className, styles.itemDisabled)}
+                {...attributes}
+            >
+                {typeof children === 'function' ? children(context) : children ?? value}
             </li>
         )
     }
 
     return (
-        <ReachComboboxOption ref={ref} {...attributes}>
+        <ReachComboboxOption ref={ref} value={value} {...attributes}>
             {children}
         </ReachComboboxOption>
     )

--- a/client/wildcard/src/components/index.ts
+++ b/client/wildcard/src/components/index.ts
@@ -45,6 +45,15 @@ export {
     createRectangle,
 } from './Popover'
 export { Collapse, CollapseHeader, CollapsePanel } from './Collapse'
+export {
+    Combobox,
+    ComboboxInput,
+    ComboboxPopover,
+    ComboboxList,
+    ComboboxOptionGroup,
+    ComboboxOption,
+    ComboboxOptionText,
+} from './Combobox'
 
 /**
  * Type Exports


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41636

## Test plan
- Enable new invite users page for org (simple override context to `true` in [`routes.tsx`](https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph.git&branch=vk%2Fmigrate-invite-users-picker&file=client%2Fweb%2Fsrc%2Forg%2Farea%2Froutes.tsx&start_row=23&start_col=47&end_row=23&end_col=70&editor=JetBrains&version=v2.0.1))
- Go to the org site admin page 
- Go to the members page
- Open invite member modal 
- Check that autocomplete works as expected (you can type user name and click invite, or you can use suggestions and pick user from these suggestions) 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-migrate-invite-users-picker.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-euvmfsrogi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
