### PR TITLE
Revert zoekt update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -223,7 +223,7 @@ require (
 )
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20220922012354-1a338228b6c9
+	github.com/sourcegraph/zoekt v0.0.0-20220921122446-2fa5f478abb8
 	github.com/stretchr/objx v0.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2098,8 +2098,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220922012354-1a338228b6c9 h1:vFWDchDc5kWioaAaLKjXbdpfaJHctoRv8XRStDydYH4=
-github.com/sourcegraph/zoekt v0.0.0-20220922012354-1a338228b6c9/go.mod h1:Te+E6i7jevKNo/FJgr2RNTo/tEcVOjic/SfiuZiTQq8=
+github.com/sourcegraph/zoekt v0.0.0-20220921122446-2fa5f478abb8 h1:RzW70Ngg2Ye82I1CyOxg/Zags6qZPOY+XmTWYzkbM9I=
+github.com/sourcegraph/zoekt v0.0.0-20220921122446-2fa5f478abb8/go.mod h1:Te+E6i7jevKNo/FJgr2RNTo/tEcVOjic/SfiuZiTQq8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Server utilizes the debug flag for zoekt-sourcegraph-indexserver which was deprecated in recent zoekt version. Revert to use previous zoekt version while resolution determined.

## Test plan

N/A zoekt version change to go.mod