### PR TITLE
monitoring: add simple e2e test for label injection

### DIFF
--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -208,6 +208,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 	}
 
 	// Clean up dangling assets
+	logger.Info("generated assets", log.Strings("files", generatedAssets))
 	if !opts.DisablePrune {
 		logger.Debug("Pruning dangling assets")
 		if err := pruneAssets(logger, generatedAssets, opts.GrafanaDir, opts.PrometheusDir); err != nil {

--- a/monitoring/monitoring/generator_test.go
+++ b/monitoring/monitoring/generator_test.go
@@ -1,0 +1,46 @@
+package monitoring_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/monitoring/definitions"
+	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
+)
+
+// TestGenerate should cover some default generator paths with definitions.Default.
+func TestGenerate(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		td := t.TempDir()
+		err := monitoring.Generate(logtest.Scoped(t),
+			monitoring.GenerateOptions{
+				DisablePrune:  true,
+				GrafanaDir:    filepath.Join(td, "grafana"),
+				PrometheusDir: filepath.Join(td, "prometheus"),
+				DocsDir:       filepath.Join(td, "docs"),
+			},
+			definitions.Default()...)
+		assert.NoError(t, err)
+	})
+
+	t.Run("with inject labels", func(t *testing.T) {
+		td := t.TempDir()
+		err := monitoring.Generate(logtest.Scoped(t),
+			monitoring.GenerateOptions{
+				DisablePrune:  true,
+				GrafanaDir:    filepath.Join(td, "grafana"),
+				PrometheusDir: filepath.Join(td, "prometheus"),
+				DocsDir:       filepath.Join(td, "docs"),
+
+				InjectLabelMatchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
+				},
+			},
+			definitions.Default()...)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Adds a simple test for the label injection introduced in #41644 using the default dashboards, using the improved parameterization of the monitoring generator introduced in #41703 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tests pass