### PR TITLE
executors: fix infinite hang

### DIFF
--- a/enterprise/cmd/executor/internal/worker/workspace/firecracker.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/firecracker.go
@@ -131,13 +131,13 @@ func setupLoopDevice(
 ) (blockDeviceFile, tmpMountDir, blockDevice string, err error) {
 	handle := logger.Log("setup.fs.workspace", nil)
 	defer func() {
-		// add the error to the bottom of the step's log output,
-		// but only if this isnt from exec.Command, as those get added
-		// by our logging wrapper
-		if !errors.HasType(err, &exec.ExitError{}) {
-			fmt.Fprint(handle, err.Error())
-		}
 		if err != nil {
+			// add the error to the bottom of the step's log output,
+			// but only if this isnt from exec.Command, as those get added
+			// by our logging wrapper
+			if !errors.HasType(err, &exec.ExitError{}) {
+				fmt.Fprint(handle, err.Error())
+			}
 			handle.Finalize(1)
 		} else {
 			handle.Finalize(0)


### PR DESCRIPTION
Panic in the defer when `err` was nil caused jobs to hang infinitely. 

<details>
<summary>Can you spot the bug?</summary>

```
        goroutine 134 [select]:
        runtime.gopark(0xc000329c68?, 0x2?, 0x0?, 0x30?, 0xc000329c0c?)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/proc.go:363 +0xd6 fp=0xc000329a10 sp=0xc0003299f0 pc=0x43e636
        runtime.selectgo(0xc000329c68, 0xc000329c08, 0x0?, 0x0, 0x0?, 0x1)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/select.go:328 +0x7bc fp=0xc000329b50 sp=0xc000329a10 pc=0x44e4bc
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command.(*logger).syncLogEntry(0xc0001361c0, 0xc0001ecb40, 0x1?, {{0xc2795f, 0x12}, {0x0, 0x0, 0x0}, {0xc0c2fd266e87ec66, 0x2d9e899, ...}, ...})
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command/logger.go:201 +0xdb fp=0xc000329eb8 sp=0xc000329b50 pc=0xa46c5b
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command.(*logger).writeEntries.func1(0x6f2ae6?, 0xc0001c2120?, {{0xc2795f, 0x12}, {0x0, 0x0, 0x0}, {0xc0c2fd266e87ec66, 0x2d9e899, 0x1201640}, ...})
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command/logger.go:188 +0xa5 fp=0xc000329f60 sp=0xc000329eb8 pc=0xa46a65
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command.(*logger).writeEntries.func3()
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command/logger.go:189 +0x55 fp=0xc000329fe0 sp=0xc000329f60 pc=0xa46995
        runtime.goexit()
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/asm_amd64.s:1594 +0x1 fp=0xc000329fe8 sp=0xc000329fe0 pc=0x46fc81
        created by github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command.(*logger).writeEntries
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command/logger.go:185 +0x605

        goroutine 44 [chan receive, 9 minutes]:
        runtime.gopark(0x4ea686?, 0x1?, 0xb0?, 0x98?, 0x408a4a?)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/proc.go:363 +0xd6 fp=0xc0002487d8 sp=0xc0002487b8 pc=0x43e636
        runtime.chanrecv(0xc00009f140, 0x0, 0x1)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/chan.go:583 +0x49b fp=0xc000248868 sp=0xc0002487d8 pc=0x40863b
        runtime.chanrecv1(0xc000411320?, 0xd34820?)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/chan.go:442 +0x18 fp=0xc000248890 sp=0xc000248868 pc=0x408138
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command.(*logger).Flush(0xc0001361c0)
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command/logger.go:141 +0x55 fp=0xc0002488e8 sp=0xc000248890 pc=0xa45f95
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker.(*handler).Handle.func2()
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/handler.go:84 +0x2f fp=0xc000248940 sp=0xc0002488e8 pc=0xa5842f
        panic({0xb4ee20, 0x11e5210})
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/panic.go:890 +0x262 fp=0xc000248a00 sp=0xc000248940 pc=0x43b482
        runtime.panicmem(...)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/panic.go:260
        runtime.sigpanic()
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/signal_unix.go:835 +0x2f6 fp=0xc000248a50 sp=0xc000248a00 pc=0x4523d6
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/workspace.setupLoopDevice.func1()
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/workspace/firecracker.go:141 +0xd0 fp=0xc000248ac0 sp=0xc000248a50 pc=0xa55810
        runtime.deferreturn()
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/panic.go:476 +0x33 fp=0xc000248b00 sp=0xc000248ac0 pc=0x43a393
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/workspace.setupLoopDevice({0xd3a5c0, 0xc0004112c0}, 0xc0004123c0?, {0xc1a9f3, 0x3}, 0x0, {0xd36ea8?, 0xc0001361c0?})
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/workspace/firecracker.go:211 +0xc49 fp=0xc000248dc0 sp=0xc000248b00 pc=0xa55329
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/workspace.NewFirecrackerWorkspace({0xd3a5c0, 0xc0004112c0}, {0x13e, {0xc0004561f8, 0x15}, {0x0, 0x0}, {0xc00003c900, 0x28}, 0x1, ...}, ...)
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/workspace/firecracker.go:34 +0xc5 fp=0xc000248f88 sp=0xc000248dc0 pc=0xa539e5
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker.(*handler).prepareWorkspace(0xc0001361c0?, {0xd3a5c0?, 0xc0004112c0?}, {0xd39778?, 0xc00015e3c0?}, {0x13e, {0xc0004561f8, 0x15}, {0x0, 0x0}, ...}, ...)
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/workspace.go:22 +0x191 fp=0xc000249110 sp=0xc000248f88 pc=0xa59bd1
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker.(*handler).Handle(0xc0000d2240, {0xd3a5c0, 0xc0004112c0}, {0xd3f2d0?, 0xc0004269c0}, {0xd35660?, 0xc00041a000?})
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/handler.go:100 +0x9cc fp=0xc000249bf8 sp=0xc000249110 pc=0xa5746c
        github.com/sourcegraph/sourcegraph/internal/workerutil.(*Worker).handle(0xc00041c140, {0xd3a550, 0xc000624640}, {0xd3a5f8, 0xc000602ae0}, {0xd35660, 0xc00041a000})
                /home/noah/Sourcegraph/sourcegraph/internal/workerutil/worker.go:393 +0x318 fp=0xc000249e80 sp=0xc000249bf8 pc=0xa1ee98
        github.com/sourcegraph/sourcegraph/internal/workerutil.(*Worker).dequeueAndHandle.func2()
                /home/noah/Sourcegraph/sourcegraph/internal/workerutil/worker.go:364 +0x125 fp=0xc000249fe0 sp=0xc000249e80 pc=0xa1e465
        runtime.goexit()
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/asm_amd64.s:1594 +0x1 fp=0xc000249fe8 sp=0xc000249fe0 pc=0x46fc81
        created by github.com/sourcegraph/sourcegraph/internal/workerutil.(*Worker).dequeueAndHandle
                /home/noah/Sourcegraph/sourcegraph/internal/workerutil/worker.go:342 +0xabb

        goroutine 122 [semacquire, 9 minutes]:
        runtime.gopark(0x4086ea?, 0xc000612240?, 0x40?, 0x22?, 0x40f2df?)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/proc.go:363 +0xd6 fp=0xc0005ebc50 sp=0xc0005ebc30 pc=0x43e636
        runtime.goparkunlock(...)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/proc.go:369
        runtime.semacquire1(0xc000600028, 0xc8?, 0x1, 0x0)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/sema.go:150 +0x1fe fp=0xc0005ebcb8 sp=0xc0005ebc50 pc=0x44f57e
        sync.runtime_Semacquire(0xc000411320?)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/sema.go:62 +0x25 fp=0xc0005ebce8 sp=0xc0005ebcb8 pc=0x46b9e5
        sync.(*WaitGroup).Wait(0xc00007e180?)
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/sync/waitgroup.go:139 +0x52 fp=0xc0005ebd10 sp=0xc0005ebce8 pc=0x487e92
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command.(*logger).writeEntries(0xc0001361c0)
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command/logger.go:192 +0x617 fp=0xc0005ebfc8 sp=0xc0005ebd10 pc=0xa468d7
        github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command.NewLogger.func1()
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command/logger.go:134 +0x26 fp=0xc0005ebfe0 sp=0xc0005ebfc8 pc=0xa45f06
        runtime.goexit()
                /nix/store/w205lbrnh8cm9680pqzw2pc07rhi43an-go-1.19/share/go/src/runtime/asm_amd64.s:1594 +0x1 fp=0xc0005ebfe8 sp=0xc0005ebfe0 pc=0x46fc81
        created by github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command.NewLogger
                /home/noah/Sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command/logger.go:134 +0x42a
```

</details>

## Test plan

Ran locally, all bueno
