### PR TITLE
batches: preserve query when creating a BC from search

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
@@ -116,7 +116,7 @@ export const LibraryPane: React.FunctionComponent<React.PropsWithChildren<Librar
 
             if (query) {
                 const searchQuery = `${query} ${patternType ? `patternType:${patternType}` : ''}`
-                const renderTemplate = createRenderTemplate(searchQuery, template)
+                const renderTemplate = createRenderTemplate(searchQuery, template, true)
                 return renderTemplate(name)
             }
         }

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useCallback } from 'react'
 
 import { mdiChevronDoubleLeft, mdiChevronDoubleRight, mdiOpenInNew } from '@mdi/js'
+import { useLocation } from 'react-router'
 import { animated, useSpring } from 'react-spring'
 
 import { Button, useLocalStorage, H3, H4, Icon, Link, Text, VIEWPORT_XL } from '@sourcegraph/wildcard'
 
 import { Scalars } from '../../../../../graphql-operations'
 import { eventLogger } from '../../../../../tracking/eventLogger'
+import { createRenderTemplate } from '../../../create/useSearchTemplate'
 import { insertNameIntoLibraryItem } from '../../yaml-util'
 
 import combySample from './comby.batch.yaml'
@@ -104,15 +106,32 @@ export const LibraryPane: React.FunctionComponent<React.PropsWithChildren<Librar
         [animateContainer, animateContent, animateHeader, setDefaultCollapsed]
     )
 
+    const { search: searchQuery } = useLocation()
+    const updateTemplateWithQueryAndName = useCallback((template: string): string => {
+        if (searchQuery) {
+            const parameters = new URLSearchParams(location.search)
+
+            const query = parameters.get('q')
+            const patternType = parameters.get('patternType')
+
+            if (query) {
+                const searchQuery = `${query} ${patternType ? `patternType:${patternType}` : ''}`
+                const renderTemplate = createRenderTemplate(searchQuery, template)
+                return renderTemplate(name)
+            }
+        }
+        return insertNameIntoLibraryItem(template, name)
+    }, [name, searchQuery])
+
     const onConfirm = useCallback(() => {
         if (selectedItem && !('isReadOnly' in props && props.isReadOnly)) {
+            const codeWithName = updateTemplateWithQueryAndName(selectedItem.code)
             const templateName = selectedItem.name
-            const codeWithName = insertNameIntoLibraryItem(selectedItem.code, name)
             eventLogger.log('batch_change_editor:template:loaded', { template: templateName })
             props.onReplaceItem(codeWithName)
             setSelectedItem(undefined)
         }
-    }, [name, selectedItem, props])
+    }, [selectedItem, props, updateTemplateWithQueryAndName])
 
     return (
         <>

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
@@ -108,7 +108,7 @@ export const LibraryPane: React.FunctionComponent<React.PropsWithChildren<Librar
 
     const { search: searchQuery } = useLocation()
     const updateTemplateWithQueryAndName = useCallback((template: string): string => {
-        if (searchQuery) {
+        if (searchQuery !== '') {
             const parameters = new URLSearchParams(location.search)
 
             const query = parameters.get('q')

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
@@ -312,21 +312,21 @@ describe('Batch spec yaml utils', () => {
     describe('insertFieldIntoLibraryItem', () => {
         it('should correctly overwrite the name in a given spec', () => {
             for (const spec of [SPEC_WITH_ONE_REPOSITORY, SPEC_WITH_IMPORT_AND_STEPS]) {
-                expect(insertFieldIntoLibraryItem(spec, 'new-name', 'name')).toEqual(
+                expect(insertFieldIntoLibraryItem(spec, 'new-name', 'name', true)).toEqual(
                     spec.replace('hello-world', 'new-name')
                 )
             }
         })
         it('should correctly quote special names', () => {
             for (const newName of ['bad: colons', 'true', 'false', '1.23']) {
-                expect(insertFieldIntoLibraryItem(SPEC_WITH_ONE_REPOSITORY, newName, 'name')).toEqual(
+                expect(insertFieldIntoLibraryItem(SPEC_WITH_ONE_REPOSITORY, newName, 'name', true)).toEqual(
                     SPEC_WITH_ONE_REPOSITORY.replace('hello-world', `"${newName}"`)
                 )
             }
         })
         it('should not quote edge-cases that do not need quoting', () => {
             for (const newName of ['"asdf"', "'asdf'", 'hello-"asdf"', 'zero', 'on', 'off', 'yes', 'no']) {
-                expect(insertFieldIntoLibraryItem(SPEC_WITH_ONE_REPOSITORY, newName, 'name')).toEqual(
+                expect(insertFieldIntoLibraryItem(SPEC_WITH_ONE_REPOSITORY, newName, 'name', true)).toEqual(
                     SPEC_WITH_ONE_REPOSITORY.replace('hello-world', newName)
                 )
             }
@@ -349,74 +349,91 @@ describe('Batch spec yaml utils', () => {
 
     describe('insertQueryIntoLibraryItem', () => {
         it('should add simple query', () => {
-            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global hello patternType:standard')
+            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global hello patternType:standard', false)
             expect(spec).toEqual(
                 'name: hello-world\n' +
                     'on:\n' +
-                    '    - repositoriesMatchingQuery: context:global hello patternType:standard\n\n'
+                    '    - repositoriesMatchingQuery: context:global hello patternType:standard\n'
             )
         })
 
         it('should add quoted query', () => {
-            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global "hello" patternType:standard')
+            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global "hello" patternType:standard', false)
             expect(spec).toEqual(
                 'name: hello-world\n' +
                     'on:\n' +
-                    '    - repositoriesMatchingQuery: context:global "hello" patternType:standard\n\n'
+                    '    - repositoriesMatchingQuery: context:global "hello" patternType:standard\n'
             )
         })
 
         it('should add unbalanced quoted query', () => {
-            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global "hello patternType:standard')
+            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global "hello patternType:standard', false)
             expect(spec).toEqual(
                 'name: hello-world\n' +
                     'on:\n' +
-                    '    - repositoriesMatchingQuery: context:global "hello patternType:standard\n\n'
+                    '    - repositoriesMatchingQuery: context:global "hello patternType:standard\n'
             )
         })
 
         it('should add query with colon', () => {
-            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global hello: world patternType:standard')
+            const spec = insertQueryIntoLibraryItem(SPEC_WITH_QUERY, 'context:global hello: world patternType:standard', false)
             expect(spec).toEqual(
                 'name: hello-world\n' +
                     'on:\n' +
-                    '    - repositoriesMatchingQuery: "context:global hello: world patternType:standard"\n\n'
+                    '    - repositoriesMatchingQuery: "context:global hello: world patternType:standard"\n'
             )
         })
 
         it('should add query with colon and quotes', () => {
             const spec = insertQueryIntoLibraryItem(
                 SPEC_WITH_QUERY,
-                'context:global hello: "world" patternType:standard'
+                'context:global hello: "world" patternType:standard',
+                false
             )
             expect(spec).toEqual(
                 'name: hello-world\n' +
                     'on:\n' +
-                    '    - repositoriesMatchingQuery: "context:global hello: \\"world\\" patternType:standard"\n\n'
+                    '    - repositoriesMatchingQuery: "context:global hello: \\"world\\" patternType:standard"\n'
             )
         })
 
         it('should add query with colon and unbalanced quotes', () => {
             const spec = insertQueryIntoLibraryItem(
                 SPEC_WITH_QUERY,
-                'context:global hello: "world patternType:standard'
+                'context:global hello: "world patternType:standard',
+                false
             )
             expect(spec).toEqual(
                 'name: hello-world\n' +
                     'on:\n' +
-                    '    - repositoriesMatchingQuery: "context:global hello: \\"world patternType:standard"\n\n'
+                    '    - repositoriesMatchingQuery: "context:global hello: \\"world patternType:standard"\n'
             )
         })
 
         it('should add query with colon and double unbalanced quotes', () => {
             const spec = insertQueryIntoLibraryItem(
                 SPEC_WITH_QUERY,
-                'context:global "hello": "world patternType:standard'
+                'context:global "hello": "world patternType:standard',
+                false
             )
             expect(spec).toEqual(
                 'name: hello-world\n' +
                     'on:\n' +
-                    '    - repositoriesMatchingQuery: "context:global \\"hello\\": \\"world patternType:standard"\n\n'
+                    '    - repositoriesMatchingQuery: "context:global \\"hello\\": \\"world patternType:standard"\n'
+            )
+        })
+
+        it('should comment out existing query when commentExistingQuery is true', () => {
+            const spec = insertQueryIntoLibraryItem(
+                SPEC_WITH_QUERY,
+                'context:global hello: "world" patternType:standard',
+                true
+            )
+            expect(spec).toEqual(
+                'name: hello-world\n' +
+                    'on:\n' +
+                    '    - repositoriesMatchingQuery: "context:global hello: \\"world\\" patternType:standard"\n' +
+                    '# - repositoriesMatchingQuery: file:README.md\n\n'
             )
         })
     })

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.test.ts
@@ -429,11 +429,11 @@ describe('Batch spec yaml utils', () => {
                 'context:global hello: "world" patternType:standard',
                 true
             )
-            expect(spec).toEqual(
-                'name: hello-world\n' +
-                    'on:\n' +
-                    '    - repositoriesMatchingQuery: "context:global hello: \\"world\\" patternType:standard"\n' +
-                    '# - repositoriesMatchingQuery: file:README.md\n\n'
+            expect(spec).toEqual(`name: hello-world
+on:
+    - repositoriesMatchingQuery: "context:global hello: \\"world\\" patternType:standard"
+# - repositoriesMatchingQuery: file:README.md
+`
             )
         })
     })

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -441,12 +441,11 @@ export const insertFieldIntoLibraryItem = (
     const finalValue = quotable ? quoteYAMLString(value) : value
 
     if (commentExistingValue) {
-        console.log('about to comment out existing value')
         existingValue = librarySpec
             .slice(fieldMapping.value.startPosition, fieldMapping.value.endPosition)
             .trim()
             .split('\n')
-            .map(line => line.startsWith('#') ? line : `# ${line}`)
+            .map(line => (line === '' || line.startsWith('#')) ? line : `# ${line}`)
             .join('\n')
         existingValue = existingValue + '\n\n'
     }

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -441,13 +441,21 @@ export const insertFieldIntoLibraryItem = (
     const finalValue = quotable ? quoteYAMLString(value) : value
 
     if (commentExistingValue) {
-        existingValue = librarySpec
+        let shouldAppendNewLine = false
+        const existingValueArray = librarySpec
             .slice(fieldMapping.value.startPosition, fieldMapping.value.endPosition)
-            .trim()
             .split('\n')
             .map(line => (line === '' || line.startsWith('#')) ? line : `# ${line}`)
-            .join('\n')
-        existingValue = existingValue + '\n\n'
+
+        existingValue = existingValueArray.join('\n')
+        if (existingValueArray.at(-1) === '') {
+            existingValue = existingValue.trim()
+            shouldAppendNewLine = true
+        }
+
+        if (shouldAppendNewLine) {
+            existingValue = existingValue + '\n'
+        }
     }
 
     // Stitch the new <value> into the spec.

--- a/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
+++ b/client/web/src/enterprise/batches/batch-spec/yaml-util.ts
@@ -441,19 +441,20 @@ export const insertFieldIntoLibraryItem = (
     const finalValue = quotable ? quoteYAMLString(value) : value
 
     if (commentExistingValue) {
-        let shouldAppendNewLine = false
+        /**
+         * We get a slice of the spec containing the fields we want to replace. By doing this we can have a copy of the old value.
+         * We then split by new line so we can check each line and comment it out, we want to also make sure we don't comment out 
+         * existing comments, so we check if each line starts with "#".
+         */
         const existingValueArray = librarySpec
             .slice(fieldMapping.value.startPosition, fieldMapping.value.endPosition)
             .split('\n')
             .map(line => (line === '' || line.startsWith('#')) ? line : `# ${line}`)
 
         existingValue = existingValueArray.join('\n')
+        // If the existing value contains a trailing new line, we also want to add that in.
         if (existingValueArray.at(-1) === '') {
             existingValue = existingValue.trim()
-            shouldAppendNewLine = true
-        }
-
-        if (shouldAppendNewLine) {
             existingValue = existingValue + '\n'
         }
     }

--- a/client/web/src/enterprise/batches/create/useSearchTemplate.ts
+++ b/client/web/src/enterprise/batches/create/useSearchTemplate.ts
@@ -8,9 +8,9 @@ interface UseSearchTemplateResult {
     renderTemplate?: (title: string) => string
 }
 
-export const createRenderTemplate = (query: string, sample: string = helloWorldSample): ((title: string) => string) => {
+export const createRenderTemplate = (query: string, sample: string = helloWorldSample, commentExistingQuery: boolean = false): ((title: string) => string) => {
     let template: string
-    template = insertQueryIntoLibraryItem(sample, query)
+    template = insertQueryIntoLibraryItem(sample, query, commentExistingQuery)
     template = template.replace(
         '# Find all repositories that contain a README.md file.',
         '# This is your query from search'

--- a/client/web/src/enterprise/batches/create/useSearchTemplate.ts
+++ b/client/web/src/enterprise/batches/create/useSearchTemplate.ts
@@ -8,9 +8,9 @@ interface UseSearchTemplateResult {
     renderTemplate?: (title: string) => string
 }
 
-const createRenderTemplate = (query: string): ((title: string) => string) => {
+export const createRenderTemplate = (query: string, sample: string = helloWorldSample): ((title: string) => string) => {
     let template: string
-    template = insertQueryIntoLibraryItem(helloWorldSample, query)
+    template = insertQueryIntoLibraryItem(sample, query)
     template = template.replace(
         '# Find all repositories that contain a README.md file.',
         '# This is your query from search'


### PR DESCRIPTION
Closes #41981

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


https://user-images.githubusercontent.com/25608335/192376057-f9edc765-a6dc-43f7-a14b-402bdf5b17cc.mp4

* Ensure the search query is persisted in the editor when a template is selected from the library pane.
* Confirm the existing functionality doesn't break

<img width="1507" alt="CleanShot 2022-09-27 at 20 10 20@2x" src="https://user-images.githubusercontent.com/25608335/192614922-6758a18d-7d6a-49b3-88d3-38799249f40f.png">



## App preview:

- [Web](https://sg-web-bo-preserve-query-batch-template.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nkbmkcwgxv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
