### PR TITLE
migrations: Cleanup logs

### DIFF
--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -128,14 +128,12 @@ func (r *Runner) runSchema(
 		}
 	}
 
-	logger.Warn("Schema not in expected state",
+	logger.Info("Schema is not in the expected state - applying migration delta",
 		log.Ints("targetDefinitions", extractIDs(definitions)),
 		log.Ints("appliedVersions", extractIDs(byState.applied)),
 		log.Ints("pendingVersions", extractIDs(byState.pending)),
 		log.Ints("failedVersions", extractIDs(byState.failed)),
 	)
-
-	logger.Info("Checking for active migrations")
 
 	for {
 		// Attempt to apply as many migrations as possible. We do this iteratively in chunks as we are unable

--- a/internal/database/migration/runner/validate.go
+++ b/internal/database/migration/runner/validate.go
@@ -50,14 +50,12 @@ func (r *Runner) validateSchema(ctx context.Context, schemaContext schemaContext
 		return nil
 	}
 
-	logger.Warn("Schema not in expected state",
+	logger.Info("Schema is not in the expected state - checking for active migrations",
 		log.String("schema", schemaContext.schema.Name),
 		log.Ints("appliedVersions", extractIDs(byState.applied)),
 		log.Ints("pendingVersions", extractIDs(byState.pending)),
 		log.Ints("failedVersions", extractIDs(byState.failed)),
 	)
-
-	logger.Info("Checking for active migrations")
 
 	for {
 		// Attempt to validate the given definitions. We may have to call this several times as

--- a/internal/database/migration/runner/validate.go
+++ b/internal/database/migration/runner/validate.go
@@ -30,7 +30,9 @@ func (r *Runner) validateSchema(ctx context.Context, schemaContext schemaContext
 	// Filter out any unlisted migrations (most likely future upgrades) and group them by status.
 	byState := groupByState(schemaContext.initialSchemaVersion, definitions)
 
-	logger := r.logger.With(log.String("schema", schemaContext.schema.Name))
+	logger := r.logger.With(
+		log.String("schema", schemaContext.schema.Name),
+	)
 
 	logger.Info("Checked current schema state",
 		log.String("schema", schemaContext.schema.Name),
@@ -45,7 +47,6 @@ func (r *Runner) validateSchema(ctx context.Context, schemaContext schemaContext
 	// to take an advisory lock and poll index creation status below.
 	if len(byState.pending) == 0 && len(byState.failed) == 0 && len(byState.applied) == len(definitions) {
 		logger.Info("Schema is in the expected state")
-
 		return nil
 	}
 
@@ -80,7 +81,6 @@ func (r *Runner) validateSchema(ctx context.Context, schemaContext schemaContext
 	}
 
 	logger.Info("Schema is in the expected state")
-
 	return nil
 }
 

--- a/internal/oobmigration/validate.go
+++ b/internal/oobmigration/validate.go
@@ -20,7 +20,7 @@ const RefreshInterval = time.Second * 30
 // left in an unexpected state for the current application version.
 func ValidateOutOfBandMigrationRunner(ctx context.Context, db database.DB, runner *Runner) error {
 	if version.IsDev(version.Version()) {
-		runner.logger.Warn("Skipping out-of-band migrations check (dev mode)", log.String("version", version.Version()))
+		// Skip check in development environments
 		return nil
 	}
 	currentVersionSemver, err := semver.NewVersion(version.Version())
@@ -34,10 +34,9 @@ func ValidateOutOfBandMigrationRunner(ctx context.Context, db database.DB, runne
 		return errors.Wrap(err, "failed to retrieve first instance version")
 	}
 	if !ok {
-		runner.logger.Warn("Skipping out-of-band migrations check (fresh instance)", log.String("version", version.Version()))
+		// Skip check on fresh instances
 		return nil
 	}
-
 	firstVersionSemver, err := semver.NewVersion(firstSemverString)
 	if err != nil {
 		runner.logger.Warn("Skipping out-of-band migrations check", log.Error(err), log.String("version", version.Version()))


### PR DESCRIPTION
Addresses some of the points in #42136.

## Test plan

Tested locally to ensure the same information is still accessible.