### PR TITLE
search ui: fix column minimum width when sidebar is hidden

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/StreamingSearchResults.module.scss
@@ -22,7 +22,7 @@
             'contents sidebar';
 
         &--with-sidebar-hidden {
-            grid-template-columns: 1fr;
+            grid-template-columns: minmax(0, 1fr);
             grid-template-areas:
                 'infobar'
                 'contents';

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -337,7 +337,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                         enableCodeInsights={codeInsightsEnabled && isCodeInsightsEnabled(props.settingsCascade)}
                         enableCodeMonitoring={enableCodeMonitoring}
                         resultsFound={resultsFound}
-                        className={classNames('flex-grow-1', styles.infobar)}
+                        className={styles.infobar}
                         allExpanded={allExpanded}
                         onExpandAllResultsToggle={onExpandAllResultsToggle}
                         onSaveQueryClick={onSaveQueryClick}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/pull/41590#issuecomment-1242802787
This happens because, by default, CSS grid column minimum width is `auto`. By using `minmax`, we can make the minimum width be less.

## Test plan

Verified by running the same search as mentioned in https://github.com/sourcegraph/sourcegraph/pull/41590#issuecomment-1242802787

## App preview:

- [Web](https://sg-web-jp-sidebarhiddenwidth.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nviasvqblu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
