### PR TITLE
Fix Scroll on Site Admin Pages

### DIFF
--- a/client/web/src/hooks/useScrollManager/useScrollManager.test.tsx
+++ b/client/web/src/hooks/useScrollManager/useScrollManager.test.tsx
@@ -46,6 +46,9 @@ describe('useScrollManager', () => {
         act(() => {
             wrapper.history.push('/page-1')
         })
+        // Called when pushing history
+        assert.callCount(scrollToMock, 1)
+        assert.calledWith(scrollToMock, 0, 0)
 
         const pageOneContainer = screen.getByTestId('page-1')
         const PAGE_ONE_SCROLL_POSITION = 100
@@ -56,6 +59,9 @@ describe('useScrollManager', () => {
         act(() => {
             wrapper.history.push('/page-2')
         })
+        // Called when pushing history
+        assert.callCount(scrollToMock, 2)
+        assert.calledWith(scrollToMock, 0, 0)
 
         const pageTwoContainer = screen.getByTestId('page-2')
         const PAGE_TWO_SCROLL_POSITION = 300
@@ -67,7 +73,7 @@ describe('useScrollManager', () => {
             wrapper.history.goBack()
         })
         // Check that we attempt to scroll back to the correct position
-        assert.callCount(scrollToMock, 1)
+        assert.callCount(scrollToMock, 3)
         assert.calledWith(scrollToMock, 0, PAGE_ONE_SCROLL_POSITION)
 
         // Navigate forwards to second page
@@ -75,14 +81,22 @@ describe('useScrollManager', () => {
             wrapper.history.goForward()
         })
         // Check that we attempt to scroll back to the correct position
-        assert.callCount(scrollToMock, 2)
+        assert.callCount(scrollToMock, 4)
         assert.calledWith(scrollToMock, 0, PAGE_TWO_SCROLL_POSITION)
 
         // Navigate directly to the first page
         act(() => {
             wrapper.history.push('/page-1')
         })
-        // Check that we have not attempted to scroll (callCount is still 2)
-        assert.callCount(scrollToMock, 2)
+        // Check that we attempted to scroll back to top on push
+        assert.callCount(scrollToMock, 5)
+        assert.calledWith(scrollToMock, 0, 0)
+
+        // Replace history with second page
+        act(() => {
+            wrapper.history.replace('/page-2')
+        })
+        // Check that we did not attempt to scroll on history replace
+        assert.callCount(scrollToMock, 5)
     })
 })

--- a/client/web/src/hooks/useScrollManager/useScrollManager.ts
+++ b/client/web/src/hooks/useScrollManager/useScrollManager.ts
@@ -101,7 +101,7 @@ export function useScrollManager(containerKey: string, containerRef: React.RefOb
                     })
             }
         } else if (action === 'PUSH') {
-            // In the case of pushing new history, make sure we always start at the top of the container
+            // In the case of pushing new history (e.g. clicking a navigation link), make sure we always start at the top of the container
             containerRef.current?.scrollTo(0, 0)
         }
 

--- a/client/web/src/hooks/useScrollManager/useScrollManager.ts
+++ b/client/web/src/hooks/useScrollManager/useScrollManager.ts
@@ -100,7 +100,11 @@ export function useScrollManager(containerKey: string, containerRef: React.RefOb
                         }
                     })
             }
+        } else if (action === 'PUSH') {
+            // In the case of pushing new history, make sure we always start at the top of the container
+            containerRef.current?.scrollTo(0, 0)
         }
+
         // This should only run when `pathname`/`action` change; ignore changes to `containerKey` or `containerRef` as those should not trigger a scroll restoration
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [location.pathname, action])

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -1,10 +1,10 @@
-import React, { useLayoutEffect, useMemo, useRef } from 'react'
+import React, { useMemo, useRef } from 'react'
 
 import classNames from 'classnames'
 import { isEqual } from 'lodash'
 import ChartLineVariantIcon from 'mdi-react/ChartLineVariantIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import { Route, RouteComponentProps, Switch, useLocation } from 'react-router'
+import { Route, RouteComponentProps, Switch } from 'react-router'
 
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -162,15 +162,7 @@ export const analyticsRoutes: readonly SiteAdminAreaRoute[] = [
 ]
 
 const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildren<SiteAdminAreaProps>> = props => {
-    const { pathname } = useLocation()
-
     const reference = useRef<HTMLDivElement>(null)
-
-    useLayoutEffect(() => {
-        if (reference.current) {
-            reference.current.scrollIntoView()
-        }
-    }, [pathname])
 
     const [isAdminAnalyticsDisabled] = useFeatureFlag('admin-analytics-disabled', false)
 


### PR DESCRIPTION
Fixes #41746.

I accidentally introduced this behavior in #41561. For some reason (exact cause still TBD), the page will scroll slightly in some cases when pushing a new location to history (when clicking on links in the application). To resolve this, we can just make sure the page scrolls the top by default during a history "push" action.

However, there is still an outstanding issue where the container will still scroll slightly on refresh, since that is a "replace" action. We **do not** want to scroll-to-top automatically on "replace," though, since that will cause the page to jump when clicking "show more" on a list (which is the original issue my PR above resolved, #32302).

## Test plan

Navigate to site admin area, clicking around among those pages should start with the scroll at the top. It should still preserve changes to scroll position for forward/back navigation.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lrh-fix-scroll-on-admin-pages.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sapmjnpvdn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
