### PR TITLE
database: Don't allow empty code host config

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -145,8 +145,9 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 	svc := types.ExternalService{
 		Kind: extsvc.KindGitHub,
 		Config: extsvc.NewUnencryptedConfig(`{
-"URL": "https://github.com",
-"Token": "secret-token"
+"url": "https://github.com",
+"token": "secret-token",
+"repos": ["owner/name"]
 }`),
 	}
 
@@ -246,21 +247,44 @@ func TestServer_RepoLookup(t *testing.T) {
 	githubSource := types.ExternalService{
 		Kind:         extsvc.KindGitHub,
 		CloudDefault: true,
-		Config:       extsvc.NewEmptyConfig(),
+		Config: extsvc.NewUnencryptedConfig(`{
+"url": "https://github.com",
+"token": "secret-token",
+"repos": ["owner/name"]
+}`),
 	}
 	awsSource := types.ExternalService{
-		Kind:   extsvc.KindAWSCodeCommit,
-		Config: extsvc.NewEmptyConfig(),
+		Kind: extsvc.KindAWSCodeCommit,
+		Config: extsvc.NewUnencryptedConfig(`
+{
+  "region": "us-east-1",
+  "accessKeyID": "abc",
+  "secretAccessKey": "abc",
+  "gitCredentials": {
+    "username": "user",
+    "password": "pass"
+  }
+}
+`),
 	}
 	gitlabSource := types.ExternalService{
 		Kind:         extsvc.KindGitLab,
 		CloudDefault: true,
-		Config:       extsvc.NewEmptyConfig(),
+		Config: extsvc.NewUnencryptedConfig(`
+{
+  "url": "https://gitlab.com",
+  "token": "abc",
+  "projectQuery": ["none"]
+}
+`),
 	}
-
 	npmSource := types.ExternalService{
-		Kind:   extsvc.KindNpmPackages,
-		Config: extsvc.NewEmptyConfig(),
+		Kind: extsvc.KindNpmPackages,
+		Config: extsvc.NewUnencryptedConfig(`
+{
+  "registry": "npm.org"
+}
+`),
 	}
 
 	if err := store.ExternalServiceStore().Upsert(ctx, &githubSource, &awsSource, &gitlabSource, &npmSource); err != nil {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -94,6 +94,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		DisplayName: "GitHub",
 		Config: extsvc.NewUnencryptedConfig(bt.MarshalJSON(t, &schema.GitHubConnection{
 			Url:   "https://github.com",
+			Token: "abc",
 			Repos: []string{"sourcegraph/sourcegraph"},
 		})),
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
@@ -133,7 +133,7 @@ func newGitHubExternalService(t *testing.T, store database.ExternalServiceStore)
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "Github - Test",
 		// The authorization field is needed to enforce permissions
-		Config:    extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "authorization": {}}`),
+		Config:    extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "authorization": {}, "token": "abc", "repos": ["owner/name"]}`),
 		CreatedAt: now,
 		UpdatedAt: now,
 	}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
@@ -47,7 +47,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 		ctx := context.Background()
 
 		cfg := &schema.BitbucketCloudConnection{
-			WebhookSecret: "secret",
+			WebhookSecret: "secretsecret",
 		}
 		esURL := bitbucketCloudExternalServiceURL
 
@@ -125,7 +125,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, es.ID, cfg, esURL)
 				assert.Nil(t, err)
 
-				u = strings.ReplaceAll(u, "&secret=secret", "")
+				u = strings.ReplaceAll(u, "&secret=secretsecret", "")
 				req, err := http.NewRequest("POST", u, bytes.NewBufferString("{}"))
 				assert.Nil(t, err)
 
@@ -143,7 +143,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, es.ID, cfg, esURL)
 				assert.Nil(t, err)
 
-				u = strings.ReplaceAll(u, "&secret=secret", "&secret=not+correct")
+				u = strings.ReplaceAll(u, "&secret=secretsecret", "&secret=not+correct")
 				req, err := http.NewRequest("POST", u, bytes.NewBufferString("{}"))
 				assert.Nil(t, err)
 
@@ -422,7 +422,6 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 // tests. Any changes made to the stores will be rolled back after the test is
 // complete.
 func bitbucketCloudTestSetup(t *testing.T, sqlDB *sql.DB) *bstore.Store {
-
 	logger := logtest.Scoped(t)
 	clock := &bt.TestClock{Time: timeutil.Now()}
 	tx := dbtest.NewTx(t, sqlDB)
@@ -444,7 +443,7 @@ func createBitbucketCloudExternalService(t *testing.T, ctx context.Context, esSt
 			Url:           bitbucketCloudExternalServiceURL,
 			Username:      "user",
 			AppPassword:   "password",
-			WebhookSecret: "secret",
+			WebhookSecret: "secretsecret",
 		})),
 	}
 	if err := esStore.Upsert(ctx, es); err != nil {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keegancsmith/sqlf"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log/logtest"
@@ -83,38 +82,6 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 				h.ServeHTTP(rec, req)
 
 				assert.EqualValues(t, http.StatusBadRequest, rec.Result().StatusCode)
-			})
-
-			t.Run("malformed external service", func(t *testing.T) {
-				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store)
-				es := createBitbucketCloudExternalService(t, ctx, store.ExternalServices())
-
-				// It's harder than it used to be to get invalid JSON into the
-				// database configuration, so let's just manipulate the database
-				// directly, since it won't make it through the
-				// ExternalServiceStore.
-				if err := store.Exec(
-					ctx,
-					sqlf.Sprintf(
-						"UPDATE external_services SET config = %s WHERE id = %s",
-						"invalid JSON",
-						es.ID,
-					),
-				); err != nil {
-					t.Fatal(err)
-				}
-
-				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, es.ID, cfg, esURL)
-				assert.Nil(t, err)
-
-				req, err := http.NewRequest("POST", u, bytes.NewBufferString("{}"))
-				assert.Nil(t, err)
-
-				rec := httptest.NewRecorder()
-				h.ServeHTTP(rec, req)
-
-				assert.EqualValues(t, http.StatusUnauthorized, rec.Result().StatusCode)
 			})
 
 			t.Run("missing secret", func(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -67,12 +67,13 @@ func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 				Webhooks: &schema.Webhooks{
 					Secret: secret,
 				},
+				Token: "abc",
 			})),
 		}
 
 		err := esStore.Upsert(ctx, extSvc)
 		if err != nil {
-			t.Fatal(t)
+			t.Fatal(err)
 		}
 
 		bitbucketSource, err := repos.NewBitbucketServerSource(ctx, logtest.Scoped(t), extSvc, cf)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -67,12 +67,13 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 				Url:      "https://github.com",
 				Repos:    []string{"sourcegraph/sourcegraph"},
 				Webhooks: []*schema.GitHubWebhook{{Org: "sourcegraph", Secret: secret}},
+				Token:    "abc",
 			})),
 		}
 
 		err := esStore.Upsert(ctx, extSvc)
 		if err != nil {
-			t.Fatal(t)
+			t.Fatal(err)
 		}
 
 		githubSrc, err := repos.NewGithubSource(ctx, logtest.Scoped(t), db.ExternalServices(), extSvc, cf)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
@@ -25,10 +25,14 @@ import (
 
 type GitLabWebhook struct {
 	*Webhook
+
+	// failHandleEvent is here so that we can explicity force a failure in the event
+	// handler in tests
+	failHandleEvent error
 }
 
 func NewGitLabWebhook(store *store.Store) *GitLabWebhook {
-	return &GitLabWebhook{&Webhook{store, extsvc.TypeGitLab}}
+	return &GitLabWebhook{Webhook: &Webhook{store, extsvc.TypeGitLab}}
 }
 
 // ServeHTTP implements the http.Handler interface.
@@ -138,6 +142,13 @@ func (h *GitLabWebhook) getExternalServiceFromRawID(ctx context.Context, raw str
 // to perform whatever changeset action is appropriate for that event.
 func (h *GitLabWebhook) handleEvent(ctx context.Context, extSvc *types.ExternalService, event any) *httpError {
 	log15.Debug("GitLab webhook received", "type", fmt.Sprintf("%T", event))
+
+	if h.failHandleEvent != nil {
+		return &httpError{
+			code: http.StatusInternalServerError,
+			err:  h.failHandleEvent,
+		}
+	}
 
 	esID, err := extractExternalServiceID(ctx, extSvc)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/keegancsmith/sqlf"
-
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -87,50 +85,6 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 					t.Errorf("unexpected status code: have %d; want %d", have, want)
 				}
 				assertBodyIncludes(t, resp.Body, "getting external service")
-			})
-
-			t.Run("malformed external service", func(t *testing.T) {
-				// TODO: Check with batch changes team
-				t.Skip("Can we remove this now that we don't allow invalid config?")
-
-				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store)
-				es := createGitLabExternalService(t, ctx, store.ExternalServices())
-
-				// It's harder than it used to be to get invalid JSON into the
-				// database configuration, so let's just manipulate the database
-				// directly, since it won't make it through the
-				// ExternalServiceStore.
-				if err := store.Exec(
-					ctx,
-					sqlf.Sprintf(
-						"UPDATE external_services SET config = %s WHERE id = %s",
-						"invalid JSON",
-						es.ID,
-					),
-				); err != nil {
-					t.Fatal(err)
-				}
-
-				u, err := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, nil, "https://example.com/")
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				req, err := http.NewRequest("POST", u, nil)
-				if err != nil {
-					t.Fatal(err)
-				}
-				req.Header.Add(webhooks.TokenHeaderName, "not a valid secret")
-
-				rec := httptest.NewRecorder()
-				h.ServeHTTP(rec, req)
-
-				resp := rec.Result()
-				if have, want := resp.StatusCode, http.StatusInternalServerError; have != want {
-					t.Errorf("unexpected status code: have %d; want %d", have, want)
-				}
-				assertBodyIncludes(t, resp.Body, "validating the shared secret")
 			})
 
 			t.Run("missing secret", func(t *testing.T) {

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -61,7 +61,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 	svc := types.ExternalService{
 		Kind:      extsvc.KindGitHub,
 		CreatedAt: timeutil.Now(),
-		Config:    extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "authorization": {}}`),
+		Config:    extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "authorization": {}, "token": "abc", "repos": ["owner/name"]}`),
 	}
 	uri, err := url.Parse("https://github.com")
 	if err != nil {

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -180,6 +180,7 @@ func CreateBbsTestRepos(t *testing.T, ctx context.Context, db database.DB, count
 		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.BitbucketServerConnection{
 			Url:   "https://bitbucket.sourcegraph.com",
 			Token: "SECRETTOKEN",
+			Repos: []string{"owner/name"},
 		})),
 	}
 
@@ -288,7 +289,11 @@ func CreateAWSCodeCommitTestRepos(t *testing.T, ctx context.Context, db database
 		DisplayName: "AWS CodeCommit",
 		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.AWSCodeCommitConnection{
 			AccessKeyID: "horse-key",
-			Region:      "horse-town",
+			Region:      "us-east-1",
+			GitCredentials: schema.AWSCodeCommitGitCredentials{
+				Username: "horse",
+				Password: "graph",
+			},
 		})),
 	}
 	if err := esStore.Upsert(ctx, ext); err != nil {

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -140,8 +140,9 @@ func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db database.DB, co
 		Kind:        extsvc.KindGitLab,
 		DisplayName: "GitLab",
 		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitLabConnection{
-			Url:   "https://gitlab.com",
-			Token: "SECRETTOKEN",
+			Url:          "https://gitlab.com",
+			Token:        "SECRETTOKEN",
+			ProjectQuery: []string{"none"},
 		})),
 	}
 	if err := esStore.Upsert(ctx, ext); err != nil {

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -29,9 +29,23 @@ func TestRepo(t *testing.T, store database.ExternalServiceStore, serviceKind str
 	svc := types.ExternalService{
 		Kind:        serviceKind,
 		DisplayName: serviceKind + " - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "authorization": {}}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
+	}
+
+	switch serviceKind {
+	case extsvc.KindGitHub:
+		svc.Config = extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "authorization": {}, "token": "abc", "repos": ["owner/name"]}`)
+	case extsvc.KindGitLab:
+		svc.Config = extsvc.NewUnencryptedConfig(`{"url": "https://gitlab.com", "token": "abc", "projectQuery": ["repo"]}`)
+	case extsvc.KindBitbucketCloud:
+		svc.Config = extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "username": "user", "appPassword": "pass"}`)
+	case extsvc.KindBitbucketServer:
+		svc.Config = extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "username": "user", "token": "abc", "repos": ["owner/name"]}`)
+	case extsvc.KindAWSCodeCommit:
+		svc.Config = extsvc.NewUnencryptedConfig(`{"region": "us-east-1", "accessKeyID": "abc", "secretAccessKey": "abc", "gitCredentials": {"username": "user", "password": "pass"}}`)
+	default:
+		panic(fmt.Sprintf("unhandled kind: %q", serviceKind))
 	}
 
 	if err := store.Upsert(context.Background(), &svc); err != nil {
@@ -181,6 +195,7 @@ func CreateGitHubSSHTestRepos(t *testing.T, ctx context.Context, db database.DB,
 			Url:        "https://github.com",
 			Token:      "SECRETTOKEN",
 			GitURLType: "ssh",
+			Repos:      []string{"owner/name"},
 		})),
 	}
 	esStore := db.ExternalServices()
@@ -216,6 +231,7 @@ func CreateBbsSSHTestRepos(t *testing.T, ctx context.Context, db database.DB, co
 			Url:        "https://bitbucket.sgdev.org",
 			Token:      "SECRETTOKEN",
 			GitURLType: "ssh",
+			Repos:      []string{"owner/name"},
 		})),
 	}
 

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -560,6 +560,9 @@ func (e *externalServiceStore) Create(ctx context.Context, confGet func() *conf.
 	if err != nil {
 		return err
 	}
+	if strings.TrimSpace(rawConfig) == "" {
+		return fmt.Errorf("config is empty")
+	}
 
 	normalized, err := ValidateExternalServiceConfig(ctx, e, ValidateExternalServiceConfigOptions{
 		Kind:            es.Kind,
@@ -647,6 +650,9 @@ func (e *externalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 		rawConfig, err := s.Config.Decrypt(ctx)
 		if err != nil {
 			return err
+		}
+		if strings.TrimSpace(rawConfig) == "" {
+			return fmt.Errorf("config is empty: service %d", s.ID)
 		}
 
 		// 🚨 SECURITY: For all GitHub and GitLab code host connections on Sourcegraph
@@ -846,6 +852,9 @@ func (e *externalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 	)
 	if update.Config != nil {
 		rawConfig := *update.Config
+		if strings.TrimSpace(rawConfig) == "" {
+			return fmt.Errorf("config is empty: service %d", id)
+		}
 
 		// Query to get the kind (which is immutable) so we can validate the new config.
 		externalService, err := e.GetByID(ctx, id)

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -658,7 +658,7 @@ func (e *externalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 			NamespaceOrgID:  s.NamespaceOrgID,
 		})
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "validating service of kind %q", s.Kind)
 		}
 
 		// 🚨 SECURITY: For all GitHub and GitLab code host connections on Sourcegraph

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -303,6 +303,7 @@ func TestExternalServicesStore_Create(t *testing.T) {
 		externalService  *types.ExternalService
 		wantUnrestricted bool
 		wantHasWebhooks  bool
+		wantError        bool
 	}{
 		{
 			name: "with webhooks",
@@ -353,7 +354,6 @@ func TestExternalServicesStore_Create(t *testing.T) {
 			},
 			wantUnrestricted: false,
 		},
-
 		{
 			name: "Cloud: auto-add authorization to code host connections for GitHub",
 			externalService: &types.ExternalService{
@@ -398,10 +398,29 @@ func TestExternalServicesStore_Create(t *testing.T) {
 			wantUnrestricted: false,
 			wantHasWebhooks:  false,
 		},
+		{
+			name: "Empty config not allowed",
+			externalService: &types.ExternalService{
+				Kind:           extsvc.KindGitLab,
+				DisplayName:    "GITLAB #1",
+				Config:         extsvc.NewUnencryptedConfig(``),
+				NamespaceOrgID: org.ID,
+			},
+			wantUnrestricted: false,
+			wantHasWebhooks:  false,
+			wantError:        true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := db.ExternalServices().Create(ctx, confGet, test.externalService)
+			if test.wantError {
+				if err == nil {
+					t.Fatal("wanted an error")
+				}
+				// We can bail out early here
+				return
+			}
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -499,6 +518,7 @@ func TestExternalServicesStore_Update(t *testing.T) {
 		wantCloudDefault   bool
 		wantHasWebhooks    bool
 		wantTokenExpiresAt bool
+		wantError          bool
 	}{
 		{
 			name: "update with authorization",
@@ -564,10 +584,23 @@ func TestExternalServicesStore_Update(t *testing.T) {
 			wantCloudDefault:   true,
 			wantTokenExpiresAt: true,
 		},
+		{
+			name: "update with empty config",
+			update: &ExternalServiceUpdate{
+				Config: strptr(``),
+			},
+			wantError: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err = db.ExternalServices().Update(ctx, nil, es.ID, test.update)
+			if test.wantError {
+				if err == nil {
+					t.Fatal("Wanted an error")
+				}
+				return
+			}
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1859,6 +1892,33 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 
 		if diff := cmp.Diff(have, []*types.ExternalService(nil), cmpopts.EquateEmpty(), et.CompareEncryptable); diff != "" {
 			t.Errorf("List:\n%s", diff)
+		}
+	})
+
+	t.Run("config can't be empty", func(t *testing.T) {
+		tx, err := db.ExternalServices().WithEncryptionKey(et.TestKey{}).Transact(ctx)
+		if err != nil {
+			t.Fatalf("Transact error: %s", err)
+		}
+		defer func() {
+			err = tx.Done(err)
+			if err != nil {
+				t.Fatalf("Done error: %s", err)
+			}
+		}()
+
+		want := typestest.GenerateExternalServices(1, svcs...)
+		oldValue, err := want[0].Config.Decrypt(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			want[0].Config.Set(oldValue)
+		})
+		want[0].Config.Set("")
+
+		if err := tx.Upsert(ctx, want...); err == nil {
+			t.Fatalf("Wanted an error")
 		}
 	})
 

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1943,7 +1943,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 		})
 		want[0].Config.Set(`// {}`)
 
-		if err := tx.Upsert(ctx, want...); err != nil {
+		if err := tx.Upsert(ctx, want...); err == nil {
 			t.Fatalf("Wanted an error")
 		}
 	})

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -495,7 +495,7 @@ func createGitHubExternalService(t *testing.T, db DB, userID int32) *types.Exter
 	svc := &types.ExternalService{
 		Kind:            extsvc.KindGitHub,
 		DisplayName:     "Github - Test",
-		Config:          extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "authorization": {}}`),
+		Config:          extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "authorization": {}, "token": "deadbeef", "repos": ["test/test"]}`),
 		NamespaceUserID: userID,
 		CreatedAt:       now,
 		UpdatedAt:       now,

--- a/internal/database/webhook_logs_test.go
+++ b/internal/database/webhook_logs_test.go
@@ -162,7 +162,7 @@ func TestWebhookLogStore(t *testing.T) {
 		es := &types.ExternalService{
 			Kind:        extsvc.KindGitLab,
 			DisplayName: "GitLab",
-			Config:      extsvc.NewEmptyConfig(),
+			Config:      extsvc.NewEmptyGitLabConfig(),
 		}
 		assert.Nil(t, esStore.Upsert(ctx, es))
 
@@ -170,11 +170,15 @@ func TestWebhookLogStore(t *testing.T) {
 
 		okTime := time.Date(2021, 10, 29, 18, 46, 0, 0, time.UTC)
 		okLog := createWebhookLog(es.ID, http.StatusOK, okTime)
-		store.Create(ctx, okLog)
+		if err := store.Create(ctx, okLog); err != nil {
+			t.Fatal(err)
+		}
 
 		errTime := time.Date(2021, 10, 29, 18, 47, 0, 0, time.UTC)
 		errLog := createWebhookLog(0, http.StatusInternalServerError, errTime)
-		store.Create(ctx, errLog)
+		if err := store.Create(ctx, errLog); err != nil {
+			t.Fatal(err)
+		}
 
 		for name, tc := range map[string]struct {
 			opts WebhookLogListOpts
@@ -278,7 +282,7 @@ func TestWebhookLogStore(t *testing.T) {
 		es := &types.ExternalService{
 			Kind:        extsvc.KindGitLab,
 			DisplayName: "GitLab",
-			Config:      extsvc.NewEmptyConfig(),
+			Config:      extsvc.NewEmptyGitLabConfig(),
 		}
 		assert.Nil(t, esStore.Upsert(ctx, es))
 

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -83,6 +83,10 @@ func NewEmptyConfig() *EncryptableConfig {
 	return NewUnencryptedConfig("{}")
 }
 
+func NewEmptyGitLabConfig() *EncryptableConfig {
+	return NewUnencryptedConfig(`{"url": "https://gitlab.com", "token": "abdef", "projectQuery":["none"]}`)
+}
+
 func NewUnencryptedConfig(value string) *EncryptableConfig {
 	return encryption.NewUnencrypted(value)
 }

--- a/internal/repos/github_webhook_handler_test.go
+++ b/internal/repos/github_webhook_handler_test.go
@@ -48,9 +48,9 @@ func TestGitHubWebhookHandle(t *testing.T) {
 	}
 
 	conn := *&schema.GitHubConnection{
-		Url:      extsvc.KindGitHub,
+		Url:      "https://github.com",
 		Token:    "token",
-		Repos:    []string{},
+		Repos:    []string{"owner/name"},
 		Webhooks: []*schema.GitHubWebhook{{Org: "ghe.sgdev.org", Secret: "secret"}},
 	}
 

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -36,7 +36,7 @@ func TestStatusMessages(t *testing.T) {
 
 	extSvc := &types.ExternalService{
 		ID:          1,
-		Config:      extsvc.NewEmptyConfig(),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "token": "beef", "repos": ["owner/name"]}`),
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "github.com - site",
 	}

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -36,18 +36,22 @@ func testSyncRateLimiters(store repos.Store) func(*testing.T) {
 			for i := 0; i < toCreate; i++ {
 				svc := &types.ExternalService{
 					ID:          int64(i) + 1,
-					Kind:        "GitHub",
-					DisplayName: "GitHub",
+					Kind:        "GITLAB",
+					DisplayName: "GitLab",
 					CreatedAt:   now,
 					UpdatedAt:   now,
 					DeletedAt:   time.Time{},
 					Config:      extsvc.NewEmptyConfig(),
 				}
 				config := schema.GitLabConnection{
-					Url: fmt.Sprintf("http://example%d.com/", i),
+					Token: "abc",
+					Url:   fmt.Sprintf("http://example%d.com/", i),
 					RateLimit: &schema.GitLabRateLimit{
 						RequestsPerHour: 3600,
 						Enabled:         true,
+					},
+					ProjectQuery: []string{
+						"None",
 					},
 				}
 				data, err := json.Marshal(config)
@@ -522,7 +526,7 @@ func mkExternalServices(now time.Time) types.ExternalServices {
 	githubSvc := types.ExternalService{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "Github - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+		Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -530,7 +534,7 @@ func mkExternalServices(now time.Time) types.ExternalServices {
 	gitlabSvc := types.ExternalService{
 		Kind:        extsvc.KindGitLab,
 		DisplayName: "GitLab - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://gitlab.com"}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://gitlab.com", "token": "abc", "projectQuery": ["none"]}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -538,7 +542,7 @@ func mkExternalServices(now time.Time) types.ExternalServices {
 	bitbucketServerSvc := types.ExternalService{
 		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket Server - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com"}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "token": "abc", "username": "user", "repos": ["owner/name"]}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -546,7 +550,7 @@ func mkExternalServices(now time.Time) types.ExternalServices {
 	bitbucketCloudSvc := types.ExternalService{
 		Kind:        extsvc.KindBitbucketCloud,
 		DisplayName: "Bitbucket Cloud - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com"}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "username": "user", "appPassword": "password"}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -554,7 +558,7 @@ func mkExternalServices(now time.Time) types.ExternalServices {
 	awsSvc := types.ExternalService{
 		Kind:        extsvc.KindAWSCodeCommit,
 		DisplayName: "AWS Code - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://aws.com"}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"region": "us-east-1", "accessKeyID": "abc", "secretAccessKey": "abc", "gitCredentials": {"username": "user", "password": "pass"}}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -562,7 +566,7 @@ func mkExternalServices(now time.Time) types.ExternalServices {
 	otherSvc := types.ExternalService{
 		Kind:        extsvc.KindOther,
 		DisplayName: "Other - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://other.com"}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://other.com", "repos": ["repo"]}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -570,7 +574,7 @@ func mkExternalServices(now time.Time) types.ExternalServices {
 	gitoliteSvc := types.ExternalService{
 		Kind:        extsvc.KindGitolite,
 		DisplayName: "Gitolite - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://gitolite.com"}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"prefix": "pre", "host": "host.com"}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}

--- a/internal/repos/sync_worker_test.go
+++ b/internal/repos/sync_worker_test.go
@@ -23,7 +23,7 @@ func testSyncWorkerPlumbing(repoStore repos.Store) func(t *testing.T) {
 		testSvc := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "TestService",
-			Config:      extsvc.NewEmptyConfig(),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 		}
 
 		// Create external service

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -153,7 +153,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		svcdup := types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github2 - Test",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   clock.Now(),
 			UpdatedAt:   clock.Now(),
 		}
@@ -1226,14 +1226,14 @@ func testOrphanedRepo(store repos.Store) func(*testing.T) {
 		svc1 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test1",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
 		svc2 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test2",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
@@ -1336,7 +1336,7 @@ func testCloudDefaultExternalServicesDontSync(store repos.Store) func(*testing.T
 		svc1 := &types.ExternalService{
 			Kind:         extsvc.KindGitHub,
 			DisplayName:  "Github - Test1",
-			Config:       extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:       extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CloudDefault: true,
 			CreatedAt:    now,
 			UpdatedAt:    now,
@@ -1376,6 +1376,8 @@ func testCloudDefaultExternalServicesDontSync(store repos.Store) func(*testing.T
 	}
 }
 
+var basicGitHubConfig = `{"url": "https://github.com", "token": "beef", "repos": ["owner/name"]}`
+
 func testConflictingSyncers(store repos.Store) func(*testing.T) {
 	return func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1386,14 +1388,14 @@ func testConflictingSyncers(store repos.Store) func(*testing.T) {
 		svc1 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test1",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
 		svc2 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test2",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
@@ -1544,14 +1546,14 @@ func testSyncRepoMaintainsOtherSources(store repos.Store) func(*testing.T) {
 		svc1 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test1",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
 		svc2 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test2",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
@@ -1640,7 +1642,7 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 		userService := &types.ExternalService{
 			Kind:            extsvc.KindGitHub,
 			DisplayName:     "Github - User",
-			Config:          extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:          extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:       now,
 			UpdatedAt:       now,
 			NamespaceUserID: userID,
@@ -1649,7 +1651,7 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 		adminService := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Private",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
@@ -1842,14 +1844,14 @@ func testNameOnConflictOnRename(store repos.Store) func(*testing.T) {
 		svc1 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test1",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
 		svc2 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test2",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
@@ -1959,14 +1961,14 @@ func testDeleteExternalService(store repos.Store) func(*testing.T) {
 		svc1 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test1",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
 		svc2 := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - Test2",
-			Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+			Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
@@ -2074,7 +2076,7 @@ func testAbortSyncWhenThereIsRepoLimitError(store repos.Store) func(*testing.T) 
 			{
 				Kind:            extsvc.KindGitHub,
 				DisplayName:     "Github - Test1",
-				Config:          extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+				Config:          extsvc.NewUnencryptedConfig(basicGitHubConfig),
 				CreatedAt:       now,
 				UpdatedAt:       now,
 				NamespaceUserID: user.ID,
@@ -2082,7 +2084,7 @@ func testAbortSyncWhenThereIsRepoLimitError(store repos.Store) func(*testing.T) 
 			{
 				Kind:           extsvc.KindGitHub,
 				DisplayName:    "Github - Test2",
-				Config:         extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+				Config:         extsvc.NewUnencryptedConfig(basicGitHubConfig),
 				CreatedAt:      now,
 				UpdatedAt:      now,
 				NamespaceOrgID: org.ID,
@@ -2191,7 +2193,7 @@ func testUserAndOrgReposAreCountedCorrectly(store repos.Store) func(*testing.T) 
 			{
 				Kind:            extsvc.KindGitHub,
 				DisplayName:     "Github - Test1",
-				Config:          extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+				Config:          extsvc.NewUnencryptedConfig(basicGitHubConfig),
 				CreatedAt:       now,
 				UpdatedAt:       now,
 				NamespaceUserID: user.ID,
@@ -2199,7 +2201,7 @@ func testUserAndOrgReposAreCountedCorrectly(store repos.Store) func(*testing.T) 
 			{
 				Kind:           extsvc.KindGitHub,
 				DisplayName:    "Github - Test2",
-				Config:         extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+				Config:         extsvc.NewUnencryptedConfig(basicGitHubConfig),
 				CreatedAt:      now,
 				UpdatedAt:      now,
 				NamespaceOrgID: org.ID,
@@ -2477,14 +2479,14 @@ func testEnqueueWebhookBuildJob(s repos.Store) func(*testing.T) {
 
 		repo := &types.Repo{
 			ID:   1,
-			Name: api.RepoName("ghe.sgdev.org/milton/test"),
+			Name: api.RepoName("milton/test"),
 		}
 		if err := repoStore.Create(ctx, repo); err != nil {
 			t.Fatal(err)
 		}
 
 		ghConn := &schema.GitHubConnection{
-			Url:      extsvc.KindGitHub,
+			Url:      "https://github.com",
 			Token:    token,
 			Repos:    []string{string(repo.Name)},
 			Webhooks: []*schema.GitHubWebhook{{Org: "ghe.sgdev.org", Secret: "secret"}},

--- a/internal/repos/webhook_build_handler_test.go
+++ b/internal/repos/webhook_build_handler_test.go
@@ -26,6 +26,11 @@ func TestWebhookBuildHandle(t *testing.T) {
 	ctx := context.Background()
 
 	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		// We need this so that the config validation below passes even when we're
+		// running against VCR data
+		token = "faketoken"
+	}
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := NewStore(logger, db)
@@ -47,9 +52,9 @@ func TestWebhookBuildHandle(t *testing.T) {
 	}
 
 	ghConn := &schema.GitHubConnection{
-		Url:      extsvc.KindGitHub,
+		Url:      "https://github.com",
 		Token:    token,
-		Repos:    []string{string(repo.Name)},
+		Repos:    []string{"milton/test"},
 		Webhooks: []*schema.GitHubWebhook{{Org: "ghe.sgdev.org", Secret: "secret"}},
 	}
 

--- a/internal/types/typestest/typestest.go
+++ b/internal/types/typestest/typestest.go
@@ -222,7 +222,7 @@ func MakeNamespacedExternalServices(userID int32, orgID int32) types.ExternalSer
 	return services
 }
 
-// Generatetypes.ExternalServices takes a list of base external services and generates n ones with different names.
+// GenerateExternalServices takes a list of base external services and generates n ones with different names.
 func GenerateExternalServices(n int, base ...*types.ExternalService) types.ExternalServices {
 	if len(base) == 0 {
 		return nil

--- a/internal/types/typestest/typestest.go
+++ b/internal/types/typestest/typestest.go
@@ -105,7 +105,7 @@ func GenerateRepos(n int, base ...*types.Repo) types.Repos {
 	return rs
 }
 
-// Maketypes.ExternalServices creates one configured external service per kind and returns the list.
+// MakeExternalServices creates one configured external service per kind and returns the list.
 func MakeExternalServices() types.ExternalServices {
 	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()

--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -36,7 +36,7 @@ func TestGetBatchChangesUsageStatistics(t *testing.T) {
 	svc := types.ExternalService{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "Github - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com"}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "token": "beef", "repos": ["owner/repo"]}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}


### PR DESCRIPTION
We already have a db constraint to stop this in most cases, but when we
have encryption enabled then even an empty config is converted into an
encrypted value so we need to do the check in our application layer too.

While investigating this we already had code to validate our config but
it had not been included in the Upsert path. That is now fixed and tests
were updated where necessary.

Closes https://github.com/sourcegraph/sourcegraph/issues/41924

## Test plan

New unit tests added and older ones updated.
