### PR TITLE
note file limit aggregation

### DIFF
--- a/doc/code_insights/explanations/search_results_aggregations.md
+++ b/doc/code_insights/explanations/search_results_aggregations.md
@@ -66,6 +66,10 @@ hello-(\w+)-(\w+)
 
 and a match like `hello-beautiful-world` only `beautiful` will be shown as a result.
 
+### Files with the same paths in distinct repositories
+
+The "file" aggregation groups only by path, not by repository, meaning files with the same path but from different repos will be grouped together. Attach a `repo:` filter to your search to focus on a specific repo. 
+
 ### Saving aggregations to a code insights dashboard
 
 Saving aggregations to a dashboard of code insights is not yet available. 


### PR DESCRIPTION
This surprised me a bit in playing with it – we should document it as a known gap until we can add repo to the path (unless this is a regression?) 

Example: 
https://sourcegraph.sourcegraph.com/search?q=context%3Aglobal+file%3A%5E%5C.eslintignore+.%5Cn&patternType=regexp&groupBy=repo

Group by repo, then group by file: 

![image](https://user-images.githubusercontent.com/11967660/191147727-b0b7132a-f3f5-4107-ae19-ff3fd42eb053.png)

![image](https://user-images.githubusercontent.com/11967660/191147744-8882493c-c36c-4a91-8675-8e238f302784.png)

## Test plan

Reviewed manually. 