### PR TITLE
[SG-41399] Replace SCSS mixins with PostCSS functions 

### DIFF
--- a/client/branded/src/global-styles/mixins.scss
+++ b/client/branded/src/global-styles/mixins.scss
@@ -1,12 +1,5 @@
 // stylelint-disable declaration-no-important
 
-// Typography
-@mixin text-emphasis-variant($parent, $color) {
-    #{$parent} {
-        color: $color !important;
-    }
-}
-
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
 // Makes the @content apply to the given breakpoint and wider.
 @mixin media-breakpoint-up($name, $breakpoints: $grid-breakpoints) {

--- a/client/branded/src/global-styles/typography.scss
+++ b/client/branded/src/global-styles/typography.scss
@@ -170,7 +170,9 @@ label.text-uppercase small,
 .theme-light,
 .theme-dark {
     @each $color, $value in $theme-colors {
-        @include text-emphasis-variant('.text-#{$color}', $value);
+        #{'.text-#{$color}'} {
+            color: $value !important;
+        }
     }
 }
 

--- a/client/browser/src/shared/code-hosts/github/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/github/codeHost.module.scss
@@ -1,17 +1,5 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
-@mixin github-dark-theme {
-    [data-color-mode='dark'] {
-        @content;
-    }
-
-    [data-color-mode='auto'] {
-        @media (prefers-color-scheme: dark) {
-            @content;
-        }
-    }
-}
-
 :root {
     /* Map out CSS variables to the theme-aware GitHub ones */
     --body-bg: var(--color-bg-canvas);
@@ -19,8 +7,14 @@
     --secondary: var(--color-auto-gray-2);
 }
 
-@include github-dark-theme {
+[data-color-mode='dark'] {
     --mark-bg: var(--mark-bg-dark);
+}
+
+[data-color-mode='auto'] {
+    @media (prefers-color-scheme: dark) {
+        --mark-bg: var(--mark-bg-dark);
+    }
 }
 
 .command-palette-popover {

--- a/client/web/src/user/UserAvatar.module.scss
+++ b/client/web/src/user/UserAvatar.module.scss
@@ -1,19 +1,3 @@
-@mixin quad-vertex-colors($v0, $v1, $v2, $v3) {
-    background: linear-gradient(to bottom, $v0, $v2);
-
-    &::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        border-radius: 50%;
-        background: linear-gradient(to right, $v1, $v3);
-        mask-image: linear-gradient(to bottom, #000000, transparent);
-    }
-}
-
 .user-avatar {
     display: inline-flex;
     border-radius: 50%;
@@ -24,7 +8,19 @@
     min-width: 1.5rem;
     min-height: 1.5rem;
     position: relative;
-    @include quad-vertex-colors(var(--logo-purple), var(--logo-purple), var(--logo-orange), var(--logo-blue));
+    background: linear-gradient(to bottom, var(--logo-purple), var(--logo-orange));
+
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        border-radius: 50%;
+        background: linear-gradient(to right, var(--logo-purple), var(--logo-blue));
+        mask-image: linear-gradient(to bottom, #000000, transparent);
+    }
 }
 
 .initials {

--- a/client/wildcard/src/components/Tabs/Tabs.module.scss
+++ b/client/wildcard/src/components/Tabs/Tabs.module.scss
@@ -4,10 +4,6 @@
     --opacity-transition: 0.3s;
     --scroll-gradient-color: var(--body-bg);
 
-    @mixin scroll-gradient($to) {
-        background: linear-gradient(to $to, var(--scroll-gradient-color) 15%, rgba(0, 0, 0, 0));
-    }
-
     --small-size-font: 0.75rem;
     --medium-size-font: 0.875rem;
     --large-size-font: 1rem;
@@ -100,14 +96,15 @@
             }
         }
 
+        // Drawing gradient color changes on scroll
         &::before {
             left: 0;
-            @include scroll-gradient(right);
+            background: linear-gradient(to right, var(--scroll-gradient-color) 15%, rgba(0, 0, 0, 0));
         }
 
         &::after {
             right: 0;
-            @include scroll-gradient(left);
+            background: linear-gradient(to left, var(--scroll-gradient-color) 15%, rgba(0, 0, 0, 0));
         }
 
         &-obscured-left::before {


### PR DESCRIPTION
### Description
Replace SCSS mixins with PostCSS functions

### Success criteria
All SCSS mixins are replaced with a combination of PostCSS functions and CSS variables.

### Implementation details
An example of PostCSS functions we use for breakpoints can be find here: client/wildcard/src/global-styles/breakpoints.scss. DM @valerybugakov in Slack to discuss the addition of new PostCSS plugins if they are required.

### Refs
[Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/41399)
[Gitstart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-41399)

### Test Plan
- Verify that there are no ui diffs where migrated classes are used.