### PR TITLE
Upgrade minio to latest version

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -74,7 +74,7 @@ COPY --from=docker.io/sourcegraph/syntect_server:21-08-31_c330964@sha256:759f331
 
 
 # install minio (keep this up to date with docker-images/minio/Dockerfile)
-ENV MINIO_VERSION=RELEASE.2022-08-26T19-53-15Z
+ENV MINIO_VERSION=RELEASE.2022-09-07T22-25-02Z
 RUN wget "https://dl.min.io/server/minio/release/linux-amd64/archive/minio.$MINIO_VERSION" && \
     chmod +x "minio.$MINIO_VERSION" && \
     mv "minio.$MINIO_VERSION" /usr/local/bin/minio

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -74,7 +74,7 @@ COPY --from=docker.io/sourcegraph/syntect_server:21-08-31_c330964@sha256:759f331
 
 
 # install minio (keep this up to date with docker-images/minio/Dockerfile)
-ENV MINIO_VERSION=RELEASE.2022-09-07T22-25-02Z
+ENV MINIO_VERSION=RELEASE.2022-09-17T00-09-45Z
 RUN wget "https://dl.min.io/server/minio/release/linux-amd64/archive/minio.$MINIO_VERSION" && \
     chmod +x "minio.$MINIO_VERSION" && \
     mv "minio.$MINIO_VERSION" /usr/local/bin/minio

--- a/docker-images/minio/build.sh
+++ b/docker-images/minio/build.sh
@@ -4,6 +4,6 @@ set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Retag the 2022-05-08 MinIO release
-MINIO_RELEASE="RELEASE.2022-09-07T22-25-02Z"
+MINIO_RELEASE="RELEASE.2022-09-17T00-09-45Z"
 docker pull minio/minio:$MINIO_RELEASE
 docker tag minio/minio:$MINIO_RELEASE "$IMAGE"

--- a/docker-images/minio/build.sh
+++ b/docker-images/minio/build.sh
@@ -4,6 +4,6 @@ set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Retag the 2022-05-08 MinIO release
-MINIO_RELEASE="RELEASE.2022-08-26T19-53-15Z"
+MINIO_RELEASE="RELEASE.2022-09-07T22-25-02Z"
 docker pull minio/minio:$MINIO_RELEASE
 docker tag minio/minio:$MINIO_RELEASE "$IMAGE"


### PR DESCRIPTION
To clear out old CVEs where possible.

This only takes us through a couple of bugfix releases, so there are no major changes here.

## Test plan
CI checks
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
