### PR TITLE
monitoring: generate Home dashboard with injected labels from template

### DIFF
--- a/docker-images/grafana/.gitignore
+++ b/docker-images/grafana/.gitignore
@@ -1,1 +1,1 @@
-monitoring
+home.json

--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -27,8 +27,7 @@ LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
 
 # hadolint ignore=DL3020
 ADD config /sg_config_grafana
-COPY home.json /usr/share/grafana/public/dashboards/home.json
-
+COPY --from=monitoring_builder /generated/grafana/home.json /usr/share/grafana/public/dashboards/home.json
 COPY --from=monitoring_builder /generated/grafana/* /sg_config_grafana/provisioning/dashboards/sourcegraph/
 
 # hadolint ignore=DL3020

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/monitoring/monitoring/internal/grafana"
 )
 
 // GenerateOptions declares options for the monitoring generator.
@@ -106,6 +107,19 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				} else {
 					glog.Info("Reloaded Grafana instance")
 				}
+			}
+		}
+
+		// Generate home page
+		if opts.GrafanaDir != "" {
+			data, err := grafana.Home(opts.InjectLabelMatchers)
+			if err != nil {
+				return errors.Wrap(err, "failed to generate home dashboard")
+			}
+			generatedDashboard := "home.json"
+			generatedAssets = append(generatedAssets, generatedDashboard)
+			if err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm); err != nil {
+				return errors.Wrap(err, "failed to generate home dashboard")
 			}
 		}
 

--- a/monitoring/monitoring/internal/grafana/home.go
+++ b/monitoring/monitoring/internal/grafana/home.go
@@ -1,0 +1,62 @@
+package grafana
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"strconv"
+	"text/template"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/monitoring/monitoring/internal/promql"
+)
+
+// homeJson is the raw dashboards JSON for the home dashboard.
+//
+//go:embed home.json.tmpl
+var homeJsonTmpl string
+
+// Home is the definition for the home dashboard. It is provided as raw JSON because it
+// is defined outside of the monitoring generator.
+func Home(injectLabelMatchers []*labels.Matcher) ([]byte, error) {
+	// Build template variables
+	vars := map[string]string{
+		"WarningAlertsExpr":       "sum by (service_name)(max by (level,service_name,name,description)(alert_count{name!=\"\",level=\"warning\"}))",
+		"CriticalAlertsExpr":      "sum by (service_name)(max by (level,service_name,name,description)(alert_count{name!=\"\",level=\"critical\"}))",
+		"AlertCountByServiceExpr": "count(sum(alert_count{name!=\"\"}) by (service_name))",
+		"AlertCountByLevelExpr":   "count(sum(alert_count{name!=\"\"}) by (level,description))",
+		"AlertLabelQuery":         "sum by (level,service_name,description,grafana_panel_id)(max by (level,service_name,name,description,grafana_panel_id)(alert_count{name!=\"\"}))",
+	}
+	for k, v := range vars {
+		var err error
+		vars[k], err = promql.Inject(v, injectLabelMatchers, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, k)
+		}
+	}
+
+	// Build and execute template
+	tmpl, err := template.New("").Funcs(template.FuncMap{
+		"escape": func(val string) string {
+			quoted := strconv.Quote(val)
+			return quoted[1 : len(quoted)-1] // strip leading and trailing quotes
+		},
+	}).Parse(homeJsonTmpl)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, &vars); err != nil {
+		return nil, err
+	}
+
+	// Validate JSON
+	data := buf.Bytes()
+	if err := json.Unmarshal(data, &map[string]interface{}{}); err != nil {
+		return nil, errors.Wrap(err, "generated dashboard is invalid")
+	}
+
+	return data, nil
+}

--- a/monitoring/monitoring/internal/grafana/home.json.tmpl
+++ b/monitoring/monitoring/internal/grafana/home.json.tmpl
@@ -116,9 +116,9 @@
       "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum by (service_name)(max by (level,service_name,name,description)(alert_count{name!=\"\",level=\"critical\"}))",
+          "expr": "{{ escape .CriticalAlertsExpr }}",
           "interval": "",
-          "legendFormat": "{{service_name}}",
+          "legendFormat": "{{`{{service_name}}`}}",
           "refId": "A"
         }
       ],
@@ -203,9 +203,9 @@
       "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum by (service_name)(max by (level,service_name,name,description)(alert_count{name!=\"\",level=\"warning\"}))",
+          "expr": "{{ escape .WarningAlertsExpr }}",
           "interval": "",
-          "legendFormat": "{{service_name}}",
+          "legendFormat": "{{`{{service_name}}`}}",
           "refId": "A"
         }
       ],
@@ -277,7 +277,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(sum(alert_count{name!=\"\"}) by (service_name))",
+          "expr": "{{ escape .AlertCountByServiceExpr }}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -496,7 +496,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "label_replace(sum by (level,service_name,description,grafana_panel_id)(max by (level,service_name,name,description,grafana_panel_id)(alert_count{name!=\"\"})), \"description\", \"$1\", \"description\", \".*: (.*)\")",
+          "expr": "label_replace({{ escape .AlertLabelQuery }}, \"description\", \"$1\", \"description\", \".*: (.*)\")",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -594,7 +594,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(sum(alert_count{name!=\"\"}) by (level,description))",
+          "expr": "{{ escape .AlertCountByServiceExpr }}",
           "instant": true,
           "interval": "",
           "legendFormat": "",


### PR DESCRIPTION
Generate the previously-hardcoded Home dashboard (the first dashboard page you see when you go to `/-/debug/grafana`) from a template, which allows us to apply the query injection introduced in https://github.com/sourcegraph/sourcegraph/pull/41644 to the panels on this dashboard.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`INJECT_LABEL_MATCHERS='ns=prod' go generate ./monitoring/...` and inspect `home.json`, then `sg start monitoring`