### PR TITLE
CodeMirror blob: Fix handling of global event handlers

### DIFF
--- a/client/shared/src/react-shortcuts/ShortcutManager.tsx
+++ b/client/shared/src/react-shortcuts/ShortcutManager.tsx
@@ -108,15 +108,15 @@ export class ShortcutManager {
 
 function isFocusedInput(): boolean {
     const target = document.activeElement
-    if (target?.tagName === null) {
+    if (target === null) {
         return false
     }
 
     return Boolean(
-        target?.tagName === 'INPUT' ||
-            target?.tagName === 'SELECT' ||
-            target?.tagName === 'TEXTAREA' ||
-            target?.hasAttribute('contenteditable')
+        target.tagName === 'INPUT' ||
+            target.tagName === 'SELECT' ||
+            target.tagName === 'TEXTAREA' ||
+            (target as HTMLElement).isContentEditable
     )
 }
 

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -207,7 +207,6 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
         ...themeProps,
         ...breadcrumbProps,
         isMacPlatform: isMacPlatform(),
-        onHandleFuzzyFinder: setIsFuzzyFinderVisible,
     }
 
     return (

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -52,7 +52,6 @@ import { parseBrowserRepoURL } from '../util/url'
 
 import { GoToCodeHostAction } from './actions/GoToCodeHostAction'
 import { fetchFileExternalLinks, ResolvedRevision, resolveRepoRevision } from './backend'
-import { BlobProps } from './blob/Blob'
 import { RepoContainerError } from './RepoContainerError'
 import { RepoHeader, RepoHeaderActionButton, RepoHeaderContributionsLifecycleProps } from './RepoHeader'
 import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
@@ -125,7 +124,6 @@ interface RepoContainerProps
         ActivationProps,
         ThemeProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
-        Pick<BlobProps, 'onHandleFuzzyFinder'>,
         BreadcrumbSetters,
         BreadcrumbsProps,
         SearchStreamingProps,
@@ -488,7 +486,6 @@ export const RepoContainer: React.FunctionComponent<React.PropsWithChildren<Repo
                                     routes={props.repoRevisionContainerRoutes}
                                     // must exactly match how the revision was encoded in the URL
                                     routePrefix={`${repoMatchURL}${rawRevision ? `@${rawRevision}` : ''}`}
-                                    onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                                 />
                             )}
                         />

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -28,7 +28,6 @@ import { RouteDescriptor } from '../util/contributions'
 import { CopyPathAction } from './actions/CopyPathAction'
 import { GoToPermalinkAction } from './actions/GoToPermalinkAction'
 import { ResolvedRevision } from './backend'
-import { BlobProps } from './blob/Blob'
 import { RepoRevisionChevronDownIcon, RepoRevisionWrapper } from './components/RepoRevision'
 import { HoverThresholdProps, RepoContainerContext } from './RepoContainer'
 import { RepoHeaderContributionsLifecycleProps } from './RepoHeader'
@@ -51,7 +50,6 @@ export interface RepoRevisionContainerContext
         ActivationProps,
         Omit<RepoContainerContext, 'onDidUpdateExternalLinks' | 'repo' | 'resolvedRevisionOrError'>,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
-        Pick<BlobProps, 'onHandleFuzzyFinder'>,
         RevisionSpec,
         BreadcrumbSetters,
         ActionItemsBarProps,
@@ -88,7 +86,6 @@ interface RepoRevisionContainerProps
         ThemeProps,
         ActivationProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
-        Pick<BlobProps, 'onHandleFuzzyFinder'>,
         RevisionSpec,
         BreadcrumbSetters,
         ActionItemsBarProps,

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -12,7 +12,6 @@ import { ErrorBoundary } from '../components/ErrorBoundary'
 import { GettingStartedTour } from '../tour/GettingStartedTour'
 import { formatHash, formatLineOrPositionOrRange } from '../util/url'
 
-import { BlobProps } from './blob/Blob'
 import { BlobPage } from './blob/BlobPage'
 import { BlobStatusBarContainer } from './blob/ui/BlobStatusBarContainer'
 import { RepoRevisionContainerContext } from './RepoRevisionContainer'
@@ -25,8 +24,7 @@ export interface RepositoryFileTreePageProps
             objectType: 'blob' | 'tree' | undefined
             filePath: string | undefined
             spec: string
-        }>,
-        Pick<BlobProps, 'onHandleFuzzyFinder'> {}
+        }> {}
 
 /** Dev feature flag to make benchmarking the file tree in isolation easier. */
 const hideRepoRevisionContent = localStorage.getItem('hideRepoRevContent')
@@ -113,7 +111,6 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                                     repoHeaderContributionsLifecycleProps={
                                         context.repoHeaderContributionsLifecycleProps
                                     }
-                                    onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                                 />
                             </TraceSpanProvider>
                         ) : resolvedRevision ? (

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -129,7 +129,6 @@ export interface BlobProps
 
     isBlameVisible?: boolean
     blameHunks?: BlameHunk[]
-    onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export interface BlobInfo extends AbsoluteRepoFile, ModeSpec {

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -51,7 +51,7 @@ import { ToggleLineWrap } from './actions/ToggleLineWrap'
 import { ToggleRenderedFileMode } from './actions/ToggleRenderedFileMode'
 import { getModeFromURL } from './actions/utils'
 import { fetchBlob } from './backend'
-import { Blob, BlobInfo, BlobProps } from './Blob'
+import { Blob, BlobInfo } from './Blob'
 import { Blob as CodeMirrorBlob } from './CodeMirrorBlob'
 import { GoToRawAction } from './GoToRawAction'
 import { BlobPanel } from './panel/BlobPanel'
@@ -74,7 +74,6 @@ interface BlobPageProps
         HoverThresholdProps,
         BreadcrumbSetters,
         SearchStreamingProps,
-        Pick<BlobProps, 'onHandleFuzzyFinder'>,
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'> {
     location: H.Location
@@ -484,7 +483,6 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                         ariaLabel="File blob"
                         isBlameVisible={isBlameVisible}
                         blameHunks={blameDecorations}
-                        onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                     />
                 </TraceSpanProvider>
             )}

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -76,28 +76,6 @@ const blameDecorationsCompartment = new Compartment()
 // Compartment for propagating component props
 const blobPropsCompartment = new Compartment()
 
-// See CodeMirrorQueryInput for a detailed comment about the pattern that's used
-// below. The CodeMirror search bar uses a similar pattern to support global
-// shortcuts (including Mod-k) while the search bar is focused.
-const [callbacksField, setCallbacks] = createUpdateableField<Pick<BlobProps, 'onHandleFuzzyFinder'>>(
-    { onHandleFuzzyFinder: () => {} },
-    callbacks => [
-        keymap.of([
-            {
-                key: 'Mod-k',
-                run: view => {
-                    const { onHandleFuzzyFinder } = view.state.field(callbacks)
-                    if (onHandleFuzzyFinder) {
-                        onHandleFuzzyFinder(true)
-                        return true
-                    }
-                    return false
-                },
-            },
-        ]),
-    ]
-)
-
 export const Blob: React.FunctionComponent<BlobProps> = props => {
     const {
         className,
@@ -113,7 +91,6 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // Reference panel specific props
         disableStatusBar,
         disableDecorations,
-        onHandleFuzzyFinder,
         navigateToLineOnAnyClick,
     } = props
 
@@ -177,7 +154,6 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     const extensions = useMemo(
         () => [
             staticExtensions,
-            callbacksField,
             selectableLineNumbers({
                 onSelection,
                 initialSelection: position.line !== undefined ? position : null,
@@ -210,12 +186,6 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         updateValueOnChange: false,
         updateOnExtensionChange: false,
     })
-
-    useEffect(() => {
-        if (editor) {
-            setCallbacks(editor, { onHandleFuzzyFinder })
-        }
-    }, [editor, onHandleFuzzyFinder])
 
     // Reconfigure editor when blobInfo or core extensions changed
     useEffect(() => {

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -10,7 +10,6 @@ import { CodeIntelligenceProps } from './codeintel'
 import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import type { LayoutProps } from './Layout'
-import { BlobProps } from './repo/blob/Blob'
 import { PageRoutes } from './routes.constants'
 import { SearchPageWrapper } from './search/SearchPageWrapper'
 import { getExperimentalFeatures, useExperimentalFeatures } from './stores'
@@ -42,8 +41,7 @@ export interface LayoutRouteComponentProps<RouteParameters extends { [K in keyof
         BreadcrumbsProps,
         BreadcrumbSetters,
         CodeIntelligenceProps,
-        BatchChangesProps,
-        Pick<BlobProps, 'onHandleFuzzyFinder'> {
+        BatchChangesProps {
     isSourcegraphDotCom: boolean
     isMacPlatform: boolean
 }


### PR DESCRIPTION
Fixes #40730 

This PR depends on https://github.com/sourcegraph/sourcegraph/pull/41882 and makes two changes (hence two commits):

- The first commit does a partial revert of https://github.com/sourcegraph/sourcegraph/pull/40563. I left the fuzzy finder code in `Layout`  which I think is a "better" location than `SearchNavbarItem` (from a component hierarchy perspective), but removed all the logic that passed the fuzzy finder handler down to the blob view.
- The second commit fixes the detection of `contenteditable` elements so that global shortcuts are processed when the CodeMirror blob view is focused (which has `contenteditable="false"`).

Demo: 

https://user-images.githubusercontent.com/179026/191712723-93223041-592a-49f9-b7b3-b4e88ba1ea82.mp4



## Test plan

- Enable CodeMirror blob view in user settings
- Open file page
- Focus blob view (e.g. by clicking on code)
- Press global keyboard shortcuts

## App preview:

- [Web](https://sg-web-fkling-cm-blob-shortcuts.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rabfadankt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

