### PR TITLE
dev/sg: create .bin if it does not exist

### DIFF
--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -48,7 +48,7 @@ func Commands(ctx context.Context, parentEnv map[string]string, verbose bool, cm
 
 	// binaries get installed to <repository-root>/.bin. If the binary is installed with go build, then go
 	// will create .bin directory. Some binaries (like docsite) get downloaded instead of built and therefore
-	// need to the directory to exist before hand.
+	// need the directory to exist before hand.
 	binDir := filepath.Join(root, ".bin")
 	if err := os.Mkdir(binDir, 0755); err != nil && !os.IsExist(err) {
 		return err

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -46,6 +46,14 @@ func Commands(ctx context.Context, parentEnv map[string]string, verbose bool, cm
 		return err
 	}
 
+	// binaries get installed to <repository-root>/.bin. If the binary is installed with go build, then go
+	// will create .bin directory. Some binaries (like docsite) get downloaded instead of built and therefore
+	// need to the directory to exist before hand.
+	binDir := filepath.Join(root, ".bin")
+	if err := os.Mkdir(binDir, 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+
 	wg := sync.WaitGroup{}
 	installSemaphore := semaphore.NewWeighted(MAX_CONCURRENT_BUILD_PROCS)
 	failures := make(chan failedRun, len(cmds))


### PR DESCRIPTION
if you've cleaned your repo with `git clean -dfx` and then decide to run your very first sg command to be `sg start web-standalone` it will fail.

It fails because any other command that builds it's binary with go, relies on go to create `.bin` in the repo root, where as, `sg start web-standalone` downloads caddy and docsite to the `.bin` directory and expect it to exist. If it doesn't - it fails
```
sg start web-standalone

💡 Installing 2 commands...

--------------------------------------------------------------------------------
Failed to build caddy: open /Users/william/code/sourcegraph/.bin/caddy_2.4.5: no such file or directory
--------------------------------------------------------------------------------
❌ failed to run caddy
```
## Test plan
1. `rm -rf .bin`
2. `go run ./dev/sg start web-standalone`
```
go run ./dev/sg start web-standalone

💡 Installing 2 commands...

caddy installed
web-standalone-http installed
✅ 2/2 commands installed  ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████  100%

✅ Everything installed! Booting up the system!
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
