### PR TITLE
search: expose query printers via GQL

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -7,8 +7,11 @@ import (
 )
 
 func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
-	Query       string
-	PatternType string
+	Query           string
+	PatternType     string
+	OutputPhase     string
+	OutputFormat    string
+	OutputVerbosity string
 }) (*JSONValue, error) {
 	var searchType query.SearchType
 	switch args.PatternType {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1418,6 +1418,18 @@ type Query {
         The parser to use for this query.
         """
         patternType: SearchPatternType = literal
+        """
+        The output corresponding to a phase in the parser pipeline.
+        """
+        outputPhase: SearchQueryOutputPhase = PARSE_TREE
+        """
+        The parser output format.
+        """
+        outputFormat: SearchQueryOutputFormat = JSON
+        """
+        The level of output format verbosity.
+        """
+        outputVerbosity: SearchQueryOutputVerbosity = MINIMAL
     ): JSONValue
     """
     The current site.
@@ -1930,6 +1942,54 @@ enum SearchPatternType {
     structural
     lucky
     keyword
+}
+
+"""
+Represents phases in query parsing. The parse tree corresponds closely to the
+input query syntax. A subsequent processing phase on the parse tree generates a
+job tree. The job tree is an internal representation analogous to a database
+query plan. The job tree discards information about query syntax and corresponds
+closely to backend services (text search, git commit search, etc.).
+"""
+enum SearchQueryOutputPhase {
+     PARSE_TREE
+     JOB_TREE
+}
+
+"""
+The output format to emit for a parsed query.
+"""
+enum SearchQueryOutputVerbosity {
+     """
+     Minimal verbosity outputs only nodes.
+     """
+     MINIMAL
+     """
+     Basic verbosity outputs nodes and essential fields associated with nodes.
+     """
+     BASIC
+     """
+     Maximal verbosity outputs nodes and all information associated with nodes.
+     """
+     MAXIMAL
+}
+
+"""
+The output format to emit for a parsed query.
+"""
+enum SearchQueryOutputFormat {
+     """
+     JSON format.
+     """
+     JSON
+     """
+     S-expression format.
+     """
+     SEXP
+     """
+     Mermaid flowchart format.
+     """
+     MERMAID
 }
 
 """


### PR DESCRIPTION
It's useful to expose our printer output via GQL for debugging. This is proposed schema changes. Thoughts? I'll implement the logic if we're happy with this.

## Test plan
Just schema change right now.