### PR TITLE
search ui: smart search toggle polish

### DIFF
--- a/client/search-ui/src/input/toggles/SmartSearchToggle.module.scss
+++ b/client/search-ui/src/input/toggles/SmartSearchToggle.module.scss
@@ -1,7 +1,28 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
+.button {
+    width: 1.5rem;
+    height: 1.5rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    svg {
+        // Tweak icon size and position to match design and be optically centered
+        transform: scale(1.5);
+        margin-left: -0.125rem;
+    }
+}
+
 .popover-window {
     // Move the popover a bit so the close button aligns with the smart search icon
     margin-top: 0.5rem;
-    margin-left: 0.875rem;
+    margin-left: 0.75rem;
+
+    @media (--xs-breakpoint-down) {
+        margin-top: 0.25rem;
+        margin-left: 1rem;
+    }
 }
 
 .label {

--- a/client/search-ui/src/input/toggles/SmartSearchToggle.module.scss
+++ b/client/search-ui/src/input/toggles/SmartSearchToggle.module.scss
@@ -1,15 +1,13 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .button {
-    width: 1.5rem;
-    height: 1.5rem;
     display: flex;
     justify-content: center;
     align-items: center;
 
     svg {
         // Tweak icon size and position to match design and be optically centered
-        transform: scale(1.5);
+        transform: scale(1.2);
         margin-left: -0.125rem;
     }
 }
@@ -17,7 +15,7 @@
 .popover-window {
     // Move the popover a bit so the close button aligns with the smart search icon
     margin-top: 0.5rem;
-    margin-left: 0.75rem;
+    margin-left: 0.875rem;
 
     @media (--xs-breakpoint-down) {
         margin-top: 0.25rem;

--- a/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
+++ b/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
-import { mdiClose, mdiLightningBolt, mdiRadioboxBlank, mdiRadioboxMarked } from '@mdi/js'
+import { mdiClose, mdiRadioboxBlank, mdiRadioboxMarked } from '@mdi/js'
 import classNames from 'classnames'
 
 import {
     Button,
-    H3,
     Icon,
     Input,
     Label,
@@ -14,12 +13,17 @@ import {
     PopoverTrigger,
     Tooltip,
     Position,
+    H1,
+    H4,
 } from '@sourcegraph/wildcard'
 
 import { ToggleProps } from './QueryInputToggle'
 
 import smartStyles from './SmartSearchToggle.module.scss'
 import styles from './Toggles.module.scss'
+
+export const smartSearchIconSvgPath =
+    'M11.3956 20H10.2961L11.3956 13.7778H7.54754C6.58003 13.7778 7.18473 13.1111 7.20671 13.0844C8.62499 11.0578 10.7579 8.03556 13.6054 4H14.7049L13.6054 10.2222H17.4645C17.9042 10.2222 18.1461 10.3911 17.9042 10.8089C13.5615 16.9333 11.3956 20 11.3956 20Z'
 
 interface SmartSearchToggleProps extends Omit<ToggleProps, 'title' | 'iconSvgPath' | 'onToggle'> {
     onSelect: (enabled: boolean) => void
@@ -51,6 +55,7 @@ export const SmartSearchToggle: React.FunctionComponent<SmartSearchToggleProps> 
                 as={Button}
                 className={classNames(
                     styles.toggle,
+                    smartStyles.button,
                     className,
                     !!disabledRule && styles.disabled,
                     isActive && styles.toggleActive,
@@ -61,7 +66,7 @@ export const SmartSearchToggle: React.FunctionComponent<SmartSearchToggleProps> 
                 {...interactiveProps}
             >
                 <Tooltip content={tooltipValue} placement="bottom">
-                    <Icon aria-label={tooltipValue} svgPath={mdiLightningBolt} />
+                    <Icon aria-label={tooltipValue} svgPath={smartSearchIconSvgPath} />
                 </Tooltip>
             </PopoverTrigger>
 
@@ -88,9 +93,9 @@ const SmartSearchToggleMenu: React.FunctionComponent<
             className={smartStyles.popoverWindow}
         >
             <div className="d-flex align-items-center px-3 py-2">
-                <H3 id="smart-search-popover-header" className="m-0 flex-1">
+                <H4 as={H1} id="smart-search-popover-header" className="m-0 flex-1">
                     Smart Search
-                </H3>
+                </H4>
                 <Button onClick={() => closeMenu()} variant="icon" aria-label="Close">
                     <Icon aria-hidden={true} svgPath={mdiClose} />
                 </Button>


### PR DESCRIPTION
Closes #41543

- Now using the custom lightning bolt icon from Figma design
- Header in the toggle popover is now an H1 (for a11y) styled as H4 (to match design), where it was previously an H3
- Location of toggle popover on xs size is tweaked slightly

## Test plan

Verify manually and with visual tests

![image](https://user-images.githubusercontent.com/206864/191824102-746caf4f-9e1e-4313-b430-007d720dd559.png)
![image](https://user-images.githubusercontent.com/206864/191824152-996a145f-6b37-4479-afb1-f420c2e0c811.png)



## App preview:

- [Web](https://sg-web-jp-smartsearchpolish.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dxnlfttgvh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
