### PR TITLE
Search backend: fix mermaid chart escaping

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -125,10 +125,7 @@ func outputJobTree(
 		sexpString := printer.SexpVerbose(j, verbosity, true)
 		return &JSONValue{Value: sexpString}, nil
 	case Mermaid:
-		if args.OutputVerbosity != Minimal {
-			return nil, errors.New("unsupported output options for MERMAID JOB_TREE, only MINIMAL verbosity is supported")
-		}
-		mermaidString := printer.Mermaid(j)
+		mermaidString := printer.MermaidVerbose(j, verbosity)
 		return &JSONValue{Value: mermaidString}, nil
 	}
 	return nil, nil

--- a/internal/search/job/printer/mermaid.go
+++ b/internal/search/job/printer/mermaid.go
@@ -69,11 +69,13 @@ func writeNode(b *bytes.Buffer, depth int, style NodeStyle, id *int, label strin
 
 func buildLabel(j job.Describer, v job.Verbosity) string {
 	b := new(strings.Builder)
+	b.WriteRune('"')
 	b.WriteString(trimmedUpperName(j.Name()))
 	enc := fieldStringEncoder{mermaidKeyValueWriter{b}}
 	for _, field := range j.Fields(v) {
 		field.Marshal(enc)
 	}
+	b.WriteRune('"')
 	return b.String()
 }
 
@@ -82,23 +84,15 @@ type mermaidKeyValueWriter struct{ io.StringWriter }
 func (w mermaidKeyValueWriter) Write(key, value string) {
 	w.WriteString(" <br> ")
 	w.WriteString(mermaidEscaper.Replace(key))
-	w.WriteString(mermaidEscaper.Replace(": "))
+	w.WriteString(": ")
 	w.WriteString(mermaidEscaper.Replace(value))
 }
 
 // Copied from the `html` package and modified for mermaid
 var mermaidEscaper = strings.NewReplacer(
-	`&`, "&amp",
-	`'`, "&#39",
-	`"`, "&#34",
-	`<`, "&lt",
-	`>`, "&gt",
-	`(`, "&#40",
-	`)`, "&#41",
-	`:`, "&#58",
-	`[`, "&#91",
-	`]`, "&#93",
-	`{`, "&#123",
-	`|`, "&#124",
-	`}`, "&#125",
+	`"`, "#quot;",
+	`'`, "#apos;",
+	`&`, "#amp;",
+	`<`, "#lt;",
+	`>`, "#gt;",
 )

--- a/internal/search/job/printer/mermaid.go
+++ b/internal/search/job/printer/mermaid.go
@@ -72,7 +72,6 @@ func buildLabel(j job.Describer, v job.Verbosity) string {
 	b.WriteString(trimmedUpperName(j.Name()))
 	enc := fieldStringEncoder{mermaidKeyValueWriter{b}}
 	for _, field := range j.Fields(v) {
-		b.WriteString(" <br> ")
 		field.Marshal(enc)
 	}
 	return b.String()
@@ -81,7 +80,25 @@ func buildLabel(j job.Describer, v job.Verbosity) string {
 type mermaidKeyValueWriter struct{ io.StringWriter }
 
 func (w mermaidKeyValueWriter) Write(key, value string) {
-	w.WriteString(key)
-	w.WriteString(": ")
-	w.WriteString(value)
+	w.WriteString(" <br> ")
+	w.WriteString(mermaidEscaper.Replace(key))
+	w.WriteString(mermaidEscaper.Replace(": "))
+	w.WriteString(mermaidEscaper.Replace(value))
 }
+
+// Copied from the `html` package and modified for mermaid
+var mermaidEscaper = strings.NewReplacer(
+	`&`, "&amp",
+	`'`, "&#39",
+	`"`, "&#34",
+	`<`, "&lt",
+	`>`, "&gt",
+	`(`, "&#40",
+	`)`, "&#41",
+	`:`, "&#58",
+	`[`, "&#91",
+	`]`, "&#93",
+	`{`, "&#123",
+	`|`, "&#124",
+	`}`, "&#125",
+)

--- a/internal/search/job/printer/testdata/TestPrettyMermaid/nonverbose/bigJob.golden
+++ b/internal/search/job/printer/testdata/TestPrettyMermaid/nonverbose/bigJob.golden
@@ -1,27 +1,27 @@
 flowchart TB
-0[FILTER]
+0["FILTER"]
   0---1
-  1[LIMIT]
+  1["LIMIT"]
     1---2
-    2[TIMEOUT]
+    2["TIMEOUT"]
       2---3
-      3[PARALLEL]
+      3["PARALLEL"]
         3---4
-        4[AND]
+        4["AND"]
           4---5
-          5[LEAF]
+          5["LEAF"]
             4---6
-          6[LEAF]
+          6["LEAF"]
             3---7
-        7[OR]
+        7["OR"]
           7---8
-          8[LEAF]
+          8["LEAF"]
             7---9
-          9[LEAF]
+          9["LEAF"]
             3---10
-        10[AND]
+        10["AND"]
           10---11
-          11[LEAF]
+          11["LEAF"]
             10---12
-          12[LEAF]
+          12["LEAF"]
             

--- a/internal/search/job/printer/testdata/TestPrettyMermaid/nonverbose/simpleJob.golden
+++ b/internal/search/job/printer/testdata/TestPrettyMermaid/nonverbose/simpleJob.golden
@@ -1,7 +1,7 @@
 flowchart TB
-0[AND]
+0["AND"]
   0---1
-  1[LEAF]
+  1["LEAF"]
     0---2
-  2[LEAF]
+  2["LEAF"]
     

--- a/internal/search/job/printer/testdata/TestPrettyMermaid/verbose/bigJob.golden
+++ b/internal/search/job/printer/testdata/TestPrettyMermaid/verbose/bigJob.golden
@@ -1,27 +1,27 @@
 flowchart TB
 0[FILTER]
   0---1
-  1[LIMIT <br> limit: 100]
+  1[LIMIT <br> limit&#58 100]
     1---2
-    2[TIMEOUT <br> duration: 50ms]
+    2[TIMEOUT <br> duration&#58 50ms]
       2---3
       3[PARALLEL]
         3---4
         4[AND]
           4---5
-          5[LEAF <br> life_meaning: 42 <br> leaf_meaning: 420]
+          5[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
             4---6
-          6[LEAF <br> life_meaning: 42 <br> leaf_meaning: 420]
+          6[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
             3---7
         7[OR]
           7---8
-          8[LEAF <br> life_meaning: 42 <br> leaf_meaning: 420]
+          8[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
             7---9
-          9[LEAF <br> life_meaning: 42 <br> leaf_meaning: 420]
+          9[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
             3---10
         10[AND]
           10---11
-          11[LEAF <br> life_meaning: 42 <br> leaf_meaning: 420]
+          11[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
             10---12
-          12[LEAF <br> life_meaning: 42 <br> leaf_meaning: 420]
+          12[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
             

--- a/internal/search/job/printer/testdata/TestPrettyMermaid/verbose/bigJob.golden
+++ b/internal/search/job/printer/testdata/TestPrettyMermaid/verbose/bigJob.golden
@@ -1,27 +1,27 @@
 flowchart TB
-0[FILTER]
+0["FILTER"]
   0---1
-  1[LIMIT <br> limit&#58 100]
+  1["LIMIT <br> limit: 100"]
     1---2
-    2[TIMEOUT <br> duration&#58 50ms]
+    2["TIMEOUT <br> duration: 50ms"]
       2---3
-      3[PARALLEL]
+      3["PARALLEL"]
         3---4
-        4[AND]
+        4["AND"]
           4---5
-          5[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
+          5["LEAF <br> life_meaning: 42 <br> leaf_meaning: 420"]
             4---6
-          6[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
+          6["LEAF <br> life_meaning: 42 <br> leaf_meaning: 420"]
             3---7
-        7[OR]
+        7["OR"]
           7---8
-          8[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
+          8["LEAF <br> life_meaning: 42 <br> leaf_meaning: 420"]
             7---9
-          9[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
+          9["LEAF <br> life_meaning: 42 <br> leaf_meaning: 420"]
             3---10
-        10[AND]
+        10["AND"]
           10---11
-          11[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
+          11["LEAF <br> life_meaning: 42 <br> leaf_meaning: 420"]
             10---12
-          12[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
+          12["LEAF <br> life_meaning: 42 <br> leaf_meaning: 420"]
             

--- a/internal/search/job/printer/testdata/TestPrettyMermaid/verbose/simpleJob.golden
+++ b/internal/search/job/printer/testdata/TestPrettyMermaid/verbose/simpleJob.golden
@@ -1,7 +1,7 @@
 flowchart TB
 0[AND]
   0---1
-  1[LEAF <br> life_meaning: 42 <br> leaf_meaning: 420]
+  1[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
     0---2
-  2[LEAF <br> life_meaning: 42 <br> leaf_meaning: 420]
+  2[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
     

--- a/internal/search/job/printer/testdata/TestPrettyMermaid/verbose/simpleJob.golden
+++ b/internal/search/job/printer/testdata/TestPrettyMermaid/verbose/simpleJob.golden
@@ -1,7 +1,7 @@
 flowchart TB
-0[AND]
+0["AND"]
   0---1
-  1[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
+  1["LEAF <br> life_meaning: 42 <br> leaf_meaning: 420"]
     0---2
-  2[LEAF <br> life_meaning&#58 42 <br> leaf_meaning&#58 420]
+  2["LEAF <br> life_meaning: 42 <br> leaf_meaning: 420"]
     


### PR DESCRIPTION
This fixes the issue described [here](https://github.com/sourcegraph/sourcegraph/pull/41893/files#r977076005) where special characters weren't being escaped in mermaid charts, causing us to emit invalid charts.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/41893

## Test plan

Manually tested that the mermaid chart correctly renders for a few different queries.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
