### PR TITLE
executors: Make docker daemon registry mirror config an executor native feature

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	NodeExporterURL               string
 	DockerRegistryNodeExporterURL string
 	WorkerHostname                string
+	DockerRegistryMirrorAddress   string
 }
 
 func defaultFirecrackerImageTag() string {
@@ -74,6 +75,7 @@ func (c *Config) Load() {
 	c.NodeExporterURL = c.GetOptional("NODE_EXPORTER_URL", "The URL of the node_exporter instance, without the /metrics path.")
 	c.DockerRegistryNodeExporterURL = c.GetOptional("DOCKER_REGISTRY_NODE_EXPORTER_URL", "The URL of the Docker Registry instance's node_exporter, without the /metrics path.")
 	c.MaxActiveTime = c.GetInterval("EXECUTOR_MAX_ACTIVE_TIME", "0", "The maximum time that can be spent by the worker dequeueing records to be handled.")
+	c.DockerRegistryMirrorAddress = c.GetOptional("EXECUTOR_DOCKER_REGISTRY_MIRROR_URL", "The address of a docker registry mirror to use in firecracker VMs.")
 
 	hn := hostname.Get()
 	// Be unique but also descriptive.
@@ -137,10 +139,11 @@ func (c *Config) WorkerOptions() workerutil.WorkerOptions {
 
 func (c *Config) FirecrackerOptions() command.FirecrackerOptions {
 	return command.FirecrackerOptions{
-		Enabled:             c.UseFirecracker,
-		Image:               c.FirecrackerImage,
-		KernelImage:         c.FirecrackerKernelImage,
-		VMStartupScriptPath: c.VMStartupScriptPath,
+		Enabled:                     c.UseFirecracker,
+		Image:                       c.FirecrackerImage,
+		KernelImage:                 c.FirecrackerKernelImage,
+		VMStartupScriptPath:         c.VMStartupScriptPath,
+		DockerRegistryMirrorAddress: c.DockerRegistryMirrorAddress,
 	}
 }
 

--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	NodeExporterURL               string
 	DockerRegistryNodeExporterURL string
 	WorkerHostname                string
-	DockerRegistryMirrorAddress   string
+	DockerRegistryMirrorURL       string
 }
 
 func defaultFirecrackerImageTag() string {
@@ -75,7 +75,7 @@ func (c *Config) Load() {
 	c.NodeExporterURL = c.GetOptional("NODE_EXPORTER_URL", "The URL of the node_exporter instance, without the /metrics path.")
 	c.DockerRegistryNodeExporterURL = c.GetOptional("DOCKER_REGISTRY_NODE_EXPORTER_URL", "The URL of the Docker Registry instance's node_exporter, without the /metrics path.")
 	c.MaxActiveTime = c.GetInterval("EXECUTOR_MAX_ACTIVE_TIME", "0", "The maximum time that can be spent by the worker dequeueing records to be handled.")
-	c.DockerRegistryMirrorAddress = c.GetOptional("EXECUTOR_DOCKER_REGISTRY_MIRROR_URL", "The address of a docker registry mirror to use in firecracker VMs.")
+	c.DockerRegistryMirrorURL = c.GetOptional("EXECUTOR_DOCKER_REGISTRY_MIRROR_URL", "The address of a docker registry mirror to use in firecracker VMs.")
 
 	hn := hostname.Get()
 	// Be unique but also descriptive.
@@ -139,11 +139,11 @@ func (c *Config) WorkerOptions() workerutil.WorkerOptions {
 
 func (c *Config) FirecrackerOptions() command.FirecrackerOptions {
 	return command.FirecrackerOptions{
-		Enabled:                     c.UseFirecracker,
-		Image:                       c.FirecrackerImage,
-		KernelImage:                 c.FirecrackerKernelImage,
-		VMStartupScriptPath:         c.VMStartupScriptPath,
-		DockerRegistryMirrorAddress: c.DockerRegistryMirrorAddress,
+		Enabled:                 c.UseFirecracker,
+		Image:                   c.FirecrackerImage,
+		KernelImage:             c.FirecrackerKernelImage,
+		VMStartupScriptPath:     c.VMStartupScriptPath,
+		DockerRegistryMirrorURL: c.DockerRegistryMirrorURL,
 	}
 }
 

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -127,7 +127,7 @@ func TestSetupFirecracker(t *testing.T) {
 	operations := NewOperations(&observation.TestContext)
 
 	logger := NewMockLogger()
-	if err := setupFirecracker(context.Background(), runner, logger, "deadbeef", "/dev/loopX", options, operations); err != nil {
+	if err := setupFirecracker(context.Background(), runner, logger, "deadbeef", "/dev/loopX", "/tmp/firecracker123", options, operations); err != nil {
 		t.Fatalf("unexpected error tearing down virtual machine: %s", err)
 	}
 
@@ -158,7 +158,7 @@ func TestTeardownFirecracker(t *testing.T) {
 	runner := NewMockCommandRunner()
 	operations := NewOperations(&observation.TestContext)
 
-	if err := teardownFirecracker(context.Background(), runner, nil, "deadbeef", operations); err != nil {
+	if err := teardownFirecracker(context.Background(), runner, nil, "deadbeef", "/tmp/firecracker123", operations); err != nil {
 		t.Fatalf("unexpected error tearing down virtual machine: %s", err)
 	}
 

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -60,6 +60,11 @@ type FirecrackerOptions struct {
 	// VMStartupScriptPath is a path to a file on the host that is loaded into a fresh
 	// virtual machine and executed on startup.
 	VMStartupScriptPath string
+
+	// DockerRegistryMirrorAddress is an optional parameter to configure a docker
+	// registry mirror for the VMs docker daemon on startup. When set, /etc/docker/daemon.json
+	// will be mounted into the VM.
+	DockerRegistryMirrorAddress string
 }
 
 type ResourceOptions struct {

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -63,10 +63,10 @@ type FirecrackerOptions struct {
 	// virtual machine and executed on startup.
 	VMStartupScriptPath string
 
-	// DockerRegistryMirrorAddress is an optional parameter to configure a docker
+	// DockerRegistryMirrorURL is an optional parameter to configure a docker
 	// registry mirror for the VMs docker daemon on startup. When set, /etc/docker/daemon.json
 	// will be mounted into the VM.
-	DockerRegistryMirrorAddress string
+	DockerRegistryMirrorURL string
 }
 
 type ResourceOptions struct {


### PR DESCRIPTION
This will pull out logic of the terraform modules and move more of it into the executor binary, so that it's more portable. This will also be faster, because we don't have to restart the daemon with this approach. This shaves off around 2-4s of the VM startup time. For fast jobs like many SSBC jobs, that's sometimes more than the actual command would take, so it's great to have gotten rid of this.

Closes https://github.com/sourcegraph/sourcegraph/issues/41910

## Test plan

Tested on k8s cluster.