### PR TITLE
Release: update config for October release

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -11,16 +11,16 @@
 {
     // Captain information
     // To get your slack username, navigate to Profile -> More -> Account settings -> Username (at the bottom) -> Expand
-    "captainSlackUsername": "camden",
-    "captainGitHubUsername": "camdencheek",
+    "captainSlackUsername": "keegan",
+    "captainGitHubUsername": "keegancsmith",
     // Release versions
-    "previousRelease": "3.43.2",
-    "upcomingRelease": "4.0.0",
-    "oneWorkingWeekBeforeRelease": "16 September 2022 10:00 PST",
-    "threeWorkingDaysBeforeRelease": "19 September 2022 10:00 PST",
-    "releaseDate": "22 September 2022 10:00 PST",
-    "oneWorkingDayAfterRelease": "23 September 2022 10:00 PST",
-    "oneWorkingWeekAfterRelease": "29 September 2022 10:00 PST",
+    "previousRelease": "4.0.0",
+    "upcomingRelease": "4.1.0",
+    "oneWorkingWeekBeforeRelease": "14 October 2022 10:00 PST",
+    "threeWorkingDaysBeforeRelease": "18 October 2022 10:00 PST",
+    "releaseDate": "21 October 2022 10:00 PST",
+    "oneWorkingDayAfterRelease": "24 October 2022 10:00 PST",
+    "oneWorkingWeekAfterRelease": "28 October 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "eng-announce",
     // Email for preparing calendar events


### PR DESCRIPTION
As in title. I'm very optimistic we will have no patch releases until then and this will stay valid.

## Test plan
N/A
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-update-release-config.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-oqtqumodyp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
