### PR TITLE
Perforce: Remove all references to PathIncludes and PathExcludes

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -271,9 +271,7 @@ func (r *Resolver) SetSubRepositoryPermissionsForUsers(ctx context.Context, args
 		}
 
 		if err := db.SubRepoPerms().Upsert(ctx, userID, repoID, authz.SubRepoPermissions{
-			Paths:        paths,
-			PathIncludes: perm.PathIncludes,
-			PathExcludes: perm.PathExcludes,
+			Paths: paths,
 		}); err != nil {
 			return nil, errors.Wrap(err, "upserting sub-repo permissions")
 		}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -731,14 +731,10 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 
 			SubRepoPermissions: map[extsvc.RepoID]*authz.SubRepoPermissions{
 				"abc": {
-					Paths:        []string{"/include1", "/include2", "-/exclude1", "-/exclude2"},
-					PathIncludes: []string{"/include1", "/include2"},
-					PathExcludes: []string{"/exclude1", "/exclude2"},
+					Paths: []string{"/include1", "/include2", "-/exclude1", "-/exclude2"},
 				},
 				"def": {
-					Paths:        []string{"/include1", "/include2", "-/exclude1", "-/exclude2"},
-					PathIncludes: []string{"/include1", "/include2"},
-					PathExcludes: []string{"/exclude1", "/exclude2"},
+					Paths: []string{"/include1", "/include2", "-/exclude1", "-/exclude2"},
 				},
 			},
 		}, nil

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -46,11 +46,7 @@ import (
 //
 // Paths are relative to the root of the repo.
 type SubRepoPermissions struct {
-	// Deprecated: Use Paths instead.
-	PathIncludes []string
-	// Deprecated: Use Paths instead.
-	PathExcludes []string
-	Paths        []string
+	Paths []string
 }
 
 // ExternalUserPermissions is a collection of accessible repository/project IDs

--- a/internal/authz/sub_repo_perms_test.go
+++ b/internal/authz/sub_repo_perms_test.go
@@ -61,9 +61,7 @@ func TestSubRepoPermsPermissions(t *testing.T) {
 				getter.GetByUserFunc.SetDefaultHook(func(ctx context.Context, i int32) (map[api.RepoName]SubRepoPermissions, error) {
 					return map[api.RepoName]SubRepoPermissions{
 						"sample": {
-							Paths:        []string{},
-							PathIncludes: []string{},
-							PathExcludes: []string{},
+							Paths: []string{},
 						},
 					}, nil
 				})
@@ -83,9 +81,7 @@ func TestSubRepoPermsPermissions(t *testing.T) {
 				getter.GetByUserFunc.SetDefaultHook(func(ctx context.Context, i int32) (map[api.RepoName]SubRepoPermissions, error) {
 					return map[api.RepoName]SubRepoPermissions{
 						"sample": {
-							Paths:        []string{"-/dev/*"},
-							PathIncludes: []string{},
-							PathExcludes: []string{"/dev/*"},
+							Paths: []string{"-/dev/*"},
 						},
 					}, nil
 				})
@@ -105,8 +101,7 @@ func TestSubRepoPermsPermissions(t *testing.T) {
 				getter.GetByUserFunc.SetDefaultHook(func(ctx context.Context, i int32) (map[api.RepoName]SubRepoPermissions, error) {
 					return map[api.RepoName]SubRepoPermissions{
 						"sample": {
-							Paths:        []string{"/*"},
-							PathIncludes: []string{"/*"},
+							Paths: []string{"/*"},
 						},
 					}, nil
 				})
@@ -126,9 +121,7 @@ func TestSubRepoPermsPermissions(t *testing.T) {
 				getter.GetByUserFunc.SetDefaultHook(func(ctx context.Context, i int32) (map[api.RepoName]SubRepoPermissions, error) {
 					return map[api.RepoName]SubRepoPermissions{
 						"sample": {
-							Paths:        []string{"/**", "-/dev/*"},
-							PathIncludes: []string{"**"},
-							PathExcludes: []string{"/dev/*"},
+							Paths: []string{"/**", "-/dev/*"},
 						},
 					}, nil
 				})
@@ -148,9 +141,7 @@ func TestSubRepoPermsPermissions(t *testing.T) {
 				getter.GetByUserFunc.SetDefaultHook(func(ctx context.Context, i int32) (map[api.RepoName]SubRepoPermissions, error) {
 					return map[api.RepoName]SubRepoPermissions{
 						"sample": {
-							Paths:        []string{"-/dev/*", "/**"},
-							PathIncludes: []string{"**"},
-							PathExcludes: []string{"/dev/*"},
+							Paths: []string{"-/dev/*", "/**"},
 						},
 					}, nil
 				})
@@ -270,20 +261,6 @@ func BenchmarkFilterActorPaths(b *testing.B) {
 					"-/subdir/remove/",
 					"-/subdir/*/also-remove/**",
 					"-/**/.secrets.env",
-				},
-				PathIncludes: []string{
-					"base/**",
-					"*/stuff/**",
-					"frontend/**/stuff/*",
-					"config.yaml",
-					"subdir/**",
-					"**/README.md",
-					"dir.yaml",
-				},
-				PathExcludes: []string{
-					"subdir/remove/",
-					"subdir/*/also-remove/**",
-					"**/.secrets.env",
 				},
 			},
 		}, nil

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -71,19 +71,17 @@ func (s *subRepoPermsStore) Done(err error) error {
 // Upsert will upsert sub repo permissions data.
 func (s *subRepoPermsStore) Upsert(ctx context.Context, userID int32, repoID api.RepoID, perms authz.SubRepoPermissions) error {
 	q := sqlf.Sprintf(`
-INSERT INTO sub_repo_permissions (user_id, repo_id, path_includes, path_excludes, paths, version, updated_at)
-VALUES (%s, %s, %s, %s, %s, %s, now())
+INSERT INTO sub_repo_permissions (user_id, repo_id, paths, version, updated_at)
+VALUES (%s, %s, %s, %s, now())
 ON CONFLICT (user_id, repo_id, version)
 DO UPDATE
 SET
   user_id = EXCLUDED.user_ID,
   repo_id = EXCLUDED.repo_id,
-  path_includes = EXCLUDED.path_includes,
-  path_excludes = EXCLUDED.path_excludes,
   paths = EXCLUDED.paths,
   version = EXCLUDED.version,
   updated_at = now()
-`, userID, repoID, pq.Array(perms.PathIncludes), pq.Array(perms.PathExcludes), pq.Array(perms.Paths), SubRepoPermsVersion)
+`, userID, repoID, pq.Array(perms.Paths), SubRepoPermsVersion)
 	return errors.Wrap(s.Exec(ctx, q), "upserting sub repo permissions")
 }
 
@@ -92,8 +90,8 @@ SET
 // nothing is written.
 func (s *subRepoPermsStore) UpsertWithSpec(ctx context.Context, userID int32, spec api.ExternalRepoSpec, perms authz.SubRepoPermissions) error {
 	q := sqlf.Sprintf(`
-INSERT INTO sub_repo_permissions (user_id, repo_id, path_includes, path_excludes, paths, version, updated_at)
-SELECT %s, id, %s, %s, %s, %s, now()
+INSERT INTO sub_repo_permissions (user_id, repo_id, paths, version, updated_at)
+SELECT %s, id, %s, %s, now()
 FROM repo
 WHERE external_service_id = %s
   AND external_service_type = %s
@@ -103,12 +101,10 @@ DO UPDATE
 SET
   user_id = EXCLUDED.user_ID,
   repo_id = EXCLUDED.repo_id,
-  path_includes = EXCLUDED.path_includes,
-  path_excludes = EXCLUDED.path_excludes,
   paths = EXCLUDED.paths,
   version = EXCLUDED.version,
   updated_at = now()
-`, userID, pq.Array(perms.PathIncludes), pq.Array(perms.PathExcludes), pq.Array(perms.Paths), SubRepoPermsVersion, spec.ServiceID, spec.ServiceType, spec.ID)
+`, userID, pq.Array(perms.Paths), SubRepoPermsVersion, spec.ServiceID, spec.ServiceType, spec.ID)
 
 	return errors.Wrap(s.Exec(ctx, q), "upserting sub repo permissions with spec")
 }
@@ -116,7 +112,7 @@ SET
 // Get will fetch sub repo rules for the given repo and user combination.
 func (s *subRepoPermsStore) Get(ctx context.Context, userID int32, repoID api.RepoID) (*authz.SubRepoPermissions, error) {
 	q := sqlf.Sprintf(`
-SELECT path_includes, path_excludes, paths
+SELECT paths
 FROM sub_repo_permissions
 WHERE repo_id = %s
   AND user_id = %s
@@ -130,14 +126,10 @@ WHERE repo_id = %s
 
 	perms := new(authz.SubRepoPermissions)
 	for rows.Next() {
-		var includes []string
-		var excludes []string
 		var paths []string
-		if err := rows.Scan(pq.Array(&includes), pq.Array(&excludes), pq.Array(&paths)); err != nil {
+		if err := rows.Scan(pq.Array(&paths)); err != nil {
 			return nil, errors.Wrap(err, "scanning row")
 		}
-		perms.PathIncludes = append(perms.PathIncludes, includes...)
-		perms.PathExcludes = append(perms.PathExcludes, excludes...)
 		perms.Paths = append(perms.Paths, paths...)
 	}
 
@@ -151,7 +143,7 @@ WHERE repo_id = %s
 // GetByUser fetches all sub repo perms for a user keyed by repo.
 func (s *subRepoPermsStore) GetByUser(ctx context.Context, userID int32) (map[api.RepoName]authz.SubRepoPermissions, error) {
 	q := sqlf.Sprintf(`
-SELECT r.name, path_includes, path_excludes, paths
+SELECT r.name, paths
 FROM sub_repo_permissions
 JOIN repo r on r.id = repo_id
 WHERE user_id = %s
@@ -167,7 +159,7 @@ WHERE user_id = %s
 	for rows.Next() {
 		var perms authz.SubRepoPermissions
 		var repoName api.RepoName
-		if err := rows.Scan(&repoName, pq.Array(&perms.PathIncludes), pq.Array(&perms.PathExcludes), pq.Array(&perms.Paths)); err != nil {
+		if err := rows.Scan(&repoName, pq.Array(&perms.Paths)); err != nil {
 			return nil, errors.Wrap(err, "scanning row")
 		}
 		result[repoName] = perms
@@ -182,7 +174,7 @@ WHERE user_id = %s
 
 func (s *subRepoPermsStore) GetByUserAndService(ctx context.Context, userID int32, serviceType string, serviceID string) (map[api.ExternalRepoSpec]authz.SubRepoPermissions, error) {
 	q := sqlf.Sprintf(`
-SELECT r.external_id, path_includes, path_excludes, paths
+SELECT r.external_id, paths
 FROM sub_repo_permissions
 JOIN repo r on r.id = repo_id
 WHERE user_id = %s
@@ -203,7 +195,7 @@ WHERE user_id = %s
 			ServiceType: serviceType,
 			ServiceID:   serviceID,
 		}
-		if err := rows.Scan(&spec.ID, pq.Array(&perms.PathIncludes), pq.Array(&perms.PathExcludes), pq.Array(&perms.Paths)); err != nil {
+		if err := rows.Scan(&spec.ID, pq.Array(&perms.Paths)); err != nil {
 			return nil, errors.Wrap(err, "scanning row")
 		}
 		result[spec] = perms

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -30,9 +30,7 @@ func TestSubRepoPermsInsert(t *testing.T) {
 	userID := int32(1)
 	repoID := api.RepoID(1)
 	perms := authz.SubRepoPermissions{
-		PathIncludes: []string{"/src/foo/*"},
-		PathExcludes: []string{"/src/bar/*"},
-		Paths:        []string{"/src/foo/*", "-/src/bar/*"},
+		Paths: []string{"/src/foo/*", "-/src/bar/*"},
 	}
 	if err := s.Upsert(ctx, userID, repoID, perms); err != nil {
 		t.Fatal(err)
@@ -64,9 +62,7 @@ func TestSubRepoPermsUpsert(t *testing.T) {
 	userID := int32(1)
 	repoID := api.RepoID(1)
 	perms := authz.SubRepoPermissions{
-		PathIncludes: []string{"/src/foo/*"},
-		PathExcludes: []string{"/src/bar/*"},
-		Paths:        []string{"/src/foo/*", "-/src/bar/*"},
+		Paths: []string{"/src/foo/*", "-/src/bar/*"},
 	}
 	// Insert initial data
 	if err := s.Upsert(ctx, userID, repoID, perms); err != nil {
@@ -75,9 +71,7 @@ func TestSubRepoPermsUpsert(t *testing.T) {
 
 	// Upsert to change perms
 	perms = authz.SubRepoPermissions{
-		PathIncludes: []string{"/src/foo_upsert/*"},
-		PathExcludes: []string{"/src/bar_upsert/*"},
-		Paths:        []string{"/src/foo_upsert/*", "-/src/bar_upsert/*"},
+		Paths: []string{"/src/foo_upsert/*", "-/src/bar_upsert/*"},
 	}
 	if err := s.Upsert(ctx, userID, repoID, perms); err != nil {
 		t.Fatal(err)
@@ -109,9 +103,7 @@ func TestSubRepoPermsUpsertWithSpec(t *testing.T) {
 	userID := int32(1)
 	repoID := api.RepoID(1)
 	perms := authz.SubRepoPermissions{
-		PathIncludes: []string{"/src/foo/*"},
-		PathExcludes: []string{"/src/bar/*"},
-		Paths:        []string{"/src/foo/*", "-/src/bar/*"},
+		Paths: []string{"/src/foo/*", "-/src/bar/*"},
 	}
 	spec := api.ExternalRepoSpec{
 		ID:          "MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==",
@@ -125,9 +117,7 @@ func TestSubRepoPermsUpsertWithSpec(t *testing.T) {
 
 	// Upsert to change perms
 	perms = authz.SubRepoPermissions{
-		PathIncludes: []string{"/src/foo_upsert/*"},
-		PathExcludes: []string{"/src/bar_upsert/*"},
-		Paths:        []string{"/src/foo_upsert/*", "-/src/bar_upsert/*"},
+		Paths: []string{"/src/foo_upsert/*", "-/src/bar_upsert/*"},
 	}
 	if err := s.UpsertWithSpec(ctx, userID, spec, perms); err != nil {
 		t.Fatal(err)
@@ -158,9 +148,7 @@ func TestSubRepoPermsGetByUser(t *testing.T) {
 
 	userID := int32(1)
 	perms := authz.SubRepoPermissions{
-		PathIncludes: []string{"/src/foo/*"},
-		PathExcludes: []string{"/src/bar/*"},
-		Paths:        []string{"/src/foo/*", "-/src/bar/*"},
+		Paths: []string{"/src/foo/*", "-/src/bar/*"},
 	}
 	if err := s.Upsert(ctx, userID, api.RepoID(1), perms); err != nil {
 		t.Fatal(err)
@@ -168,9 +156,7 @@ func TestSubRepoPermsGetByUser(t *testing.T) {
 
 	userID = int32(1)
 	perms = authz.SubRepoPermissions{
-		PathIncludes: []string{"/src/foo2/*"},
-		PathExcludes: []string{"/src/bar2/*"},
-		Paths:        []string{"/src/foo2/*", "-/src/bar2/*"},
+		Paths: []string{"/src/foo2/*", "-/src/bar2/*"},
 	}
 	if err := s.Upsert(ctx, userID, api.RepoID(2), perms); err != nil {
 		t.Fatal(err)
@@ -183,14 +169,10 @@ func TestSubRepoPermsGetByUser(t *testing.T) {
 
 	want := map[api.RepoName]authz.SubRepoPermissions{
 		"github.com/foo/bar": {
-			PathIncludes: []string{"/src/foo/*"},
-			PathExcludes: []string{"/src/bar/*"},
-			Paths:        []string{"/src/foo/*", "-/src/bar/*"},
+			Paths: []string{"/src/foo/*", "-/src/bar/*"},
 		},
 		"github.com/foo/baz": {
-			PathIncludes: []string{"/src/foo2/*"},
-			PathExcludes: []string{"/src/bar2/*"},
-			Paths:        []string{"/src/foo2/*", "-/src/bar2/*"},
+			Paths: []string{"/src/foo2/*", "-/src/bar2/*"},
 		},
 	}
 
@@ -215,9 +197,7 @@ func TestSubRepoPermsGetByUserAndService(t *testing.T) {
 
 	userID := int32(1)
 	perms := authz.SubRepoPermissions{
-		PathIncludes: []string{"/src/foo/*"},
-		PathExcludes: []string{"/src/bar/*"},
-		Paths:        []string{"/src/foo/*", "-/src/bar/*"},
+		Paths: []string{"/src/foo/*", "-/src/bar/*"},
 	}
 	if err := s.Upsert(ctx, userID, api.RepoID(1), perms); err != nil {
 		t.Fatal(err)
@@ -225,9 +205,7 @@ func TestSubRepoPermsGetByUserAndService(t *testing.T) {
 
 	userID = int32(1)
 	perms = authz.SubRepoPermissions{
-		PathIncludes: []string{"/src/foo2/*"},
-		PathExcludes: []string{"/src/bar2/*"},
-		Paths:        []string{"/src/foo2/*", "-/src/bar2/*"},
+		Paths: []string{"/src/foo2/*", "-/src/bar2/*"},
 	}
 	if err := s.Upsert(ctx, userID, api.RepoID(2), perms); err != nil {
 		t.Fatal(err)
@@ -258,18 +236,14 @@ func TestSubRepoPermsGetByUserAndService(t *testing.T) {
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
 				}: {
-					PathIncludes: []string{"/src/foo/*"},
-					PathExcludes: []string{"/src/bar/*"},
-					Paths:        []string{"/src/foo/*", "-/src/bar/*"},
+					Paths: []string{"/src/foo/*", "-/src/bar/*"},
 				},
 				{
 					ID:          "MDEwOlJlcG9zaXRvcnk0MTI4ODcwOB==",
 					ServiceType: "github",
 					ServiceID:   "https://github.com/",
 				}: {
-					PathIncludes: []string{"/src/foo2/*"},
-					PathExcludes: []string{"/src/bar2/*"},
-					Paths:        []string{"/src/foo2/*", "-/src/bar2/*"},
+					Paths: []string{"/src/foo2/*", "-/src/bar2/*"},
 				},
 			},
 		},

--- a/internal/gitserver/integration_tests/tree_test.go
+++ b/internal/gitserver/integration_tests/tree_test.go
@@ -49,9 +49,7 @@ func TestReadDir_SubRepoFiltering(t *testing.T) {
 	srpGetter := database.NewMockSubRepoPermsStore()
 	testSubRepoPerms := map[api.RepoName]authz.SubRepoPermissions{
 		repo: {
-			Paths:        []string{"/**", "-/app/**"},
-			PathIncludes: []string{"**"},
-			PathExcludes: []string{"app/**"},
+			Paths: []string{"/**", "-/app/**"},
 		},
 	}
 	srpGetter.GetByUserFunc.SetDefaultReturn(testSubRepoPerms, nil)


### PR DESCRIPTION
Solves #41992 

Removes all references to PathIncludes and PathExcludes from the code. This prevents them from sneaking in unexpectedly and relying on old behaviours.

The DB columns remain untouched for now in case a rollback is required.

## Test plan

Test updates

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
