### PR TITLE
docs: Add information on how a SG account is linked to an auth provider account

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -441,7 +441,7 @@ Some proxies add a prefix to the username header value. For example, Google IAP 
 ## Linking a Sourcegraph account to an auth provider
 
 The link between a Sourcegraph account and an authentication provider account happens via email only.
-Consequently, you can only sign in or sign up with [GitHub](#github), [GitLab](#gitlab), or other supported auth providers ([SAML](saml/index.md),  [OpenID Connect](#openid-connect), [HTTP Proxies](#http-authentication-proxies)) if your email matches the one configured in the auth provider.
+Consequently, you can only sign in with [GitHub](#github), [GitLab](#gitlab), or other supported auth providers ([SAML](saml/index.md),  [OpenID Connect](#openid-connect), [HTTP Proxies](#http-authentication-proxies)) if your email on Sourcegraph matches the one configured in the auth provider.
 
 Let's say the email field in your Sourcegraph account was kept blank when a site admin created the account for you, but the username matches your username on GitHub or GitLab. Will this work? If you try to sign in to SG with GitHub or GitLab, it won't work, and you will see an error informing you that a verified email is missing.
 

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -437,6 +437,14 @@ Some proxies add a prefix to the username header value. For example, Google IAP 
   ]
 }
 ```
+
+## Linking a Sourcegraph account to an auth provider
+
+The link between a Sourcegraph account and an authentication provider account happens via email only.
+Consequently, you can only sign in or sign up with [GitHub](#github), [GitLab](#gitlab), or other supported auth providers ([SAML](saml/index.md),  [OpenID Connect](#openid-connect), [HTTP Proxies](#http-authentication-proxies)) if your email matches the one configured in the auth provider.
+
+Let's say the email field in your Sourcegraph account was kept blank when a site admin created the account for you, but the username matches your username on GitHub or GitLab. Will this work? If you try to sign in to SG with GitHub or GitLab, it won't work, and you will see an error informing you that a verified email is missing.
+
 ## Linking accounts from multiple auth providers
 Sourcegraph will automatically link accounts from multiple external auth providers, resulting in a single user account on Sourcegraph. That way a user can login with multiple auth methods and end up being logged in with the same Sourcegraph account. In general, to link accounts, the following condition needs to be met:
 


### PR DESCRIPTION
Updating our docs to make sure we are more clear when informing our customers how an SG account is linked to an auth provider account.
This is based on a recent question raised by a customer that thought it would be possible to link their SG account to an auth provider via username only.


## Test plan
Manually tested, in my local instance, that the links are working and the updated page is showing the changes.
To better read/review the changes, you can [use this link](https://github.com/sourcegraph/sourcegraph/blob/a316dfe3fd737fbf61843b009aa2b112b3192514/doc/admin/auth/index.md#linking-a-sourcegraph-account-to-an-auth-provider). 