### PR TITLE
vsce: patch release v2.2.10

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -10,6 +10,12 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 
 ### Changes
 
+### Fixes
+
+## 2.2.10
+
+### Changes
+
 - Remove tracking parameters from all shareable URLs [pull/42022](https://github.com/sourcegraph/sourcegraph/pull/42022)
 
 ### Fixes

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@sourcegraph/vscode",
   "displayName": "Sourcegraph",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "Sourcegraph for VS Code",
   "publisher": "sourcegraph",
   "sideEffects": true,


### PR DESCRIPTION
Release Sourcegraph for VSCode v2.2.10

## Test plan
N/A
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-vsce-2-2-10.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-igkirjtziy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
