### PR TITLE
JetBrains: Remove pointer cursor in the web view.

### DIFF
--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
@@ -87,6 +87,7 @@
         > button:focus {
             height: 1.5rem;
             padding: 0.125rem 1rem;
+            cursor: default;
             background: var(--jb-button-bg);
             border: 1px solid var(--jb-border-color);
             border-radius: 4px;
@@ -164,6 +165,7 @@
                     background: var(--jb-button-bg);
                     border: 1px solid var(--jb-border-color);
                     border-radius: 4px;
+                    cursor: default;
                     color: var(--jb-text-color);
                     font-weight: normal;
 
@@ -184,6 +186,7 @@
         button[data-search-context-spec],
         :global(button.disabled.dropdown-item) {
             padding: 0 0.75rem;
+            cursor: default;
 
             > small:not(:first-child),
             > span {

--- a/client/jetbrains/webview/src/search/input/JetBrainsToggles.module.scss
+++ b/client/jetbrains/webview/src/search/input/JetBrainsToggles.module.scss
@@ -19,6 +19,10 @@
 }
 
 .cancel-button {
+    &:not(:disabled) {
+        cursor: default;
+    }
+
     font-size: 1rem;
     color: var(--jb-icon-color);
 }
@@ -31,7 +35,7 @@
 
 .toggle {
     display: flex;
-    cursor: pointer;
+    cursor: default;
     border-radius: 4px;
     border: 2px solid transparent;
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/39564

It was an easy CSS fix: adding “cursor:default;” at five places solved the issue.

## Test plan

[22-sec Loom](https://www.loom.com/share/09d6e584d1dd4e97b9db1a332ee6711e) where I go through all the places with my cursor.

## App preview:

- [Web](https://sg-web-dv-jetbrains-avoid-pointer-cursor.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nzejpwobjt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
