### PR TITLE
Make fuzzy finder modal wide again

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -1,6 +1,6 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
-.modal {
+#modal {
     height: 80vh;
     width: 80vw;
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -1,8 +1,11 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
-#modal {
+.modal {
     height: 80vh;
-    width: 80vw;
+    // `!important` is required to ensure that this rule is applied in the production bundle.
+    // It can be removed after addressing the following issue:
+    // https://github.com/sourcegraph/sourcegraph/issues/42217
+    width: 80vw !important;
 }
 
 .content {

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -231,7 +231,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
     return (
         <Modal
             position="center"
-            id={styles.modal}
+            className={styles.modal}
             onDismiss={() => props.onClose()}
             aria-label="Fuzzy finder: Find file"
         >

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -231,7 +231,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
     return (
         <Modal
             position="center"
-            className={styles.modal}
+            id={styles.modal}
             onDismiss={() => props.onClose()}
             aria-label="Fuzzy finder: Find file"
         >


### PR DESCRIPTION
The width of the fuzzy finder modal recently became very narrow. I wasn't able to track down the exact PR that impacted the width, but at some point the priority of the Wildcard `Modal` component overwrote the custom `width: 80vw` style we defined specifically for the fuzzy finder. This commit fixes the priority by use an `id` attribute instead of `class`.


Before
![CleanShot 2022-09-19 at 15 30 39](https://user-images.githubusercontent.com/1408093/191028911-8853aa7a-d3ad-4448-a8e8-fd9776405ae8.png)

After
![CleanShot 2022-09-19 at 15 29 46](https://user-images.githubusercontent.com/1408093/191028945-8f7dc2d9-0c04-4cf4-92de-092d7b51afc6.png)



## Test plan

Manually tested the PR locally and posted screenshots in the PR description.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-wider-fuzzy-finder.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-difkjjhsfe.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
