### PR TITLE
Remove extensions status bar on code mirror

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -477,7 +477,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                         isLightTheme={isLightTheme}
                         telemetryService={props.telemetryService}
                         location={props.location}
-                        disableStatusBar={false}
+                        disableStatusBar={!window.context.enableLegacyExtensions}
                         disableDecorations={false}
                         role="region"
                         ariaLabel="File blob"


### PR DESCRIPTION
Closes #41959

This was an oversight of mine when I re-added the extensions controller for the migrated code intel stuff.

Since we can't remove the `sourcegrpah-extensions` plugin from code mirror, we have to manually turn off the status bar in case legacy extensions are not enabled.

We are working on removing the migrated code intel APIs from needing the extensions interface but given the big surface of it, this was too risky for the short time we had to work on it.

## Test plan

Status bar be gone

![Screenshot 2022-09-23 at 10 44 35](https://user-images.githubusercontent.com/458591/191924232-cd211319-e7fb-40cb-ad48-ce365b50e617.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-cm-hide-status-bar-when.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-omhzsgdqng.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

