### PR TITLE
web: format stream.ts

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -87,9 +87,9 @@ interface LineMatch {
 }
 
 interface ChunkMatch {
-   content: string
-   contentStart: Location
-   ranges: Range[]
+    content: string
+    contentStart: Location
+    ranges: Range[]
 }
 
 export interface SymbolMatch {


### PR DESCRIPTION
Editor picked up a stray unformatted definition (lint didn't catch this, weird?)

## Test plan
N/A

## App preview:

- [Web](https://sg-web-rvt-fix-format-streamts.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-foncntcukd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
