### PR TITLE
search: Disable flaky code monitor screenshot test

### DIFF
--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -119,7 +119,8 @@ describe('Code monitoring', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring/new')
             await driver.page.waitForSelector('[data-testid="name-input"]')
 
-            await percySnapshotWithVariants(driver.page, 'Code monitoring - Form')
+            // Screenshot test disabled: https://github.com/sourcegraph/sourcegraph/issues/41743
+            // await percySnapshotWithVariants(driver.page, 'Code monitoring - Form')
             await accessibilityAudit(driver.page)
 
             await driver.page.type('[data-testid="name-input"]', 'test monitor')


### PR DESCRIPTION
I'm only disable the screenshot test part of it so that the behavior is still tested.

Tracked in https://github.com/sourcegraph/sourcegraph/issues/41743

## Test plan

CI

## App preview:

- [Web](https://sg-web-fkling-codemonitor-flake.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mazwrivsyo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
