### PR TITLE
dev/sg: add 'sg monitoring metrics' for metrics listing

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -971,12 +971,25 @@ Flags:
 
 List and describe the default dashboards.
 
+Arguments: `<dashboard...>`
 
 Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--groups`: Show row groups
 * `--metrics`: Show metrics used in dashboards
+
+### sg monitoring metrics
+
+List metrics used in dashboards.
+
+For per-dashboard summaries, use 'sg monitoring dashboards' instead.
+
+Arguments: `<dashboard...>`
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
 
 ## sg secret
 

--- a/monitoring/monitoring/internal/promql/promql.go
+++ b/monitoring/monitoring/internal/promql/promql.go
@@ -49,18 +49,6 @@ func Inject(expression string, matchers []*labels.Matcher, vars VariableApplier)
 	return revertExpr(expr)
 }
 
-// replaceAndParse applies vars to the expression and parses the result into a PromQL AST.
-func replaceAndParse(expression string, vars VariableApplier) (promqlparser.Expr, error) {
-	if vars != nil {
-		expression = vars.ApplySentinelValues(expression)
-	}
-	expr, err := promqlparser.ParseExpr(expression)
-	if err != nil {
-		return nil, errors.Wrapf(err, "%q", expression)
-	}
-	return expr, nil
-}
-
 // ListMetrics returns all unique metrics used in the expression.
 func ListMetrics(expression string, vars VariableApplier) ([]string, error) {
 	// Generate AST
@@ -82,4 +70,16 @@ func ListMetrics(expression string, vars VariableApplier) ([]string, error) {
 		return nil
 	})
 	return metrics, nil
+}
+
+// replaceAndParse applies vars to the expression and parses the result into a PromQL AST.
+func replaceAndParse(expression string, vars VariableApplier) (promqlparser.Expr, error) {
+	if vars != nil {
+		expression = vars.ApplySentinelValues(expression)
+	}
+	expr, err := promqlparser.ParseExpr(expression)
+	if err != nil {
+		return nil, errors.Wrapf(err, "%q", expression)
+	}
+	return expr, nil
 }


### PR DESCRIPTION
A simpler output format for listing metrics. Also makes the support for dashboards varargs more consistent:

```
sg monitoring metrics frontend executor
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
$ go run ./dev/sg monitoring metrics frontend executor   
src_search_streaming_latency_seconds_bucket
src_graphql_search_response
src_http_request_duration_seconds_bucket
src_graphql_field_seconds_bucket
src_codeintel_resolvers_total
src_codeintel_resolvers_duration_seconds_bucket
src_codeintel_resolvers_errors_total
src_codeintel_autoindex_enqueuer_total
src_codeintel_autoindex_enqueuer_duration_seconds_bucket
src_codeintel_autoindex_enqueuer_errors_total
src_codeintel_dbstore_total
src_codeintel_dbstore_duration_seconds_bucket
src_codeintel_dbstore_errors_total
src_workerutil_dbworker_store_codeintel_index_total
src_workerutil_dbworker_store_codeintel_index_duration_seconds_bucket
src_workerutil_dbworker_store_codeintel_index_errors_total
src_codeintel_lsifstore_total
src_codeintel_lsifstore_duration_seconds_bucket
src_codeintel_lsifstore_errors_total
src_codeintel_gitserver_total
src_codeintel_gitserver_duration_seconds_bucket
src_codeintel_gitserver_errors_total
src_codeintel_repoupdater_total
...
```
