### PR TITLE
search: distinct alert kinds for smart search

### DIFF
--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -113,13 +113,20 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             telemetryService.log('search.ranking.result-clicked', { index, type })
 
             // Lucky search A/B test events on Sourcegraph.com. To be removed at latest by 12/2022.
-            if (smartSearchEnabled && !(results?.alert?.kind === 'lucky-search-queries')) {
+            if (
+                smartSearchEnabled &&
+                !(
+                    results?.alert?.kind === 'smart-search-additional-results' ||
+                    results?.alert?.kind === 'smart-search-pure-results'
+                )
+            ) {
                 telemetryService.log('SearchResultClickedAutoNone')
             }
 
             if (
                 smartSearchEnabled &&
-                results?.alert?.kind === 'lucky-search-queries' &&
+                (results?.alert?.kind === 'smart-search-additional-results' ||
+                    results?.alert?.kind === 'smart-search-pure-results') &&
                 results?.alert?.title &&
                 results.alert.proposedQueries
             ) {

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -232,7 +232,7 @@ export interface Filter {
     kind: 'file' | 'repo' | 'lang' | 'utility'
 }
 
-export type AlertKind = 'lucky-search-queries'
+export type AlertKind = 'smart-search-additional-results' | 'smart-search-pure-results'
 
 interface Alert {
     title: string

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -193,7 +193,8 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         }
         if (
             smartSearchEnabled &&
-            results?.alert?.kind === 'lucky-search-queries' &&
+            (results?.alert?.kind === 'smart-search-additional-results' ||
+                results?.alert?.kind === 'smart-search-pure-results') &&
             results?.alert?.title &&
             results.alert.proposedQueries
         ) {

--- a/client/web/src/search/suggestion/SmartSearch.tsx
+++ b/client/web/src/search/suggestion/SmartSearch.tsx
@@ -24,7 +24,9 @@ const processDescription = (description: string): string => {
 export const SmartSearch: React.FunctionComponent<React.PropsWithChildren<SmartSearchProps>> = ({ alert }) => {
     const [isCollapsed, setIsCollapsed] = useTemporarySetting('search.results.collapseSmartSearch')
 
-    return alert?.kind && alert.kind !== 'lucky-search-queries' ? null : (
+    return alert?.kind &&
+        alert.kind !== 'smart-search-additional-results' &&
+        alert.kind !== 'smart-search-pure-results' ? null : (
         <div className={styles.root}>
             <Collapse isOpen={!isCollapsed} onOpenChange={opened => setIsCollapsed(!opened)}>
                 <CollapseHeader className={styles.collapseButton}>

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -210,7 +210,10 @@ func (o *Observer) Done() (*search.Alert, error) {
 
 type alertKind string
 
-const luckySearchQueries alertKind = "lucky-search-queries"
+const (
+	smartSearchAdditionalResults alertKind = "smart-search-additional-results"
+	smartSearchPureResults                 = "smart-search-pure-results"
+)
 
 func (o *Observer) errorToAlert(ctx context.Context, err error) (*search.Alert, error) {
 	if err == nil {
@@ -262,14 +265,16 @@ func (o *Observer) errorToAlert(ctx context.Context, err error) (*search.Alert, 
 	if errors.As(err, &lErr) {
 		title := "Also showing additional results"
 		description := "We returned all the results for your query. We also added results for similar queries that might interest you."
+		kind := string(smartSearchAdditionalResults)
 		if lErr.Type == LuckyAlertPure {
 			title = "No results for original query. Showing related results instead"
 			description = "The original query returned no results. Below are results for similar queries that might interest you."
+			kind = string(smartSearchPureResults)
 		}
 		return &search.Alert{
-			PrometheusType:  "lucky_search_notice",
+			PrometheusType:  "smart_search_notice",
 			Title:           title,
-			Kind:            string(luckySearchQueries),
+			Kind:            kind,
 			Description:     description,
 			ProposedQueries: lErr.ProposedQueries,
 		}, nil


### PR DESCRIPTION
Unblocks https://github.com/sourcegraph/sourcegraph/pull/42122

This replaces references of alert kinds `lucky-search-queries` to use two distinct alert kinds instead:

- `smart-search-additional-results` meaning additional results are associated with smart search queries, in addition to results for the original query
- `smart-search-pure-results` meaning results are returned purely by smart search queries, and there are no results for the original query

The client can use these values to provide contextual alerts instead of editing/formatting alert contents generated by the backend.

## Test plan
Type-checking and existing logic

## App preview:

- [Web](https://sg-web-rvt-smart-alert-kinds.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xomcwcevbz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
