### PR TITLE
Add experimental "auditLog" site config setting.

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -66,7 +66,7 @@ type ApiRatelimit struct {
 	PerUser int `json:"perUser"`
 }
 
-// AuditLog description: EXPERIMENTAL: Audit Log
+// AuditLog description: EXPERIMENTAL: Configuration for audit logging (specially formatted log entries for tracking sensitive events)
 type AuditLog struct {
 	// GitserverAccess description: Capture gitserver access logs as part of the audit log.
 	GitserverAccess bool `json:"gitserverAccess"`
@@ -605,8 +605,6 @@ type ExperimentalFeatures struct {
 	AndOrQuery string `json:"andOrQuery,omitempty"`
 	// ApidocsSearchIndexing description: Deprecated.
 	ApidocsSearchIndexing string `json:"apidocs.search.indexing,omitempty"`
-	// AuditLog description: EXPERIMENTAL: Audit Log
-	AuditLog *AuditLog `json:"auditLog,omitempty"`
 	// BitbucketServerFastPerm description: DEPRECATED: Configure in Bitbucket Server config.
 	BitbucketServerFastPerm string `json:"bitbucketServerFastPerm,omitempty"`
 	// CustomGitFetch description: JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command.
@@ -1121,6 +1119,8 @@ type JVMPackagesConnection struct {
 
 // Log description: Configuration for logging and alerting, including to external services.
 type Log struct {
+	// AuditLog description: EXPERIMENTAL: Configuration for audit logging (specially formatted log entries for tracking sensitive events)
+	AuditLog *AuditLog `json:"auditLog,omitempty"`
 	// GitserverAccessLogs description: Enable gitserver access logging.
 	GitserverAccessLogs bool `json:"gitserver.accessLogs,omitempty"`
 	// Sentry description: Configuration for Sentry

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -66,6 +66,16 @@ type ApiRatelimit struct {
 	PerUser int `json:"perUser"`
 }
 
+// AuditLog description: EXPERIMENTAL: Audit Log
+type AuditLog struct {
+	// GitserverAccess description: Capture gitserver access logs as part of the audit log.
+	GitserverAccess bool `json:"gitserverAccess"`
+	// GraphQL description: Capture GraphQL requests and responses as part of the audit log.
+	GraphQL bool `json:"graphQL"`
+	// SecurityEvents description: Capture security events as part of the audit log.
+	SecurityEvents bool `json:"securityEvents"`
+}
+
 // AuthAccessTokens description: Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.
 type AuthAccessTokens struct {
 	// Allow description: Allow or restrict the use of access tokens. The default is "all-users-create", which enables all users to create access tokens. Use "none" to disable access tokens entirely. Use "site-admin-create" to restrict creation of new tokens to admin users (existing tokens will still work until revoked).
@@ -595,6 +605,8 @@ type ExperimentalFeatures struct {
 	AndOrQuery string `json:"andOrQuery,omitempty"`
 	// ApidocsSearchIndexing description: Deprecated.
 	ApidocsSearchIndexing string `json:"apidocs.search.indexing,omitempty"`
+	// AuditLog description: EXPERIMENTAL: Audit Log
+	AuditLog *AuditLog `json:"auditLog,omitempty"`
 	// BitbucketServerFastPerm description: DEPRECATED: Configure in Bitbucket Server config.
 	BitbucketServerFastPerm string `json:"bitbucketServerFastPerm,omitempty"`
 	// CustomGitFetch description: JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -534,36 +534,6 @@
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
-        },
-        "auditLog": {
-          "description": "EXPERIMENTAL: Configuration for audit logging (specially formatted log entries for tracking sensitive events)",
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "securityEvents": {
-              "description": "Capture security events as part of the audit log.",
-              "type": "boolean",
-              "default": true
-            },
-            "graphQL": {
-              "description": "Capture GraphQL requests and responses as part of the audit log.",
-              "type": "boolean",
-              "default": false
-            },
-            "gitserverAccess": {
-              "description": "Capture gitserver access logs as part of the audit log.",
-              "type": "boolean",
-              "default": false
-            }
-          },
-          "required": ["securityEvents", "graphQL", "gitserverAccess"],
-          "examples": [
-            {
-              "securityEvents": true,
-              "graphQL": false,
-              "gitserverAccess": false
-            }
-          ]
         }
       },
       "examples": [
@@ -1222,6 +1192,36 @@
           "description": "Enable gitserver access logging.",
           "type": "boolean",
           "default": false
+        },
+        "auditLog": {
+          "description": "EXPERIMENTAL: Configuration for audit logging (specially formatted log entries for tracking sensitive events)",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "securityEvents": {
+              "description": "Capture security events as part of the audit log.",
+              "type": "boolean",
+              "default": true
+            },
+            "graphQL": {
+              "description": "Capture GraphQL requests and responses as part of the audit log.",
+              "type": "boolean",
+              "default": false
+            },
+            "gitserverAccess": {
+              "description": "Capture gitserver access logs as part of the audit log.",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": ["securityEvents", "graphQL", "gitserverAccess"],
+          "examples": [
+            {
+              "securityEvents": true,
+              "graphQL": false,
+              "gitserverAccess": false
+            }
+          ]
         }
       }
     },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -536,7 +536,7 @@
           "!go": { "pointer": true }
         },
         "auditLog": {
-          "description": "EXPERIMENTAL: Audit Log",
+          "description": "EXPERIMENTAL: Configuration for audit logging (specially formatted log entries for tracking sensitive events)",
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -534,6 +534,36 @@
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
+        },
+        "auditLog": {
+          "description": "EXPERIMENTAL: Audit Log",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "securityEvents": {
+              "description": "Capture security events as part of the audit log.",
+              "type": "boolean",
+              "default": true
+            },
+            "graphQL": {
+              "description": "Capture GraphQL requests and responses as part of the audit log.",
+              "type": "boolean",
+              "default": false
+            },
+            "gitserverAccess": {
+              "description": "Capture gitserver access logs as part of the audit log.",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": ["securityEvents", "graphQL", "gitserverAccess"],
+          "examples": [
+            {
+              "securityEvents": true,
+              "graphQL": false,
+              "gitserverAccess": false
+            }
+          ]
         }
       },
       "examples": [


### PR DESCRIPTION
## Description

Add an experimental site config setting to enable audit log.

The setting is selective, the admin will specify which parts of the audit log they want enabled.

```
  "experimentalFeatures": {
    "auditLog": {
      "securityEvents": true,
      "graphQL": false,
      "gitserverAccess": false
    }
  },
```

## Test plan

Manually checked that the autocompletion in site config works.
