### PR TITLE
Bundle legacy code intel extension for native integrations

### DIFF
--- a/client/browser/scripts/build-npm.ts
+++ b/client/browser/scripts/build-npm.ts
@@ -5,6 +5,8 @@ import { writeFile } from 'mz/fs'
 import * as semver from 'semver'
 import signale from 'signale'
 
+import { copyInlineExtensions } from './tasks'
+
 export const packagePath = path.resolve(__dirname, '..', 'build', 'integration')
 
 /**
@@ -41,4 +43,6 @@ export async function buildNpm(bumpVersion?: boolean): Promise<void> {
     signale.info(`New version is ${packageJson.version}`)
     // Write package.json
     await writeFile(path.join(packagePath, 'package.json'), JSON.stringify(packageJson, null, 2))
+
+    copyInlineExtensions(packagePath)
 }

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -111,7 +111,7 @@ function copyExtensionAssets(toDirectory: string): void {
  *
  * The pre-requisite step is to first clone, build, and copy into `build/extensions`.
  */
-function copyInlineExtensions(toDirectory: string): void {
+export function copyInlineExtensions(toDirectory: string): void {
     shelljs.cp('-R', 'build/extensions', toDirectory)
 }
 

--- a/client/browser/src/shared/platform/inlineExtensionsService.ts
+++ b/client/browser/src/shared/platform/inlineExtensionsService.ts
@@ -8,7 +8,6 @@ import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 
 import extensions from '../../../code-intel-extensions.json'
 import { EnableLegacyExtensionsResult } from '../../graphql-operations'
-import { isExtension } from '../context'
 
 const DEFAULT_ENABLE_LEGACY_EXTENSIONS = false
 
@@ -45,7 +44,16 @@ export const shouldUseInlineExtensions = (requestGraphQL: PlatformContext['reque
                 return DEFAULT_ENABLE_LEGACY_EXTENSIONS
             }
         }),
-        map(enableLegacyExtensions => !enableLegacyExtensions && isExtension)
+        map(enableLegacyExtensions => {
+            // TODO: The Phabricator native extension is currently the only runtime that runs the
+            // browser extension code but does not use bundled extensions yet. We will fix this
+            // when we update the browser extensions to use the new code intel APIs (#42104).
+            if (window.SOURCEGRAPH_PHABRICATOR_EXTENSION === true) {
+                return false
+            }
+
+            return !enableLegacyExtensions
+        })
     )
 
 /**
@@ -54,10 +62,23 @@ export const shouldUseInlineExtensions = (requestGraphQL: PlatformContext['reque
 function getURLsForInlineExtension(extensionID: string): { manifestURL: string; scriptURL: string } {
     const kebabCaseExtensionID = extensionID.replace(/^sourcegraph\//, 'sourcegraph-')
 
-    return {
-        manifestURL: browser.extension.getURL(`extensions/${kebabCaseExtensionID}/package.json`),
-        scriptURL: browser.extension.getURL(`extensions/${kebabCaseExtensionID}/extension.js`),
+    const manifestPath = `extensions/${kebabCaseExtensionID}/package.json`
+    const scriptPath = `extensions/${kebabCaseExtensionID}/extension.js`
+
+    if (typeof window.browser !== 'undefined') {
+        return {
+            manifestURL: browser.extension.getURL(manifestPath),
+            scriptURL: browser.extension.getURL(scriptPath),
+        }
     }
+    if (window.SOURCEGRAPH_ASSETS_URL) {
+        return {
+            manifestURL: new URL(manifestPath, window.SOURCEGRAPH_ASSETS_URL).toString(),
+            scriptURL: new URL(scriptPath, window.SOURCEGRAPH_ASSETS_URL).toString(),
+        }
+    }
+
+    throw new Error('Can not construct extension URLs')
 }
 
 export function getInlineExtensions(): Observable<ExecutableExtension[]> {

--- a/client/browser/src/shared/platform/inlineExtensionsService.ts
+++ b/client/browser/src/shared/platform/inlineExtensionsService.ts
@@ -65,12 +65,16 @@ function getURLsForInlineExtension(extensionID: string): { manifestURL: string; 
     const manifestPath = `extensions/${kebabCaseExtensionID}/package.json`
     const scriptPath = `extensions/${kebabCaseExtensionID}/extension.js`
 
+    // In a browser extension environment, we need to find the absolute ULR in the browser extension
+    // asssets directory.
     if (typeof window.browser !== 'undefined') {
         return {
             manifestURL: browser.extension.getURL(manifestPath),
             scriptURL: browser.extension.getURL(scriptPath),
         }
     }
+    // If SOURCEGRAPH_ASSETS_URL is defined (happening for e.g. GitLab native extenisons), we can
+    // use this URL as the root for bundled assets.
     if (window.SOURCEGRAPH_ASSETS_URL) {
         return {
             manifestURL: new URL(manifestPath, window.SOURCEGRAPH_ASSETS_URL).toString(),


### PR DESCRIPTION
Part of #41921

We have a deployment method of the browser extensions that we call "native integrations". The idea here is that we inject the browser extension code directly from the code host so that users do not need to install an extension. Most prominently, this is used by GitLab who currently bundles a version of the native integrations package with their on-premise builds so instance admins can enable this for users.

The issue with this deployment model is that we have no impact on when these clients are updated. We rely on GitLabs rollout and update policies so these cycles are super slow. For the upcoming release, we had to cut a corner for this and made the extensions GraphQL endpoints handle eventual native integration requests with special care to not break them. 

Since we eventually want to remove these APIs, we want to move fast here and provide a new native integration build that does not use these APIs anymore. Before we can update the bundled version on the GitLab end, we need to make sure that the package contains a bundled version of the code intel APIs (similar to our browser extensions right now). This is what's happening here:

- This PR adds bundles the legacy code intel APIs to the `@sourcegraph/code-host-integration` package.
- It also changes the gating of the inlined extensions so that they are loaded on GitLab.

## Test plan

It was quite a struggle to get both Sourcegraph _and_ GitLab running in development on my machine at the same time (since both use Postgres for example). However, I eventually managed to do that and tested by this symlink: `gitlab/node_module/@sourcegraph/code-host-integration -> ../sourcegraph/client/browser/build/integration`. 

### `enableLegacyExtensions = false`

![Screenshot 2022-09-26 at 13 13 51](https://user-images.githubusercontent.com/458591/192311098-b032679d-0997-458c-b60c-8a99d169c646.png)

### `enableLegacyExtensions = true`

![Screenshot 2022-09-26 at 13 15 49](https://user-images.githubusercontent.com/458591/192311134-4195da04-9b04-4213-b293-2ea6ada38290.png)



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-native-extensions-for-ext.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ivjpuyvrfw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
