### PR TITLE
Disable terminal cursor toggling when not in a terminal

### DIFF
--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -131,11 +131,13 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 func (o *Output) Lock() {
 	o.lock.Lock()
 
-	// Hide the cursor while we update: this reduces the jitteriness of the
-	// whole thing, and some terminals are smart enough to make the update we're
-	// about to render atomic if the cursor is hidden for a short length of
-	// time.
-	o.w.Write([]byte("\033[?25l"))
+	if o.caps.Isatty {
+		// Hide the cursor while we update: this reduces the jitteriness of the
+		// whole thing, and some terminals are smart enough to make the update we're
+		// about to render atomic if the cursor is hidden for a short length of
+		// time.
+		o.w.Write([]byte("\033[?25l"))
+	}
 }
 
 func (o *Output) SetVerbose() {
@@ -151,8 +153,10 @@ func (o *Output) UnsetVerbose() {
 }
 
 func (o *Output) Unlock() {
-	// Show the cursor once more.
-	o.w.Write([]byte("\033[?25h"))
+	if o.caps.Isatty {
+		// Show the cursor once more.
+		o.w.Write([]byte("\033[?25h"))
+	}
 
 	o.lock.Unlock()
 }


### PR DESCRIPTION
Fix for the cursor escape codes polluting the output when `lib/output` is writing to a non-terminal (e.g. when piped to another command)

The escape code `[?25l` hides the terminal cursor and `[?25h` unhides the terminal cursor.

This assumes that TTY detection is working accurately so in the context of `sg` (where we observed this and tested it) it relies on disabling `forceTTY` in #42017 

From sg hacking hour with @mucles and @danieldides

## Test plan

**Before**

```
go run ./dev/sg version | less
```

(omitting the error message that should get fixed in #42017)

```
ESC[?25hESC[?25ldev
ESC[?25h
```

**After**
```
go run ./dev/sg version | less
```
```
dev
```
