### PR TITLE
Prepare for src-cli 4.0.0.

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.43.0"
+const MinimumVersion = "4.0.0"


### PR DESCRIPTION
I did regenerate the docs as well, but there were no changes from 3.43.2.

## Test plan

Mark one eyeball.