### PR TITLE
prometheus: increase scrape and evaluation intervals to 1m

### DIFF
--- a/docker-images/prometheus/config/prometheus.yml
+++ b/docker-images/prometheus/config/prometheus.yml
@@ -1,7 +1,7 @@
 # Prometheus global config
 global:
-  scrape_interval: 30s # Scrape services for updated metrics every 30s. Default is 1m.
-  evaluation_interval: 30s # Evaluate rules every 30s. Default is 1m.
+  scrape_interval: 1m # Scrape services for updated metrics every 1m.
+  evaluation_interval: 1m # Evaluate rules every 1m.
   # scrape_timeout is set to the global default (10s).
 
 # Alertmanager configuration


### PR DESCRIPTION
This change of `scrape_interval` and `evaluation_interval` back to the Prometheus defaults of `1m` will significantly reduce Prometheus load, and for those that export these metrics (just us for now) it can drastically reduce the costs associated with using a third-party metrics backend. With the default dashboard view being 6h I don't think this should make a significant impact on dashboards, and a quick search indicates queries do not aggregate on <`1m` intervals (but we _do_ aggregate a lot on `1m`, so we avoid bumping this to `2m`):

```
repo:^github\.com/sourcegraph/sourcegraph$ f:monitoring/definitions [^%.\s]\[(\w+)\][^.(] count:all
```

<img width="998" alt="image" src="https://user-images.githubusercontent.com/23356519/191567563-5529cf3a-c893-45ce-91ca-48f85ad79b35.png">

Also see the [#dev-backend discussion](https://sourcegraph.slack.com/archives/C02UC4WUX1Q/p1663779216804779).

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Prometheus starts up with `sg run prometheus`