### PR TITLE
analytics: Warm the code intel analytics cache

### DIFF
--- a/internal/adminanalytics/cache.go
+++ b/internal/adminanalytics/cache.go
@@ -115,6 +115,16 @@ func refreshAnalyticsCache(ctx context.Context, db database.DB) error {
 				}
 			}
 		}
+
+		_, err := GetCodeIntelByLanguage(ctx, db, true, dateRange)
+		if err != nil {
+			return err
+		}
+
+		_, err = GetCodeIntelTopRepositories(ctx, db, true, dateRange)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Warms the caches to avoid slow initial load.

## Test plan

Ran locally
