### PR TITLE
jaeger: upgrade to 1.38.0

### DIFF
--- a/docker-images/jaeger-agent/build.sh
+++ b/docker-images/jaeger-agent/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-export JAEGER_VERSION="${JAEGER_VERSION:-1.36.0}"
+export JAEGER_VERSION="${JAEGER_VERSION:-1.38.0}"
 IMAGE=${IMAGE:-sourcegraph/jaeger-agent}
 
 echo "Building image ${IMAGE} from Jaeger ${JAEGER_VERSION}"

--- a/docker-images/jaeger-all-in-one/build.sh
+++ b/docker-images/jaeger-all-in-one/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-export JAEGER_VERSION="${JAEGER_VERSION:-1.36.0}"
+export JAEGER_VERSION="${JAEGER_VERSION:-1.38.0}"
 IMAGE=${IMAGE:-sourcegraph/jaeger-all-in-one}
 
 echo "Building image ${IMAGE} from Jaeger ${JAEGER_VERSION}"


### PR DESCRIPTION
Bump to try out some Jaeger features with the new release (https://sourcegraph.slack.com/archives/C07KZF47K/p1663343529307719). This is low-risk for 4.0 because Jaeger is no longer run by default.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg run jaeger`