### PR TITLE
Have perforce permissions enforced using the new  column

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -731,10 +731,12 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 
 			SubRepoPermissions: map[extsvc.RepoID]*authz.SubRepoPermissions{
 				"abc": {
+					Paths:        []string{"/include1", "/include2", "-/exclude1", "-/exclude2"},
 					PathIncludes: []string{"/include1", "/include2"},
 					PathExcludes: []string{"/exclude1", "/exclude2"},
 				},
 				"def": {
+					Paths:        []string{"/include1", "/include2", "-/exclude1", "-/exclude2"},
 					PathIncludes: []string{"/include1", "/include2"},
 					PathExcludes: []string{"/exclude1", "/exclude2"},
 				},

--- a/enterprise/internal/authz/perforce/cmd/scanprotects/main.go
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/sourcegraph/log"
 
@@ -55,11 +56,12 @@ func run(logger log.Logger, depot string, input io.Reader) {
 	}
 	for depot, subRepo := range perms.SubRepoPermissions {
 		logger.Debug("Sub repo permissions", log.String("depot", string(depot)))
-		for _, include := range subRepo.PathIncludes {
-			logger.Debug("Include rule", log.String("rule", include))
-		}
-		for _, exclude := range subRepo.PathExcludes {
-			logger.Debug("Include rule", log.String("rule", exclude))
+		for _, path := range subRepo.Paths {
+			if strings.HasPrefix(path, "-") {
+				logger.Debug("Exclude rule", log.String("rule", path))
+			} else {
+				logger.Debug("Include rule", log.String("rule", path))
+			}
 		}
 	}
 }

--- a/enterprise/internal/authz/perforce/perforce_test.go
+++ b/enterprise/internal/authz/perforce/perforce_test.go
@@ -290,12 +290,6 @@ read user alice * -//Sourcegraph/Security/...
 			Exacts: []extsvc.RepoID{"//Sourcegraph/"},
 			SubRepoPermissions: map[extsvc.RepoID]*authz.SubRepoPermissions{
 				"//Sourcegraph/": {
-					PathIncludes: []string{
-						mustGlobPattern(t, "/Engineering/..."),
-					},
-					PathExcludes: []string{
-						mustGlobPattern(t, "/Security/..."),
-					},
 					Paths: []string{
 						mustGlobPattern(t, "/Engineering/..."),
 						mustGlobPattern(t, "-/Security/..."),

--- a/enterprise/internal/authz/perforce/protects.go
+++ b/enterprise/internal/authz/perforce/protects.go
@@ -387,27 +387,8 @@ func fullRepoPermsScanner(logger log.Logger, perms *authz.ExternalUserPermission
 				for _, depot := range depots {
 					srp := getSubRepoPerms(depot)
 					newIncludes := convertRulesForWildcardDepotMatch(match, depot, patternsToGlob)
-					srp.PathIncludes = append(srp.PathIncludes, newIncludes...)
 					srp.Paths = append(srp.Paths, newIncludes...)
 					logger.Debug("Adding include rules", log.Strings("rules", newIncludes))
-
-					var i int
-					for _, exclude := range srp.PathExcludes {
-						// Perforce ACLs can have conflicting rules and the later one wins, so
-						// if we get a match here we drop the existing rule.
-						originalExclude, exists := patternsToGlob[exclude]
-						if !exists {
-							i++
-							continue
-						}
-						checkWithDepotAdded := !strings.HasPrefix(originalExclude.pattern, "//") && match.Match(string(depot)+originalExclude.pattern)
-						if originalExclude.Match(match.original) || checkWithDepotAdded {
-							logger.Debug("Removing conflicting exclude rule", log.String("rule", originalExclude.pattern))
-							srp.PathExcludes = append(srp.PathExcludes[:i], srp.PathExcludes[i+1:]...)
-						} else {
-							i++
-						}
-					}
 				}
 
 				return nil
@@ -418,36 +399,17 @@ func fullRepoPermsScanner(logger log.Logger, perms *authz.ExternalUserPermission
 
 				// Special case: exclude entire depot
 				if strings.TrimPrefix(match.original, string(depot)) == perforceWildcardMatchAll {
-					logger.Debug("Exclude entire depot, removing all include rules")
-					srp.PathIncludes = nil
+					logger.Debug("Exclude entire depot, removing all previous rules")
+					srp.Paths = nil
 				}
 
 				newExcludes := convertRulesForWildcardDepotMatch(match, depot, patternsToGlob)
-				srp.PathExcludes = append(srp.PathExcludes, newExcludes...)
 
 				// Adding leading "-" sign to indicate exclusion
 				for _, exclude := range newExcludes {
 					srp.Paths = append(srp.Paths, "-"+exclude)
 				}
 				logger.Debug("Adding exclude rules", log.Strings("rules", newExcludes))
-
-				var i int
-				for _, include := range srp.PathIncludes {
-					// Perforce ACLs can have conflicting rules and the later one wins, so
-					// if we get a match here we drop the existing rule.
-					originalInclude, exists := patternsToGlob[include]
-					if !exists {
-						i++
-						continue
-					}
-					checkWithDepotAdded := !strings.HasPrefix(originalInclude.pattern, "//") && match.Match(string(depot)+originalInclude.pattern)
-					if match.Match(originalInclude.original) || checkWithDepotAdded {
-						logger.Debug("Removing conflicting include rule", log.String("rule", originalInclude.pattern))
-						srp.PathIncludes = append(srp.PathIncludes[:i], srp.PathIncludes[i+1:]...)
-					} else {
-						i++
-					}
-				}
 			}
 
 			return nil
@@ -458,10 +420,20 @@ func fullRepoPermsScanner(logger log.Logger, perms *authz.ExternalUserPermission
 				srp, exists := perms.SubRepoPermissions[depot]
 				if !exists {
 					continue
-				} else if len(srp.PathIncludes) == 0 {
-					// Depots with no inclusions can just be dropped
-					delete(perms.SubRepoPermissions, depot)
-					continue
+				} else {
+					onlyExclusions := true
+					for _, path := range srp.Paths {
+						if !strings.HasPrefix(path, "-") {
+							onlyExclusions = false
+							break
+						}
+					}
+
+					if onlyExclusions {
+						// Depots with no inclusions can just be dropped
+						delete(perms.SubRepoPermissions, depot)
+						continue
+					}
 				}
 
 				// Rules should not include the depot name. We want them to be relative so that
@@ -469,12 +441,6 @@ func fullRepoPermsScanner(logger log.Logger, perms *authz.ExternalUserPermission
 				// repositoryPathPattern has been used. We also need to remove any `//` prefixes
 				// which are included in all Helix server rules.
 				depotString := string(depot)
-				for i := range srp.PathIncludes {
-					srp.PathIncludes[i] = trimDepotNameAndSlashes(srp.PathIncludes[i], depotString)
-				}
-				for i := range srp.PathExcludes {
-					srp.PathExcludes[i] = trimDepotNameAndSlashes(srp.PathExcludes[i], depotString)
-				}
 				for i := range srp.Paths {
 					path := srp.Paths[i]
 

--- a/internal/gitserver/integration_tests/tree_test.go
+++ b/internal/gitserver/integration_tests/tree_test.go
@@ -49,6 +49,7 @@ func TestReadDir_SubRepoFiltering(t *testing.T) {
 	srpGetter := database.NewMockSubRepoPermsStore()
 	testSubRepoPerms := map[api.RepoName]authz.SubRepoPermissions{
 		repo: {
+			Paths:        []string{"/**", "-/app/**"},
 			PathIncludes: []string{"**"},
 			PathExcludes: []string{"app/**"},
 		},

--- a/internal/search/symbol/symbol_test.go
+++ b/internal/search/symbol/symbol_test.go
@@ -31,7 +31,7 @@ func TestFilterZoektResults(t *testing.T) {
 	ctx = actor.WithActor(ctx, &actor.Actor{
 		UID: 1,
 	})
-	checker, err := authz.NewSimpleChecker(repoName, []string{"**"}, []string{"*_test.go"})
+	checker, err := authz.NewSimpleChecker(repoName, []string{"/**", "-/*_test.go"})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Solves #41788 

This PR makes all Perforce permissions application logic use the new `paths` column in the `sub_repo_permissions` table. We have to iterate through the entire permissions list, and preference is given to the last applicable rule (as opposed to exclusions taking preference in the past).

## Test plan

Added new test cases, updated test cases.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
