### PR TITLE
client: Use 'reprolang' as scheme instead of 'repro'.

### DIFF
--- a/client/shared/src/languages.ts
+++ b/client/shared/src/languages.ts
@@ -361,7 +361,7 @@ function getModeFromExtension(extension: string): string | undefined {
         case 'rsx':
             return 'r'
         case 'repro':
-            return 'repro'
+            return 'reprolang'
 
         // Ruby
         case 'rb':


### PR DESCRIPTION
This is to match up the scheme with previous PR #41978,
otherwise, we get an error when doing Find References.

## Test plan

Manually tested, see Find References screenshot in https://github.com/sourcegraph/scip/pull/88#issuecomment-1256062446 

## App preview:

- [Web](https://sg-web-vg-fix-reprolang-scheme.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-flnwnruvsf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
