### PR TITLE
upgrade puppeteer to 18.0.5

### DIFF
--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -10,7 +10,6 @@ import { readFile } from 'mz/fs'
 import puppeteer, {
     PageEventObject,
     Page,
-    Serializable,
     LaunchOptions,
     ConsoleMessage,
     Target,
@@ -527,7 +526,7 @@ export class Driver {
         )
     }
 
-    private async makeRequest<T = void>({ url, init }: { url: string; init: RequestInit & Serializable }): Promise<T> {
+    private async makeRequest<T = void>({ url, init }: { url: string; init: RequestInit }): Promise<T> {
         const handle = await this.page.evaluateHandle(
             (url, init) => fetch(url, init).then(response => response.json()),
             url,
@@ -680,7 +679,7 @@ export class Driver {
     public async findElementWithText(
         text: string,
         options: FindElementOptions & { action?: 'click' } = {}
-    ): Promise<puppeteer.ElementHandle<Element>> {
+    ): Promise<puppeteer.ElementHandle<Node>> {
         const { selector: tagName, fuzziness, wait } = options
         const tag = tagName || '*'
         const regexps = findElementRegexpStrings(text, { fuzziness })

--- a/package.json
+++ b/package.json
@@ -317,7 +317,7 @@
     "prettier": "2.2.1",
     "process": "^0.11.10",
     "protoc-gen-ts": "0.8.1",
-    "puppeteer": "^13.5.1",
+    "puppeteer": "^18.0.5",
     "react-refresh": "^0.10.0",
     "rimraf": "^3.0.2",
     "sass": "^1.32.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15068,6 +15068,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"devtools-protocol@npm:0.0.1036444":
+  version: 0.0.1036444
+  resolution: "devtools-protocol@npm:0.0.1036444"
+  checksum: 6975c8def95a5e1a4207d6deb05322e335d6a37bdaa3e589cbd5bde40fbbe3ab0df2cfedb1b3ad2785401f208c150fd489a6a065a4624b56e4c0c4c1bfd89172
+  languageName: node
+  linkType: hard
+
 "devtools-protocol@npm:0.0.981744":
   version: 0.0.981744
   resolution: "devtools-protocol@npm:0.0.981744"
@@ -26998,7 +27005,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"puppeteer@npm:^13.0.0, puppeteer@npm:^13.5.1":
+"puppeteer@npm:^13.0.0":
   version: 13.7.0
   resolution: "puppeteer@npm:13.7.0"
   dependencies:
@@ -27015,6 +27022,25 @@ __metadata:
     unbzip2-stream: 1.4.3
     ws: 8.5.0
   checksum: 4062b3ac3330e70d58095c1e0c5a46cada39a3fc5608e0e0e204448a400aef4d785a3b21d9e7733b2b2dc8cf686a476abf016f05d2e9108b3753dd41d62b9d1c
+  languageName: node
+  linkType: hard
+
+"puppeteer@npm:^18.0.5":
+  version: 18.0.5
+  resolution: "puppeteer@npm:18.0.5"
+  dependencies:
+    cross-fetch: 3.1.5
+    debug: 4.3.4
+    devtools-protocol: 0.0.1036444
+    extract-zip: 2.0.1
+    https-proxy-agent: 5.0.1
+    progress: 2.0.3
+    proxy-from-env: 1.1.0
+    rimraf: 3.0.2
+    tar-fs: 2.1.1
+    unbzip2-stream: 1.4.3
+    ws: 8.8.1
+  checksum: 6a6e4225d0da440c1dfa6a00af3f6fa7cadf98b41c7b38e2ad8ea7ef7e978359115ab9699846feb5401fc6b2fa078be4d93a9a46d03d0e007de7d9605a41ec9c
   languageName: node
   linkType: hard
 
@@ -29046,7 +29072,7 @@ pvutils@latest:
     process: ^0.11.10
     prop-types: ^15.7.2
     protoc-gen-ts: 0.8.1
-    puppeteer: ^13.5.1
+    puppeteer: ^18.0.5
     react: 18.1.0
     react-calendar: ^3.7.0
     react-circular-progressbar: ^2.0.3
@@ -34002,6 +34028,21 @@ pvutils@latest:
   languageName: node
   linkType: hard
 
+"ws@npm:8.8.1, ws@npm:^8.0.0, ws@npm:^8.1.0, ws@npm:^8.2.3, ws@npm:^8.3.0":
+  version: 8.8.1
+  resolution: "ws@npm:8.8.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 2152cf862cae0693f3775bc688a6afb2e989d19d626d215e70f5fcd8eb55b1c3b0d3a6a4052905ec320e2d7734e20aeedbf9744496d62f15a26ad79cf4cf7dae
+  languageName: node
+  linkType: hard
+
 "ws@npm:^5.2.0 || ^6.0.0 || ^7.0.0, ws@npm:^7.3.1, ws@npm:^7.4.6, ws@npm:~7.4.2":
   version: 7.4.6
   resolution: "ws@npm:7.4.6"
@@ -34014,21 +34055,6 @@ pvutils@latest:
     utf-8-validate:
       optional: true
   checksum: 3a990b32ed08c72070d5e8913e14dfcd831919205be52a3ff0b4cdd998c8d554f167c9df3841605cde8b11d607768cacab3e823c58c96a5c08c987e093eb767a
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.0.0, ws@npm:^8.1.0, ws@npm:^8.2.3, ws@npm:^8.3.0":
-  version: 8.8.0
-  resolution: "ws@npm:8.8.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 6ceed1ca1cb800ef60c7fc8346c7d5d73d73be754228eb958765abf5d714519338efa20ffe674167039486eb3a813aae5a497f8d319e16b4d96216a31df5bd95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrade puppeteer to 18.0.5

## Test plan

All browser tests should pass

## App preview:

- [Web](https://sg-web-jdb-upgrade-puppeteer.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uktwofdbci.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
