### PR TITLE
Code Insights: Remove extension based ad creation card from the insight creation UI flow

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -14,7 +14,6 @@ import { CodeInsightsPage } from '../../../../components'
 import {
     CaptureGroupInsightCard,
     ComputeInsightCard,
-    ExtensionInsightsCard,
     LangStatsInsightCard,
     SearchInsightCard,
 } from './cards/InsightCards'
@@ -49,11 +48,6 @@ export const IntroCreationPage: React.FunctionComponent<React.PropsWithChildren<
     const handleCreateCodeStatsInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateCodeStatsInsightClick')
         history.push(`/insights/create/lang-stats${search}`)
-    }
-
-    const handleExploreExtensionsClick = (): void => {
-        telemetryService.log('CodeInsightsExploreInsightExtensionsClick')
-        history.push('/extensions?query=category:Insights&experimental=true')
     }
 
     useEffect(() => {
@@ -105,8 +99,6 @@ export const IntroCreationPage: React.FunctionComponent<React.PropsWithChildren<
                         use cases.
                     </Link>
                 </div>
-
-                <ExtensionInsightsCard data-testid="explore-extensions" handleCreate={handleExploreExtensionsClick} />
             </div>
         </CodeInsightsPage>
     )

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
@@ -61,18 +61,3 @@
         background-color: transparent;
     }
 }
-
-.images {
-    display: flex;
-    height: 10rem;
-    justify-content: center;
-    align-items: center;
-    gap: 1rem;
-    width: 6rem;
-    margin: auto;
-}
-
-.image {
-    object-fit: contain;
-    width: 1.75rem;
-}

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { Link, Button, CardBody, Card, H2, H3, Text } from '@sourcegraph/wildcard'
+import { Button, CardBody, Card, H2, H3, Text } from '@sourcegraph/wildcard'
 
 import {
     CaptureGroupInsightChart,
@@ -104,36 +104,5 @@ export const CaptureGroupInsightCard: React.FunctionComponent<React.PropsWithChi
         </InsightCardBody>
 
         <InsightCardExampleBlock>Detecting and tracking language or package versions.</InsightCardExampleBlock>
-    </InsightCard>
-)
-
-export const ExtensionInsightsCard: React.FunctionComponent<React.PropsWithChildren<InsightCardProps>> = props => (
-    <InsightCard {...props} className={styles.cardExtensionCard}>
-        <div className={styles.images}>
-            <img
-                className={styles.image}
-                src={`${window.context?.assetsRoot || ''}/img/codecov.png`}
-                data-skip-percy={true}
-                alt="Codecov logo"
-            />
-            <img
-                className={styles.image}
-                src={`${window.context?.assetsRoot || ''}/img/eslint.png`}
-                data-skip-percy={true}
-                alt="Eslint logo"
-            />
-            <img
-                className={styles.image}
-                src={`${window.context?.assetsRoot || ''}/img/snyk.png`}
-                data-skip-percy={true}
-                alt="Snyk logo"
-            />
-        </div>
-
-        <InsightCardBody title="Based on Sourcegraph extensions">
-            Enable the extension and go to the README.md to learn how to set up code insights for selected Sourcegraph
-            extensions.
-            <Link to="/extensions?query=category:Insights&experimental=true">Explore the extensions</Link>
-        </InsightCardBody>
     </InsightCard>
 )

--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -47,7 +47,6 @@ describe('Code insight create insight page', () => {
         // Waiting for all important part page be rendered.
         await driver.page.waitForSelector('[data-testid="create-search-insights"]')
         await driver.page.waitForSelector('[data-testid="create-lang-usage-insight"]')
-        await driver.page.waitForSelector('[data-testid="explore-extensions"]')
 
         await percySnapshotWithVariants(driver.page, 'Create new insight page — Welcome popup')
         await accessibilityAudit(driver.page)
@@ -60,7 +59,6 @@ describe('Code insight create insight page', () => {
         // Waiting for all important part page be rendered.
         await driver.page.waitForSelector('[data-testid="create-search-insights"]')
         await driver.page.waitForSelector('[data-testid="create-lang-usage-insight"]')
-        await driver.page.waitForSelector('[data-testid="explore-extensions"]')
 
         await percySnapshotWithVariants(driver.page, 'Create new insight page')
         await accessibilityAudit(driver.page)


### PR DESCRIPTION
Simply removes extensions based card from the creation UI flow.

| Before | After |
| ------------- | ------------- |
| ![Screenshot 2022-09-20 at 23 07 11](https://user-images.githubusercontent.com/18492575/191354453-d2458379-36a0-4ff0-920b-3b097b4392d9.png) | ![Screenshot 2022-09-20 at 23 04 50](https://user-images.githubusercontent.com/18492575/191354423-54160244-7af8-41c1-95cb-c85f6889a4da.png) |

## Test plan
- Check that the `/insights/create` page doesn't have extension based insight card and any visual regressions

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
