### PR TITLE
Add support for SCIP's testing DSL: reprolang

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
+++ b/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
@@ -27,6 +27,13 @@ const apexSpec: LanguageSpec = {
     commentStyles: [javaStyleComment],
 }
 
+const reprolangSpec: LanguageSpec = {
+    languageID: 'reprolang',
+    stylized: 'Reprolang',
+    fileExts: ['repro'],
+    commentStyles: pythonSpec.commentStyles,
+}
+
 const starlarkSpec: LanguageSpec = {
     languageID: 'starlark',
     stylized: 'Starlark',
@@ -385,6 +392,7 @@ export const languageSpecs: LanguageSpec[] = [
     pythonSpec,
     tclSpec,
     rSpec,
+    reprolangSpec,
     rubySpec,
     rustSpec,
     scalaSpec,


### PR DESCRIPTION
Without this commit, we can't manually test LSIF uploads for `*.repro` files.


## Test plan

Manually verified that it works locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-reprolang.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jykwokklyj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
