### PR TITLE
dev/sg: Disable forced TTY and forced color in NewOutput

### DIFF
--- a/dev/sg/internal/std/output.go
+++ b/dev/sg/internal/std/output.go
@@ -33,9 +33,7 @@ func NewOutput(dst io.Writer, verbose bool) *Output {
 
 	return &Output{
 		Output: output.NewOutput(dst, output.OutputOpts{
-			ForceColor: false,
-			ForceTTY:   false,
-			Verbose:    verbose,
+			Verbose: verbose,
 		}),
 		buildkite: inBuildkite,
 	}

--- a/dev/sg/internal/std/output.go
+++ b/dev/sg/internal/std/output.go
@@ -33,8 +33,8 @@ func NewOutput(dst io.Writer, verbose bool) *Output {
 
 	return &Output{
 		Output: output.NewOutput(dst, output.OutputOpts{
-			ForceColor: true,
-			ForceTTY:   true,
+			ForceColor: false,
+			ForceTTY:   false,
 			Verbose:    verbose,
 		}),
 		buildkite: inBuildkite,


### PR DESCRIPTION
Fix for the error message seen in #41838 #39687 #41507 and #42136 when running `sg` when stdout is not a terminal (e.g. when piping to another comand).

```
❗️ An error was returned when detecting the terminal size and capabilities:
   
   GetWinsize: inappropriate ioctl for device
```

Disabling `forceTTY` allows terminal detection to work and avoids calling `GetWinSize` on a non-TTY.

Also disable `forceColor` based on the same rationale.

Worked on during sg hack hour with @mucles and @danieldides 

## Test plan

**Before**

```
go run ./dev/sg version | less -r
```

```
❗️ An error was returned when detecting the terminal size and capabilities:
   
   GetWinsize: inappropriate ioctl for device
   
   Execution will continue, but please report this, along with your operating
   system, terminal, and any other details, to:
     https://github.com/sourcegraph/sourcegraph/issues/new
   
dev
``` 

**After**

```
go run ./dev/sg version | less -r
```
```
dev
```
