### PR TITLE
Show number of indexed repositories on repos list page

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -204,6 +204,13 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 tooltip: 'The number of repositories that have been cloned.',
             },
             {
+                value: data.repositoryStats.indexed,
+                description: 'Indexed',
+                color: 'var(--body-color)',
+                position: 'right',
+                tooltip: 'The number of repositories that have been index for search.',
+            },
+            {
                 value: data.repositoryStats.failedFetch,
                 description: 'Failed',
                 color: data.repositoryStats.failedFetch > 0 ? 'var(--warning)' : 'var(--body-color)',

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -208,7 +208,7 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 description: 'Indexed',
                 color: 'var(--body-color)',
                 position: 'right',
-                tooltip: 'The number of repositories that have been index for search.',
+                tooltip: 'The number of repositories that have been indexed for search.',
             },
             {
                 value: data.repositoryStats.failedFetch,

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -839,6 +839,7 @@ export const REPOSITORY_STATS = gql`
             cloned
             cloning
             failedFetch
+            indexed
         }
     }
 `

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -7,32 +7,92 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
 
 type repositoryStatsResolver struct {
 	db database.DB
 
-	indexedRepos      int
-	gitDirBytes       uint64
-	indexedLinesCount uint64
+	indexedStatsOnce  sync.Once
+	indexedRepos      int32
+	indexedLinesCount int64
+	indexedStatsErr   error
 
 	repoStatisticsOnce sync.Once
 	repoStatistics     database.RepoStatistics
 	repoStatisticsErr  error
+
+	gitDirBytesOnce sync.Once
+	gitDirBytes     int64
+	gitDirBytesErr  error
 }
 
-func (r *repositoryStatsResolver) GitDirBytes() BigInt {
-	return BigInt{Int: int64(r.gitDirBytes)}
+func (r *repositoryStatsResolver) GitDirBytes(ctx context.Context) (BigInt, error) {
+	gitDirBytes, err := r.computeGitDirBytes(ctx)
+	if err != nil {
+		return BigInt{}, err
+	}
+	return BigInt{Int: gitDirBytes}, nil
+
 }
 
-func (r *repositoryStatsResolver) IndexedLinesCount() BigInt {
-	return BigInt{Int: int64(r.indexedLinesCount)}
+func (r *repositoryStatsResolver) computeGitDirBytes(ctx context.Context) (int64, error) {
+	r.gitDirBytesOnce.Do(func() {
+		stats, err := gitserver.NewClient(r.db).ReposStats(ctx)
+		if err != nil {
+			r.gitDirBytesErr = err
+			return
+		}
+
+		var gitDirBytes int64
+		for _, stat := range stats {
+			gitDirBytes += int64(stat.GitDirBytes)
+		}
+		r.gitDirBytes = gitDirBytes
+	})
+
+	return r.gitDirBytes, r.gitDirBytesErr
 }
 
-func (r *repositoryStatsResolver) Indexed(ctx context.Context) int32 {
-	return int32(r.indexedRepos)
+func (r *repositoryStatsResolver) Indexed(ctx context.Context) (int32, error) {
+	indexedRepos, _, err := r.computeIndexedStats(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return indexedRepos, nil
+}
+
+func (r *repositoryStatsResolver) IndexedLinesCount(ctx context.Context) (BigInt, error) {
+	_, indexedLinesCount, err := r.computeIndexedStats(ctx)
+	if err != nil {
+		return BigInt{}, err
+	}
+	return BigInt{Int: indexedLinesCount}, nil
+}
+
+func (r *repositoryStatsResolver) computeIndexedStats(ctx context.Context) (int32, int64, error) {
+	r.indexedStatsOnce.Do(func() {
+		var (
+			indexedRepos     int32
+			indexedLineCount int64
+		)
+
+		if conf.SearchIndexEnabled() {
+			repos, err := search.ListAllIndexed(ctx)
+			if err != nil {
+				r.indexedStatsErr = err
+				return
+			}
+			indexedRepos = int32(len(repos.Minimal))
+			indexedLineCount = int64(repos.Stats.DefaultBranchNewLinesCount) + int64(repos.Stats.OtherBranchesNewLinesCount)
+		}
+
+		r.indexedRepos = indexedRepos
+		r.indexedLinesCount = indexedLineCount
+	})
+
+	return r.indexedRepos, r.indexedLinesCount, r.indexedStatsErr
 }
 
 func (r *repositoryStatsResolver) Total(ctx context.Context) (int32, error) {
@@ -89,29 +149,5 @@ func (r *schemaResolver) RepositoryStats(ctx context.Context) (*repositoryStatsR
 		return nil, err
 	}
 
-	stats, err := usagestats.GetRepositories(ctx, db)
-	if err != nil {
-		return nil, err
-	}
-
-	var (
-		indexedRepos     int
-		indexedLineCount uint64
-	)
-
-	if conf.SearchIndexEnabled() {
-		repos, err := search.ListAllIndexed(ctx)
-		if err != nil {
-			return nil, err
-		}
-		indexedRepos = len(repos.Minimal)
-		indexedLineCount = repos.Stats.DefaultBranchNewLinesCount + repos.Stats.OtherBranchesNewLinesCount
-	}
-
-	return &repositoryStatsResolver{
-		db:                db,
-		indexedRepos:      indexedRepos,
-		gitDirBytes:       stats.GitDirBytes,
-		indexedLinesCount: indexedLineCount,
-	}, nil
+	return &repositoryStatsResolver{db: db}, nil
 }

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -47,7 +47,7 @@ func (r *repositoryStatsResolver) computeGitDirBytes(ctx context.Context) (int64
 
 		var gitDirBytes int64
 		for _, stat := range stats {
-			gitDirBytes += int64(stat.GitDirBytes)
+			gitDirBytes += stat.GitDirBytes
 		}
 		r.gitDirBytes = gitDirBytes
 	})

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -12,6 +12,7 @@ import (
 type repositoryStatsResolver struct {
 	db database.DB
 
+	indexedRepos      int
 	gitDirBytes       uint64
 	indexedLinesCount uint64
 
@@ -26,6 +27,10 @@ func (r *repositoryStatsResolver) GitDirBytes() BigInt {
 
 func (r *repositoryStatsResolver) IndexedLinesCount() BigInt {
 	return BigInt{Int: int64(r.indexedLinesCount)}
+}
+
+func (r *repositoryStatsResolver) Indexed(ctx context.Context) int32 {
+	return int32(r.indexedRepos)
 }
 
 func (r *repositoryStatsResolver) Total(ctx context.Context) (int32, error) {
@@ -89,6 +94,7 @@ func (r *schemaResolver) RepositoryStats(ctx context.Context) (*repositoryStatsR
 
 	return &repositoryStatsResolver{
 		db:                db,
+		indexedRepos:      stats.Repos,
 		gitDirBytes:       stats.GitDirBytes,
 		indexedLinesCount: stats.DefaultBranchNewLinesCount + stats.OtherBranchesNewLinesCount,
 	}, nil

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7383,6 +7383,10 @@ type RepositoryStats {
     The number of repositories where initial cloning or subsequent fetching resulted in an error.
     """
     failedFetch: Int!
+    """
+    The number of indexed repositories
+    """
+    indexed: Int!
 }
 
 """

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -91,6 +91,14 @@ func Indexed() zoekt.Streamer {
 	return indexedSearch
 }
 
+// ListAllIndexed lists all indexed repositories with `Minimal: true`. If
+// indexed search is disabled it returns ErrIndexDisabled.
+func ListAllIndexed(ctx context.Context) (*zoekt.RepoList, error) {
+	q := &query.Const{Value: true}
+	opts := &zoekt.ListOptions{Minimal: true}
+	return Indexed().List(ctx, q, opts)
+}
+
 func Indexers() *backend.Indexers {
 	indexersOnce.Do(func() {
 		indexers = &backend.Indexers{

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -3,9 +3,6 @@ package usagestats
 import (
 	"context"
 
-	"github.com/sourcegraph/zoekt"
-	"github.com/sourcegraph/zoekt/query"
-
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -13,9 +10,6 @@ import (
 )
 
 type Repositories struct {
-	// Repos is the number of indexed repositories.
-	Repos int
-
 	// GitDirBytes is the amount of bytes stored in .git directories.
 	GitDirBytes uint64
 
@@ -57,13 +51,11 @@ func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error)
 		return &total, nil
 	}
 
-	opts := &zoekt.ListOptions{Minimal: true}
-	repos, err := search.Indexed().List(ctx, &query.Const{Value: true}, opts)
+	repos, err := search.ListAllIndexed(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	total.Repos = len(repos.Minimal)
 	total.NewLinesCount = repos.Stats.NewLinesCount
 	total.DefaultBranchNewLinesCount = repos.Stats.DefaultBranchNewLinesCount
 	total.OtherBranchesNewLinesCount = repos.Stats.OtherBranchesNewLinesCount

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -13,6 +13,9 @@ import (
 )
 
 type Repositories struct {
+	// Repos is the number of indexed repositories.
+	Repos int
+
 	// GitDirBytes is the amount of bytes stored in .git directories.
 	GitDirBytes uint64
 
@@ -60,6 +63,7 @@ func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error)
 		return nil, err
 	}
 
+	total.Repos = len(repos.Minimal)
 	total.NewLinesCount = repos.Stats.NewLinesCount
 	total.DefaultBranchNewLinesCount = repos.Stats.DefaultBranchNewLinesCount
 	total.OtherBranchesNewLinesCount = repos.Stats.OtherBranchesNewLinesCount


### PR DESCRIPTION
This adds another number to the repositories list page in the admin area: the number of currently indexed repositories.

![screenshot_2022-09-26_16 29 46@2x](https://user-images.githubusercontent.com/1185253/192302927-3ea832b7-4cc5-419e-9a48-5dfb700e3848.png)

Since we already do the call to Zoekt when we query those numbers, this is essentially free.

cc @sourcegraph/search-core am I using this correctly? I assume that this is always the number of indexed repositories in Zoekt, regardless of how many revisions are indexed per repository, right? Also: what happens when a repository is deleted on Sourcegraph: I assume Zoekt takes a while to remove it, right? Until then the number here might be higher than number of repositories, right?

Still not sure whether I'd want to merge this in that case.

## Test plan

- Manual testing
