### PR TITLE
ranking: flush queue based on size in bytes

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -84,15 +84,6 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 	var mu sync.Mutex
 	rq := newResultQueue(siteConfig, endpoints)
 
-	defer func() {
-		mu.Lock()
-		metricReorderQueueSize.WithLabelValues().Observe(float64(rq.metricMaxLength))
-		metricMaxMatchCount.WithLabelValues().Observe(float64(rq.metricMaxMatchCount))
-		metricFinalQueueSize.Add(float64(rq.queue.Len()))
-		metricMaxSizeBytes.WithLabelValues().Observe(float64(rq.metricMaxSizeBytes))
-		mu.Unlock()
-	}()
-
 	// Flush the queue latest after maxReorderDuration. The longer
 	// maxReorderDuration, the more stable the ranking and the more MEM pressure we
 	// put on frontend. maxReorderDuration is effectively the budget we give each
@@ -182,6 +173,11 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 	}
 
 	mu.Lock()
+	metricReorderQueueSize.WithLabelValues().Observe(float64(rq.metricMaxLength))
+	metricMaxMatchCount.WithLabelValues().Observe(float64(rq.metricMaxMatchCount))
+	metricFinalQueueSize.Add(float64(rq.queue.Len()))
+	metricMaxSizeBytes.WithLabelValues().Observe(float64(rq.metricMaxSizeBytes))
+
 	rq.FlushAll(streamer)
 	mu.Unlock()
 

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -348,7 +348,7 @@ func TestResultQueueSettingsFromConfig(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			settings := resultQueueSettingsFromConfig(tt.siteConfig)
+			settings := newRankingSiteConfig(tt.siteConfig)
 
 			if settings.maxQueueDepth != tt.wantMaxQueueDepth {
 				t.Fatalf("want %d, got %d", tt.wantMaxQueueDepth, settings.maxQueueDepth)

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -348,22 +348,22 @@ func TestResultQueueSettingsFromConfig(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			haveMaxQueueDepth, haveMaxReorderDuration, haveMaxQueueMatchCount, haveMaxSizesBytes := resultQueueSettingsFromConfig(tt.siteConfig)
+			settings := resultQueueSettingsFromConfig(tt.siteConfig)
 
-			if haveMaxQueueDepth != tt.wantMaxQueueDepth {
-				t.Fatalf("want %d, got %d", tt.wantMaxQueueDepth, haveMaxQueueDepth)
+			if settings.maxQueueDepth != tt.wantMaxQueueDepth {
+				t.Fatalf("want %d, got %d", tt.wantMaxQueueDepth, settings.maxQueueDepth)
 			}
 
-			if haveMaxReorderDuration != tt.wantMaxReorderDuration {
-				t.Fatalf("want %d, got %d", tt.wantMaxReorderDuration, haveMaxReorderDuration)
+			if settings.maxReorderDuration != tt.wantMaxReorderDuration {
+				t.Fatalf("want %d, got %d", tt.wantMaxReorderDuration, settings.maxReorderDuration)
 			}
 
-			if haveMaxQueueMatchCount != tt.wantMaxQueueMatchCount {
-				t.Fatalf("want %d, got %d", tt.wantMaxQueueMatchCount, haveMaxQueueMatchCount)
+			if settings.maxMatchCount != tt.wantMaxQueueMatchCount {
+				t.Fatalf("want %d, got %d", tt.wantMaxQueueMatchCount, settings.maxMatchCount)
 			}
 
-			if haveMaxSizesBytes != tt.wantMaxSizeBytes {
-				t.Fatalf("want %d, got %d", tt.wantMaxSizeBytes, haveMaxSizesBytes)
+			if settings.maxSizeBytes != tt.wantMaxSizeBytes {
+				t.Fatalf("want %d, got %d", tt.wantMaxSizeBytes, settings.maxSizeBytes)
 			}
 		})
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1552,6 +1552,8 @@ type QuickLink struct {
 type Ranking struct {
 	// MaxQueueMatchCount description: The maximum number of matches that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs for queries with extremely high count of matches per repository.
 	MaxQueueMatchCount *int `json:"maxQueueMatchCount,omitempty"`
+	// MaxQueueSizeBytes description: The maximum number of bytes that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs.
+	MaxQueueSizeBytes *int `json:"maxQueueSizeBytes,omitempty"`
 	// MaxReorderDurationMS description: The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.
 	MaxReorderDurationMS int `json:"maxReorderDurationMS,omitempty"`
 	// MaxReorderQueueSize description: The maximum number of search results that can be buffered to sort results. -1 is unbounded. The default is 24. Set this to small integers to limit latency increases from slow backends.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -498,6 +498,13 @@
               "group": "Search",
               "!go": { "pointer": true }
             },
+            "maxQueueSizeBytes": {
+              "description": "The maximum number of bytes that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs.",
+              "default": -1,
+              "type": "integer",
+              "group": "Search",
+              "!go": { "pointer": true }
+            },
             "maxReorderDurationMS": {
               "description": "The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.",
               "type": "integer",


### PR DESCRIPTION
We estimate the current size of the search results queue and flush it
once it reaches a critical level.

This give us very granular control over the amount of MEM we are
willing to spend on ranking results per query.

Alternatives considered:
We could have estimated the size already in Zoekt and send it as part of stats, which would simplify the change here. However this would mean to add an expensive computation in Zoekt without much benefit for other users of Zoekt.

EDIT: another reason why zoekt.Stats might be a poor fit: Stats has to be aggregateable and the size of a search result in MEM is not additive.  

Note:
In its current form, we track redundant metrics (#events, #matches, #bytes). We are probably going to end up just with #bytes and once that is clear we can remove the other two. For now I left everything in place. We can disable metrics via the site-config.

## Test plan
- updated unit test
- I ran an instance of Sourcegraph and verified that the queue gets flushed early for queries with lots of results and vice versa, it doesn't flush -- at least not because of sizeBytes -- for queries that are more specific. 

