### PR TITLE
Don't announce 4.0.0 release in update check yet

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -34,17 +34,17 @@ var (
 	// non-cluster, non-docker-compose, and non-pure-docker installations what the latest
 	// version is. The version here _must_ be available at https://hub.docker.com/r/sourcegraph/server/tags/
 	// before landing in master.
-	latestReleaseDockerServerImageBuild = newBuild("4.0.0")
+	latestReleaseDockerServerImageBuild = newBuild("3.43.2")
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newBuild("4.0.0")
+	latestReleaseKubernetesBuild = newBuild("3.43.2")
 
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
 	// available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
-	latestReleaseDockerComposeOrPureDocker = newBuild("4.0.0")
+	latestReleaseDockerComposeOrPureDocker = newBuild("3.43.2")
 )
 
 func getLatestRelease(deployType string) build {


### PR DESCRIPTION
We have to revert this on the 27th, but as per [slack discussion](https://sourcegraph.slack.com/archives/C07KZF47K/p1663920213804409), we want to avoid confusion this can cause when site admins see the 4.0.0 update banner but no evidence of it existing yet.



## Test plan

Traced down that the only use of this is to serve the latest version in the update check handler. This should not have side-effects. 