### PR TITLE
dev/sg: add metrics regexp generator, fix promql.ListMetrics

### DIFF
--- a/dev/sg/sg_monitoring.go
+++ b/dev/sg/sg_monitoring.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -122,13 +123,20 @@ Also refer to the generated reference documentation available for site admins:
 					for _, m := range uniqueMetrics {
 						md.WriteString(fmt.Sprintf("- `%s`\n", m))
 					}
-					return std.Out.WriteMarkdown(md.String())
+					if err := std.Out.WriteMarkdown(md.String()); err != nil {
+						return err
+					}
 
 				case "plain":
 					std.Out.Write(strings.Join(uniqueMetrics, "\n"))
 
 				case "regexp":
-					std.Out.Write("(" + strings.Join(uniqueMetrics, "|") + ")")
+					reString := "(" + strings.Join(uniqueMetrics, "|") + ")"
+					re, err := regexp.Compile(reString)
+					if err != nil {
+						return errors.Wrap(err, "generated regexp was invalid")
+					}
+					std.Out.Write(re.String())
 
 				default:
 					return errors.Newf("unknown format %q", format)

--- a/dev/sg/sg_monitoring.go
+++ b/dev/sg/sg_monitoring.go
@@ -86,6 +86,14 @@ Also refer to the generated reference documentation available for site admins:
 			ArgsUsage:   "<dashboard...>",
 			Usage:       "List metrics used in dashboards",
 			Description: `For per-dashboard summaries, use 'sg monitoring dashboards' instead.`,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    "format",
+					Aliases: []string{"f"},
+					Usage:   "Output format of list ('markdown', 'plain', 'regexp')",
+					Value:   "markdown",
+				},
+			},
 			Action: func(c *cli.Context) error {
 				dashboards, err := dashboardsFromArgs(c.Args())
 				if err != nil {
@@ -96,10 +104,34 @@ Also refer to the generated reference documentation available for site admins:
 				if err != nil {
 					return errors.Wrap(err, "failed to list metrics")
 				}
+
+				foundMetrics := make(map[string]struct{})
+				var uniqueMetrics []string
 				for _, metrics := range results {
 					for _, metric := range metrics {
-						std.Out.Write(metric)
+						if _, exists := foundMetrics[metric]; !exists {
+							uniqueMetrics = append(uniqueMetrics, metric)
+							foundMetrics[metric] = struct{}{}
+						}
 					}
+				}
+
+				switch format := c.String("format"); format {
+				case "markdown":
+					var md strings.Builder
+					for _, m := range uniqueMetrics {
+						md.WriteString(fmt.Sprintf("- `%s`\n", m))
+					}
+					return std.Out.WriteMarkdown(md.String())
+
+				case "plain":
+					std.Out.Write(strings.Join(uniqueMetrics, "\n"))
+
+				case "regexp":
+					std.Out.Write("(" + strings.Join(uniqueMetrics, "|") + ")")
+
+				default:
+					return errors.Newf("unknown format %q", format)
 				}
 
 				return nil

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -990,6 +990,7 @@ Arguments: `<dashboard...>`
 Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--format, -f="<value>"`: Output format of list ('markdown', 'plain', 'regexp') (default: markdown)
 
 ## sg secret
 


### PR DESCRIPTION
Adds markdown, plain, and regexp output types for `sg monitoring metrics`.

Also fixes promql.ListMetrics by correctly handling `{__name__="..."}` queries.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
$ go run ./dev/sg monitoring metrics
$ go run ./dev/sg monitoring metrics -f=regexp
```

Example regexp:

```
(src_codeintel_upload_total|src_codeintel_upload_processor_total|src_codeintel_upload_queued_duration_seconds_total|src_codeintel_upload_processor_handlers|src_codeintel_upload_processor_upload_size|src_codeintel_upload_processor_duration_seconds_bucket|src_codeintel_upload_processor_errors_total|src_codeintel_dbstore_total|src_codeintel_dbstore_duration_seconds_bucket|src_codeintel_dbstore_errors_total|src_codeintel_lsifstore_total|src_codeintel_lsifstore_duration_seconds_bucket|src_codeintel_lsifstore_errors_total|src_workerutil_dbworker_store_codeintel_upload_total|src_workerutil_dbworker_store_codeintel_upload_duration_seconds_bucket|src_workerutil_dbworker_store_codeintel_upload_errors_total|src_codeintel_gitserver_total|src_codeintel_gitserver_duration_seconds_bucket|src_codeintel_gitserver_errors_total|src_codeintel_uploadstore_total|src_codeintel_uploadstore_duration_seconds_bucket|src_codeintel_uploadstore_errors_total|src_frontend_internal_request_duration_seconds_count|src_pgsql_conns_max_open|src_pgsql_conns_open|src_pgsql_conns_in_use|src_pgsql_conns_idle|src_pgsql_conns_blocked_seconds|src_pgsql_conns_waited_for|src_pgsql_conns_closed_max_idle|src_pgsql_conns_closed_max_lifetime|src_pgsql_conns_closed_max_idle_time|container_last_seen|cadvisor_container_cpu_usage_percentage_total|cadvisor_container_memory_usage_percentage_total|container_fs_reads_total|container_fs_writes_total|container_oom_events_total|go_goroutines|go_gc_duration_seconds|up|src_codeintel_dbstore_indexes_inserted|src_codeintel_index_scheduler_errors_total|src_codeintel_index_scheduler_total|src_executor_total|src_executor_processor_total|src_executor_queued_duration_seconds_total|src_codeintel_autoindexing_total|src_codeintel_autoindexing_duration_seconds_bucket|src_codeintel_autoindexing_errors_total|src_codeintel_autoindexing_store_total|src_codeintel_autoindexing_store_duration_seconds_bucket|src_codeintel_autoindexing_store_errors_total|src_codeintel_autoindexing_inference_total|src_codeintel_autoindexing_inference_duration_seconds_bucket|src_codeintel_autoindexing_inference_errors_total|src_luasandbox_total|src_luasandbox_duration_seconds_bucket|src_luasandbox_errors_total|src_codeintel_uploads_total|src_codeintel_uploads_duration_seconds_bucket|src_codeintel_uploads_errors_total|src_codeintel_uploads_store_total|src_codeintel_uploads_store_duration_seconds_bucket|src_codeintel_uploads_store_errors_total|src_codeintel_uploads_transport_graphql_total|src_codeintel_uploads_transport_graphql_duration_seconds_bucket|src_codeintel_uploads_transport_graphql_errors_total|src_codeintel_uploads_transport_http_total|src_codeintel_uploads_transport_http_duration_seconds_bucket|src_codeintel_uploads_transport_http_errors_total|src_codeintel_background_upload_records_removed_total|src_codeintel_background_index_records_removed_total|src_codeintel_background_uploads_purged_total|src_codeintel_background_audit_log_records_expired_total|src_codeintel_uploads_background_cleanup_errors_total|src_codeintel_commit_graph_total|src_codeintel_commit_graph_processor_total|src_codeintel_commit_graph_queued_duration_seconds_total|src_codeintel_background_repositories_scanned_total_total|src_codeintel_background_upload_records_scanned_total_total|src_codeintel_background_commits_scanned_total_total|src_codeintel_background_upload_records_expired_total_total|node_exporter_build_info|src_executor_processor_handlers|src_executor_processor_duration_seconds_bucket|src_executor_processor_errors_total|src_apiworker_apiclient_total|src_apiworker_apiclient_duration_seconds_bucket|src_apiworker_apiclient_errors_total|src_apiworker_command_total|src_apiworker_command_duration_seconds_bucket|src_apiworker_command_errors_total|node_cpu_seconds_total|node_pressure_cpu_waiting_seconds_total|node_memory_MemAvailable_bytes|node_memory_MemTotal_bytes|node_vmstat_pgsteal_anon|node_vmstat_pgsteal_direct|node_vmstat_pgsteal_file|node_vmstat_pgsteal_kswapd|node_vmstat_pgscan_anon|node_vmstat_pgscan_direct|node_vmstat_pgscan_file|node_vmstat_pgscan_kswapd|node_pressure_memory_stalled_seconds_total|node_disk_io_time_seconds_total|node_disk_io_time_weighted_seconds_total|node_pressure_io_stalled_seconds_total|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_receive_errs_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|node_network_transmit_errs_total|src_codeintel_background_policies_updated_total_total|src_telemetry_job_total|src_telemetry_job_duration_seconds_bucket|src_telemetry_job_errors_total|src_telemetry_job_queue_size_total|src_telemetry_job_queue_size_processor_total|src_telemetry_job_max_throughput|src_worker_jobs|src_records_encrypted_at_rest_total|src_records_unencrypted_at_rest_total|src_records_encrypted_total|src_records_decrypted_total|src_record_encryption_errors_total|src_codeintel_commit_graph_processor_duration_seconds_bucket|src_codeintel_commit_graph_processor_errors_total|src_codeintel_dependency_index_total|src_codeintel_dependency_index_processor_total|src_codeintel_dependency_index_queued_duration_seconds_total|src_codeintel_dependency_index_processor_handlers|src_codeintel_dependency_index_processor_duration_seconds_bucket|src_codeintel_dependency_index_processor_errors_total|src_codeintel_background_repositories_scanned_total|src_codeintel_background_upload_records_scanned_total|src_codeintel_background_commits_scanned_total|src_codeintel_background_upload_records_expired_total|src_codeintel_background_documentation_search_records_removed_total|src_codeintel_background_errors_total|src_codeintel_index_scheduler_duration_seconds_bucket|src_workerutil_dbworker_store_codeintel_dependency_index_total|src_workerutil_dbworker_store_codeintel_dependency_index_duration_seconds_bucket|src_workerutil_dbworker_store_codeintel_dependency_index_errors_total|src_codeintel_repoupdater_total|src_codeintel_repoupdater_duration_seconds_bucket|src_codeintel_repoupdater_errors_total|src_codeintel_dependency_repos_total|src_codeintel_dependency_repos_duration_seconds_bucket|src_codeintel_dependency_repos_errors_total|src_batches_dbstore_total|src_batches_dbstore_duration_seconds_bucket|src_batches_dbstore_errors_total|src_batches_service_total|src_batches_service_duration_seconds_bucket|src_batches_service_errors_total|src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_total|src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_duration_seconds_bucket|src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_errors_total|src_workerutil_dbworker_store_batches_bulk_worker_store_total|src_workerutil_dbworker_store_batches_bulk_worker_store_duration_seconds_bucket|src_workerutil_dbworker_store_batches_bulk_worker_store_errors_total|src_workerutil_dbworker_store_batches_reconciler_worker_store_total|src_workerutil_dbworker_store_batches_reconciler_worker_store_duration_seconds_bucket|src_workerutil_dbworker_store_batches_reconciler_worker_store_errors_total|src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_total|src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_duration_seconds_bucket|src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total|src_codeintel_background_upload_record_resets_total|src_codeintel_background_upload_record_reset_failures_total|src_codeintel_background_upload_record_reset_errors_total|src_codeintel_background_index_record_resets_total|src_codeintel_background_index_record_reset_failures_total|src_codeintel_background_index_record_reset_errors_total|src_codeintel_background_dependency_index_record_resets_total|src_codeintel_background_dependency_index_record_reset_failures_total|src_codeintel_background_dependency_index_record_reset_errors_total|src_query_runner_worker_total|src_query_runner_worker_processor_total|src_query_runner_worker_processor_handlers|src_query_runner_worker_processor_duration_seconds_bucket|src_query_runner_worker_processor_errors_total|src_query_runner_worker_record_resets_total|src_query_runner_worker_record_reset_failures_total|src_query_runner_worker_record_reset_errors_total|src_workerutil_dbworker_store_insights_query_runner_jobs_store_total|src_workerutil_dbworker_store_insights_query_runner_jobs_store_duration_seconds_bucket|src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total|src_repoupdater_syncer_sync_last_time|src_repoupdater_max_sync_backoff|src_repoupdater_syncer_sync_errors_total|src_repoupdater_syncer_start_sync|src_repoupdater_syncer_sync_duration_seconds_bucket|src_repoupdater_source_duration_seconds_bucket|src_repoupdater_syncer_synced_repos_total|src_repoupdater_source_repos_total|src_repoupdater_user_repos_total|src_repoupdater_purge_failed|src_repoupdater_sched_auto_fetch|src_repoupdater_sched_manual_fetch|src_repoupdater_sched_known_repos|src_repoupdater_sched_update_queue_length|src_repoupdater_sched_loops|src_repoupdater_stale_repos|src_repoupdater_sched_error|src_repoupdater_perms_syncer_perms_gap_seconds|src_repoupdater_perms_syncer_stale_perms|src_repoupdater_perms_syncer_no_perms|src_repoupdater_perms_syncer_outdated_perms|src_repoupdater_perms_syncer_sync_duration_seconds_bucket|src_repoupdater_perms_syncer_queue_size|src_repoupdater_perms_syncer_sync_errors_total|src_repoupdater_perms_syncer_schedule_repos_total|src_repoupdater_external_services_total|src_repoupdater_user_external_services_total|src_repoupdater_queued_sync_jobs_total|src_repoupdater_completed_sync_jobs_total|src_repoupdater_errored_sync_jobs_percentage|src_github_rate_limit_remaining_v2|src_github_rate_limit_wait_duration_seconds|src_gitlab_rate_limit_remaining|src_gitlab_rate_limit_wait_duration_seconds|src_internal_rate_limit_wait_duration_bucket|src_internal_rate_limit_wait_duration_count|src_codeintel_coursier_total|src_codeintel_coursier_duration_seconds_bucket|src_codeintel_coursier_errors_total|src_codeintel_npm_total|src_codeintel_npm_duration_seconds_bucket|src_codeintel_npm_errors_total|src_http_request_duration_seconds_count|src_http_request_duration_seconds_bucket|src_syntax_highlighting_requests|index_num_assigned|index_num_stopped_tracking_total|resolve_revision_seconds_sum|resolve_revision_seconds_count|get_index_options_error_total|src_zoekt_request_duration_seconds_count|zoekt_shards_sched|index_fetch_seconds_bucket|index_repo_seconds_count|index_repo_seconds_bucket|index_queue_len|index_queue_age_seconds_bucket|index_number_compound_shards|index_shard_merging_duration_seconds_sum|index_shard_merging_duration_seconds_count|index_shard_merging_running|index_vacuum_running|container_network_transmit_bytes_total|container_network_receive_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_errors_total|container_network_receive_packets_dropped_total|container_network_receive_errors_total|src_search_streaming_latency_seconds_bucket|src_graphql_search_response|src_graphql_field_seconds_bucket|src_codeintel_resolvers_total|src_codeintel_resolvers_duration_seconds_bucket|src_codeintel_resolvers_errors_total|src_codeintel_autoindex_enqueuer_total|src_codeintel_autoindex_enqueuer_duration_seconds_bucket|src_codeintel_autoindex_enqueuer_errors_total|src_workerutil_dbworker_store_codeintel_index_total|src_workerutil_dbworker_store_codeintel_index_duration_seconds_bucket|src_workerutil_dbworker_store_codeintel_index_errors_total|src_codeintel_dependencies_total|src_codeintel_dependencies_duration_seconds_bucket|src_codeintel_dependencies_errors_total|src_codeintel_lockfiles_total|src_codeintel_lockfiles_duration_seconds_bucket|src_codeintel_lockfiles_errors_total|src_gitserver_client_total|src_gitserver_client_duration_seconds_bucket|src_gitserver_client_errors_total|src_oobmigration_total|src_oobmigration_duration_seconds_bucket|src_oobmigration_errors_total|searcher_service_request_total|src_gitserver_request_duration_seconds_bucket|src_gitserver_request_duration_seconds_count|observability_test_metric_warning|observability_test_metric_critical|src_frontend_account_failed_sign_in_attempts_total|src_frontend_account_lockouts_total|src_graphql_request_duration_seconds_count|src_graphql_request_duration_seconds_bucket|src_cloudkms_cryptographic_total|src_encryption_cache_hit_total|src_encryption_cache_miss_total|src_encryption_cache_eviction_total|src_search_ranking_result_clicked_sum|src_search_ranking_result_clicked_count|src_search_response_latency_seconds_sum|src_search_response_latency_seconds_count|src_search_streaming_latency_seconds_sum|src_search_streaming_latency_seconds_count|src_search_response_latency_seconds_bucket|src_insights_aggregations_total|src_insights_aggregations_duration_seconds_bucket|src_insights_aggregations_errors_total|src_gitserver_exec_running|container_memory_working_set_bytes|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_periods_total|container_cpu_usage_seconds_total|src_gitserver_disk_space_available|src_gitserver_disk_space_total|container_fs_reads_bytes_total|container_fs_writes_bytes_total|src_gitserver_exec_duration_seconds_count|src_gitserver_clone_queue|src_gitserver_lsremote_queue|src_gitserver_echo_duration_seconds|src_gitserver_api_total|src_gitserver_api_duration_seconds_bucket|src_gitserver_api_errors_total|src_batch_log_semaphore_wait_duration_seconds_bucket|src_gitserver_gitservice_duration_seconds_bucket|src_gitserver_gitservice_duration_seconds_count|src_gitserver_gitservice_running|src_gitserver_janitor_running|src_gitserver_janitor_job_duration_seconds_bucket|src_gitserver_janitor_job_duration_seconds_count|src_gitserver_repos_removed_disk_pressure|src_gitserver_non_existing_repos_removed|src_gitserver_maintenance_status|src_gitserver_prune_status|src_gitserver_search_latency_seconds_sum|src_gitserver_search_latency_seconds_count|src_gitserver_search_duration_seconds_sum|src_gitserver_search_duration_seconds_count|src_gitserver_search_running|pg_stat_activity_count|pg_settings_max_connections|pg_settings_superuser_reserved_connections|pg_stat_activity_max_tx_duration|pg_up|pg_invalid_index_count|pg_exporter_last_scrape_error|pg_sg_migration_status|pg_table_bloat_size|pg_table_bloat_ratio|pg_index_bloat_size|pg_index_bloat_ratio|src_codeintel_symbols_api_total|src_codeintel_symbols_api_duration_seconds_bucket|src_codeintel_symbols_api_errors_total|src_codeintel_symbols_parsing|src_codeintel_symbols_parse_queue_size|src_codeintel_symbols_parse_queue_timeouts_total|src_codeintel_symbols_parse_failed_total|src_codeintel_symbols_parser_total|src_codeintel_symbols_parser_duration_seconds_bucket|src_codeintel_symbols_parser_errors_total|src_codeintel_symbols_store_cache_size_bytes|src_codeintel_symbols_store_evictions_total|src_codeintel_symbols_store_errors_total|src_codeintel_symbols_fetching|src_codeintel_symbols_fetch_queue_size|src_codeintel_symbols_repository_fetcher_total|src_codeintel_symbols_repository_fetcher_duration_seconds_bucket|src_codeintel_symbols_repository_fetcher_errors_total|src_codeintel_symbols_gitserver_total|src_codeintel_symbols_gitserver_duration_seconds_bucket|src_codeintel_symbols_gitserver_errors_total|prometheus_rule_group_last_duration_seconds|prometheus_rule_evaluation_failures_total|alertmanager_notification_latency_seconds_sum|alertmanager_notifications_failed_total|prometheus_config_last_reload_successful|alertmanager_config_last_reload_successful|prometheus_tsdb_(.*)_failed_total|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|github_proxy_waiting_requests|redis_up)
```