### PR TITLE
Open in Editor: Fix paths for Perforce repos

### DIFF
--- a/client/web/src/open-in-editor/build-url.test.ts
+++ b/client/web/src/open-in-editor/build-url.test.ts
@@ -1,4 +1,6 @@
-import { buildEditorUrl } from './build-url'
+import { parseBrowserRepoURL } from '../util/url'
+
+import { buildEditorUrl, buildRepoBaseNameAndPath } from './build-url'
 import { EditorSettings } from './editor-settings'
 
 function buildSettings(props: EditorSettings = {}): EditorSettings {
@@ -9,7 +11,37 @@ function buildSettings(props: EditorSettings = {}): EditorSettings {
     }
 }
 
-describe('buildUrl tests', () => {
+describe('buildRepoBaseNameAndPath tests', () => {
+    it('builds the correct string for GitHub URLs', () => {
+        const url = 'https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/tsconfig.json'
+        const { repoName, filePath } = parseBrowserRepoURL(url)
+
+        const result = buildRepoBaseNameAndPath(repoName, filePath)
+
+        expect(result).toEqual('sourcegraph/sourcegraph/tsconfig.json')
+    })
+
+    it('builds the correct string for Perforce URLs', () => {
+        const url =
+            'https://cse-k8s.sgdev.org/perforce.beatrix.com/app/b200/patch/core/-/blob/test/1.js?toast=integrations'
+        const { repoName, filePath } = parseBrowserRepoURL(url)
+
+        const result = buildRepoBaseNameAndPath(repoName, filePath)
+
+        expect(result).toEqual('app/b200/patch/core/test/1.js')
+    })
+
+    it('builds the correct string for other URLs', () => {
+        const url = 'https://sourcegraph.com/maven/com.esotericsoftware.minlog/minlog/-/blob/lsif-java.json'
+        const { repoName, filePath } = parseBrowserRepoURL(url)
+
+        const result = buildRepoBaseNameAndPath(repoName, filePath)
+
+        expect(result).toEqual('com.esotericsoftware.minlog/minlog/lsif-java.json')
+    })
+})
+
+describe('buildEditorUrl tests', () => {
     const defaultRange = { start: { line: 43, character: 0 }, end: { line: 43, character: 0 } }
     const defaultPath = 'sourcegraph/.gitignore'
     const baseUrl = 'https://sourcegraph.com'

--- a/client/web/src/open-in-editor/build-url.test.ts
+++ b/client/web/src/open-in-editor/build-url.test.ts
@@ -18,7 +18,7 @@ describe('buildRepoBaseNameAndPath tests', () => {
 
         const result = buildRepoBaseNameAndPath(repoName, filePath)
 
-        expect(result).toEqual('sourcegraph/sourcegraph/tsconfig.json')
+        expect(result).toEqual('sourcegraph/tsconfig.json')
     })
 
     it('builds the correct string for Perforce URLs', () => {

--- a/client/web/src/open-in-editor/build-url.test.ts
+++ b/client/web/src/open-in-editor/build-url.test.ts
@@ -21,6 +21,24 @@ describe('buildRepoBaseNameAndPath tests', () => {
         expect(result).toEqual('sourcegraph/tsconfig.json')
     })
 
+    it('builds the correct string for GitLab URLs', () => {
+        const url = 'https://sourcegraph.com/gitlab.com/gitlab-org/gitlab-foss/-/blob/.eslintignore'
+        const { repoName, filePath } = parseBrowserRepoURL(url)
+
+        const result = buildRepoBaseNameAndPath(repoName, filePath)
+
+        expect(result).toEqual('gitlab-foss/.eslintignore')
+    })
+
+    it('builds the correct string for Bitbucket Cloud URLs', () => {
+        const url = 'https://sourcegraph.com/bitbucket.org/atlassian/stash-example-plugin/src/master/README.md'
+        const { repoName, filePath } = parseBrowserRepoURL(url)
+
+        const result = buildRepoBaseNameAndPath(repoName, filePath)
+
+        expect(result).toEqual('stash-example-plugin/src/master/README.md')
+    })
+
     it('builds the correct string for Perforce URLs', () => {
         const url =
             'https://cse-k8s.sgdev.org/perforce.beatrix.com/app/b200/patch/core/-/blob/test/1.js?toast=integrations'

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -6,7 +6,10 @@ import type { EditorReplacements, EditorSettings } from './editor-settings'
 import { Editor, getEditor, supportedEditors } from './editors'
 
 export function buildRepoBaseNameAndPath(repoName: string, filePath: string | undefined): string {
-    return path.join(...[...repoName.split('/').slice(1), ...(filePath ? [filePath] : [])])
+    const codeHostsWithOwnerInUrl = ['github.com', 'gitlab.com', 'bitbucket.org']
+    const repoNameIncludesOwner = codeHostsWithOwnerInUrl.some(url => repoName.startsWith(url + '/'))
+    const bareRepoNamePieces = repoName.split('/').slice(repoNameIncludesOwner ? 2 : 1);
+    return path.join(...[...bareRepoNamePieces, ...(filePath ? [filePath] : [])])
 }
 
 export function buildEditorUrl(

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -8,7 +8,7 @@ import { Editor, getEditor, supportedEditors } from './editors'
 export function buildRepoBaseNameAndPath(repoName: string, filePath: string | undefined): string {
     const codeHostsWithOwnerInUrl = ['github.com', 'gitlab.com', 'bitbucket.org']
     const repoNameIncludesOwner = codeHostsWithOwnerInUrl.some(url => repoName.startsWith(url + '/'))
-    const bareRepoNamePieces = repoName.split('/').slice(repoNameIncludesOwner ? 2 : 1);
+    const bareRepoNamePieces = repoName.split('/').slice(repoNameIncludesOwner ? 2 : 1)
     return path.join(...[...bareRepoNamePieces, ...(filePath ? [filePath] : [])])
 }
 
@@ -34,7 +34,7 @@ export function buildEditorUrl(
             : ''
 
     const absolutePath = path.join(projectPath, repoBaseNameAndPath)
-    const { line, column } = range ? { line: range.start.line, column: range.start.character } : { line: 1, column: 1 }
+    const {line, column} = range ? {line: range.start.line, column: range.start.character} : {line: 1, column: 1}
     const url = urlPattern
         .replace('%file', pathPrefix + absolutePath)
         .replace('%line', `${line}`)

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -9,7 +9,7 @@ export function buildRepoBaseNameAndPath(repoName: string, filePath: string | un
     const codeHostsWithOwnerInUrl = ['github.com', 'gitlab.com', 'bitbucket.org']
     const repoNameIncludesOwner = codeHostsWithOwnerInUrl.some(url => repoName.startsWith(url + '/'))
     const bareRepoNamePieces = repoName.split('/').slice(repoNameIncludesOwner ? 2 : 1)
-    return path.join(...[...bareRepoNamePieces, ...(filePath ? [filePath] : [])])
+    return path.join(...bareRepoNamePieces, ...(filePath ? [filePath] : []))
 }
 
 export function buildEditorUrl(

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -34,7 +34,7 @@ export function buildEditorUrl(
             : ''
 
     const absolutePath = path.join(projectPath, repoBaseNameAndPath)
-    const {line, column} = range ? {line: range.start.line, column: range.start.character} : {line: 1, column: 1}
+    const { line, column } = range ? { line: range.start.line, column: range.start.character } : { line: 1, column: 1 }
     const url = urlPattern
         .replace('%file', pathPrefix + absolutePath)
         .replace('%line', `${line}`)

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -5,6 +5,10 @@ import type { UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 import type { EditorReplacements, EditorSettings } from './editor-settings'
 import { Editor, getEditor, supportedEditors } from './editors'
 
+export function buildRepoBaseNameAndPath(repoName: string, filePath: string | undefined): string {
+    return path.join(...[...repoName.split('/').slice(1), ...(filePath ? [filePath] : [])])
+}
+
 export function buildEditorUrl(
     repoBaseNameAndPath: string,
     range: UIRangeSpec['range'] | undefined,

--- a/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
+++ b/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router'
 
 import { parseBrowserRepoURL } from '../util/url'
 
-import { buildEditorUrl } from './build-url'
+import { buildEditorUrl, buildRepoBaseNameAndPath } from './build-url'
 import { EditorSettings } from './editor-settings'
 
 /**
@@ -20,7 +20,7 @@ export const useOpenCurrentUrlInEditor = (): ((
         (editorSettings: EditorSettings, sourcegraphURL: string, editorIndex = 0) => {
             const { repoName, filePath, range } = parseBrowserRepoURL(location.pathname)
             const url = buildEditorUrl(
-                `${repoName.split('/').pop() ?? ''}/${filePath}`,
+                buildRepoBaseNameAndPath(repoName, filePath),
                 range,
                 editorSettings,
                 sourcegraphURL,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41713

Added an "IF github OR gitlab OR bitbucket cloud THEN remove code host and owner from the url ELSE only remove the code host" logic.
The reasoning is that
- we know about these three particular code hosts that they include the owner in the URL which we don't want to include, to maintain backward compatibility
- we know that Perforce users don't want to remove any other piece from the URL than the code host.
- we don't know about each of [the rest of the code hosts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/extsvc/types.go?L111%3A12=) so we want to stay on the safe side and not remove any part of the URL that the user might want.

If there are user complaints about this behavior (e.g. Bitbucket Server users flag that the owner is included in their URLs and it's always redundant) then we can add more to this list, either based on the URL itself, or by filtering based on `repository.externalRepository.serviceType`.

Note: I kept the logic of filtering based on URL rather than based on `repository.externalRepository.serviceType` because the URL contains all the info we currently need and the interface to the logic is smaller this way, which seemed more elegant.

## Test plan

Only the background logic changed and I've added a bunch of unit tests, it should be enough.

## App preview:

- [Web](https://sg-web-dv-fix-open-in-editor-for-perforce.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zvkevuayhk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
