### PR TITLE
allow `git shortlog --after` to fix contributors time ranges

### DIFF
--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -29,7 +29,7 @@ var (
 		"tag":          {"--list", "--sort", "-creatordate", "--format", "--points-at"},
 		"merge-base":   {"--"},
 		"show-ref":     {"--heads"},
-		"shortlog":     {"-s", "-n", "-e", "--no-merges"},
+		"shortlog":     {"-s", "-n", "-e", "--no-merges", "--after", "--before"},
 		"cat-file":     {},
 
 		// Used in tests to simulate errors with runCommand in handleExec of gitserver.


### PR DESCRIPTION
The repository contributors page relies on `git shortlog --after=...`, but the `--after` command-line option was not in the allowlist. This commit adds it there. This is safe because the `--after` (and `--before`) string is just interpreted as a date and can't have bad side effects; it's also allowed for `git log`, where it has the same meaning.

Fixes https://github.com/sourcegraph/sourcegraph/issues/41825.


![image](https://user-images.githubusercontent.com/1976/192128410-3314664d-f5ae-4c7e-b13d-b1b44ee6c893.png)


## Test plan

Visit any repository's contributors page, and select a time period other than "All time".