### PR TITLE
search: Disable "apply suggestion on enter" by default and remove Tab hint

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -155,19 +155,6 @@
                         font-weight: bold;
                     }
 
-                    .tabStyle {
-                        border: 1px solid var(--text-muted);
-                        border-radius: 0.25rem;
-                        height: 1.25rem;
-                        font-size: 0.65rem;
-                        line-height: 1;
-                        padding: 0.25rem 0.375rem;
-                        margin-left: auto;
-                        color: var(--text-muted);
-                        opacity: 0.75;
-                        display: none;
-                    }
-
                     &[aria-selected] {
                         color: var(--search-query-text-color);
                         background-color: var(--color-bg-2);

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -60,8 +60,6 @@ import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
 import { queryTokens } from './parsedQuery'
 
-import styles from '../CodeMirrorQueryInput.module.scss'
-
 type CompletionType = SymbolKind | 'queryfilter' | 'repository' | 'searchhistory'
 
 // See SymbolIcon
@@ -196,21 +194,6 @@ export function searchQueryAutocompletion(
             position: 30,
         },
     ]
-
-    if (!applyOnEnter) {
-        // This renders the "Tab" indicator after the details text. It's
-        // only visible for the currently selected suggestion (handled
-        // by CSS).
-        addToOptions.push({
-            render() {
-                const node = document.createElement('span')
-                node.classList.add('completion-hint', styles.tabStyle)
-                node.textContent = 'Tab'
-                return node
-            },
-            position: 200,
-        })
-    }
 
     return [
         // Uses the default keymapping but changes accepting suggestions from Enter

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -19,6 +19,7 @@ const defaultSettings: SettingsExperimentalFeatures = {
     showCodeMonitoringLogs: true,
     codeInsightsCompute: false,
     editor: 'codemirror6',
+    applySearchQuerySuggestionOnEnter: false,
 }
 
 export const useExperimentalFeatures = create<SettingsExperimentalFeatures>(() => ({}))


### PR DESCRIPTION
Alternative to https://github.com/sourcegraph/sourcegraph/pull/41758 for 4.0

Because the switch from "tab to apply suggestion" to "arrow down + tab/enter to apply suggestion" is possibly a major disruption in existing user's workflows, we are disabling it by default. It can still be enabled via the feature flag. We'll work on properly communicating this change before we turn it on by default.

Because the Tab hint doesn't look/work great anymore for the new suggestion style we remove it.



## Test plan

Open search homepage, enter query and wait for suggestions to appear. First suggestions should be selected by default.

## App preview:

- [Web](https://sg-web-fkling-disable-query-input.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mssymlmmbf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
