### PR TITLE
monitoring: add default metrics to ListMetrics

### DIFF
--- a/monitoring/monitoring/aggregations.go
+++ b/monitoring/monitoring/aggregations.go
@@ -21,6 +21,10 @@ func ListMetrics(dashboards ...*Dashboard) (map[*Dashboard][]string, error) {
 			}
 		}
 
+		// Add metrics used by fixed variables added in generateDashboards(). This is kind
+		// of hack, but easiest to do manually.
+		addMetrics([]string{"ALERTS", "alert_count", "src_service_metadata"})
+
 		// Add variable queries if any
 		for _, v := range d.Variables {
 			if v.OptionsLabelValues.Query != "" {
@@ -31,7 +35,6 @@ func ListMetrics(dashboards ...*Dashboard) (map[*Dashboard][]string, error) {
 				addMetrics(metrics)
 			}
 		}
-
 		// Iterate for Observables
 		for _, g := range d.Groups {
 			for _, r := range g.Rows {


### PR DESCRIPTION
Noticed we were missing some metrics in the listing. This is a bit hack, but oh well

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
```sh
$ sg monitoring metrics
# ...
Found 381 metrics in use.
$ go run ./dev/sg monitoring metrics
# ...
Found 384 metrics in use.
```