### PR TITLE
insights: add integration tests for aggregations API

### DIFF
--- a/dev/gqltest/search_aggregations_test.go
+++ b/dev/gqltest/search_aggregations_test.go
@@ -1,0 +1,1 @@
+package main

--- a/dev/gqltest/search_aggregations_test.go
+++ b/dev/gqltest/search_aggregations_test.go
@@ -82,7 +82,7 @@ func TestAggregations(t *testing.T) {
 		t.Skip("Environment variable GITHUB_TOKEN is not set")
 	}
 
-	_, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
+	esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "gqltest-github-search",
 		Config: mustMarshalJSONString(struct {
@@ -102,6 +102,7 @@ func TestAggregations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	removeExternalServiceAfterTest(t, esID)
 
 	err = client.WaitForReposToBeCloned(
 		"sgtest/go-diff",

--- a/dev/gqltest/search_aggregations_test.go
+++ b/dev/gqltest/search_aggregations_test.go
@@ -84,7 +84,7 @@ func TestAggregations(t *testing.T) {
 
 	esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
 		Kind:        extsvc.KindGitHub,
-		DisplayName: "gqltest-github-search",
+		DisplayName: "gqltest-aggregation-search",
 		Config: mustMarshalJSONString(struct {
 			URL                   string   `json:"url"`
 			Token                 string   `json:"token"`

--- a/dev/gqltest/search_aggregations_test.go
+++ b/dev/gqltest/search_aggregations_test.go
@@ -1,1 +1,22 @@
 package main
+
+import "testing"
+
+func TestModeAvailability(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid query returns unavailable", func(t *testing.T) {
+		availabilities, err := client.ModeAvailability("fork:insights test", "literal")
+		if err != nil {
+			t.Error(err)
+		}
+		for _, response := range availabilities {
+			if response.Available == true {
+				t.Errorf("expected mode %v to be unavailable", response.Mode)
+			}
+			if response.ReasonUnavailable == nil {
+				t.Errorf("expected to receive an unavailable reason, got nil")
+			}
+		}
+	})
+}

--- a/dev/gqltest/search_aggregations_test.go
+++ b/dev/gqltest/search_aggregations_test.go
@@ -8,7 +8,7 @@ func TestModeAvailability(t *testing.T) {
 	t.Run("invalid query returns unavailable", func(t *testing.T) {
 		availabilities, err := client.ModeAvailability("fork:insights test", "literal")
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		for _, response := range availabilities {
 			if response.Available == true {
@@ -19,4 +19,58 @@ func TestModeAvailability(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("returns repo path capture group", func(t *testing.T) {
+		query := `(\w)\s\*testing.T`
+		availabilities, err := client.ModeAvailability(query, "regexp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for mode, response := range availabilities {
+			if mode == "REPO" || mode == "PATH" || mode == "CAPTURE_GROUP" {
+				if response.Available != true {
+					t.Errorf("expected mode %v to be available for query %q", response.Mode, query)
+				}
+				if response.ReasonUnavailable != nil {
+					t.Errorf("expected to be available, got %q", *response.ReasonUnavailable)
+				}
+			} else {
+				if response.Available == true {
+					t.Errorf("expected mode %v to be unavailable for query %q", response.Mode, query)
+				}
+				if response.ReasonUnavailable == nil {
+					t.Errorf("expected to receive an unavailable reason, got nil")
+				}
+			}
+		}
+	})
+
+	t.Run("returns repo author", func(t *testing.T) {
+		query := "type:commit insights"
+		availabilities, err := client.ModeAvailability(query, "literal")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for mode, response := range availabilities {
+			if mode == "REPO" || mode == "AUTHOR" {
+				if response.Available != true {
+					t.Errorf("expected mode %v to be available for query %q", response.Mode, query)
+				}
+				if response.ReasonUnavailable != nil {
+					t.Errorf("expected to be available, got %q", *response.ReasonUnavailable)
+				}
+			} else {
+				if response.Available == true {
+					t.Errorf("expected mode %v to be unavailable for query %q", response.Mode, query)
+				}
+				if response.ReasonUnavailable == nil {
+					t.Errorf("expected to receive an unavailable reason, got nil")
+				}
+			}
+		}
+	})
+}
+
+func TestAggregations(t *testing.T) {
+
 }

--- a/dev/gqltest/search_aggregations_test.go
+++ b/dev/gqltest/search_aggregations_test.go
@@ -104,7 +104,7 @@ func TestAggregations(t *testing.T) {
 	}
 
 	err = client.WaitForReposToBeCloned(
-		"sgtest/go-dff",
+		"sgtest/go-diff",
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/dev/gqltest/search_aggregations_test.go
+++ b/dev/gqltest/search_aggregations_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 	"testing"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 )
 
 func TestModeAvailability(t *testing.T) {
@@ -93,7 +94,7 @@ func TestAggregations(t *testing.T) {
 			URL:   "https://ghe.sgdev.org/",
 			Token: *githubToken,
 			Repos: []string{
-				"sgtest/mux",
+				"sgtest/go-diff",
 			},
 			RepositoryPathPattern: "github.com/{nameWithOwner}",
 		}),
@@ -103,14 +104,14 @@ func TestAggregations(t *testing.T) {
 	}
 
 	err = client.WaitForReposToBeCloned(
-		"sgtest/mux",
+		"sgtest/go-dff",
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = client.WaitForReposToBeIndexed(
-		"sgtest/mux",
+		"sgtest/go-diff",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -152,7 +153,7 @@ func TestAggregations(t *testing.T) {
 	t.Run("returns results", func(t *testing.T) {
 		mode := "CAPTURE_GROUP"
 		args := gqltestutil.AggregationArgs{
-			Query:       `repo:^github\.com/sgtest/mux$ (\w+)\s*mux lang:go -file:test`,
+			Query:       `(\w+) main lang:go`,
 			PatternType: "regexp",
 			Mode:        &mode,
 		}
@@ -172,7 +173,7 @@ func TestAggregations(t *testing.T) {
 				t.Fatalf("Got unexpected unavailable reason: %v", resp.Reason)
 			}
 			// We don't assert on the results because these could change, but we want to get some.
-			// However, the query is for `mux`, given the repo we should always get at least *one* result.
+			// However, the query is for `main`, given the go repo we should always get at least *one* result.
 			if len(resp.Groups) == 0 {
 				t.Error("Did not get any results")
 			}

--- a/dev/gqltest/search_aggregations_test.go
+++ b/dev/gqltest/search_aggregations_test.go
@@ -105,14 +105,14 @@ func TestAggregations(t *testing.T) {
 	removeExternalServiceAfterTest(t, esID)
 
 	err = client.WaitForReposToBeCloned(
-		"sgtest/go-diff",
+		"github.com/sgtest/go-diff",
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = client.WaitForReposToBeIndexed(
-		"sgtest/go-diff",
+		"github.com/sgtest/go-diff",
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -7,10 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/observation"
-
-	"github.com/sourcegraph/sourcegraph/internal/search/limits"
-
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -20,8 +16,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )

--- a/enterprise/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/internal/insights/resolvers/aggregates_resolvers.go
@@ -48,7 +48,7 @@ const generalTimeoutMsg = "The query was unable to complete in the allocated tim
 const proactiveResultLimitMsg = "The query exceeded the number of results allowed over this time period."
 
 // These should be very rare
-const unknowAggregationModeMsg = "The requested grouping is not supported."                     // example if a request with mode = NOT_A_REAL_MODE came in, should fail at graphql level
+const unknownAggregationModeMsg = "The requested grouping is not supported."                    // example if a request with mode = NOT_A_REAL_MODE came in, should fail at graphql level
 const unableToModifyQueryMsg = "The search query was unable to be updated to support grouping." // if the query was valid but we were unable to add timeout: & count:all
 const unableToCountGroupsMsg = "The search results were unable to be grouped successfully."     // if there was a failure while adding up the results
 
@@ -146,7 +146,7 @@ func (r *searchAggregateResolver) Aggregations(ctx context.Context, args graphql
 		r.getLogger().Error("no aggregation counting function for mode", log.String("mode", string(aggregationMode)), log.Error(err))
 		return &searchAggregationResultResolver{
 			resolver: newSearchAggregationNotAvailableResolver(
-				notAvailableReason{reason: unknowAggregationModeMsg, reasonType: types.ERROR_OCCURRED},
+				notAvailableReason{reason: unknownAggregationModeMsg, reasonType: types.ERROR_OCCURRED},
 				aggregationMode),
 		}, nil
 	}

--- a/internal/gqltestutil/search_aggregations.go
+++ b/internal/gqltestutil/search_aggregations.go
@@ -67,6 +67,7 @@ func (c *Client) Aggregations(args AggregationArgs) (AggregationResponse, error)
 			  }
 			  ... on SearchAggregationNotAvailable {
 				reason
+				reasonType
 			  }
 			}
 		  }
@@ -74,10 +75,11 @@ func (c *Client) Aggregations(args AggregationArgs) (AggregationResponse, error)
 	`
 
 	variables := map[string]any{
-		"query":       args.Query,
-		"patternType": args.PatternType,
-		"mode":        args.Mode,
-		"limit":       args.Limit,
+		"query":           args.Query,
+		"patternType":     args.PatternType,
+		"mode":            args.Mode,
+		"limit":           args.Limit,
+		"extendedTimeout": args.ExtendedTimeout,
 	}
 
 	var resp struct {
@@ -96,14 +98,16 @@ func (c *Client) Aggregations(args AggregationArgs) (AggregationResponse, error)
 }
 
 type AggregationArgs struct {
-	Query       string
-	PatternType string
-	Mode        *string
-	Limit       *int32
+	Query           string
+	PatternType     string
+	ExtendedTimeout bool
+	Mode            *string
+	Limit           *int32
 }
 
 type AggregationResponse struct {
-	Reason string // If this is set the fields below will be empty.
+	ReasonType string
+	Reason     string // If this is set the fields below will be empty.
 
 	Groups []string // List of results in form of labels
 	Mode   string

--- a/internal/gqltestutil/search_aggregations.go
+++ b/internal/gqltestutil/search_aggregations.go
@@ -1,1 +1,50 @@
 package gqltestutil
+
+//type AggregationArgs struct {
+//	Query       string `json:"query"`
+//	PatternType string `json:"patternType"`
+//}
+
+func (c *Client) ModeAvailability(query, patternType string) (map[string]ModeAvailabilityResponse, error) {
+	const gqlQuery = `
+		query ModeAvailability($query: String!, $patternType: SearchPatternType!) {
+			searchQueryAggregate(query: $query, patternType: $patternType) {
+				modeAvailability {
+					mode
+					available
+					reasonUnavailable
+				}
+			}
+		}
+	`
+
+	variables := map[string]any{
+		"query":       query,
+		"patternType": patternType,
+	}
+	var resp struct {
+		Data struct {
+			SearchQueryAggregate struct {
+				ModeAvailability []ModeAvailabilityResponse
+			} `json:"searchQueryAggregate"`
+		} `json:"data"`
+	}
+
+	err := c.GraphQL("", gqlQuery, variables, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	modeAvailability := make(map[string]ModeAvailabilityResponse)
+	for _, response := range resp.Data.SearchQueryAggregate.ModeAvailability {
+		modeAvailability[response.Mode] = response
+	}
+
+	return modeAvailability, nil
+}
+
+type ModeAvailabilityResponse struct {
+	Mode              string  `json:"mode"`
+	Available         bool    `json:"available"`
+	ReasonUnavailable *string `json:"reasonUnavailable"`
+}

--- a/internal/gqltestutil/search_aggregations.go
+++ b/internal/gqltestutil/search_aggregations.go
@@ -1,10 +1,5 @@
 package gqltestutil
 
-//type AggregationArgs struct {
-//	Query       string `json:"query"`
-//	PatternType string `json:"patternType"`
-//}
-
 func (c *Client) ModeAvailability(query, patternType string) (map[string]ModeAvailabilityResponse, error) {
 	const gqlQuery = `
 		query ModeAvailability($query: String!, $patternType: SearchPatternType!) {
@@ -47,4 +42,69 @@ type ModeAvailabilityResponse struct {
 	Mode              string  `json:"mode"`
 	Available         bool    `json:"available"`
 	ReasonUnavailable *string `json:"reasonUnavailable"`
+}
+
+func (c *Client) Aggregations(args AggregationArgs) (AggregationResponse, error) {
+	gqlQuery := `
+		query ModeAvailability(
+		  $query: String!
+		  $patternType: SearchPatternType!
+		  $mode: SearchAggregationMode
+		) {
+		  searchQueryAggregate(query: $query, patternType: $patternType) {
+			aggregations(mode: $mode) {
+			  ... on ExhaustiveSearchAggregationResult {
+				mode
+				groups {
+				  query
+				}
+			  }
+			  ... on NonExhaustiveSearchAggregationResult {
+				mode
+				groups {
+				  query
+				}
+			  }
+			  ... on SearchAggregationNotAvailable {
+				reason
+			  }
+			}
+		  }
+		}
+	`
+
+	variables := map[string]any{
+		"query":       args.Query,
+		"patternType": args.PatternType,
+		"mode":        args.Mode,
+		"limit":       args.Limit,
+	}
+
+	var resp struct {
+		Data struct {
+			SearchQueryAggregate struct {
+				Aggregations AggregationResponse
+			} `json:"searchQueryAggregate"`
+		} `json:"data"`
+	}
+
+	err := c.GraphQL("", gqlQuery, variables, &resp)
+	if err != nil {
+		return AggregationResponse{}, err
+	}
+	return resp.Data.SearchQueryAggregate.Aggregations, nil
+}
+
+type AggregationArgs struct {
+	Query       string
+	PatternType string
+	Mode        *string
+	Limit       *int32
+}
+
+type AggregationResponse struct {
+	Reason string // If this is set the fields below will be empty.
+
+	Groups []string // List of results in form of labels
+	Mode   string
 }

--- a/internal/gqltestutil/search_aggregations.go
+++ b/internal/gqltestutil/search_aggregations.go
@@ -1,0 +1,1 @@
+package gqltestutil

--- a/internal/gqltestutil/search_aggregations.go
+++ b/internal/gqltestutil/search_aggregations.go
@@ -109,6 +109,10 @@ type AggregationResponse struct {
 	ReasonType string
 	Reason     string // If this is set the fields below will be empty.
 
-	Groups []string // List of results in form of labels
-	Mode   string
+	Groups []struct {
+		Label string
+		Count int32
+		Query string
+	} // List of results in form of labels
+	Mode string
 }


### PR DESCRIPTION
closes #41701 

adds some base for aggregations integrations tests

these should be straightforward to answer. I wasn't sure if there were particular cases we wanted to cover as we cover so many in unit tests so feel free to suggest.

## Test plan

these have run on CI:
```
sg ci build backend-integration
```

I've made them run locally with the following setup:
* copy the github token from our extsvc config
* change the extsvc test url to github.com
* run `sg start enterprise-e2e`
* call the following:
```
GITHUB_TOKEN="TOKEN" go test -long -run TestAggregations -base-url "https://sourcegraph.test:3443" -v
```

for the mode availability tests you don't need the token, you can just run them against our docker image. here are the commands:
```
docker run --publish 7080:7080 --rm sourcegraph/server:insiders
go test -long -run TestModeAvailability -v
```