### PR TITLE
search: never send if no pending results

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -334,6 +334,10 @@ func (q *resultQueue) pop() *zoekt.SearchResult {
 // should be sent up the stream. Retrieve search results by calling pop() on
 // resultQueue.
 func (q *resultQueue) hasResultsToSend(maxPending float64) bool {
+	if q.queue.Len() == 0 {
+		return false
+	}
+
 	if q.maxQueueDepth >= 0 && q.queue.Len() > q.maxQueueDepth {
 		return true
 	}


### PR DESCRIPTION
Right now we are getting a panic trying to pop from the result queue. The likely cause of this is a recent introduction which checks results counts to decide to send. We now gate this decision by ensuring we always have items on the queue.

We should work out why the maxMatchCount logic is firing here (I am assuming it is the cause). But for now this will fix the panic.

Test Plan: CI