### PR TITLE
Add troubleshooting for unauthorised git requests

### DIFF
--- a/doc/admin/troubleshooting.md
+++ b/doc/admin/troubleshooting.md
@@ -136,3 +136,13 @@ If you can get repository results when you explicitly include `repo:{your reposi
 - Your site config file does not include `"search.index.enabled": true`. It should be included, and you should set it to true; if it's false, it means Sourcegraph won't index anything and will only search in real-time.
 - There is an issue indexing the repository: check the logs of repo-updater and/or search-indexer.
 - The search index is unavailable for some reason: try the search query `repo:<the_repository> index:only`. If it returns no results, the repository has not been indexed.
+
+### Sourcegraph is making unauthorized requests to the git server
+
+This is normal and happens whenever git is used over HTTP. To avoid unnecessarily sending a password over HTTP, git first
+makes a request without the password included. If a 401 Unauthorized is returned, git sends the request with the password.
+
+More information can be found [here](https://confluence.atlassian.com/bitbucketserverkb/two-401-responses-for-every-git-opperation-938854756.html).
+
+If this behaviour is undesired, the `gitURLType` in the [external service configuration](https://docs.sourcegraph.com/admin/external_service/github#configuration)
+should be set to `ssh` instead of `http`. This will also require [ssh keys to be set up](https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication).

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -20,7 +20,7 @@
       "examples": ["https://github.com", "https://github-enterprise.example.com"]
     },
     "gitURLType": {
-      "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitHub instance.\n\nIf \"http\", Sourcegraph will access GitHub repositories using Git URLs of the form http(s)://github.com/myteam/myproject.git (using https: if the GitHub instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitHub repositories using Git URLs of the form git@github.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
+      "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitHub instance.\n\nIf \"http\", Sourcegraph will access GitHub repositories using Git URLs of the form http(s)://github.com/myteam/myproject.git (using https: if the GitHub instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitHub repositories using Git URLs of the form git@github.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.\n\nNote: Using http can cause unauthorized requests to appear on the github server. This is normal and part of how git functions: https://confluence.atlassian.com/bitbucketserverkb/two-401-responses-for-every-git-opperation-938854756.html",
       "type": "string",
       "enum": ["http", "ssh"],
       "default": "http"

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -20,7 +20,7 @@
       "examples": ["https://github.com", "https://github-enterprise.example.com"]
     },
     "gitURLType": {
-      "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitHub instance.\n\nIf \"http\", Sourcegraph will access GitHub repositories using Git URLs of the form http(s)://github.com/myteam/myproject.git (using https: if the GitHub instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitHub repositories using Git URLs of the form git@github.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.\n\nNote: Using http can cause unauthorized requests to appear on the github server. This is normal and part of how git functions: https://confluence.atlassian.com/bitbucketserverkb/two-401-responses-for-every-git-opperation-938854756.html",
+      "description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitHub instance.\n\nIf \"http\", Sourcegraph will access GitHub repositories using Git URLs of the form http(s)://github.com/myteam/myproject.git (using https: if the GitHub instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitHub repositories using Git URLs of the form git@github.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
       "type": "string",
       "enum": ["http", "ssh"],
       "default": "http"


### PR DESCRIPTION
Figured this out after a customer query. Thought it was worth documenting, as it is not intuitive.

## Test plan

Test locally that it displays correctly.

Also confirmed that this does indeed happen by testing with Gogs:

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/6427795/190926352-3867ff62-d895-4048-b244-2e8231f743f8.png">
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
