### PR TITLE
search additionalLanguages for language spec

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
+++ b/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
@@ -411,7 +411,9 @@ export const languageSpecs: LanguageSpec[] = [
  * matches is configured with the given identifier an error is thrown.
  */
 export function findLanguageSpec(languageID: string): LanguageSpec {
-    const languageSpec = languageSpecs.find(spec => spec.languageID === languageID)
+    const languageSpec = languageSpecs.find(
+        spec => spec.languageID === languageID || spec.additionalLanguages?.includes(languageID)
+    )
     if (languageSpec) {
         return languageSpec
     }


### PR DESCRIPTION
`javascript` is an `additionalLanguage` in the `typescript` language spec. When looking for a language spec by languageID, we need to also search the `additionalLanguages`.

**NOTE:** I haven't thoroughly tested this, and I don't have much experience in this part of the codebase. This PR should be taken over by a code intel team member.

Fixes https://github.com/sourcegraph/sourcegraph/issues/41745.


## Test plan

TBD, on https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/gulpfile.js?L37:3#tab=references :
![image](https://user-images.githubusercontent.com/1976/192156103-f38b88e0-76a3-411f-8969-b5ab71a7090e.png)

## App preview:

- [Web](https://sg-web-sqs-fix-js-refs.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hkmshgcuqj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
