### PR TITLE
Search backend: search merges in commit search

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1208,12 +1208,12 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:   `commit results without repo filter`,
 				query:  `type:commit LSIF`,
-				counts: counts{Commit: 9},
+				counts: counts{Commit: 11},
 			},
 			{
 				name:   `commit results with repo filter`,
 				query:  `repo:contains.file(path:diff.pb.go) type:commit LSIF`,
-				counts: counts{Commit: 1},
+				counts: counts{Commit: 2},
 			},
 			{
 				name:   `predicate logic does not conflict with unrecognized patterns`,

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -64,7 +64,6 @@ var (
 		"log",
 		"--decorate=full",
 		"-z",
-		"--no-merges",
 		"--format=format:" + "%x1E" + strings.Join(commitFields, "%x00") + "%x00",
 	}
 


### PR DESCRIPTION
We currently explicitly skip merge commits in commit search. This is historical behavior, and is problematic because merge commits sometimes contain useful information. More context [here](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1660075874735709). 

In an ideal world, this would be configurable in the search query language, but I don't want to dig that deep right now.

## Test plan

Tested locally that merges show up in commit results now.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
