### PR TITLE
prevent extraneous props (groupSearch, title, repositories) from being applied to <svg>

### DIFF
--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/code-insight-example-card/CodeInsightExampleCard.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/code-insight-example-card/CodeInsightExampleCard.tsx
@@ -127,7 +127,12 @@ interface CodeInsightCaptureExampleProps extends TelemetryProps {
 }
 
 const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProps> = props => {
-    const { content, templateLink, className, telemetryService } = props
+    const {
+        content: { title, groupSearch, repositories, ...content },
+        templateLink,
+        className,
+        telemetryService,
+    } = props
     const seriesToggleState = useSeriesToggle()
 
     const {
@@ -152,13 +157,9 @@ const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProp
     return (
         <InsightCard className={className} onMouseEnter={trackMouseEnter} onMouseLeave={trackMouseLeave}>
             <InsightCardHeader
-                title={content.title}
+                title={title}
                 subtitle={
-                    <CodeInsightsQueryBlock
-                        as={SyntaxHighlightedSearchQuery}
-                        query={content.repositories}
-                        className="mt-1"
-                    />
+                    <CodeInsightsQueryBlock as={SyntaxHighlightedSearchQuery} query={repositories} className="mt-1" />
                 }
             >
                 {templateLink && (
@@ -193,7 +194,7 @@ const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProp
                 <InsightCardLegend series={content.series} className={styles.legend} />
             </div>
 
-            <CodeInsightsQueryBlock as={SyntaxHighlightedSearchQuery} query={content.groupSearch} className="mt-3" />
+            <CodeInsightsQueryBlock as={SyntaxHighlightedSearchQuery} query={groupSearch} className="mt-3" />
         </InsightCard>
     )
 }


### PR DESCRIPTION
Fixes devtools console errors on `/insights/about`:
    
```
react-dom.development.js:86 Warning: React does not recognize the `groupSearch` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `groupsearch` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

## Test plan

Visit page and confirm there are no such devtools messages.

## App preview:

- [Web](https://sg-web-sqs-codeinsights-props.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fltdknarrz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
