### PR TITLE
monitoring: always render full generated alert query in docs

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -32,6 +32,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.99, sum by(le) (rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))) >= 20)`
+
+</details>
+
 <br />
 
 ## frontend: 90th_percentile_search_request_duration
@@ -59,6 +66,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.9, sum by(le) (rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))) >= 15)`
+
+</details>
+
 <br />
 
 ## frontend: hard_timeout_search_responses
@@ -81,6 +95,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max(((sum(increase(src_graphql_search_response{request_name!="CodeIntelSearch",source="browser",status="timeout"}[5m])) + sum(increase(src_graphql_search_response{alert_type="timed_out",request_name!="CodeIntelSearch",source="browser",status="alert"}[5m]))) / sum(increase(src_graphql_search_response{request_name!="CodeIntelSearch",source="browser"}[5m])) * 100) >= 2)`
+
+</details>
 
 <br />
 
@@ -105,6 +126,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(status) (increase(src_graphql_search_response{request_name!="CodeIntelSearch",source="browser",status=~"error"}[5m])) / ignoring(status) group_left() sum(increase(src_graphql_search_response{request_name!="CodeIntelSearch",source="browser"}[5m])) * 100) >= 2)`
+
+</details>
+
 <br />
 
 ## frontend: partial_timeout_search_responses
@@ -127,6 +155,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(status) (increase(src_graphql_search_response{request_name!="CodeIntelSearch",source="browser",status="partial_timeout"}[5m])) / ignoring(status) group_left() sum(increase(src_graphql_search_response{request_name!="CodeIntelSearch",source="browser"}[5m])) * 100) >= 5)`
+
+</details>
 
 <br />
 
@@ -151,6 +186,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(alert_type) (increase(src_graphql_search_response{alert_type!~"timed_out|no_results__suggest_quotes",request_name!="CodeIntelSearch",source="browser",status="alert"}[5m])) / ignoring(alert_type) group_left() sum(increase(src_graphql_search_response{request_name!="CodeIntelSearch",source="browser"}[5m])) * 100) >= 5)`
+
+</details>
 
 <br />
 
@@ -178,6 +220,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route!="blob",route!="raw",route!~"graphql.*"}[10m])))) >= 2)`
+
+</details>
+
 <br />
 
 ## frontend: blob_load_latency
@@ -203,6 +252,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route="blob"}[10m])))) >= 5)`
+
+</details>
 
 <br />
 
@@ -232,6 +288,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.99, sum by(le) (rate(src_graphql_field_seconds_bucket{error="false",field="results",request_name="CodeIntelSearch",source="browser",type="Search"}[5m])))) >= 20)`
+
+</details>
+
 <br />
 
 ## frontend: 90th_percentile_search_codeintel_request_duration
@@ -260,6 +323,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.9, sum by(le) (rate(src_graphql_field_seconds_bucket{error="false",field="results",request_name="CodeIntelSearch",source="browser",type="Search"}[5m])))) >= 15)`
+
+</details>
+
 <br />
 
 ## frontend: hard_timeout_search_codeintel_responses
@@ -282,6 +352,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max(((sum(increase(src_graphql_search_response{request_name="CodeIntelSearch",source="browser",status="timeout"}[5m])) + sum(increase(src_graphql_search_response{alert_type="timed_out",request_name="CodeIntelSearch",source="browser",status="alert"}[5m]))) / sum(increase(src_graphql_search_response{request_name="CodeIntelSearch",source="browser"}[5m])) * 100) >= 2)`
+
+</details>
 
 <br />
 
@@ -306,6 +383,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(status) (increase(src_graphql_search_response{request_name="CodeIntelSearch",source="browser",status=~"error"}[5m])) / ignoring(status) group_left() sum(increase(src_graphql_search_response{request_name="CodeIntelSearch",source="browser"}[5m])) * 100) >= 2)`
+
+</details>
+
 <br />
 
 ## frontend: partial_timeout_search_codeintel_responses
@@ -328,6 +412,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(status) (increase(src_graphql_search_response{request_name="CodeIntelSearch",source="browser",status="partial_timeout"}[5m])) / ignoring(status) group_left() sum(increase(src_graphql_search_response{request_name="CodeIntelSearch",source="browser",status="partial_timeout"}[5m])) * 100) >= 5)`
+
+</details>
 
 <br />
 
@@ -352,6 +443,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(alert_type) (increase(src_graphql_search_response{alert_type!~"timed_out",request_name="CodeIntelSearch",source="browser",status="alert"}[5m])) / ignoring(alert_type) group_left() sum(increase(src_graphql_search_response{request_name="CodeIntelSearch",source="browser"}[5m])) * 100) >= 5)`
+
+</details>
 
 <br />
 
@@ -380,6 +478,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.99, sum by(le) (rate(src_graphql_field_seconds_bucket{error="false",field="results",source="other",type="Search"}[5m])))) >= 50)`
+
+</details>
+
 <br />
 
 ## frontend: 90th_percentile_search_api_request_duration
@@ -407,6 +512,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.9, sum by(le) (rate(src_graphql_field_seconds_bucket{error="false",field="results",source="other",type="Search"}[5m])))) >= 40)`
+
+</details>
+
 <br />
 
 ## frontend: hard_error_search_api_responses
@@ -430,6 +542,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(status) (increase(src_graphql_search_response{source="other",status=~"error"}[5m])) / ignoring(status) group_left() sum(increase(src_graphql_search_response{source="other"}[5m]))) >= 2)`
+
+</details>
+
 <br />
 
 ## frontend: partial_timeout_search_api_responses
@@ -452,6 +571,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(increase(src_graphql_search_response{source="other",status="partial_timeout"}[5m])) / sum(increase(src_graphql_search_response{source="other"}[5m]))) >= 5)`
+
+</details>
 
 <br />
 
@@ -477,6 +603,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(alert_type) (increase(src_graphql_search_response{alert_type!~"timed_out|no_results__suggest_quotes",source="other",status="alert"}[5m])) / ignoring(alert_type) group_left() sum(increase(src_graphql_search_response{source="other",status="alert"}[5m]))) >= 5)`
+
+</details>
+
 <br />
 
 ## frontend: internal_indexed_search_error_responses
@@ -500,6 +633,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(code) (increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left() sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100) >= 5)`
+
+</details>
 
 <br />
 
@@ -525,6 +665,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(code) (increase(searcher_service_request_total{code!~"2.."}[5m])) / ignoring(code) group_left() sum(increase(searcher_service_request_total[5m])) * 100) >= 5)`
+
+</details>
+
 <br />
 
 ## frontend: internalapi_error_responses
@@ -549,6 +696,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(category) (increase(src_frontend_internal_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left() sum(increase(src_frontend_internal_request_duration_seconds_count[5m])) * 100) >= 5)`
+
+</details>
+
 <br />
 
 ## frontend: 99th_percentile_gitserver_duration
@@ -572,6 +726,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.99, sum by(le, category) (rate(src_gitserver_request_duration_seconds_bucket{job=~"(sourcegraph-)?frontend"}[5m])))) >= 20)`
+
+</details>
+
 <br />
 
 ## frontend: gitserver_error_responses
@@ -594,6 +755,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(category) (increase(src_gitserver_request_duration_seconds_count{code!~"2..",job=~"(sourcegraph-)?frontend"}[5m])) / ignoring(code) group_left() sum by(category) (increase(src_gitserver_request_duration_seconds_count{job=~"(sourcegraph-)?frontend"}[5m])) * 100) >= 5)`
+
+</details>
 
 <br />
 
@@ -619,6 +787,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(owner) (observability_test_metric_warning)) >= 1)`
+
+</details>
+
 <br />
 
 ## frontend: observability_test_alert_critical
@@ -642,6 +817,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max by(owner) (observability_test_metric_critical)) >= 1)`
+
+</details>
 
 <br />
 
@@ -668,6 +850,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(increase(src_cloudkms_cryptographic_total[1m]))) >= 15000)`
+
+Generated query for critical alert: `max((sum(increase(src_cloudkms_cryptographic_total[1m]))) >= 30000)`
+
+</details>
 
 <br />
 
@@ -696,6 +887,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="frontend"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="frontend"}[5m]))) >= 0.05)`
+
+Generated query for critical alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="frontend"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="frontend"}[5m]))) >= 0.1)`
+
+</details>
+
 <br />
 
 ## frontend: container_cpu_usage
@@ -720,6 +920,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -746,6 +953,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## frontend: provisioning_container_cpu_usage_long_term
@@ -770,6 +984,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -796,6 +1017,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## frontend: provisioning_container_cpu_usage_short_term
@@ -820,6 +1048,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -846,6 +1081,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## frontend: container_oomkill_events_total
@@ -871,6 +1113,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^(frontend|sourcegraph-frontend).*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## frontend: go_goroutines
@@ -894,6 +1143,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_goroutines{job=~".*(frontend|sourcegraph-frontend)"})) >= 10000)`
+
+</details>
+
 <br />
 
 ## frontend: go_gc_duration_seconds
@@ -916,6 +1172,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_gc_duration_seconds{job=~".*(frontend|sourcegraph-frontend)"})) >= 2)`
+
+</details>
 
 <br />
 
@@ -941,6 +1204,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) * 100) <= 90)`
+
+</details>
 
 <br />
 
@@ -970,6 +1240,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*",status="success"}[2h])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*",status="success"}[2h]))) >= 5)`
+
+Generated query for critical alert: `max((sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*",status="success"}[2h])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*",status="success"}[2h]))) >= 8)`
+
+</details>
+
 <br />
 
 ## frontend: mean_sentinel_stream_latency_over_2h
@@ -997,6 +1276,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[2h])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[2h]))) >= 2)`
+
+Generated query for critical alert: `max((sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[2h])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[2h]))) >= 3)`
+
+</details>
 
 <br />
 
@@ -1026,6 +1314,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.9, sum by(le) (label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*",status="success"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))) >= 5)`
+
+Generated query for critical alert: `max((histogram_quantile(0.9, sum by(le) (label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*",status="success"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))) >= 10)`
+
+</details>
+
 <br />
 
 ## frontend: 90th_percentile_sentinel_stream_latency_over_2h
@@ -1054,6 +1351,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/departments/engineering/teams/search/product).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.9, sum by(le) (label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))) >= 4)`
+
+Generated query for critical alert: `max((histogram_quantile(0.9, sum by(le) (label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))) >= 6)`
+
+</details>
+
 <br />
 
 ## gitserver: disk_space_remaining
@@ -1079,6 +1385,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min(((src_gitserver_disk_space_available / src_gitserver_disk_space_total) * 100) <= 25)`
+
+Generated query for critical alert: `min(((src_gitserver_disk_space_available / src_gitserver_disk_space_total) * 100) <= 15)`
+
+</details>
 
 <br />
 
@@ -1108,6 +1423,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(instance, cmd) (src_gitserver_exec_running{instance=~"${shard:regex}"})) >= 50)`
+
+Generated query for critical alert: `max((sum by(instance, cmd) (src_gitserver_exec_running{instance=~"${shard:regex}"})) >= 100)`
+
+</details>
+
 <br />
 
 ## gitserver: repository_clone_queue_size
@@ -1132,6 +1456,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(src_gitserver_clone_queue)) >= 25)`
+
+</details>
 
 <br />
 
@@ -1158,6 +1489,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(src_gitserver_lsremote_queue)) >= 25)`
+
+</details>
 
 <br />
 
@@ -1189,6 +1527,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(category) (increase(src_frontend_internal_request_duration_seconds_count{code!~"2..",job="gitserver"}[5m])) / ignoring(category) group_left() sum(increase(src_frontend_internal_request_duration_seconds_count{job="gitserver"}[5m]))) >= 2)`
+
+</details>
+
 <br />
 
 ## gitserver: mean_blocked_seconds_per_conn_request
@@ -1216,6 +1561,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="gitserver"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="gitserver"}[5m]))) >= 0.05)`
+
+Generated query for critical alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="gitserver"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="gitserver"}[5m]))) >= 0.1)`
+
+</details>
+
 <br />
 
 ## gitserver: container_cpu_usage
@@ -1240,6 +1594,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -1266,6 +1627,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^gitserver.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## gitserver: provisioning_container_cpu_usage_long_term
@@ -1290,6 +1658,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -1316,6 +1691,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## gitserver: container_oomkill_events_total
@@ -1341,6 +1723,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^gitserver.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## gitserver: go_goroutines
@@ -1364,6 +1753,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_goroutines{job=~".*gitserver"})) >= 10000)`
+
+</details>
+
 <br />
 
 ## gitserver: go_gc_duration_seconds
@@ -1386,6 +1782,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_gc_duration_seconds{job=~".*gitserver"})) >= 2)`
+
+</details>
 
 <br />
 
@@ -1412,6 +1815,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*gitserver"}) / count by(app) (up{app=~".*gitserver"}) * 100) <= 90)`
+
+</details>
+
 <br />
 
 ## github-proxy: github_proxy_waiting_requests
@@ -1436,6 +1846,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(github_proxy_waiting_requests)) >= 100)`
+
+</details>
 
 <br />
 
@@ -1462,6 +1879,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^github-proxy.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## github-proxy: container_memory_usage
@@ -1486,6 +1910,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^github-proxy.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -1512,6 +1943,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^github-proxy.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## github-proxy: provisioning_container_memory_usage_long_term
@@ -1536,6 +1974,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^github-proxy.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -1562,6 +2007,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^github-proxy.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## github-proxy: provisioning_container_memory_usage_short_term
@@ -1586,6 +2038,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^github-proxy.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -1612,6 +2071,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^github-proxy.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## github-proxy: go_goroutines
@@ -1635,6 +2101,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_goroutines{job=~".*github-proxy"})) >= 10000)`
+
+</details>
+
 <br />
 
 ## github-proxy: go_gc_duration_seconds
@@ -1657,6 +2130,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_gc_duration_seconds{job=~".*github-proxy"})) >= 2)`
+
+</details>
 
 <br />
 
@@ -1683,6 +2163,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*github-proxy"}) / count by(app) (up{app=~".*github-proxy"}) * 100) <= 90)`
+
+</details>
+
 <br />
 
 ## postgres: connections
@@ -1705,6 +2192,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((sum by(job) (pg_stat_activity_count{datname!~"template.*|postgres|cloudsqladmin"}) or sum by(job) (pg_stat_activity_count{datname!~"template.*|cloudsqladmin",job="codeinsights-db"})) <= 5)`
+
+</details>
 
 <br />
 
@@ -1732,6 +2226,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(job) (pg_stat_activity_count) / (sum by(job) (pg_settings_max_connections) - sum by(job) (pg_settings_superuser_reserved_connections)) * 100) >= 80)`
+
+Generated query for critical alert: `max((sum by(job) (pg_stat_activity_count) / (sum by(job) (pg_settings_max_connections) - sum by(job) (pg_settings_superuser_reserved_connections)) * 100) >= 100)`
+
+</details>
+
 <br />
 
 ## postgres: transaction_durations
@@ -1754,6 +2257,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin",job!="codeintel-db"}) or sum by(job) (pg_stat_activity_max_tx_duration{datname!~"template.*|cloudsqladmin",job="codeinsights-db"})) >= 0.3)`
+
+</details>
 
 <br />
 
@@ -1788,6 +2298,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((pg_up) <= 0)`
+
+</details>
+
 <br />
 
 ## postgres: invalid_indexes
@@ -1811,6 +2328,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `sum((max by(relname) (pg_invalid_index_count)) >= 1)`
+
+</details>
 
 <br />
 
@@ -1836,6 +2360,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((pg_exporter_last_scrape_error) >= 1)`
+
+</details>
+
 <br />
 
 ## postgres: migration_in_progress
@@ -1859,6 +2390,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((pg_sg_migration_status) >= 1)`
+
+</details>
 
 <br />
 
@@ -1885,6 +2423,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## postgres: provisioning_container_memory_usage_long_term
@@ -1909,6 +2454,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -1935,6 +2487,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## postgres: provisioning_container_memory_usage_short_term
@@ -1959,6 +2518,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -1985,6 +2551,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^(pgsql|codeintel-db|codeinsights).*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## postgres: pods_available_percentage
@@ -2009,6 +2582,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*(pgsql|codeintel-db|codeinsights)"}) / count by(app) (up{app=~".*(pgsql|codeintel-db|codeinsights)"}) * 100) <= 90)`
+
+</details>
 
 <br />
 
@@ -2035,6 +2615,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max(src_codeintel_upload_queued_duration_seconds_total{job=~"^precise-code-intel-worker.*"})) >= 18000)`
+
+</details>
 
 <br />
 
@@ -2066,6 +2653,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(category) (increase(src_frontend_internal_request_duration_seconds_count{code!~"2..",job="precise-code-intel-worker"}[5m])) / ignoring(category) group_left() sum(increase(src_frontend_internal_request_duration_seconds_count{job="precise-code-intel-worker"}[5m]))) >= 2)`
+
+</details>
+
 <br />
 
 ## precise-code-intel-worker: mean_blocked_seconds_per_conn_request
@@ -2093,6 +2687,15 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="precise-code-intel-worker"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="precise-code-intel-worker"}[5m]))) >= 0.05)`
+
+Generated query for critical alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="precise-code-intel-worker"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="precise-code-intel-worker"}[5m]))) >= 0.1)`
+
+</details>
+
 <br />
 
 ## precise-code-intel-worker: container_cpu_usage
@@ -2117,6 +2720,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel-worker.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -2143,6 +2753,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-intel-worker.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## precise-code-intel-worker: provisioning_container_cpu_usage_long_term
@@ -2167,6 +2784,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -2193,6 +2817,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## precise-code-intel-worker: provisioning_container_cpu_usage_short_term
@@ -2217,6 +2848,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -2243,6 +2881,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## precise-code-intel-worker: container_oomkill_events_total
@@ -2268,6 +2913,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^precise-code-intel-worker.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## precise-code-intel-worker: go_goroutines
@@ -2291,6 +2943,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_goroutines{job=~".*precise-code-intel-worker"})) >= 10000)`
+
+</details>
+
 <br />
 
 ## precise-code-intel-worker: go_gc_duration_seconds
@@ -2313,6 +2972,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_gc_duration_seconds{job=~".*precise-code-intel-worker"})) >= 2)`
+
+</details>
 
 <br />
 
@@ -2339,6 +3005,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*precise-code-intel-worker"}) / count by(app) (up{app=~".*precise-code-intel-worker"}) * 100) <= 90)`
+
+</details>
+
 <br />
 
 ## redis: redis-store_up
@@ -2363,6 +3036,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((redis_up{app="redis-store"}) < 1)`
+
+</details>
+
 <br />
 
 ## redis: redis-cache_up
@@ -2386,6 +3066,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((redis_up{app="redis-cache"}) < 1)`
+
+</details>
 
 <br />
 
@@ -2412,6 +3099,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^redis-cache.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## redis: provisioning_container_memory_usage_long_term
@@ -2436,6 +3130,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-cache.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -2462,6 +3163,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^redis-cache.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## redis: provisioning_container_memory_usage_short_term
@@ -2487,6 +3195,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-cache.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## redis: container_oomkill_events_total
@@ -2511,6 +3226,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^redis-cache.*"})) >= 1)`
+
+</details>
 
 <br />
 
@@ -2537,6 +3259,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^redis-store.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## redis: provisioning_container_memory_usage_long_term
@@ -2561,6 +3290,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-store.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -2587,6 +3323,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^redis-store.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## redis: provisioning_container_memory_usage_short_term
@@ -2611,6 +3354,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-store.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -2637,6 +3387,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^redis-store.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## redis: pods_available_percentage
@@ -2662,6 +3419,13 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*redis-cache"}) / count by(app) (up{app=~".*redis-cache"}) * 100) <= 90)`
+
+</details>
+
 <br />
 
 ## redis: pods_available_percentage
@@ -2686,6 +3450,13 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*redis-store"}) / count by(app) (up{app=~".*redis-store"}) * 100) <= 90)`
+
+</details>
 
 <br />
 
@@ -2716,6 +3487,15 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `(min((sum(src_worker_jobs{job="worker",job_name="codeintel-upload-janitor"})) < 1)) or (absent(sum(src_worker_jobs{job="worker",job_name="codeintel-upload-janitor"})) == 1)`
+
+Generated query for critical alert: `(min((sum(src_worker_jobs{job="worker",job_name="codeintel-upload-janitor"})) < 1)) or (absent(sum(src_worker_jobs{job="worker",job_name="codeintel-upload-janitor"})) == 1)`
+
+</details>
+
 <br />
 
 ## worker: worker_job_codeintel-commitgraph-updater_count
@@ -2744,6 +3524,15 @@ count being required for the volume of uploads.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `(min((sum(src_worker_jobs{job="worker",job_name="codeintel-commitgraph-updater"})) < 1)) or (absent(sum(src_worker_jobs{job="worker",job_name="codeintel-commitgraph-updater"})) == 1)`
+
+Generated query for critical alert: `(min((sum(src_worker_jobs{job="worker",job_name="codeintel-commitgraph-updater"})) < 1)) or (absent(sum(src_worker_jobs{job="worker",job_name="codeintel-commitgraph-updater"})) == 1)`
+
+</details>
 
 <br />
 
@@ -2774,6 +3563,15 @@ count being required for the volume of uploads.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `(min((sum(src_worker_jobs{job="worker",job_name="codeintel-autoindexing-scheduler"})) < 1)) or (absent(sum(src_worker_jobs{job="worker",job_name="codeintel-autoindexing-scheduler"})) == 1)`
+
+Generated query for critical alert: `(min((sum(src_worker_jobs{job="worker",job_name="codeintel-autoindexing-scheduler"})) < 1)) or (absent(sum(src_worker_jobs{job="worker",job_name="codeintel-autoindexing-scheduler"})) == 1)`
+
+</details>
+
 <br />
 
 ## worker: codeintel_commit_graph_queued_max_age
@@ -2799,6 +3597,13 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max(src_codeintel_commit_graph_queued_duration_seconds_total{job=~"^worker.*"})) >= 3600)`
+
+</details>
+
 <br />
 
 ## worker: insights_queue_unutilized_size
@@ -2822,6 +3627,13 @@ an underprovisioned main postgres instance.
 ```
 
 <sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(src_query_runner_worker_total{job=~"^worker.*"}) > 0 and on(job) sum by(op) (increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*",op="Dequeue"}[5m])) < 1) > 0)`
+
+</details>
 
 <br />
 
@@ -2853,6 +3665,13 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(category) (increase(src_frontend_internal_request_duration_seconds_count{code!~"2..",job="worker"}[5m])) / ignoring(category) group_left() sum(increase(src_frontend_internal_request_duration_seconds_count{job="worker"}[5m]))) >= 2)`
+
+</details>
+
 <br />
 
 ## worker: mean_blocked_seconds_per_conn_request
@@ -2880,6 +3699,15 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="worker"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="worker"}[5m]))) >= 0.05)`
+
+Generated query for critical alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="worker"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="worker"}[5m]))) >= 0.1)`
+
+</details>
+
 <br />
 
 ## worker: container_cpu_usage
@@ -2904,6 +3732,13 @@ an underprovisioned main postgres instance.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -2930,6 +3765,13 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## worker: provisioning_container_cpu_usage_long_term
@@ -2954,6 +3796,13 @@ an underprovisioned main postgres instance.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -2980,6 +3829,13 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## worker: provisioning_container_cpu_usage_short_term
@@ -3004,6 +3860,13 @@ an underprovisioned main postgres instance.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -3030,6 +3893,13 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## worker: container_oomkill_events_total
@@ -3055,6 +3925,13 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^worker.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## worker: go_goroutines
@@ -3078,6 +3955,13 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_goroutines{job=~".*worker"})) >= 10000)`
+
+</details>
+
 <br />
 
 ## worker: go_gc_duration_seconds
@@ -3100,6 +3984,13 @@ an underprovisioned main postgres instance.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_gc_duration_seconds{job=~".*worker"})) >= 2)`
+
+</details>
 
 <br />
 
@@ -3125,6 +4016,13 @@ an underprovisioned main postgres instance.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*worker"}) / count by(app) (up{app=~".*worker"}) * 100) <= 90)`
+
+</details>
 
 <br />
 
@@ -3155,6 +4053,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max(src_repoupdater_max_sync_backoff)) >= 32400)`
+
+</details>
 
 <br />
 
@@ -3188,6 +4093,15 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user",reason!="internal_rate_limit",reason!="invalid_npm_path"}[5m]))) > 0.5)`
+
+Generated query for critical alert: `max((max by(family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user",reason!="internal_rate_limit",reason!="invalid_npm_path"}[5m]))) > 1)`
+
+</details>
+
 <br />
 
 ## repo-updater: syncer_sync_start
@@ -3211,6 +4125,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((max by(family) (rate(src_repoupdater_syncer_start_sync{family="Syncer.SyncExternalService"}[9h]))) <= 0)`
+
+</details>
 
 <br />
 
@@ -3236,6 +4157,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.95, max by(le, family, success) (rate(src_repoupdater_syncer_sync_duration_seconds_bucket[1m])))) >= 30)`
+
+</details>
+
 <br />
 
 ## repo-updater: source_duration
@@ -3259,6 +4187,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.95, max by(le) (rate(src_repoupdater_source_duration_seconds_bucket[1m])))) >= 30)`
+
+</details>
 
 <br />
 
@@ -3284,6 +4219,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(rate(src_repoupdater_syncer_synced_repos_total[1m]))) <= 0)`
+
+</details>
+
 <br />
 
 ## repo-updater: sourced_repos
@@ -3307,6 +4249,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((max(rate(src_repoupdater_source_repos_total[1m]))) <= 0)`
+
+</details>
 
 <br />
 
@@ -3332,6 +4281,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max(src_repoupdater_user_repos_total)) >= 720000)`
+
+</details>
+
 <br />
 
 ## repo-updater: purge_failed
@@ -3355,6 +4311,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(rate(src_repoupdater_purge_failed[1m]))) > 0)`
+
+</details>
 
 <br />
 
@@ -3380,6 +4343,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((max(rate(src_repoupdater_sched_auto_fetch[1m]))) <= 0)`
+
+</details>
+
 <br />
 
 ## repo-updater: sched_known_repos
@@ -3403,6 +4373,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((max(src_repoupdater_sched_known_repos)) <= 0)`
+
+</details>
 
 <br />
 
@@ -3428,6 +4405,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max(deriv(src_repoupdater_sched_update_queue_length[5m]))) > 0)`
+
+</details>
+
 <br />
 
 ## repo-updater: sched_loops
@@ -3451,6 +4435,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((max(rate(src_repoupdater_sched_loops[1m]))) <= 0)`
+
+</details>
 
 <br />
 
@@ -3477,6 +4468,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(src_repoupdater_stale_repos)) >= 1)`
+
+</details>
+
 <br />
 
 ## repo-updater: sched_error
@@ -3500,6 +4498,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max(rate(src_repoupdater_sched_error[1m]))) >= 1)`
+
+</details>
 
 <br />
 
@@ -3525,6 +4530,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(type) (src_repoupdater_perms_syncer_perms_gap_seconds)) >= 259200)`
+
+</details>
+
 <br />
 
 ## repo-updater: perms_syncer_stale_perms
@@ -3548,6 +4560,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(type) (src_repoupdater_perms_syncer_stale_perms)) >= 100)`
+
+</details>
 
 <br />
 
@@ -3574,6 +4593,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(type) (src_repoupdater_perms_syncer_no_perms)) >= 100)`
+
+</details>
+
 <br />
 
 ## repo-updater: perms_syncer_outdated_perms
@@ -3599,6 +4625,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(type) (src_repoupdater_perms_syncer_outdated_perms)) >= 100)`
+
+</details>
+
 <br />
 
 ## repo-updater: perms_syncer_sync_duration
@@ -3622,6 +4655,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((histogram_quantile(0.95, max by(le, type) (rate(src_repoupdater_perms_syncer_sync_duration_seconds_bucket[1m])))) >= 30)`
+
+</details>
 
 <br />
 
@@ -3648,6 +4688,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(src_repoupdater_perms_syncer_queue_size)) >= 100)`
+
+</details>
+
 <br />
 
 ## repo-updater: perms_syncer_sync_errors
@@ -3673,6 +4720,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max by(type) (ceil(rate(src_repoupdater_perms_syncer_sync_errors_total[1m])))) >= 1)`
+
+</details>
+
 <br />
 
 ## repo-updater: src_repoupdater_external_services_total
@@ -3697,6 +4751,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max(src_repoupdater_external_services_total)) >= 20000)`
+
+</details>
+
 <br />
 
 ## repo-updater: src_repoupdater_user_external_services_total
@@ -3720,6 +4781,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(src_repoupdater_user_external_services_total)) >= 20000)`
+
+</details>
 
 <br />
 
@@ -3746,6 +4814,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(src_repoupdater_queued_sync_jobs_total)) >= 100)`
+
+</details>
+
 <br />
 
 ## repo-updater: repoupdater_completed_sync_jobs_total
@@ -3769,6 +4844,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(src_repoupdater_completed_sync_jobs_total)) >= 100000)`
+
+</details>
 
 <br />
 
@@ -3794,6 +4876,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(src_repoupdater_errored_sync_jobs_percentage)) > 10)`
+
+</details>
+
 <br />
 
 ## repo-updater: github_graphql_rate_limit_remaining
@@ -3817,6 +4906,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((max by(name) (src_github_rate_limit_remaining_v2{resource="graphql"})) <= 250)`
+
+</details>
 
 <br />
 
@@ -3842,6 +4938,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((max by(name) (src_github_rate_limit_remaining_v2{resource="rest"})) <= 250)`
+
+</details>
+
 <br />
 
 ## repo-updater: github_search_rate_limit_remaining
@@ -3866,6 +4969,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((max by(name) (src_github_rate_limit_remaining_v2{resource="search"})) <= 5)`
+
+</details>
+
 <br />
 
 ## repo-updater: gitlab_rest_rate_limit_remaining
@@ -3889,6 +4999,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((max by(name) (src_gitlab_rate_limit_remaining{resource="rest"})) <= 30)`
+
+</details>
 
 <br />
 
@@ -3920,6 +5037,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(category) (increase(src_frontend_internal_request_duration_seconds_count{code!~"2..",job="repo-updater"}[5m])) / ignoring(category) group_left() sum(increase(src_frontend_internal_request_duration_seconds_count{job="repo-updater"}[5m]))) >= 2)`
+
+</details>
+
 <br />
 
 ## repo-updater: mean_blocked_seconds_per_conn_request
@@ -3947,6 +5071,15 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="repo-updater"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="repo-updater"}[5m]))) >= 0.05)`
+
+Generated query for critical alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="repo-updater"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="repo-updater"}[5m]))) >= 0.1)`
+
+</details>
+
 <br />
 
 ## repo-updater: container_cpu_usage
@@ -3971,6 +5104,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -3997,6 +5137,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"}) >= 90)`
+
+</details>
+
 <br />
 
 ## repo-updater: provisioning_container_cpu_usage_long_term
@@ -4021,6 +5168,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -4047,6 +5201,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## repo-updater: provisioning_container_cpu_usage_short_term
@@ -4071,6 +5232,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -4097,6 +5265,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## repo-updater: container_oomkill_events_total
@@ -4122,6 +5297,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^repo-updater.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## repo-updater: go_goroutines
@@ -4145,6 +5327,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_goroutines{job=~".*repo-updater"})) >= 10000)`
+
+</details>
+
 <br />
 
 ## repo-updater: go_gc_duration_seconds
@@ -4167,6 +5356,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_gc_duration_seconds{job=~".*repo-updater"})) >= 2)`
+
+</details>
 
 <br />
 
@@ -4193,6 +5389,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/engineering/teams/repo-management).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*repo-updater"}) / count by(app) (up{app=~".*repo-updater"}) * 100) <= 90)`
+
+</details>
+
 <br />
 
 ## searcher: unindexed_search_request_errors
@@ -4216,6 +5419,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(code) (increase(searcher_service_request_total{code!="200",code!="canceled"}[5m])) / ignoring(code) group_left() sum(increase(searcher_service_request_total[5m])) * 100) >= 5)`
+
+</details>
+
 <br />
 
 ## searcher: replica_traffic
@@ -4238,6 +5448,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(instance) (rate(searcher_service_request_total[10m]))) >= 5)`
+
+</details>
 
 <br />
 
@@ -4265,6 +5482,15 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="searcher"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="searcher"}[5m]))) >= 0.05)`
+
+Generated query for critical alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="searcher"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="searcher"}[5m]))) >= 0.1)`
+
+</details>
 
 <br />
 
@@ -4296,6 +5522,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(category) (increase(src_frontend_internal_request_duration_seconds_count{code!~"2..",job="searcher"}[5m])) / ignoring(category) group_left() sum(increase(src_frontend_internal_request_duration_seconds_count{job="searcher"}[5m]))) >= 2)`
+
+</details>
+
 <br />
 
 ## searcher: container_cpu_usage
@@ -4320,6 +5553,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -4346,6 +5586,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## searcher: provisioning_container_cpu_usage_long_term
@@ -4370,6 +5617,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -4396,6 +5650,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## searcher: provisioning_container_cpu_usage_short_term
@@ -4420,6 +5681,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -4446,6 +5714,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## searcher: container_oomkill_events_total
@@ -4471,6 +5746,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^searcher.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## searcher: go_goroutines
@@ -4494,6 +5776,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_goroutines{job=~".*searcher"})) >= 10000)`
+
+</details>
+
 <br />
 
 ## searcher: go_gc_duration_seconds
@@ -4516,6 +5805,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_gc_duration_seconds{job=~".*searcher"})) >= 2)`
+
+</details>
 
 <br />
 
@@ -4541,6 +5837,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*searcher"}) / count by(app) (up{app=~".*searcher"}) * 100) <= 90)`
+
+</details>
 
 <br />
 
@@ -4568,6 +5871,15 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="symbols"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="symbols"}[5m]))) >= 0.05)`
+
+Generated query for critical alert: `max((sum by(app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="symbols"}[5m])) / sum by(app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="symbols"}[5m]))) >= 0.1)`
+
+</details>
 
 <br />
 
@@ -4599,6 +5911,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(category) (increase(src_frontend_internal_request_duration_seconds_count{code!~"2..",job="symbols"}[5m])) / ignoring(category) group_left() sum(increase(src_frontend_internal_request_duration_seconds_count{job="symbols"}[5m]))) >= 2)`
+
+</details>
+
 <br />
 
 ## symbols: container_cpu_usage
@@ -4623,6 +5942,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -4649,6 +5975,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## symbols: provisioning_container_cpu_usage_long_term
@@ -4673,6 +6006,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -4699,6 +6039,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## symbols: provisioning_container_cpu_usage_short_term
@@ -4723,6 +6070,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -4749,6 +6103,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## symbols: container_oomkill_events_total
@@ -4774,6 +6135,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^symbols.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## symbols: go_goroutines
@@ -4797,6 +6165,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_goroutines{job=~".*symbols"})) >= 10000)`
+
+</details>
+
 <br />
 
 ## symbols: go_gc_duration_seconds
@@ -4819,6 +6194,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(instance) (go_gc_duration_seconds{job=~".*symbols"})) >= 2)`
+
+</details>
 
 <br />
 
@@ -4845,6 +6227,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*symbols"}) / count by(app) (up{app=~".*symbols"}) * 100) <= 90)`
+
+</details>
+
 <br />
 
 ## syntect-server: container_cpu_usage
@@ -4869,6 +6258,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -4895,6 +6291,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## syntect-server: provisioning_container_cpu_usage_long_term
@@ -4919,6 +6322,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -4945,6 +6355,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## syntect-server: provisioning_container_cpu_usage_short_term
@@ -4969,6 +6386,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -4995,6 +6419,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## syntect-server: container_oomkill_events_total
@@ -5019,6 +6450,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^syntect-server.*"})) >= 1)`
+
+</details>
 
 <br />
 
@@ -5045,6 +6483,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*syntect-server"}) / count by(app) (up{app=~".*syntect-server"}) * 100) <= 90)`
+
+</details>
+
 <br />
 
 ## zoekt: average_resolve_revision_duration
@@ -5067,6 +6512,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(rate(resolve_revision_seconds_sum[5m])) / sum(rate(resolve_revision_seconds_count[5m]))) >= 15)`
+
+</details>
 
 <br />
 
@@ -5096,6 +6548,15 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(increase(get_index_options_error_total[5m]))) >= 100)`
+
+Generated query for critical alert: `max((sum(increase(get_index_options_error_total[5m]))) >= 100)`
+
+</details>
+
 <br />
 
 ## zoekt: indexed_search_request_errors
@@ -5118,6 +6579,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(code) (increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left() sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100) >= 5)`
+
+</details>
 
 <br />
 
@@ -5144,6 +6612,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## zoekt: container_memory_usage
@@ -5168,6 +6643,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserver.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -5194,6 +6676,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## zoekt: container_memory_usage
@@ -5218,6 +6707,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -5244,6 +6740,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## zoekt: provisioning_container_memory_usage_long_term
@@ -5268,6 +6771,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserver.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -5294,6 +6804,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## zoekt: provisioning_container_memory_usage_short_term
@@ -5319,6 +6836,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserver.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## zoekt: container_oomkill_events_total
@@ -5343,6 +6867,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^zoekt-indexserver.*"})) >= 1)`
+
+</details>
 
 <br />
 
@@ -5369,6 +6900,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## zoekt: provisioning_container_memory_usage_long_term
@@ -5393,6 +6931,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -5419,6 +6964,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## zoekt: provisioning_container_memory_usage_short_term
@@ -5443,6 +6995,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -5469,6 +7028,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^zoekt-webserver.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## zoekt: pods_available_percentage
@@ -5493,6 +7059,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*indexed-search"}) / count by(app) (up{app=~".*indexed-search"}) * 100) <= 90)`
+
+</details>
 
 <br />
 
@@ -5520,6 +7093,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(rule_group) (avg_over_time(prometheus_rule_group_last_duration_seconds[10m]))) >= 30)`
+
+</details>
+
 <br />
 
 ## prometheus: prometheus_rule_eval_failures
@@ -5545,6 +7125,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(rule_group) (rate(prometheus_rule_evaluation_failures_total[5m]))) > 0)`
+
+</details>
 
 <br />
 
@@ -5572,6 +7159,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(integration) (rate(alertmanager_notification_latency_seconds_sum[1m]))) >= 1)`
+
+</details>
+
 <br />
 
 ## prometheus: alertmanager_notification_failures
@@ -5596,6 +7190,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(integration) (rate(alertmanager_notifications_failed_total[1m]))) > 0)`
+
+</details>
 
 <br />
 
@@ -5622,6 +7223,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((prometheus_config_last_reload_successful) < 1)`
+
+</details>
+
 <br />
 
 ## prometheus: alertmanager_config_status
@@ -5645,6 +7253,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `min((alertmanager_config_last_reload_successful) < 1)`
+
+</details>
 
 <br />
 
@@ -5670,6 +7285,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((increase(label_replace({__name__=~"prometheus_tsdb_(.*)_failed_total"}, "operation", "$1", "__name__", "(.+)s_failed_total")[5m:1m])) > 0)`
+
+</details>
+
 <br />
 
 ## prometheus: prometheus_target_sample_exceeded
@@ -5694,6 +7316,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((increase(prometheus_target_scrapes_exceeded_sample_limit_total[10m])) > 0)`
+
+</details>
+
 <br />
 
 ## prometheus: prometheus_target_sample_duplicate
@@ -5717,6 +7346,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[10m])) > 0)`
+
+</details>
 
 <br />
 
@@ -5743,6 +7379,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}) >= 99)`
+
+</details>
+
 <br />
 
 ## prometheus: container_memory_usage
@@ -5767,6 +7410,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}) >= 99)`
+
+</details>
 
 <br />
 
@@ -5793,6 +7443,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}[1d])) >= 80)`
+
+</details>
+
 <br />
 
 ## prometheus: provisioning_container_memory_usage_long_term
@@ -5817,6 +7474,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}[1d])) >= 80)`
+
+</details>
 
 <br />
 
@@ -5843,6 +7507,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}[5m])) >= 90)`
+
+</details>
+
 <br />
 
 ## prometheus: provisioning_container_memory_usage_short_term
@@ -5867,6 +7538,13 @@ with your code hosts connections or networking issues affecting communication wi
 ```
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}[5m])) >= 90)`
+
+</details>
 
 <br />
 
@@ -5893,6 +7571,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(name) (container_oom_events_total{name=~"^prometheus.*"})) >= 1)`
+
+</details>
+
 <br />
 
 ## prometheus: pods_available_percentage
@@ -5918,6 +7603,13 @@ with your code hosts connections or networking issues affecting communication wi
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `min((sum by(app) (up{app=~".*prometheus"}) / count by(app) (up{app=~".*prometheus"}) * 100) <= 90)`
+
+</details>
+
 <br />
 
 ## executor: executor_handlers
@@ -5927,17 +7619,6 @@ with your code hosts connections or networking issues affecting communication wi
 **Descriptions**
 
 - <span class="badge badge-critical">critical</span> executor: 0 active executor handlers and > 0 queue size for 5m0s
-
-<details>
-<summary>Technical details</summary>
-
-Custom alert query: `
-		(sum(src_executor_processor_handlers{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}) OR vector(0)) == 0
-			AND
-		(sum by (queue)(src_executor_total{job=~"^sourcegraph-executors.*"})) > 0
-	`
-
-</details>
 
 **Next steps**
 
@@ -5955,6 +7636,13 @@ Custom alert query: `
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Custom query for critical alert: `min(((sum(src_executor_processor_handlers{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}) or vector(0)) == 0 and (sum by(queue) (src_executor_total{job=~"^sourcegraph-executors.*"})) > 0) <= 0)`
+
+</details>
+
 <br />
 
 ## executor: executor_processor_error_rate
@@ -5964,13 +7652,6 @@ Custom alert query: `
 **Descriptions**
 
 - <span class="badge badge-critical">critical</span> executor: 100%+ executor operation error rate over 5m for 1h0m0s
-
-<details>
-<summary>Technical details</summary>
-
-Custom alert query: `last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) / (last_over_time(sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) + last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:])) * 100`
-
-</details>
 
 **Next steps**
 
@@ -5988,6 +7669,13 @@ problem is not know to be resolved until jobs start succeeding again.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Custom query for critical alert: `max((last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) / (last_over_time(sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) + last_over_time(sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:])) * 100) >= 100)`
+
+</details>
 
 <br />
 
@@ -6012,6 +7700,13 @@ problem is not know to be resolved until jobs start succeeding again.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(sg_instance) (go_goroutines{sg_job=~".*sourcegraph-executors"})) >= 10000)`
+
+</details>
+
 <br />
 
 ## executor: go_gc_duration_seconds
@@ -6034,6 +7729,13 @@ problem is not know to be resolved until jobs start succeeding again.
 ```
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by(sg_instance) (go_gc_duration_seconds{sg_job=~".*sourcegraph-executors"})) >= 2)`
+
+</details>
 
 <br />
 
@@ -6060,6 +7762,13 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for critical alert: `max((max(src_codeintel_commit_graph_queued_duration_seconds_total{job=~"^.*"})) >= 3600)`
+
+</details>
+
 <br />
 
 ## telemetry: telemetry_job_error_rate
@@ -6084,6 +7793,13 @@ an underprovisioned main postgres instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum by(op) (increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m])) / (sum by(op) (increase(src_telemetry_job_total{job=~"^worker.*"}[5m])) + sum by(op) (increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))) * 100) > 0)`
+
+</details>
+
 <br />
 
 ## telemetry: telemetry_job_utilized_throughput
@@ -6107,6 +7823,13 @@ an underprovisioned main postgres instance.
 ```
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((rate(src_telemetry_job_total{op="SendEvents"}[1h]) / on() group_right() src_telemetry_job_max_throughput * 100) > 90)`
+
+</details>
 
 <br />
 


### PR DESCRIPTION
This effectively allows us to track rendered alerts in Git as well, and check how they have changed when the generator is changed, and could be a useful reference in general to have on hand (e.g. when making changes like https://github.com/sourcegraph/sourcegraph/pull/41957, we can see a diff)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Review `alerts.md`, tests pass