### PR TITLE
Add lint rule for consistent type exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ const config = {
     // All other rules should go into https://github.com/sourcegraph/eslint-config
     'monorepo/no-relative-import': 'error',
     '@sourcegraph/sourcegraph/check-help-links': 'error',
+    '@typescript-eslint/consistent-type-exports': 'warn',
     'no-restricted-imports': [
       'error',
       {


### PR DESCRIPTION
ESLint will shout at you for incorrectly exporting types:

<img width="847" alt="image" src="https://user-images.githubusercontent.com/6427795/192324344-391a9a02-2b6d-4657-8844-2aad494dca96.png">

## Test plan

Tested in IDE

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-eslint-consistent-types.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tggjwkcpbs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
