### PR TITLE
fix sg backgrounding when executing shell commands on Linux

### DIFF
--- a/dev/sg/internal/usershell/command.go
+++ b/dev/sg/internal/usershell/command.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/sourcegraph/run"
@@ -37,17 +36,6 @@ func wrap(ctx context.Context, cmd string) wrapped {
 
 	case ShellType(ctx) == FishShell:
 		w.Command = fmt.Sprintf("fish || true; %s", cmd)
-
-	case runtime.GOOS == "linux":
-		// The default Ubuntu bashrc comes with a caveat that prevents the bashrc to be
-		// reloaded unless the shell is interactive. Therefore, we need to request for an
-		// interactive one.
-		//
-		// But because we are running an interactive shell, we also need to exit explictly.
-		// To avoid messing up with the output checking that depends on this function,
-		// we silence the exit commands, which otherwise, prints "exit".
-		w.Command = fmt.Sprintf("%s; \nexit $? 2>/dev/null", strings.TrimSpace(cmd))
-		w.ShellFlags = append(w.ShellFlags, "-i")
 
 	default:
 		// The above interactive shell approach fails on OSX because the default shell configuration


### PR DESCRIPTION
`sg` has a special case when running shell commands on Linux. We want it to run shell commands with the benefit of the user's bashrc so that we can check whether things work in their actual shell environment with aliases and other conveniences set up. But Ubuntu's default bashrc includes the following, which prevents the bashrc from running if the shell is non-interactive:

```
[ -z "$PS1" ] && return
```

Or in more recent Ubuntu versions:

```
case $- in
    *i*) ;;
      *) return;;
esac
```

This special handling, however, caused a bug (https://github.com/sourcegraph/sourcegraph/issues/35639) where the `sg` (on Linux using bash, at least for bash 5.1.16) would stop (i.e., become a background job in the shell). I was unable to fix this even with an empty bashrc file, and the workaround seemed hacky to begin with, so I felt the best solution was to just remove this. The consequence is that `sg` will not run the checks in the user's true shell environment; env vars will be inherited, but aliases will not be.

Fixes https://github.com/sourcegraph/sourcegraph/issues/35639.




## Test plan

`sg` only. Tested `sg setup` on Linux (`Pop!_OS 22.04`).