### PR TITLE
Link direction to private instance vs. cloud

### DIFF
--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -75,7 +75,7 @@ As with any Sourcegraph enterprise customer, you will also receive support from 
 
 - A dedicated project manager point of contact for the rollout process
 - A mutual non-disclosure agreement, and any additional approvals or special status required to allow Sourcegraph to manage infrastructure access tokens (listed below)
-- Acceptance of our [Terms of Service for private instances](https://about.sourcegraph.com/terms-private) or an enterprise contract
+- Acceptance of our [Terms of Service for Cloud](https://about.sourcegraph.com/terms/cloud) or an enterprise contract
 
 ### Technical
 


### PR DESCRIPTION
I think this URL link and documentation should be pointed at your Sourcegraph Cloud ToS but instead is pointing at private--I could be wrong though



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
