### PR TITLE
docs: fix exhaustive search page

### DIFF
--- a/doc/code_search/how-to/exhaustive.md
+++ b/doc/code_search/how-to/exhaustive.md
@@ -17,16 +17,19 @@ Over time the priority of a query is reduced. This is to ensure that we have the
 There are two sources of timeouts in a `count:all` query:
 
 - A timeout in the HTTP load balancer in front of Sourcegraph (nginx/ELB/Cloudflare/etc). Your admin will likely need to increase timeouts for Sourcegraph endpoints. In particular the `.api/search/stream` path. This uses [SSE](https://en.wikipedia.org/wiki/Server-sent_events), so your reverse proxy may have specific support for these requests.
-- A maximum timeout enforced by Sourcegraph. Your admin may need to increase the site configuration value (default 60s) with the following setting: 
+- A maximum timeout enforced by Sourcegraph. Your admin may need to increase the site configuration value (default 60s) with the following setting:
+
 ```json
 "search.limits": {
     "maxTimeoutSeconds": 60,
   },
-  ```
+```
 
 ### Large result sets
 
-The Sourcegraph webapp will only display up to 500 results (however will continue to display accurate statistics). If you need to process more than 500 results, please use the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli). For now, you will need to pass in the `-stream` flag to efficiently get large result sets.
+The Sourcegraph webapp will only display up to 500 results (however will continue to display accurate statistics). 
+If you need to process more than 500 results, please use the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli). 
+For now, you will need to pass in the `-stream` flag to efficiently get large result sets.
 
 ## Limitations
 

--- a/doc/code_search/how-to/exhaustive.md
+++ b/doc/code_search/how-to/exhaustive.md
@@ -27,9 +27,7 @@ There are two sources of timeouts in a `count:all` query:
 
 ### Large result sets
 
-The Sourcegraph webapp will only display up to 500 results (however will continue to display accurate statistics). 
-If you need to process more than 500 results, please use the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli). 
-For now, you will need to pass in the `-stream` flag to efficiently get large result sets.
+The Sourcegraph webapp will only display up to 500 results (however will continue to display accurate statistics). If you need to process more than 500 results, please use the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli). For now, you will need to pass in the `-stream` flag to efficiently get large result sets.
 
 ## Limitations
 


### PR DESCRIPTION
page was malformatted: https://docs.sourcegraph.com/code_search/how-to/exhaustive

## Test plan

visual check with `sg run docsite`

<img width="853" alt="image" src="https://user-images.githubusercontent.com/29406849/192477094-90e956d0-af75-410e-ae0f-8c0dff979495.png">
