### PR TITLE
Add empty dashboard integration test

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.tsx
@@ -82,7 +82,7 @@ export const DashboardSelect: React.FunctionComponent<React.PropsWithChildren<Da
                 value={value ?? 'unknown'}
                 onChange={handleChange}
             >
-                <MenuButton dashboards={rawDashboards} />
+                <MenuButton dashboards={rawDashboards} data-testid="dashboard-select-button" />
 
                 <ListboxPopover className={classNames(styles.popover)} portal={true}>
                     <ListboxList

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/components/menu-button/MenuButton.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/components/menu-button/MenuButton.tsx
@@ -21,10 +21,14 @@ interface MenuButtonProps {
  * Renders ListBox menu button for dashboard select component.
  */
 export const MenuButton: React.FunctionComponent<React.PropsWithChildren<MenuButtonProps>> = props => {
-    const { dashboards, className } = props
+    const { dashboards, className, ...attributes } = props
 
     return (
-        <ListboxButton id="insight-dashboard-select-button" className={classNames(styles.button, className)}>
+        <ListboxButton
+            id="insight-dashboard-select-button"
+            className={classNames(styles.button, className)}
+            {...attributes}
+        >
             {({ value, isExpanded }) => {
                 const dashboard = dashboards.find(dashboard => dashboard.id === value)
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
@@ -71,6 +71,7 @@ export const EmptySettingsBasedDashboard: React.FunctionComponent<
                 onClick={onAddInsight}
                 variant="secondary"
                 className="p-0 w-100 border-0"
+                data-testid="add-insights-button-card"
             >
                 <Tooltip content={addRemoveInsightPermissions.tooltip} placement="right">
                     <Card className={styles.itemCard}>

--- a/client/web/src/integration/insights/dashboards/render-empty-dashboard.test.ts
+++ b/client/web/src/integration/insights/dashboards/render-empty-dashboard.test.ts
@@ -41,12 +41,21 @@ describe('Code insights empty dashboard', () => {
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/EMPTY_DASHBOARD')
 
-        const button = await driver.page.waitForSelector('[data-testid="dashboard-select-button"')
+        const dashboardSelectButton = await driver.page.waitForSelector('[data-testid="dashboard-select-button"')
+        const addInsightsButtonCard = await driver.page.waitForSelector('[data-testid="add-insights-button-card"')
 
-        assert(button)
+        assert(dashboardSelectButton)
 
-        const buttonText: string = (await driver.page.evaluate(button => button.textContent, button)) as string
+        const dashboardSelectButtonText: string = (await driver.page.evaluate(
+            button => button.textContent,
+            dashboardSelectButton
+        )) as string
+        const addInsightsButtonCardText: string = (await driver.page.evaluate(
+            button => button.textContent,
+            addInsightsButtonCard
+        )) as string
 
-        assert(/empty dashboard/i.test(buttonText))
+        assert(/empty dashboard/i.test(dashboardSelectButtonText))
+        assert(/add insights/i.test(addInsightsButtonCardText))
     })
 })

--- a/client/web/src/integration/insights/dashboards/render-empty-dashboard.test.ts
+++ b/client/web/src/integration/insights/dashboards/render-empty-dashboard.test.ts
@@ -1,0 +1,52 @@
+import assert from 'assert'
+
+import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
+import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
+
+import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../../context'
+import { GET_DASHBOARD_INSIGHTS, INSIGHTS_DASHBOARDS } from '../fixtures/dashboards'
+import { overrideInsightsGraphQLApi } from '../utils/override-insights-graphql-api'
+
+describe('Code insights empty dashboard', () => {
+    let driver: Driver
+    let testContext: WebIntegrationTestContext
+
+    before(async () => {
+        driver = await createDriverForTest()
+    })
+
+    beforeEach(async function () {
+        testContext = await createWebIntegrationTestContext({
+            driver,
+            currentTest: this.currentTest!,
+            directory: __dirname,
+            customContext: {
+                // Enforce using a new gql API for code insights pages
+                codeInsightsGqlApiEnabled: true,
+            },
+        })
+    })
+
+    after(() => driver?.close())
+    afterEachSaveScreenshotIfFailed(() => driver.page)
+
+    it('renders empty dashboard', async () => {
+        overrideInsightsGraphQLApi({
+            testContext,
+            overrides: {
+                InsightsDashboards: () => INSIGHTS_DASHBOARDS,
+                GetDashboardInsights: () => GET_DASHBOARD_INSIGHTS,
+            },
+        })
+
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/EMPTY_DASHBOARD')
+
+        const button = await driver.page.waitForSelector('[data-testid="dashboard-select-button"')
+
+        assert(button)
+
+        const buttonText: string = (await driver.page.evaluate(button => button.textContent, button)) as string
+
+        assert(/empty dashboard/i.test(buttonText))
+    })
+})

--- a/client/web/src/integration/insights/fixtures/dashboards.ts
+++ b/client/web/src/integration/insights/fixtures/dashboards.ts
@@ -1,0 +1,51 @@
+import { testUserID } from '@sourcegraph/shared/src/testing/integration/graphQlResults'
+
+import { InsightsDashboardsResult } from '../../../graphql-operations'
+
+export const GET_DASHBOARD_INSIGHTS = {
+    insightsDashboards: {
+        nodes: [
+            {
+                id: 'EMPTY_DASHBOARD',
+                views: { nodes: [] },
+            },
+        ],
+    },
+}
+
+export const INSIGHTS_DASHBOARDS: InsightsDashboardsResult = {
+    currentUser: {
+        __typename: 'User',
+        id: testUserID,
+        organizations: {
+            __typename: 'OrgConnection',
+            nodes: [
+                {
+                    __typename: 'Org',
+                    id: 'Org_test_id',
+                    displayName: 'Test organization OVERRIDDEN',
+                },
+            ],
+        },
+    },
+    insightsDashboards: {
+        __typename: 'InsightsDashboardConnection',
+        nodes: [
+            {
+                __typename: 'InsightsDashboard',
+                id: 'EMPTY_DASHBOARD',
+                title: 'Empty Dashboard',
+                views: {
+                    __typename: 'InsightViewConnection',
+                    nodes: [],
+                },
+                grants: {
+                    __typename: 'InsightsPermissionGrants',
+                    users: [testUserID],
+                    organizations: [],
+                    global: false,
+                },
+            },
+        ],
+    },
+}

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -39,6 +39,7 @@ interface OverrideGraphQLExtensionsProps {
  * extension js bundle requests.
  *
  * @param props - Custom override for code insight APIs (gql, user setting, extensions)
+ * @param [props.overrides] - GraphQL calls to override. Note: Overrides need all __typename fields included for Apollo cache to work.
  */
 export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps): void {
     const { testContext, overrides = {} } = props


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41800

- Use puppeteer
- Mock data for dashboard with no insights
- Go to `/insights/dashboards/TEST_ID`

## Assertions
- [x] Dashboard select renders with test dashboard name
- [x] Add insight card renders

## Test plan

Integration tests should pass

Run locally

In one terminal `sg start web-standalone`
In another `sg test web-integration:debug lient/web/src/integration/insights/insight-dashboard.test.ts`

## App preview:

- [Web](https://sg-web-insights-integration-test-empty.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-usumldnrou.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
