### PR TITLE
search ui: add bitbucket.org repo icon

### DIFF
--- a/client/search-ui/src/components/CodeHostIcon.tsx
+++ b/client/search-ui/src/components/CodeHostIcon.tsx
@@ -14,6 +14,7 @@ export const CodeHostIcon: React.FunctionComponent<
         'github.com': mdiGithub,
         'gitlab.com': mdiGitlab,
         'bitbucket.com': mdiBitbucket,
+        'bitbucket.org': mdiBitbucket,
     }
 
     const hostName = repoName.split('/')[0]

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
@@ -73,8 +73,15 @@ const filters: Filter[] = [
         kind: 'repo',
     },
     {
-        label: 'bitbucket.com/test/test',
-        value: 'repo:^bitbucket\\.com/test/test$',
+        label: 'bitbucket.com/com/test',
+        value: 'repo:^bitbucket\\.com/com/test$',
+        count: 1,
+        limitHit: true,
+        kind: 'repo',
+    },
+    {
+        label: 'bitbucket.org/org/test',
+        value: 'repo:^bitbucket\\.org/org/test$',
         count: 1,
         limitHit: true,
         kind: 'repo',


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/pull/21362#discussion_r975599776

Repos starting with `bitbucket.org` should also show the bitbucket icon. We previously only did it with `bitbucket.com`.

(I'm not sure if bitbucket.com is even a thing; the canonical URL seems to be bitbucket.org. But in case it is a thing, I'm adding instead of replacing.)

## Test plan

Verify with storybook tests

![image](https://user-images.githubusercontent.com/206864/191318994-44f7bf2e-61b5-4284-b9f4-8fd63ebb83eb.png)


## App preview:

- [Web](https://sg-web-jp-bitbucketorgicon.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-znudjoindv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
