### PR TITLE
search: query printer defaults to standard mode

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1417,7 +1417,7 @@ type Query {
         """
         The parser to use for this query.
         """
-        patternType: SearchPatternType = literal
+        patternType: SearchPatternType = standard
         """
         The output corresponding to a phase in the parser pipeline.
         """


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/41893.

## Test plan
Only a utility/debugging function change to reflect our current default query mode
