### PR TITLE
search: simplify GQL return type for parseSearchQuery

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1429,7 +1429,7 @@ type Query {
         The level of output format verbosity.
         """
         outputVerbosity: SearchQueryOutputVerbosity = BASIC
-    ): JSONValue
+    ): String!
     """
     The current site.
     """


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/41964

Changes resolver return type `JSONValue` -> `string`.

It turns out the GQL response is exactly the same despite this change. I think the Go library does some magic underneath the hood, so this isn't a breaking change or anything.

## Test plan
Existing GQL schema tests pass
