### PR TITLE
fuzzy finder: Refactor and simplify query input implementation

### DIFF
--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
@@ -57,8 +57,6 @@ export interface JetBrainsSearchBoxProps
     /** Don't show search help button */
     hideHelpButton?: boolean
 
-    onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
-
     /** Set in JSContext only available to the web app. */
     isExternalServicesUserModeAll?: boolean
 

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -76,7 +76,6 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
     onBlur,
     isSourcegraphDotCom,
     globbing,
-    onHandleFuzzyFinder,
     onEditorCreated,
     interpretComments,
     isLightTheme,
@@ -212,10 +211,9 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
                 onFocus,
                 onBlur,
                 onCompletionItemSelected,
-                onHandleFuzzyFinder,
             })
         }
-    }, [editor, onChange, onSubmit, onFocus, onBlur, onCompletionItemSelected, onHandleFuzzyFinder])
+    }, [editor, onChange, onSubmit, onFocus, onBlur, onCompletionItemSelected])
 
     // Always focus the editor on 'selectedSearchContextSpec' change
     useEffect(() => {
@@ -435,10 +433,7 @@ export const CodeMirrorQueryInput: React.FunctionComponent<
 // Instead of creating a separate field for every handler, all handlers are set
 // via a single field to keep complexity manageable.
 const [callbacksField, setCallbacks] = createUpdateableField<
-    Pick<
-        MonacoQueryInputProps,
-        'onChange' | 'onSubmit' | 'onFocus' | 'onBlur' | 'onCompletionItemSelected' | 'onHandleFuzzyFinder'
-    >
+    Pick<MonacoQueryInputProps, 'onChange' | 'onSubmit' | 'onFocus' | 'onBlur' | 'onCompletionItemSelected'>
 >({ onChange: () => {} }, callbacks => [
     Prec.high(
         keymap.of([
@@ -457,19 +452,6 @@ const [callbacksField, setCallbacks] = createUpdateableField<
             },
         ])
     ),
-    keymap.of([
-        {
-            key: 'Mod-k',
-            run: view => {
-                const { onHandleFuzzyFinder } = view.state.field(callbacks)
-                if (onHandleFuzzyFinder) {
-                    onHandleFuzzyFinder(true)
-                    return true
-                }
-                return false
-            },
-        },
-    ]),
     EditorView.updateListener.of((update: ViewUpdate) => {
         const { state, view } = update
         const { onChange, onFocus, onBlur, onCompletionItemSelected } = state.field(callbacks)

--- a/client/search-ui/src/input/MonacoQueryInput.story.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.story.tsx
@@ -31,7 +31,6 @@ const defaultProps: MonacoQueryInputProps = {
     selectedSearchContextSpec: 'global',
     onChange: () => {},
     onSubmit: () => {},
-    onHandleFuzzyFinder: () => {},
 }
 
 export const MonacoQueryInputStory: Story = () => (

--- a/client/search-ui/src/input/MonacoQueryInput.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.tsx
@@ -74,7 +74,6 @@ export interface MonacoQueryInputProps
     onEditorCreated?: (editor: IEditor) => void
     fetchStreamSuggestions?: typeof defaultFetchStreamSuggestions // Alternate implementation is used in the VS Code extension.
     autoFocus?: boolean
-    onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
     // Whether globbing is enabled for filters.
     globbing: boolean
 
@@ -195,7 +194,6 @@ export const MonacoQueryInput: React.FunctionComponent<React.PropsWithChildren<M
     height = 17,
     preventNewLine = true,
     editorOptions,
-    onHandleFuzzyFinder,
     editorClassName,
     onEditorCreated: onEditorCreatedCallback,
     placeholder,
@@ -395,23 +393,12 @@ export const MonacoQueryInput: React.FunctionComponent<React.PropsWithChildren<M
             }),
         ]
 
-        if (onHandleFuzzyFinder) {
-            disposables.push(
-                editor.addAction({
-                    id: 'triggerFuzzyFinder',
-                    label: 'triggerFuzzyFinder',
-                    keybindings: [Monaco.KeyMod.CtrlCmd | Monaco.KeyCode.KEY_K],
-                    run: () => onHandleFuzzyFinder(true),
-                })
-            )
-        }
-
         return () => {
             for (const disposable of disposables) {
                 disposable.dispose()
             }
         }
-    }, [editor, onSubmit, onHandleFuzzyFinder])
+    }, [editor, onSubmit])
 
     return (
         <div

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -32,7 +32,6 @@ export interface SearchBoxProps
             | 'interpretComments'
             | 'onChange'
             | 'onCompletionItemSelected'
-            | 'onHandleFuzzyFinder'
             | 'applySuggestionsOnEnter'
             | 'suggestionSources'
             | 'defaultSuggestionsShowWhenEmpty'
@@ -122,7 +121,6 @@ export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBo
                         onChange={props.onChange}
                         onCompletionItemSelected={props.onCompletionItemSelected}
                         onFocus={props.onFocus}
-                        onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                         onSubmit={props.onSubmit}
                         patternType={props.patternType}
                         queryState={queryState}

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useEffect, useState } from 'react'
+import React, { Suspense, useCallback, useState } from 'react'
 
 import classNames from 'classnames'
 import { Redirect, Route, RouteComponentProps, Switch, matchPath } from 'react-router'
@@ -28,7 +28,7 @@ import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { AppRouterContainer } from './components/AppRouterContainer'
 import { useBreadcrumbs } from './components/Breadcrumbs'
 import { ErrorBoundary } from './components/ErrorBoundary'
-import { FuzzyFinder } from './components/fuzzyFinder/FuzzyFinder'
+import { FuzzyFinderContainer } from './components/fuzzyFinder/FuzzyFinder'
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 import { useScrollToLocationHash } from './components/useScrollToLocationHash'
 import { GlobalContributions } from './contributions'
@@ -130,22 +130,12 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     const isSearchNotebookListPage = props.location.pathname === PageRoutes.Notebooks
     const isRepositoryRelatedPage = routeMatch === '/:repoRevAndRest+' ?? false
 
-    const [isFuzzyFinderVisible, setIsFuzzyFinderVisible] = useState(false)
-    const fuzzyFinderShortcut = useKeyboardShortcut('fuzzyFinder')
-    const [retainFuzzyFinderCache, setRetainFuzzyFinderCache] = useState(true)
-
     let { fuzzyFinder } = getExperimentalFeatures(props.settingsCascade.final)
     if (fuzzyFinder === undefined) {
         // Happens even when `"default": true` is defined in
         // settings.schema.json.
         fuzzyFinder = true
     }
-
-    useEffect(() => {
-        if (!isRepositoryRelatedPage && isFuzzyFinderVisible) {
-            setIsFuzzyFinderVisible(false)
-        }
-    }, [isRepositoryRelatedPage, isFuzzyFinderVisible])
 
     const communitySearchContextPaths = communitySearchContextsRoutes.map(route => route.path)
     const isCommunitySearchContextPage = communitySearchContextPaths.includes(props.location.pathname)
@@ -250,7 +240,6 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
                     isSearchAutoFocusRequired={!isSearchAutoFocusRequired}
                     isRepositoryRelatedPage={isRepositoryRelatedPage}
                     showKeyboardShortcutsHelp={showKeyboardShortcutsHelp}
-                    onHandleFuzzyFinder={setIsFuzzyFinderVisible}
                 />
             )}
             {needsSiteInit && !isSiteInit && <Redirect to="/site-admin/init" />}
@@ -310,27 +299,8 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
             {(isSearchNotebookListPage || (isSearchRelatedPage && !isSearchHomepage)) && (
                 <NotepadContainer onCreateNotebook={props.onCreateNotebookFromNotepad} />
             )}
-            {fuzzyFinderShortcut?.keybindings.map((keybinding, index) => (
-                <Shortcut
-                    key={index}
-                    {...keybinding}
-                    onMatch={() => {
-                        setIsFuzzyFinderVisible(true)
-                        setRetainFuzzyFinderCache(true)
-                        const input = document.querySelector<HTMLInputElement>('#fuzzy-modal-input')
-                        input?.focus()
-                        input?.select()
-                    }}
-                />
-            ))}
-            {isRepositoryRelatedPage && retainFuzzyFinderCache && fuzzyFinder && (
-                <FuzzyFinder
-                    setIsVisible={bool => setIsFuzzyFinderVisible(bool)}
-                    isVisible={isFuzzyFinderVisible}
-                    telemetryService={props.telemetryService}
-                    location={props.location}
-                    setCacheRetention={bool => setRetainFuzzyFinderCache(bool)}
-                />
+            {isRepositoryRelatedPage && fuzzyFinder && (
+                <FuzzyFinderContainer telemetryService={props.telemetryService} location={props.location} />
             )}
         </div>
     )

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -83,7 +83,6 @@ interface Props
     isRepositoryRelatedPage?: boolean
     branding?: typeof window.context.branding
     showKeyboardShortcutsHelp: () => void
-    onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 /**

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -32,7 +32,6 @@ interface Props
     globbing: boolean
     isSearchAutoFocusRequired?: boolean
     isRepositoryRelatedPage?: boolean
-    onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const selectQueryState = ({
@@ -111,7 +110,6 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 submitSearchOnSearchContextChange={submitSearchOnChange}
                 autoFocus={autoFocus}
                 hideHelpButton={isSearchPage}
-                onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                 isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                 structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
             />


### PR DESCRIPTION
The main purpose of this commit is to configure the fuzzy finder keyboard shortcut to also be triggered when the target is an input element (`ignoreInput={true}`; I know the prop name is not intuitive 🤷🏻‍♂️). **Note:** I don't see why we wouldn't want to trigger fuzzy finder anywhere on a repo page but maybe I'm missing something.

This in turn allows us to remove `onHandleFuzzyFinder` from the query input making its implementation and API, and the APIs of all intermediate components simpler.

Since we don't have to pass down that handler anymore we can now also consolidate the fuzzy finder logic into its own component. I considered just moving everything into `FuzzyFinder` itself, but to keep changes of existing code to a minimum I decided to introduce `FuzzyFinderContainer` instead. Happy to merge those though if you think that's better.



## Test plan

- Open a file page.
- Press `ctrl+k` to open fuzzy finder.
- Focus query input, press `ctrl-k` to open fuzzy finder
- Enable old Monaco query input (`"editor": "monaco"`), focus query input, press `ctrl-k` to open fuzzy finder

## App preview:

- [Web](https://sg-web-fkling-query-input-shortcut.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bogpvxabux.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
