### PR TITLE
search: add ChunkMatch type in search client

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -52,7 +52,7 @@ export interface ContentMatch {
     branches?: string[]
     commit?: string
     lineMatches: LineMatch[]
-    chunkMatches: ChunkMatch[]
+    chunkMatches?: ChunkMatch[]
     hunks?: DecoratedHunk[]
 }
 

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -52,6 +52,7 @@ export interface ContentMatch {
     branches?: string[]
     commit?: string
     lineMatches: LineMatch[]
+    chunkMatches: ChunkMatch[]
     hunks?: DecoratedHunk[]
 }
 
@@ -83,6 +84,12 @@ interface LineMatch {
     lineNumber: number
     offsetAndLengths: number[][]
     aggregableBadges?: AggregableBadge[]
+}
+
+interface ChunkMatch {
+   content: string
+   contentStart: Location
+   ranges: Range[]
 }
 
 export interface SymbolMatch {


### PR DESCRIPTION
Introduce `ChunkMatch` as a type in the search client, and add it as a field on the `ContentMatch` type, in anticipation of migrating the client to request chunk matches from the backend instead of line matches.



## Test plan
N/A, just introducing a new type and field, both currently unused
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tl-add-chunkmatch-type-to-client.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nuonbzuera.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
