### PR TITLE
insights: chore: move `BuildFrames` to `timeseries` package

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/querybuilder"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/timeseries"
@@ -548,7 +547,7 @@ func (a *backfillAnalyzer) buildForRepo(ctx context.Context, definitions []itype
 
 	// For every series that we want to potentially gather historical data for, try.
 	for _, series := range definitions {
-		frames := query.BuildFrames(12, timeseries.TimeInterval{
+		frames := timeseries.BuildFrames(12, timeseries.TimeInterval{
 			Unit:  itypes.IntervalUnit(series.SampleIntervalUnit),
 			Value: series.SampleIntervalValue,
 		}, series.CreatedAt.Truncate(time.Hour*24))

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -8,16 +8,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/segmentio/ksuid"
-
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
-	"golang.org/x/time/rate"
-
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/segmentio/ksuid"
 	sglog "github.com/sourcegraph/log"
-
-	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
@@ -41,6 +37,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/insights/priority"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"

--- a/enterprise/internal/insights/query/capture_group_executor.go
+++ b/enterprise/internal/insights/query/capture_group_executor.go
@@ -65,7 +65,7 @@ func (c *CaptureGroupExecutor) Execute(ctx context.Context, query string, reposi
 	}
 	log15.Debug("Generated repoIds", "repoids", repoIds)
 
-	frames := BuildFrames(7, interval, c.clock())
+	frames := timeseries.BuildFrames(7, interval, c.clock())
 	pivoted := make(map[string]timeCounts)
 
 	for _, repository := range repositories {

--- a/enterprise/internal/insights/query/just_in_time_executor.go
+++ b/enterprise/internal/insights/query/just_in_time_executor.go
@@ -1,12 +1,9 @@
 package query
 
 import (
-	"sort"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/timeseries"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
@@ -33,30 +30,4 @@ func generateTimes(plan compression.BackfillPlan) map[time.Time]int {
 		}
 	}
 	return times
-}
-
-func BuildFrames(numPoints int, interval timeseries.TimeInterval, now time.Time) []types.Frame {
-	current := now
-	times := make([]time.Time, 0, numPoints)
-	times = append(times, now)
-	times = append(times, now) // looks weird but is so we can get a frame that is the current point
-
-	for i := 0 - numPoints + 1; i < 0; i++ {
-		current = interval.StepBackwards(current)
-		times = append(times, current)
-	}
-
-	frames := make([]types.Frame, 0, len(times)-1)
-	for i := 1; i < len(times); i++ {
-		prev := times[i-1]
-		frames = append(frames, types.Frame{
-			From: times[i],
-			To:   prev,
-		})
-	}
-
-	sort.Slice(frames, func(i, j int) bool {
-		return frames[i].From.Before(frames[j].From)
-	})
-	return frames
 }

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -45,9 +45,9 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 	}
 	log15.Debug("Generated repoIds", "repoids", repoIds)
 
-	frames := BuildFrames(7, interval, c.clock().Truncate(time.Hour*24))
+	frames := timeseries.BuildFrames(7, interval, c.clock().Truncate(time.Hour*24))
 	points := timeCounts{}
-	timeseries := []TimeDataPoint{}
+	timeDataPoints := []TimeDataPoint{}
 
 	for _, repository := range repositories {
 		firstCommit, err := discovery.GitFirstEverCommit(ctx, c.db, api.RepoName(repository))
@@ -105,19 +105,19 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 	}
 
 	for pointTime, pointCount := range points {
-		timeseries = append(timeseries, TimeDataPoint{
+		timeDataPoints = append(timeDataPoints, TimeDataPoint{
 			Time:  pointTime,
 			Count: pointCount,
 		})
 	}
 
-	sort.Slice(timeseries, func(i, j int) bool {
-		return timeseries[i].Time.Before(timeseries[j].Time)
+	sort.Slice(timeDataPoints, func(i, j int) bool {
+		return timeDataPoints[i].Time.Before(timeDataPoints[j].Time)
 	})
 	generated := []GeneratedTimeSeries{{
 		Label:    seriesLabel,
 		SeriesId: seriesID,
-		Points:   timeseries,
+		Points:   timeDataPoints,
 	}}
 	return generated, nil
 

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -55,7 +55,7 @@ func (r *insightSeriesResolver) Points(ctx context.Context, _ *graphqlbackend.In
 	opts.SeriesID = &seriesID
 
 	// Default to last 12 frames of data
-	frames := query.BuildFrames(12, timeseries.TimeInterval{
+	frames := timeseries.BuildFrames(12, timeseries.TimeInterval{
 		Unit:  types.IntervalUnit(r.series.SampleIntervalUnit),
 		Value: r.series.SampleIntervalValue,
 	}, time.Now())
@@ -334,7 +334,7 @@ func getRecordedSeriesPointOpts(ctx context.Context, db database.DB, definition 
 	opts.SeriesID = &seriesID
 
 	// Default to last 12 points of data
-	frames := query.BuildFrames(12, timeseries.TimeInterval{
+	frames := timeseries.BuildFrames(12, timeseries.TimeInterval{
 		Unit:  types.IntervalUnit(definition.SampleIntervalUnit),
 		Value: definition.SampleIntervalValue,
 	}, time.Now())

--- a/enterprise/internal/insights/timeseries/frames.go
+++ b/enterprise/internal/insights/timeseries/frames.go
@@ -1,0 +1,34 @@
+package timeseries
+
+import (
+	"sort"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+)
+
+func BuildFrames(numPoints int, interval TimeInterval, now time.Time) []types.Frame {
+	current := now
+	times := make([]time.Time, 0, numPoints)
+	times = append(times, now)
+	times = append(times, now) // looks weird but is so we can get a frame that is the current point
+
+	for i := 0 - numPoints + 1; i < 0; i++ {
+		current = interval.StepBackwards(current)
+		times = append(times, current)
+	}
+
+	frames := make([]types.Frame, 0, len(times)-1)
+	for i := 1; i < len(times); i++ {
+		prev := times[i-1]
+		frames = append(frames, types.Frame{
+			From: times[i],
+			To:   prev,
+		})
+	}
+
+	sort.Slice(frames, func(i, j int) bool {
+		return frames[i].From.Before(frames[j].From)
+	})
+	return frames
+}

--- a/enterprise/internal/insights/timeseries/frames_test.go
+++ b/enterprise/internal/insights/timeseries/frames_test.go
@@ -1,4 +1,4 @@
-package query
+package timeseries
 
 import (
 	"testing"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hexops/autogold"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/timeseries"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 )
 
@@ -20,7 +19,7 @@ func TestBuildFrames(t *testing.T) {
 		}
 		return got
 	}
-	buildFrameTest := func(count int, interval timeseries.TimeInterval, current time.Time) [][]string {
+	buildFrameTest := func(count int, interval TimeInterval, current time.Time) [][]string {
 		got := BuildFrames(count, interval, current)
 		return convert(got)
 	}
@@ -29,7 +28,7 @@ func TestBuildFrames(t *testing.T) {
 		autogold.Want("one point", [][]string{{
 			"2021-12-01 00:00:00 +0000 UTC",
 			"2021-12-01 00:00:00 +0000 UTC",
-		}}).Equal(t, buildFrameTest(1, timeseries.TimeInterval{Unit: types.Month, Value: 1}, startTime))
+		}}).Equal(t, buildFrameTest(1, TimeInterval{Unit: types.Month, Value: 1}, startTime))
 	})
 
 	t.Run("two points 1 month intervals", func(t *testing.T) {
@@ -42,7 +41,7 @@ func TestBuildFrames(t *testing.T) {
 				"2021-12-01 00:00:00 +0000 UTC",
 				"2021-12-01 00:00:00 +0000 UTC",
 			},
-		}).Equal(t, buildFrameTest(2, timeseries.TimeInterval{Unit: types.Month, Value: 1}, startTime))
+		}).Equal(t, buildFrameTest(2, TimeInterval{Unit: types.Month, Value: 1}, startTime))
 	})
 
 	t.Run("6 points 1 month intervals", func(t *testing.T) {
@@ -71,7 +70,7 @@ func TestBuildFrames(t *testing.T) {
 				"2021-12-01 00:00:00 +0000 UTC",
 				"2021-12-01 00:00:00 +0000 UTC",
 			},
-		}).Equal(t, buildFrameTest(6, timeseries.TimeInterval{Unit: types.Month, Value: 1}, startTime))
+		}).Equal(t, buildFrameTest(6, TimeInterval{Unit: types.Month, Value: 1}, startTime))
 	})
 
 	t.Run("12 points 2 week intervals", func(t *testing.T) {
@@ -124,7 +123,7 @@ func TestBuildFrames(t *testing.T) {
 				"2021-12-01 00:00:00 +0000 UTC",
 				"2021-12-01 00:00:00 +0000 UTC",
 			},
-		}).Equal(t, buildFrameTest(12, timeseries.TimeInterval{Unit: types.Week, Value: 2}, startTime))
+		}).Equal(t, buildFrameTest(12, TimeInterval{Unit: types.Week, Value: 2}, startTime))
 	})
 
 	t.Run("6 points 2 day intervals", func(t *testing.T) {
@@ -153,7 +152,7 @@ func TestBuildFrames(t *testing.T) {
 				"2021-12-01 00:00:00 +0000 UTC",
 				"2021-12-01 00:00:00 +0000 UTC",
 			},
-		}).Equal(t, buildFrameTest(6, timeseries.TimeInterval{Unit: types.Day, Value: 2}, startTime))
+		}).Equal(t, buildFrameTest(6, TimeInterval{Unit: types.Day, Value: 2}, startTime))
 	})
 
 	t.Run("6 points 2 hour intervals", func(t *testing.T) {
@@ -182,7 +181,7 @@ func TestBuildFrames(t *testing.T) {
 				"2021-12-01 00:00:00 +0000 UTC",
 				"2021-12-01 00:00:00 +0000 UTC",
 			},
-		}).Equal(t, buildFrameTest(6, timeseries.TimeInterval{Unit: types.Hour, Value: 2}, startTime))
+		}).Equal(t, buildFrameTest(6, TimeInterval{Unit: types.Hour, Value: 2}, startTime))
 	})
 
 	t.Run("6 points 1 year intervals", func(t *testing.T) {
@@ -211,6 +210,6 @@ func TestBuildFrames(t *testing.T) {
 				"2021-12-01 00:00:00 +0000 UTC",
 				"2021-12-01 00:00:00 +0000 UTC",
 			},
-		}).Equal(t, buildFrameTest(6, timeseries.TimeInterval{Unit: types.Year, Value: 1}, startTime))
+		}).Equal(t, buildFrameTest(6, TimeInterval{Unit: types.Year, Value: 1}, startTime))
 	})
 }


### PR DESCRIPTION
`BuildFrames` was being used across our resolvers and background processes and it's a helper very related to our timeseries. I thought it made more sense for it to live in that package.

## Test plan

no functional changes, monitoring CI.