### PR TITLE
search: use basic verbosity for parseSearchQuery

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -68,8 +68,8 @@ func outputParseTree(searchType query.SearchType, args *args) (*JSONValue, error
 		return nil, err
 	}
 
-	if args.OutputFormat != Json || args.OutputVerbosity != Minimal {
-		return nil, errors.New("unsupported output options for PARSE_TREE, only JSON output with MINIMAL verbosity is supported")
+	if args.OutputFormat != Json || args.OutputVerbosity != Basic {
+		return nil, errors.New("unsupported output options for PARSE_TREE, only JSON output with BASIC verbosity is supported")
 	}
 	jsonString, err := query.ToJSON(plan.ToQ())
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1428,7 +1428,7 @@ type Query {
         """
         The level of output format verbosity.
         """
-        outputVerbosity: SearchQueryOutputVerbosity = MINIMAL
+        outputVerbosity: SearchQueryOutputVerbosity = BASIC
     ): JSONValue
     """
     The current site.


### PR DESCRIPTION
Basic verbosity is a better default for `JOB_TREE` output and the parse tree, now that the mermaid printer works :3

## Test plan
Manual for utility/debugging functionality.