### PR TITLE
JetBrains: Update “Learn more” URL to link the blog post in the update notification

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -75,7 +75,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
         AnAction learnMoreAction = new DumbAwareAction("Learn More", "Opens browser to describe the latest changes", null) {
             @Override
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-                String whatsNewUrl = "https://plugins.jetbrains.com/plugin/9682-sourcegraph#:~:text=What%E2%80%99s%20New";
+                String whatsNewUrl = "https://about.sourcegraph.com/blog/jetbrains-plugin";
 
                 BrowserOpener.openInBrowser(project, whatsNewUrl);
             }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/40560

Replaced the hard-coded URL.

## Test plan

The URL change should not modify the behavior. The previous behavior (link opening) was tested, and I see no way this change could break it.

## App preview:

- [Web](https://sg-web-dv-jetbrains-update-whats-new-url.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kpvrusmvfj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
