### PR TITLE
Increases the font weight of homepage blocks

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -18,6 +18,9 @@ title: Get Started
     border: 1px solid;
     background-color: white;
     text-align: center;
+    font-weight: 400;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
   }
   .app-btn:hover {
     box-shadow: 0 0 10px #00cbec;

--- a/doc/index.md
+++ b/doc/index.md
@@ -18,7 +18,6 @@ title: Get Started
     border: 1px solid;
     background-color: white;
     text-align: center;
-    font-weight: 100;
   }
   .app-btn:hover {
     box-shadow: 0 0 10px #00cbec;
@@ -28,7 +27,6 @@ title: Get Started
   }
   .app-btn > h3 {
     font-size: 1.5em;
-    font-weight: lighter;
     margin-top: .2em;
     margin-bottom: 1em;
   }

--- a/doc/index.md
+++ b/doc/index.md
@@ -27,6 +27,7 @@ title: Get Started
   }
   .app-btn > h3 {
     font-size: 1.5em;
+    font-weight: 500;
     margin-top: .2em;
     margin-bottom: 1em;
   }


### PR DESCRIPTION
For improved readability and accesbility, since they were too thin

Before: 
<img width="1011" alt="Screenshot 2022-09-20 at 11 19 18" src="https://user-images.githubusercontent.com/7814431/191246064-acedb95b-b942-4e2c-bc74-de8ade2fe89e.png">


After
<img width="849" alt="Screenshot 2022-09-20 at 11 19 56" src="https://user-images.githubusercontent.com/7814431/191246108-556df90d-6e94-4be8-a7d5-42534daa1f70.png">


## Test plan

I've tested this with the dev tools of the browser


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
