### PR TITLE
fix typo Get{Lastest => Latest}

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
@@ -32,7 +32,7 @@ type DBStoreShim struct {
 }
 
 type IndexingSettingStore interface {
-	GetLastestSchemaSettings(context.Context, api.SettingsSubject) (*schema.Settings, error)
+	GetLatestSchemaSettings(context.Context, api.SettingsSubject) (*schema.Settings, error)
 }
 
 type IndexingRepoStore interface {

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
@@ -2388,9 +2388,9 @@ func (c IndexingRepoStoreListMinimalReposFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel/indexing)
 // used for unit testing.
 type MockIndexingSettingStore struct {
-	// GetLastestSchemaSettingsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetLastestSchemaSettings.
-	GetLastestSchemaSettingsFunc *IndexingSettingStoreGetLastestSchemaSettingsFunc
+	// GetLatestSchemaSettingsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetLatestSchemaSettings.
+	GetLatestSchemaSettingsFunc *IndexingSettingStoreGetLatestSchemaSettingsFunc
 }
 
 // NewMockIndexingSettingStore creates a new mock of the
@@ -2398,7 +2398,7 @@ type MockIndexingSettingStore struct {
 // results, unless overwritten.
 func NewMockIndexingSettingStore() *MockIndexingSettingStore {
 	return &MockIndexingSettingStore{
-		GetLastestSchemaSettingsFunc: &IndexingSettingStoreGetLastestSchemaSettingsFunc{
+		GetLatestSchemaSettingsFunc: &IndexingSettingStoreGetLatestSchemaSettingsFunc{
 			defaultHook: func(context.Context, api.SettingsSubject) (r0 *schema.Settings, r1 error) {
 				return
 			},
@@ -2411,9 +2411,9 @@ func NewMockIndexingSettingStore() *MockIndexingSettingStore {
 // overwritten.
 func NewStrictMockIndexingSettingStore() *MockIndexingSettingStore {
 	return &MockIndexingSettingStore{
-		GetLastestSchemaSettingsFunc: &IndexingSettingStoreGetLastestSchemaSettingsFunc{
+		GetLatestSchemaSettingsFunc: &IndexingSettingStoreGetLatestSchemaSettingsFunc{
 			defaultHook: func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
-				panic("unexpected invocation of MockIndexingSettingStore.GetLastestSchemaSettings")
+				panic("unexpected invocation of MockIndexingSettingStore.GetLatestSchemaSettings")
 			},
 		},
 	}
@@ -2424,43 +2424,43 @@ func NewStrictMockIndexingSettingStore() *MockIndexingSettingStore {
 // implementation, unless overwritten.
 func NewMockIndexingSettingStoreFrom(i IndexingSettingStore) *MockIndexingSettingStore {
 	return &MockIndexingSettingStore{
-		GetLastestSchemaSettingsFunc: &IndexingSettingStoreGetLastestSchemaSettingsFunc{
-			defaultHook: i.GetLastestSchemaSettings,
+		GetLatestSchemaSettingsFunc: &IndexingSettingStoreGetLatestSchemaSettingsFunc{
+			defaultHook: i.GetLatestSchemaSettings,
 		},
 	}
 }
 
-// IndexingSettingStoreGetLastestSchemaSettingsFunc describes the behavior
-// when the GetLastestSchemaSettings method of the parent
+// IndexingSettingStoreGetLatestSchemaSettingsFunc describes the behavior
+// when the GetLatestSchemaSettings method of the parent
 // MockIndexingSettingStore instance is invoked.
-type IndexingSettingStoreGetLastestSchemaSettingsFunc struct {
+type IndexingSettingStoreGetLatestSchemaSettingsFunc struct {
 	defaultHook func(context.Context, api.SettingsSubject) (*schema.Settings, error)
 	hooks       []func(context.Context, api.SettingsSubject) (*schema.Settings, error)
-	history     []IndexingSettingStoreGetLastestSchemaSettingsFuncCall
+	history     []IndexingSettingStoreGetLatestSchemaSettingsFuncCall
 	mutex       sync.Mutex
 }
 
-// GetLastestSchemaSettings delegates to the next hook function in the queue
+// GetLatestSchemaSettings delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockIndexingSettingStore) GetLastestSchemaSettings(v0 context.Context, v1 api.SettingsSubject) (*schema.Settings, error) {
-	r0, r1 := m.GetLastestSchemaSettingsFunc.nextHook()(v0, v1)
-	m.GetLastestSchemaSettingsFunc.appendCall(IndexingSettingStoreGetLastestSchemaSettingsFuncCall{v0, v1, r0, r1})
+func (m *MockIndexingSettingStore) GetLatestSchemaSettings(v0 context.Context, v1 api.SettingsSubject) (*schema.Settings, error) {
+	r0, r1 := m.GetLatestSchemaSettingsFunc.nextHook()(v0, v1)
+	m.GetLatestSchemaSettingsFunc.appendCall(IndexingSettingStoreGetLatestSchemaSettingsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetLastestSchemaSettings method of the parent MockIndexingSettingStore
+// GetLatestSchemaSettings method of the parent MockIndexingSettingStore
 // instance is invoked and the hook queue is empty.
-func (f *IndexingSettingStoreGetLastestSchemaSettingsFunc) SetDefaultHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
+func (f *IndexingSettingStoreGetLatestSchemaSettingsFunc) SetDefaultHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetLastestSchemaSettings method of the parent MockIndexingSettingStore
+// GetLatestSchemaSettings method of the parent MockIndexingSettingStore
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *IndexingSettingStoreGetLastestSchemaSettingsFunc) PushHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
+func (f *IndexingSettingStoreGetLatestSchemaSettingsFunc) PushHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2468,20 +2468,20 @@ func (f *IndexingSettingStoreGetLastestSchemaSettingsFunc) PushHook(hook func(co
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *IndexingSettingStoreGetLastestSchemaSettingsFunc) SetDefaultReturn(r0 *schema.Settings, r1 error) {
+func (f *IndexingSettingStoreGetLatestSchemaSettingsFunc) SetDefaultReturn(r0 *schema.Settings, r1 error) {
 	f.SetDefaultHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *IndexingSettingStoreGetLastestSchemaSettingsFunc) PushReturn(r0 *schema.Settings, r1 error) {
+func (f *IndexingSettingStoreGetLatestSchemaSettingsFunc) PushReturn(r0 *schema.Settings, r1 error) {
 	f.PushHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
 		return r0, r1
 	})
 }
 
-func (f *IndexingSettingStoreGetLastestSchemaSettingsFunc) nextHook() func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
+func (f *IndexingSettingStoreGetLatestSchemaSettingsFunc) nextHook() func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2494,28 +2494,28 @@ func (f *IndexingSettingStoreGetLastestSchemaSettingsFunc) nextHook() func(conte
 	return hook
 }
 
-func (f *IndexingSettingStoreGetLastestSchemaSettingsFunc) appendCall(r0 IndexingSettingStoreGetLastestSchemaSettingsFuncCall) {
+func (f *IndexingSettingStoreGetLatestSchemaSettingsFunc) appendCall(r0 IndexingSettingStoreGetLatestSchemaSettingsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// IndexingSettingStoreGetLastestSchemaSettingsFuncCall objects describing
+// IndexingSettingStoreGetLatestSchemaSettingsFuncCall objects describing
 // the invocations of this function.
-func (f *IndexingSettingStoreGetLastestSchemaSettingsFunc) History() []IndexingSettingStoreGetLastestSchemaSettingsFuncCall {
+func (f *IndexingSettingStoreGetLatestSchemaSettingsFunc) History() []IndexingSettingStoreGetLatestSchemaSettingsFuncCall {
 	f.mutex.Lock()
-	history := make([]IndexingSettingStoreGetLastestSchemaSettingsFuncCall, len(f.history))
+	history := make([]IndexingSettingStoreGetLatestSchemaSettingsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// IndexingSettingStoreGetLastestSchemaSettingsFuncCall is an object that
-// describes an invocation of method GetLastestSchemaSettings on an instance
+// IndexingSettingStoreGetLatestSchemaSettingsFuncCall is an object that
+// describes an invocation of method GetLatestSchemaSettings on an instance
 // of MockIndexingSettingStore.
-type IndexingSettingStoreGetLastestSchemaSettingsFuncCall struct {
+type IndexingSettingStoreGetLatestSchemaSettingsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2532,13 +2532,13 @@ type IndexingSettingStoreGetLastestSchemaSettingsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c IndexingSettingStoreGetLastestSchemaSettingsFuncCall) Args() []interface{} {
+func (c IndexingSettingStoreGetLatestSchemaSettingsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c IndexingSettingStoreGetLastestSchemaSettingsFuncCall) Results() []interface{} {
+func (c IndexingSettingStoreGetLatestSchemaSettingsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -23,7 +23,7 @@ import (
 // SettingStore is a subset of the API exposed by the database.Settings() store.
 type SettingStore interface {
 	GetLatest(context.Context, api.SettingsSubject) (*api.Settings, error)
-	GetLastestSchemaSettings(context.Context, api.SettingsSubject) (*schema.Settings, error)
+	GetLatestSchemaSettings(context.Context, api.SettingsSubject) (*schema.Settings, error)
 }
 
 // InsightFilterArgs contains arguments that will filter out insights when discovered if matched.

--- a/enterprise/internal/insights/discovery/mocks_temp.go
+++ b/enterprise/internal/insights/discovery/mocks_temp.go
@@ -324,25 +324,25 @@ func (c RepoStoreListFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery)
 // used for unit testing.
 type MockSettingStore struct {
-	// GetLastestSchemaSettingsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetLastestSchemaSettings.
-	GetLastestSchemaSettingsFunc *SettingStoreGetLastestSchemaSettingsFunc
 	// GetLatestFunc is an instance of a mock function object controlling
 	// the behavior of the method GetLatest.
 	GetLatestFunc *SettingStoreGetLatestFunc
+	// GetLatestSchemaSettingsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetLatestSchemaSettings.
+	GetLatestSchemaSettingsFunc *SettingStoreGetLatestSchemaSettingsFunc
 }
 
 // NewMockSettingStore creates a new mock of the SettingStore interface. All
 // methods return zero values for all results, unless overwritten.
 func NewMockSettingStore() *MockSettingStore {
 	return &MockSettingStore{
-		GetLastestSchemaSettingsFunc: &SettingStoreGetLastestSchemaSettingsFunc{
-			defaultHook: func(context.Context, api.SettingsSubject) (r0 *schema.Settings, r1 error) {
+		GetLatestFunc: &SettingStoreGetLatestFunc{
+			defaultHook: func(context.Context, api.SettingsSubject) (r0 *api.Settings, r1 error) {
 				return
 			},
 		},
-		GetLatestFunc: &SettingStoreGetLatestFunc{
-			defaultHook: func(context.Context, api.SettingsSubject) (r0 *api.Settings, r1 error) {
+		GetLatestSchemaSettingsFunc: &SettingStoreGetLatestSchemaSettingsFunc{
+			defaultHook: func(context.Context, api.SettingsSubject) (r0 *schema.Settings, r1 error) {
 				return
 			},
 		},
@@ -353,14 +353,14 @@ func NewMockSettingStore() *MockSettingStore {
 // interface. All methods panic on invocation, unless overwritten.
 func NewStrictMockSettingStore() *MockSettingStore {
 	return &MockSettingStore{
-		GetLastestSchemaSettingsFunc: &SettingStoreGetLastestSchemaSettingsFunc{
-			defaultHook: func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
-				panic("unexpected invocation of MockSettingStore.GetLastestSchemaSettings")
-			},
-		},
 		GetLatestFunc: &SettingStoreGetLatestFunc{
 			defaultHook: func(context.Context, api.SettingsSubject) (*api.Settings, error) {
 				panic("unexpected invocation of MockSettingStore.GetLatest")
+			},
+		},
+		GetLatestSchemaSettingsFunc: &SettingStoreGetLatestSchemaSettingsFunc{
+			defaultHook: func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
+				panic("unexpected invocation of MockSettingStore.GetLatestSchemaSettings")
 			},
 		},
 	}
@@ -371,125 +371,13 @@ func NewStrictMockSettingStore() *MockSettingStore {
 // overwritten.
 func NewMockSettingStoreFrom(i SettingStore) *MockSettingStore {
 	return &MockSettingStore{
-		GetLastestSchemaSettingsFunc: &SettingStoreGetLastestSchemaSettingsFunc{
-			defaultHook: i.GetLastestSchemaSettings,
-		},
 		GetLatestFunc: &SettingStoreGetLatestFunc{
 			defaultHook: i.GetLatest,
 		},
+		GetLatestSchemaSettingsFunc: &SettingStoreGetLatestSchemaSettingsFunc{
+			defaultHook: i.GetLatestSchemaSettings,
+		},
 	}
-}
-
-// SettingStoreGetLastestSchemaSettingsFunc describes the behavior when the
-// GetLastestSchemaSettings method of the parent MockSettingStore instance
-// is invoked.
-type SettingStoreGetLastestSchemaSettingsFunc struct {
-	defaultHook func(context.Context, api.SettingsSubject) (*schema.Settings, error)
-	hooks       []func(context.Context, api.SettingsSubject) (*schema.Settings, error)
-	history     []SettingStoreGetLastestSchemaSettingsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetLastestSchemaSettings delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockSettingStore) GetLastestSchemaSettings(v0 context.Context, v1 api.SettingsSubject) (*schema.Settings, error) {
-	r0, r1 := m.GetLastestSchemaSettingsFunc.nextHook()(v0, v1)
-	m.GetLastestSchemaSettingsFunc.appendCall(SettingStoreGetLastestSchemaSettingsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetLastestSchemaSettings method of the parent MockSettingStore instance
-// is invoked and the hook queue is empty.
-func (f *SettingStoreGetLastestSchemaSettingsFunc) SetDefaultHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetLastestSchemaSettings method of the parent MockSettingStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *SettingStoreGetLastestSchemaSettingsFunc) PushHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *SettingStoreGetLastestSchemaSettingsFunc) SetDefaultReturn(r0 *schema.Settings, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *SettingStoreGetLastestSchemaSettingsFunc) PushReturn(r0 *schema.Settings, r1 error) {
-	f.PushHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
-		return r0, r1
-	})
-}
-
-func (f *SettingStoreGetLastestSchemaSettingsFunc) nextHook() func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *SettingStoreGetLastestSchemaSettingsFunc) appendCall(r0 SettingStoreGetLastestSchemaSettingsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// SettingStoreGetLastestSchemaSettingsFuncCall objects describing the
-// invocations of this function.
-func (f *SettingStoreGetLastestSchemaSettingsFunc) History() []SettingStoreGetLastestSchemaSettingsFuncCall {
-	f.mutex.Lock()
-	history := make([]SettingStoreGetLastestSchemaSettingsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// SettingStoreGetLastestSchemaSettingsFuncCall is an object that describes
-// an invocation of method GetLastestSchemaSettings on an instance of
-// MockSettingStore.
-type SettingStoreGetLastestSchemaSettingsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.SettingsSubject
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 *schema.Settings
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c SettingStoreGetLastestSchemaSettingsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c SettingStoreGetLastestSchemaSettingsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // SettingStoreGetLatestFunc describes the behavior when the GetLatest
@@ -597,5 +485,116 @@ func (c SettingStoreGetLatestFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c SettingStoreGetLatestFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// SettingStoreGetLatestSchemaSettingsFunc describes the behavior when the
+// GetLatestSchemaSettings method of the parent MockSettingStore instance is
+// invoked.
+type SettingStoreGetLatestSchemaSettingsFunc struct {
+	defaultHook func(context.Context, api.SettingsSubject) (*schema.Settings, error)
+	hooks       []func(context.Context, api.SettingsSubject) (*schema.Settings, error)
+	history     []SettingStoreGetLatestSchemaSettingsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetLatestSchemaSettings delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockSettingStore) GetLatestSchemaSettings(v0 context.Context, v1 api.SettingsSubject) (*schema.Settings, error) {
+	r0, r1 := m.GetLatestSchemaSettingsFunc.nextHook()(v0, v1)
+	m.GetLatestSchemaSettingsFunc.appendCall(SettingStoreGetLatestSchemaSettingsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetLatestSchemaSettings method of the parent MockSettingStore instance is
+// invoked and the hook queue is empty.
+func (f *SettingStoreGetLatestSchemaSettingsFunc) SetDefaultHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetLatestSchemaSettings method of the parent MockSettingStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *SettingStoreGetLatestSchemaSettingsFunc) PushHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *SettingStoreGetLatestSchemaSettingsFunc) SetDefaultReturn(r0 *schema.Settings, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *SettingStoreGetLatestSchemaSettingsFunc) PushReturn(r0 *schema.Settings, r1 error) {
+	f.PushHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
+		return r0, r1
+	})
+}
+
+func (f *SettingStoreGetLatestSchemaSettingsFunc) nextHook() func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SettingStoreGetLatestSchemaSettingsFunc) appendCall(r0 SettingStoreGetLatestSchemaSettingsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of SettingStoreGetLatestSchemaSettingsFuncCall
+// objects describing the invocations of this function.
+func (f *SettingStoreGetLatestSchemaSettingsFunc) History() []SettingStoreGetLatestSchemaSettingsFuncCall {
+	f.mutex.Lock()
+	history := make([]SettingStoreGetLatestSchemaSettingsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SettingStoreGetLatestSchemaSettingsFuncCall is an object that describes
+// an invocation of method GetLatestSchemaSettings on an instance of
+// MockSettingStore.
+type SettingStoreGetLatestSchemaSettingsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.SettingsSubject
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *schema.Settings
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SettingStoreGetLatestSchemaSettingsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SettingStoreGetLatestSchemaSettingsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -33859,12 +33859,12 @@ type MockSettingsStore struct {
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *SettingsStoreDoneFunc
-	// GetLastestSchemaSettingsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetLastestSchemaSettings.
-	GetLastestSchemaSettingsFunc *SettingsStoreGetLastestSchemaSettingsFunc
 	// GetLatestFunc is an instance of a mock function object controlling
 	// the behavior of the method GetLatest.
 	GetLatestFunc *SettingsStoreGetLatestFunc
+	// GetLatestSchemaSettingsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetLatestSchemaSettings.
+	GetLatestSchemaSettingsFunc *SettingsStoreGetLatestSchemaSettingsFunc
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *SettingsStoreHandleFunc
@@ -33893,13 +33893,13 @@ func NewMockSettingsStore() *MockSettingsStore {
 				return
 			},
 		},
-		GetLastestSchemaSettingsFunc: &SettingsStoreGetLastestSchemaSettingsFunc{
-			defaultHook: func(context.Context, api.SettingsSubject) (r0 *schema.Settings, r1 error) {
+		GetLatestFunc: &SettingsStoreGetLatestFunc{
+			defaultHook: func(context.Context, api.SettingsSubject) (r0 *api.Settings, r1 error) {
 				return
 			},
 		},
-		GetLatestFunc: &SettingsStoreGetLatestFunc{
-			defaultHook: func(context.Context, api.SettingsSubject) (r0 *api.Settings, r1 error) {
+		GetLatestSchemaSettingsFunc: &SettingsStoreGetLatestSchemaSettingsFunc{
+			defaultHook: func(context.Context, api.SettingsSubject) (r0 *schema.Settings, r1 error) {
 				return
 			},
 		},
@@ -33940,14 +33940,14 @@ func NewStrictMockSettingsStore() *MockSettingsStore {
 				panic("unexpected invocation of MockSettingsStore.Done")
 			},
 		},
-		GetLastestSchemaSettingsFunc: &SettingsStoreGetLastestSchemaSettingsFunc{
-			defaultHook: func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
-				panic("unexpected invocation of MockSettingsStore.GetLastestSchemaSettings")
-			},
-		},
 		GetLatestFunc: &SettingsStoreGetLatestFunc{
 			defaultHook: func(context.Context, api.SettingsSubject) (*api.Settings, error) {
 				panic("unexpected invocation of MockSettingsStore.GetLatest")
+			},
+		},
+		GetLatestSchemaSettingsFunc: &SettingsStoreGetLatestSchemaSettingsFunc{
+			defaultHook: func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
+				panic("unexpected invocation of MockSettingsStore.GetLatestSchemaSettings")
 			},
 		},
 		HandleFunc: &SettingsStoreHandleFunc{
@@ -33984,11 +33984,11 @@ func NewMockSettingsStoreFrom(i SettingsStore) *MockSettingsStore {
 		DoneFunc: &SettingsStoreDoneFunc{
 			defaultHook: i.Done,
 		},
-		GetLastestSchemaSettingsFunc: &SettingsStoreGetLastestSchemaSettingsFunc{
-			defaultHook: i.GetLastestSchemaSettings,
-		},
 		GetLatestFunc: &SettingsStoreGetLatestFunc{
 			defaultHook: i.GetLatest,
+		},
+		GetLatestSchemaSettingsFunc: &SettingsStoreGetLatestSchemaSettingsFunc{
+			defaultHook: i.GetLatestSchemaSettings,
 		},
 		HandleFunc: &SettingsStoreHandleFunc{
 			defaultHook: i.Handle,
@@ -34225,118 +34225,6 @@ func (c SettingsStoreDoneFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// SettingsStoreGetLastestSchemaSettingsFunc describes the behavior when the
-// GetLastestSchemaSettings method of the parent MockSettingsStore instance
-// is invoked.
-type SettingsStoreGetLastestSchemaSettingsFunc struct {
-	defaultHook func(context.Context, api.SettingsSubject) (*schema.Settings, error)
-	hooks       []func(context.Context, api.SettingsSubject) (*schema.Settings, error)
-	history     []SettingsStoreGetLastestSchemaSettingsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetLastestSchemaSettings delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockSettingsStore) GetLastestSchemaSettings(v0 context.Context, v1 api.SettingsSubject) (*schema.Settings, error) {
-	r0, r1 := m.GetLastestSchemaSettingsFunc.nextHook()(v0, v1)
-	m.GetLastestSchemaSettingsFunc.appendCall(SettingsStoreGetLastestSchemaSettingsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetLastestSchemaSettings method of the parent MockSettingsStore instance
-// is invoked and the hook queue is empty.
-func (f *SettingsStoreGetLastestSchemaSettingsFunc) SetDefaultHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetLastestSchemaSettings method of the parent MockSettingsStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *SettingsStoreGetLastestSchemaSettingsFunc) PushHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *SettingsStoreGetLastestSchemaSettingsFunc) SetDefaultReturn(r0 *schema.Settings, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *SettingsStoreGetLastestSchemaSettingsFunc) PushReturn(r0 *schema.Settings, r1 error) {
-	f.PushHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
-		return r0, r1
-	})
-}
-
-func (f *SettingsStoreGetLastestSchemaSettingsFunc) nextHook() func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *SettingsStoreGetLastestSchemaSettingsFunc) appendCall(r0 SettingsStoreGetLastestSchemaSettingsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// SettingsStoreGetLastestSchemaSettingsFuncCall objects describing the
-// invocations of this function.
-func (f *SettingsStoreGetLastestSchemaSettingsFunc) History() []SettingsStoreGetLastestSchemaSettingsFuncCall {
-	f.mutex.Lock()
-	history := make([]SettingsStoreGetLastestSchemaSettingsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// SettingsStoreGetLastestSchemaSettingsFuncCall is an object that describes
-// an invocation of method GetLastestSchemaSettings on an instance of
-// MockSettingsStore.
-type SettingsStoreGetLastestSchemaSettingsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.SettingsSubject
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 *schema.Settings
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c SettingsStoreGetLastestSchemaSettingsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c SettingsStoreGetLastestSchemaSettingsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // SettingsStoreGetLatestFunc describes the behavior when the GetLatest
 // method of the parent MockSettingsStore instance is invoked.
 type SettingsStoreGetLatestFunc struct {
@@ -34442,6 +34330,118 @@ func (c SettingsStoreGetLatestFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c SettingsStoreGetLatestFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// SettingsStoreGetLatestSchemaSettingsFunc describes the behavior when the
+// GetLatestSchemaSettings method of the parent MockSettingsStore instance
+// is invoked.
+type SettingsStoreGetLatestSchemaSettingsFunc struct {
+	defaultHook func(context.Context, api.SettingsSubject) (*schema.Settings, error)
+	hooks       []func(context.Context, api.SettingsSubject) (*schema.Settings, error)
+	history     []SettingsStoreGetLatestSchemaSettingsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetLatestSchemaSettings delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockSettingsStore) GetLatestSchemaSettings(v0 context.Context, v1 api.SettingsSubject) (*schema.Settings, error) {
+	r0, r1 := m.GetLatestSchemaSettingsFunc.nextHook()(v0, v1)
+	m.GetLatestSchemaSettingsFunc.appendCall(SettingsStoreGetLatestSchemaSettingsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetLatestSchemaSettings method of the parent MockSettingsStore instance
+// is invoked and the hook queue is empty.
+func (f *SettingsStoreGetLatestSchemaSettingsFunc) SetDefaultHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetLatestSchemaSettings method of the parent MockSettingsStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *SettingsStoreGetLatestSchemaSettingsFunc) PushHook(hook func(context.Context, api.SettingsSubject) (*schema.Settings, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *SettingsStoreGetLatestSchemaSettingsFunc) SetDefaultReturn(r0 *schema.Settings, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *SettingsStoreGetLatestSchemaSettingsFunc) PushReturn(r0 *schema.Settings, r1 error) {
+	f.PushHook(func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
+		return r0, r1
+	})
+}
+
+func (f *SettingsStoreGetLatestSchemaSettingsFunc) nextHook() func(context.Context, api.SettingsSubject) (*schema.Settings, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SettingsStoreGetLatestSchemaSettingsFunc) appendCall(r0 SettingsStoreGetLatestSchemaSettingsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// SettingsStoreGetLatestSchemaSettingsFuncCall objects describing the
+// invocations of this function.
+func (f *SettingsStoreGetLatestSchemaSettingsFunc) History() []SettingsStoreGetLatestSchemaSettingsFuncCall {
+	f.mutex.Lock()
+	history := make([]SettingsStoreGetLatestSchemaSettingsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SettingsStoreGetLatestSchemaSettingsFuncCall is an object that describes
+// an invocation of method GetLatestSchemaSettings on an instance of
+// MockSettingsStore.
+type SettingsStoreGetLatestSchemaSettingsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.SettingsSubject
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *schema.Settings
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SettingsStoreGetLatestSchemaSettingsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SettingsStoreGetLatestSchemaSettingsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -20,7 +20,7 @@ import (
 type SettingsStore interface {
 	CreateIfUpToDate(ctx context.Context, subject api.SettingsSubject, lastID *int32, authorUserID *int32, contents string) (*api.Settings, error)
 	Done(error) error
-	GetLastestSchemaSettings(context.Context, api.SettingsSubject) (*schema.Settings, error)
+	GetLatestSchemaSettings(context.Context, api.SettingsSubject) (*schema.Settings, error)
 	GetLatest(context.Context, api.SettingsSubject) (*api.Settings, error)
 	ListAll(ctx context.Context, impreciseSubstring string) ([]*api.Settings, error)
 	Transact(context.Context) (SettingsStore, error)
@@ -131,7 +131,7 @@ func (o *settingsStore) GetLatest(ctx context.Context, subject api.SettingsSubje
 	return settings[0], nil
 }
 
-func (o *settingsStore) GetLastestSchemaSettings(ctx context.Context, subject api.SettingsSubject) (*schema.Settings, error) {
+func (o *settingsStore) GetLatestSchemaSettings(ctx context.Context, subject api.SettingsSubject) (*schema.Settings, error) {
 	apiSettings, err := o.GetLatest(ctx, subject)
 	if err != nil {
 		return nil, err

--- a/internal/database/settings_test.go
+++ b/internal/database/settings_test.go
@@ -111,7 +111,7 @@ func TestGetLatestSchemaSettings(t *testing.T) {
 		t.Error(err)
 	}
 
-	settings, err := db.Settings().GetLastestSchemaSettings(ctx, api.SettingsSubject{User: &user1.ID})
+	settings, err := db.Settings().GetLatestSchemaSettings(ctx, api.SettingsSubject{User: &user1.ID})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This was a typo in several Go method names. It was not exposed in any external or cross-process APIs, so this change does not require backcompat.




## Test plan

Internal, non-cross-process, Go-typechecked API change only.