### PR TITLE
search: Select first suggestion on Tab

### DIFF
--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -211,7 +211,7 @@ export function searchQueryAutocompletion(
                               run(view) {
                                   // Select first completion item if none is selected
                                   // and items are available.
-                                  if (selectedCompletion(view.state) == null) {
+                                  if (selectedCompletion(view.state) === null) {
                                       if (currentCompletions(view.state).length > 0) {
                                           view.dispatch({ effects: setSelectedCompletion(0) })
                                           return true

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -9,6 +9,9 @@ import {
     snippet,
     CompletionSource,
     acceptCompletion,
+    selectedCompletion,
+    currentCompletions,
+    setSelectedCompletion,
 } from '@codemirror/autocomplete'
 import { Extension, Prec } from '@codemirror/state'
 import { keymap, EditorView } from '@codemirror/view'
@@ -201,7 +204,25 @@ export function searchQueryAutocompletion(
         Prec.highest(
             keymap.of(
                 applyOnEnter
-                    ? [...completionKeymap, { key: 'Tab', run: acceptCompletion }]
+                    ? [
+                          ...completionKeymap,
+                          {
+                              key: 'Tab',
+                              run(view) {
+                                  // Select first completion item if none is selected
+                                  // and items are available.
+                                  if (selectedCompletion(view.state) == null) {
+                                      if (currentCompletions(view.state).length > 0) {
+                                          view.dispatch({ effects: setSelectedCompletion(0) })
+                                          return true
+                                      }
+                                      return false
+                                  }
+                                  // Otherwise apply the selected completion item
+                                  return acceptCompletion(view)
+                              },
+                          },
+                      ]
                     : completionKeymap.map(keybinding =>
                           keybinding.key === 'Enter' ? { ...keybinding, key: 'Tab' } : keybinding
                       )


### PR DESCRIPTION
To ease the transition to not having the first selection be selected by default, this commit changes the Tab behavior to select the first suggestion if none is selected.
That means if the suggestions are open and a user presses Tab (out of habit) instead of moving focus to the next focusable element, the first suggestion is selected. Pressing Tab a second time would apply (i.e. insert) the suggestion.

[Original discussion on Slack](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1662572086260509).

Demo (you can't see it but I'm pressing Tab twice):


https://user-images.githubusercontent.com/179026/191105381-addd47aa-6685-4558-bf2a-4c2b7cb572a1.mp4


Not quite sure how we want to proceed merging this for 4.0 since the branch cut was already today...


## Test plan

- Open search homepage
- Enter query
- Wait for suggestion to appear and press Tab
  - First suggestion should be selected
- Press Tab again and suggestion should be applied

## App preview:

- [Web](https://sg-web-fkling-query-input-suggestions-tab.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uqwmhbskyk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
