### PR TITLE
search: Fix search home page autofocus when search history is disabled

### DIFF
--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -165,7 +165,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         queryState={props.queryState}
                         onChange={props.setQueryState}
                         onSubmit={onSubmit}
-                        autoFocus={!coreWorkflowImprovementsEnabled && !isTouchOnlyDevice && props.autoFocus !== false}
+                        autoFocus={!showSearchHistory && !isTouchOnlyDevice && props.autoFocus !== false}
                         isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
                         applySuggestionsOnEnter={coreWorkflowImprovementsEnabled || applySuggestionsOnEnter}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41694

The search history feature used to be connected with the simple UI changes, but got its own feature flag at some point. This conditional needs to be updated to make auto focus work when the feature is disabled.



## Test plan

Open search home page, search input is auto focused again.

## App preview:

- [Web](https://sg-web-fkling-search-history-autofocus.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rwbtomrglw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
