### PR TITLE
Remove experimental badges from in-product analytics

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -5,10 +5,8 @@ import { startCase } from 'lodash'
 import { RouteComponentProps } from 'react-router'
 
 import { useQuery } from '@sourcegraph/http-client'
-import { AlertType } from '@sourcegraph/shared/src/graphql-operations'
 import { Card, LoadingSpinner, useMatchMedia, Text, LineChart, BarChart, Series } from '@sourcegraph/wildcard'
 
-import { GlobalAlert } from '../../../global/GlobalAlert'
 import { UsersStatisticsResult, UsersStatisticsVariables } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
@@ -132,15 +130,6 @@ export const AnalyticsUsersPage: FC<RouteComponentProps> = () => {
                 <div className="d-flex justify-content-end align-items-stretch mb-2 text-nowrap">
                     <HorizontalSelect<typeof dateRange.value> {...dateRange} />
                 </div>
-                <GlobalAlert
-                    alert={{
-                        message:
-                            'Note these charts are experimental. For billing information, use [usage stats](/site-admin/usage-statistics).',
-                        type: AlertType.INFO,
-                        isDismissibleWithKey: '',
-                    }}
-                    className="my-3"
-                />
                 {legends && <ValueLegendList className="mb-3" items={legends} />}
                 {activities && (
                     <div>

--- a/client/web/src/site-admin/analytics/components/AnalyticsPageTitle.tsx
+++ b/client/web/src/site-admin/analytics/components/AnalyticsPageTitle.tsx
@@ -3,13 +3,12 @@ import React from 'react'
 import { mdiChartLineVariant } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Badge, H2, Icon } from '@sourcegraph/wildcard'
+import { H2, Icon } from '@sourcegraph/wildcard'
 
 import styles from './AnalyticsPageTitle.module.scss'
 
 export const AnalyticsPageTitle: React.FunctionComponent<React.PropsWithChildren<{}>> = ({ children }) => (
     <div className="d-flex flex-column justify-content-between align-items-start">
-        <Badge variant="merged">Experimental</Badge>
 
         <H2 className="mb-4 mt-2 d-flex align-items-center">
             <Icon


### PR DESCRIPTION

## Test plan
Removing badges only, not functionality changes. Tested locally. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-rpp-remove-analytics-experimental.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uprzjpchvv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
