### PR TITLE
make file history panel scrollable

### DIFF
--- a/client/branded/src/components/panel/views/PanelView.module.scss
+++ b/client/branded/src/components/panel/views/PanelView.module.scss
@@ -2,4 +2,5 @@
     flex: 1;
     overflow: auto;
     padding: 0.25rem 1rem;
+    height: 100%;
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/42001.

![image](https://user-images.githubusercontent.com/1976/192128255-1197a9f7-a48e-4f91-9be8-d3a349dc6389.png)


## Test plan

Open up a file, then open up the history panel. Size the panel so that scrolling is needed. Confirm that it scrolls. Confirm that the reference panel still works.

## App preview:

- [Web](https://sg-web-sqs-scrollable-history-panel.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jjzwzzmfmg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
