### PR TITLE
blob: Fix fonts and spacing in CodeMirror blob view

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -39,19 +39,25 @@ const staticExtensions: Extension = [
     editorHeight({ height: '100%' }),
     EditorView.theme({
         '&': {
+            backgroundColor: 'var(--code-bg)',
+        },
+        '.cm-scroller': {
             fontFamily: 'var(--code-font-family)',
             fontSize: 'var(--code-font-size)',
+            lineHeight: '1rem',
+        },
+        '.cm-gutters': {
             backgroundColor: 'var(--code-bg)',
+            borderRight: 'initial',
+        },
+        '.cm-line': {
+            paddingLeft: '1rem',
         },
         '.selected-line': {
             backgroundColor: 'var(--code-selection-bg)',
         },
         '.highlighted-line': {
             backgroundColor: 'var(--code-selection-bg)',
-        },
-        '.cm-gutters': {
-            backgroundColor: 'var(--code-bg)',
-            borderRight: 'initial',
         },
     }),
     // Note that these only work out-of-the-box because the editor is

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -129,10 +129,6 @@ export type HovercardSource = (view: EditorView, position: UIPosition) => Observ
  * Some style overrides to replicate the existing hovercard style.
  */
 const hovercardTheme = EditorView.theme({
-    '.cm-code-intel-hovercard': {
-        // Without this all text in the hovercard is monospace
-        fontFamily: 'sans-serif',
-    },
     [`.${webOverlayStyles.webHoverOverlay}`]: {
         // This is normally "position: 'absolute'". CodeMirror does the
         // positioning. Without this CodeMirror thinks the hover content is


### PR DESCRIPTION
Fixes #40484 #40485 #40486 

The fonts for the code had been set on the wrong element so that CodeMirror's default font setting took precedence. The font overwrite for code intel popovers isn't necessary anymore, the original problem doesn't exist anymore (but I can't recall what changed).

I also wanted to add the same top padding to the content, `0.5.rem`, but caused some misalignment with the line numbers. It appears that CodeMirror doesn't handle fractional pixels when computing the offset for the line number gutter (`0.5rem = 8.5px` for me, but CodeMirror computed the top padding of the gutter to be `8px`).

Old blob view: 
<img width="960" alt="2022-09-21_11-12" src="https://user-images.githubusercontent.com/179026/191467617-5c7c3b6e-5c92-4fcd-8902-9c209948ef82.png">

New blob view:
<img width="960" alt="2022-09-21_11-17" src="https://user-images.githubusercontent.com/179026/191467703-c6ee69db-5fa1-48b4-9ddb-26608b1ccffe.png">



## Test plan

Open file in new blob view and compared fonts and spacing to old blob view side-by-side.
