### PR TITLE
Open in Editor: Make paths backward compatible for self-hosted code hosts

### DIFF
--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
@@ -17,6 +17,7 @@ const repoDefaults: RepositoryFields = {
     defaultBranch: null,
     viewerCanAdminister: false,
     externalURLs: [],
+    externalRepository: { serviceType: 'github' },
     id: 'repoid',
     name: 'github.com/sourcegraph/awesome',
     url: 'http://test.test/awesome',

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -256,7 +256,7 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
                         {window.context.isAuthenticatedUser && (
                             <OpenInEditorActionItem
                                 platformContext={props.platformContext}
-                                externalServiceType={props.repo?.externalRepository.serviceType}
+                                externalServiceType={props.repo?.externalRepository?.serviceType}
                             />
                         )}
                     </>

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { mdiChevronDoubleUp, mdiMenuDown, mdiMenuUp, mdiPlus, mdiPuzzleOutline, mdiChevronDoubleDown } from '@mdi/js'
+import { mdiChevronDoubleDown, mdiChevronDoubleUp, mdiMenuDown, mdiMenuUp, mdiPlus, mdiPuzzleOutline } from '@mdi/js'
 import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 import * as H from 'history'
@@ -254,7 +254,10 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
                     <>
                         <ToggleBlameAction />
                         {window.context.isAuthenticatedUser && (
-                            <OpenInEditorActionItem platformContext={props.platformContext} />
+                            <OpenInEditorActionItem
+                                platformContext={props.platformContext}
+                                externalServiceType={props.repo?.externalRepository.serviceType}
+                            />
                         )}
                     </>
                 )}

--- a/client/web/src/integration/graphQlResponseHelpers.ts
+++ b/client/web/src/integration/graphQlResponseHelpers.ts
@@ -3,11 +3,11 @@ import { TreeEntriesResult } from '@sourcegraph/shared/src/graphql-operations'
 
 import {
     BlobResult,
-    FileExternalLinksResult,
-    ResolveRepoRevResult,
     ExternalServiceKind,
-    RepoChangesetsStatsResult,
+    FileExternalLinksResult,
     FileNamesResult,
+    RepoChangesetsStatsResult,
+    ResolveRepoRevResult,
 } from '../graphql-operations'
 
 export const createTreeEntriesResult = (url: string, toplevelFiles: string[]): TreeEntriesResult => ({
@@ -82,6 +82,7 @@ export const createResolveRepoRevisionResult = (treeUrl: string, oid = '1'.repea
                 serviceKind: ExternalServiceKind.GITHUB,
             },
         ],
+        externalRepository: { serviceType: 'github' },
         description: 'bla',
         viewerCanAdminister: false,
         defaultBranch: { displayName: 'master', abbrevName: 'master' },
@@ -107,6 +108,7 @@ export const createResolveCloningRepoRevisionResult = (
                 serviceKind: ExternalServiceKind.GITHUB,
             },
         ],
+        externalRepository: { serviceType: 'github' },
         description: 'bla',
         viewerCanAdminister: false,
         defaultBranch: null,

--- a/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
+++ b/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
@@ -21,10 +21,11 @@ import styles from './OpenInEditorActionItem.module.scss'
 
 export interface OpenInEditorActionItemProps {
     platformContext: PlatformContext
+    externalServiceType?: string
     assetsRoot?: string
 }
 
-// We only want to attemt to upgrade the legacy open in editor settings once per
+// We only want to attempt to upgrade the legacy open in editor settings once per
 // page load.
 let didAttemptToUpgradeSettings = false
 
@@ -89,6 +90,7 @@ export const OpenInEditorActionItem: React.FunctionComponent<OpenInEditorActionI
                                 eventLogger.log('OpenInEditorClicked', { editor: editor.id }, { editor: editor.id })
                                 openCurrentUrlInEditor(
                                     settings?.openInEditor,
+                                    props.externalServiceType,
                                     props.platformContext.sourcegraphURL,
                                     index
                                 )

--- a/client/web/src/open-in-editor/build-url.test.ts
+++ b/client/web/src/open-in-editor/build-url.test.ts
@@ -1,6 +1,6 @@
 import { parseBrowserRepoURL } from '../util/url'
 
-import { buildEditorUrl, buildRepoBaseNameAndPath } from './build-url'
+import { buildEditorUrl, buildRepoBaseNameAndPath, ExternalServiceType } from './build-url'
 import { EditorSettings } from './editor-settings'
 
 function buildSettings(props: EditorSettings = {}): EditorSettings {
@@ -16,25 +16,44 @@ describe('buildRepoBaseNameAndPath tests', () => {
         const url = 'https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/tsconfig.json'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.GitHub, filePath)
 
         expect(result).toEqual('sourcegraph/tsconfig.json')
+    })
+
+    it('builds the correct string for GitHub Enterprise URLs', () => {
+        const url = 'https://k8s.sgdev.org/ghe.sgdev.org/sourcegraph/idan-test/-/blob/README.md'
+        const { repoName, filePath } = parseBrowserRepoURL(url)
+
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.GitHub, filePath)
+
+        expect(result).toEqual('idan-test/README.md')
     })
 
     it('builds the correct string for GitLab URLs', () => {
         const url = 'https://sourcegraph.com/gitlab.com/gitlab-org/gitlab-foss/-/blob/.eslintignore'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.GitLab, filePath)
 
         expect(result).toEqual('gitlab-foss/.eslintignore')
+    })
+
+    it('builds the correct string for self-hosted GitLab URLs', () => {
+        const url =
+            'https://k8s.sgdev.org/gitlab.sgdev.org/sg-repos/public-sg-repos/gophercon-2018-liveblog/-/blob/README.md'
+        const { repoName, filePath } = parseBrowserRepoURL(url)
+
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.GitLab, filePath)
+
+        expect(result).toEqual('public-sg-repos/gophercon-2018-liveblog/README.md')
     })
 
     it('builds the correct string for Bitbucket Cloud URLs', () => {
         const url = 'https://sourcegraph.com/bitbucket.org/atlassian/stash-example-plugin/src/master/README.md'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, 'bitbucketCloud', filePath)
 
         expect(result).toEqual('stash-example-plugin/src/master/README.md')
     })
@@ -44,7 +63,7 @@ describe('buildRepoBaseNameAndPath tests', () => {
             'https://cse-k8s.sgdev.org/perforce.beatrix.com/app/b200/patch/core/-/blob/test/1.js?toast=integrations'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.Perforce, filePath)
 
         expect(result).toEqual('app/b200/patch/core/test/1.js')
     })
@@ -53,7 +72,7 @@ describe('buildRepoBaseNameAndPath tests', () => {
         const url = 'https://sourcegraph.com/maven/com.esotericsoftware.minlog/minlog/-/blob/lsif-java.json'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.Other, filePath)
 
         expect(result).toEqual('com.esotericsoftware.minlog/minlog/lsif-java.json')
     })

--- a/client/web/src/open-in-editor/build-url.test.ts
+++ b/client/web/src/open-in-editor/build-url.test.ts
@@ -1,6 +1,7 @@
+import { ExternalServiceKind } from '../graphql-operations'
 import { parseBrowserRepoURL } from '../util/url'
 
-import { buildEditorUrl, buildRepoBaseNameAndPath, ExternalServiceType } from './build-url'
+import { buildEditorUrl, buildRepoBaseNameAndPath } from './build-url'
 import { EditorSettings } from './editor-settings'
 
 function buildSettings(props: EditorSettings = {}): EditorSettings {
@@ -16,7 +17,7 @@ describe('buildRepoBaseNameAndPath tests', () => {
         const url = 'https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/tsconfig.json'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.GitHub, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceKind.GITHUB, filePath)
 
         expect(result).toEqual('sourcegraph/tsconfig.json')
     })
@@ -25,7 +26,7 @@ describe('buildRepoBaseNameAndPath tests', () => {
         const url = 'https://k8s.sgdev.org/ghe.sgdev.org/sourcegraph/idan-test/-/blob/README.md'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.GitHub, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceKind.GITHUB, filePath)
 
         expect(result).toEqual('idan-test/README.md')
     })
@@ -34,7 +35,7 @@ describe('buildRepoBaseNameAndPath tests', () => {
         const url = 'https://sourcegraph.com/gitlab.com/gitlab-org/gitlab-foss/-/blob/.eslintignore'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.GitLab, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceKind.GITLAB, filePath)
 
         expect(result).toEqual('gitlab-foss/.eslintignore')
     })
@@ -44,7 +45,7 @@ describe('buildRepoBaseNameAndPath tests', () => {
             'https://k8s.sgdev.org/gitlab.sgdev.org/sg-repos/public-sg-repos/gophercon-2018-liveblog/-/blob/README.md'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.GitLab, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceKind.GITLAB, filePath)
 
         expect(result).toEqual('public-sg-repos/gophercon-2018-liveblog/README.md')
     })
@@ -63,7 +64,7 @@ describe('buildRepoBaseNameAndPath tests', () => {
             'https://cse-k8s.sgdev.org/perforce.beatrix.com/app/b200/patch/core/-/blob/test/1.js?toast=integrations'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.Perforce, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceKind.PERFORCE, filePath)
 
         expect(result).toEqual('app/b200/patch/core/test/1.js')
     })
@@ -72,7 +73,7 @@ describe('buildRepoBaseNameAndPath tests', () => {
         const url = 'https://sourcegraph.com/maven/com.esotericsoftware.minlog/minlog/-/blob/lsif-java.json'
         const { repoName, filePath } = parseBrowserRepoURL(url)
 
-        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceType.Other, filePath)
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceKind.OTHER, filePath)
 
         expect(result).toEqual('com.esotericsoftware.minlog/minlog/lsif-java.json')
     })

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -2,34 +2,15 @@ import * as path from 'path'
 
 import type { UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 
+import { ExternalServiceKind } from '../graphql-operations'
+
 import type { EditorReplacements, EditorSettings } from './editor-settings'
 import { Editor, getEditor, supportedEditors } from './editors'
 
-// A hard-coded copy of the Type* constants of `extsvc/types.go`
-export enum ExternalServiceType {
-    AWSCodeCommit = 'awscodecommit',
-    BitbucketServer = 'bitbucketServer',
-    BitbucketCloud = 'bitbucketCloud',
-    Gerrit = 'gerrit',
-    GitHub = 'github',
-    GitHubApp = 'githubApp',
-    GitLab = 'gitlab',
-    Gitolite = 'gitolite',
-    Perforce = 'perforce',
-    Phabricator = 'phabricator',
-    JVMPackages = 'jvmPackages',
-    Pagure = 'pagure',
-    NpmPackages = 'npmPackages',
-    GoModules = 'goModules',
-    PythonPackages = 'pythonPackages',
-    RustPackages = 'rustPackages',
-    Other = 'other',
-}
-
 const serviceTypesWithOwnerInUrl = new Set<string>([
-    ExternalServiceType.GitHub,
-    ExternalServiceType.GitLab,
-    ExternalServiceType.BitbucketCloud,
+    ExternalServiceKind.GITHUB.toLowerCase(),
+    ExternalServiceKind.GITLAB.toLowerCase(),
+    ExternalServiceKind.BITBUCKETCLOUD.toLowerCase(),
 ])
 
 export function buildRepoBaseNameAndPath(
@@ -39,7 +20,7 @@ export function buildRepoBaseNameAndPath(
 ): string {
     const bareRepoNamePieces = repoName
         .split('/')
-        .slice(serviceTypesWithOwnerInUrl.has(externalServiceType || '') ? 2 : 1)
+        .slice(serviceTypesWithOwnerInUrl.has((externalServiceType || '').toLowerCase()) ? 2 : 1)
     return path.join(...bareRepoNamePieces, ...(filePath ? [filePath] : []))
 }
 

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -5,10 +5,40 @@ import type { UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 import type { EditorReplacements, EditorSettings } from './editor-settings'
 import { Editor, getEditor, supportedEditors } from './editors'
 
-export function buildRepoBaseNameAndPath(repoName: string, filePath: string | undefined): string {
-    const codeHostsWithOwnerInUrl = ['github.com', 'gitlab.com', 'bitbucket.org']
-    const repoNameIncludesOwner = codeHostsWithOwnerInUrl.some(url => repoName.startsWith(url + '/'))
-    const bareRepoNamePieces = repoName.split('/').slice(repoNameIncludesOwner ? 2 : 1)
+// A hard-coded copy of the Type* constants of `extsvc/types.go`
+export enum ExternalServiceType {
+    AWSCodeCommit = 'awscodecommit',
+    BitbucketServer = 'bitbucketServer',
+    BitbucketCloud = 'bitbucketCloud',
+    Gerrit = 'gerrit',
+    GitHub = 'github',
+    GitHubApp = 'githubApp',
+    GitLab = 'gitlab',
+    Gitolite = 'gitolite',
+    Perforce = 'perforce',
+    Phabricator = 'phabricator',
+    JVMPackages = 'jvmPackages',
+    Pagure = 'pagure',
+    NpmPackages = 'npmPackages',
+    GoModules = 'goModules',
+    PythonPackages = 'pythonPackages',
+    RustPackages = 'rustPackages',
+    Other = 'other',
+}
+
+export function buildRepoBaseNameAndPath(
+    repoName: string,
+    externalServiceType: string | undefined,
+    filePath: string | undefined
+): string {
+    const serviceTypesWithOwnerInUrl: string[] = [
+        ExternalServiceType.GitHub,
+        ExternalServiceType.GitLab,
+        ExternalServiceType.BitbucketCloud,
+    ]
+    const bareRepoNamePieces = repoName
+        .split('/')
+        .slice(serviceTypesWithOwnerInUrl.includes(externalServiceType || '') ? 2 : 1)
     return path.join(...bareRepoNamePieces, ...(filePath ? [filePath] : []))
 }
 

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -26,19 +26,20 @@ export enum ExternalServiceType {
     Other = 'other',
 }
 
+const serviceTypesWithOwnerInUrl = new Set<string>([
+    ExternalServiceType.GitHub,
+    ExternalServiceType.GitLab,
+    ExternalServiceType.BitbucketCloud,
+])
+
 export function buildRepoBaseNameAndPath(
     repoName: string,
     externalServiceType: string | undefined,
     filePath: string | undefined
 ): string {
-    const serviceTypesWithOwnerInUrl: string[] = [
-        ExternalServiceType.GitHub,
-        ExternalServiceType.GitLab,
-        ExternalServiceType.BitbucketCloud,
-    ]
     const bareRepoNamePieces = repoName
         .split('/')
-        .slice(serviceTypesWithOwnerInUrl.includes(externalServiceType || '') ? 2 : 1)
+        .slice(serviceTypesWithOwnerInUrl.has(externalServiceType || '') ? 2 : 1)
     return path.join(...bareRepoNamePieces, ...(filePath ? [filePath] : []))
 }
 

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -7,6 +7,9 @@ import { ExternalServiceKind } from '../graphql-operations'
 import type { EditorReplacements, EditorSettings } from './editor-settings'
 import { Editor, getEditor, supportedEditors } from './editors'
 
+// Just lowercasing these for now, it's a bit of a gamble because it's only a coincidence that ExternalServiceKind
+// and ExternalServiceType only differs in casing. But it works for now.
+// Discussion about this here: https://github.com/sourcegraph/sourcegraph/pull/41914#discussion_r977418118
 const serviceTypesWithOwnerInUrl = new Set<string>([
     ExternalServiceKind.GITHUB.toLowerCase(),
     ExternalServiceKind.GITLAB.toLowerCase(),

--- a/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
+++ b/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
@@ -12,15 +12,21 @@ import { EditorSettings } from './editor-settings'
  */
 export const useOpenCurrentUrlInEditor = (): ((
     editorSettings: EditorSettings,
+    externalServiceType: string | undefined,
     sourcegraphURL: string,
     editorIndex?: number
 ) => void) => {
     const location = useLocation()
     return useCallback(
-        (editorSettings: EditorSettings, sourcegraphURL: string, editorIndex = 0) => {
+        (
+            editorSettings: EditorSettings,
+            externalServiceType: string | undefined,
+            sourcegraphURL: string,
+            editorIndex = 0
+        ) => {
             const { repoName, filePath, range } = parseBrowserRepoURL(location.pathname)
             const url = buildEditorUrl(
-                buildRepoBaseNameAndPath(repoName, filePath),
+                buildRepoBaseNameAndPath(repoName, externalServiceType, filePath),
                 range,
                 editorSettings,
                 sourcegraphURL,

--- a/client/web/src/repo/backend.ts
+++ b/client/web/src/repo/backend.ts
@@ -12,9 +12,9 @@ import {
 import {
     makeRepoURI,
     RepoRevision,
-    RevisionSpec,
     RepoSpec,
     ResolvedRevisionSpec,
+    RevisionSpec,
 } from '@sourcegraph/shared/src/util/url'
 
 import { queryGraphQL } from '../backend/graphql'
@@ -35,6 +35,9 @@ export const repositoryFragment = gql`
         externalURLs {
             url
             serviceKind
+        }
+        externalRepository {
+            serviceType
         }
         description
         viewerCanAdminister


### PR DESCRIPTION
In this new version, I'm determining the owner removal based on externalServiceType rather than based on the URL only.

The whole fuss is about whether to remove this part (the **owner** of the repo) of URLs:

```
                                        ↓
https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/tsconfig.json
```

Behavior before this PR:
 - Remove the owner for github.com, gitlab.com, and bitbucket.org URLs
 - Do not remove the owner for Perforce URLs (which was a requirement for https://github.com/sourcegraph/sourcegraph/issues/41713)
 - Do not remove the owner for any other URLs either

Behavior change in this PR:
 - Remove the URL for GitHub Enterprise and self-hosted GitLab code hosts

This ensures that it works correctly for all GitHub, GitLab, Bitbucket Cloud, and Perforce users.
This does not ensure that it works correctly for any other code hosts (including Bitbucket Server) where we don't know the URL pattern.

**Caveat:** I'm using hard-coded values in an enum for the known externalServiceTypes, which is not nice. A nicer solution would be to tweak the process that generates `web/shared/graphql-operations.ts`, and add the service types automatically. But I haven't been able to figure out how to tweak that process and at this point, I think it was not worth the effort to investigate it further. If I get any pointers on how to to that, I'm glad to add automatic enum generation.

## Test plan

I've added more unit tests to cover the new cases, which makes me sure that it works well for all cases we considered.

Co-authored-by: Taras Yemets <yemets.taras@gmail.com>

## App preview:

- [Web](https://sg-web-dv-open-in-editor-fix-paths-for.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vplxgyujxx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
