### PR TITLE
dev/sg: integrate monitoring generator with 'sg monitoring generate'

### DIFF
--- a/dev/sg/cliutil/completions.go
+++ b/dev/sg/cliutil/completions.go
@@ -1,4 +1,4 @@
-package main
+package cliutil
 
 import (
 	"fmt"
@@ -6,10 +6,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// completeOptions provides autocompletions based on the options returned by
+// CompleteOptions provides autocompletions based on the options returned by
 // generateOptions. generateOptions must not write to output, or reference any resources
 // that are initialized elsewhere.
-func completeOptions(generateOptions func() (options []string)) cli.BashCompleteFunc {
+func CompleteOptions(generateOptions func() (options []string)) cli.BashCompleteFunc {
 	return func(cmd *cli.Context) {
 		for _, opt := range generateOptions() {
 			fmt.Fprintf(cmd.App.Writer, "%s\n", opt)

--- a/dev/sg/cliutil/doc.go
+++ b/dev/sg/cliutil/doc.go
@@ -1,0 +1,2 @@
+// cliutil provides utilities for the urfave/cli library.
+package cliutil

--- a/dev/sg/cliutil/exit.go
+++ b/dev/sg/cliutil/exit.go
@@ -1,4 +1,4 @@
-package main
+package cliutil
 
 import "github.com/urfave/cli/v2"
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -263,6 +263,7 @@ var sg = &cli.App{
 		migrationCommand,
 		insightsCommand,
 		telemetryCommand,
+		monitoringCommand,
 
 		// Dev environment
 		secretCommand,

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -19,6 +19,7 @@ import (
 	sgrun "github.com/sourcegraph/run"
 
 	"github.com/sourcegraph/sourcegraph/dev/ci/runtype"
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/bk"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/loki"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/open"
@@ -398,7 +399,7 @@ can provide it directly (for example, 'sg ci build [runtype] [argument]').
 
 Learn more about pipeline run types in https://docs.sourcegraph.com/dev/background-information/ci/reference.`,
 			strings.Join(getAllowedBuildTypeArgs(), "\n* ")),
-		BashComplete: completeOptions(getAllowedBuildTypeArgs),
+		BashComplete: cliutil.CompleteOptions(getAllowedBuildTypeArgs),
 		Flags: []cli.Flag{
 			&ciPipelineFlag,
 			&cli.StringFlag{
@@ -451,7 +452,7 @@ Learn more about pipeline run types in https://docs.sourcegraph.com/dev/backgrou
 				if rt == runtype.PullRequest {
 					std.Out.WriteFailuref("Unsupported runtype %q", cmd.Args().First())
 					std.Out.Writef("Supported runtypes:\n\n\t%s\n\nSee 'sg ci docs' to learn more.", strings.Join(getAllowedBuildTypeArgs(), ", "))
-					return NewEmptyExitErr(1)
+					return cliutil.NewEmptyExitErr(1)
 				}
 			}
 			if rt != runtype.PullRequest {

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/db"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -199,7 +200,7 @@ func dbResetPGExec(ctx *cli.Context) error {
 	std.Out.WriteNoticef("This will reset database(s) %s%s%s. Are you okay with this?",
 		output.StyleOrange, strings.Join(schemaNames, ", "), output.StyleReset)
 	if ok := getBool(); !ok {
-		return NewEmptyExitErr(1)
+		return cliutil.NewEmptyExitErr(1)
 	}
 
 	for _, dsn := range dsnMap {

--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
@@ -93,7 +94,7 @@ func (gt generateTargets) Commands() (cmds []*cli.Command) {
 	for _, c := range gt {
 		var completions cli.BashCompleteFunc
 		if c.Completer != nil {
-			completions = completeOptions(c.Completer)
+			completions = cliutil.CompleteOptions(c.Completer)
 		}
 		cmds = append(cmds, &cli.Command{
 			Name:         c.Name,

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/linters"
@@ -138,7 +139,7 @@ func (lt lintTargets) Commands() (cmds []*cli.Command) {
 				return runner.Check(cmd.Context, repoState)
 			},
 			// Completions to chain multiple commands
-			BashComplete: completeOptions(func() (options []string) {
+			BashComplete: cliutil.CompleteOptions(func() (options []string) {
 				for _, c := range lt {
 					options = append(options, c.Name)
 				}

--- a/dev/sg/sg_live.go
+++ b/dev/sg/sg_live.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -41,7 +42,7 @@ sg live -n 50 s2
 			Usage:   "Number of commits to check for live version",
 		},
 	},
-	BashComplete: completeOptions(func() (options []string) {
+	BashComplete: cliutil.CompleteOptions(func() (options []string) {
 		return append(environmentNames(), `https\://...`)
 	}),
 }
@@ -64,11 +65,11 @@ func liveExec(ctx *cli.Context) error {
 	args := ctx.Args().Slice()
 	if len(args) == 0 {
 		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: No environment specified"))
-		return NewEmptyExitErr(1)
+		return cliutil.NewEmptyExitErr(1)
 	}
 	if len(args) != 1 {
 		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: Too many arguments"))
-		return NewEmptyExitErr(1)
+		return cliutil.NewEmptyExitErr(1)
 	}
 
 	e, ok := getEnvironment(args[0])
@@ -77,7 +78,7 @@ func liveExec(ctx *cli.Context) error {
 			e = environment{Name: customURL.Host, URL: customURL.String()}
 		} else {
 			std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: Environment %q not found, or is not a valid URL :(", args[0]))
-			return NewEmptyExitErr(1)
+			return cliutil.NewEmptyExitErr(1)
 		}
 	}
 

--- a/dev/sg/sg_monitoring.go
+++ b/dev/sg/sg_monitoring.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	monitoringcmd "github.com/sourcegraph/sourcegraph/monitoring/command"
+	"github.com/sourcegraph/sourcegraph/monitoring/definitions"
+)
+
+var monitoringCommand = &cli.Command{
+	Name:  "monitoring",
+	Usage: "Sourcegraph's monitoring generator (dashboards, alerts, etc)",
+	Description: `Learn more about the Sourcegraph monitoring generator here: https://docs.sourcegraph.com/dev/background-information/observability/monitoring-generator
+
+Also refer to the generated reference documentation available for site admins:
+
+- https://docs.sourcegraph.com/admin/observability/dashboards
+- https://docs.sourcegraph.com/admin/observability/alerts
+`,
+	Category: CategoryDev,
+	Subcommands: []*cli.Command{
+		monitoringcmd.Generate("sg monitoring", func() string {
+			root, _ := root.RepositoryRoot()
+			return root
+		}()),
+		{
+			Name:  "dashboards",
+			Usage: "List and describe the default dashboards",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "groups",
+					Usage: "Show row groups",
+					Value: true,
+				},
+			},
+			Action: func(c *cli.Context) error {
+				dashboards := definitions.Default()
+				var summary strings.Builder
+				for _, d := range dashboards {
+					summary.WriteString(fmt.Sprintf("* **%s** (`%s`): %s\n",
+						d.Title, d.Name, d.Description))
+
+					if c.Bool("groups") {
+						for _, g := range d.Groups {
+							summary.WriteString(fmt.Sprintf("  * %s (%d rows)\n",
+								g.Title, len(g.Rows)))
+						}
+					}
+				}
+				return std.Out.WriteMarkdown(summary.String())
+			},
+		},
+	},
+}

--- a/dev/sg/sg_run.go
+++ b/dev/sg/sg_run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -38,7 +39,7 @@ sg run gitserver frontend repo-updater
 	Category: CategoryDev,
 	Flags:    []cli.Flag{},
 	Action:   runExec,
-	BashComplete: completeOptions(func() (options []string) {
+	BashComplete: cliutil.CompleteOptions(func() (options []string) {
 		config, _ := getConfig()
 		if config == nil {
 			return

--- a/dev/sg/sg_secret.go
+++ b/dev/sg/sg_secret.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -33,7 +34,7 @@ sg secret reset buildkite
 				ArgsUsage:    "<...key>",
 				Usage:        "Remove a specific secret from secrets file",
 				Action:       resetSecretExec,
-				BashComplete: completeOptions(bashCompleteSecrets),
+				BashComplete: cliutil.CompleteOptions(bashCompleteSecrets),
 			},
 			{
 				Name:  "list",

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/dependencies"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -35,7 +36,7 @@ var setupCommand = &cli.Command{
 	Action: func(cmd *cli.Context) error {
 		if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 			std.Out.WriteLine(output.Styled(output.StyleWarning, "'sg setup' currently only supports macOS and Linux"))
-			return NewEmptyExitErr(1)
+			return cliutil.NewEmptyExitErr(1)
 		}
 
 		currentOS := runtime.GOOS

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
@@ -86,7 +87,7 @@ sg start --debug=gitserver --error=enterprise-worker,enterprise-frontend enterpr
 				Destination: &critStartServices,
 			},
 		},
-		BashComplete: completeOptions(func() (options []string) {
+		BashComplete: cliutil.CompleteOptions(func() (options []string) {
 			config, _ := getConfig()
 			if config == nil {
 				return
@@ -165,14 +166,14 @@ func startExec(ctx *cli.Context) error {
 		repoRoot, err := root.RepositoryRoot()
 		if err != nil {
 			std.Out.WriteLine(output.Styledf(output.StyleWarning, "Failed to determine repository root location: %s", err))
-			return NewEmptyExitErr(1)
+			return cliutil.NewEmptyExitErr(1)
 		}
 
 		devPrivatePath := filepath.Join(repoRoot, "..", "dev-private")
 		exists, err := pathExists(devPrivatePath)
 		if err != nil {
 			std.Out.WriteLine(output.Styledf(output.StyleWarning, "Failed to check whether dev-private repository exists: %s", err))
-			return NewEmptyExitErr(1)
+			return cliutil.NewEmptyExitErr(1)
 		}
 		if !exists {
 			std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: dev-private repository not found!"))
@@ -190,7 +191,7 @@ func startExec(ctx *cli.Context) error {
 `, set.Name))
 			std.Out.Write("")
 
-			return NewEmptyExitErr(1)
+			return cliutil.NewEmptyExitErr(1)
 		}
 	}
 

--- a/dev/sg/sg_tests.go
+++ b/dev/sg/sg_tests.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -38,7 +39,7 @@ sg test -help
 sg test backend-integration -run TestSearch
 `,
 	Category: CategoryDev,
-	BashComplete: completeOptions(func() (options []string) {
+	BashComplete: cliutil.CompleteOptions(func() (options []string) {
 		config, _ := getConfig()
 		if config == nil {
 			return

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -924,6 +924,57 @@ Flags:
 * `--migration`: Create migration files with the generated SQL.
 * `--name="<value>"`: Specifies the name of the resulting migration. (default: sg_telemetry_allowlist)
 
+## sg monitoring
+
+Sourcegraph's monitoring generator (dashboards, alerts, etc).
+
+Learn more about the Sourcegraph monitoring generator here: https://docs.sourcegraph.com/dev/background-information/observability/monitoring-generator
+
+Also refer to the generated reference documentation available for site admins:
+
+- https://docs.sourcegraph.com/admin/observability/dashboards
+- https://docs.sourcegraph.com/admin/observability/alerts
+
+
+
+### sg monitoring generate
+
+Generate monitoring assets - dashboards, alerts, and more.
+
+```sh
+# Generate all dashboards with default configuration
+$ sg monitoring generate
+
+# Generate and reload local instances of Grafana, Prometheus, etc.
+$ sg monitoring generate -reload
+
+# Render dashboards in a custom directory
+$ sg monitoring generate -grafana.dir /tmp/my-dashboards
+```
+
+Flags:
+
+* `--docs.dir="<value>"`: Output directory for generated documentation (default: $SG_ROOT/doc/admin/observability/)
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--grafana.creds="<value>"`: Credentials for the Grafana instance to reload (default: admin:admin)
+* `--grafana.dir="<value>"`: Output directory for generated Grafana assets (default: $SG_ROOT/docker-images/grafana/config/provisioning/dashboards/sourcegraph/)
+* `--grafana.url="<value>"`: Address for the Grafana instance to reload (default: http://127.0.0.1:3370)
+* `--inject-label-matcher="<value>"`: Labels to inject into all selectors in Prometheus expressions: observable queries, dashboard template variables, etc.
+* `--no-prune`: Toggles pruning of dangling generated assets through simple heuristic - should be disabled during builds.
+* `--prometheus.dir="<value>"`: Output directory for generated Prometheus assets (default: $SG_ROOT/docker-images/prometheus/config/)
+* `--prometheus.url="<value>"`: Address for the Prometheus instance to reload (default: http://127.0.0.1:9090)
+* `--reload`: Trigger reload of active Prometheus or Grafana instance (requires respective output directories)
+
+### sg monitoring dashboards
+
+List and describe the default dashboards.
+
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--groups`: Show row groups
+
 ## sg secret
 
 Manipulate secrets stored in memory and in file.

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -942,18 +942,19 @@ Also refer to the generated reference documentation available for site admins:
 Generate monitoring assets - dashboards, alerts, and more.
 
 ```sh
-# Generate all dashboards with default configuration
-$ sg monitoring generate
+# Generate all monitoring with default configuration into a temporary directory
+$ sg monitoring generate -all.dir /tmp/monitoring
 
 # Generate and reload local instances of Grafana, Prometheus, etc.
 $ sg monitoring generate -reload
 
-# Render dashboards in a custom directory
-$ sg monitoring generate -grafana.dir /tmp/my-dashboards
+# Render dashboards in a custom directory, and disable rendering of docs
+$ sg monitoring generate -grafana.dir /tmp/my-dashboards -docs.dir ''
 ```
 
 Flags:
 
+* `--all.dir="<value>"`: Override all other '-*.dir' directories
 * `--docs.dir="<value>"`: Output directory for generated documentation (default: $SG_ROOT/doc/admin/observability/)
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--grafana.creds="<value>"`: Credentials for the Grafana instance to reload (default: admin:admin)

--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ require (
 	github.com/uber/gonduit v0.13.0
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
-	github.com/urfave/cli/v2 v2.6.0
+	github.com/urfave/cli/v2 v2.16.3
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/xeonx/timeago v1.0.0-rc4
 	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9
@@ -207,6 +207,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
 )
@@ -214,6 +215,7 @@ require (
 require github.com/hmarr/codeowners v0.4.0
 
 require (
+	github.com/hashicorp/hcl v1.0.0
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.13
 	github.com/prometheus/prometheus v0.37.1
 	go.opentelemetry.io/otel/exporters/jaeger v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -2221,8 +2221,8 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli/v2 v2.6.0 h1:yj2Drkflh8X/zUrkWlWlUjZYHyWN7WMmpVxyxXIUyv8=
-github.com/urfave/cli/v2 v2.6.0/go.mod h1:oDzoM7pVwz6wHn5ogWgFUU1s4VJayeQS+aEZDqXIEJs=
+github.com/urfave/cli/v2 v2.16.3 h1:gHoFIwpPjoyIMbJp/VFd+/vuD0dAgFK4B6DpEMFJfQk=
+github.com/urfave/cli/v2 v2.16.3/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/uudashr/gocognit v1.0.1/go.mod h1:j44Ayx2KW4+oB6SWMv8KsmHzZrOInQav7D3cQMJ5JUM=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
@@ -2276,6 +2276,8 @@ github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6Ut
 github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=

--- a/monitoring/command/generate.go
+++ b/monitoring/command/generate.go
@@ -1,0 +1,180 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/hcl/hcl/strconv"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/monitoring/definitions"
+	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
+)
+
+// Generate creates a 'generate' command that generates the default monitoring dashboards.
+func Generate(cmdRoot string, sgRoot string) *cli.Command {
+	return &cli.Command{
+		Name:      "generate",
+		ArgsUsage: "<dashboard>",
+		UsageText: fmt.Sprintf(`
+# Generate all dashboards with default configuration
+%[1]s generate
+
+# Generate and reload local instances of Grafana, Prometheus, etc.
+%[1]s generate -reload
+
+# Render dashboards in a custom directory
+%[1]s generate -grafana.dir /tmp/my-dashboards
+`, cmdRoot),
+		Usage: "Generate monitoring assets - dashboards, alerts, and more",
+		// Flags should correspond to monitoring.GenerateOpts
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "no-prune",
+				EnvVars: []string{"NO_PRUNE"},
+				Usage:   "Toggles pruning of dangling generated assets through simple heuristic - should be disabled during builds.",
+			},
+			&cli.BoolFlag{
+				Name:    "reload",
+				EnvVars: []string{"RELOAD"},
+				Usage:   "Trigger reload of active Prometheus or Grafana instance (requires respective output directories)",
+			},
+			&cli.StringFlag{
+				Name:    "grafana.dir",
+				EnvVars: []string{"GRAFANA_DIR"},
+				Value:   "$SG_ROOT/docker-images/grafana/config/provisioning/dashboards/sourcegraph/",
+				Usage:   "Output directory for generated Grafana assets",
+			},
+			&cli.StringFlag{
+				Name:  "grafana.url",
+				Value: "http://127.0.0.1:3370",
+				Usage: "Address for the Grafana instance to reload",
+			},
+			&cli.StringFlag{
+				Name:  "grafana.creds",
+				Value: "admin:admin",
+				Usage: "Credentials for the Grafana instance to reload",
+			},
+
+			&cli.StringFlag{
+				Name:    "prometheus.dir",
+				EnvVars: []string{"PROMETHEUS_DIR"},
+				Value:   "$SG_ROOT/docker-images/prometheus/config/",
+				Usage:   "Output directory for generated Prometheus assets",
+			},
+			&cli.StringFlag{
+				Name:  "prometheus.url",
+				Value: "http://127.0.0.1:9090",
+				Usage: "Address for the Prometheus instance to reload",
+			},
+
+			&cli.StringFlag{
+				Name:    "docs.dir",
+				EnvVars: []string{"DOCS_DIR"},
+				Value:   "$SG_ROOT/doc/admin/observability/",
+				Usage:   "Output directory for generated documentation",
+			},
+			&cli.StringSliceFlag{
+				Name:    "inject-label-matcher",
+				EnvVars: []string{"INJECT_LABEL_MATCHERS"},
+				Usage:   "Labels to inject into all selectors in Prometheus expressions: observable queries, dashboard template variables, etc.",
+			},
+		},
+		BashComplete: cliutil.CompleteOptions(func() (options []string) {
+			return definitions.Default().Names()
+		}),
+		Action: func(c *cli.Context) error {
+			logger := log.Scoped(c.Command.Name, c.Command.Description)
+
+			// expandErr is set from within expandWithSgRoot
+			var expandErr error
+			expandWithSgRoot := func(key string) string {
+				// Lookup first, to allow overrides of SG_ROOT
+				if v, set := os.LookupEnv(key); set {
+					return v
+				}
+				if key == "SG_ROOT" {
+					if sgRoot == "" {
+						expandErr = errors.New("$SG_ROOT is required to use the default paths")
+					}
+					return sgRoot
+				}
+				return ""
+			}
+
+			options := monitoring.GenerateOptions{
+				DisablePrune: c.Bool("no-prune"),
+				Reload:       c.Bool("reload"),
+
+				GrafanaDir:         os.Expand(c.String("grafana.dir"), expandWithSgRoot),
+				GrafanaURL:         c.String("grafana.url"),
+				GrafanaCredentials: c.String("grafana.creds"),
+
+				PrometheusDir: os.Expand(c.String("prometheus.dir"), expandWithSgRoot),
+				PrometheusURL: c.String("prometheus.url"),
+
+				DocsDir: os.Expand(c.String("docs.dir"), expandWithSgRoot),
+
+				InjectLabelMatchers: func() []*labels.Matcher {
+					var matchers []*labels.Matcher
+					for _, entry := range c.StringSlice("inject-label-matcher") {
+						if len(entry) == 0 {
+							continue
+						}
+
+						parts := strings.Split(entry, "=")
+						if len(parts) != 2 {
+							logger.Error("discarding invalid INJECT_LABEL_MATCHERS entry",
+								log.String("entry", entry))
+							continue
+						}
+
+						label := parts[0]
+						value, err := strconv.Unquote(parts[1])
+						if err != nil {
+							value = parts[1]
+						}
+						matcher, err := labels.NewMatcher(labels.MatchEqual, label, value)
+						if err != nil {
+							logger.Error("discarding invalid INJECT_LABEL_MATCHERS entry",
+								log.String("entry", entry),
+								log.Error(err))
+							continue
+						}
+						matchers = append(matchers, matcher)
+					}
+					return matchers
+				}(),
+			}
+
+			if expandErr != nil {
+				return expandErr
+			}
+
+			var dashboards definitions.Dashboards
+			if c.Args().Len() == 0 {
+				dashboards = definitions.Default()
+			} else {
+				for _, arg := range c.Args().Slice() {
+					d := definitions.Default().GetByName(c.Args().First())
+					if d == nil {
+						return errors.Newf("Dashboard %q not found", arg)
+					}
+					dashboards = append(dashboards, d)
+				}
+			}
+
+			logger.Info("generating dashboards",
+				log.Strings("dashboards", dashboards.Names()))
+
+			return monitoring.Generate(logger, options, dashboards...)
+		},
+	}
+
+}

--- a/monitoring/definitions/dashboards.go
+++ b/monitoring/definitions/dashboards.go
@@ -1,0 +1,51 @@
+package definitions
+
+import (
+	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
+)
+
+type Dashboards []*monitoring.Dashboard
+
+// Default is the default set of monitoring dashboards to generate. Ensure that any
+// dashboards created or removed are updated in the return value here as required.
+func Default() Dashboards {
+	return []*monitoring.Dashboard{
+		Frontend(),
+		GitServer(),
+		GitHubProxy(),
+		Postgres(),
+		PreciseCodeIntelWorker(),
+		Redis(),
+		Worker(),
+		RepoUpdater(),
+		Searcher(),
+		Symbols(),
+		SyntectServer(),
+		Zoekt(),
+		Prometheus(),
+		Executor(),
+		Containers(),
+		CodeIntelAutoIndexing(),
+		CodeIntelUploads(),
+		CodeIntelPolicies(),
+		Telemetry(),
+	}
+}
+
+// Names returns the names of all dashboards.
+func (ds Dashboards) Names() (names []string) {
+	for _, d := range ds {
+		names = append(names, d.Name)
+	}
+	return
+}
+
+// GetByName retrieves the dashboard of the given name, otherwise returns nil.
+func (ds Dashboards) GetByName(name string) *monitoring.Dashboard {
+	for _, d := range ds {
+		if d.Name == name {
+			return d
+		}
+	}
+	return nil
+}

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -18,13 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const (
-	localGrafanaURL         = "http://127.0.0.1:3370"
-	localGrafanaCredentials = "admin:admin"
-
-	localPrometheusURL = "http://127.0.0.1:9090"
-)
-
 // GenerateOptions declares options for the monitoring generator.
 type GenerateOptions struct {
 	// Toggles pruning of dangling generated assets through simple heuristic, should be disabled during builds
@@ -34,8 +27,17 @@ type GenerateOptions struct {
 
 	// Output directory for generated Grafana assets
 	GrafanaDir string
+	// GrafanaURL is the address for the Grafana instance to reload
+	GrafanaURL string
+	// GrafanaCredentials is the basic auth credentials for the Grafana instance at
+	// GrafanaURL, e.g. "admin:admin"
+	GrafanaCredentials string
+
 	// Output directory for generated Prometheus assets
 	PrometheusDir string
+	// PrometheusURL is the address for the Prometheus instance to reload
+	PrometheusURL string
+
 	// Output directory for generated documentation
 	DocsDir string
 
@@ -47,9 +49,7 @@ type GenerateOptions struct {
 
 // Generate is the main Sourcegraph monitoring generator entrypoint.
 func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard) error {
-	logger.Info("Regenerating monitoring",
-		log.String("options", fmt.Sprintf("%+v", opts)),
-		log.Int("dashboards", len(dashboards)))
+	logger.Info("Regenerating monitoring", log.String("options", fmt.Sprintf("%+v", opts)))
 
 	var generatedAssets []string
 
@@ -66,15 +66,17 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 	}
 
 	// Generate Grafana content for all dashboards
-	dlog := logger.Scoped("grafana", "grafana dashboard generation")
 	for _, dashboard := range dashboards {
 		// Logger for dashboard
-		clog := dlog.With(log.String("dashboard", dashboard.Name), log.String("instance", localGrafanaURL))
+		dlog := logger.With(log.String("dashboard", dashboard.Name))
+
 		// Prepare Grafana assets
 		if opts.GrafanaDir != "" {
+			glog := dlog.Scoped("grafana", "grafana dashboard generation").
+				With(log.String("instance", opts.GrafanaURL))
 			os.MkdirAll(opts.GrafanaDir, os.ModePerm)
 
-			clog.Debug("Rendering Grafana assets")
+			glog.Debug("Rendering Grafana assets")
 			board, err := dashboard.renderDashboard(opts.InjectLabelMatchers)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
@@ -93,8 +95,8 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 
 			// Reload specific dashboard
 			if opts.Reload {
-				clog.Debug("Reloading Grafana instance")
-				client, err := sdk.NewClient(localGrafanaURL, localGrafanaCredentials, sdk.DefaultHTTPClient)
+				glog.Debug("Reloading Grafana instance")
+				client, err := sdk.NewClient(opts.GrafanaURL, opts.GrafanaCredentials, sdk.DefaultHTTPClient)
 				if err != nil {
 					return errors.Wrapf(err, "Failed to initialize Grafana client for dashboard %q", dashboard.Title)
 				}
@@ -102,16 +104,18 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				if err != nil {
 					return errors.Wrapf(err, "Could not reload Grafana instance for dashboard %q", dashboard.Title)
 				} else {
-					clog.Info("Reloaded Grafana instance")
+					glog.Info("Reloaded Grafana instance")
 				}
 			}
 		}
 
 		// Prepare Prometheus assets
 		if opts.PrometheusDir != "" {
+			plog := dlog.Scoped("prometheus", "prometheus rules generation")
+
 			os.MkdirAll(opts.PrometheusDir, os.ModePerm)
 
-			clog.Debug("Rendering Prometheus assets")
+			plog.Debug("Rendering Prometheus assets")
 			promAlertsFile, err := dashboard.renderRules(opts.InjectLabelMatchers)
 			if err != nil {
 				return errors.Wrapf(err, "Unable to generate alerts for dashboard %q", dashboard.Title)
@@ -131,12 +135,13 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 
 	// Reload all Prometheus rules
 	if opts.PrometheusDir != "" && opts.Reload {
-		rlog := logger.Scoped("prometheus", "prometheus alerts generation").With(log.String("instance", localPrometheusURL))
+		rlog := logger.Scoped("prometheus", "prometheus alerts generation").
+			With(log.String("instance", opts.PrometheusURL))
 		// Reload all Prometheus rules
 		rlog.Debug("Reloading Prometheus instance")
-		resp, err := http.Post(localPrometheusURL+"/-/reload", "", nil)
+		resp, err := http.Post(opts.PrometheusURL+"/-/reload", "", nil)
 		if err != nil {
-			return errors.Wrapf(err, "Could not reload Prometheus at %q", localPrometheusURL)
+			return errors.Wrapf(err, "Could not reload Prometheus at %q", opts.PrometheusURL)
 		} else {
 			defer resp.Body.Close()
 			if resp.StatusCode != 200 {


### PR DESCRIPTION
Work on https://github.com/sourcegraph/sourcegraph/pull/41644 indicates we will likely need a bunch of additional configuration options that need to be available to the monitoring generator to enable dashboard export. As the complexity grows, it will be valuable to have some more structured control over the CLI, so we add a command that can be used to have 1:1 parity with the existing `go run ./monitoring` while enabling more advanced options that can be enabled in `sg`, which now has the following commands:

```sh
sg monitoring generate   # similar to `go generate ./monitoring`, with more options
sg monitoring dashboards # misc command to show we can add more stuff like listing alerts in the future
```

This also adds the Grafana/Prometheus URLs as options to take advantage of having the self-documenting options, and also creates a new package `dev/sg/cliutil` to allow access to the completions utilities.

Related: https://github.com/sourcegraph/sourcegraph/issues/35380

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go generate ./monitoring` still generates the expected output as before

```sh
$ go run ./dev/sg monitoring
NAME:
   sg monitoring - Sourcegraph's monitoring generator (dashboards, alerts, etc)

USAGE:
   sg monitoring command [command options] [arguments...]

DESCRIPTION:
   Learn more about the Sourcegraph monitoring generator here: https://docs.sourcegraph.com/dev/background-information/observability/monitoring-generator
   
   Also refer to the generated reference documentation available for site admins:
   
   - https://docs.sourcegraph.com/admin/observability/dashboards
   - https://docs.sourcegraph.com/admin/observability/alerts
   

COMMANDS:
     generate    Generate monitoring assets - dashboards, alerts, and more.
     dashboards  List and describe the default dashboards
     help, h     Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help (default: false)
```