### PR TITLE
internal/tracer: only start OTEL spans if ShouldTrace is true

### DIFF
--- a/internal/trace/policy/policy.go
+++ b/internal/trace/policy/policy.go
@@ -43,7 +43,8 @@ const shouldTraceKey key = iota
 func ShouldTrace(ctx context.Context) bool {
 	v, ok := ctx.Value(shouldTraceKey).(bool)
 	if !ok {
-		return false
+		// If ShouldTrace is set to false, we respect TraceAll instead.
+		return GetTracePolicy() == TraceAll
 	}
 	return v
 }

--- a/internal/tracer/should_trace.go
+++ b/internal/tracer/should_trace.go
@@ -1,0 +1,40 @@
+package tracer
+
+import (
+	"context"
+
+	"github.com/sourcegraph/log"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
+)
+
+var otelNoOpTracer = oteltrace.NewNoopTracerProvider().Tracer("internal/tracer/no-op")
+
+// shouldTraceTracer only starts a trace if policy.ShouldTrace evaluates to true in
+// contexts.
+type shouldTraceTracer struct {
+	logger log.Logger
+	debug  bool
+	tracer oteltrace.Tracer
+}
+
+var _ oteltrace.Tracer = &shouldTraceTracer{}
+
+func (t *shouldTraceTracer) Start(ctx context.Context, spanName string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+	shouldTrace := policy.ShouldTrace(ctx)
+	if shouldTrace {
+		if t.debug {
+			t.logger.Info("starting span",
+				log.Bool("shouldTrace", shouldTrace),
+				log.String("spanName", spanName))
+		}
+		return t.tracer.Start(ctx, spanName, opts...)
+	}
+	if t.debug {
+		t.logger.Info("starting no-op span",
+			log.Bool("shouldTrace", shouldTrace),
+			log.String("spanName", spanName))
+	}
+	return otelNoOpTracer.Start(ctx, spanName, opts...)
+}

--- a/internal/tracer/watch_test.go
+++ b/internal/tracer/watch_test.go
@@ -44,7 +44,10 @@ func TestConfigWatcher(t *testing.T) {
 		update()
 
 		// should all be no-op
-		assert.Equal(t, oteltrace.NewNoopTracerProvider().Tracer(""), switchableOTel.Tracer(""))
+		assert.Equal(t,
+			oteltrace.NewNoopTracerProvider().Tracer(""),
+			// should be a wrapped tracer
+			switchableOTel.Tracer("").(*shouldTraceTracer).tracer)
 		assert.Equal(t, opentracing.NoopTracer{}, switchableOT.tracer)
 	})
 


### PR DESCRIPTION
Currently we rely on implementors to explicitly check `ShouldTrace`. This works implicitly through `internal/trace/ot` which guards against `ShouldTrace` and returns no-op OpenTracing tracers, which worked until we started moving code over to use OpenTelemetry libraries directly, where a similar guard was not implemented.

This wraps all tracers provided from the global switchable `oteltrace.TracerProvider` to only start spans when `ShouldTrace` evaluates to true without the caller having to do anything explicitly. Also updates `ShouldTrace` to respect global trace-all without requiring the context set.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start` and see all the no-op logs coming through with `observability.tracing: { debug: true }` with `sampling: selective` or `sampling: none`

