### PR TITLE
remove needless ?toast=integrations from post-sign-in redirect URL

### DIFF
--- a/client/web/src/auth/SignInSignUpCommon.tsx
+++ b/client/web/src/auth/SignInSignUpCommon.tsx
@@ -74,6 +74,5 @@ export function getReturnTo(location: H.Location): string {
     const returnTo = searchParameters.get('returnTo') || '/search'
     const newURL = new URL(returnTo, window.location.href)
 
-    newURL.searchParams.append('toast', 'integrations')
     return newURL.pathname + newURL.search + newURL.hash
 }


### PR DESCRIPTION
We used to use this to trigger display of a toast to recommend users to install our browser extension. We no longer show that because it was annoying and users didn't like it. For some reason, the URL after sign-in or signup had `?toast=integrations` manually added to it. This didn't do anything, and there is no reason to keep it.




## Test plan

Tried signing in and confirmed there is no `?toast=integrations` in the URL.

## App preview:

- [Web](https://sg-web-sqs-rm-toast-integrations-url.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xwpislxfdv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
