### PR TITLE
upgrade: Update k8s instructions

### DIFF
--- a/doc/admin/deploy/kubernetes/update.md
+++ b/doc/admin/deploy/kubernetes/update.md
@@ -77,14 +77,14 @@ To perform a multi-version upgrade on a Sourcegraph instance running on Kubernet
       1. It's assumed that your fork of `deploy-sourcegraph` is up to date with your instance's current version. Pull the upstream changes for `v3.27.0` and resolve any git merge conflicts. We need to temporarily boot the containers defined at this specific version to rewrite existing data to the new Postgres 12 format.
       1. Run `kubectl apply -l deploy=sourcegraph -f base/pgsql` to launch a new Postgres 12 container and rewrite the old Postgres 11 data. This may take a while, but streaming container logs should show progress.
       1. Wait until the database container is accepting connections. Once ready, run the command `kubectl exec --stdin --tty pgsql -- psql -U sg` to open an interactive pgsql prompt.
-      1. Issue the command `REINDEX database sg` in the pgsql prompt to repair indexes that were silently invalidated by previous data rewrite step. **If you skip this step**, then some data may become inaccessible under normal operation. The following steps are not guaranteed to work, and **data loss will occur**.
+      1. Issue the command `REINDEX database sg` in the pgsql prompt to repair indexes that were silently invalidated by the previous data rewrite step. **If you skip this step**, then some data may become inaccessible under normal operation. The following steps are not guaranteed to work, and **data loss will occur**.
       1. Follow the same steps for the `codeintel-db`:
-          - Run `kubectl apply -l deploy=sourcegraph -f base/codeintel-db` to launch Postgres 12
-          - Run `kubectl exec --stdin --tty codeintel-db -- psql -U sg` to open a pgsql prompt
-          - Run `REINDEX database sg` in the pgsql prompt
+          - Run `kubectl apply -l deploy=sourcegraph -f base/codeintel-db` to launch Postgres 12.
+          - Run `kubectl exec --stdin --tty codeintel-db -- psql -U sg` to open a pgsql prompt.
+          - Run `REINDEX database sg` in the pgsql prompt.
       1. Leave these databases running while the subsequent migration steps are performed.
 1. Pull the upstream changes for the target instance version and resolve any git merge conflicts. The [standard upgrade procedure](#standard-upgrades) describes this step in more detail.
-1. Follow the instructions on [how to run the migrator job in Kubernetes](http://localhost:5080/admin/how-to/manual_database_migrations#kubernetes) to perform the upgrade migration. For specific documentation on the `upgrade` command, see the [command documentation](./../../how-to/manual_database_migrations.md#upgrade). The following basic steps will be performed:
+1. Follow the instructions on [how to run the migrator job in Kubernetes](http://localhost:5080/admin/how-to/manual_database_migrations#kubernetes) to perform the upgrade migration. For specific documentation on the `upgrade` command, see the [command documentation](./../../how-to/manual_database_migrations.md#upgrade). The following specific steps are an easy way to run the upgrade command:
   1. Edit the file `configure/migrator/migrator.Job.yaml` and set the value of the `command` key to `["upgrade", "--from=<old version>", "--to=<new version>"]`.
   1. Run `kubectl delete -f configure/migrator/migrator.Job.yaml` to ensure no previous job invocations will conflict with our current invocation.
   1. Start the migrator job via `kubectl apply -f configure/migrator/migrator.Job.yaml`.

--- a/doc/admin/deploy/kubernetes/update.md
+++ b/doc/admin/deploy/kubernetes/update.md
@@ -59,7 +59,7 @@ A [multi-version upgrade](../../updates/index.md#multi-version-upgrades) is a do
 
 To perform a multi-version upgrade on a Sourcegraph instance running on Kubernetes:
 
-1. Spin down any pods that access the database. This must be done for the following deployments and stateful sets listed below. This can be performed directly via a series of `kubectl` commands (given below), or by setting `replicas: 0` in each deployment/stateful set's configuration and re-applying.
+1. Spin down any pods that access the database. This must be done for the following deployments and stateful sets listed below. This can be performed directly via a series of `kubectl` commands (given below), or by setting `replicas: 0` in each deployment/stateful set's definitions and re-applying the configuration.
   - Deployments (e.g., `kubectl scale deployment <name> --replicas=0`)
       - precise-code-intel-worker
       - repo-updater
@@ -71,8 +71,28 @@ To perform a multi-version upgrade on a Sourcegraph instance running on Kubernet
   - Stateful sets (e.g., `kubectl scale sts <name> --replicas=0`):
       - gitserver
       - indexed-search
-1. Run the `migrator upgrade` command targetting the same databases as your instance. See the [command documentation](./../../how-to/manual_database_migrations.md#upgrade) for additional details. In short, the migrator is invoked as a [Kubernetes job](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/configure/migrator/migrator.Job.yaml) (a short-lived container) using the same Kubernetes cluster and using environment variables indicating the instance's databases.
-1. Now that the data has been prepared to run against a new version of Sourcegraph, the infrastructure can be updated. The remaining steps follow the [standard upgrade for Kubernetes](#standard-upgrades).
+1. **If upgrading from 3.26 or before to 3.27 or later**, the `pgsql` and `codeintel-db` databases must be upgraded from Postgres 11 to Postgres 12. If this step is not performed, then the following upgrade procedure will fail fast (and leave all existing data untouched).
+  - If using an external database, follow the [upgrading external PostgreSQL instances](../../postgres.md#upgrading-external-postgresql-instances) guide.
+  - Otherwise, perform the following steps from the [upgrading internal Postgres instances](../../postgres.md#upgrading-internal-postgresql-instances) guide:
+      1. It's assumed that your fork of `deploy-sourcegraph` is up to date with your instance's current version. Pull the upstream changes for `v3.27.0` and resolve any git merge conflicts. We need to temporarily boot the containers defined at this specific version to rewrite existing data to the new Postgres 12 format.
+      1. Run `kubectl apply -l deploy=sourcegraph -f base/pgsql` to launch a new Postgres 12 container and rewrite the old Postgres 11 data. This may take a while, but streaming container logs should show progress.
+      1. Wait until the database container is accepting connections. Once ready, run the command `kubectl exec --stdin --tty pgsql -- psql -U sg` to open an interactive pgsql prompt.
+      1. Issue the command `REINDEX database sg` in the pgsql prompt to repair indexes that were silently invalidated by previous data rewrite step. **If you skip this step**, then some data may become inaccessible under normal operation. The following steps are not guaranteed to work, and **data loss will occur**.
+      1. Follow the same steps for the `codeintel-db`:
+          - Run `kubectl apply -l deploy=sourcegraph -f base/codeintel-db` to launch Postgres 12
+          - Run `kubectl exec --stdin --tty codeintel-db -- psql -U sg` to open a pgsql prompt
+          - Run `REINDEX database sg` in the pgsql prompt
+      1. Leave these databases running while the subsequent migration steps are performed.
+1. Pull the upstream changes for the target instance version and resolve any git merge conflicts. The [standard upgrade procedure](#standard-upgrades) describes this step in more detail.
+1. Follow the instructions on [how to run the migrator job in Kubernetes](http://localhost:5080/admin/how-to/manual_database_migrations#kubernetes) to perform the upgrade migration. For specific documentation on the `upgrade` command, see the [command documentation](./../../how-to/manual_database_migrations.md#upgrade). The following basic steps will be performed:
+  1. Edit the file `configure/migrator/migrator.Job.yaml` and set the value of the `command` key to `["upgrade", "--from=<old version>", "--to=<new version>"]`.
+  1. Run `kubectl delete -f configure/migrator/migrator.Job.yaml` to ensure no previous job invocations will conflict with our current invocation.
+  1. Start the migrator job via `kubectl apply -f configure/migrator/migrator.Job.yaml`.
+  1. Run `kubectl wait -f configure/migrator/migrator.Job.yaml --for=condition=complete --timeout=-1s` to wait for the job to complete.
+1. The remaining infrastructure can now be updated. The [standard upgrade procedure](#standard-upgrades) describes this step in more detail.
+  - Ensure that the replica counts adjusted in the previous steps are turned back up.
+  - Run `./kubectl-apply-all.sh` to deploy the new pods to the Kubernetes cluster.
+  - Monitor the status of the deployment via `kubectl get pods -o wide --watch`.
 
 ## Rollback
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -13,21 +13,9 @@
 ## Multi-version upgrade procedure
 
 1. Read our [update policy](index.md#update-policy) to learn about Sourcegraph updates.
-1. For each version within the multi-version upgrade range, read the stepwise update notes on this page. For example, when upgrading from 3.20 to 3.23, update notes for the stepwise updates [3.20 -> 3.21](#3-20-3-21), [3.21 -> 3.22](#3-21-3-22), and [3.22 -> 3.23](#3-22-3-23) are relevant. Neglecting this step can cause you to [miss important upgrade notes](#if-you-wish-to-keep-existing-lsif-data) and data that required special treatment can be lost permanently.
-1. Check the [update notes](#multi-version-upgrade-notes) specific to multi-version upgrades.
-1. After checking the relevant update notes, refer to either of the following guides to upgrade your instance:
+1. Refer to either of the following guides to upgrade your instance:
     * [Kubernetes with Helm upgrade guide](../deploy/kubernetes/helm.md#multi-version-upgrades)
     * [Kubernetes without Helm upgrade guide](../deploy/kubernetes/update.md#multi-version-upgrades)
-
-### Multi-version upgrade notes
-
-Some stepwise upgrade notes have multi-version considerations.
-
-- **Upgrades crossing 3.26 -> 3.27** will require an update to Postgres 12.
-    - If you are using an external database, follow the [upgrade instructions](../postgres.md#upgrading-external-postgresql-instances) prior to starting the upgrade procedure.
-    - If you are using the provided database containers, update the `pgsql` and `codeintel-db` images to the new version prior to starting the upgrade procedure. These images will convert postgres 9.6 data on-disk to a Postgres 12-compatible format.
-- **Upgrades crossing 3.26 -> 3.27** will require a deprecation of TimescaleDB for codeinsights. This should not require special treatment from the user: the old `codeinsights-db` image is compatible with Postgres 12. This database's image should be updated with the rest of the instance after the migrator has ran successfully.
-- **Upgrades crossing 3.20 -> 3.21** wil require a new `codeintel-db` database. This database should be added to the instance prior to starting the upgrade procedure.
 
 <!-- GENERATE UPGRADE GUIDE ON RELEASE (release tooling uses this to add entries) -->
 


### PR DESCRIPTION
Updates to multi-version upgrades for k8s.

cc @sourcegraph/cse; these doc updates narrate what the 3.25 -> 4.0 upgrade path was like in the [loom video](https://www.loom.com/share/51801665b262489bbb539110b7fe1e61). Additional Slack context [here](https://sourcegraph.slack.com/archives/C01JKF7KUBD/p1664206670653989?thread_ts=1663791439.452619&cid=C01JKF7KUBD).

## Test plan

N/A.