### PR TITLE
go: run 'go mod tidy'

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1123,6 +1123,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.0.0-20191010200024-a3d713f9b7f8/go.mod h1:KyKXa9ciM8+lgMXwOVsXi7UxGrsf9mM61Mzs+xKUrKE=


### PR DESCRIPTION
Noticed [the `lsif-go` job failing](https://github.com/sourcegraph/sourcegraph/actions/runs/3093505009/jobs/5005941920#step:4:9) due to out-of-sync `go.sum`:

```
error: failed to list dependencies: failed to list modules: exit status 1
go: cloud.google.com/go@v0.102.0 requires
	github.com/google/go-cmp@v0.5.[8](https://github.com/sourcegraph/sourcegraph/actions/runs/3093505009/jobs/5005941920#step:4:9): missing go.sum entry; to add it:
	go mod download github.com/google/go-cmp
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes