### PR TITLE
use jsonc.Unmarshal helper

### DIFF
--- a/internal/conf/parse.go
+++ b/internal/conf/parse.go
@@ -1,8 +1,6 @@
 package conf
 
 import (
-	"encoding/json"
-
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -12,11 +10,7 @@ import (
 // pointer.
 func parseConfigData(data string, cfg any) error {
 	if data != "" {
-		data, err := jsonc.Parse(data)
-		if err != nil {
-			return err
-		}
-		if err := json.Unmarshal(data, cfg); err != nil {
+		if err := jsonc.Unmarshal(data, cfg); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Test plan

Tested adding invalid and valid site config JSON. The behavior was the same as prior to this change.