### PR TITLE
Add GraphQL endpoint to delete repository from disk

### DIFF
--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -301,6 +301,14 @@ export function scheduleRepositoryPermissionsSync(args: { repository: Scalars['I
     )
 }
 
+export const DELETE_REPOSITORY_MUTATION = gql`
+    mutation DeleteRepository($name: String) {
+        deleteRepository(name: $name) {
+            alwaysNil
+        }
+    }
+`
+
 /**
  * Fetches usage statistics for all users.
  *

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -301,9 +301,9 @@ export function scheduleRepositoryPermissionsSync(args: { repository: Scalars['I
     )
 }
 
-export const RECLONE_REPOSITORY_MUTATION = gql`
-    mutation RecloneRepository($name: String) {
-        recloneRepository(name: $name) {
+export const DELETE_REPOSITORY_FROM_DISK_MUTATION = gql`
+    mutation DeleteRepositoryFromDisk($name: String) {
+        deleteRepositoryFromDisk(name: $name) {
             alwaysNil
         }
     }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -301,9 +301,9 @@ export function scheduleRepositoryPermissionsSync(args: { repository: Scalars['I
     )
 }
 
-export const DELETE_REPOSITORY_FROM_DISK_MUTATION = gql`
-    mutation DeleteRepositoryFromDisk($name: String) {
-        deleteRepositoryFromDisk(name: $name) {
+export const RECLONE_REPOSITORY_MUTATION = gql`
+    mutation RecloneRepository($name: String) {
+        recloneRepository(name: $name) {
             alwaysNil
         }
     }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -301,9 +301,9 @@ export function scheduleRepositoryPermissionsSync(args: { repository: Scalars['I
     )
 }
 
-export const DELETE_REPOSITORY_MUTATION = gql`
-    mutation DeleteRepository($name: String) {
-        deleteRepository(name: $name) {
+export const RECLONE_REPOSITORY_MUTATION = gql`
+    mutation RecloneRepository($name: String) {
+        recloneRepository(name: $name) {
             alwaysNil
         }
     }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -302,8 +302,8 @@ export function scheduleRepositoryPermissionsSync(args: { repository: Scalars['I
 }
 
 export const RECLONE_REPOSITORY_MUTATION = gql`
-    mutation RecloneRepository($name: String) {
-        recloneRepository(name: $name) {
+    mutation RecloneRepository($repo: ID!) {
+        recloneRepository(repo: $repo) {
             alwaysNil
         }
     }

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -263,3 +263,16 @@ func (s *repos) DeleteRepositoryFromDisk(ctx context.Context, repoID api.RepoID)
 	err = gitserver.NewClient(s.db).Remove(ctx, repo.Name)
 	return err
 }
+
+func (s *repos) RequestRepositoryUpdate(ctx context.Context, repoID api.RepoID) (err error) {
+	repo, err := s.Get(ctx, repoID)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error while fetching repo with ID %d", repoID))
+	}
+
+	ctx, done := trace(ctx, "Repos", "RequestRepositoryUpdate", repoID, &err)
+	defer done()
+
+	_, err = gitserver.NewClient(s.db).RequestRepoUpdate(ctx, repo.Name, 1*time.Second)
+	return err
+}

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -245,3 +245,15 @@ func (s *repos) GetInventory(ctx context.Context, repo *types.Repo, commitID api
 	}
 	return &inv, nil
 }
+
+func (s *repos) Delete(ctx context.Context, name api.RepoName) (err error) {
+	if Mocks.Repos.Delete != nil {
+		return Mocks.Repos.Delete(ctx, name)
+	}
+
+	ctx, done := trace(ctx, "Repos", "Delete", name, &err)
+	defer done()
+
+	err = gitserver.NewClient(s.db).Remove(ctx, name)
+	return err
+}

--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -20,6 +20,7 @@ type MockRepos struct {
 	GetCommit    func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*gitdomain.Commit, error)
 	ResolveRev   func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
 	GetInventory func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
+    Delete       func(v0 context.Context, name api.RepoName) (error)
 }
 
 var errRepoNotFound = &errcode.Mock{
@@ -75,6 +76,15 @@ func (s *MockRepos) MockList(t *testing.T, wantRepos ...api.RepoName) (called *b
 			repos[i] = &types.Repo{Name: repo}
 		}
 		return repos, nil
+	}
+	return
+}
+
+func (s *MockRepos) MockDelete(t *testing.T, wantRepos ...api.RepoName) (called *bool) {
+    called = new(bool)
+	s.Delete = func(_ context.Context, name api.RepoName) (error) {
+		*called = true
+		return nil
 	}
 	return
 }

--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -14,13 +14,13 @@ import (
 )
 
 type MockRepos struct {
-	Get          func(v0 context.Context, id api.RepoID) (*types.Repo, error)
-	GetByName    func(v0 context.Context, name api.RepoName) (*types.Repo, error)
-	List         func(v0 context.Context, v1 database.ReposListOptions) ([]*types.Repo, error)
-	GetCommit    func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*gitdomain.Commit, error)
-	ResolveRev   func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
-	GetInventory func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
-	Delete       func(v0 context.Context, name api.RepoName) error
+	Get                      func(v0 context.Context, id api.RepoID) (*types.Repo, error)
+	GetByName                func(v0 context.Context, name api.RepoName) (*types.Repo, error)
+	List                     func(v0 context.Context, v1 database.ReposListOptions) ([]*types.Repo, error)
+	GetCommit                func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*gitdomain.Commit, error)
+	ResolveRev               func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
+	GetInventory             func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
+	DeleteRepositoryFromDisk func(v0 context.Context, name api.RepoID) error
 }
 
 var errRepoNotFound = &errcode.Mock{
@@ -80,9 +80,9 @@ func (s *MockRepos) MockList(t *testing.T, wantRepos ...api.RepoName) (called *b
 	return
 }
 
-func (s *MockRepos) MockDelete(t *testing.T, wantRepos ...api.RepoName) (called *bool) {
+func (s *MockRepos) MockDeleteRepositoryFromDisk(t *testing.T) (called *bool) {
 	called = new(bool)
-	s.Delete = func(_ context.Context, name api.RepoName) error {
+	s.DeleteRepositoryFromDisk = func(_ context.Context, repo api.RepoID) error {
 		*called = true
 		return nil
 	}

--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -20,7 +20,7 @@ type MockRepos struct {
 	GetCommit    func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*gitdomain.Commit, error)
 	ResolveRev   func(v0 context.Context, repo *types.Repo, rev string) (api.CommitID, error)
 	GetInventory func(v0 context.Context, repo *types.Repo, commitID api.CommitID) (*inventory.Inventory, error)
-    Delete       func(v0 context.Context, name api.RepoName) (error)
+	Delete       func(v0 context.Context, name api.RepoName) error
 }
 
 var errRepoNotFound = &errcode.Mock{
@@ -81,8 +81,8 @@ func (s *MockRepos) MockList(t *testing.T, wantRepos ...api.RepoName) (called *b
 }
 
 func (s *MockRepos) MockDelete(t *testing.T, wantRepos ...api.RepoName) (called *bool) {
-    called = new(bool)
-	s.Delete = func(_ context.Context, name api.RepoName) (error) {
+	called = new(bool)
+	s.Delete = func(_ context.Context, name api.RepoName) error {
 		*called = true
 		return nil
 	}

--- a/cmd/frontend/backend/repos_mock.go
+++ b/cmd/frontend/backend/repos_mock.go
@@ -80,10 +80,10 @@ func (s *MockRepos) MockList(t *testing.T, wantRepos ...api.RepoName) (called *b
 	return
 }
 
-func (s *MockRepos) MockDeleteRepositoryFromDisk(t *testing.T) (called *bool) {
+func (s *MockRepos) MockDeleteRepositoryFromDisk(t *testing.T, wantRepo api.RepoID) (called *bool) {
 	called = new(bool)
 	s.DeleteRepositoryFromDisk = func(_ context.Context, repo api.RepoID) error {
-		*called = true
+		*called = repo == wantRepo
 		return nil
 	}
 	return

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -593,6 +593,20 @@ func (r *schemaResolver) Repository(ctx context.Context, args *struct {
 	return resolver.repo, nil
 }
 
+// DeleteRepository deletes a repository from the gitserver and marks it as not cloned.
+func (r *schemaResolver) DeleteRepository(ctx context.Context, args *struct {
+	Name *string
+}) (*EmptyResponse, error) {
+	// 🚨 SECURITY: Only site admins can delete repositories.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	err := backend.NewRepos(r.logger, r.db).Delete(ctx, api.RepoName(*args.Name))
+
+	return &EmptyResponse{}, err
+}
+
 func (r *schemaResolver) repositoryByID(ctx context.Context, id graphql.ID) (*RepositoryResolver, error) {
 	var repoID api.RepoID
 	if err := relay.UnmarshalSpec(id, &repoID); err != nil {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -593,9 +593,9 @@ func (r *schemaResolver) Repository(ctx context.Context, args *struct {
 	return resolver.repo, nil
 }
 
-// DeleteRepositoryFromDisk deletes a repository from the gitserver disk and marks it as not cloned
-// in the database.
-func (r *schemaResolver) DeleteRepositoryFromDisk(ctx context.Context, args *struct {
+// RecloneRepository deletes a repository from the gitserver disk and marks it as not cloned
+// in the database, and then starts a repo clone.
+func (r *schemaResolver) RecloneRepository(ctx context.Context, args *struct {
 	Name *string
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins can delete repositories.

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -593,8 +593,9 @@ func (r *schemaResolver) Repository(ctx context.Context, args *struct {
 	return resolver.repo, nil
 }
 
-// DeleteRepository deletes a repository from the gitserver and marks it as not cloned.
-func (r *schemaResolver) DeleteRepository(ctx context.Context, args *struct {
+// RecloneRepository deletes a repository from the gitserver disk, marks it as not cloned, and restarts
+// the repo cloning process.
+func (r *schemaResolver) RecloneRepository(ctx context.Context, args *struct {
 	Name *string
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins can delete repositories.

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -602,6 +602,10 @@ func (r *schemaResolver) DeleteRepository(ctx context.Context, args *struct {
 		return nil, err
 	}
 
+	if args.Name == nil || *args.Name == "" {
+		return &EmptyResponse{}, errors.New("repository name required")
+	}
+
 	err := backend.NewRepos(r.logger, r.db).Delete(ctx, api.RepoName(*args.Name))
 
 	return &EmptyResponse{}, err

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -634,8 +634,8 @@ func (r *schemaResolver) RecloneRepository(ctx context.Context, args *struct {
 	return &EmptyResponse{}, nil
 }
 
-// RecloneRepository deletes a repository from the gitserver disk and marks it as not cloned
-// in the database, and then starts a repo clone.
+// DeleteRepositoryFromDisk deletes a repository from the gitserver disk and marks it as not cloned
+// in the database.
 func (r *schemaResolver) DeleteRepositoryFromDisk(ctx context.Context, args *struct {
 	Repo graphql.ID
 }) (*EmptyResponse, error) {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -609,7 +609,7 @@ func (r *schemaResolver) RecloneRepository(ctx context.Context, args *struct {
 		return &EmptyResponse{}, errors.New("repository name required")
 	}
 
-	if err := backend.NewRepos(r.logger, r.db).Delete(ctx, api.RepoName(*args.Name)); err != nil {
+	if err := backend.NewRepos(r.logger, r.db).Delete(ctx, *args.Name); err != nil {
 		return &EmptyResponse{}, errors.Wrap(err, fmt.Sprintf("error while deleting repository %s", *args.Name))
 	}
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -593,9 +593,9 @@ func (r *schemaResolver) Repository(ctx context.Context, args *struct {
 	return resolver.repo, nil
 }
 
-// RecloneRepository deletes a repository from the gitserver disk, marks it as not cloned, and restarts
-// the repo cloning process.
-func (r *schemaResolver) RecloneRepository(ctx context.Context, args *struct {
+// DeleteRepositoryFromDisk deletes a repository from the gitserver disk and marks it as not cloned
+// in the database.
+func (r *schemaResolver) DeleteRepositoryFromDisk(ctx context.Context, args *struct {
 	Name *string
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins can delete repositories.

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	sgtrace "github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -614,7 +615,7 @@ func (r *schemaResolver) RecloneRepository(ctx context.Context, args *struct {
 		return &EmptyResponse{}, errors.Wrap(err, fmt.Sprintf("error while fetching repository with ID %d", repoID))
 	}
 
-	if repo.CloneStatus == "cloning" {
+	if repo.CloneStatus == types.CloneStatusCloning {
 		return &EmptyResponse{}, errors.Wrap(err, fmt.Sprintf("cannot reclone repository %d: busy cloning", repo.RepoID))
 	}
 
@@ -649,8 +650,8 @@ func (r *schemaResolver) DeleteRepositoryFromDisk(ctx context.Context, args *str
 		return &EmptyResponse{}, errors.Wrap(err, fmt.Sprintf("error while fetching repository with ID %d", repoID))
 	}
 
-	if repo.CloneStatus == "cloning" {
-		return &EmptyResponse{}, errors.Wrap(err, fmt.Sprintf("cannot reclone repository %d: busy cloning", repo.RepoID))
+	if repo.CloneStatus == types.CloneStatusCloning {
+		return &EmptyResponse{}, errors.Wrap(err, fmt.Sprintf("cannot delete repository %d: busy cloning", repo.RepoID))
 	}
 
 	if err := backend.NewRepos(r.logger, r.db).DeleteRepositoryFromDisk(ctx, repoID); err != nil {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -623,8 +623,8 @@ func (r *schemaResolver) RecloneRepository(ctx context.Context, args *struct {
 		return &EmptyResponse{}, errors.Wrap(err, fmt.Sprintf("error while deleting repository with ID %d", repoID))
 	}
 
-	if err := repos.RequestRepositoryUpdate(ctx, repoID); err != nil {
-		return &EmptyResponse{}, errors.Wrap(err, fmt.Sprintf("error while requesting update for repository with ID %d", repoID))
+	if err := repos.RequestRepositoryClone(ctx, repoID); err != nil {
+		return &EmptyResponse{}, errors.Wrap(err, fmt.Sprintf("error while requesting clone for repository with ID %d", repoID))
 	}
 
 	return &EmptyResponse{}, nil

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -104,14 +104,14 @@ func TestDeleteRepository(t *testing.T) {
 			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
                 mutation {
-                    recloneRepository(name: "github.com/gorilla/mux") {
+                    deleteRepositoryFromDisk(name: "github.com/gorilla/mux") {
                         alwaysNil
                     }
                 }
             `,
 			ExpectedResult: `
                 {
-                    "recloneRepository": {
+                    "deleteRepositoryFromDisk": {
                         "alwaysNil": null
                     }
                 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -121,9 +121,13 @@ func TestRecloneRepository(t *testing.T) {
 	users := database.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
 
+    gitserverRepos := database.NewMockGitserverRepoStore()
+    gitserverRepos.GetByIDFunc.SetDefaultReturn(&types.GitserverRepo{RepoID: 1, CloneStatus: "cloned"}, nil)
+
 	db := database.NewMockDB()
 	db.ReposFunc.SetDefaultReturn(repos)
 	db.UsersFunc.SetDefaultReturn(users)
+    db.GitserverReposFunc.SetDefaultReturn(gitserverRepos)
 
 	called := backend.Mocks.Repos.MockDeleteRepositoryFromDisk(t, 1)
 
@@ -155,14 +159,20 @@ func TestRecloneRepository(t *testing.T) {
 
 func TestDeleteRepositoryFromDisk(t *testing.T) {
 	resetMocks()
-	db := database.NewMockDB()
+
 	repos := database.NewMockRepoStore()
-	db.ReposFunc.SetDefaultReturn(repos)
+
 	users := database.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
-	db.UsersFunc.SetDefaultReturn(users)
 	called := backend.Mocks.Repos.MockDeleteRepositoryFromDisk(t, 1)
 
+    gitserverRepos := database.NewMockGitserverRepoStore()
+    gitserverRepos.GetByIDFunc.SetDefaultReturn(&types.GitserverRepo{RepoID: 1, CloneStatus: "cloned"}, nil)
+    
+	db := database.NewMockDB()
+	db.ReposFunc.SetDefaultReturn(repos)
+	db.UsersFunc.SetDefaultReturn(users)
+    db.GitserverReposFunc.SetDefaultReturn(gitserverRepos)
 	repoID := base64.StdEncoding.EncodeToString([]byte("Repository:1"))
 
 	RunTests(t, []*Test{

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -104,14 +104,14 @@ func TestDeleteRepository(t *testing.T) {
 			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
                 mutation {
-                    deleteRepository(name: "github.com/gorilla/mux") {
+                    recloneRepository(name: "github.com/gorilla/mux") {
                         alwaysNil
                     }
                 }
             `,
 			ExpectedResult: `
                 {
-                    "deleteRepository": {
+                    "recloneRepository": {
                         "alwaysNil": null
                     }
                 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -125,7 +125,7 @@ func TestRecloneRepository(t *testing.T) {
 	db.ReposFunc.SetDefaultReturn(repos)
 	db.UsersFunc.SetDefaultReturn(users)
 
-	called := backend.Mocks.Repos.MockDeleteRepositoryFromDisk(t)
+	called := backend.Mocks.Repos.MockDeleteRepositoryFromDisk(t, 1)
 
 	RunTests(t, []*Test{
 		{
@@ -160,7 +160,7 @@ func TestDeleteRepositoryFromDisk(t *testing.T) {
 	users := database.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
 	db.UsersFunc.SetDefaultReturn(users)
-	called := backend.Mocks.Repos.MockDeleteRepositoryFromDisk(t)
+	called := backend.Mocks.Repos.MockDeleteRepositoryFromDisk(t, 1)
 
 	RunTests(t, []*Test{
 		{

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -121,13 +121,13 @@ func TestRecloneRepository(t *testing.T) {
 	users := database.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
 
-    gitserverRepos := database.NewMockGitserverRepoStore()
-    gitserverRepos.GetByIDFunc.SetDefaultReturn(&types.GitserverRepo{RepoID: 1, CloneStatus: "cloned"}, nil)
+	gitserverRepos := database.NewMockGitserverRepoStore()
+	gitserverRepos.GetByIDFunc.SetDefaultReturn(&types.GitserverRepo{RepoID: 1, CloneStatus: "cloned"}, nil)
 
 	db := database.NewMockDB()
 	db.ReposFunc.SetDefaultReturn(repos)
 	db.UsersFunc.SetDefaultReturn(users)
-    db.GitserverReposFunc.SetDefaultReturn(gitserverRepos)
+	db.GitserverReposFunc.SetDefaultReturn(gitserverRepos)
 
 	called := backend.Mocks.Repos.MockDeleteRepositoryFromDisk(t, 1)
 
@@ -166,13 +166,13 @@ func TestDeleteRepositoryFromDisk(t *testing.T) {
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
 	called := backend.Mocks.Repos.MockDeleteRepositoryFromDisk(t, 1)
 
-    gitserverRepos := database.NewMockGitserverRepoStore()
-    gitserverRepos.GetByIDFunc.SetDefaultReturn(&types.GitserverRepo{RepoID: 1, CloneStatus: "cloned"}, nil)
-    
+	gitserverRepos := database.NewMockGitserverRepoStore()
+	gitserverRepos.GetByIDFunc.SetDefaultReturn(&types.GitserverRepo{RepoID: 1, CloneStatus: "cloned"}, nil)
+
 	db := database.NewMockDB()
 	db.ReposFunc.SetDefaultReturn(repos)
 	db.UsersFunc.SetDefaultReturn(users)
-    db.GitserverReposFunc.SetDefaultReturn(gitserverRepos)
+	db.GitserverReposFunc.SetDefaultReturn(gitserverRepos)
 	repoID := base64.StdEncoding.EncodeToString([]byte("Repository:1"))
 
 	RunTests(t, []*Test{

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -89,15 +89,15 @@ func TestRepository(t *testing.T) {
 }
 
 func TestDeleteRepository(t *testing.T) {
-    resetMocks()
+	resetMocks()
 	db := database.NewMockDB()
 	repos := database.NewMockRepoStore()
 	repos.DeleteFunc.SetDefaultReturn(nil)
 	db.ReposFunc.SetDefaultReturn(repos)
 	users := database.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
-    db.UsersFunc.SetDefaultReturn(users)
-    called := backend.Mocks.Repos.MockDelete(t, "github.com/gorilla/mux")
+	db.UsersFunc.SetDefaultReturn(users)
+	called := backend.Mocks.Repos.MockDelete(t, "github.com/gorilla/mux")
 
 	RunTests(t, []*Test{
 		{
@@ -119,7 +119,7 @@ func TestDeleteRepository(t *testing.T) {
 		},
 	})
 
-    assert.True(t, *called)
+	assert.True(t, *called)
 }
 
 func TestResolverTo(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -790,6 +790,11 @@ type Mutation {
     """
     recloneRepository(name: String): EmptyResponse!
 
+    """
+    Delete a repository from the gitserver. This involves deleting the file on disk,
+    and marking it as not-cloned in the database.
+    """
+    deleteRepositoryFromDisk(name: String): EmptyResponse!
 
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -785,9 +785,10 @@ type Mutation {
     deleteRepoKeyValuePair(repo: ID!, key: String!): EmptyResponse!
 
     """
-    Delete a repository from the gitserver and mark it as not cloned.
+    Reclone a repository from the gitserver. This involves deleting the file on disk,
+    marking it as not-cloned in the database, and then restarting the clone process.
     """
-    deleteRepository(name: String): EmptyResponse!
+    recloneRepository(name: String): EmptyResponse!
 
 
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -789,13 +789,13 @@ type Mutation {
     the file on disk, marking it as not-cloned in the database, and then initiating
     a repo clone.
     """
-    recloneRepository(name: String): EmptyResponse!
+    recloneRepository(repo: ID!): EmptyResponse!
 
     """
     INTERNAL ONLY: Delete a repository from the gitserver. This involves deleting
     the file on disk, and marking it as not-cloned in the database.
     """
-    deleteRepositoryFromDisk(name: String): EmptyResponse!
+    deleteRepositoryFromDisk(repo: ID!): EmptyResponse!
 
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -788,7 +788,7 @@ type Mutation {
     Reclone a repository from the gitserver. This involves deleting the file on disk,
     marking it as not-cloned in the database, and then restarting the clone process.
     """
-    recloneRepository(name: String): EmptyResponse!
+    deleteRepositoryFromDisk(name: String): EmptyResponse!
 
 
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -785,14 +785,15 @@ type Mutation {
     deleteRepoKeyValuePair(repo: ID!, key: String!): EmptyResponse!
 
     """
-    Reclone a repository from the gitserver. This involves deleting the file on disk,
-    marking it as not-cloned in the database, and then initiating a repo clone.
+    INTERNAL ONLY: Reclone a repository from the gitserver. This involves deleting
+    the file on disk, marking it as not-cloned in the database, and then initiating
+    a repo clone.
     """
     recloneRepository(name: String): EmptyResponse!
 
     """
-    Delete a repository from the gitserver. This involves deleting the file on disk,
-    and marking it as not-cloned in the database.
+    INTERNAL ONLY: Delete a repository from the gitserver. This involves deleting
+    the file on disk, and marking it as not-cloned in the database.
     """
     deleteRepositoryFromDisk(name: String): EmptyResponse!
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -786,9 +786,9 @@ type Mutation {
 
     """
     Reclone a repository from the gitserver. This involves deleting the file on disk,
-    marking it as not-cloned in the database, and then restarting the clone process.
+    marking it as not-cloned in the database, and then initiating a repo clone.
     """
-    deleteRepositoryFromDisk(name: String): EmptyResponse!
+    recloneRepository(name: String): EmptyResponse!
 
 
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -783,6 +783,13 @@ type Mutation {
     Delete a key-value pair associated with a repo.
     """
     deleteRepoKeyValuePair(repo: ID!, key: String!): EmptyResponse!
+
+    """
+    Delete a repository from the gitserver and mark it as not cloned.
+    """
+    deleteRepository(name: String): EmptyResponse!
+
+
 }
 
 """

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -801,7 +801,7 @@ func dirSize(d string) int64 {
 	return size
 }
 
-// removeRepoDirectory atomically removes a directory from s.ReposDir.
+// removeRepoDirectory automically removes a directory from s.ReposDir.
 //
 // It first moves the directory to a temporary location to avoid leaving
 // partial state in the event of server restart or concurrent modifications to

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -801,7 +801,7 @@ func dirSize(d string) int64 {
 	return size
 }
 
-// removeRepoDirectory automically removes a directory from s.ReposDir.
+// removeRepoDirectory atomically removes a directory from s.ReposDir.
 //
 // It first moves the directory to a temporary location to avoid leaving
 // partial state in the event of server restart or concurrent modifications to

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -464,7 +464,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/repo-clone-progress", trace.WithRouteName("repo-clone-progress", s.handleRepoCloneProgress))
 	mux.HandleFunc("/delete", trace.WithRouteName("delete", s.handleRepoDelete))
 	mux.HandleFunc("/repo-update", trace.WithRouteName("repo-update", s.handleRepoUpdate))
-	mux.HandleFunc("/repo-clone", trace.WithRouteName("repo-reclone", s.handleRepoClone))
+	mux.HandleFunc("/repo-clone", trace.WithRouteName("repo-clone", s.handleRepoClone))
 	mux.HandleFunc("/create-commit-from-patch", trace.WithRouteName("create-commit-from-patch", s.handleCreateCommitFromPatch))
 	mux.HandleFunc("/ping", trace.WithRouteName("ping", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1020,7 +1020,8 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleRepoClone is an asynchronous (does not wait for update to complete or
-// time out) function to clone a repository.
+// time out) call to clone a repository.
+// Asynchronous errors will have to be checked in the gitserver_repos table under last_error.
 func (s *Server) handleRepoClone(w http.ResponseWriter, r *http.Request) {
 	logger := s.Logger.Scoped("handleRepoClone", "asynchronous http handler for repo clones")
 	var req protocol.RepoCloneRequest

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1032,7 +1032,7 @@ func (s *Server) handleRepoClone(w http.ResponseWriter, r *http.Request) {
 	var resp protocol.RepoCloneResponse
 	req.Repo = protocol.NormalizeRepo(req.Repo)
 
-	_, err := s.cloneRepo(context.Background(), req.Repo, &cloneOptions{Block: false, Overwrite: true})
+	_, err := s.cloneRepo(context.Background(), req.Repo, &cloneOptions{Block: false})
 	if err != nil {
 		logger.Warn("error cloning repo", log.String("repo", string(req.Repo)), log.Error(err))
 		resp.Error = err.Error()

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -464,6 +464,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/repo-clone-progress", trace.WithRouteName("repo-clone-progress", s.handleRepoCloneProgress))
 	mux.HandleFunc("/delete", trace.WithRouteName("delete", s.handleRepoDelete))
 	mux.HandleFunc("/repo-update", trace.WithRouteName("repo-update", s.handleRepoUpdate))
+    mux.HandleFunc("/repo-reclone", trace.WithRouteName("repo-reclone", s.handleRepoReclone))
 	mux.HandleFunc("/create-commit-from-patch", trace.WithRouteName("create-commit-from-patch", s.handleCreateCommitFromPatch))
 	mux.HandleFunc("/ping", trace.WithRouteName("ping", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -1011,6 +1012,30 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 			resp.Error = updateErr.Error()
 		}
 	}
+
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+// handleRepoReclone is a asynchronous (does not wait for update to complete or
+// time out). Returns an error if a clone is already in progress.
+func (s *Server) handleRepoReclone(w http.ResponseWriter, r *http.Request) {
+	logger := s.Logger.Scoped("handleRepoReclone", "asynchronous http handler for repo reclones")
+	var req protocol.RepoRecloneRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var resp protocol.RepoRecloneResponse
+	req.Repo = protocol.NormalizeRepo(req.Repo)
+
+    _, err := s.cloneRepo(context.Background(), req.Repo, &cloneOptions{Block: false, Overwrite: true})
+    if err != nil {
+        logger.Warn("error cloning repo", log.String("repo", string(req.Repo)), log.Error(err))
+        resp.Error = err.Error()
+    }
 
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -243,6 +243,9 @@ type Client interface {
 	// update won't happen.
 	RequestRepoUpdate(context.Context, api.RepoName, time.Duration) (*protocol.RepoUpdateResponse, error)
 
+	// RequestRepoReclone is an asynchronous request to reclone a repository.
+	RequestRepoReclone(context.Context, api.RepoName) (*protocol.RepoRecloneResponse, error)
+
 	// Search executes a search as specified by args, streaming the results as
 	// it goes by calling onMatches with each set of results it receives in
 	// response.
@@ -894,6 +897,29 @@ func (c *clientImplementor) RequestRepoMigrate(ctx context.Context, repo api.Rep
 	var info *protocol.RepoUpdateResponse
 	err = json.NewDecoder(resp.Body).Decode(&info)
 
+	return info, err
+}
+
+// RequestRepoReclone requests that the gitserver does an asynchronous reclone of the repository.
+func (c *clientImplementor) RequestRepoReclone(ctx context.Context, repo api.RepoName) (*protocol.RepoRecloneResponse, error) {
+	req := &protocol.RepoRecloneRequest{
+		Repo: repo,
+	}
+	resp, err := c.httpPost(ctx, repo, "repo-reclone", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, &url.Error{
+			URL: resp.Request.URL.String(),
+			Op:  "RepoInfo",
+			Err: errors.Errorf("RepoInfo: http status %d: %s", resp.StatusCode, readResponseBody(io.LimitReader(resp.Body, 200))),
+		}
+	}
+
+	var info *protocol.RepoRecloneResponse
+	err = json.NewDecoder(resp.Body).Decode(&info)
 	return info, err
 }
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -243,8 +243,8 @@ type Client interface {
 	// update won't happen.
 	RequestRepoUpdate(context.Context, api.RepoName, time.Duration) (*protocol.RepoUpdateResponse, error)
 
-	// RequestRepoReclone is an asynchronous request to reclone a repository.
-	RequestRepoReclone(context.Context, api.RepoName) (*protocol.RepoRecloneResponse, error)
+	// RequestRepoClone is an asynchronous request to clone a repository.
+	RequestRepoClone(context.Context, api.RepoName) (*protocol.RepoCloneResponse, error)
 
 	// Search executes a search as specified by args, streaming the results as
 	// it goes by calling onMatches with each set of results it receives in
@@ -900,12 +900,12 @@ func (c *clientImplementor) RequestRepoMigrate(ctx context.Context, repo api.Rep
 	return info, err
 }
 
-// RequestRepoReclone requests that the gitserver does an asynchronous reclone of the repository.
-func (c *clientImplementor) RequestRepoReclone(ctx context.Context, repo api.RepoName) (*protocol.RepoRecloneResponse, error) {
-	req := &protocol.RepoRecloneRequest{
+// RequestRepoClone requests that the gitserver does an asynchronous clone of the repository.
+func (c *clientImplementor) RequestRepoClone(ctx context.Context, repo api.RepoName) (*protocol.RepoCloneResponse, error) {
+	req := &protocol.RepoCloneRequest{
 		Repo: repo,
 	}
-	resp, err := c.httpPost(ctx, repo, "repo-reclone", req)
+	resp, err := c.httpPost(ctx, repo, "repo-clone", req)
 	if err != nil {
 		return nil, err
 	}
@@ -918,7 +918,7 @@ func (c *clientImplementor) RequestRepoReclone(ctx context.Context, repo api.Rep
 		}
 	}
 
-	var info *protocol.RepoRecloneResponse
+	var info *protocol.RepoCloneResponse
 	err = json.NewDecoder(resp.Body).Decode(&info)
 	return info, err
 }

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -158,6 +158,9 @@ type MockClient struct {
 	// ReposStatsFunc is an instance of a mock function object controlling
 	// the behavior of the method ReposStats.
 	ReposStatsFunc *ClientReposStatsFunc
+	// RequestRepoCloneFunc is an instance of a mock function object
+	// controlling the behavior of the method RequestRepoClone.
+	RequestRepoCloneFunc *ClientRequestRepoCloneFunc
 	// RequestRepoMigrateFunc is an instance of a mock function object
 	// controlling the behavior of the method RequestRepoMigrate.
 	RequestRepoMigrateFunc *ClientRequestRepoMigrateFunc
@@ -402,6 +405,11 @@ func NewMockClient() *MockClient {
 		},
 		ReposStatsFunc: &ClientReposStatsFunc{
 			defaultHook: func(context.Context) (r0 map[string]*protocol.ReposStats, r1 error) {
+				return
+			},
+		},
+		RequestRepoCloneFunc: &ClientRequestRepoCloneFunc{
+			defaultHook: func(context.Context, api.RepoName) (r0 *protocol.RepoCloneResponse, r1 error) {
 				return
 			},
 		},
@@ -667,6 +675,11 @@ func NewStrictMockClient() *MockClient {
 				panic("unexpected invocation of MockClient.ReposStats")
 			},
 		},
+		RequestRepoCloneFunc: &ClientRequestRepoCloneFunc{
+			defaultHook: func(context.Context, api.RepoName) (*protocol.RepoCloneResponse, error) {
+				panic("unexpected invocation of MockClient.RequestRepoClone")
+			},
+		},
 		RequestRepoMigrateFunc: &ClientRequestRepoMigrateFunc{
 			defaultHook: func(context.Context, api.RepoName, string, string) (*protocol.RepoUpdateResponse, error) {
 				panic("unexpected invocation of MockClient.RequestRepoMigrate")
@@ -840,6 +853,9 @@ func NewMockClientFrom(i Client) *MockClient {
 		},
 		ReposStatsFunc: &ClientReposStatsFunc{
 			defaultHook: i.ReposStats,
+		},
+		RequestRepoCloneFunc: &ClientRequestRepoCloneFunc{
+			defaultHook: i.RequestRepoClone,
 		},
 		RequestRepoMigrateFunc: &ClientRequestRepoMigrateFunc{
 			defaultHook: i.RequestRepoMigrate,
@@ -5827,6 +5843,114 @@ func (c ClientReposStatsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ClientReposStatsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ClientRequestRepoCloneFunc describes the behavior when the
+// RequestRepoClone method of the parent MockClient instance is invoked.
+type ClientRequestRepoCloneFunc struct {
+	defaultHook func(context.Context, api.RepoName) (*protocol.RepoCloneResponse, error)
+	hooks       []func(context.Context, api.RepoName) (*protocol.RepoCloneResponse, error)
+	history     []ClientRequestRepoCloneFuncCall
+	mutex       sync.Mutex
+}
+
+// RequestRepoClone delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockClient) RequestRepoClone(v0 context.Context, v1 api.RepoName) (*protocol.RepoCloneResponse, error) {
+	r0, r1 := m.RequestRepoCloneFunc.nextHook()(v0, v1)
+	m.RequestRepoCloneFunc.appendCall(ClientRequestRepoCloneFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the RequestRepoClone
+// method of the parent MockClient instance is invoked and the hook queue is
+// empty.
+func (f *ClientRequestRepoCloneFunc) SetDefaultHook(hook func(context.Context, api.RepoName) (*protocol.RepoCloneResponse, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RequestRepoClone method of the parent MockClient instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ClientRequestRepoCloneFunc) PushHook(hook func(context.Context, api.RepoName) (*protocol.RepoCloneResponse, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ClientRequestRepoCloneFunc) SetDefaultReturn(r0 *protocol.RepoCloneResponse, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName) (*protocol.RepoCloneResponse, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ClientRequestRepoCloneFunc) PushReturn(r0 *protocol.RepoCloneResponse, r1 error) {
+	f.PushHook(func(context.Context, api.RepoName) (*protocol.RepoCloneResponse, error) {
+		return r0, r1
+	})
+}
+
+func (f *ClientRequestRepoCloneFunc) nextHook() func(context.Context, api.RepoName) (*protocol.RepoCloneResponse, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ClientRequestRepoCloneFunc) appendCall(r0 ClientRequestRepoCloneFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ClientRequestRepoCloneFuncCall objects
+// describing the invocations of this function.
+func (f *ClientRequestRepoCloneFunc) History() []ClientRequestRepoCloneFuncCall {
+	f.mutex.Lock()
+	history := make([]ClientRequestRepoCloneFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ClientRequestRepoCloneFuncCall is an object that describes an invocation
+// of method RequestRepoClone on an instance of MockClient.
+type ClientRequestRepoCloneFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoName
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *protocol.RepoCloneResponse
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ClientRequestRepoCloneFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ClientRequestRepoCloneFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -180,14 +180,14 @@ type RepoUpdateResponse struct {
 	Error string `json:",omitempty"`
 }
 
-// RepoRecloneRequest is a request to completely reclone a repository asynchronously.
-type RepoRecloneRequest struct {
+// RepoCloneRequest is a request to clone a repository asynchronously.
+type RepoCloneRequest struct {
 	Repo api.RepoName `json:"repo"`
 }
 
-// RepoRecloneResponse returns an error if the repo reclone request failed.
-type RepoRecloneResponse struct {
-	Error string `json:",omtempty"`
+// RepoCloneResponse returns an error if the repo clone request failed.
+type RepoCloneResponse struct {
+	Error string `json:",omitempty"`
 }
 
 type NotFoundPayload struct {

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -180,6 +180,16 @@ type RepoUpdateResponse struct {
 	Error string `json:",omitempty"`
 }
 
+// RepoRecloneRequest is a request to completely reclone a repository asynchronously.
+type RepoRecloneRequest struct {
+	Repo api.RepoName `json:"repo"`
+}
+
+// RepoRecloneResponse returns an error if the repo reclone request failed.
+type RepoRecloneResponse struct {
+	Error string `json:",omtempty"`
+}
+
 type NotFoundPayload struct {
 	CloneInProgress bool `json:"cloneInProgress"` // If true, exec returned with noop because clone is in progress.
 


### PR DESCRIPTION
Sometimes repositories on gitserver get corrupted and stuck, and we require customers to ssh into their instance and manually delete the repository folders. This PR exposes an endpoint that allows us to delete a repository from the disk so that it can be recloned through the API.

More user friendly UI option in Site Admin will follow, GraphQL was required first.

Loom: https://loom.com/share/0a4ed2daaa4b46b8bd34bd1a1e358e36

## Test plan
Added unit test to verify that query is called correctly. But nature of functionality makes it a bit tricky to unit test. Suggestions welcome.

Verified to work manually as well.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
