### PR TITLE
Remove tracking codes from shareable URLs in IDE and browser extensions

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
+- Remove tracking parameters from all shareable URLs [pull/42022](https://github.com/sourcegraph/sourcegraph/pull/42022)
+
 ## Chrome v22.9.14.1335, Firefox v22.9.14.1616, Safari v1.15
 
 - Fix code-intel issue on GitHub Enterprise: [pull/41646](https://github.com/sourcegraph/sourcegraph/pull/41646)

--- a/client/browser/src/end-to-end/phabricator.test.ts
+++ b/client/browser/src/end-to-end/phabricator.test.ts
@@ -78,7 +78,7 @@ async function addPhabricatorRepo(driver: Driver): Promise<void> {
     // Activate the repo and wait for it to clone
     await driver.page.goto(PHABRICATOR_BASE_URL + '/source/jrpc/manage/')
     const activateButton = await driver.page.waitForSelector('a[href="/source/jrpc/edit/activate/"]')
-    const buttonLabel = ((await (await activateButton!.getProperty('textContent')).jsonValue()) as string).trim()
+    const buttonLabel = (await (await activateButton!.getProperty('textContent')).jsonValue()).trim()
     // Don't click if it says "Deactivate Repository"
     if (buttonLabel === 'Activate Repository') {
         await activateButton!.click()

--- a/client/browser/src/end-to-end/shared.ts
+++ b/client/browser/src/end-to-end/shared.ts
@@ -5,7 +5,6 @@ import puppeteer from 'puppeteer'
 
 import { Driver } from '@sourcegraph/shared/src/testing/driver'
 import { retry } from '@sourcegraph/shared/src/testing/utils'
-import { createURLWithUTM } from '@sourcegraph/shared/src/tracking/utm'
 
 /**
  * Defines e2e tests for a single-file page of a code host.
@@ -59,11 +58,8 @@ export function testSingleFilePage({
                                 '[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]'
                             )?.href
                     ),
-                    createURLWithUTM(
-                        new URL(
-                            `${sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go`
-                        ),
-                        { utm_source: `${getDriver().browserType}-extension`, utm_campaign: 'open-on-sourcegraph' }
+                    new URL(
+                        `${sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go`
                     ).href
                 )
             })

--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -7,7 +7,6 @@ import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/dri
 import { setupExtensionMocking, simpleHoverProvider } from '@sourcegraph/shared/src/testing/integration/mockExtension'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 import { readEnvironmentBoolean, readEnvironmentString, retry } from '@sourcegraph/shared/src/testing/utils'
-import { createURLWithUTM } from '@sourcegraph/shared/src/tracking/utm'
 
 import { BrowserIntegrationTestContext, createBrowserIntegrationTestContext } from './context'
 import { closeInstallPageTab, percySnapshot } from './shared'
@@ -143,11 +142,8 @@ describe('GitHub', () => {
                             '[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]'
                         )?.href
                 ),
-                createURLWithUTM(
-                    new URL(
-                        `${driver.sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go`
-                    ),
-                    { utm_source: `${driver.browserType}-extension`, utm_campaign: 'open-on-sourcegraph' }
+                new URL(
+                    `${driver.sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go`
                 ).href
             )
         })

--- a/client/browser/src/integration/gitlab.test.ts
+++ b/client/browser/src/integration/gitlab.test.ts
@@ -5,7 +5,6 @@ import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/dri
 import { setupExtensionMocking, simpleHoverProvider } from '@sourcegraph/shared/src/testing/integration/mockExtension'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 import { readEnvironmentString, retry } from '@sourcegraph/shared/src/testing/utils'
-import { createURLWithUTM } from '@sourcegraph/shared/src/tracking/utm'
 
 import { BrowserIntegrationTestContext, createBrowserIntegrationTestContext } from './context'
 import { closeInstallPageTab } from './shared'
@@ -140,11 +139,8 @@ describe('GitLab', () => {
                             '[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]'
                         )?.href
                 ),
-                createURLWithUTM(
-                    new URL(
-                        `${driver.sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go`
-                    ),
-                    { utm_source: `${driver.browserType}-extension`, utm_campaign: 'open-on-sourcegraph' }
+                new URL(
+                    `${driver.sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go`
                 ).href
             )
         })

--- a/client/browser/src/shared/components/OpenOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenOnSourcegraph.tsx
@@ -2,11 +2,9 @@ import * as React from 'react'
 
 import classNames from 'classnames'
 
-import { createURLWithUTM } from '@sourcegraph/shared/src/tracking/utm'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { OpenInSourcegraphProps } from '../repo'
-import { getPlatformName } from '../util/context'
 
 import { SourcegraphIconButton, SourcegraphIconButtonProps } from './SourcegraphIconButton'
 
@@ -19,10 +17,7 @@ export const OpenOnSourcegraph: React.FunctionComponent<React.PropsWithChildren<
     className,
     ...props
 }) => {
-    const url = createURLWithUTM(new URL(toPrettyBlobURL({ repoName, revision, filePath }), sourcegraphURL), {
-        utm_source: getPlatformName(),
-        utm_campaign: 'open-on-sourcegraph',
-    })
+    const url = new URL(toPrettyBlobURL({ repoName, revision, filePath }), sourcegraphURL)
     return (
         <SourcegraphIconButton
             {...props}

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Removed
 
+- Removed tracking parameters from all shareable URLs [pull/42022](https://github.com/sourcegraph/sourcegraph/pull/42022)
+
 ### Fixed
 
 ### Security

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/URLBuilder.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/URLBuilder.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.website;
 
-import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.config.ConfigUtil;
@@ -21,13 +20,13 @@ public class URLBuilder {
             + "&start_col=" + URLEncoder.encode(Integer.toString(start.column), StandardCharsets.UTF_8)) : "")
             + (end != null ? ("&end_row=" + URLEncoder.encode(Integer.toString(end.line), StandardCharsets.UTF_8)
             + "&end_col=" + URLEncoder.encode(Integer.toString(end.column), StandardCharsets.UTF_8)) : "")
-            + "&" + buildMarketingParams();
+            + "&" + buildVersionParams();
     }
 
     @NotNull
     public static String buildEditorSearchUrl(@NotNull Project project, @NotNull String search, @Nullable String remoteUrl, @Nullable String branchName) {
         String url = ConfigUtil.getSourcegraphUrl(project) + "-/editor"
-            + "?" + buildMarketingParams()
+            + "?" + buildVersionParams()
             + "&search=" + URLEncoder.encode(search, StandardCharsets.UTF_8);
 
         if (remoteUrl != null) {
@@ -48,18 +47,12 @@ public class URLBuilder {
             + (start != null ? ("L" + URLEncoder.encode(Integer.toString(start.line + 1), StandardCharsets.UTF_8)
             + ":" + URLEncoder.encode(Integer.toString(start.column + 1), StandardCharsets.UTF_8)) : "")
             + (end != null ? ("-" + URLEncoder.encode(Integer.toString(end.line + 1), StandardCharsets.UTF_8)
-            + ":" + URLEncoder.encode(Integer.toString(end.column + 1), StandardCharsets.UTF_8)) : "")
-            + "&" + buildMarketingParams();
+            + ":" + URLEncoder.encode(Integer.toString(end.column + 1), StandardCharsets.UTF_8)) : "");
     }
 
     @NotNull
-    private static String buildMarketingParams() {
-        String productName = ApplicationInfo.getInstance().getVersionName();
-        String productVersion = ApplicationInfo.getInstance().getFullVersion();
-
+    private static String buildVersionParams() {
         return "editor=" + URLEncoder.encode("JetBrains", StandardCharsets.UTF_8)
-            + "&version=v" + URLEncoder.encode(ConfigUtil.getPluginVersion(), StandardCharsets.UTF_8)
-            + "&utm_product_name=" + URLEncoder.encode(productName, StandardCharsets.UTF_8)
-            + "&utm_product_version=" + URLEncoder.encode(productVersion, StandardCharsets.UTF_8);
+            + "&version=v" + URLEncoder.encode(ConfigUtil.getPluginVersion(), StandardCharsets.UTF_8);
     }
 }

--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 
 ### Changes
 
+- Remove tracking parameters from all shareable URLs [pull/42022](https://github.com/sourcegraph/sourcegraph/pull/42022)
+
 ### Fixes
 
 ## 2.2.9

--- a/client/vscode/src/commands/browserActionsNode.ts
+++ b/client/vscode/src/commands/browserActionsNode.ts
@@ -1,7 +1,7 @@
 import vscode, { env } from 'vscode'
 
 import { getSourcegraphFileUrl, repoInfo } from './git-helpers'
-import { generateSourcegraphBlobLink, vsceUtms } from './initialize'
+import { generateSourcegraphBlobLink } from './initialize'
 /**
  * Open active file in the browser on the configured Sourcegraph instance.
  */
@@ -45,7 +45,7 @@ export async function browserActions(action: string, logRedirectEvent: (uri: str
                 return
             }
         }
-        sourcegraphUrl = getSourcegraphFileUrl(instanceUrl, remoteURL, branch, fileRelative, editor) + vsceUtms
+        sourcegraphUrl = getSourcegraphFileUrl(instanceUrl, remoteURL, branch, fileRelative, editor)
     }
     // Decode URI
     const decodedUri = decodeURIComponent(sourcegraphUrl)

--- a/client/vscode/src/commands/browserActionsWeb.ts
+++ b/client/vscode/src/commands/browserActionsWeb.ts
@@ -1,6 +1,6 @@
 import vscode, { env } from 'vscode'
 
-import { generateSourcegraphBlobLink, vsceUtms } from './initialize'
+import { generateSourcegraphBlobLink } from './initialize'
 
 /**
  * browser Actions for Web does not run node modules to get git info
@@ -28,7 +28,7 @@ export async function browserActions(action: string, logRedirectEvent: (uri: str
         const repoInfo = uri.fsPath.split('/')
         const repositoryName = `${repoInfo[1]}/${repoInfo[2]}`
         const filePath = repoInfo.length === 4 ? repoInfo[3] : repoInfo.slice(3).join('/')
-        sourcegraphUrl = `${instanceUrl}github.com/${repositoryName}/-/blob/${filePath || ''}${vsceUtms}`
+        sourcegraphUrl = `${instanceUrl}github.com/${repositoryName}/-/blob/${filePath || ''}`
     } else {
         await vscode.window.showInformationMessage('Non-Remote files are not supported on VS Code Web currently')
     }

--- a/client/vscode/src/commands/initialize.ts
+++ b/client/vscode/src/commands/initialize.ts
@@ -4,7 +4,6 @@ import { EventSource } from '@sourcegraph/shared/src/graphql-operations'
 
 import { version } from '../../package.json'
 import { logEvent } from '../backend/eventLogger'
-import { VSCE_COMMANDS_PARAMS } from '../common/links'
 import { SourcegraphUri } from '../file-system/SourcegraphUri'
 import { LocalStorageService, ANONYMOUS_USER_ID_KEY } from '../settings/LocalStorageService'
 
@@ -39,7 +38,7 @@ export function initializeCodeSharingCommands(
             }
             const uri = `${instanceUrl}/search?q=context:global+${encodeURIComponent(
                 selectedQuery
-            )}&patternType=literal${vsceUtms}`
+            )}&patternType=literal`
             await vscode.env.openExternal(vscode.Uri.parse(uri))
         })
     )
@@ -57,8 +56,6 @@ export function initializeCodeSharingCommands(
     }
 }
 
-export const vsceUtms = '&' + VSCE_COMMANDS_PARAMS
-
 export function generateSourcegraphBlobLink(
     uri: vscode.Uri,
     startLine: number,
@@ -74,6 +71,6 @@ export function generateSourcegraphBlobLink(
     const finalUri = new URL(decodedUri.uri)
     finalUri.search = `L${encodeURIComponent(String(startLine))}:${encodeURIComponent(
         String(startChar)
-    )}-${encodeURIComponent(String(endLine))}:${encodeURIComponent(String(endChar))}${vsceUtms}`
+    )}-${encodeURIComponent(String(endLine))}:${encodeURIComponent(String(endChar))}`
     return finalUri.href.replace(finalUri.protocol, instanceUrl.protocol)
 }

--- a/client/vscode/src/common/links.ts
+++ b/client/vscode/src/common/links.ts
@@ -23,13 +23,6 @@ const VSCE_LINK_PARAMS_TOKEN_REDIRECT = {
     returnTo: 'user/settings/tokens/new',
 }
 const VSCE_LINK_PARAMS_EDITOR = { editor: 'vscode' }
-// UTM for Commands
-const VSCE_LINK_PARAMS_UTM_COMMANDS = {
-    utm_campaign: 'vscode-extension',
-    utm_medium: 'direct_traffic',
-    utm_source: 'vscode-extension',
-    utm_content: 'vsce-commands',
-}
 // UTM for Sidebar actions
 const VSCE_LINK_PARAMS_UTM_SIDEBAR = {
     utm_campaign: 'vsce-sign-up',
@@ -37,7 +30,6 @@ const VSCE_LINK_PARAMS_UTM_SIDEBAR = {
     utm_source: 'sidebar',
     utm_content: 'sign-up',
 }
-export const VSCE_COMMANDS_PARAMS = new URLSearchParams({ ...VSCE_LINK_PARAMS_UTM_COMMANDS }).toString()
 // MISC
 export const VSCE_LINK_MARKETPLACE = 'https://marketplace.visualstudio.com/items?itemName=sourcegraph.sourcegraph'
 export const VSCE_LINK_USER_DOCS =


### PR DESCRIPTION
Closes #41987
Closes #41988

We're removing all UTM campaign parameters from the IDE and browser extensions. Time for cleaner URLs! Some context on the decision [in this Slack thread](https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1663923103346749).

I've conveniently combined all the changes into one PR but I can split it up if someone wants 😅.

## Test plan

### Browser extension

https://www.loom.com/share/988eb32903474ded9ac42a4eec266831

### VS Code

https://www.loom.com/share/e2021b0d5668447ca1c7fe3949c66c8e

### JetBrains

https://www.loom.com/share/1a6b4a96270747d0aa09ffc7835e90d1


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-remove-shareable-urls-tracking.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dowqloaveg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

