### PR TITLE
Export as types to quiet webpack warnings when transpilation occurs

### DIFF
--- a/client/shared/src/react-shortcuts/index.ts
+++ b/client/shared/src/react-shortcuts/index.ts
@@ -1,9 +1,13 @@
-export { Shortcut, Props as ShortcutProps } from './Shortcut'
+export { Shortcut } from './Shortcut'
+export type { Props as ShortcutProps } from './Shortcut'
 
-export { ShortcutProvider, Props as ProviderProps, Context, Provider as ContextProvider } from './ShortcutProvider'
+export { ShortcutProvider, Provider as ContextProvider } from './ShortcutProvider'
+
+export type { Context } from './ShortcutProvider'
+export type { Props as ProviderProps } from './ShortcutProvider'
 
 export { ShortcutManager } from './ShortcutManager'
-export {
+export type {
     Key,
     AlphabetKey,
     NumericKey,

--- a/client/shared/src/react-shortcuts/index.ts
+++ b/client/shared/src/react-shortcuts/index.ts
@@ -2,11 +2,10 @@ export { Shortcut } from './Shortcut'
 export type { Props as ShortcutProps } from './Shortcut'
 
 export { ShortcutProvider, Provider as ContextProvider } from './ShortcutProvider'
-
-export type { Context } from './ShortcutProvider'
-export type { Props as ProviderProps } from './ShortcutProvider'
+export type { Context, Props as ProviderProps } from './ShortcutProvider'
 
 export { ShortcutManager } from './ShortcutManager'
+
 export type {
     Key,
     AlphabetKey,


### PR DESCRIPTION
Re-exports types and interfaces as types. When transpiling from TypeScript to JavaScript, the type exports get removed. However, if a type is re-exported, and it is not redeclared as a type, then that import stays, and you get annoying console errors saying that the re-export cannot find the original import. This PR simply re-exports those types as types again so that they can be removed correctly.

Reduces the number of warnings from 26 to 3. Your browser console will thank you.

The leftover warnings are from a node module, so I'm not sure if we can do anything about those.

Before:

![image](https://user-images.githubusercontent.com/6427795/192202838-383940a8-c58b-4fc8-ade1-3f0de0f01c09.png)

After:

![image](https://user-images.githubusercontent.com/6427795/192202671-dafd134b-376a-4443-89bd-6998eb8dac34.png)

## Test plan

Build and linters still work. Confirmed in terminal and console.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-ts-webpack-warnings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sjrwokzrfb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
