### PR TITLE
scanprotects: Add even more logging

### DIFF
--- a/enterprise/internal/authz/perforce/cmd/scanprotects/README.md
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/README.md
@@ -22,32 +22,124 @@ p4 protects -u USER | ./scanprotects -d "//some/test/depot/" |& jq '{"Body": .Bo
 
 ```
 ...
-DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "list group everyone * -//..."}
-DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": ["//depot/main/"]}
-DEBUG fullRepoPermsScanner perforce/protects.go:426 Adding exclude rules {"rules": ["//**"]}
-DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "read group readonly * //..."}
-DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": ["//depot/main/"]}
-DEBUG fullRepoPermsScanner perforce/protects.go:391 Adding include rules {"rules": ["//**"]}
-DEBUG fullRepoPermsScanner perforce/protects.go:404 Removing conflicting exclude rule {"rule": "//**"}
-DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "write group dev * //depot/main/..."}
-DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": ["//depot/main/"]}
-DEBUG fullRepoPermsScanner perforce/protects.go:391 Adding include rules {"rules": ["**"]}
-DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "open group dev * //depot/main/migration/..."}
-DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": ["//depot/main/"]}
-DEBUG fullRepoPermsScanner perforce/protects.go:391 Adding include rules {"rules": ["migration/**"]}
-DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "write group dev * //depot/training/..."}
-DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
-DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "write group dev * //depot/test/..."}
-DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
-DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "read group baseapp_readonly * //depot/630/..."}
-DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
-DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "read group baseapp_readonly * //depot/636/..."}
-DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
-DEBUG scanProtects perforce/protects.go:228 Scanning protects line {"line": "write group dev * //depot/630/..."}
-DEBUG fullRepoPermsScanner perforce/protects.go:382 Relevant depots {"depots": []}
+"Processing parsed line"
+{
+  "match": "//depot/main/base/jkl/...",
+  "isExclusion": false
+}
+"Relevant depots"
+{
+  "depots": [
+    "//depot/main"
+  ]
+}
+"Adding include rules"
+{
+  "rules": [
+    "base/jkl/**"
+  ]
+}
+"Processing parsed line"
+{
+  "match": "//depot/.../.../base/foo/...",
+  "isExclusion": false
+}
+"Relevant depots"
+{
+  "depots": [
+    "//depot/main"
+  ]
+}
+"Adding include rules"
+{
+  "rules": [
+    "**/**/base/foo/**"
+  ]
+}
+"Processing parsed line"
+{
+  "match": "//depot/.../.../base/jkl/...",
+  "isExclusion": false
+}
+"Relevant depots"
+{
+  "depots": [
+    "//depot/main"
+  ]
+}
+"Adding include rules"
+{
+  "rules": [
+    "**/**/base/jkl/**"
+  ]
+}
+"Processing parsed line"
+{
+  "match": "//depot/.../.../base/foo/config/labels/...",
+  "isExclusion": false
+}
+"Relevant depots"
+{
+  "depots": [
+    "//depot/main"
+  ]
+}
+"Adding include rules"
+{
+  "rules": [
+    "**/**/base/foo/config/labels/**"
+  ]
+}
+"Processing parsed line"
+{
+  "match": "//depot/.../.../base/foo-test/...",
+  "isExclusion": false
+}
+"Relevant depots"
+{
+  "depots": [
+    "//depot/main"
+  ]
+}
+"Adding include rules"
+{
+  "rules": [
+    "**/**/base/foo-test/**"
+  ]
+}
+"Processing parsed line"
+{
+  "match": "//depot/.../.../base/jkl/test/...",
+  "isExclusion": false
+}
+"Relevant depots"
+{
+  "depots": [
+    "//depot/main"
+  ]
+}
+"Adding include rules"
+{
+  "rules": [
+    "**/**/base/jkl/test/**"
+  ]
+}
+"Processing parsed line"
+{
+  "match": "//depot/.../base/foo/config/labels/...",
+  "isExclusion": false
+}
+"Relevant depots"
+{
+  "depots": [
+    "//depot/main"
+  ]
+}
+"Adding include rules"
+{
+  "rules": [
+    "**/base/foo/config/labels/**"
+  ]
+}
 ...
-DEBUG scanprotects scanprotects/main.go:50 Depot {"depot": "//depot/main/"}
-DEBUG scanprotects scanprotects/main.go:53 Sub repo permissions {"depot": "//depot/main/"}
-DEBUG scanprotects scanprotects/main.go:55 Include rule {"rule": "base/foo/**"}
-DEBUG scanprotects scanprotects/main.go:55 Include rule {"rule": "base/jkl/**"}
 ```

--- a/enterprise/internal/authz/perforce/cmd/scanprotects/main_test.go
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/main_test.go
@@ -26,7 +26,7 @@ func TestPerformDebugScan(t *testing.T) {
 	logged := exporter()
 	// For now we'll just check that the count as well as first and last lines are
 	// what we expect
-	assert.Len(t, logged, 395)
+	assert.Len(t, logged, 449)
 	assert.Equal(t, "Converted depot to glob", logged[0].Message)
 	assert.Equal(t, "Include rule", logged[len(logged)-1].Message)
 }

--- a/enterprise/internal/authz/perforce/protects.go
+++ b/enterprise/internal/authz/perforce/protects.go
@@ -255,6 +255,7 @@ func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner) error {
 
 		// Do stuff to line
 		if err := s.processLine(parsedLine); err != nil {
+			logger.Error("processLine error", log.Error(err))
 			return err
 		}
 	}
@@ -366,6 +367,7 @@ func fullRepoPermsScanner(logger log.Logger, perms *authz.ExternalUserPermission
 
 	return &protectsScanner{
 		processLine: func(line p4ProtectLine) error {
+			logger.Debug("Processing parsed line", log.String("match", line.match), log.Bool("isExclusion", line.isExclusion))
 			match, err := convertToGlobMatch(line.match)
 			if err != nil {
 				return err
@@ -374,6 +376,11 @@ func fullRepoPermsScanner(logger log.Logger, perms *authz.ExternalUserPermission
 
 			// Depots that this match pertains to
 			depots := relevantDepots(match)
+
+			if len(depots) == 0 {
+				logger.Debug("Zero relevant depots, returning early")
+				return nil
+			}
 
 			depotStrings := make([]string, len(depots))
 			for i := range depots {


### PR DESCRIPTION
This is to try and debug an issue we're seeing where we see a line being
logged but but then no subsequent "relevant depots" logs. More events
are now logged between those events.

Sample output was also updated.

## Test plan

Tests updated