### PR TITLE
CodeMirror Blob: Improve search input styles

### DIFF
--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -60,6 +60,7 @@ import { getSuggestionQuery } from '@sourcegraph/shared/src/search/query/provide
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
 import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
+import { createSVGIcon } from '@sourcegraph/shared/src/util/dom'
 
 import { queryTokens } from './parsedQuery'
 
@@ -97,19 +98,6 @@ const typeIconMap: Record<CompletionType, string> = {
     queryfilter: mdiFilterOutline,
     repository: mdiSourceBranch,
     searchhistory: mdiHistory,
-}
-
-function createIcon(pathSpec: string): Node {
-    const svgNS = 'http://www.w3.org/2000/svg'
-    const svg = document.createElementNS(svgNS, 'svg')
-    svg.setAttributeNS(null, 'viewBox', '0 0 24 24')
-    svg.setAttribute('aria-hidden', 'true')
-
-    const path = document.createElementNS(svgNS, 'path')
-    path.setAttribute('d', pathSpec)
-
-    svg.append(path)
-    return svg
 }
 
 interface SuggestionContext {
@@ -158,7 +146,7 @@ export function searchQueryAutocompletion(
         // This renders the completion icon
         {
             render(completion) {
-                return createIcon(
+                return createSVGIcon(
                     completion.type && completion.type in typeIconMap
                         ? typeIconMap[completion.type as CompletionType]
                         : typeIconMap[SymbolKind.UNKNOWN]

--- a/client/shared/src/util/dom.test.ts
+++ b/client/shared/src/util/dom.test.ts
@@ -1,4 +1,4 @@
-import { isInputElement } from './dom'
+import { createSVGIcon, isInputElement } from './dom'
 
 describe('isInputElement', () => {
     test('detect <input> elements as input', () => {
@@ -31,5 +31,20 @@ describe('isInputElement', () => {
         parent.append(element)
 
         expect(isInputElement(element)).toBe(true)
+    })
+})
+
+describe('createSVGIcon', () => {
+    test('create SVG icon', () => {
+        expect(createSVGIcon('M 10 10')).toMatchInlineSnapshot(`
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M 10 10"
+              />
+            </svg>
+        `)
     })
 })

--- a/client/shared/src/util/dom.ts
+++ b/client/shared/src/util/dom.ts
@@ -30,3 +30,19 @@ function elementIsContentEditable(element: HTMLElement): boolean {
             return element.parentElement ? elementIsContentEditable(element.parentElement) : false
     }
 }
+
+/**
+ * Creates an SVG node. To be used together with path specs from @mdi/js
+ */
+export function createSVGIcon(pathSpec: string): Node {
+    const svgNS = 'http://www.w3.org/2000/svg'
+    const svg = document.createElementNS(svgNS, 'svg')
+    svg.setAttributeNS(null, 'viewBox', '0 0 24 24')
+    svg.setAttribute('aria-hidden', 'true')
+
+    const path = document.createElementNS(svgNS, 'path')
+    path.setAttribute('d', pathSpec)
+
+    svg.append(path)
+    return svg
+}

--- a/client/web/src/integration/codemirror-blob-view.test.ts
+++ b/client/web/src/integration/codemirror-blob-view.test.ts
@@ -1,0 +1,179 @@
+import assert from 'assert'
+
+import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
+import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
+import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
+
+import { WebGraphQlOperations } from '../graphql-operations'
+
+import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
+import {
+    createResolveRepoRevisionResult,
+    createFileExternalLinksResult,
+    createTreeEntriesResult,
+    createBlobContentResult,
+} from './graphQlResponseHelpers'
+import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
+
+describe('CodeMirror blob view', () => {
+    let driver: Driver
+    before(async () => {
+        driver = await createDriverForTest()
+    })
+    after(() => driver?.close())
+    let testContext: WebIntegrationTestContext
+    beforeEach(async function () {
+        testContext = await createWebIntegrationTestContext({
+            driver,
+            currentTest: this.currentTest!,
+            directory: __dirname,
+        })
+    })
+    afterEachSaveScreenshotIfFailed(() => driver.page)
+    afterEach(() => testContext?.dispose())
+
+    const { graphqlResults, filePaths } = createBlobPageData({
+        repoName: 'github.com/sourcegraph/jsonrpc2',
+        blobInfo: {
+            'test.ts': {
+                content: 'line1\nLine2\nline3',
+            },
+        },
+    })
+
+    const commonBlobGraphQlResults: Partial<WebGraphQlOperations & SharedGraphQlOperations> = {
+        ...commonWebGraphQlResults,
+        ...createViewerSettingsGraphQLOverride({
+            user: {
+                experimentalFeatures: {
+                    enableCodeMirrorFileView: true,
+                },
+            },
+        }),
+        ...graphqlResults,
+    }
+
+    beforeEach(() => {
+        testContext.overrideGraphQL(commonBlobGraphQlResults)
+    })
+
+    const blobSelector = '[data-testid="repo-blob"] .cm-editor'
+
+    describe('in-document search', () => {
+        function getMatchCount(): Promise<number> {
+            return driver.page.evaluate<() => number>(() => document.querySelectorAll('.cm-searchMatch').length)
+        }
+
+        async function pressCtrlF(): Promise<void> {
+            await driver.page.keyboard.down('Control')
+            await driver.page.keyboard.press('f')
+            await driver.page.keyboard.up('Control')
+        }
+
+        function getSelectedMatch(): Promise<string | null | undefined> {
+            return driver.page.evaluate<() => string | null | undefined>(
+                () => document.querySelector('.cm-searchMatch-selected')?.textContent
+            )
+        }
+
+        it('renders a working in-document search', async () => {
+            await driver.page.goto(`${driver.sourcegraphBaseUrl}${filePaths['test.ts']}`)
+            await driver.page.waitForSelector(blobSelector)
+            // Wait for page to "settle" so that focus management works better
+            await driver.page.waitForTimeout(1000)
+
+            // Focus file view and trigger in-document search
+            await driver.page.click(blobSelector)
+            await pressCtrlF()
+            await driver.page.waitForSelector('.search-container')
+
+            // Start searching (which implies that the search input has focus)
+            await driver.page.keyboard.type('line')
+            // All three lines should have matches
+            assert.strictEqual(await getMatchCount(), 3, 'finds three matches')
+
+            // Enable case sensitive search. This should update the matches
+            // immediately.
+            await driver.page.click('[data-testid="blob-view-search-case-sensitive"]')
+            assert.strictEqual(await getMatchCount(), 2, 'finds two matches')
+
+            // Pressing CTRL+f again focuses the search input again and selects
+            // the value so that it can be easily replaced.
+            await pressCtrlF()
+            await driver.page.keyboard.type('line\\d')
+            assert.strictEqual(
+                await driver.page.evaluate<() => string | null | undefined>(
+                    () => document.querySelector<HTMLInputElement>('.search-container [name="search"]')?.value
+                ),
+                'line\\d'
+            )
+
+            // Enabling regexp search.
+            await driver.page.click('[data-testid="blob-view-search-regexp"]')
+            assert.strictEqual(await getMatchCount(), 2, 'finds two matches')
+
+            // Pressing previous / next buttons focuses next/previous match
+            await driver.page.click('[data-testid="blob-view-search-next"]')
+            const selectedMatch = await getSelectedMatch()
+            assert.strictEqual(!!selectedMatch, true, 'match is selected')
+
+            await driver.page.click('[data-testid="blob-view-search-previous"]')
+            assert.notStrictEqual(selectedMatch, await getSelectedMatch())
+
+            // Pressing Esc closes the search form
+            await driver.page.keyboard.press('Escape')
+            assert.strictEqual(
+                await driver.page.evaluate(() => document.querySelector('.search-container')),
+                null,
+                'search form is not presetn'
+            )
+        })
+    })
+})
+
+interface BlobInfo {
+    [fileName: string]: {
+        content: string
+        html?: string
+    }
+}
+
+function createBlobPageData<T extends BlobInfo>({
+    repoName,
+    blobInfo,
+}: {
+    repoName: string
+    blobInfo: T
+}): {
+    graphqlResults: Pick<WebGraphQlOperations, 'ResolveRepoRev' | 'FileExternalLinks' | 'Blob' | 'FileNames'> &
+        Pick<SharedGraphQlOperations, 'TreeEntries'>
+    filePaths: { [k in keyof T]: string }
+} {
+    const repositorySourcegraphUrl = `/${repoName}`
+    const fileNames = Object.keys(blobInfo)
+
+    return {
+        filePaths: fileNames.reduce((paths, fileName) => {
+            paths[fileName as keyof T] = `/${repoName}/-/blob/${fileName}`
+            return paths
+        }, {} as { [k in keyof T]: string }),
+        graphqlResults: {
+            ResolveRepoRev: () => createResolveRepoRevisionResult(repositorySourcegraphUrl),
+            FileExternalLinks: ({ filePath }) =>
+                createFileExternalLinksResult(`https://${repoName}/blob/master/${filePath}`),
+            TreeEntries: () => createTreeEntriesResult(repositorySourcegraphUrl, fileNames),
+            Blob: ({ filePath }) => createBlobContentResult(blobInfo[filePath].content, blobInfo[filePath].html),
+            FileNames: () => ({
+                repository: {
+                    id: 'repo-123',
+                    __typename: 'Repository',
+                    commit: {
+                        id: 'c0ff33',
+                        __typename: 'GitCommit',
+                        fileNames,
+                    },
+                },
+            }),
+        },
+    }
+}

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -4,9 +4,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { search, searchKeymap } from '@codemirror/search'
 import { Compartment, EditorState, Extension } from '@codemirror/state'
-import { EditorView, keymap } from '@codemirror/view'
+import { EditorView } from '@codemirror/view'
 import { isEqual } from 'lodash'
 
 import {
@@ -24,6 +23,7 @@ import { showGitBlameDecorations } from './codemirror/blame-decorations'
 import { syntaxHighlight } from './codemirror/highlight'
 import { hovercardRanges } from './codemirror/hovercard'
 import { selectLines, selectableLineNumbers, SelectedLineRange } from './codemirror/linenumbers'
+import { search } from './codemirror/search'
 import { sourcegraphExtensions } from './codemirror/sourcegraph-extensions'
 import { isValidLineRange, offsetToUIPosition, uiPositionToOffset } from './codemirror/utils'
 
@@ -61,9 +61,8 @@ const staticExtensions: Extension = [
         },
     }),
     // Note that these only work out-of-the-box because the editor is
-    // *focusable* but read-only (see EditorState.readOnly above).
-    search({ top: true }),
-    keymap.of(searchKeymap),
+    // *focusable* by setting `tab-index: 0`.
+    search,
 ]
 
 // Compartments are used to reconfigure some parts of the editor without
@@ -256,7 +255,15 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [position, hasPin])
 
-    return <div ref={setContainer} aria-label={ariaLabel} role={role} className={`${className} overflow-hidden`} />
+    return (
+        <div
+            ref={setContainer}
+            aria-label={ariaLabel}
+            role={role}
+            data-testid="repo-blob"
+            className={`${className} overflow-hidden`}
+        />
+    )
 }
 
 /**

--- a/client/web/src/repo/blob/codemirror/search.ts
+++ b/client/web/src/repo/blob/codemirror/search.ts
@@ -1,0 +1,180 @@
+/**
+ * This extension exends CodeMirro's own search extension with a custom search
+ * UI.
+ */
+
+import {
+    findNext,
+    findPrevious,
+    getSearchQuery,
+    search as codemirrorSearch,
+    searchKeymap,
+    SearchQuery,
+    setSearchQuery,
+} from '@codemirror/search'
+import { Extension } from '@codemirror/state'
+import { EditorView, keymap, Panel, runScopeHandlers, ViewUpdate } from '@codemirror/view'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
+
+import { createSVGIcon } from '@sourcegraph/shared/src/util/dom'
+import { ButtonStyles, LabelStyles } from '@sourcegraph/wildcard'
+
+import { createElement } from '../../../util/dom'
+
+class SearchPanel implements Panel {
+    public dom: HTMLElement
+    public top = true
+    private query: SearchQuery
+    private input: HTMLInputElement
+    private caseSensitive: HTMLInputElement
+    private regexp: HTMLInputElement
+
+    constructor(private view: EditorView) {
+        const previous = createElement(
+            'button',
+            {
+                type: 'button',
+                className: [ButtonStyles.btn, ButtonStyles.btnSm, ButtonStyles.btnOutlineSecondary].join(' '),
+                onclick: () => findPrevious(view),
+            },
+            createSVGIcon(mdiChevronUp),
+            'Previous'
+        )
+        previous.setAttribute('data-testid', 'blob-view-search-next')
+        const next = createElement(
+            'button',
+            {
+                type: 'button',
+                className: [ButtonStyles.btn, ButtonStyles.btnSm, ButtonStyles.btnOutlineSecondary].join(' '),
+                onclick: () => findNext(view),
+            },
+            createSVGIcon(mdiChevronDown),
+            'Next'
+        )
+        next.setAttribute('data-testid', 'blob-view-search-previous')
+
+        this.input = createElement('input', {
+            name: 'search',
+            placeholder: 'Find...',
+            className: 'form-control form-control-sm',
+            onchange: this.commit,
+            onkeyup: this.commit,
+        })
+        this.input.setAttribute('main-field', 'true')
+
+        this.caseSensitive = createElement('input', { type: 'checkbox', onchange: this.commit })
+        this.caseSensitive.setAttribute('data-testid', 'blob-view-search-case-sensitive')
+        this.regexp = createElement('input', { type: 'checkbox', onchange: this.commit })
+        this.regexp.setAttribute('data-testid', 'blob-view-search-regexp')
+
+        this.dom = createElement(
+            'div',
+            { className: 'search-container', onkeydown: this.onkeydown },
+            this.input,
+            previous,
+            next,
+            createElement(
+                'label',
+                { className: `form-check-label small mx-2 ml-3 ${LabelStyles.label}` },
+                this.caseSensitive,
+                ' Match case'
+            ),
+            createElement(
+                'label',
+                { className: `form-check-label small mx-2 ${LabelStyles.label}` },
+                this.regexp,
+                ' Regexp'
+            )
+        )
+
+        this.query = getSearchQuery(this.view.state)
+
+        this.setQuery(this.query)
+    }
+
+    public update(update: ViewUpdate): void {
+        const currentQuery = getSearchQuery(update.state)
+        if (!currentQuery.eq(getSearchQuery(update.startState))) {
+            this.setQuery(currentQuery)
+        }
+    }
+
+    public mount(): void {
+        this.input.focus()
+        this.input.select()
+    }
+
+    // Taken from CodeMirror's default serach panel implementation. This is
+    // necessary so that pressing Meta+F (and other CodeMirror keybindings) will
+    // trigger the configured event handlers and not just fall back to the
+    // browser's default behavior.
+    private onkeydown = (event: KeyboardEvent): void => {
+        if (runScopeHandlers(this.view, event, 'search-panel')) {
+            event.preventDefault()
+        } else if (event.keyCode === 13 && event.target === this.input) {
+            event.preventDefault()
+            if (event.shiftKey) {
+                findPrevious(this.view)
+            } else {
+                findNext(this.view)
+            }
+        }
+    }
+
+    private commit = (): void => {
+        const query = new SearchQuery({
+            search: this.input.value,
+            caseSensitive: this.caseSensitive.checked,
+            regexp: this.regexp.checked,
+        })
+
+        if (!query.eq(this.query)) {
+            this.view.dispatch({ effects: setSearchQuery.of(query) })
+        }
+    }
+
+    private setQuery(query: SearchQuery): void {
+        this.query = query
+        this.input.value = this.query.search
+        this.caseSensitive.checked = this.query.caseSensitive
+        this.regexp.checked = this.query.regexp
+    }
+}
+
+export const search: Extension = [
+    EditorView.theme({
+        '.search-container': {
+            backgroundColor: 'var(--code-bg)',
+            display: 'flex',
+            alignItems: 'center',
+            padding: '0.25rem',
+        },
+        '.search-container > *': {
+            margin: '0 0.25rem',
+        },
+        '.search-container > input.form-control': {
+            width: '15rem',
+        },
+        '.search-container input[type="checkbox"]': {
+            verticalAlign: 'text-bottom',
+        },
+        '.search-container svg': {
+            width: 'var(--icon-inline-size)',
+            height: 'var(--icon-inline-size)',
+            boxSizing: 'border-box',
+            textAlign: 'center',
+            marginRight: '0.25rem',
+            // The icons contain whitespace themselves, this makes the button
+            // look more centered
+            marginLeft: '-0.125rem',
+            verticalAlign: 'text-bottom',
+        },
+        '.cm-searchMatch:not(.cm-searchMatch-selected)': {
+            backgroundColor: 'var(--mark-bg)',
+        },
+    }),
+    keymap.of(searchKeymap),
+    codemirrorSearch({
+        createPanel: view => new SearchPanel(view),
+    }),
+]

--- a/client/web/src/repo/blob/codemirror/search.ts
+++ b/client/web/src/repo/blob/codemirror/search.ts
@@ -17,9 +17,12 @@ import { EditorView, keymap, Panel, runScopeHandlers, ViewUpdate } from '@codemi
 import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 
 import { createSVGIcon } from '@sourcegraph/shared/src/util/dom'
-import { ButtonStyles, LabelStyles } from '@sourcegraph/wildcard'
+import { getButtonClassName, getLabelClassName } from '@sourcegraph/wildcard'
 
 import { createElement } from '../../../util/dom'
+
+const buttonClassName = getButtonClassName({ size: 'sm', outline: true, variant: 'secondary' })
+const labelClassName = getLabelClassName({ size: 'small', mode: 'single-line' })
 
 class SearchPanel implements Panel {
     public dom: HTMLElement
@@ -34,13 +37,7 @@ class SearchPanel implements Panel {
             'button',
             {
                 type: 'button',
-                className: [
-                    ButtonStyles.btn,
-                    ButtonStyles.btnSm,
-                    ButtonStyles.btnOutline,
-                    ButtonStyles.btnSecondary,
-                    'mr-2',
-                ].join(' '),
+                className: [buttonClassName, 'mr-2'].join(' '),
                 onclick: () => findPrevious(view),
             },
             createSVGIcon(mdiChevronUp),
@@ -51,12 +48,7 @@ class SearchPanel implements Panel {
             'button',
             {
                 type: 'button',
-                className: [
-                    ButtonStyles.btn,
-                    ButtonStyles.btnSm,
-                    ButtonStyles.btnOutline,
-                    ButtonStyles.btnSecondary,
-                ].join(' '),
+                className: buttonClassName,
                 onclick: () => findNext(view),
             },
             createSVGIcon(mdiChevronDown),
@@ -86,16 +78,11 @@ class SearchPanel implements Panel {
             next,
             createElement(
                 'label',
-                { className: `form-check-label small mx-2 ml-3 ${LabelStyles.label}` },
+                { className: `form-check-label mx-2 ml-3 ${labelClassName}` },
                 this.caseSensitive,
                 'Match case'
             ),
-            createElement(
-                'label',
-                { className: `form-check-label small mx-2 ${LabelStyles.label}` },
-                this.regexp,
-                'Regexp'
-            )
+            createElement('label', { className: `form-check-label mx-2 ${labelClassName}` }, this.regexp, 'Regexp')
         )
 
         this.query = getSearchQuery(this.view.state)
@@ -177,8 +164,11 @@ export const search: Extension = [
             marginLeft: '-0.125rem',
             verticalAlign: 'text-bottom',
         },
-        '.cm-searchMatch:not(.cm-searchMatch-selected)': {
+        '.cm-searchMatch': {
             backgroundColor: 'var(--mark-bg)',
+        },
+        '.cm-searchMatch-selected': {
+            backgroundColor: 'var(--oc-orange-3)',
         },
     }),
     keymap.of(searchKeymap),

--- a/client/web/src/repo/blob/codemirror/search.ts
+++ b/client/web/src/repo/blob/codemirror/search.ts
@@ -34,7 +34,13 @@ class SearchPanel implements Panel {
             'button',
             {
                 type: 'button',
-                className: [ButtonStyles.btn, ButtonStyles.btnSm, ButtonStyles.btnOutlineSecondary].join(' '),
+                className: [
+                    ButtonStyles.btn,
+                    ButtonStyles.btnSm,
+                    ButtonStyles.btnOutline,
+                    ButtonStyles.btnSecondary,
+                    'mr-2',
+                ].join(' '),
                 onclick: () => findPrevious(view),
             },
             createSVGIcon(mdiChevronUp),
@@ -45,7 +51,12 @@ class SearchPanel implements Panel {
             'button',
             {
                 type: 'button',
-                className: [ButtonStyles.btn, ButtonStyles.btnSm, ButtonStyles.btnOutlineSecondary].join(' '),
+                className: [
+                    ButtonStyles.btn,
+                    ButtonStyles.btnSm,
+                    ButtonStyles.btnOutline,
+                    ButtonStyles.btnSecondary,
+                ].join(' '),
                 onclick: () => findNext(view),
             },
             createSVGIcon(mdiChevronDown),
@@ -56,15 +67,15 @@ class SearchPanel implements Panel {
         this.input = createElement('input', {
             name: 'search',
             placeholder: 'Find...',
-            className: 'form-control form-control-sm',
+            className: 'form-control form-control-sm mr-2',
             onchange: this.commit,
             onkeyup: this.commit,
         })
         this.input.setAttribute('main-field', 'true')
 
-        this.caseSensitive = createElement('input', { type: 'checkbox', onchange: this.commit })
+        this.caseSensitive = createElement('input', { type: 'checkbox', className: 'mr-2', onchange: this.commit })
         this.caseSensitive.setAttribute('data-testid', 'blob-view-search-case-sensitive')
-        this.regexp = createElement('input', { type: 'checkbox', onchange: this.commit })
+        this.regexp = createElement('input', { type: 'checkbox', className: 'mr-2', onchange: this.commit })
         this.regexp.setAttribute('data-testid', 'blob-view-search-regexp')
 
         this.dom = createElement(
@@ -77,13 +88,13 @@ class SearchPanel implements Panel {
                 'label',
                 { className: `form-check-label small mx-2 ml-3 ${LabelStyles.label}` },
                 this.caseSensitive,
-                ' Match case'
+                'Match case'
             ),
             createElement(
                 'label',
                 { className: `form-check-label small mx-2 ${LabelStyles.label}` },
                 this.regexp,
-                ' Regexp'
+                'Regexp'
             )
         )
 
@@ -147,10 +158,7 @@ export const search: Extension = [
             backgroundColor: 'var(--code-bg)',
             display: 'flex',
             alignItems: 'center',
-            padding: '0.25rem',
-        },
-        '.search-container > *': {
-            margin: '0 0.25rem',
+            padding: '0.375rem 1rem',
         },
         '.search-container > input.form-control': {
             width: '15rem',

--- a/client/web/src/util/dom.ts
+++ b/client/web/src/util/dom.ts
@@ -99,3 +99,15 @@ export function useBreakpoint(size: keyof typeof breakpoints, debounceMs = 50): 
 const normalizeResizeObserverSize = (
     resizeObserverSize: undefined | readonly ResizeObserverSize[] | ResizeObserverSize
 ): ResizeObserverSize | undefined => (!Array.isArray(resizeObserverSize) ? resizeObserverSize : resizeObserverSize[0])
+
+export function createElement<K extends keyof HTMLElementTagNameMap>(
+    tagName: K,
+    properties: Partial<HTMLElementTagNameMap[K]> | null = null,
+    ...children: (Node | string)[]
+): HTMLElementTagNameMap[K] {
+    const element = Object.assign(document.createElement(tagName), properties)
+    for (const child of children) {
+        element.append(typeof child === 'string' ? document.createTextNode(child) : child)
+    }
+    return element
+}

--- a/client/wildcard/src/components/Button/Button.tsx
+++ b/client/wildcard/src/components/Button/Button.tsx
@@ -6,9 +6,7 @@ import { useWildcardTheme } from '../../hooks'
 import { ForwardReferenceComponent } from '../../types'
 
 import { BUTTON_VARIANTS, BUTTON_SIZES, BUTTON_DISPLAY } from './constants'
-import { getButtonSize, getButtonStyle, getButtonDisplay } from './utils'
-
-import styles from './Button.module.scss'
+import { getButtonClassName } from './utils'
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     /**
@@ -45,7 +43,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
  * Tips:
  * - Avoid using button styling for links where possible. Buttons should typically trigger an action, links should navigate to places.
  */
-// eslint-disable-next-line react/display-name
+
 export const Button = React.forwardRef(
     (
         {
@@ -65,12 +63,7 @@ export const Button = React.forwardRef(
     ) => {
         const { isBranded } = useWildcardTheme()
 
-        const brandedButtonClassname = classNames(
-            styles.btn,
-            variant && getButtonStyle({ variant, outline }),
-            display && getButtonDisplay({ display }),
-            size && getButtonSize({ size })
-        )
+        const brandedButtonClassname = getButtonClassName({ variant, outline, display, size })
 
         return (
             <Component

--- a/client/wildcard/src/components/Button/utils.ts
+++ b/client/wildcard/src/components/Button/utils.ts
@@ -26,3 +26,22 @@ interface GetButtonDisplayParameters {
 
 export const getButtonDisplay = ({ display }: GetButtonDisplayParameters): string =>
     styles[`btn${upperFirst(display)}` as keyof typeof styles]
+
+/**
+ * Returns the class name to style a button with the given options. This can be
+ * used to for generating the right CSS class combination for plain DOM buttons,
+ * but it should be used sparingly.
+ */
+export function getButtonClassName({
+    variant,
+    display,
+    size,
+    outline,
+}: Partial<GetButtonStyleParameters & GetButtonSizeParameters & GetButtonDisplayParameters> = {}): string {
+    return classNames(
+        styles.btn,
+        variant && getButtonStyle({ variant, outline }),
+        display && getButtonDisplay({ display }),
+        size && getButtonSize({ size })
+    )
+}

--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -3,10 +3,9 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { ForwardReferenceComponent } from '../../../types'
-import { getAlignmentStyle, getFontWeightStyle, getModeStyle, TypographyProps } from '../utils'
+import { TypographyProps } from '../utils'
 
-import typographyStyles from '../Typography.module.scss'
-import styles from './Label.module.scss'
+import { getLabelClassName } from './utils'
 
 interface LabelProps extends React.HTMLAttributes<HTMLLabelElement>, TypographyProps {
     size?: 'small' | 'base'
@@ -33,14 +32,7 @@ export const Label = React.forwardRef((props, reference) => {
         <Component
             ref={reference}
             className={classNames(
-                styles.label,
-                isUnderline && styles.labelUnderline,
-                isUppercase && styles.labelUppercase,
-                size === 'small' && typographyStyles.small,
-                weight && getFontWeightStyle({ weight }),
-                alignment && getAlignmentStyle({ alignment }),
-                mode && getModeStyle({ mode }),
-                mode === 'single-line' && styles.labelSingleLine,
+                getLabelClassName({ isUppercase, isUnderline, alignment, weight, size, mode }),
                 className
             )}
             {...rest}

--- a/client/wildcard/src/components/Typography/Label/utils.ts
+++ b/client/wildcard/src/components/Typography/Label/utils.ts
@@ -1,0 +1,43 @@
+import classNames from 'classnames'
+
+import {
+    getAlignmentStyle,
+    GetAlignmentStyleParameters,
+    getFontWeightStyle,
+    GetFontWeightStyleParameters,
+    getModeStyle,
+    GetModeStyleParameters,
+} from '../utils'
+
+import typographyStyles from '../Typography.module.scss'
+import styles from './Label.module.scss'
+
+interface GetLabelClassNameParameters
+    extends GetAlignmentStyleParameters,
+        GetModeStyleParameters,
+        GetFontWeightStyleParameters {
+    size?: 'small' | 'base'
+    weight?: 'regular' | 'medium' | 'bold'
+    isUnderline?: boolean
+    isUppercase?: boolean
+}
+
+export function getLabelClassName({
+    mode,
+    size,
+    weight,
+    alignment,
+    isUnderline,
+    isUppercase,
+}: GetLabelClassNameParameters = {}): string {
+    return classNames(
+        styles.label,
+        isUnderline && styles.labelUnderline,
+        isUppercase && styles.labelUppercase,
+        size === 'small' && typographyStyles.small,
+        weight && getFontWeightStyle({ weight }),
+        alignment && getAlignmentStyle({ alignment }),
+        mode && getModeStyle({ mode }),
+        mode === 'single-line' && styles.labelSingleLine
+    )
+}

--- a/client/wildcard/src/components/Typography/utils.ts
+++ b/client/wildcard/src/components/Typography/utils.ts
@@ -11,15 +11,15 @@ export interface TypographyProps {
     as?: React.ElementType
 }
 
-interface GetAlignmentStyleParameters {
+export interface GetAlignmentStyleParameters {
     alignment?: typeof TYPOGRAPHY_ALIGNMENTS[number]
 }
 
-interface GetModeStyleParameters {
+export interface GetModeStyleParameters {
     mode?: typeof TYPOGRAPHY_MODES[number]
 }
 
-interface GetFontWeightStyleParameters {
+export interface GetFontWeightStyleParameters {
     weight?: typeof TYPOGRAPHY_WEIGHTS[number]
 }
 

--- a/client/wildcard/src/components/index.ts
+++ b/client/wildcard/src/components/index.ts
@@ -76,8 +76,8 @@ export type { BadgeProps, BadgeVariantType, ProductStatusType, BaseProductStatus
 export type { ModalProps } from './Modal'
 
 /**
- * Style exports to be used with plain DOM nodes.
+ * Class name helpers to be used with plain DOM nodes.
  * NOTE: Prefer using the React components is possible.
  */
-export { default as ButtonStyles } from './Button/Button.module.scss'
-export { default as LabelStyles } from './Typography/Label/Label.module.scss'
+export { getButtonClassName } from './Button/utils'
+export { getLabelClassName } from './Typography/Label/utils'

--- a/client/wildcard/src/components/index.ts
+++ b/client/wildcard/src/components/index.ts
@@ -74,3 +74,10 @@ export type { TooltipProps } from './Tooltip'
 export type { HeadingProps, HeadingElement } from './Typography'
 export type { BadgeProps, BadgeVariantType, ProductStatusType, BaseProductStatusBadgeProps } from './Badge'
 export type { ModalProps } from './Modal'
+
+/**
+ * Style exports to be used with plain DOM nodes.
+ * NOTE: Prefer using the React components is possible.
+ */
+export { default as ButtonStyles } from './Button/Button.module.scss'
+export { default as LabelStyles } from './Typography/Label/Label.module.scss'


### PR DESCRIPTION
Closes #40542 

This commit replaces the default search panel with a custom implementation that uses Wildcard styles. Because I wanted to avoid interfacing with React as much as possible I used plain DOM.
<img width="716" alt="2022-09-26_19-11" src="https://user-images.githubusercontent.com/179026/192360584-6929e354-210f-4853-8c6a-c3103329a2e8.png">



As per slack discussion I exported the Wildcard styles.

I added a new integration test that I'll merge with #39973 somehow.

For match highlighting I used the same background color with use in search results (`var(--mark-bg)`).

## Test plan

- Focus file (by clicking on it).
- Press <kbd>CMD</kbd>/<kbd>CTRL</kbd> + <kbd>F</kbd> -> search form appears and input is focused.
- Enter search term -> matches are highlighted
- Click previous/next buttons -> view scrolls to previous/next match
- Try regex and case sensitive matches
- Click on file content to remove focus from search input but still focus file.
- Pressing <kbd>CMD</kbd>/<kbd>CTRL</kbd> + <kbd>F</kbd> again will refocus search input and select existing content
- Pressing <kbd>Esc</kbd> will close search form


## App preview:

- [Web](https://sg-web-fkling-40542-cm-blob-search-design.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tcdpcidtdg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

