### PR TITLE
simplify wording of NPS question

### DIFF
--- a/client/web/src/marketing/backend.ts
+++ b/client/web/src/marketing/backend.ts
@@ -43,6 +43,7 @@ export function fetchAllSurveyResponses(): Observable<FetchSurveyResponsesResult
                 score
                 reason
                 better
+                otherUseCase
                 createdAt
             }
         `
@@ -81,6 +82,7 @@ export function fetchAllUsersWithSurveyResponses(args: {
                     score
                     reason
                     better
+                    otherUseCase
                     createdAt
                 }
                 usageStatistics {

--- a/client/web/src/marketing/components/SurveyUseCaseForm.tsx
+++ b/client/web/src/marketing/components/SurveyUseCaseForm.tsx
@@ -15,6 +15,12 @@ interface SurveyUseCaseFormProps extends UseCaseFeedbackState, UseCaseFeedbackMo
     authenticatedUser?: AuthenticatedUser | null
 }
 
+export const SURVEY_QUESTIONS: Record<'otherUseCase' | 'better' | 'reason', string> = {
+    otherUseCase: 'What do you use Sourcegraph for?',
+    better: 'How can we make Sourcegraph better?',
+    reason: 'What is the most important reason for the score you gave Sourcegraph?',
+}
+
 export const SurveyUseCaseForm: React.FunctionComponent<SurveyUseCaseFormProps> = ({
     otherUseCase,
     onChangeOtherUseCase,
@@ -33,7 +39,7 @@ export const SurveyUseCaseForm: React.FunctionComponent<SurveyUseCaseFormProps> 
             containerClassName="mt-3"
             label={
                 <H4 as="span" className={classNames('d-flex', styles.title, formLabelClassName)}>
-                    What do you use Sourcegraph for?
+                    {SURVEY_QUESTIONS.otherUseCase}
                 </H4>
             }
             onChange={event => onChangeOtherUseCase(event.target.value)}
@@ -45,7 +51,7 @@ export const SurveyUseCaseForm: React.FunctionComponent<SurveyUseCaseFormProps> 
             containerClassName="mt-3"
             label={
                 <H4 as="span" className={classNames('d-flex', styles.title, formLabelClassName)}>
-                    What would make Sourcegraph better?
+                    {SURVEY_QUESTIONS.better}
                 </H4>
             }
             onChange={event => onChangeBetter(event.target.value)}

--- a/client/web/src/marketing/page/SurveyPage.test.tsx
+++ b/client/web/src/marketing/page/SurveyPage.test.tsx
@@ -56,7 +56,7 @@ describe('SurveyPage', () => {
             expect(otherUseCaseInput).toBeVisible()
             fireEvent.change(otherUseCaseInput, { target: { value: mockVariables.otherUseCase } })
 
-            const reasonInput = renderResult.getByLabelText('What would make Sourcegraph better?')
+            const reasonInput = renderResult.getByLabelText('How can we make Sourcegraph better?')
             expect(reasonInput).toBeVisible()
             fireEvent.change(reasonInput, { target: { value: mockVariables.better } })
 

--- a/client/web/src/marketing/toast/SurveyToast.test.tsx
+++ b/client/web/src/marketing/toast/SurveyToast.test.tsx
@@ -213,11 +213,11 @@ describe('SurveyToast', () => {
 
         it('Should render use case form correctly', () => {
             expect(renderResult.getByLabelText('What do you use Sourcegraph for?')).toBeVisible()
-            expect(renderResult.getByLabelText('What would make Sourcegraph better?')).toBeVisible()
+            expect(renderResult.getByLabelText('How can we make Sourcegraph better?')).toBeVisible()
         })
 
         it('Should show some gratitude after usecase submission', async () => {
-            const reasonInput = renderResult.getByLabelText('What would make Sourcegraph better?')
+            const reasonInput = renderResult.getByLabelText('How can we make Sourcegraph better?')
             expect(reasonInput).toBeVisible()
             fireEvent.change(reasonInput, { target: { value: mockVariables.better } })
 

--- a/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
@@ -49,8 +49,6 @@ interface SurveyResponseNodeProps {
     node: SurveyResponseFields
 }
 
-interface SurveyResponseNodeState {}
-
 function scoreToClassSuffix(score: number): typeof BADGE_VARIANTS[number] {
     return score > 8 ? 'success' : score > 6 ? 'info' : 'danger'
 }
@@ -61,50 +59,44 @@ const ScoreBadge: React.FunctionComponent<React.PropsWithChildren<{ score: numbe
     </Badge>
 )
 
-class SurveyResponseNode extends React.PureComponent<SurveyResponseNodeProps, SurveyResponseNodeState> {
-    public state: SurveyResponseNodeState = {}
-
-    public render(): JSX.Element | null {
-        return (
-            <li className="list-group-item py-2">
-                <div className="d-flex align-items-center justify-content-between">
-                    <div>
-                        <strong>
-                            {this.props.node.user ? (
-                                <Link to={userURL(this.props.node.user.username)}>{this.props.node.user.username}</Link>
-                            ) : this.props.node.email ? (
-                                this.props.node.email
-                            ) : (
-                                'anonymous user'
-                            )}
-                        </strong>
-                        <ScoreBadge score={this.props.node.score} />
-                    </div>
-                    <div>
-                        <Timestamp date={this.props.node.createdAt} />
-                    </div>
-                </div>
-                {(this.props.node.reason || this.props.node.better) && (
-                    <dl className="mt-3">
-                        {this.props.node.reason && this.props.node.reason !== '' && (
-                            <>
-                                <dt>What is the most important reason for the score you gave Sourcegraph?</dt>
-                                <dd>{this.props.node.reason}</dd>
-                            </>
-                        )}
-                        {this.props.node.reason && this.props.node.better && <div className="mt-2" />}
-                        {this.props.node.better && this.props.node.better !== '' && (
-                            <>
-                                <dt>What could Sourcegraph do to provide a better product?</dt>
-                                <dd>{this.props.node.better}</dd>
-                            </>
-                        )}
-                    </dl>
+const SurveyResponseNode: React.FunctionComponent<SurveyResponseNodeProps> = props => (
+    <li className="list-group-item py-2">
+        <div className="d-flex align-items-center justify-content-between">
+            <div>
+                <strong>
+                    {props.node.user ? (
+                        <Link to={userURL(props.node.user.username)}>{props.node.user.username}</Link>
+                    ) : props.node.email ? (
+                        props.node.email
+                    ) : (
+                        'anonymous user'
+                    )}
+                </strong>
+                <ScoreBadge score={props.node.score} />
+            </div>
+            <div>
+                <Timestamp date={props.node.createdAt} />
+            </div>
+        </div>
+        {(props.node.reason || props.node.better) && (
+            <dl className="mt-3">
+                {props.node.reason && props.node.reason !== '' && (
+                    <>
+                        <dt>What is the most important reason for the score you gave Sourcegraph?</dt>
+                        <dd>{props.node.reason}</dd>
+                    </>
                 )}
-            </li>
-        )
-    }
-}
+                {props.node.reason && props.node.better && <div className="mt-2" />}
+                {props.node.better && props.node.better !== '' && (
+                    <>
+                        <dt>What could Sourcegraph do to provide a better product?</dt>
+                        <dd>{props.node.better}</dd>
+                    </>
+                )}
+            </dl>
+        )}
+    </li>
+)
 
 const UserSurveyResponsesHeader: React.FunctionComponent<
     React.PropsWithChildren<{ nodes: UserWithSurveyResponseFields[] }>

--- a/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
@@ -34,6 +34,7 @@ import {
     fetchAllUsersWithSurveyResponses,
     fetchSurveyResponseAggregates,
 } from '../marketing/backend'
+import { SURVEY_QUESTIONS } from '../marketing/components/SurveyUseCaseForm'
 import { eventLogger } from '../tracking/eventLogger'
 import { userURL } from '../user'
 
@@ -80,16 +81,21 @@ const SurveyResponseNode: React.FunctionComponent<SurveyResponseNodeProps> = pro
         </div>
         {(props.node.reason || props.node.better) && (
             <dl className="mt-3">
+                {props.node.otherUseCase && props.node.otherUseCase !== '' && (
+                    <>
+                        <dt>{SURVEY_QUESTIONS.otherUseCase}</dt>
+                        <dd>{props.node.otherUseCase}</dd>
+                    </>
+                )}
                 {props.node.reason && props.node.reason !== '' && (
                     <>
-                        <dt>What is the most important reason for the score you gave Sourcegraph?</dt>
+                        <dt>{SURVEY_QUESTIONS.reason}</dt>
                         <dd>{props.node.reason}</dd>
                     </>
                 )}
-                {props.node.reason && props.node.better && <div className="mt-2" />}
                 {props.node.better && props.node.better !== '' && (
                     <>
-                        <dt>What could Sourcegraph do to provide a better product?</dt>
+                        <dt>{SURVEY_QUESTIONS.better}</dt>
                         <dd>{props.node.better}</dd>
                     </>
                 )}
@@ -173,20 +179,24 @@ class UserSurveyResponseNode extends React.PureComponent<UserSurveyResponseNodeP
                                         <Timestamp date={response.createdAt} />
                                         <ScoreBadge score={response.score} />
                                         <br />
-                                        {(response.reason || response.better) && <div className="mt-2" />}
+                                        {(response.otherUseCase || response.reason || response.better) && (
+                                            <div className="mt-2" />
+                                        )}
+                                        {response.otherUseCase && response.otherUseCase !== '' && (
+                                            <>
+                                                <dt>{SURVEY_QUESTIONS.otherUseCase}</dt>
+                                                <dd>{response.otherUseCase}</dd>
+                                            </>
+                                        )}
                                         {response.reason && response.reason !== '' && (
                                             <>
-                                                <dt>
-                                                    What is the most important reason for the score you gave
-                                                    Sourcegraph?
-                                                </dt>
+                                                <dt>{SURVEY_QUESTIONS.reason}</dt>
                                                 <dd>{response.reason}</dd>
                                             </>
                                         )}
-                                        {response.reason && response.better && <div className="mt-2" />}
                                         {response.better && response.better !== '' && (
                                             <>
-                                                <dt>What could Sourcegraph do to provide a better product?</dt>
+                                                <dt>{SURVEY_QUESTIONS.better}</dt>
                                                 <dd>{response.better}</dd>
                                             </>
                                         )}


### PR DESCRIPTION
Instead of `What could Sourcegraph do to provide a better product?`, it's now `How can we make Sourcegraph better?`.

I personally find "provide a better product" to be overly formal/stilted language.

## Test plan

Visited the `/site-admin/survey` page.

## App preview:

- [Web](https://sg-web-sqs-nps-survey.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mbhxkxwqpx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
