### PR TITLE
inference: Add lua shim for pattern construction

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/libs/patterns.go
+++ b/internal/codeintel/autoindexing/internal/inference/libs/patterns.go
@@ -40,6 +40,10 @@ func (api patternAPI) LuaAPI() map[string]lua.LGFunction {
 	}
 
 	return map[string]lua.LGFunction{
+		"backdoor": util.WrapLuaFunction(func(state *lua.LState) error {
+			state.Push(luar.New(state, luatypes.NewPattern(state.CheckString(1))))
+			return nil
+		}),
 		"path_literal":   util.WrapLuaFunction(newPathPatternConstructor("^", "$")),
 		"path_segment":   util.WrapLuaFunction(newPathPatternConstructor("(^|/)", "(/|$)")),
 		"path_basename":  util.WrapLuaFunction(newPathPatternConstructor("(^|/)", "$")),

--- a/internal/codeintel/autoindexing/internal/inference/lua/clang.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/clang.lua
@@ -1,5 +1,5 @@
 local path = require "path"
-local patterns = require "sg.patterns"
+local pattern = require "sg.autoindex.patterns"
 local recognizers = require "sg.recognizers"
 
 local indexer = "sourcegraph/lsif-clang"
@@ -10,20 +10,20 @@ end
 
 return recognizers.path_recognizer {
   patterns = {
-    patterns.path_extension "cpp",
-    patterns.path_extension "c",
-    patterns.path_extension "h",
-    patterns.path_extension "hpp",
-    patterns.path_extension "cxx",
-    patterns.path_extension "cc",
-    patterns.path_basename "CMakeLists.txt",
-    patterns.path_basename "CMakelists.txt",
-    patterns.path_basename "CmakeLists.txt",
-    patterns.path_basename "Cmakelists.txt",
-    patterns.path_basename "cMakeLists.txt",
-    patterns.path_basename "cMakelists.txt",
-    patterns.path_basename "cmakeLists.txt",
-    patterns.path_basename "cmakelists.txt",
+    pattern.new_path_extension "cpp",
+    pattern.new_path_extension "c",
+    pattern.new_path_extension "h",
+    pattern.new_path_extension "hpp",
+    pattern.new_path_extension "cxx",
+    pattern.new_path_extension "cc",
+    pattern.new_path_basename "CMakeLists.txt",
+    pattern.new_path_basename "CMakelists.txt",
+    pattern.new_path_basename "CmakeLists.txt",
+    pattern.new_path_basename "Cmakelists.txt",
+    pattern.new_path_basename "cMakeLists.txt",
+    pattern.new_path_basename "cMakelists.txt",
+    pattern.new_path_basename "cmakeLists.txt",
+    pattern.new_path_basename "cmakelists.txt",
   },
 
   -- Invoked when c, cpp, header, or cmakelist files exist

--- a/internal/codeintel/autoindexing/internal/inference/lua/go.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/go.lua
@@ -1,19 +1,19 @@
 local path = require "path"
-local patterns = require "sg.patterns"
+local pattern = require "sg.autoindex.patterns"
 local recognizers = require "sg.recognizers"
 
 local shared = require "sg.autoindex.shared"
 
 local indexer = "sourcegraph/lsif-go:latest"
 
-local exclude_paths = patterns.path_combine(shared.exclude_paths, {
-  patterns.path_segment "vendor",
+local exclude_paths = pattern.new_path_combine(shared.exclude_paths, {
+  pattern.new_path_segment "vendor",
 })
 
 local gomod_recognizer = recognizers.path_recognizer {
   patterns = {
-    patterns.path_basename "go.mod",
-    patterns.path_exclude(exclude_paths),
+    pattern.new_path_basename "go.mod",
+    pattern.new_path_exclude(exclude_paths),
   },
 
   -- Invoked when go.mod files exist
@@ -43,8 +43,8 @@ local gomod_recognizer = recognizers.path_recognizer {
 
 local goext_recognizer = recognizers.path_recognizer {
   patterns = {
-    patterns.path_extension "go",
-    patterns.path_exclude(exclude_paths),
+    pattern.new_path_extension "go",
+    pattern.new_path_exclude(exclude_paths),
   },
 
   -- Invoked when no go.mod files exist but go extensions exist somewhere

--- a/internal/codeintel/autoindexing/internal/inference/lua/java.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/java.lua
@@ -1,5 +1,5 @@
 local path = require "path"
-local patterns = require "sg.patterns"
+local pattern = require "sg.autoindex.patterns"
 local recognizers = require "sg.recognizers"
 
 local indexer = "sourcegraph/scip-java"
@@ -11,19 +11,19 @@ end
 
 return recognizers.path_recognizer {
   patterns = {
-    patterns.path_extension "java",
-    patterns.path_extension "scala",
-    patterns.path_extension "kt",
-    patterns.path_basename "pom.xml",
-    patterns.path_basename "build.gradle",
-    patterns.path_basename "build.gradle.kts",
+    pattern.new_path_extension "java",
+    pattern.new_path_extension "scala",
+    pattern.new_path_extension "kt",
+    pattern.new_path_basename "pom.xml",
+    pattern.new_path_basename "build.gradle",
+    pattern.new_path_basename "build.gradle.kts",
   },
 
   -- Invoked when Java, Scala, Kotlin, or Gradle build files exist
   generate = function(api)
     api:register(recognizers.path_recognizer {
       patterns = {
-        patterns.path_literal "lsif-java.json",
+        pattern.new_path_literal "lsif-java.json",
       },
 
       -- Invoked when lsif-java.json exists in root of repository

--- a/internal/codeintel/autoindexing/internal/inference/lua/patterns.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/patterns.lua
@@ -1,0 +1,39 @@
+local patterns = require("sg.patterns")
+
+local M = {}
+
+local quote = function(pattern)
+	-- regexp meta chars: `| { }`
+	-- regexp AND lua meta chars: ` . + * ? ( ) [ ] ^ $` (escaped with %)
+	return string.gsub(pattern, "([|{}%.%+%*%?%(%)%[%]%^%$])", "\\%1")
+end
+
+local new_pattern = function(prefix, pattern, suffix)
+	return patterns.backdoor(prefix .. quote(pattern) .. suffix)
+end
+
+M.new_path_literal = function(pattern)
+	return new_pattern("^", pattern, "$")
+end
+
+M.new_path_segment = function(pattern)
+	return new_pattern("(^|/)", pattern, "(/|$)")
+end
+
+M.new_path_basename = function(pattern)
+	return new_pattern("(^|/)", pattern, "$")
+end
+
+M.new_path_extension = function(pattern)
+	return new_pattern("(^|/)[^/]+.", pattern, "$")
+end
+
+M.new_path_combine = function(pattern)
+	return patterns.path_combine(pattern)
+end
+
+M.new_path_exclude = function(pattern)
+	return patterns.path_exclude(pattern)
+end
+
+return M

--- a/internal/codeintel/autoindexing/internal/inference/lua/rust.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/rust.lua
@@ -1,4 +1,4 @@
-local patterns = require "sg.patterns"
+local pattern = require "sg.autoindex.patterns"
 local recognizers = require "sg.recognizers"
 
 local indexer = "sourcegraph/lsif-rust"
@@ -6,7 +6,7 @@ local outfile = "dump.lsif"
 
 return recognizers.path_recognizer {
   patterns = {
-    patterns.path_basename "Cargo.toml",
+    pattern.new_path_basename "Cargo.toml",
   },
 
   -- Invoked when Cargo.toml exists anywhere in repository

--- a/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
@@ -1,6 +1,6 @@
 local json = require "json"
 local path = require "path"
-local patterns = require "sg.patterns"
+local pattern = require "sg.autoindex.patterns"
 local recognizers = require "sg.recognizers"
 
 local shared = require "sg.autoindex.shared"
@@ -10,8 +10,8 @@ local indexer = "sourcegraph/scip-typescript:autoindex"
 local typescript_nmusl_command =
   "N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto"
 
-local exclude_paths = patterns.path_combine(shared.exclude_paths, {
-  patterns.path_segment "node_modules",
+local exclude_paths = pattern.new_path_combine(shared.exclude_paths, {
+  pattern.new_path_segment "node_modules",
 })
 
 local check_lerna_file = function(root, contents_by_path)
@@ -57,21 +57,21 @@ local infer_typescript_job = function(api, tsconfig_path, should_infer_config)
   api:register(recognizers.path_recognizer {
     patterns = {
       -- To disambiguate installation steps
-      patterns.path_basename "yarn.lock",
+      pattern.new_path_basename "yarn.lock",
       -- Try to determine version
-      patterns.path_basename ".n-node-version",
-      patterns.path_basename ".node-version",
-      patterns.path_basename ".nvmrc",
+      pattern.new_path_basename ".n-node-version",
+      pattern.new_path_basename ".node-version",
+      pattern.new_path_basename ".nvmrc",
       -- To reinvoke simple cases with no other files
-      patterns.path_basename "tsconfig.json",
-      patterns.path_exclude(exclude_paths),
+      pattern.new_path_basename "tsconfig.json",
+      pattern.new_path_exclude(exclude_paths),
     },
 
     patterns_for_content = {
       -- To read explicitly configured engines and npm client
-      patterns.path_basename "package.json",
-      patterns.path_basename "lerna.json",
-      patterns.path_exclude(exclude_paths),
+      pattern.new_path_basename "package.json",
+      pattern.new_path_basename "lerna.json",
+      pattern.new_path_exclude(exclude_paths),
     },
 
     -- Invoked when any of the files listed in the patterns above exist.
@@ -133,9 +133,9 @@ end
 
 return recognizers.path_recognizer {
   patterns = {
-    patterns.path_basename "package.json",
-    patterns.path_basename "tsconfig.json",
-    patterns.path_exclude(exclude_paths),
+    pattern.new_path_basename "package.json",
+    pattern.new_path_basename "tsconfig.json",
+    pattern.new_path_exclude(exclude_paths),
   },
 
   -- Invoked when package.json or tsconfig.json files exist

--- a/internal/database/migration/cliutil/drift_schema.go
+++ b/internal/database/migration/cliutil/drift_schema.go
@@ -27,7 +27,7 @@ func GCSExpectedSchemaFactory(filename, version string) (schemaDescription descr
 // GitHubExpectedSchemaFactory reads schema definitions from the sourcegraph/sourcegraph repository via the
 // GitHub raw API. A false-valued flag is returned if the schema does not exist for this version.
 func GitHubExpectedSchemaFactory(filename, version string) (descriptions.SchemaDescription, bool, error) {
-	if !regexp.MustCompile(`(^v\d+\.\d+\.\d+$)|(^[A-Fa-f0-9]{40}$)`).MatchString(version) {
+	if !regexp.MustCompile(`(^\d+.\d+$)|(^v\d+\.\d+\.\d+$)|(^[A-Fa-f0-9]{40}$)`).MatchString(version) {
 		return descriptions.SchemaDescription{}, false, errors.Newf("failed to parse %q - expected a version of the form `vX.Y.Z` or a 40-character commit hash", version)
 	}
 


### PR DESCRIPTION
Put a small Lua shim in between user code and Go code for pattern construction. Now that we have a Lua shim we can do more light-weight validation and use lua builtin types rather than usertypes.

## Test plan

Existing unit tests.
