### PR TITLE
Fix wrong repo sizes on repositories page

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -135,7 +135,7 @@ interface State {
     error?: Error
 }
 
-function prettyBytesBigint(bytes: bigint): string {
+export function prettyBytesBigint(bytes: bigint): string {
     let unit = 0
     const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
     const threshold = BigInt(1000)

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -19,6 +19,7 @@ import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
 import { Scalars, SettingsAreaRepositoryFields } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
+import { prettyBytesBigint } from '../../util/prettyBytesBigint'
 
 import styles from './RepoSettingsIndexPage.module.scss'
 
@@ -133,19 +134,6 @@ interface State {
     textSearchIndex?: GQL.IRepositoryTextSearchIndex | null
     loading: boolean
     error?: Error
-}
-
-export function prettyBytesBigint(bytes: bigint): string {
-    let unit = 0
-    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-    const threshold = BigInt(1000)
-
-    while (bytes >= threshold) {
-        bytes /= threshold
-        unit += 1
-    }
-
-    return bytes.toString() + ' ' + units[unit]
 }
 
 /**

--- a/client/web/src/site-admin/components/RepoMirrorInfo.tsx
+++ b/client/web/src/site-admin/components/RepoMirrorInfo.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 
 import { mdiCloudOutline } from '@mdi/js'
-import prettyBytes from 'pretty-bytes'
 
 import { Icon, LoadingSpinner, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../components/time/Timestamp'
 import { MirrorRepositoryInfoFields } from '../../graphql-operations'
+import { prettyBytesBigint } from '../../repo/settings/RepoSettingsIndexPage'
 
 export const RepoMirrorInfo: React.FunctionComponent<
     React.PropsWithChildren<{
@@ -32,7 +32,8 @@ export const RepoMirrorInfo: React.FunctionComponent<
                     <>Not yet synced from code host.</>
                 ) : (
                     <>
-                        Last synced <Timestamp date={mirrorInfo.updatedAt} />. Size: {prettyBytes(mirrorInfo.byteSize)}.
+                        Last synced <Timestamp date={mirrorInfo.updatedAt} />. Size:{' '}
+                        {prettyBytesBigint(BigInt(mirrorInfo.byteSize))}.
                     </>
                 )}
             </small>

--- a/client/web/src/site-admin/components/RepoMirrorInfo.tsx
+++ b/client/web/src/site-admin/components/RepoMirrorInfo.tsx
@@ -6,7 +6,7 @@ import { Icon, LoadingSpinner, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../components/time/Timestamp'
 import { MirrorRepositoryInfoFields } from '../../graphql-operations'
-import { prettyBytesBigint } from '../../repo/settings/RepoSettingsIndexPage'
+import { prettyBytesBigint } from '../../util/prettyBytesBigint'
 
 export const RepoMirrorInfo: React.FunctionComponent<
     React.PropsWithChildren<{

--- a/client/web/src/util/prettyBytesBigint.ts
+++ b/client/web/src/util/prettyBytesBigint.ts
@@ -1,0 +1,12 @@
+export function prettyBytesBigint(bytes: bigint): string {
+    let unit = 0
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    const threshold = BigInt(1000)
+
+    while (bytes >= threshold) {
+        bytes /= threshold
+        unit += 1
+    }
+
+    return bytes.toString() + ' ' + units[unit]
+}

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -158,13 +158,13 @@ func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*DateTime
 	return &DateTime{Time: info.LastFetched}, nil
 }
 
-func (r *repositoryMirrorInfoResolver) ByteSize(ctx context.Context) (int32, error) {
+func (r *repositoryMirrorInfoResolver) ByteSize(ctx context.Context) (BigInt, error) {
 	info, err := r.computeGitserverRepo(ctx)
 	if err != nil {
-		return 0, err
+		return BigInt{Int: 0}, err
 	}
 
-	return int32(info.RepoSizeBytes), nil
+	return BigInt{Int: info.RepoSizeBytes}, err
 }
 
 func (r *repositoryMirrorInfoResolver) UpdateSchedule(ctx context.Context) (*updateScheduleResolver, error) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3009,7 +3009,7 @@ type MirrorRepositoryInfo {
     """
     The byte size of the repo.
     """
-    byteSize: Int!
+    byteSize: BigInt!
 }
 
 """


### PR DESCRIPTION
Turns out some repos are bigger than can be expressed in int32. We need `BigInt`.

This also needs to go in 4.0.

## Test plan

- Manually tested locally