### PR TITLE
CodeMirror Blob: Be more defensive against out-of-range values

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -305,8 +305,12 @@ const [pinnedRangeField, updatePinnedRangeField] = createUpdateableField<LineOrP
         }
         const from = uiPositionToOffset(state.doc, startPosition, startLine)
 
+        if (from === null) {
+            return []
+        }
+
         let endPosition: UIPositionSpec['position']
-        let to: number
+        let to: number | null = null
 
         if (position.endLine && position.endCharacter) {
             endPosition = {
@@ -323,6 +327,10 @@ const [pinnedRangeField, updatePinnedRangeField] = createUpdateableField<LineOrP
             }
             to = word.to
             endPosition = offsetToUIPosition(state.doc, word.to)
+        }
+
+        if (to === null || endPosition === null) {
+            return []
         }
 
         return [

--- a/client/web/src/repo/blob/codemirror/document-highlights.test.ts
+++ b/client/web/src/repo/blob/codemirror/document-highlights.test.ts
@@ -1,6 +1,8 @@
-import { Decoration } from '@codemirror/view'
 import { RangeSet, Text } from '@codemirror/state'
+import { Decoration } from '@codemirror/view'
+
 import { DocumentHighlight } from '@sourcegraph/codeintellify'
+
 import { documentHighlightsToRangeSet } from './document-highlights'
 
 describe('document-highlights', () => {

--- a/client/web/src/repo/blob/codemirror/document-highlights.test.ts
+++ b/client/web/src/repo/blob/codemirror/document-highlights.test.ts
@@ -1,0 +1,61 @@
+import { Decoration } from '@codemirror/view'
+import { RangeSet, Text } from '@codemirror/state'
+import { DocumentHighlight } from '@sourcegraph/codeintellify'
+import { documentHighlightsToRangeSet } from './document-highlights'
+
+describe('document-highlights', () => {
+    describe('documentHighlightsToRangeSet', () => {
+        const textDocument = Text.of([
+            // Don't forget to account for line breaks between lines!
+            '012345',
+            '789',
+        ])
+        const decoration = Decoration.mark({})
+
+        it('converts document highlights to a range set', () => {
+            const highlights: DocumentHighlight[] = [
+                { range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } } },
+                { range: { start: { line: 1, character: 1 }, end: { line: 1, character: 2 } } },
+            ]
+            const rangeSet = documentHighlightsToRangeSet(textDocument, highlights, decoration)
+
+            expect(rangeSet).toEqual(
+                RangeSet.of([
+                    { from: 0, to: 5, value: decoration },
+                    { from: 8, to: 9, value: decoration },
+                ])
+            )
+        })
+
+        it('ignores highlights outside the document', () => {
+            const highlights: DocumentHighlight[] = [
+                { range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } } },
+                { range: { start: { line: 1, character: 1 }, end: { line: 1, character: 2 } } },
+                { range: { start: { line: 10, character: 1 }, end: { line: 10, character: 2 } } },
+            ]
+            const rangeSet = documentHighlightsToRangeSet(textDocument, highlights, decoration)
+
+            expect(rangeSet).toEqual(
+                RangeSet.of([
+                    { from: 0, to: 5, value: decoration },
+                    { from: 8, to: 9, value: decoration },
+                ])
+            )
+        })
+
+        it('sorts highlights by start position', () => {
+            const highlights: DocumentHighlight[] = [
+                { range: { start: { line: 1, character: 1 }, end: { line: 1, character: 2 } } },
+                { range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } } },
+            ]
+            const rangeSet = documentHighlightsToRangeSet(textDocument, highlights, decoration)
+
+            expect(rangeSet).toEqual(
+                RangeSet.of([
+                    { from: 0, to: 5, value: decoration },
+                    { from: 8, to: 9, value: decoration },
+                ])
+            )
+        })
+    })
+})

--- a/client/web/src/repo/blob/codemirror/document-highlights.ts
+++ b/client/web/src/repo/blob/codemirror/document-highlights.ts
@@ -7,7 +7,16 @@
  * and converted to CodeMirror decorations via the {@link showDocumentHighlights}
  * facet.
  */
-import { Extension, Facet, RangeSetBuilder, StateEffectType, StateField } from '@codemirror/state'
+import {
+    Extension,
+    Facet,
+    RangeSet,
+    RangeSetBuilder,
+    RangeValue,
+    StateEffectType,
+    StateField,
+    Text,
+} from '@codemirror/state'
 import { Decoration, DecorationSet, EditorView, ViewPlugin } from '@codemirror/view'
 import { from, fromEvent, Observable, Subscription } from 'rxjs'
 import { switchMap, filter, mergeAll, map, tap } from 'rxjs/operators'
@@ -41,29 +50,40 @@ export const showDocumentHighlights = Facet.define<DocumentHighlight[], Document
                     return decorations
                 }
 
-                if (documentHighlights) {
-                    const builder = new RangeSetBuilder<Decoration>()
-
-                    // Most of the time number of highlights is small and close
-                    // together so it's likely ok to iterate over all them and
-                    // not just the ones in the current viewport.
-                    for (const highlight of documentHighlights) {
-                        builder.add(
-                            positionToOffset(view.state.doc, highlight.range.start),
-                            positionToOffset(view.state.doc, highlight.range.end),
-                            highlightDecoration
-                        )
-                    }
-
-                    decorations = builder.finish()
-                } else {
-                    decorations = Decoration.none
-                }
-
-                return decorations
+                return (decorations = documentHighlightsToRangeSet(
+                    view.state.doc,
+                    documentHighlights,
+                    highlightDecoration
+                ))
             }
         }),
 })
+
+// This helper function is exported for testing purposes
+export function documentHighlightsToRangeSet<T extends RangeValue>(
+    textDocument: Text,
+    highlights: DocumentHighlight[],
+    rangeValue: T
+): RangeSet<T> {
+    if (documentHighlights?.length > 0) {
+        const builder = new RangeSetBuilder<T>()
+
+        // Most of the time number of highlights is small and close
+        // together so it's likely ok to iterate over all them and
+        // not just the ones in the current viewport.
+        for (const highlight of sortRangeValuesByStart(highlights)) {
+            const rangeStart = positionToOffset(textDocument, highlight.range.start)
+            const rangeEnd = positionToOffset(textDocument, highlight.range.end)
+            if (rangeStart !== null && rangeEnd !== null) {
+                builder.add(rangeStart, rangeEnd, rangeValue)
+            }
+        }
+
+        return builder.finish()
+    } else {
+        return RangeSet.empty
+    }
+}
 
 /**
  * Facet with which an extension can provide a document highlight source. Each
@@ -134,8 +154,7 @@ class DocumentHighlightsManager {
                     from(position ? view.state.facet(this.sources).map(source => source(position)) : []).pipe(
                         mergeAll()
                     )
-                ),
-                map(sortRangeValuesByStart)
+                )
             )
             .subscribe(highlights => {
                 if (highlights.length === 0 && view.state.field(documentHighlightsField).length === 0) {

--- a/client/web/src/repo/blob/codemirror/document-highlights.ts
+++ b/client/web/src/repo/blob/codemirror/document-highlights.ts
@@ -80,9 +80,8 @@ export function documentHighlightsToRangeSet<T extends RangeValue>(
         }
 
         return builder.finish()
-    } else {
-        return RangeSet.empty
     }
+    return RangeSet.empty
 }
 
 /**

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -4,6 +4,7 @@ import { Decoration, DecorationSet, EditorView, PluginValue, ViewPlugin, ViewUpd
 import { Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 
 import { BlobInfo } from '../Blob'
+
 import { positionToOffset } from './utils'
 
 /**

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -4,6 +4,7 @@ import { Decoration, DecorationSet, EditorView, PluginValue, ViewPlugin, ViewUpd
 import { Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 
 import { BlobInfo } from '../Blob'
+import { positionToOffset } from './utils'
 
 /**
  * This data structure combines the syntax highlighting data received from the
@@ -94,10 +95,13 @@ class SyntaxHighlightManager implements PluginValue {
             if (startIndex !== undefined) {
                 // Iterate over the rendered line (numbers) and get the
                 // corresponding occurrences from the highlighting table.
+                const textDocument = view.state.doc
+
                 for (let index = startIndex; index < occurrences.length; index++) {
                     const occurrence = occurrences[index]
+                    const occurenceStartLine = occurrence.range.start.line + 1
 
-                    if (occurrence.range.start.line > toLine.number) {
+                    if (occurenceStartLine > toLine.number) {
                         break
                     }
 
@@ -106,14 +110,22 @@ class SyntaxHighlightManager implements PluginValue {
                     }
 
                     // Fetch new line information if necessary
-                    if (line.number !== occurrence.range.start.line + 1) {
-                        line = view.state.doc.line(occurrence.range.start.line + 1)
+                    if (line.number !== occurenceStartLine) {
+                        // If the next occurrence doesn't map to a valid
+                        // document position, stop
+                        if (occurenceStartLine > textDocument.lines) {
+                            break
+                        }
+                        line = textDocument.line(occurenceStartLine)
                     }
 
-                    const from = line.from + occurrence.range.start.character
+                    const from = Math.min(line.from + occurrence.range.start.character, line.to)
+                    // Should the range end be not a valid position in the
+                    // document we fall back to the end of the current line
                     const to = occurrence.range.isSingleLine()
-                        ? line.from + occurrence.range.end.character
-                        : view.state.doc.line(occurrence.range.end.line + 1).from + occurrence.range.end.character
+                        ? Math.min(line.from + occurrence.range.end.character, line.to)
+                        : positionToOffset(textDocument, occurrence.range.end) ?? line.to
+
                     const decoration =
                         this.decorationCache[occurrence.kind] ||
                         (this.decorationCache[occurrence.kind] = Decoration.mark({

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -253,10 +253,12 @@ function isOffsetInHoverRange(offset: number, range: HovercardRange, textDocumen
 
 function getHoverOffsets(range: HovercardRange, textDocument: Text): { from: number; to: number } {
     if (range.providerRange) {
-        return {
-            from: uiPositionToOffset(textDocument, range.providerRange.start),
-            to: uiPositionToOffset(textDocument, range.providerRange.end),
-        }
+        const from = uiPositionToOffset(textDocument, range.providerRange.start)
+        const to = uiPositionToOffset(textDocument, range.providerRange.end)
+        // We only use the code intel range if it maps to a valid position
+        // within the document. Otherwise we fall back to the range
+        // determined by CodeMirror
+        return { from: from ?? range.from, to: to ?? range.to }
     }
     return range
 }

--- a/client/web/src/repo/blob/codemirror/utils.test.ts
+++ b/client/web/src/repo/blob/codemirror/utils.test.ts
@@ -1,0 +1,120 @@
+import { Text } from '@codemirror/state'
+import {
+    isValidLineRange,
+    offsetToUIPosition,
+    positionToOffset,
+    rangesContain,
+    sortRangeValuesByStart,
+    uiPositionToOffset,
+} from './utils'
+
+describe('blob/codemirror/utils', () => {
+    describe('rangeContains', () => {
+        const ranges = [
+            { from: 10, to: 20 },
+            { from: 30, to: 40 },
+        ]
+
+        it('returns true when the point is within one of the specific ranges (inclusively)', () => {
+            expect(rangesContain(ranges, 15)).toBe(true)
+            expect(rangesContain(ranges, 20)).toBe(true)
+        })
+
+        it('returns false when the point is within one of the specific ranges (inclusively)', () => {
+            expect(rangesContain(ranges, 25)).toBe(false)
+        })
+    })
+
+    describe('positionToOffset', () => {
+        const textDocument = Text.of([
+            // Don't forget to account for line breaks between lines!
+            '0123',
+            '5678',
+        ])
+
+        it('returns a valid offset', () => {
+            expect(positionToOffset(textDocument, { line: 1, character: 2 })).toBe(7)
+        })
+
+        it('null when the position is not valid inside the document', () => {
+            // Out-of-range character
+            expect(positionToOffset(textDocument, { line: 1, character: 20 })).toBe(null)
+            // Out-of-range line
+            expect(positionToOffset(textDocument, { line: 2, character: 2 })).toBe(null)
+        })
+    })
+
+    describe('uiPositionToOffset', () => {
+        const textDocument = Text.of([
+            // Don't forget to account for line breaks between lines!
+            '0123',
+            '5678',
+        ])
+
+        it('returns a valid offset', () => {
+            expect(uiPositionToOffset(textDocument, { line: 1, character: 2 })).toBe(1)
+        })
+
+        it('null when the position is not valid inside the document', () => {
+            // Out-of-range character
+            expect(uiPositionToOffset(textDocument, { line: 1, character: 20 })).toBe(null)
+            // Out-of-range line
+            expect(uiPositionToOffset(textDocument, { line: 3, character: 2 })).toBe(null)
+        })
+    })
+
+    describe('offsetToUIPosition', () => {
+        const textDocument = Text.of([
+            // Don't forget to account for line breaks between lines!
+            '0123',
+            '5678',
+        ])
+
+        it('returns a valid position', () => {
+            expect(offsetToUIPosition(textDocument, 6)).toEqual({ line: 2, character: 2 })
+        })
+
+        it('returns a valid range', () => {
+            expect(offsetToUIPosition(textDocument, 2, 6)).toEqual({
+                start: { line: 1, character: 3 },
+                end: { line: 2, character: 2 },
+            })
+        })
+    })
+
+    describe('sortRangeValuesByStart', () => {
+        it('sort ranges by start line and character', () => {
+            expect(
+                sortRangeValuesByStart([
+                    { range: { start: { line: 4, character: 5 } } },
+                    { range: { start: { line: 7, character: 1 } } },
+                    { range: { start: { line: 4, character: 1 } } },
+                ])
+            ).toEqual([
+                { range: { start: { line: 4, character: 1 } } },
+                { range: { start: { line: 4, character: 5 } } },
+                { range: { start: { line: 7, character: 1 } } },
+            ])
+        })
+    })
+
+    describe('isValidLineRange', () => {
+        const textDocument = Text.of(['', '', '32345', '42345'])
+
+        it('returns true if the line range is inside the document', () => {
+            // Empty line
+            expect(isValidLineRange({ line: 2 }, textDocument)).toBe(true)
+            // Empty line + first character
+            expect(isValidLineRange({ line: 1, character: 1 }, textDocument)).toBe(true)
+            expect(isValidLineRange({ line: 3, character: 3 }, textDocument)).toBe(true)
+            expect(isValidLineRange({ line: 3, character: 2, endLine: 4, endCharacter: 5 }, textDocument)).toBe(true)
+        })
+
+        it('returns false if the line range is outside the document', () => {
+            expect(isValidLineRange({ line: 10 }, textDocument)).toBe(false)
+            expect(isValidLineRange({ line: 1, character: 2 }, textDocument)).toBe(false)
+            expect(isValidLineRange({ line: 3, character: 2, endLine: 4, endCharacter: 8 }, textDocument)).toBe(false)
+            expect(isValidLineRange({ line: 3, character: 8, endLine: 4, endCharacter: 1 }, textDocument)).toBe(false)
+        })
+    })
+})

--- a/client/web/src/repo/blob/codemirror/utils.test.ts
+++ b/client/web/src/repo/blob/codemirror/utils.test.ts
@@ -1,4 +1,5 @@
 import { Text } from '@codemirror/state'
+
 import {
     isValidLineRange,
     offsetToUIPosition,

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -1,4 +1,4 @@
-import { Text } from '@codemirror/state'
+import { Line, Text } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { OperatorFunction, pipe } from 'rxjs'
 import { scan, distinctUntilChanged } from 'rxjs/operators'
@@ -16,25 +16,45 @@ export function rangesContain(ranges: readonly { from: number; to: number }[], p
 
 /**
  * Converts 0-based line/character positions to document offsets.
+ * Returns null if the position cannot be mapped to a valid offset within the
+ * document.
  */
-export function positionToOffset(textDocument: Text, position: Position): number {
+export function positionToOffset(textDocument: Text, position: Position): number | null {
     // Position is 0-based
-    return textDocument.line(position.line + 1).from + position.character
+    const lineNumber = position.line + 1
+    if (lineNumber > textDocument.lines) {
+        return null
+    }
+    const line = textDocument.line(lineNumber)
+    const offset = line.from + position.character
+
+    return offset <= line.to ? offset : null
 }
 
 /*
  * Converts 1-based line/character positions to document offsets.
+ * Returns null if the position cannot be mapped to a valid offset within the
+ * document.
  */
 export function uiPositionToOffset(
     textDocument: Text,
     position: UIPositionSpec['position'],
-    line = textDocument.line(position.line)
-): number {
-    return line.from + position.character - 1
+    line?: Line
+): number | null {
+    const lineNumber = position.line
+    if (lineNumber > textDocument.lines) {
+        return null
+    }
+    if (!line) {
+        line = textDocument.line(position.line)
+    }
+    const offset = line.from + position.character - 1
+
+    return offset <= line.to ? offset : null
 }
 
 /**
- * Converts document offsets 1-based line/character positions.
+ * Converts document offsets to 1-based line/character positions.
  */
 export function offsetToUIPosition(textDocument: Text, from: number): UIPositionSpec['position']
 export function offsetToUIPosition(textDocument: Text, from: number, to: number): UIRangeSpec['range']
@@ -44,7 +64,7 @@ export function offsetToUIPosition(
     to?: number
 ): UIRangeSpec['range'] | UIPositionSpec['position'] {
     const startLine = textDocument.lineAt(from)
-    const startCharacter = Math.max(0, from - startLine.from) + 1
+    const startCharacter = from - startLine.from + 1
 
     const startPosition: Position = {
         line: startLine.number,
@@ -53,7 +73,7 @@ export function offsetToUIPosition(
 
     if (to !== undefined) {
         const endLine = to <= startLine.to ? startLine : textDocument.lineAt(to)
-        const endCharacter = Math.max(0, to - endLine.to) + 1
+        const endCharacter = to - endLine.from + 1
 
         return {
             start: startPosition,
@@ -74,7 +94,7 @@ export function viewPortChanged(
     return previous?.from !== next.from || previous.to !== next.to
 }
 
-export function sortRangeValuesByStart<T extends { range: Range }>(values: T[]): T[] {
+export function sortRangeValuesByStart<T extends { range: { start: Position } }>(values: T[]): T[] {
     return values.sort(({ range: rangeA }, { range: rangeB }) =>
         rangeA.start.line === rangeB.start.line
             ? rangeA.start.character - rangeB.start.character
@@ -161,16 +181,12 @@ export function isValidLineRange(
         return false
     }
 
-    // Verify precise character positions (if present)
-    if (range.character && textDocument.line(range.line).to < range.line + range.character - 1) {
+    if (range.character && uiPositionToOffset(textDocument, range) === null) {
         return false
     }
-    if (
-        range.endLine &&
-        range.endCharacter &&
-        textDocument.line(range.endLine).to < range.endLine + range.endCharacter - 1
-    ) {
-        return false
+
+    if (range.endLine && range.endCharacter) {
+        return uiPositionToOffset(textDocument, { line: range.endLine, character: range.endCharacter }) !== null
     }
 
     return true

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -3,7 +3,7 @@ import { EditorView } from '@codemirror/view'
 import { OperatorFunction, pipe } from 'rxjs'
 import { scan, distinctUntilChanged } from 'rxjs/operators'
 
-import { Position, Range } from '@sourcegraph/extension-api-types'
+import { Position } from '@sourcegraph/extension-api-types'
 import { UIPositionSpec, UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 
 /**
@@ -181,8 +181,13 @@ export function isValidLineRange(
         return false
     }
 
-    if (range.character && uiPositionToOffset(textDocument, range) === null) {
-        return false
+    {
+        // Some juggling to make Typescript happy (passing range directly
+        // doesn't work)
+        const { character, line } = range
+        if (character && uiPositionToOffset(textDocument, { line, character }) === null) {
+            return false
+        }
     }
 
     if (range.endLine && range.endCharacter) {


### PR DESCRIPTION
I encountered an issue where the server returned incorrect document highlights data, including ranges that were outside of the document. This currently causes the CodeMirror blob view to crash.

This commit makes core functions used to map positions to document offsets return `null` if the position is outside the document, and consequently updates callsites to handle that case (by either ignoring the range or by falling back to another value).

I also added a couple of unit tests and fixed issues uncovered by those tests.

Hovercard and highlights work as expected in manual testing:

<img width="716" alt="2022-09-23_15-18" src="https://user-images.githubusercontent.com/179026/191970149-387d7210-f645-48dc-8a88-7b7beaeb00d4.png">



## Test plan

Unit tests and manual testing.

## App preview:

- [Web](https://sg-web-fkling-cm-blob-ranges.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qkwanmglhe.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
