### PR TITLE
Disable flaky e2e test and restore reverted PRs

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
+## Chrome v22.9.14.1335, Firefox v22.9.14.1616, Safari v1.15
+
 - Fix code-intel issue on GitHub Enterprise: [pull/41646](https://github.com/sourcegraph/sourcegraph/pull/41646)
 
 ## Chrome & Firefox 22.7.29.851, Safari v1.14 (22.8.2.1319)

--- a/client/browser/scripts/release-firefox.sh
+++ b/client/browser/scripts/release-firefox.sh
@@ -8,7 +8,8 @@ rm -rf build/web-ext
 mkdir -p build/web-ext
 
 # Sign the bundle
-web-ext sign --source-dir ./build/firefox --artifacts-dir ./build/web-ext --api-key "$FIREFOX_AMO_ISSUER" --api-secret "$FIREFOX_AMO_SECRET"
+yarn add web-ext
+yarn web-ext sign --source-dir ./build/firefox --artifacts-dir ./build/web-ext --api-key "$FIREFOX_AMO_ISSUER" --api-secret "$FIREFOX_AMO_SECRET"
 
 # Upload to gcp and make it public
 pushd build/web-ext

--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -496,7 +496,7 @@ describe('Repository component', () => {
 
     describe('hovers', () => {
         describe('Blob', () => {
-            test('gets displayed and updates URL when hovering over a token', async () => {
+            test.skip('gets displayed and updates URL when hovering over a token', async () => {
                 await driver.page.goto(
                     sourcegraphBaseUrl +
                         '/github.com/gorilla/mux@15a353a636720571d19e37b34a14499c3afa9991/-/blob/mux.go'

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -252,7 +252,7 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
 
                 {source === 'blob' && (
                     <>
-                        <ToggleBlameAction location={props.location} />
+                        <ToggleBlameAction />
                         {window.context.isAuthenticatedUser && (
                             <OpenInEditorActionItem platformContext={props.platformContext} />
                         )}

--- a/client/web/src/repo/actions/ToggleBlameAction.tsx
+++ b/client/web/src/repo/actions/ToggleBlameAction.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 
 import { mdiGit } from '@mdi/js'
 import classNames from 'classnames'
-import * as H from 'history'
 
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
 import { Icon } from '@sourcegraph/wildcard'
@@ -12,13 +11,8 @@ import { useBlameVisibility } from '../blame/useBlameVisibility'
 
 import styles from './ToggleBlameAction.module.scss'
 
-export const ToggleBlameAction: React.FC<{ location: H.Location }> = ({ location }) => {
+export const ToggleBlameAction: React.FC = () => {
     const [isBlameVisible, setIsBlameVisible] = useBlameVisibility()
-
-    // Turn off visibility when the file path changes.
-    useEffect(() => {
-        setIsBlameVisible(false)
-    }, [location.pathname, setIsBlameVisible])
 
     const descriptiveText = `${isBlameVisible ? 'Hide' : 'Show'} Git blame line annotations`
 

--- a/client/web/src/repo/blame/useBlameVisibility.tsx
+++ b/client/web/src/repo/blame/useBlameVisibility.tsx
@@ -1,12 +1,22 @@
+import { useCallback } from 'react'
+
 import { BehaviorSubject } from 'rxjs'
 
-import { useObservable } from '@sourcegraph/wildcard'
+import { useLocalStorage, useObservable } from '@sourcegraph/wildcard'
 
-const isBlameVisible = new BehaviorSubject<boolean>(false)
-const setIsBlameVisible = (isVisible: boolean): void => isBlameVisible.next(isVisible)
+const IS_BLAME_VISIBLE_STORAGE_KEY = 'GitBlame.isVisible'
+const isBlameVisible = new BehaviorSubject<boolean | undefined>(undefined)
 
 export const useBlameVisibility = (): [boolean, (isVisible: boolean) => void] => {
-    const isVisible = useObservable(isBlameVisible)
+    const [isVisibleFromLocalStorage, updateLocalStorageValue] = useLocalStorage(IS_BLAME_VISIBLE_STORAGE_KEY, false)
+    const isVisibleFromObservable = useObservable(isBlameVisible)
+    const setIsBlameVisible = useCallback(
+        (isVisible: boolean): void => {
+            isBlameVisible.next(isVisible)
+            updateLocalStorageValue(isVisible)
+        },
+        [updateLocalStorageValue]
+    )
 
-    return [Boolean(isVisible), setIsBlameVisible]
+    return [isVisibleFromObservable ?? isVisibleFromLocalStorage, setIsBlameVisible]
 }

--- a/client/web/src/repo/blob/BlameColumn.module.scss
+++ b/client/web/src/repo/blob/BlameColumn.module.scss
@@ -22,4 +22,9 @@ tr:global(.highlighted) {
 
 .wrapper {
     height: 1rem;
+
+    &.visible {
+        // stylelint-disable-next-line declaration-property-unit-allowed-list
+        width: 240px;
+    }
 }

--- a/client/web/src/repo/blob/BlameColumn.tsx
+++ b/client/web/src/repo/blob/BlameColumn.tsx
@@ -9,8 +9,9 @@ import { BlameDecoration } from './BlameDecoration'
 
 import styles from './BlameColumn.module.scss'
 
-interface ColumnDecoratorProps {
-    blameHunks: BlameHunk[]
+interface BlameColumnProps {
+    isBlameVisible?: boolean
+    blameHunks?: BlameHunk[]
     codeViewElements: ReplaySubject<HTMLElement | null>
 }
 
@@ -22,7 +23,7 @@ const getRowByLine = (line: number): HTMLTableRowElement | null | undefined =>
 const selectRow = (line: number): void => getRowByLine(line)?.classList.add('highlighted')
 const deselectRow = (line: number): void => getRowByLine(line)?.classList.remove('highlighted')
 
-export const BlameColumn = React.memo<ColumnDecoratorProps>(({ codeViewElements, blameHunks }) => {
+export const BlameColumn = React.memo<BlameColumnProps>(({ isBlameVisible, codeViewElements, blameHunks }) => {
     /**
      * Array to store the DOM element and the blame hunk to render in it.
      * As blame decorations are displayed in the column view, we need to add a corresponding
@@ -75,6 +76,10 @@ export const BlameColumn = React.memo<ColumnDecoratorProps>(({ codeViewElements,
                         // add decorations wrapper
                         const wrapper = document.createElement('div')
                         wrapper.classList.add(styles.wrapper)
+                        if (isBlameVisible) {
+                            // ensure blame column has needed width to avoid content jumping after blame hunks are loaded
+                            wrapper.classList.add(styles.visible)
+                        }
                         cell.append(wrapper)
 
                         // add extra spacers to first and last rows (if table has only one row add both spacers)
@@ -91,7 +96,7 @@ export const BlameColumn = React.memo<ColumnDecoratorProps>(({ codeViewElements,
                         }
                     }
 
-                    const currentLineDecorations = blameHunks.find(hunk => hunk.startLine - 1 === index)
+                    const currentLineDecorations = blameHunks?.find(hunk => hunk.startLine - 1 === index)
 
                     // store created cell and corresponding blame hunk (or undefined if no blame hunk)
                     addedCells.push([cell, currentLineDecorations])
@@ -108,7 +113,7 @@ export const BlameColumn = React.memo<ColumnDecoratorProps>(({ codeViewElements,
             subscription.unsubscribe()
             cleanup()
         }
-    }, [codeViewElements, blameHunks])
+    }, [codeViewElements, isBlameVisible, blameHunks])
 
     return (
         <>

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -127,6 +127,7 @@ export interface BlobProps
     role?: string
     ariaLabel?: string
 
+    isBlameVisible?: boolean
     blameHunks?: BlameHunk[]
     onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
 }
@@ -866,7 +867,11 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                     />
                 )}
 
-                {props.blameHunks && <BlameColumn blameHunks={props.blameHunks} codeViewElements={codeViewElements} />}
+                <BlameColumn
+                    isBlameVisible={props.isBlameVisible}
+                    blameHunks={props.blameHunks}
+                    codeViewElements={codeViewElements}
+                />
 
                 {groupedDecorations &&
                     iterate(groupedDecorations)

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -40,6 +40,7 @@ import { useNotepad, useExperimentalFeatures } from '../../stores'
 import { basename } from '../../util/path'
 import { toTreeURL } from '../../util/url'
 import { useBlameHunks } from '../blame/useBlameHunks'
+import { useBlameVisibility } from '../blame/useBlameVisibility'
 import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 import { HoverThresholdProps } from '../RepoContainer'
 import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
@@ -281,6 +282,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
         return `${repoString}`
     }
 
+    const [isBlameVisible] = useBlameVisibility()
     const blameDecorations = useBlameHunks({ repoName, revision, filePath }, props.platformContext.sourcegraphURL)
 
     const isSearchNotebook = Boolean(
@@ -480,6 +482,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                         disableDecorations={false}
                         role="region"
                         ariaLabel="File blob"
+                        isBlameVisible={isBlameVisible}
                         blameHunks={blameDecorations}
                         onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                     />

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -126,11 +126,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         [wrapCode, isLightTheme]
     )
 
-    const blameDecorations = useMemo(
-        () => (blameHunks ? [showGitBlameDecorations.of(blameHunks)] : []),
-
-        [blameHunks]
-    )
+    const blameDecorations = useMemo(() => (blameHunks ? [showGitBlameDecorations.of(blameHunks)] : []), [blameHunks])
 
     // Keep history and location in a ref so that we can use the latest value in
     // the onSelection callback without having to recreate it and having to


### PR DESCRIPTION
Disables flaky test and reverts [commit reverting 3 PRs because of this test failing](https://github.com/sourcegraph/sourcegraph/pull/41842).
More context in [this thread](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1663756044164159).

Follow-up issue: https://github.com/sourcegraph/sourcegraph/issues/41850

## Test plan
`sg ci build main-dry-run` passes ([build](https://buildkite.com/sourcegraph/sourcegraph/builds/173369))

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-disable-flaky-test.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ehwsekxtps.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

