### PR TITLE
docs: Remove references to zero-downtime

### DIFF
--- a/doc/admin/updates/index.md
+++ b/doc/admin/updates/index.md
@@ -10,7 +10,7 @@ A **standard upgrade** moves an instance from one version to an adjacent minor v
 
 > NOTE: Due to its compatibility with previous versions, we support the upgrade `v3.43 -> v4.0.1` as a one-minor-version "standard" upgrade.
 
-This upgrade process involves updating only infrastructure: containers must reflect new version tags, additions and removal of services must be addressed, resource allocation may need to be readjusted, etc. For environments that support rolling updates, this process minimizes instance downtime, and eventually will become a zero-downtime process.
+This upgrade process involves updating only infrastructure: containers must reflect new version tags, additions and removal of services must be addressed, resource allocation may need to be readjusted, etc. For environments that support rolling updates (Kubernetes with or without Helm), a standard upgrade minimizes service disruption as new and old versions of the instance can work with the same database schema for a short period.
 
 **We recommend following this upgrade process and keeping your instance up-to-date.** If your instance is currently more than one minor version behind the latest release, a single [multi-version upgrade](#multi-version-upgrades) can bring you up to speed.
 

--- a/doc/dev/background-information/sql/migrations.md
+++ b/doc/dev/background-information/sql/migrations.md
@@ -1,6 +1,6 @@
 # Migrations
 
-For each of our Postgres instances, we define a sequence of SQL schema commands that must be applied before the database is in the state the application expects. We also support zero-downtime upgrades between one minor version on Sourcegraph.com, Cloud managed instances, and enterprise instances.
+For each of our Postgres instances, we define a sequence of SQL schema commands that must be applied before the database is in the state the application expects. We define migrations to be backwards compatible with the previous minor version release. This aids in minimizing downtime when using rolling restarts, as new and old services can operate with the same schema without failure. Such deployments are used on Sourcegraph.com, Cloud managed instances, and enterprise instances deployed via Kubernetes.
 
 In development environments, these migrations are applied automatically on application startup. This is a specific choice to keep the response latency small during development. In production environments, a typical upgrade requires that the site-administrator first run a `migrator` service to prepare the database schema for the new version of the application. This is a type of _database-first_ deployment (opposed to _code-first_ deployments), where database migrations are applied prior to the corresponding code change.
 

--- a/internal/database/migration/cliutil/multiversion.go
+++ b/internal/database/migration/cliutil/multiversion.go
@@ -220,7 +220,7 @@ func runMigration(
 		//
 		// Note that we don't want to get rid of that check entirely from the frontend, as we do
 		// still want to catch the cases where site-admins "jump forward" several versions while
-		// using the zero-downtime upgrade path (not the migrator upgrade utility).
+		// using the standard upgrade path (not a multi-version upgrade that handles these cases).
 
 		if err := setServiceVersion(ctx, r, plan.to); err != nil {
 			return err


### PR DESCRIPTION
Remove references to "zero-downtime" where we actually mean "best-effort to minimize service disruption with caveats".

## Test plan

N/A.