### PR TITLE
JetBrains: Make the plugin compatible with 3.42.0 and below

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -139,8 +139,19 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
         }
     }
 
+    public void indicateSearchError(@NotNull String errorMessage, @NotNull Date date) {
+        if (lastPreviewUpdate.before(date)) {
+            this.lastPreviewUpdate = date;
+            browserAndLoadingPanel.setState(BrowserAndLoadingPanel.State.ERROR, errorMessage);
+            selectionMetadataPanel.clearSelectionMetadataLabel();
+            previewPanel.setState(PreviewPanel.State.NO_PREVIEW_AVAILABLE);
+            footerPanel.setPreviewContent(null);
+        }
+    }
+
     public void indicateLoadingIfInTime(@NotNull Date date) {
         if (lastPreviewUpdate.before(date)) {
+            this.lastPreviewUpdate = date;
             selectionMetadataPanel.clearSelectionMetadataLabel();
             previewPanel.setState(PreviewPanel.State.LOADING);
             footerPanel.setPreviewContent(null);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -19,6 +19,7 @@ import com.intellij.util.ui.components.BorderLayoutPanel;
 import com.sourcegraph.Icons;
 import com.sourcegraph.find.browser.BrowserAndLoadingPanel;
 import com.sourcegraph.find.browser.JSToJavaBridgeRequestHandler;
+import com.sourcegraph.find.browser.JavaToJSBridge;
 import com.sourcegraph.find.browser.SourcegraphJBCefBrowser;
 import org.jdesktop.swingx.util.OS;
 import org.jetbrains.annotations.NotNull;
@@ -124,10 +125,24 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
         return previewPanel;
     }
 
+    @Nullable
+    public JavaToJSBridge getJavaToJSBridge() {
+        return browser != null ? browser.getJavaToJSBridge() : null;
+    }
+
+    public BrowserAndLoadingPanel.ConnectionAndAuthState getConnectionAndAuthState() {
+        return browserAndLoadingPanel.getConnectionAndAuthState();
+    }
+
+    public boolean browserHasSearchError() {
+        return browserAndLoadingPanel.hasSearchError();
+    }
+
     public void indicateAuthenticationStatus(boolean wasServerAccessSuccessful, boolean authenticated) {
-        browserAndLoadingPanel.setState(wasServerAccessSuccessful
-            ? (authenticated ? BrowserAndLoadingPanel.State.AUTHENTICATED : BrowserAndLoadingPanel.State.COULD_CONNECT_BUT_NOT_AUTHENTICATED)
-            : BrowserAndLoadingPanel.State.COULD_NOT_CONNECT);
+        browserAndLoadingPanel.setConnectionAndAuthState(wasServerAccessSuccessful
+            ? (authenticated ? BrowserAndLoadingPanel.ConnectionAndAuthState.AUTHENTICATED
+            : BrowserAndLoadingPanel.ConnectionAndAuthState.COULD_CONNECT_BUT_NOT_AUTHENTICATED)
+            : BrowserAndLoadingPanel.ConnectionAndAuthState.COULD_NOT_CONNECT);
 
         if (wasServerAccessSuccessful) {
             previewPanel.setState(PreviewPanel.State.PREVIEW_AVAILABLE);
@@ -142,7 +157,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
     public void indicateSearchError(@NotNull String errorMessage, @NotNull Date date) {
         if (lastPreviewUpdate.before(date)) {
             this.lastPreviewUpdate = date;
-            browserAndLoadingPanel.setState(BrowserAndLoadingPanel.State.ERROR, errorMessage);
+            browserAndLoadingPanel.setBrowserSearchErrorMessage(errorMessage);
             selectionMetadataPanel.clearSelectionMetadataLabel();
             previewPanel.setState(PreviewPanel.State.NO_PREVIEW_AVAILABLE);
             footerPanel.setPreviewContent(null);
@@ -161,6 +176,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
     public void setPreviewContentIfInTime(@NotNull PreviewContent previewContent) {
         if (lastPreviewUpdate.before(previewContent.getReceivedDateTime())) {
             this.lastPreviewUpdate = previewContent.getReceivedDateTime();
+            browserAndLoadingPanel.setBrowserSearchErrorMessage(null);
             selectionMetadataPanel.setSelectionMetadataLabel(previewContent);
             previewPanel.setContent(previewContent);
             footerPanel.setPreviewContent(previewContent);
@@ -170,6 +186,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
     public void clearPreviewContentIfInTime(@NotNull Date date) {
         if (lastPreviewUpdate.before(date)) {
             this.lastPreviewUpdate = date;
+            browserAndLoadingPanel.setBrowserSearchErrorMessage(null);
             selectionMetadataPanel.clearSelectionMetadataLabel();
             previewPanel.setState(PreviewPanel.State.NO_PREVIEW_AVAILABLE);
             footerPanel.setPreviewContent(null);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -8,6 +8,8 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ex.WindowManagerEx;
 import com.intellij.util.ui.UIUtil;
+import com.sourcegraph.find.browser.BrowserAndLoadingPanel;
+import com.sourcegraph.find.browser.JavaToJSBridge;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
@@ -43,6 +45,15 @@ public class FindService implements Disposable {
         if (popup != null) {
             if (!popup.isVisible()) {
                 popup.show();
+
+                // Retry auth and search if the popup is in a possible connection error state
+                if (mainPanel.browserHasSearchError()
+                    || mainPanel.getConnectionAndAuthState() == BrowserAndLoadingPanel.ConnectionAndAuthState.COULD_NOT_CONNECT) {
+                    JavaToJSBridge bridge = mainPanel.getJavaToJSBridge();
+                    if (bridge != null) {
+                        bridge.callJS("retrySearch", null);
+                    }
+                }
             }
         } else {
             popup = new FindPopupDialog(project, mainPanel);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
@@ -25,6 +25,8 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
     private final JBPanelWithEmptyText overlayPanel;
     private final JBPanelWithEmptyText jcefPanel;
     private boolean isBrowserVisible = false;
+    private ConnectionAndAuthState connectionAndAuthState = ConnectionAndAuthState.LOADING;
+    private String errorMessage = null;
 
     public BrowserAndLoadingPanel(Project project) {
         this.project = project;
@@ -32,7 +34,7 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
             "Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
 
         overlayPanel = new JBPanelWithEmptyText();
-        setState(State.LOADING);
+        setConnectionAndAuthState(ConnectionAndAuthState.LOADING);
 
         // We need to use the add(Component, Object) overload of the add method to ensure that the constraints are
         // properly set.
@@ -40,24 +42,31 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
         add(jcefPanel, Integer.valueOf(2));
     }
 
-    public void setState(@NotNull State state) {
-        this.setState(state, null);
+    public void setBrowserSearchErrorMessage(@Nullable String errorMessage) {
+        this.errorMessage = errorMessage;
+        refreshUI();
     }
 
-    public void setState(@NotNull State state, @Nullable String errorMessage) {
-        StatusText emptyText = overlayPanel.getEmptyText();
+    public void setConnectionAndAuthState(@NotNull ConnectionAndAuthState state) {
+        this.connectionAndAuthState = state;
+        refreshUI();
+    }
 
-        isBrowserVisible = state == State.AUTHENTICATED || state == State.COULD_CONNECT_BUT_NOT_AUTHENTICATED;
-        if (state == State.LOADING) {
-            emptyText.setText("Loading...");
-        } else if (state == State.COULD_NOT_CONNECT) {
+    private void refreshUI() {
+        StatusText emptyText = overlayPanel.getEmptyText();
+        isBrowserVisible = errorMessage == null
+            && (connectionAndAuthState == ConnectionAndAuthState.AUTHENTICATED
+            || connectionAndAuthState == ConnectionAndAuthState.COULD_CONNECT_BUT_NOT_AUTHENTICATED);
+
+        if (connectionAndAuthState == ConnectionAndAuthState.COULD_NOT_CONNECT) {
             emptyText.setText("Could not connect to Sourcegraph.");
             emptyText.appendLine("Make sure your Sourcegraph URL and access token are correct to use search.");
             emptyText.appendLine("Click here to configure your Sourcegraph settings.",
                 new SimpleTextAttributes(STYLE_PLAIN, JBUI.CurrentTheme.Link.Foreground.ENABLED),
                 __ -> ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class)
             );
-        } else if (state == State.ERROR) {
+
+        } else if (errorMessage != null) {
             String wrappedText = WordUtils.wrap("Error: " + errorMessage, 100);
             String[] lines = wrappedText.split(SystemUtils.LINE_SEPARATOR);
             emptyText.setText(lines[0]);
@@ -72,12 +81,22 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
             emptyText.appendLine("mentioning the above error message and your plugin and Sourcegraph version.");
             emptyText.appendLine("Sorry for the inconvenience.");
 
+        } else if (connectionAndAuthState == ConnectionAndAuthState.LOADING) {
+            emptyText.setText("Loading...");
         } else {
             // We need to do this because the "COULD_NOT_CONNECT" link is clickable even when the empty text is hidden! :o
             emptyText.setText("");
         }
         revalidate();
         repaint();
+    }
+
+    public ConnectionAndAuthState getConnectionAndAuthState() {
+        return connectionAndAuthState;
+    }
+
+    public boolean hasSearchError() {
+        return errorMessage != null;
     }
 
     public void setBrowser(@NotNull SourcegraphJBCefBrowser browser) {
@@ -99,11 +118,10 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
         return getBounds().getSize();
     }
 
-    public enum State {
+    public enum ConnectionAndAuthState {
         LOADING,
         AUTHENTICATED,
         COULD_NOT_CONNECT,
-        COULD_CONNECT_BUT_NOT_AUTHENTICATED,
-        ERROR
+        COULD_CONNECT_BUT_NOT_AUTHENTICATED
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
@@ -7,7 +7,10 @@ import com.intellij.ui.components.JBPanelWithEmptyText;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.StatusText;
 import com.sourcegraph.config.SettingsConfigurable;
+import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang.WordUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
@@ -37,7 +40,11 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
         add(jcefPanel, Integer.valueOf(2));
     }
 
-    public void setState(State state) {
+    public void setState(@NotNull State state) {
+        this.setState(state, null);
+    }
+
+    public void setState(@NotNull State state, @Nullable String errorMessage) {
         StatusText emptyText = overlayPanel.getEmptyText();
 
         isBrowserVisible = state == State.AUTHENTICATED || state == State.COULD_CONNECT_BUT_NOT_AUTHENTICATED;
@@ -50,6 +57,16 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
                 new SimpleTextAttributes(STYLE_PLAIN, JBUI.CurrentTheme.Link.Foreground.ENABLED),
                 __ -> ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class)
             );
+        } else if (state == State.ERROR) {
+            String wrappedText = WordUtils.wrap("Error: " + errorMessage, 100);
+            String[] lines = wrappedText.split(SystemUtils.LINE_SEPARATOR);
+            emptyText.setText(lines[0]);
+            for (int i = 1; i < lines.length; i++) {
+                if (!lines[i].trim().isEmpty()) {
+                    emptyText.appendLine(lines[i]);
+                }
+            }
+
         } else {
             // We need to do this because the "COULD_NOT_CONNECT" link is clickable even when the empty text is hidden! :o
             emptyText.setText("");
@@ -81,6 +98,7 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
         LOADING,
         AUTHENTICATED,
         COULD_NOT_CONNECT,
-        COULD_CONNECT_BUT_NOT_AUTHENTICATED
+        COULD_CONNECT_BUT_NOT_AUTHENTICATED,
+        ERROR
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
@@ -66,6 +66,11 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
                     emptyText.appendLine(lines[i]);
                 }
             }
+            emptyText.appendLine("");
+            emptyText.appendLine("If you believe this is a bug, please raise this at support@sourcegraph.com,");
+            //noinspection DialogTitleCapitalization
+            emptyText.appendLine("mentioning the above error message and your plugin and Sourcegraph version.");
+            emptyText.appendLine("Sorry for the inconvenience.");
 
         } else {
             // We need to do this because the "COULD_NOT_CONNECT" link is clickable even when the empty text is hidden! :o

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
@@ -103,7 +103,8 @@ public class JSToJavaBridgeRequestHandler {
                     try {
                         previewContent = PreviewContent.fromJson(project, arguments);
                     } catch (Exception e) {
-                        return createErrorResponse("Parsing error while opening link: " + e.getClass().getName() + ": " + e.getMessage(), convertStackTraceToString(e));
+                        return createErrorResponse("Parsing error while opening link: "
+                            + e.getClass().getName() + ": " + e.getMessage(), convertStackTraceToString(e));
                     }
 
                     ApplicationManager.getApplication().invokeLater(() -> {
@@ -117,7 +118,9 @@ public class JSToJavaBridgeRequestHandler {
                     return createSuccessResponse(null);
                 case "indicateFinishedLoading":
                     arguments = request.getAsJsonObject("arguments");
-                    ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.indicateAuthenticationStatus(arguments.get("wasServerAccessSuccessful").getAsBoolean(), arguments.get("wasAuthenticationSuccessful").getAsBoolean()));
+                    ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.indicateAuthenticationStatus(
+                        arguments.get("wasServerAccessSuccessful").getAsBoolean(),
+                        arguments.get("wasAuthenticationSuccessful").getAsBoolean()));
                     return createSuccessResponse(null);
                 case "windowClose":
                     ApplicationManager.getApplication().invokeLater(findService::hidePopup);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
@@ -42,6 +42,14 @@ public class JSToJavaBridgeRequestHandler {
                 case "getTheme":
                     JsonObject currentThemeAsJson = ThemeUtil.getCurrentThemeAsJson();
                     return createSuccessResponse(currentThemeAsJson);
+                case "indicateSearchError":
+                    arguments = request.getAsJsonObject("arguments");
+                    ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.indicateSearchError(
+                        arguments.get("errorMessage").getAsString(),
+                        Date.from(Instant.from(
+                            DateTimeFormatter.ISO_INSTANT.parse(arguments.get("timeAsISOString").getAsString())))));
+                    return createSuccessResponse(null);
+
                 case "saveLastSearch":
                     arguments = request.getAsJsonObject("arguments");
                     String query = arguments.get("query").getAsString();

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/browser/SourcegraphJBCefBrowser.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/browser/SourcegraphJBCefBrowser.java
@@ -10,6 +10,8 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 
 public class SourcegraphJBCefBrowser extends JBCefBrowser {
+    private final JavaToJSBridge javaToJSBridge;
+
     public SourcegraphJBCefBrowser(@NotNull JSToJavaBridgeRequestHandler requestHandler) {
         super("http://sourcegraph/html/index.html");
         // Create and set up JCEF browser
@@ -19,7 +21,7 @@ public class SourcegraphJBCefBrowser extends JBCefBrowser {
         String initJSCode = "window.initializeSourcegraph();";
         JSToJavaBridge jsToJavaBridge = new JSToJavaBridge(this, requestHandler, initJSCode);
         Disposer.register(this, jsToJavaBridge);
-        JavaToJSBridge javaToJSBridge = new JavaToJSBridge(this);
+        javaToJSBridge = new JavaToJSBridge(this);
 
         requestHandler.getProject().getService(SettingsChangeListener.class).setJavaToJSBridge(javaToJSBridge);
 
@@ -28,5 +30,10 @@ public class SourcegraphJBCefBrowser extends JBCefBrowser {
                 javaToJSBridge.callJS("themeChanged", ThemeUtil.getCurrentThemeAsJson());
             }
         });
+    }
+
+    @NotNull
+    public JavaToJSBridge getJavaToJSBridge() {
+        return javaToJSBridge;
     }
 }

--- a/client/jetbrains/standalone/src/index.html
+++ b/client/jetbrains/standalone/src/index.html
@@ -25,12 +25,43 @@
             margin: 20px 0;
         }
 
-        #webview {
+        #webview-and-overlay {
+            position: relative;
             width: 960px;
-            max-width: 100%;
             height: 400px;
+        }
+
+        #webview-overlay {
+            position: absolute;
+            visibility: hidden;
+            width: calc(100% - 2 * 150px);
+            height: 100%;
+            z-index: 2;
+            display: flex;
+            padding: 0 150px;
+            justify-content: center;
+            align-items: center;
+            text-align: center;
+            line-height: 1.5em;
+        }
+
+        html.dark #webview-overlay, .dark body #webview-overlay {
+            background-color: #3c3f41;
+            color: #bbbbbb;
+        }
+
+        html.light #webview-overlay, .light body #webview-overlay {
+            background-color: rgb(242, 242, 242);
+            color: #bbbbbb;
+        }
+
+        #webview {
+            position: absolute;
+            width: 100%;
+            height: 100%;
             margin: 0;
             border-top: 0 !important;
+            z-index: 1
         }
 
         .dark #webview {
@@ -93,12 +124,12 @@
 
         .dark #code-details-highlight {
             background-color: #ebcb8b;
-            color:#4f5b66;
+            color: #4f5b66;
         }
 
         .light #code-details-highlight {
             background-color: #ebcb8b;
-            color:#4f5b66;
+            color: #4f5b66;
         }
     </style>
     <meta charset="UTF-8">
@@ -106,7 +137,10 @@
 <body>
 <div id="modal">
     <div id="title"><img alt="Sourcegraph logo" height="16" src="/icons/sourcegraphLogo.svg" width="16" /> Sourcegraph</div>
-    <iframe height="100%" id="webview" src="/html/index.html" width="100%"></iframe>
+    <div id="webview-and-overlay">
+        <div id="webview-overlay"></div>
+        <iframe height="100%" id="webview" src="/html/index.html" width="100%"></iframe>
+    </div>
     <div id="code-details"></div>
 
     <script type="module" src="/dist/bridgeMock.js"></script>

--- a/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
+++ b/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
@@ -22,6 +22,7 @@ let savedSearch: Search = savedSearchFromLocalStorage
           selectedSearchContextSpec: 'global',
       }
 
+const webviewOverlay = document.querySelector('#webview-overlay') as HTMLPreElement
 const codeDetailsNode = document.querySelector('#code-details') as HTMLPreElement
 
 let previewContent: PreviewRequest['arguments'] | null = null
@@ -66,13 +67,21 @@ function handleRequest(
             break
         }
 
+        case 'indicateSearchError': {
+            setOverlay(`Search error: ${request.arguments.errorMessage}`)
+            onSuccessCallback('null')
+            break
+        }
+
         case 'previewLoading': {
+            setOverlay(null)
             codeDetailsNode.innerHTML = 'Loading...'
             onSuccessCallback('null')
             break
         }
 
         case 'preview': {
+            setOverlay(null)
             previewContent = request.arguments
 
             const start =
@@ -105,6 +114,7 @@ function handleRequest(
         }
 
         case 'clearPreview': {
+            setOverlay(null)
             codeDetailsNode.textContent = ''
             onSuccessCallback('null')
             break
@@ -134,6 +144,7 @@ function handleRequest(
         }
 
         case 'indicateFinishedLoading': {
+            setOverlay(null)
             onSuccessCallback('null')
             break
         }
@@ -154,6 +165,11 @@ function handleRequest(
 
 export function setDarkMode(value: boolean): void {
     isDarkTheme = value
+}
+
+function setOverlay(content: string | null): void {
+    webviewOverlay.style.visibility = content !== null ? 'visible' : 'hidden'
+    webviewOverlay.innerHTML = content || ''
 }
 
 function escapeHTML(unsafe: string): string {

--- a/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
+++ b/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
@@ -8,7 +8,9 @@ import type { Search, Theme } from '../search/types'
 import { dark } from './theme-snapshots/dark'
 import { light } from './theme-snapshots/light'
 
+/* Set these to connect to a different server */
 const instanceURL = 'https://sourcegraph.com/'
+const accessToken = null
 
 let isDarkTheme = false
 
@@ -53,7 +55,7 @@ function handleRequest(
                 JSON.stringify({
                     instanceURL,
                     isGlobbingEnabled: true,
-                    accessToken: null,
+                    accessToken,
                     anonymousUserId: 'test',
                     pluginVersion: '1.2.3',
                 })

--- a/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
+++ b/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
@@ -16,11 +16,11 @@ const savedSearchFromLocalStorage = localStorage.getItem('savedSearch')
 let savedSearch: Search = savedSearchFromLocalStorage
     ? (JSON.parse(savedSearchFromLocalStorage) as Search)
     : {
-          query: 'r:github.com/sourcegraph/sourcegraph jetbrains',
-          caseSensitive: false,
-          patternType: SearchPatternType.literal,
-          selectedSearchContextSpec: 'global',
-      }
+        query: 'r:github.com/sourcegraph/sourcegraph jetbrains',
+        caseSensitive: false,
+        patternType: SearchPatternType.literal,
+        selectedSearchContextSpec: 'global',
+    }
 
 const webviewOverlay = document.querySelector('#webview-overlay') as HTMLPreElement
 const codeDetailsNode = document.querySelector('#code-details') as HTMLPreElement

--- a/client/jetbrains/webview/src/search/StatusBar.tsx
+++ b/client/jetbrains/webview/src/search/StatusBar.tsx
@@ -11,11 +11,11 @@ interface Props {
     authState: 'initial' | 'validating' | 'success' | 'failure'
 }
 
-export const StatusBar: React.FunctionComponent<Props> = ({ progress, progressState }: Props) => (
+export const StatusBar: React.FunctionComponent<Props> = props => (
     <div className={styles.statusBar}>
-        {progressState !== null && (
-            <StreamingProgressCount progress={progress} state={progressState} className={styles.progressCount} />
-        )}
+        {props.progressState !== null && (props.progressState === 'error' ? ''
+            : <StreamingProgressCount progress={props.progress} state={props.progressState}
+                                      className={styles.progressCount} />)}
         <div className={styles.spacer} />
     </div>
 )

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -48,7 +48,7 @@ window.initializeSourcegraph = async () => {
 
         let isServerAccessSuccessful = false
         try {
-            const {site, currentUser} = await getSiteVersionAndAuthenticatedUser(instanceURL, accessToken)
+            const { site, currentUser } = await getSiteVersionAndAuthenticatedUser(instanceURL, accessToken)
             authenticatedUser = currentUser
             backendVersion = site?.productVersion || null
             isServerAccessSuccessful = true

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -4,7 +4,7 @@ import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import polyfillEventSource from '@sourcegraph/shared/src/polyfills/vendor/eventSource'
 import { AnchorLink, setLinkComponent } from '@sourcegraph/wildcard'
 
-import { getAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
+import { getSiteVersionAndAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
 import { EventLogger } from '../telemetry/EventLogger'
 
 import { App } from './App'
@@ -31,6 +31,7 @@ let anonymousUserId: string
 let pluginVersion: string
 let initialSearch: Search | null = null
 let authenticatedUser: AuthenticatedUser | null = null
+let backendVersion: string | null = null
 let telemetryService: EventLogger
 
 window.initializeSourcegraph = async () => {
@@ -47,7 +48,9 @@ window.initializeSourcegraph = async () => {
 
         let isServerAccessSuccessful = false
         try {
-            authenticatedUser = await getAuthenticatedUser(instanceURL, accessToken)
+            const {site, currentUser} = await getSiteVersionAndAuthenticatedUser(instanceURL, accessToken)
+            authenticatedUser = currentUser
+            backendVersion = site?.productVersion || null
             isServerAccessSuccessful = true
         } catch (error) {
             console.info('Could not authenticate with current URL and token settings', instanceURL, accessToken, error)
@@ -86,6 +89,7 @@ export function renderReactApp(): void {
             onPreviewChange={onPreviewChange}
             onPreviewClear={onPreviewClear}
             onSearchError={onSearchError}
+            backendVersion={backendVersion}
             authenticatedUser={authenticatedUser}
             telemetryService={telemetryService}
         />,

--- a/client/jetbrains/webview/src/search/java-to-js-bridge.ts
+++ b/client/jetbrains/webview/src/search/java-to-js-bridge.ts
@@ -28,7 +28,7 @@ export async function handleRequest(
         const pluginConfig = argumentsAsObject as PluginSettingsChangedRequestArguments
         applyConfig(pluginConfig)
         try {
-            const {currentUser} = await getSiteVersionAndAuthenticatedUser(pluginConfig.instanceURL, pluginConfig.accessToken)
+            const { currentUser } = await getSiteVersionAndAuthenticatedUser(pluginConfig.instanceURL, pluginConfig.accessToken)
             await indicateFinishedLoading(true, !!currentUser)
         } catch {
             await indicateFinishedLoading(false, false)

--- a/client/jetbrains/webview/src/search/java-to-js-bridge.ts
+++ b/client/jetbrains/webview/src/search/java-to-js-bridge.ts
@@ -1,4 +1,4 @@
-import { getAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
+import { getSiteVersionAndAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
 
 import { indicateFinishedLoading } from './js-to-java-bridge'
 import { PluginConfig, Theme } from './types'
@@ -28,8 +28,8 @@ export async function handleRequest(
         const pluginConfig = argumentsAsObject as PluginSettingsChangedRequestArguments
         applyConfig(pluginConfig)
         try {
-            const authenticatedUser = await getAuthenticatedUser(pluginConfig.instanceURL, pluginConfig.accessToken)
-            await indicateFinishedLoading(true, !!authenticatedUser)
+            const {currentUser} = await getSiteVersionAndAuthenticatedUser(pluginConfig.instanceURL, pluginConfig.accessToken)
+            await indicateFinishedLoading(true, !!currentUser)
         } catch {
             await indicateFinishedLoading(false, false)
         }

--- a/client/jetbrains/webview/src/search/java-to-js-bridge.ts
+++ b/client/jetbrains/webview/src/search/java-to-js-bridge.ts
@@ -1,9 +1,15 @@
-import { getSiteVersionAndAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
-
 import { indicateFinishedLoading } from './js-to-java-bridge'
 import { PluginConfig, Theme } from './types'
 
-import { applyConfig, applyTheme, renderReactApp } from './index'
+import {
+    applyConfig,
+    applyTheme,
+    getAuthenticatedUser,
+    renderReactApp,
+    retrySearch,
+    updateVersionAndAuthDataFromServer,
+    wasServerAccessSuccessful
+} from './index'
 
 export type ActionName = 'themeChanged' | 'pluginSettingsChanged'
 
@@ -27,12 +33,18 @@ export async function handleRequest(
     if (action === 'pluginSettingsChanged') {
         const pluginConfig = argumentsAsObject as PluginSettingsChangedRequestArguments
         applyConfig(pluginConfig)
-        try {
-            const { currentUser } = await getSiteVersionAndAuthenticatedUser(pluginConfig.instanceURL, pluginConfig.accessToken)
-            await indicateFinishedLoading(true, !!currentUser)
-        } catch {
-            await indicateFinishedLoading(false, false)
+        await updateVersionAndAuthDataFromServer()
+        await indicateFinishedLoading(wasServerAccessSuccessful() || false, !!getAuthenticatedUser())
+        renderReactApp()
+        return callback(JSON.stringify(null))
+    }
+
+    if (action === 'retrySearch') {
+        if (!wasServerAccessSuccessful()) {
+            await updateVersionAndAuthDataFromServer()
         }
+        await indicateFinishedLoading(wasServerAccessSuccessful() || false, !!getAuthenticatedUser())
+        retrySearch()
         renderReactApp()
         return callback(JSON.stringify(null))
     }

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -64,6 +64,11 @@ interface GetThemeRequest {
     action: 'getTheme'
 }
 
+interface IndicateSearchError {
+    action: 'indicateSearchError'
+    arguments: { errorMessage: string, timeAsISOString: string }
+}
+
 export interface SaveLastSearchRequest {
     action: 'saveLastSearch'
     arguments: Search
@@ -88,6 +93,7 @@ export type Request =
     | OpenRequest
     | GetConfigRequest
     | GetThemeRequest
+    | IndicateSearchError
     | SaveLastSearchRequest
     | LoadLastSearchRequest
     | ClearPreviewRequest
@@ -120,6 +126,18 @@ export async function getThemeAlwaysFulfill(): Promise<Theme> {
             isDarkTheme: false,
             intelliJTheme: {},
         }
+    }
+}
+
+export async function onSearchError(errorMessage: string): Promise<void> {
+    try {
+        lastPreviewUpdateCallSendDateTime = new Date()
+        await callJava({
+            action: 'indicateSearchError',
+            arguments: { errorMessage, timeAsISOString: lastPreviewUpdateCallSendDateTime.toISOString() },
+        })
+    } catch (error) {
+        console.error(`Failed to indicate search error: ${(error as Error).message}`)
     }
 }
 

--- a/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
+++ b/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
@@ -1,17 +1,63 @@
-import { requestGraphQLCommon } from '@sourcegraph/http-client'
-import { AuthenticatedUser, currentAuthStateQuery } from '@sourcegraph/shared/src/auth'
+import { gql, requestGraphQLCommon } from '@sourcegraph/http-client'
+import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { CurrentAuthStateResult, CurrentAuthStateVariables } from '@sourcegraph/shared/src/graphql-operations'
 
-export async function getAuthenticatedUser(
+export type SiteVersionAndCurrentAuthStateResult = CurrentAuthStateResult & {
+    site: {
+        productVersion: string
+    }
+}
+
+export const siteVersionAndUserQuery = gql`
+    query SiteVersionAndCurrentUser {
+        site {
+            productVersion
+        }
+        currentUser {
+            __typename
+            id
+            databaseID
+            username
+            avatarURL
+            email
+            displayName
+            siteAdmin
+            tags
+            url
+            settingsURL
+            organizations {
+                nodes {
+                    id
+                    name
+                    displayName
+                    url
+                    settingsURL
+                }
+            }
+            session {
+                canSignOut
+            }
+            viewerCanAdminister
+            tags
+        }
+    }
+`
+
+export interface SiteVersionAndCurrentUser {
+    site: {productVersion: string} | null,
+    currentUser: AuthenticatedUser | null
+}
+
+export async function getSiteVersionAndAuthenticatedUser(
     instanceURL: string,
     accessToken: string | null
-): Promise<AuthenticatedUser | null> {
+): Promise<SiteVersionAndCurrentUser> {
     if (!instanceURL) {
-        return null
+        return {site: null, currentUser: null}
     }
 
-    const result = await requestGraphQLCommon<CurrentAuthStateResult, CurrentAuthStateVariables>({
-        request: currentAuthStateQuery,
+    const result = await requestGraphQLCommon<SiteVersionAndCurrentAuthStateResult, CurrentAuthStateVariables>({
+        request: siteVersionAndUserQuery,
         variables: {},
         baseUrl: instanceURL,
         headers: {
@@ -22,5 +68,5 @@ export async function getAuthenticatedUser(
         },
     }).toPromise()
 
-    return result.data?.currentUser ?? null
+    return result.data ?? {site: null, currentUser: null}
 }

--- a/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
+++ b/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
@@ -8,6 +8,7 @@ export type SiteVersionAndCurrentAuthStateResult = CurrentAuthStateResult & {
     }
 }
 
+// TODO: Could be deduplicated with `currentAuthStateQuery` in `shared/src/auth.ts`, using fragments
 export const siteVersionAndUserQuery = gql`
     query SiteVersionAndCurrentUser {
         site {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41897

The problem is that Sourcegraph version 3.42.0 and the ones below didn't have `patternType: standard`. ([source](https://docs.sourcegraph.com/CHANGELOG#3-43-0))

The fix gets the version from Sourcegraph at the initial auth (I managed to achieve this in an elegant way without an additional request), and if the version is affected, it falls back to `patternType: literal`. I didn't find the difference between these two, but they should be the same for most purposes, if not all.

I made sure that the standalone version remains a useful testing tool, so I've updated it in all the ways that made sense.

For the reviewer: going commit by commit might help, I tried my best to leave nice commit messages.

Note: It handles custom builds (like "174153_2022-09-26_f120e7801981") well as long as they are newer than 3.42.0 (it just considers all non-standard versions as newer).

## Test plan

The test situations are tricky to create ([this helps](https://docs.sourcegraph.com/admin/deploy/docker-single-container)), so I've tested in this in this [5-min Loom](https://www.loom.com/share/2f7620d411d24109af8c08a471e862e4).

Also added the note to the overlay that I mentioned in the video:

![CleanShot 2022-09-26 at 16 57 10@2x](https://user-images.githubusercontent.com/2552265/192310687-31341d4c-1f1a-4be2-a2b3-d810f3c69488.png)

## App preview:

- [Web](https://sg-web-dv-jetbrains-make-compatible-with.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ddzcqikuah.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
