### PR TITLE
Remove contributions API reliance of new references panel

### DIFF
--- a/client/branded/src/components/panel/MixPreciseAndSearchBasedReferencesToggle.tsx
+++ b/client/branded/src/components/panel/MixPreciseAndSearchBasedReferencesToggle.tsx
@@ -10,7 +10,7 @@ import styles from './TabbedPanelContent.module.scss'
 
 interface Props extends PlatformContextProps, SettingsCascadeProps {}
 
-export const MixPreciseAndSearchBasedReferencesToggle = (props: Props): React.ReactNode => {
+export const MixPreciseAndSearchBasedReferencesToggle = (props: Props): React.ReactElement | null => {
     const { settingsCascade, platformContext } = props
 
     const disableSearchBased = getSettingsValue(settingsCascade, 'codeIntel.disableSearchBased')

--- a/client/branded/src/components/panel/MixPreciseAndSearchBasedReferencesToggle.tsx
+++ b/client/branded/src/components/panel/MixPreciseAndSearchBasedReferencesToggle.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback } from 'react'
+
+import { isErrorLike } from '@sourcegraph/common'
+import { updateSettings } from '@sourcegraph/shared/src/api/client/services/settings'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { SettingsCascadeOrError, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { Button, Tooltip } from '@sourcegraph/wildcard'
+
+import styles from './TabbedPanelContent.module.scss'
+
+interface Props extends PlatformContextProps, SettingsCascadeProps {}
+
+export const MixPreciseAndSearchBasedReferencesToggle = (props: Props): React.ReactNode => {
+    const { settingsCascade, platformContext } = props
+
+    const disableSearchBased = getSettingsValue(settingsCascade, 'codeIntel.disableSearchBased')
+    const mixPreciseAndSearchBasedReferences = getSettingsValue(
+        settingsCascade,
+        'codeIntel.mixPreciseAndSearchBasedReferences'
+    )
+
+    const onClick = useCallback(async () => {
+        await updateSettings(platformContext, {
+            path: ['codeIntel.mixPreciseAndSearchBasedReferences'],
+            value: !mixPreciseAndSearchBasedReferences,
+        })
+    }, [mixPreciseAndSearchBasedReferences, platformContext])
+
+    if (disableSearchBased) {
+        return null
+    }
+
+    return (
+        <li className="px-2 mx-2">
+            <Tooltip
+                content={
+                    mixPreciseAndSearchBasedReferences
+                        ? 'Hide search-based results when precise results are available'
+                        : null
+                }
+            >
+                <Button variant="link" className={styles.actionItem} onClick={onClick}>
+                    {mixPreciseAndSearchBasedReferences
+                        ? 'Hide search-based results'
+                        : 'Mix precise and search-based results'}
+                </Button>
+            </Tooltip>
+        </li>
+    )
+}
+
+function getSettingsValue(settings: SettingsCascadeOrError, key: string): boolean {
+    return !isErrorLike(settings.final) && settings.final !== null && settings.final[key]
+}

--- a/client/branded/src/components/panel/TabbedPanelContent.module.scss
+++ b/client/branded/src/components/panel/TabbedPanelContent.module.scss
@@ -41,3 +41,12 @@
 .action-item-unconstrained {
     max-width: none;
 }
+
+.action-item {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: inherit;
+    letter-spacing: inherit;
+}

--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -12,6 +12,7 @@ import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import { isDefined, combineLatestOrDefault, isErrorLike } from '@sourcegraph/common'
 import { Location } from '@sourcegraph/extension-api-types'
 import { FetchFileParameters } from '@sourcegraph/search-ui'
+import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
 import { ActionsNavItems } from '@sourcegraph/shared/src/actions/ActionsNavItems'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { match } from '@sourcegraph/shared/src/api/client/types/textDocument'
@@ -306,29 +307,32 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
                 wrapperClassName={classNames(styles.panelHeader, 'sticky-top')}
                 actions={
                     <div className="align-items-center d-flex">
-                        {activeTab && extensionsController !== null && (
-                            <>
-                                <ActionsNavItems
-                                    {...props}
-                                    extensionsController={extensionsController}
-                                    // TODO remove references to global branded classes from shared, get class name from prop
-                                    // This is okay for now because the Panel is currently only used in the webapp
-                                    listClass="d-flex justify-content-end list-unstyled m-0 align-items-center"
-                                    listItemClass="px-2 mx-2"
-                                    actionItemClass={classNames(styles.actionItemUnconstrained, 'font-weight-medium')}
-                                    actionItemIconClass="icon-inline"
-                                    menu={ContributableMenu.PanelToolbar}
-                                    scope={{
-                                        type: 'panelView',
-                                        id: activeTab.id,
-                                        hasLocations: Boolean(activeTab.hasLocations),
-                                    }}
-                                    wrapInList={true}
-                                    location={location}
-                                    transformContributions={transformPanelContributions}
-                                />
-                            </>
-                        )}
+                        <ul className="d-flex justify-content-end list-unstyled m-0 align-items-center">
+                            {activeTab && extensionsController !== null && (
+                                <>
+                                    <ActionsNavItems
+                                        {...props}
+                                        extensionsController={extensionsController}
+                                        listClass="r"
+                                        listItemClass="px-2 mx-2"
+                                        actionItemClass={classNames(
+                                            styles.actionItemUnconstrained,
+                                            'font-weight-medium'
+                                        )}
+                                        actionItemIconClass="icon-inline"
+                                        menu={ContributableMenu.PanelToolbar}
+                                        scope={{
+                                            type: 'panelView',
+                                            id: activeTab.id,
+                                            hasLocations: Boolean(activeTab.hasLocations),
+                                        }}
+                                        wrapInList={false}
+                                        location={location}
+                                        transformContributions={transformPanelContributions}
+                                    />
+                                </>
+                            )}
+                        </ul>
                         <Tooltip content="Close panel" placement="left">
                             <Button
                                 onClick={handlePanelClose}

--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -12,7 +12,6 @@ import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import { isDefined, combineLatestOrDefault, isErrorLike } from '@sourcegraph/common'
 import { Location } from '@sourcegraph/extension-api-types'
 import { FetchFileParameters } from '@sourcegraph/search-ui'
-import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
 import { ActionsNavItems } from '@sourcegraph/shared/src/actions/ActionsNavItems'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { match } from '@sourcegraph/shared/src/api/client/types/textDocument'
@@ -27,6 +26,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Button, useObservable, Tab, TabList, TabPanel, TabPanels, Tabs, Icon, Tooltip } from '@sourcegraph/wildcard'
 
+import { MixPreciseAndSearchBasedReferencesToggle } from './MixPreciseAndSearchBasedReferencesToggle'
 import { registerPanelToolbarContributions } from './views/contributions'
 import { EmptyPanelView } from './views/EmptyPanelView'
 import { ExtensionsLoadingPanelView } from './views/ExtensionsLoadingView'
@@ -308,6 +308,12 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
                 actions={
                     <div className="align-items-center d-flex">
                         <ul className="d-flex justify-content-end list-unstyled m-0 align-items-center">
+                            {activeTab && (
+                                <MixPreciseAndSearchBasedReferencesToggle
+                                    settingsCascade={props.settingsCascade}
+                                    platformContext={props.platformContext}
+                                />
+                            )}
                             {activeTab && extensionsController !== null && (
                                 <>
                                     <ActionsNavItems

--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -319,7 +319,6 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
                                     <ActionsNavItems
                                         {...props}
                                         extensionsController={extensionsController}
-                                        listClass="r"
                                         listItemClass="px-2 mx-2"
                                         actionItemClass={classNames(
                                             styles.actionItemUnconstrained,

--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -395,7 +395,11 @@ function transformPanelContributions(contributions: Evaluated<Contributions>): E
         // work for the case this is hackily trying to prevent: multiple extensions generated with the
         // same manifest.
         const strings = new Set(panelMenuItems.map(menuItem => JSON.stringify(menuItem)))
-        const uniquePanelMenuItems = [...strings].map(string => JSON.parse(string))
+        const uniquePanelMenuItems = [...strings]
+            .map(string => JSON.parse(string))
+            // We render the MixPreciseAndSearchBasedReferencesToggle in React now
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+            .filter((item: any) => item.action !== 'mixPreciseAndSearchBasedReferences.toggle')
 
         return {
             ...contributions,

--- a/client/shared/src/hover/actions.ts
+++ b/client/shared/src/hover/actions.ts
@@ -484,28 +484,6 @@ export function registerHoverContributions({
             if (window.context?.enableLegacyExtensions === false) {
                 const promise = extensionHostAPI.registerContributions({
                     actions: [
-                        {
-                            actionItem: {
-                                description:
-                                    // eslint-disable-next-line no-template-curly-in-string
-                                    '${!!config.codeIntel.mixPreciseAndSearchBasedReferences && "Hide search-based results when precise results are available" || ""}',
-                                label:
-                                    // eslint-disable-next-line no-template-curly-in-string
-                                    '${!!config.codeIntel.mixPreciseAndSearchBasedReferences && "Hide search-based results" || "Mix precise and search-based results"}',
-                            },
-                            command: 'updateConfiguration',
-                            commandArguments: [
-                                ['codeIntel.mixPreciseAndSearchBasedReferences'],
-                                // eslint-disable-next-line no-template-curly-in-string
-                                '${!config.codeIntel.mixPreciseAndSearchBasedReferences}',
-                                null,
-                                'json',
-                            ],
-                            id: 'mixPreciseAndSearchBasedReferences.toggle',
-                            title:
-                                // eslint-disable-next-line no-template-curly-in-string
-                                '${!!config.codeIntel.mixPreciseAndSearchBasedReferences && "Hide search-based results when precise results are available" || "Mix precise and search-based results"}',
-                        },
                         ...languageSpecs.map(spec => ({
                             actionItem: { label: 'Find implementations' },
                             command: 'open',
@@ -529,12 +507,6 @@ export function registerHoverContributions({
                                 // eslint-disable-next-line no-template-curly-in-string
                                 "' && get(context, `implementations_${resource.language}`) && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error)",
                         })),
-                        'panel/toolbar': [
-                            {
-                                action: 'mixPreciseAndSearchBasedReferences.toggle',
-                                when: "panel.activeView.id == 'references' && !config.codeIntel.disableSearchBased",
-                            },
-                        ],
                     },
                 })
                 implementationsContributionPromise = promise


### PR DESCRIPTION
Part of #42165
Part of #41782

There are currently two parts of code intel that rely on the old extensions contributions API:

1. The "Mix precise and search-based results" button in the references panel.
2. The buttons shown on hover tooltips

This PR removes the reliance on the extensions API for 1. by implementing the button as a React component.

Since we want to still support the possibility to enable legacy extensions, the `TabbedPanelContent` still queries the contributions API if it is present. If the same action is found, it will not be rendered twice though. When this refactoring is complete, contributions won't be loaded anymore as `extensionsController` will become `null`.

## Open question

For the old references panel I only migrated the "Mix precise and search-based results" button because the other one was pulling in confusing context. Do we expect the old references panel (`"codeIntel.referencesPanel": "tabbed"`), to work with the extensions deprecation? If this is the case, we need to invest more time into updating it before we make the extension controller nullable.

This is noted as a TBD in #41782 as well and since this PR does not remove contributions yet, the outcome of this discussion is not blocking this change.

## Test plan

I have verified that all interactions with the buttons are exactly the same as they were with extensions enabled (same padding/margins/font sizes/accessibility features/texts). 

https://user-images.githubusercontent.com/458591/192531205-1483c250-3b59-451b-94e8-8eff89951379.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-remove-conrtributions-reliance.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mslqvhurfe.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
