### PR TITLE
analytics: Fix goToDefinition.preloaded and findReferences event triggers

### DIFF
--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -304,43 +304,45 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
 
         return (
             <Tooltip content={tooltipOrErrorMessage}>
-                <ButtonLink
-                    data-content={this.props.dataContent}
-                    disabledClassName={this.props.inactiveClassName}
-                    aria-disabled={disabled}
-                    data-action-item-pressed={pressed}
-                    className={classNames(
-                        'test-action-item',
-                        this.props.className,
-                        showLoadingSpinner && styles.actionItemLoading,
-                        pressed && [this.props.pressedClassName],
-                        buttonLinkProps.variant === 'link' && styles.actionItemLink,
-                        disabled && this.props.inactiveClassName
-                    )}
-                    pressed={pressed}
-                    onSelect={this.runAction}
-                    // If the command is 'open' or 'openXyz' (builtin commands), render it as a link. Otherwise render
-                    // it as a button that executes the command.
-                    to={to}
-                    {...newTabProps}
-                    {...buttonLinkProps}
-                    {...sharedProps}
-                >
-                    {content}{' '}
-                    {!this.props.hideExternalLinkIcon && primaryTo && isExternalLink(primaryTo) && (
-                        <Icon
-                            className={this.props.iconClassName}
-                            svgPath={mdiOpenInNew}
-                            inline={false}
-                            aria-hidden={true}
-                        />
-                    )}
-                    {showLoadingSpinner && (
-                        <div className={styles.loader} data-testid="action-item-spinner">
-                            <LoadingSpinner inline={false} className={this.props.iconClassName} />
-                        </div>
-                    )}
-                </ButtonLink>
+                <span>
+                    <ButtonLink
+                        data-content={this.props.dataContent}
+                        disabledClassName={this.props.inactiveClassName}
+                        aria-disabled={disabled}
+                        data-action-item-pressed={pressed}
+                        className={classNames(
+                            'test-action-item',
+                            this.props.className,
+                            showLoadingSpinner && styles.actionItemLoading,
+                            pressed && [this.props.pressedClassName],
+                            buttonLinkProps.variant === 'link' && styles.actionItemLink,
+                            disabled && this.props.inactiveClassName
+                        )}
+                        pressed={pressed}
+                        onSelect={this.runAction}
+                        // If the command is 'open' or 'openXyz' (builtin commands), render it as a link. Otherwise render
+                        // it as a button that executes the command.
+                        to={to}
+                        {...newTabProps}
+                        {...buttonLinkProps}
+                        {...sharedProps}
+                    >
+                        {content}{' '}
+                        {!this.props.hideExternalLinkIcon && primaryTo && isExternalLink(primaryTo) && (
+                            <Icon
+                                className={this.props.iconClassName}
+                                svgPath={mdiOpenInNew}
+                                inline={false}
+                                aria-hidden={true}
+                            />
+                        )}
+                        {showLoadingSpinner && (
+                            <div className={styles.loader} data-testid="action-item-spinner">
+                                <LoadingSpinner inline={false} className={this.props.iconClassName} />
+                            </div>
+                        )}
+                    </ButtonLink>
+                </span>
             </Tooltip>
         )
     }

--- a/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -2,57 +2,66 @@
 
 exports[`ActionItem "open" command renders as link 1`] = `
 <DocumentFragment>
-  <a
-    class="anchorLink btn btnLink test-action-item actionItemLink"
+  <span
     data-state="closed"
-    href="https://example.com/bar"
-    tabindex="0"
   >
-     t 
-  </a>
+    <a
+      class="anchorLink btn btnLink test-action-item actionItemLink"
+      href="https://example.com/bar"
+      tabindex="0"
+    >
+       t 
+    </a>
+  </span>
 </DocumentFragment>
 `;
 
 exports[`ActionItem "open" command renders as link that opens in a new tab, but without icon for a different origin as the alt action and a primary action defined 1`] = `
 <DocumentFragment>
-  <a
-    class="anchorLink btn btnLink test-action-item actionItemLink"
+  <span
     data-state="closed"
-    href="https://other.com/foo"
-    rel="noopener noreferrer"
-    tabindex="0"
-    target="_blank"
   >
-     primary 
-  </a>
+    <a
+      class="anchorLink btn btnLink test-action-item actionItemLink"
+      href="https://other.com/foo"
+      rel="noopener noreferrer"
+      tabindex="0"
+      target="_blank"
+    >
+       primary 
+    </a>
+  </span>
 </DocumentFragment>
 `;
 
 exports[`ActionItem "open" command renders as link with icon and opens a new tab for a different origin 1`] = `
 <DocumentFragment>
-  <a
-    class="anchorLink btn btnLink test-action-item actionItemLink"
+  <span
     data-state="closed"
-    href="https://other.com/foo"
-    rel="noopener noreferrer"
-    tabindex="0"
-    target="_blank"
   >
-     t 
-    <svg
-      aria-hidden="true"
-      class="mdi-icon"
-      fill="currentColor"
-      height="24"
-      role="img"
-      viewBox="0 0 24 24"
-      width="24"
+    <a
+      class="anchorLink btn btnLink test-action-item actionItemLink"
+      href="https://other.com/foo"
+      rel="noopener noreferrer"
+      tabindex="0"
+      target="_blank"
     >
-      <path
-        d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
-      />
-    </svg>
-  </a>
+       t 
+      <svg
+        aria-hidden="true"
+        class="mdi-icon"
+        fill="currentColor"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+        />
+      </svg>
+    </a>
+  </span>
 </DocumentFragment>
 `;
 


### PR DESCRIPTION
After https://github.com/sourcegraph/sourcegraph/pull/38838 was merged, the click callback wasn't being called when clicking on "Go to definition" or "Find references" (because both use the `open` extension command which has a `to` prop and therefore skips over the `if` statement [here](https://github.com/sourcegraph/sourcegraph/blob/2f5cd394904585b0fda0612bece9127ae4656539/client/shared/src/actions/ActionItem.tsx#L276) and uses a `ButtonLink` component which is [known](https://github.com/sourcegraph/sourcegraph/blob/2f5cd394904585b0fda0612bece9127ae4656539/client/wildcard/src/components/Tooltip/Tooltip.tsx#L41-L42) to be problematic), so no event was being recorded, which was causing analytics to lose a lot of code intel actions:

![CleanShot 2022-09-21 at 19 16 59@2x](https://user-images.githubusercontent.com/1387653/191637245-43ff6cc4-0f30-493f-ab9e-bc1c022cf2d8.png)

Ignore whitespace when reviewing 👀

Original [Slack thread](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1663808093247979?thread_ts=1661342332.528259&cid=CHXHX7XAS)

## Test plan

Ran locally

## App preview:

- [Web](https://sg-web-fix-go-to-definition-analytics.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ftsvcdmruu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

