### PR TITLE
worker: Move commandLogger out of executor

### DIFF
--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -59,7 +59,7 @@ func (h *handler) PreDequeue(ctx context.Context, logger log.Logger) (dequeueabl
 
 // Handle clones the target code into a temporary directory, invokes the target indexer in a
 // fresh docker container, and uploads the results to the external frontend API.
-func (h *handler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+func (h *handler) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) (err error) {
 	job := record.(executor.Job)
 	logger = logger.With(
 		log.Int("jobID", job.ID),

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -55,7 +55,7 @@ var (
 // errCommitDoesNotExist occurs when gitserver does not recognize the commit attached to the upload.
 var errCommitDoesNotExist = errors.Errorf("commit does not exist")
 
-func (h *handler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+func (h *handler) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) (err error) {
 	upload := record.(store.Upload)
 
 	var requeued bool

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -31,7 +31,7 @@ type batchSpecWorkspaceCreator struct {
 // HandlerFunc returns a workerutil.HandlerFunc that can be passed to a
 // workerutil.Worker to process queued changesets.
 func (r *batchSpecWorkspaceCreator) HandlerFunc() workerutil.HandlerFunc {
-	return func(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+	return func(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) (err error) {
 		job := record.(*btypes.BatchSpecResolutionJob)
 
 		return r.process(ctx, service.NewWorkspaceResolver, job)

--- a/enterprise/cmd/worker/internal/batches/workers/bulk_processor_worker.go
+++ b/enterprise/cmd/worker/internal/batches/workers/bulk_processor_worker.go
@@ -47,7 +47,7 @@ type bulkProcessorWorker struct {
 }
 
 func (b *bulkProcessorWorker) HandlerFunc() workerutil.HandlerFunc {
-	return func(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+	return func(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) (err error) {
 		job := record.(*btypes.ChangesetJob)
 
 		tx, err := b.store.Transact(ctx)

--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
@@ -82,7 +82,7 @@ var _ workerutil.Handler = &dependencyIndexingSchedulerHandler{}
 // recently completed processing. Each moniker is interpreted according to its
 // scheme to determine the dependent repository and commit. A set of indexing
 // jobs are enqueued for each repository and commit pair.
-func (h *dependencyIndexingSchedulerHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) error {
+func (h *dependencyIndexingSchedulerHandler) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) error {
 	if !autoIndexingEnabled() || disableIndexScheduler {
 		return nil
 	}

--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
@@ -66,7 +66,7 @@ type dependencySyncSchedulerHandler struct {
 	extsvcStore ExternalServiceStore
 }
 
-func (h *dependencySyncSchedulerHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) error {
+func (h *dependencySyncSchedulerHandler) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) error {
 	if !autoIndexingEnabled() {
 		return nil
 	}

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -86,7 +86,7 @@ type bitbucketProjectPermissionsHandler struct {
 }
 
 // Handle implements the workerutil.Handler interface.
-func (h *bitbucketProjectPermissionsHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+func (h *bitbucketProjectPermissionsHandler) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) (err error) {
 	logger = logger.Scoped("BitbucketProjectPermissionsHandler", "handles jobs to apply explicit permissions to all repositories of a Bitbucket Project")
 	defer func() {
 		if err != nil {

--- a/enterprise/internal/batches/reconciler/reconciler.go
+++ b/enterprise/internal/batches/reconciler/reconciler.go
@@ -42,7 +42,7 @@ func New(gitClient GitserverClient, sourcer sources.Sourcer, store *store.Store)
 // HandlerFunc returns a dbworker.HandlerFunc that can be passed to a
 // workerutil.Worker to process queued changesets.
 func (r *Reconciler) HandlerFunc() workerutil.HandlerFunc {
-	return func(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+	return func(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) (err error) {
 		tx, err := r.store.Transact(ctx)
 		if err != nil {
 			return err

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -132,7 +132,7 @@ type queryRunner struct {
 	db edb.EnterpriseDB
 }
 
-func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) (err error) {
 	defer func() {
 		if err != nil {
 			logger.Error("queryRunner.Handle", log.Error(err))
@@ -209,7 +209,7 @@ type actionRunner struct {
 	edb.CodeMonitorStore
 }
 
-func (r *actionRunner) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+func (r *actionRunner) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) (err error) {
 	logger.Info("actionRunner.Handle starting")
 	defer func() {
 		if err != nil {

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -296,7 +296,7 @@ func filterRecordingsBySeriesRepos(ctx context.Context, repoStore discovery.Repo
 
 }
 
-func (r *workHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+func (r *workHandler) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) (err error) {
 	// 🚨 SECURITY: The request is performed without authentication, we get back results from every
 	// repository on Sourcegraph - results will be filtered when users query for insight data based on the
 	// repositories they can see.

--- a/internal/repos/sync_worker_test.go
+++ b/internal/repos/sync_worker_test.go
@@ -84,7 +84,7 @@ type fakeRepoSyncHandler struct {
 	jobChan chan *repos.SyncJob
 }
 
-func (h *fakeRepoSyncHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) error {
+func (h *fakeRepoSyncHandler) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) error {
 	sj, ok := record.(*repos.SyncJob)
 	if !ok {
 		return errors.Errorf("expected repos.SyncJob, got %T", record)

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -2553,7 +2553,7 @@ type fakeWebhookBuildHandler struct {
 	jobChan chan *webhookworker.Job
 }
 
-func (h *fakeWebhookBuildHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) error {
+func (h *fakeWebhookBuildHandler) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) error {
 	job, ok := record.(*webhookworker.Job)
 	if !ok {
 		return errors.Newf("expected webhookworker.Job, got %T", record)

--- a/internal/repos/webhook_build_handler.go
+++ b/internal/repos/webhook_build_handler.go
@@ -32,7 +32,7 @@ func newWebhookBuildHandler(store Store, doer httpcli.Doer) *webhookBuildHandler
 	return &webhookBuildHandler{store: store, doer: doer}
 }
 
-func (w *webhookBuildHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) error {
+func (w *webhookBuildHandler) Handle(ctx context.Context, logger log.Logger, _ workerutil.Logger, record workerutil.Record) error {
 	job, ok := record.(*webhookworker.Job)
 	if !ok {
 		return errcode.MakeNonRetryable(errors.Newf("expected Job, got %T", record))

--- a/internal/workerutil/handler.go
+++ b/internal/workerutil/handler.go
@@ -11,13 +11,13 @@ import (
 // interfaces to further configure the behavior of the worker routine.
 type Handler interface {
 	// Handle processes a single record.
-	Handle(ctx context.Context, logger log.Logger, record Record) error
+	Handle(ctx context.Context, logger log.Logger, commandLogger Logger, record Record) error
 }
 
-type HandlerFunc func(ctx context.Context, logger log.Logger, record Record) error
+type HandlerFunc func(ctx context.Context, logger log.Logger, commandLogger Logger, record Record) error
 
-func (f HandlerFunc) Handle(ctx context.Context, logger log.Logger, record Record) error {
-	return f(ctx, logger, record)
+func (f HandlerFunc) Handle(ctx context.Context, logger log.Logger, commandLogger Logger, record Record) error {
+	return f(ctx, logger, commandLogger, record)
 }
 
 // WithPreDequeue is an extension of the Handler interface.

--- a/internal/workerutil/logger.go
+++ b/internal/workerutil/logger.go
@@ -1,0 +1,263 @@
+package workerutil
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// Logger tracks command invocations and stores the command's output and
+// error stream values.
+type Logger interface {
+	// Flush waits until all entries have been written to the store and all
+	// background goroutines that watch a log entry and possibly update it have
+	// exited.
+	Flush() error
+	// Log redacts secrets from the given log entry and stores it.
+	Log(key string, command []string) LogEntry
+}
+
+// LogEntry is returned by Logger.Log and implements the io.WriteCloser
+// interface to allow clients to update the Out field of the ExecutionLogEntry.
+//
+// The Close() method *must* be called once the client is done writing log
+// output to flush the entry to the database.
+type LogEntry interface {
+	io.WriteCloser
+	Finalize(exitCode int)
+	CurrentLogEntry() ExecutionLogEntry
+}
+
+type ExecutionLogEntryStore interface {
+	AddExecutionLogEntry(ctx context.Context, id int, entry ExecutionLogEntry) (int, error)
+	UpdateExecutionLogEntry(ctx context.Context, id, entryID int, entry ExecutionLogEntry) error
+}
+
+type entryHandle struct {
+	logEntry ExecutionLogEntry
+	replacer *strings.Replacer
+
+	done chan struct{}
+
+	mu         sync.Mutex
+	buf        *bytes.Buffer
+	exitCode   *int
+	durationMs *int
+}
+
+func (h *entryHandle) Write(p []byte) (n int, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.buf.Write(p)
+}
+
+func (h *entryHandle) Finalize(exitCode int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	durationMs := int(time.Since(h.logEntry.StartTime) / time.Millisecond)
+	h.exitCode = &exitCode
+	h.durationMs = &durationMs
+}
+
+func (h *entryHandle) Close() error {
+	close(h.done)
+	return nil
+}
+
+func (h *entryHandle) CurrentLogEntry() ExecutionLogEntry {
+	logEntry := h.currentLogEntry()
+	redact(&logEntry, h.replacer)
+	return logEntry
+}
+
+func (h *entryHandle) currentLogEntry() ExecutionLogEntry {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	logEntry := h.logEntry
+	logEntry.ExitCode = h.exitCode
+	logEntry.Out = h.buf.String()
+	logEntry.DurationMs = h.durationMs
+	return logEntry
+}
+
+type logger struct {
+	store   ExecutionLogEntryStore
+	done    chan struct{}
+	handles chan *entryHandle
+
+	recordID int
+
+	replacer *strings.Replacer
+
+	errs   error
+	errsMu sync.Mutex
+}
+
+// logEntryBufSize is the maximum number of log entries that are logged by the
+// task execution but not yet written to the database.
+const logEntryBufsize = 50
+
+// NewLogger creates a new logger instance with the given store, job, record,
+// and replacement map.
+// When the log messages are serialized, any occurrence of sensitive values are
+// replace with a non-sensitive value.
+// Each log message is written to the store in a goroutine. The Flush method
+// must be called to ensure all entries are written.
+func NewLogger(store ExecutionLogEntryStore, recordID int, replacements map[string]string) Logger {
+	oldnew := make([]string, 0, len(replacements)*2)
+	for k, v := range replacements {
+		oldnew = append(oldnew, k, v)
+	}
+
+	l := &logger{
+		store:    store,
+		recordID: recordID,
+		done:     make(chan struct{}),
+		handles:  make(chan *entryHandle, logEntryBufsize),
+		replacer: strings.NewReplacer(oldnew...),
+		errs:     nil,
+	}
+
+	go l.writeEntries()
+
+	return l
+}
+
+func (l *logger) Flush() error {
+	close(l.handles)
+	<-l.done
+
+	l.errsMu.Lock()
+	defer l.errsMu.Unlock()
+
+	return l.errs
+}
+
+func (l *logger) Log(key string, command []string) LogEntry {
+	handle := &entryHandle{
+		logEntry: ExecutionLogEntry{
+			Key:       key,
+			Command:   command,
+			StartTime: time.Now(),
+		},
+		replacer: l.replacer,
+		buf:      &bytes.Buffer{},
+		done:     make(chan struct{}),
+	}
+
+	l.handles <- handle
+	return handle
+}
+
+func (l *logger) writeEntries() {
+	defer close(l.done)
+
+	var wg sync.WaitGroup
+	for handle := range l.handles {
+		initialLogEntry := handle.CurrentLogEntry()
+		entryID, err := l.store.AddExecutionLogEntry(context.Background(), l.recordID, initialLogEntry)
+		if err != nil {
+			// If there is a timeout or cancellation error we don't want to skip
+			// writing these logs as users will often want to see how far something
+			// progressed prior to a timeout.
+			log15.Warn("Failed to upload execution log entry for job", "id", l.recordID, "error", err)
+
+			l.appendError(err)
+
+			continue
+		}
+
+		wg.Add(1)
+		go func(handle *entryHandle, entryID int, initialLogEntry ExecutionLogEntry) {
+			defer wg.Done()
+
+			l.syncLogEntry(handle, entryID, initialLogEntry)
+		}(handle, entryID, initialLogEntry)
+	}
+
+	wg.Wait()
+}
+
+const syncLogEntryInterval = 1 * time.Second
+
+func (l *logger) syncLogEntry(handle *entryHandle, entryID int, old ExecutionLogEntry) {
+	lastWrite := false
+
+	for !lastWrite {
+		select {
+		case <-handle.done:
+			lastWrite = true
+		case <-time.After(syncLogEntryInterval):
+		}
+
+		current := handle.CurrentLogEntry()
+		if !entryWasUpdated(old, current) {
+			continue
+		}
+
+		logArgs := make([]any, 0, 16)
+		logArgs = append(
+			logArgs,
+			"recordID", l.recordID,
+			"entryID", entryID,
+			"key", current.Key,
+			"outLen", len(current.Out),
+		)
+		if current.ExitCode != nil {
+			logArgs = append(logArgs, "exitCode", current.ExitCode)
+		}
+		if current.DurationMs != nil {
+			logArgs = append(logArgs, "durationMs", current.DurationMs)
+		}
+
+		log15.Debug("Updating executor log entry", logArgs...)
+
+		if err := l.store.UpdateExecutionLogEntry(context.Background(), l.recordID, entryID, current); err != nil {
+			logMethod := log15.Warn
+			if lastWrite {
+				logMethod = log15.Error
+				// If lastWrite, this MUST complete for the job to be considered successful,
+				// so we want to hard-fail otherwise. We store away the error.
+				l.appendError(err)
+			}
+
+			logMethod(
+				"Failed to update execution log entry for job",
+				"recordID", l.recordID,
+				"entryID", entryID,
+				"lastWrite", lastWrite,
+				"error", err,
+			)
+		} else {
+			old = current
+		}
+	}
+}
+
+func (l *logger) appendError(err error) {
+	l.errsMu.Lock()
+	l.errs = errors.Append(l.errs, err)
+	l.errsMu.Unlock()
+}
+
+// If old didn't have exit code or duration and current does, update; we're finished.
+// Otherwise, update if the log text has changed since the last write to the API.
+func entryWasUpdated(old, current ExecutionLogEntry) bool {
+	return (current.ExitCode != nil && old.ExitCode == nil) || (current.DurationMs != nil && old.DurationMs == nil) || current.Out != old.Out
+}
+
+func redact(entry *ExecutionLogEntry, replacer *strings.Replacer) {
+	for i, arg := range entry.Command {
+		entry.Command[i] = replacer.Replace(arg)
+	}
+	entry.Out = replacer.Replace(entry.Out)
+}


### PR DESCRIPTION
This might be useful elsewhere, to demo it I added a bunch of logs to the repo syncer. It's relatively easy to expose these in the UI: There's a unmarshal helper for the DB and a helper to create a GQL resolver for the ExecutionLogEntry type. To do a quick PoC, I skipped this part. This logger supports "streaming" logs in that it occasionally dumps the current buffer into the DB. This is also used in executors for showing live logs of what's going on. 

<img width="1061" alt="Screenshot 2022-09-26 at 13 15 52@2x" src="https://user-images.githubusercontent.com/19534377/192263324-d23db734-85c2-4ade-a6a3-dabc58df886e.png">

Just a rough sketch, tests would need to be moved, some wordings likely need to be adjusted and the executor log entry model doesn't 100% fit into the background job model with exit codes etc, but maybe that is just irrelevant and we should always store nothing when it's not applicable?

## Test plan

Needs tests to be moved etc. Not final.