### PR TITLE
insights: Add correct number of args for scan to fix pings

### DIFF
--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -426,6 +426,7 @@ func GetGroupResultsExpandedViewPing(ctx context.Context, db database.DB, pingNa
 			&groupResultsExpandedViewPing.Count,
 			&groupResultsExpandedViewPing.AggregationMode,
 			&noop,
+			&noop,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

When we added in the `BarIndex` argument to our GroupResults pings, this started throwing a scan error. 

## Test plan

Verify locally in site-admin that our pings object is no longer null.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
