### PR TITLE
ci: hotfix the token for QA test suite

### DIFF
--- a/dev/ci/integration/qa/run.sh
+++ b/dev/ci/integration/qa/run.sh
@@ -19,4 +19,7 @@ echo "--- Running QA tests"
 
 echo "--- test.sh"
 export IMAGE=${IMAGE:-"us.gcr.io/sourcegraph-dev/server:$CANDIDATE_VERSION"}
+# Hotfix (Owner: @jhchabran)
+GITHUB_TOKEN="$(gcloud secrets versions access latest --secret=QA_GITHUB_TOKEN --quiet --project=sourcegraph-ci)"
+export GITHUB_TOKEN
 ./dev/ci/integration/run-integration.sh "${root_dir}/dev/ci/integration/qa/test.sh"

--- a/dev/ci/integration/qa/run.sh
+++ b/dev/ci/integration/qa/run.sh
@@ -19,7 +19,9 @@ echo "--- Running QA tests"
 
 echo "--- test.sh"
 export IMAGE=${IMAGE:-"us.gcr.io/sourcegraph-dev/server:$CANDIDATE_VERSION"}
+set +x
 # Hotfix (Owner: @jhchabran)
 GITHUB_TOKEN="$(gcloud secrets versions access latest --secret=QA_GITHUB_TOKEN --quiet --project=sourcegraph-ci)"
 export GITHUB_TOKEN
+set -x
 ./dev/ci/integration/run-integration.sh "${root_dir}/dev/ci/integration/qa/test.sh"


### PR DESCRIPTION
The support ticket with GitHub is taking too long, this PR forces the QA test suite to use a different token, to avoid having all those flakes. This should have been done way earlier, my bad. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Ran a main-dry-run here: https://buildkite.com/sourcegraph/sourcegraph/builds/172914#0183567a-a069-4e97-af4c-063a691c626e 

I have leaked the token in there by accident (missing `set +x`, I've since then regenerated that token, so we're good) 
