### PR TITLE
code intel: Fix empty popovers

### DIFF
--- a/client/shared/src/codeintel/api.ts
+++ b/client/shared/src/codeintel/api.ts
@@ -40,7 +40,7 @@ export interface CodeIntelAPI {
         context: sourcegraph.ReferenceContext
     ): Observable<clientType.Location[]>
     getImplementations(parameters: TextDocumentPositionParameters): Observable<clientType.Location[]>
-    getHover(textParameters: TextDocumentPositionParameters): Observable<HoverMerged>
+    getHover(textParameters: TextDocumentPositionParameters): Observable<HoverMerged | null>
     getDocumentHighlights(textParameters: TextDocumentPositionParameters): Observable<sglegacy.DocumentHighlight[]>
 }
 
@@ -87,14 +87,14 @@ class DefaultCodeIntelAPI implements CodeIntelAPI {
             request.providers.implementations.provideLocations(request.document, request.position)
         )
     }
-    public getHover(textParameters: TextDocumentPositionParameters): Observable<HoverMerged> {
+    public getHover(textParameters: TextDocumentPositionParameters): Observable<HoverMerged | null> {
         const request = requestFor(textParameters)
         return (
             request.providers.hover
                 .provideHover(request.document, request.position)
                 // We intentionally don't use `defaultIfEmpty()` here because
                 // that makes the popover load with an empty docstring.
-                .pipe(map(result => fromHoverMerged([result]) || { contents: [] }))
+                .pipe(map(result => fromHoverMerged([result])))
         )
     }
     public getDocumentHighlights(


### PR DESCRIPTION
Fixes #41931

It looks like defaulting to `{contents: []}` is wrong here. Comparing the data received from the `getHovers` when legacy extensions are *enabled* I can see that the last value received is

```typescript
{isLoading: false, result: null}
```

whereas with the migrated extensions its

```typescript
{isLoading: false, result: {contents: []}}
```

If my investigation is correct then the equivalent code path in the legacy extensions does not fall back to a default value. From https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@3fc4cf0b5429353b06fba32a65e5b02f61fb8f9f/-/blob/client/shared/src/codeintel/api.ts?L97 :

```typescript
return proxySubscribable(
    callProviders(
        state.hoverProviders,
        providers => providersForDocument(document, providers, ({ selector }) => selector),
        ({ provider }) => provider.provideHover(document, position),
        results => fromHoverMerged(mergeProviderResults(results))
    )
)
```

With the change in this commit the empty popup does not appear. Having said that, since I'm not that familiar with this part of the code base, I definitely need someone to confirm that this is the right way to fix this.



## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-41931-empty-popovers.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uajjtsmnqm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
