### PR TITLE
uploadstore: Allow S3 endpoint to be set when backend != `minio`

### DIFF
--- a/internal/uploadstore/config.go
+++ b/internal/uploadstore/config.go
@@ -24,6 +24,9 @@ func normalizeConfig(t Config) Config {
 	if o.Backend == "minio" {
 		// No manual provisioning on minIO.
 		o.ManageBucket = true
+
+		// No subdomains on built-inminIO.
+		o.S3.UsePathStyle = true
 	}
 	return o
 }

--- a/internal/uploadstore/config.go
+++ b/internal/uploadstore/config.go
@@ -25,7 +25,7 @@ func normalizeConfig(t Config) Config {
 		// No manual provisioning on minIO.
 		o.ManageBucket = true
 
-		// No subdomains on built-inminIO.
+		// No subdomains on built-in minIO.
 		o.S3.UsePathStyle = true
 	}
 	return o

--- a/internal/uploadstore/config_test.go
+++ b/internal/uploadstore/config_test.go
@@ -8,45 +8,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestS3ClientOptions(t *testing.T) {
 	config := Config{
 		S3: S3Config{
-			Endpoint: "http://minio:9000",
+			Endpoint:     "http://minio:9000",
+			UsePathStyle: true,
 		},
 	}
 
-	// minIO
-	{
-		options := &s3.Options{}
-		s3ClientOptions("minio", config.S3)(options)
+	options := &s3.Options{}
+	s3ClientOptions(config.S3)(options)
 
-		if options.EndpointResolver == nil {
-			t.Fatalf("unexpected endpoint option")
-		}
-		endpoint, err := options.EndpointResolver.ResolveEndpoint("us-east-2", s3.EndpointResolverOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if endpoint.URL != "http://minio:9000" {
-			t.Errorf("unexpected endpoint. want=%s have=%s", "http://minio:9000", endpoint.URL)
-		}
-
-		if !options.UsePathStyle {
-			t.Errorf("invalid UsePathStyle setting for S3Options")
-		}
+	if options.EndpointResolver == nil {
+		t.Fatalf("unexpected endpoint option")
+	}
+	endpoint, err := options.EndpointResolver.ResolveEndpoint("us-east-2", s3.EndpointResolverOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if endpoint.URL != "http://minio:9000" {
+		t.Errorf("unexpected endpoint. want=%s have=%s", "http://minio:9000", endpoint.URL)
 	}
 
-	// S3
-	{
-		options := &s3.Options{}
-		s3ClientOptions("s3", config.S3)(options)
-
-		if diff := cmp.Diff(&s3.Options{}, options, cmpopts.IgnoreUnexported(s3.Options{})); diff != "" {
-			t.Fatalf("invalid s3 options returned for S3: %s", diff)
-		}
+	if !options.UsePathStyle {
+		t.Errorf("invalid UsePathStyle setting for S3Options")
 	}
 }
 

--- a/internal/uploadstore/s3_client.go
+++ b/internal/uploadstore/s3_client.go
@@ -36,6 +36,7 @@ var _ Store = &s3Store{}
 type S3Config struct {
 	Region          string
 	Endpoint        string
+	UsePathStyle    bool
 	AccessKeyID     string
 	SecretAccessKey string
 	SessionToken    string
@@ -48,7 +49,7 @@ func newS3FromConfig(ctx context.Context, config Config, operations *Operations)
 		return nil, err
 	}
 
-	s3Client := s3.NewFromConfig(cfg, s3ClientOptions(config.Backend, config.S3))
+	s3Client := s3.NewFromConfig(cfg, s3ClientOptions(config.S3))
 	api := &s3APIShim{s3Client}
 	uploader := &s3UploaderShim{manager.NewUploader(s3Client)}
 	return newS3WithClients(api, uploader, config.Bucket, config.ManageBucket, s3BucketLifecycleConfiguration(config.Backend, config.TTL), operations), nil
@@ -336,12 +337,13 @@ func s3ClientConfig(ctx context.Context, s3config S3Config) (aws.Config, error) 
 	return awsconfig.LoadDefaultConfig(ctx, optFns...)
 }
 
-func s3ClientOptions(backend string, config S3Config) func(o *s3.Options) {
+func s3ClientOptions(config S3Config) func(o *s3.Options) {
 	return func(o *s3.Options) {
-		if backend == "minio" {
+		if config.Endpoint != "" {
 			o.EndpointResolver = s3.EndpointResolverFromURL(config.Endpoint)
-			o.UsePathStyle = true
 		}
+
+		o.UsePathStyle = config.UsePathStyle
 	}
 }
 


### PR DESCRIPTION
Fixes #41597. This PR allows the S3 endpoint to be set while not requiring use of the minio backend (which forces other settings to be hard-coded as we assume it was *our* minio instance).

## Test plan

Existing unit and integration tests.