### PR TITLE
standardize JSONC handling with respect to empty documents

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -357,6 +357,14 @@ func doValidate(inputStr, schema string) (messages []string, err error) {
 			keyPath = e.Field()
 		}
 
+		// Use an easier-to-understand description for the common case when the root is not an
+		// object (which can happen when the input is derived from JSONC that is entirely commented
+		// out, for example).
+		if e, ok := e.(*gojsonschema.InvalidTypeError); ok && e.Field() == "(root)" && strings.HasPrefix(e.Description(), "Invalid type. Expected: object, given: ") {
+			messages = append(messages, "must be a JSON object (use {} for empty)")
+			continue
+		}
+
 		messages = append(messages, fmt.Sprintf("%s: %s", keyPath, e.Description()))
 	}
 	return messages, nil

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -94,6 +95,70 @@ func TestValidateCustom(t *testing.T) {
 				}
 			}
 			t.Fatalf("could not find problem %q in %v", test.wantProblem, problems)
+		})
+	}
+}
+
+func TestValidateSettings(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		wantProblems []string
+	}{
+		"valid": {
+			input:        `{}`,
+			wantProblems: []string{},
+		},
+		"comment only": {
+			input:        `// a`,
+			wantProblems: []string{"(root): Invalid type. Expected: object, given: null"},
+		},
+		"invalid per JSON Schema": {
+			input:        `{"experimentalFeatures":123}`,
+			wantProblems: []string{"experimentalFeatures: Invalid type. Expected: object, given: integer"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			problems, err := ValidateSetting(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(problems, test.wantProblems) {
+				t.Errorf("got problems %v, want %v", problems, test.wantProblems)
+			}
+		})
+	}
+}
+
+func TestDoValidate(t *testing.T) {
+	schema := schema.SiteSchemaJSON
+
+	tests := map[string]struct {
+		input        string
+		wantProblems []string
+	}{
+		"valid": {
+			input:        `{}`,
+			wantProblems: []string{},
+		},
+		"invalid root": {
+			input:        `null`,
+			wantProblems: []string{`(root): Invalid type. Expected: object, given: null`},
+		},
+		"invalid per JSON Schema": {
+			input:        `{"externalURL":123}`,
+			wantProblems: []string{"externalURL: Invalid type. Expected: string, given: integer"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			problems, err := doValidate(test.input, schema)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(problems, test.wantProblems) {
+				t.Errorf("got problems %v, want %v", problems, test.wantProblems)
+			}
 		})
 	}
 }

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -110,7 +110,7 @@ func TestValidateSettings(t *testing.T) {
 		},
 		"comment only": {
 			input:        `// a`,
-			wantProblems: []string{"(root): Invalid type. Expected: object, given: null"},
+			wantProblems: []string{"must be a JSON object (use {} for empty)"},
 		},
 		"invalid per JSON Schema": {
 			input:        `{"experimentalFeatures":123}`,
@@ -143,7 +143,7 @@ func TestDoValidate(t *testing.T) {
 		},
 		"invalid root": {
 			input:        `null`,
-			wantProblems: []string{`(root): Invalid type. Expected: object, given: null`},
+			wantProblems: []string{`must be a JSON object (use {} for empty)`},
 		},
 		"invalid per JSON Schema": {
 			input:        `{"externalURL":123}`,

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -47,10 +47,6 @@ func (s *settingsStore) Transact(ctx context.Context) (SettingsStore, error) {
 }
 
 func (o *settingsStore) CreateIfUpToDate(ctx context.Context, subject api.SettingsSubject, lastID *int32, authorUserID *int32, contents string) (latestSetting *api.Settings, err error) {
-	if strings.TrimSpace(contents) == "" {
-		return nil, errors.Errorf("blank settings are invalid (you can clear the settings by entering an empty JSON object: {})")
-	}
-
 	// Validate JSON syntax before saving.
 	if _, errs := jsonx.Parse(contents, jsonx.ParseOptions{Comments: true, TrailingCommas: true}); len(errs) > 0 {
 		return nil, errors.Errorf("invalid settings JSON: %v", errs)

--- a/internal/jsonc/jsonc.go
+++ b/internal/jsonc/jsonc.go
@@ -2,7 +2,6 @@ package jsonc
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/sourcegraph/jsonx"
 
@@ -16,18 +15,19 @@ func Unmarshal(text string, v any) error {
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(text) == "" {
-		return nil
-	}
 	return json.Unmarshal(data, v)
 }
 
 // Parse converts JSON with comments, trailing commas, and some types of syntax errors into standard
-// JSON. If there is an error that it can't unambiguously resolve, it returns the error.
+// JSON. If there is an error that it can't unambiguously resolve, it returns the error. If the
+// error is non-nil, it always returns a valid JSON document.
 func Parse(text string) ([]byte, error) {
 	data, errs := jsonx.Parse(text, jsonx.ParseOptions{Comments: true, TrailingCommas: true})
 	if len(errs) > 0 {
 		return data, errors.Errorf("failed to parse JSON: %v", errs)
+	}
+	if data == nil {
+		return []byte("null"), nil
 	}
 	return data, nil
 }
@@ -36,8 +36,8 @@ func Parse(text string) ([]byte, error) {
 // JSON is a subset of the input.
 func Normalize(input string) []byte {
 	output, _ := jsonx.Parse(input, jsonx.ParseOptions{Comments: true, TrailingCommas: true})
-	if len(output) == 0 {
-		return []byte("{}")
+	if output == nil {
+		return []byte("null")
 	}
 	return output
 }

--- a/internal/jsonc/jsonc_test.go
+++ b/internal/jsonc/jsonc_test.go
@@ -2,36 +2,101 @@ package jsonc
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 )
 
 func TestUnmarshal(t *testing.T) {
-	const input = `
-{
+	tests := []struct {
+		input string
+		want  any
+	}{
+		{
+			input: `{
 // comment
 /* another comment */
 "hello": "world",
-}`
-	want := map[string]any{"hello": "world"}
-
-	var got any
-	if err := Unmarshal(input, &got); err != nil {
-		t.Fatal(err)
+}`,
+			want: map[string]any{"hello": "world"},
+		},
+		{
+			input: `// just
+		// comments
+		// here`,
+			want: nil,
+		},
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %+v, want %+v", got, want)
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var got any
+			if err := Unmarshal(test.input, &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("got %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		input string
+		want  any
+	}{
+		{
+			input: `{
+// comment
+/* another comment */
+"hello": "world",
+}`,
+			want: `{"hello":"world"}`,
+		},
+		{
+			input: `// just
+		// comments
+		// here`,
+			want: `null`,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got, err := Parse(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != test.want {
+				t.Errorf("got %s, want %s", got, test.want)
+			}
+		})
 	}
 }
 
 func TestNormalize(t *testing.T) {
-	const input = `
-{
+	tests := []struct{ input, want string }{
+		{
+			input: `{
 // comment
 /* another comment */
 "hello": "world",
-}`
-	want := `{"hello":"world"}`
-	if got := string(Normalize(input)); got != want {
-		t.Errorf("got %s, want %s", got, want)
+}`,
+			want: `{"hello":"world"}`,
+		},
+		{
+			input: `// just
+// comments
+// here`,
+			want: "null",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			if got := string(Normalize(test.input)); got != test.want {
+				t.Errorf("got %s, want %s\ninput: %s", got, test.want, test.input)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/42000.

## standardize jsonc parsing, unmarshaling, and normalization on empty documents
    
Empty JSONC documents that consisted of ONLY whitespace and comments were treated differently by
    
- jsonc.Normalize, which converted them to `{}` (an object)
- jsonc.Parse, which returned the empty string (which is invalid JSON)
- jsonc.Unmarshal, which would fail with an error from json.Unmarshal (but it would correctly handle completely empty JSONC documents, with only whitespace and NO comments--this was a partially incorrect attempt at preventing the bug in #42000)
    
Now, they all treat these empty JSONC documents the same (as though the JSONC document was `null`, i.e. JSON null, which is a valid JSON document).
    
Fixes https://github.com/sourcegraph/sourcegraph/issues/42000 because the validation (which used the too-lenient jsonc.Normalize code path) now reports an error due to `null` not conforming to the JSON Schema (which expects the root to be an object).

## show nicer error message when attempting to save empty settings
    
The previous commit fixed https://github.com/sourcegraph/sourcegraph/issues/42000. This commit presents a nicer error for that case: instead of `invalid settings: (root): Invalid type. Expected: object, given: null`, the user now sees `invalid settings: must be a JSON object (use {} for empty)`.

I decided to just improve the error message for this case. I decided AGAINST making this "just work" (letting users save an empty or entirely commented-out settings document) because this would be a special case to handle, and I didn't want to reintroduce more complexity into the JSONC code (given that I just removed complexity that led to a bug here). Someone else who owns this code long-term may decide differently.

## Test plan

I confirmed that the bug in #42000 can't be triggered:

![2022-09-24_11-04](https://user-images.githubusercontent.com/1976/192112919-e8e130fa-5049-4968-a1ca-168a5175095e.png)

I also needed to make sure that the increased strictness would not cause other issues, such as rejecting a `EXTSVC_CONFIG_FILE` or `GLOBAL_SETTINGS_FILE` that previously was accepted.

- I confirmed that Sourcegraph (even prior to this PR) does not support invalid JSONC supplied via the file system (eg `GLOBAL_SETTINGS_FILE`, `EXTSVG_CONFIG_FILE`). I did this by editing the `dev-private` config JSON files to just contain comments (as in #42000), and I confirmed it shows an error `[   frontend] ERROR server.overrideExtSvcConfig.watch cli/config.go:370 failed to update configuration from modified config override file {"files": ["../dev-private/enterprise/dev/external-services-config.json"], "error": "parsing EXTSVC_CONFIG_FILE: unexpected end of JSON input"}`.
- I confirmed that an empty site config document would not be allowed to be saved (even prior to this PR) because it is prevented by the JSON Schema, which requires at least `auth.providers` to be provided.
- I confirmed that an empty external service config document would not be allowed to be saved (even prior to this PR) because it is already checked correctly (it does not use the jsonc.Normalize path) and would trigger an error `Unable to validate config against schema: EOF`.
- It IS possible to trigger #42000 by updating org or global settings, but there is no backcompat concern here because if those settings were in this bad state, then the instance would be unusable (as seen in #42000). This fix is desirable for those cases.