### PR TITLE
growth: remove old issue pings for growth label

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -15,7 +15,6 @@ jobs:
              message: /cc {recipients}
              recipients: |
                   team/integrations=@muratsu @jjinnii @ryankscott
-                  team/growth=@muratsu @a-bergevin
                   team/cloud=@sourcegraph/cloud
                   team/search-product=@benvenker @lguychard
                   team/search-core=@sourcegraph/search-core

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -15,6 +15,7 @@ jobs:
              message: /cc {recipients}
              recipients: |
                   team/integrations=@muratsu @jjinnii @ryankscott
+                  team/growth=@sourcegraph/growth
                   team/cloud=@sourcegraph/cloud
                   team/search-product=@benvenker @lguychard
                   team/search-core=@sourcegraph/search-core


### PR DESCRIPTION
Removes the out-of-date pings on issues that have the team/growth label applied. I could swap it to someone more relevant, but I don't want to create more noise unless we think it'd actually be useful.

## Test plan

Just a GH workflow change.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
