### PR TITLE
search: implement GQL query printers

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -3,16 +3,44 @@ package graphqlbackend
 import (
 	"context"
 
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/client"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
+	"github.com/sourcegraph/sourcegraph/internal/search/job/printer"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
+const (
+	// cf. SearchQueryOutputPhase in GQL definitions.
+	ParseTree = "PARSE_TREE"
+	JobTree   = "JOB_TREE"
+
+	// cf. SearchQueryOutputFormat in GQL definitions.
+	Json    = "JSON"
+	Sexp    = "SEXP"
+	Mermaid = "MERMAID"
+
+	// cf. SearchQueryOutputVerbosity in GQL definitions.
+	Minimal = "MINIMAL"
+	Basic   = "BASIC"
+	Maximal = "MAXIMAL"
+)
+
+type args struct {
 	Query           string
 	PatternType     string
 	OutputPhase     string
 	OutputFormat    string
 	OutputVerbosity string
-}) (*JSONValue, error) {
+}
+
+func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *args) (*JSONValue, error) {
 	var searchType query.SearchType
 	switch args.PatternType {
 	case "literal":
@@ -25,14 +53,83 @@ func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 		searchType = query.SearchTypeLiteral
 	}
 
+	switch args.OutputPhase {
+	case ParseTree:
+		return outputParseTree(searchType, args)
+	case JobTree:
+		return outputJobTree(ctx, searchType, args, r.db, r.logger)
+	}
+	return nil, nil
+}
+
+func outputParseTree(searchType query.SearchType, args *args) (*JSONValue, error) {
 	plan, err := query.Pipeline(query.Init(args.Query, searchType))
 	if err != nil {
 		return nil, err
 	}
 
+	if args.OutputFormat != Json || args.OutputVerbosity != Minimal {
+		return nil, errors.New("unsupported output options for PARSE_TREE, only JSON output with MINIMAL verbosity is supported")
+	}
 	jsonString, err := query.ToJSON(plan.ToQ())
 	if err != nil {
 		return nil, err
 	}
 	return &JSONValue{Value: jsonString}, nil
+}
+
+func outputJobTree(
+	ctx context.Context,
+	searchType query.SearchType,
+	args *args,
+	db database.DB,
+	logger log.Logger,
+) (*JSONValue, error) {
+	plan, err := query.Pipeline(query.Init(args.Query, searchType))
+	if err != nil {
+		return nil, err
+	}
+
+	settings, err := DecodedViewerFinalSettings(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	inputs := &search.Inputs{
+		UserSettings:        settings,
+		PatternType:         searchType,
+		Protocol:            search.Streaming,
+		Features:            client.ToFeatures(featureflag.FromContext(ctx), logger),
+		OnSourcegraphDotCom: envvar.SourcegraphDotComMode(),
+	}
+	j, err := jobutil.NewPlanJob(inputs, plan)
+	if err != nil {
+		return nil, err
+	}
+
+	var verbosity job.Verbosity
+	switch args.OutputVerbosity {
+	case Minimal:
+		verbosity = job.VerbosityNone
+	case Basic:
+		verbosity = job.VerbosityBasic
+	case Maximal:
+		verbosity = job.VerbosityMax
+	}
+
+	switch args.OutputFormat {
+	case Json:
+		jsonString := printer.JSONVerbose(j, verbosity)
+		return &JSONValue{Value: jsonString}, nil
+	case Sexp:
+		sexpString := printer.SexpVerbose(j, verbosity, true)
+		return &JSONValue{Value: sexpString}, nil
+	case Mermaid:
+		if args.OutputVerbosity != Minimal {
+			return nil, errors.New("unsupported output options for MERMAID JOB_TREE, only MINIMAL verbosity is supported")
+		}
+		mermaidString := printer.Mermaid(j)
+		return &JSONValue{Value: mermaidString}, nil
+	}
+	return nil, nil
 }

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -113,7 +113,7 @@ func (s *searchClient) Plan(
 		OriginalQuery:       searchQuery,
 		UserSettings:        settings,
 		OnSourcegraphDotCom: sourcegraphDotComMode,
-		Features:            toFeatures(featureflag.FromContext(ctx), s.logger),
+		Features:            ToFeatures(featureflag.FromContext(ctx), s.logger),
 		PatternType:         searchType,
 		Protocol:            protocol,
 	}
@@ -230,7 +230,7 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 	return searchType
 }
 
-func toFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Features {
+func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Features {
 	if flagSet == nil {
 		flagSet = &featureflag.FlagSet{}
 		metricFeatureFlagUnavailable.Inc()


### PR DESCRIPTION
Implements printers (follow up of https://github.com/sourcegraph/sourcegraph/pull/41835)

## Test plan
Exhaustively tested via GQL console. This is a debugging/observability utility and underlying functionality is already tested.
