### PR TITLE
gitserver: Reduce ratelimit logspam

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2460,7 +2460,11 @@ func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName, revspec st
 
 			err = s.doBackgroundRepoUpdate(repo, revspec)
 			if err != nil {
-				s.Logger.Error("performing background repo update", log.Error(err))
+				// We don't want to spam our logs when the rate limiter has been set to block all
+				// updates
+				if !errors.Is(err, ratelimit.ErrBlockAll) {
+					s.Logger.Error("performing background repo update", log.Error(err))
+				}
 			}
 			s.setLastErrorNonFatal(s.ctx, repo, err)
 		})

--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // DefaultRegistry is the default global rate limit registry, which holds rate
@@ -137,6 +138,12 @@ func (i *InstrumentedLimiter) Wait(ctx context.Context) error {
 // canceled, or the expected wait time exceeds the Context's Deadline.
 // The burst limit is ignored if the rate limit is Inf.
 func (i *InstrumentedLimiter) WaitN(ctx context.Context, n int) error {
+	if i.Limit() == 0 && i.Burst() == 0 {
+		// We're not allowing anything through the limiter, return a custom error so that
+		// we can handle it correctly.
+		return ErrBlockAll
+	}
+
 	start := time.Now()
 	err := i.Limiter.WaitN(ctx, n)
 	d := time.Since(start)
@@ -167,6 +174,9 @@ func (i *InstrumentedLimiter) SetBurst(newBurst int) {
 func (i *InstrumentedLimiter) SetLimit(newLimit rate.Limit) {
 	i.Limiter.SetLimitAt(time.Now(), newLimit)
 }
+
+// ErrBlockAll indicates that the limiter is set to block all requests
+var ErrBlockAll = errors.New("ratelimit: limit and burst are zero")
 
 var metricWaitDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "src_internal_rate_limit_wait_duration",

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	gitserverprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -218,7 +219,11 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 					subLogger.Error("error requesting repo update", log.Error(err), log.String("uri", string(repo.Name)))
 				} else if resp != nil && resp.Error != "" {
 					schedError.WithLabelValues("repoUpdateResponse").Inc()
-					subLogger.Error("error updating repo", log.String("err", resp.Error), log.String("uri", string(repo.Name)))
+					// We don't want to spam our logs when the rate limiter has been set to block all
+					// updates
+					if !strings.Contains(resp.Error, ratelimit.ErrBlockAll.Error()) {
+						subLogger.Error("error updating repo", log.String("err", resp.Error), log.String("uri", string(repo.Name)))
+					}
 				}
 
 				if interval := getCustomInterval(subLogger, conf.Get(), string(repo.Name)); interval > 0 {


### PR DESCRIPTION
It's possible to set `gitMaxCodehostRequestsPerSecond` to zero, which
blocks all calls to external code hosts, including clones and fetches.
When set to zero, we would previously see logs spammed with this error:

"rate: Wait(n=1) exceeds limiter's burst 0"

We now instead return a custom error and don't log when we see this
error. The errors will still be stored in the gitserver_repos table
however.

Closes https://github.com/sourcegraph/sourcegraph/issues/41152

## Test plan

Tests pass and also tests locally that logs are no longer spammed.
