### PR TITLE
cmd/server: remove -debug from zoekt-indexserver command

### DIFF
--- a/cmd/server/shared/zoekt.go
+++ b/cmd/server/shared/zoekt.go
@@ -21,13 +21,8 @@ func maybeZoektProcFile() []string {
 	frontendInternalHost := os.Getenv("SRC_FRONTEND_INTERNAL")
 	indexDir := filepath.Join(DataDir, "zoekt/index")
 
-	debugFlag := ""
-	if verbose {
-		debugFlag = "-debug"
-	}
-
 	return []string{
-		fmt.Sprintf("zoekt-indexserver: env GOGC=25 HOSTNAME=%s zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 -cpu_fraction 0.25 %s", defaultHost, frontendInternalHost, indexDir, debugFlag),
+		fmt.Sprintf("zoekt-indexserver: env GOGC=25 HOSTNAME=%s zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 -cpu_fraction 0.25", defaultHost, frontendInternalHost, indexDir),
 		fmt.Sprintf("zoekt-webserver: env GOGC=25 zoekt-webserver -rpc -pprof -listen %s -index %s", defaultHost, indexDir),
 	}
 }


### PR DESCRIPTION
Fixes integration tests, this flag was removed in https://github.com/sourcegraph/zoekt/pull/374

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a