### PR TITLE
remove confusing error return from JSON Schema validation functions

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -165,10 +165,7 @@ func (ps Problems) ExternalService() (problems Problems) {
 // Validate validates the configuration against the JSON Schema and other
 // custom validation checks.
 func Validate(input conftypes.RawUnified) (problems Problems, err error) {
-	siteProblems, err := doValidate(input.Site, schema.SiteSchemaJSON)
-	if err != nil {
-		return nil, err
-	}
+	siteProblems := doValidate(input.Site, schema.SiteSchemaJSON)
 	problems = append(problems, NewSiteProblems(siteProblems...)...)
 
 	customProblems, err := validateCustomRaw(conftypes.RawUnified{
@@ -333,16 +330,20 @@ func RedactSecrets(raw conftypes.RawUnified) (empty conftypes.RawUnified, err er
 	}, err
 }
 
-func ValidateSetting(input string) (problems []string, err error) {
+// ValidateSettings validates the JSONC input against the settings JSON Schema, returning a list of
+// problems (if any).
+func ValidateSettings(input string) (problems []string) {
 	return doValidate(input, schema.SettingsSchemaJSON)
 }
 
-func doValidate(inputStr, schema string) (messages []string, err error) {
+func doValidate(inputStr, schema string) (messages []string) {
 	input := jsonc.Normalize(inputStr)
 
 	res, err := validate([]byte(schema), input)
 	if err != nil {
-		return nil, err
+		// We can't return more detailed problems because the input completely failed to parse, so
+		// just return the parse error as the problem.
+		return []string{err.Error()}
 	}
 	messages = make([]string, 0, len(res.Errors()))
 	for _, e := range res.Errors() {
@@ -359,7 +360,7 @@ func doValidate(inputStr, schema string) (messages []string, err error) {
 
 		messages = append(messages, fmt.Sprintf("%s: %s", keyPath, e.Description()))
 	}
-	return messages, nil
+	return messages
 }
 
 func validate(schema, input []byte) (*gojsonschema.Result, error) {

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -47,6 +48,32 @@ func TestValidate(t *testing.T) {
 			t.Error("want invalid")
 		}
 	})
+}
+
+func TestDoValidate(t *testing.T) {
+	schema := schema.SiteSchemaJSON
+
+	tests := map[string]struct {
+		input        string
+		wantProblems []string
+	}{
+		"valid": {
+			input:        `{"externalURL":"https://example.com"}`,
+			wantProblems: []string{},
+		},
+		"invalid per JSON Schema": {
+			input:        `{"externalURL":123}`,
+			wantProblems: []string{"externalURL: Invalid type. Expected: string, given: integer"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			problems := doValidate(test.input, schema)
+			if !reflect.DeepEqual(problems, test.wantProblems) {
+				t.Errorf("got problems %v, want %v", problems, test.wantProblems)
+			}
+		})
+	}
 }
 
 func TestValidateCustom(t *testing.T) {

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -57,11 +57,7 @@ func (o *settingsStore) CreateIfUpToDate(ctx context.Context, subject api.Settin
 	}
 
 	// Validate setting schema
-	problems, err := conf.ValidateSetting(contents)
-	if err != nil {
-		return nil, err
-	}
-	if len(problems) > 0 {
+	if problems := conf.ValidateSettings(contents); len(problems) > 0 {
 		return nil, errors.Errorf("invalid settings: %s", strings.Join(problems, ","))
 	}
 

--- a/internal/database/settings_test.go
+++ b/internal/database/settings_test.go
@@ -95,6 +95,32 @@ func TestCreateIfUpToDate(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("valid settings", func(t *testing.T) {
+		contents := `{"experimentalFeatures": {}}`
+		_, err := db.Settings().CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, contents)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("invalid settings per JSON Schema", func(t *testing.T) {
+		contents := `{"experimentalFeatures": 1}`
+		wantErr := "invalid settings: experimentalFeatures: Invalid type. Expected: object, given: integer"
+		_, err := db.Settings().CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, contents)
+		if err == nil || err.Error() != wantErr {
+			t.Errorf("got err %q, want %q", err, wantErr)
+		}
+	})
+
+	t.Run("syntactically invalid settings", func(t *testing.T) {
+		contents := `{`
+		wantErr := "invalid settings JSON: [CloseBraceExpected]"
+		_, err := db.Settings().CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, contents)
+		if err == nil || err.Error() != wantErr {
+			t.Errorf("got err %q, want %q", err, wantErr)
+		}
+	})
 }
 
 func TestGetLatestSchemaSettings(t *testing.T) {


### PR DESCRIPTION
It would be easy for callers to assume a nil error means no problems. That assumption would be false, and it could lead to callers unintentionally accepting invalid JSON.

This removal of the error return makes the API impossible to use incorrectly.




## Test plan

Added unit tests.