### PR TITLE
improve query performance to extract series data

### DIFF
--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -276,7 +276,7 @@ const fullVectorSeriesAggregation = `
 SELECT sub.series_id, sub.interval_time, SUM(sub.value) as value, sub.capture FROM (
 	SELECT sp.repo_name_id, sp.series_id, date_trunc('seconds', sp.time) AS interval_time, MAX(value) as value, capture
 	FROM (  select * from series_points
-			union
+			union all
 			select * from series_points_snapshots
 	) AS sp
 	%s

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -192,14 +192,14 @@ func (s *Store) LoadSeriesInMem(ctx context.Context, opts SeriesPointsOpts) (poi
 	}
 
 	q := `select date_trunc('seconds', sp.time) AS interval_time, max(value), repo_id, capture FROM (
-				select * from series_points
-				union
-				select * from series_points_snapshots
-				) as sp
-		  JOIN repo_names rn ON sp.repo_name_id = rn.id
-          where %s
-		  GROUP BY sp.series_id, interval_time, sp.repo_id, capture
-;`
+					select * from series_points
+					union all
+					select * from series_points_snapshots
+					) as sp
+			  %s
+	          where %s
+			  GROUP BY sp.series_id, interval_time, sp.repo_id, capture
+	;`
 	fullQ := seriesPointsQuery(q, opts)
 	err = s.query(ctx, fullQ, func(sc scanner) (err error) {
 		var row loadStruct
@@ -279,7 +279,7 @@ SELECT sub.series_id, sub.interval_time, SUM(sub.value) as value, sub.capture FR
 			union
 			select * from series_points_snapshots
 	) AS sp
-	JOIN repo_names rn ON sp.repo_name_id = rn.id
+	%s
 	WHERE %s
 	GROUP BY sp.series_id, interval_time, sp.repo_name_id, capture
 	ORDER BY sp.series_id, interval_time, sp.repo_name_id
@@ -304,8 +304,14 @@ func seriesPointsQuery(baseQuery string, opts SeriesPointsOpts) *sqlf.Query {
 	if opts.Limit > 0 {
 		limitClause = fmt.Sprintf("LIMIT %d", opts.Limit)
 	}
+	repoFilterJoinClause := " "
+	if len(opts.IncludeRepoRegex) > 0 || len(opts.ExcludeRepoRegex) > 0 {
+		repoFilterJoinClause = ` JOIN repo_names rn ON sp.repo_name_id = rn.id `
+	}
+
+	queryWithJoin := fmt.Sprintf(baseQuery, repoFilterJoinClause, `%s`) // this is a little janky
 	return sqlf.Sprintf(
-		baseQuery+limitClause,
+		queryWithJoin+limitClause,
 		sqlf.Join(preds, "\n AND "),
 	)
 }


### PR DESCRIPTION
@chwarwick and I found two major performance improvements when inspecting our query to load points:
1. We were using `union` instead of `union all` which was causing a sort based on a 4 dimensional key that was about 90% of the query cost
2. We are joining `repo_names` even if we aren't filtering on the repo name.

In practice we were able to see approximately a 10x improvement, even such that we could load an insight with 10 million rows in approx 5 seconds (down from 75, failing due to proxy timeout).

I will have better benchmarks once merged and pointed towards k8s.


## Test plan

Using the all insights page to confirm correctness and speed.
