### PR TITLE
search: guard against nil span when tracing

### DIFF
--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -98,7 +98,9 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 	if isLeaf && opts != nil && policy.ShouldTrace(ctx) {
 		// Replace any existing spanContext with a new one, given we've done additional tracing
 		spanContext := make(map[string]string)
-		if err := ot.GetTracer(ctx).Inject(opentracing.SpanFromContext(ctx).Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err == nil {
+		if span := opentracing.SpanFromContext(ctx); span == nil {
+			m.log.Warn("ctx does not have a trace span associated with it")
+		} else if err := ot.GetTracer(ctx).Inject(span.Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err == nil {
 			newOpts := *opts
 			newOpts.SpanContext = spanContext
 			opts = &newOpts


### PR DESCRIPTION
It seems like it is possible to have policy.ShouldTrace(ctx) true, but not have a span associated with the ctx. My guess this has something to do with transitionary state between opentracing and otel.

For now it is better to just log a warning than panic.

Test Plan: CI