### PR TITLE
dev/sg: add count of all metrics in use

### DIFF
--- a/dev/sg/sg_monitoring.go
+++ b/dev/sg/sg_monitoring.go
@@ -123,6 +123,8 @@ Also refer to the generated reference documentation available for site admins:
 					for _, m := range uniqueMetrics {
 						md.WriteString(fmt.Sprintf("- `%s`\n", m))
 					}
+					md.WriteString(fmt.Sprintf("\nFound %d metrics in use.\n", len(uniqueMetrics)))
+
 					if err := std.Out.WriteMarkdown(md.String()); err != nil {
 						return err
 					}


### PR DESCRIPTION
Add a quick summary for the markdown output format, using this for a quick comparison

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```sh
$ go run ./dev/sg monitoring metrics
# ... 
Found 381 metrics in use.
```