### PR TITLE
aggregate code insights in memory as an experiment, and collect metri…

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -395,7 +395,6 @@ func fetchSeries(ctx context.Context, definition types.InsightViewSeries, filter
 			return nil, err
 		}
 	} else {
-		log15.Info("alternative")
 		points, err = r.timeSeriesStore.LoadSeriesInMem(ctx, *opts)
 		if err != nil {
 			return nil, err

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -410,6 +410,9 @@ func fetchSeries(ctx context.Context, definition types.InsightViewSeries, filter
 
 func recordedSeries(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters) (_ []graphqlbackend.InsightSeriesResolver, err error) {
 	points, err := fetchSeries(ctx, definition, filters, &r)
+	if err != nil {
+		return nil, err
+	}
 
 	status, err := queryrunner.QueryJobsStatus(ctx, r.workerBaseStore, definition.SeriesID)
 	if err != nil {
@@ -435,6 +438,9 @@ func recordedSeries(ctx context.Context, definition types.InsightViewSeries, r b
 
 func expandCaptureGroupSeriesRecorded(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error) {
 	allPoints, err := fetchSeries(ctx, definition, filters, &r)
+	if err != nil {
+		return nil, err
+	}
 	groupedByCapture := make(map[string][]store.SeriesPoint)
 
 	for i := range allPoints {

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -24,7 +24,6 @@ import (
 // for actual API usage.
 type Interface interface {
 	SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]SeriesPoint, error)
-	LoadSeriesInMem(ctx context.Context, opts SeriesPointsOpts) ([]SeriesPoint, error)
 	RecordSeriesPoint(ctx context.Context, v RecordSeriesPointArgs) error
 	RecordSeriesPoints(ctx context.Context, pts []RecordSeriesPointArgs) error
 	CountData(ctx context.Context, opts CountDataOpts) (int, error)

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -166,7 +166,6 @@ func (s *Store) LoadSeriesInMem(ctx context.Context, opts SeriesPointsOpts) (poi
 	}
 
 	type loadStruct struct {
-		// Time (always UTC).
 		Time    time.Time
 		Value   float64
 		RepoID  int
@@ -196,11 +195,6 @@ func (s *Store) LoadSeriesInMem(ctx context.Context, opts SeriesPointsOpts) (poi
 	filter := func(id int) bool {
 		return denyBitmap.Contains(uint32(id))
 	}
-	// SELECT sp.repo_name_id, sp.series_id, date_trunc('seconds', sp.time) AS interval_time, MAX(value) as value, null as metadata, capture
-	//	FROM (  select * from series_points
-	//			union
-	//			select * from series_points_snapshots
-	//	) AS sp
 
 	q := `select date_trunc('seconds', sp.time) AS interval_time, max(value), repo_id, capture FROM (
 				select * from series_points

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/RoaringBitmap/roaring"
 
 	"github.com/keegancsmith/sqlf"
@@ -121,9 +119,6 @@ type SeriesPointsOpts struct {
 // SeriesPoints queries data points over time for a specific insights' series.
 func (s *Store) SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]SeriesPoint, error) {
 	points := make([]SeriesPoint, 0, opts.Limit)
-
-	log15.Info("seriesPoints", "opts", opts)
-
 	// 🚨 SECURITY: This is a double-negative repo permission enforcement. The list of authorized repos is generally expected to be very large, and nearly the full
 	// set of repos installed on Sourcegraph. To make this faster, we query Postgres for a list of repos the current user cannot see, and then exclude those from the
 	// time series results. 🚨

--- a/enterprise/internal/insights/store/store_benchs_test.go
+++ b/enterprise/internal/insights/store/store_benchs_test.go
@@ -20,10 +20,7 @@ import (
 )
 
 func initializeData(ctx context.Context, store *Store, repos, times int, withCapture bool) string {
-	// captureVals := []string{"one", "two"}
-	//
 	var cv []*string
-	//
 	strPtr := func(s string) *string {
 		return &s
 	}
@@ -52,7 +49,7 @@ func initializeData(ctx context.Context, store *Store, repos, times int, withCap
 					},
 					RepoName:    &repoName,
 					RepoID:      &id,
-					PersistMode: "record",
+					PersistMode: RecordMode,
 				})
 				if err != nil {
 					panic(err)
@@ -142,16 +139,6 @@ func BenchmarkLoadTimes(b *testing.B) {
 		repos int
 		times int
 	}{
-		// {
-		// 	name:  "simple",
-		// 	repos: 10000,
-		// 	times: 12,
-		// },
-		// {
-		// 	name:  "simple",
-		// 	repos: 1000,
-		// 	times: 12,
-		// },
 		{
 			name:  "simple",
 			repos: 1000,

--- a/enterprise/internal/insights/store/store_benchs_test.go
+++ b/enterprise/internal/insights/store/store_benchs_test.go
@@ -1,0 +1,192 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/sourcegraph/log/logtest"
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+)
+
+func initializeData(ctx context.Context, store *Store, repos, times int, withCapture bool) string {
+	// captureVals := []string{"one", "two"}
+	//
+	var cv []*string
+	//
+	strPtr := func(s string) *string {
+		return &s
+	}
+
+	if withCapture {
+		cv = append(cv, strPtr("one"))
+		cv = append(cv, strPtr("two"))
+	} else {
+		cv = append(cv, nil)
+	}
+
+	seriesID := rand.String(8)
+	currentTime := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < times; i++ {
+		for j := 0; j < repos; j++ {
+			repoName := fmt.Sprintf("repo-%d", j)
+			id := api.RepoID(j)
+			for _, val := range cv {
+				err := store.RecordSeriesPoint(ctx, RecordSeriesPointArgs{
+					SeriesID: seriesID,
+					Point: SeriesPoint{
+						SeriesID: seriesID,
+						Time:     currentTime,
+						Value:    float64(rand.Intn(500)),
+						Capture:  val,
+					},
+					RepoName:    &repoName,
+					RepoID:      &id,
+					PersistMode: "record",
+				})
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+
+		currentTime = currentTime.AddDate(0, 1, 0)
+	}
+
+	return seriesID
+}
+
+func TestCompareLoadMethods(t *testing.T) {
+
+	toStr := func(pts []SeriesPoint) []string {
+		var elems []string
+		for _, pt := range pts {
+			var cap string
+			if pt.Capture != nil {
+				cap = *pt.Capture
+			}
+
+			elems = append(elems, fmt.Sprintf("%s-%s-%s-%f", pt.SeriesID, cap, pt.Time, pt.Value))
+		}
+		return elems
+	}
+
+	t.Run("no capture values", func(t *testing.T) {
+		logger := logtest.Scoped(t)
+		ctx := context.Background()
+		clock := timeutil.Now
+		insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+		postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+		permStore := NewInsightPermissionStore(postgres)
+		store := NewWithClock(insightsDB, permStore, clock)
+
+		seriesID := initializeData(ctx, store, 500, 5, false)
+
+		db, _ := store.SeriesPoints(ctx, SeriesPointsOpts{SeriesID: &seriesID})
+		mem, _ := store.LoadSeriesInMem(ctx, SeriesPointsOpts{SeriesID: &seriesID})
+
+		dbStr := toStr(db)
+		memStr := toStr(mem)
+
+		sort.Slice(dbStr, func(i, j int) bool {
+			return dbStr[i] < dbStr[j]
+		})
+
+		sort.Slice(memStr, func(i, j int) bool {
+			return memStr[i] < memStr[j]
+		})
+		require.ElementsMatchf(t, dbStr, memStr, "db aggregation not equal to mem aggregation")
+	})
+
+	t.Run("with captured values", func(t *testing.T) {
+		logger := logtest.Scoped(t)
+		ctx := context.Background()
+		clock := timeutil.Now
+		insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+		postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+		permStore := NewInsightPermissionStore(postgres)
+		store := NewWithClock(insightsDB, permStore, clock)
+
+		seriesID := initializeData(ctx, store, 500, 5, true)
+
+		db, _ := store.SeriesPoints(ctx, SeriesPointsOpts{SeriesID: &seriesID})
+		mem, _ := store.LoadSeriesInMem(ctx, SeriesPointsOpts{SeriesID: &seriesID})
+
+		dbStr := toStr(db)
+		memStr := toStr(mem)
+
+		sort.Slice(dbStr, func(i, j int) bool {
+			return dbStr[i] < dbStr[j]
+		})
+
+		sort.Slice(memStr, func(i, j int) bool {
+			return memStr[i] < memStr[j]
+		})
+		require.ElementsMatchf(t, dbStr, memStr, "db aggregation not equal to mem aggregation")
+	})
+}
+
+func BenchmarkLoadTimes(b *testing.B) {
+	benchmarks := []struct {
+		name  string
+		repos int
+		times int
+	}{
+		// {
+		// 	name:  "simple",
+		// 	repos: 10000,
+		// 	times: 12,
+		// },
+		// {
+		// 	name:  "simple",
+		// 	repos: 1000,
+		// 	times: 12,
+		// },
+		{
+			name:  "simple",
+			repos: 1000,
+			times: 12,
+		},
+	}
+	for _, bm := range benchmarks {
+		logger := logtest.Scoped(b)
+		ctx := context.Background()
+		clock := timeutil.Now
+		insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, b))
+		postgres := database.NewDB(logger, dbtest.NewDB(logger, b))
+		permStore := NewInsightPermissionStore(postgres)
+		store := NewWithClock(insightsDB, permStore, clock)
+
+		seriesID := initializeData(ctx, store, bm.repos, bm.times, false)
+
+		opts := SeriesPointsOpts{SeriesID: &seriesID}
+
+		b.Run("in-db-aggregate", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := store.SeriesPoints(ctx, opts)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run("in-mem-aggregate", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := store.LoadSeriesInMem(ctx, opts)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -1249,8 +1249,6 @@ github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/goware/urlx v0.3.1 h1:BbvKl8oiXtJAzOzMqAQ0GfIhf96fKeNEZfm9ocNSUBI=
 github.com/goware/urlx v0.3.1/go.mod h1:h8uwbJy68o+tQXCGZNa9D73WN8n0r9OBae5bUnLcgjw=
-github.com/grafana-tools/sdk v0.0.0-20220203092117-edae16afa87b h1:R9LID2XreyUOQfJ/NKLGuYOF4/Wz6ljmYFAhlOaHVQ4=
-github.com/grafana-tools/sdk v0.0.0-20220203092117-edae16afa87b/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85Tnn+WEvr8fDpfwibmEPgfgFEaC87G24=
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/regexp v0.0.0-20220304100321-149c8afcd6cb h1:wwzNkyaQwcXCzQuKoWz3lwngetmcyg+EhW0fF5lz73M=

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -631,6 +631,8 @@ type ExperimentalFeatures struct {
 	GitServerPinnedRepos map[string]string `json:"gitServerPinnedRepos,omitempty"`
 	// GoPackages description: Allow adding Go package host connections
 	GoPackages string `json:"goPackages,omitempty"`
+	// InsightsAlternateLoadingStrategy description: Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.
+	InsightsAlternateLoadingStrategy bool `json:"insightsAlternateLoadingStrategy,omitempty"`
 	// JvmPackages description: Allow adding JVM package host connections
 	JvmPackages string `json:"jvmPackages,omitempty"`
 	// NpmPackages description: Allow adding npm package code host connections
@@ -1863,6 +1865,8 @@ type SettingsExperimentalFeatures struct {
 	HomePanelsComputeSuggestions bool `json:"homePanelsComputeSuggestions,omitempty"`
 	// HomepageUserInvitation description: Shows a panel to invite collaborators to Sourcegraph on home page.
 	HomepageUserInvitation *bool `json:"homepageUserInvitation,omitempty"`
+	// InsightsAlternateLoadingStrategy description: Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.
+	InsightsAlternateLoadingStrategy bool `json:"insightsAlternateLoadingStrategy,omitempty"`
 	// ProactiveSearchResultsAggregations description: Search results aggregations are triggered automatically with a search.
 	ProactiveSearchResultsAggregations *bool `json:"proactiveSearchResultsAggregations,omitempty"`
 	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -404,6 +404,11 @@
           "!go": {
             "pointer": true
           }
+        },
+        "insightsAlternateLoadingStrategy": {
+          "description": "Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.",
+          "type": "boolean",
+          "default": false
         }
       },
       "group": "Experimental"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -534,6 +534,11 @@
           "type": "boolean",
           "default": false,
           "!go": { "pointer": true }
+        },
+        "insightsAlternateLoadingStrategy": {
+          "description": "Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.",
+          "type": "boolean",
+          "default": false
         }
       },
       "examples": [


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/41878

When we think about ways to unlock post-hoc repository permissions for Code Insights the obvious answer to the problem of having to load IDs into the database is "what if we just didn't?". This PR is a first stab at what if we didn't.

Behind a site feature flag we:
1. Load Code Insight time series data _per grouped row_ and aggregate in memory
2. Load permissions into a bitmap and filter as we pull rows out of the database
3. Measure what is the difference in above

Repository name filtering is still performed in the DB, thought it isn't a requirement.

The goal of this PR is to do some testing in a more "real" environment, such as k8s-dogfod.

## Test plan

I tested this locally by flagging on and off and scrolling wildly around the all insights page, both watching for performance and correctness. Having said that, since the purpose of this PR is to put something in the dogfood environment and measure this against _really big_ insights, this isn't necessarily guaranteeing correctness parity at this time.

I also added some automated tests to compare the two functions responses from some randomly generated test data (both capture groups and not).
