### PR TITLE
Fix insight preview links broken for capture group insights

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-insight-preview.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-insight-preview.ts
@@ -74,12 +74,21 @@ export const getInsightsPreview = (
 
             // TODO Revisit live preview and dashboard insight resolver methods in order to
             // improve series data handling and manipulation
-            const seriesMetadata = indexedSeries.map((generatedSeries, index) => ({
-                id: generatedSeries.seriesId,
-                name: generatedSeries.label,
-                query: inputMetadata[`${generatedSeries.label}-${index}`]?.query || '',
-                stroke: getColorForSeries(generatedSeries.label, index),
-            }))
+            const seriesMetadata = indexedSeries.map((generatedSeries, index) => {
+                // inputMetaData is keyed using the label provided by the user.
+                // Capture groups do not have a label, so we omit the label and look
+                // for a meta object without it.
+                // Note we only support 1 capture group right now, so the "index" is always 0.
+                // https://github.com/sourcegraph/sourcegraph/issues/38098
+                const metaData = inputMetadata[`${generatedSeries.label}-${index}`] ?? inputMetadata[`-${0}`]
+
+                return {
+                    id: generatedSeries.seriesId,
+                    name: generatedSeries.label,
+                    query: metaData?.query || '',
+                    stroke: getColorForSeries(generatedSeries.label, index),
+                }
+            })
 
             const seriesDefinitionMap = Object.fromEntries(
                 seriesMetadata.map(definition => [definition.id, definition])


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/38098

add fall back for meta data without labels

This should be a temporary fix. The backend will provide
this type of information directly in the future.



## Test plan

- Navigate to create capture group `/insights/create/capture-group`
- Add `github.com/sourcegraph/sourcegraph, ` for the repo input
- Add `file:package.json "license":\s"(.*)"` for the query
- Add Test for the title
- Clicking any of the data points should open the search for that query in a new window.
- The search should include the query from above

## App preview:

- [Web](https://sg-web-insights-fix-preview-click-through.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-eqihegxsom.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
