### PR TITLE
Remove ~70 nils by adding constructors for specific GraphQL schemas

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -350,6 +350,18 @@ func prometheusGraphQLRequestName(requestName string) string {
 	return "other"
 }
 
+func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {
+	return NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, notebooks, nil, nil)
+}
+
+func NewSchemaWithAuthzResolver(db database.DB, authz AuthzResolver) (*graphql.Schema, error) {
+	return NewSchema(db, nil, nil, nil, authz, nil, nil, nil, nil, nil, nil, nil)
+}
+
+func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver) (*graphql.Schema, error) {
+	return NewSchema(db, batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+}
+
 func NewSchema(
 	db database.DB,
 	batchChanges BatchChangesResolver,

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -362,6 +362,14 @@ func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChanges
 	return NewSchema(db, batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
+func NewSchemaWithCodeMonitorsResolver(db database.DB, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
+	return NewSchema(db, nil, nil, nil, nil, codeMonitors, nil, nil, nil, nil, nil, nil)
+}
+
+func NewSchemaWithLicenseResolver(db database.DB, license LicenseResolver) (*graphql.Schema, error) {
+	return NewSchema(db, nil, nil, nil, nil, nil, license, nil, nil, nil, nil, nil)
+}
+
 func NewSchema(
 	db database.DB,
 	batchChanges BatchChangesResolver,

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -41,7 +41,7 @@ func clock() time.Time {
 func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 	t.Helper()
 
-	parsedSchema, err := graphqlbackend.NewSchema(db, nil, nil, nil, NewResolver(db, clock), nil, nil, nil, nil, nil, nil, nil)
+	parsedSchema, err := graphqlbackend.NewSchemaWithAuthzResolver(db, NewResolver(db, clock))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
@@ -120,7 +120,7 @@ func parseJSONTime(t testing.TB, ts string) time.Time {
 }
 
 func newSchema(db database.DB, r graphqlbackend.BatchChangesResolver) (*graphql.Schema, error) {
-	return graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return graphqlbackend.NewSchemaWithBatchChangesResolver(db, r)
 }
 
 func newGitHubExternalService(t *testing.T, store database.ExternalServiceStore) *types.ExternalService {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -375,7 +375,7 @@ func TestQueryMonitor(t *testing.T) {
 	_, err = r.insertTestMonitorWithOpts(ctx, t, actionOpt, postHookOpt)
 	require.NoError(t, err)
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, r, nil, nil, nil, nil, nil, nil)
+	schema, err := graphqlbackend.NewSchemaWithCodeMonitorsResolver(db, r)
 	require.NoError(t, err)
 
 	t.Run("query by user", func(t *testing.T) {
@@ -702,7 +702,7 @@ func TestEditCodeMonitor(t *testing.T) {
 
 	// Update the code monitor.
 	// We update all fields, delete one action, and add a new action.
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, r, nil, nil, nil, nil, nil, nil)
+	schema, err := graphqlbackend.NewSchemaWithCodeMonitorsResolver(db, r)
 	require.NoError(t, err)
 	updateInput := map[string]any{
 		"monitorID": string(relay.MarshalID(MonitorKind, 1)),

--- a/enterprise/cmd/frontend/internal/licensing/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/resolvers/resolvers_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestEnterpriseLicenseHasFeature(t *testing.T) {
 	r := &LicenseResolver{}
-	schema, err := graphqlbackend.NewSchema(nil, nil, nil, nil, nil, nil, r, nil, nil, nil, nil, nil)
+	schema, err := graphqlbackend.NewSchemaWithLicenseResolver(nil, r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
@@ -207,7 +207,7 @@ func TestSingleNotebookCRUD(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
+	schema, err := graphqlbackend.NewSchemaWithNotebooksResolver(db, NewResolver(db))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,7 +600,7 @@ func TestListNotebooks(t *testing.T) {
 		return ids
 	}
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
+	schema, err := graphqlbackend.NewSchemaWithNotebooksResolver(db, NewResolver(db))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -737,7 +737,7 @@ func TestGetNotebookWithSoftDeletedUserColumns(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
+	schema, err := graphqlbackend.NewSchemaWithNotebooksResolver(db, NewResolver(db))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
@@ -79,7 +79,7 @@ func TestCreateAndDeleteNotebookStars(t *testing.T) {
 
 	createdNotebooks := createNotebooks(t, db, []*notebooks.Notebook{userNotebookFixture(user1.ID, true), userNotebookFixture(user1.ID, false)})
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
+	schema, err := graphqlbackend.NewSchemaWithNotebooksResolver(db, NewResolver(db))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestListNotebookStars(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil, nil)
+	schema, err := graphqlbackend.NewSchemaWithNotebooksResolver(db, NewResolver(db))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The `nil`s and their order have bit me more than once so this has been on my list for a while.

It removes all the invocations of `NewSchema` and replaces them with specific constructors that only take 2 arguments.

## Test plan

- Existing tests