### PR TITLE
Add test proving that audit logs are immune to sampling

### DIFF
--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/sourcegraph/log"
@@ -143,4 +144,24 @@ func TestLog(t *testing.T) {
 			assert.Equal(t, tc.expectedEntry, logs[0].Fields)
 		})
 	}
+}
+
+func TestSampling(t *testing.T) {
+	_ = os.Setenv("SRC_LOG_SAMPLING_INITIAL", "5")
+
+	ctx := context.Background()
+	logger, exportLogs := logtest.Captured(t)
+
+	t.Run("audit logs are never sampled", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			Log(ctx, logger, Record{
+				Entity: "test",
+				Action: "sampling test",
+				Fields: nil,
+			})
+		}
+	})
+
+	logs := exportLogs()
+	assert.Equal(t, 10, len(logs))
 }


### PR DESCRIPTION
## Description

Telemetry sampling is a native observability concept that helps the emitter to reduce the volume of telemetry data to a manageable level. This is usually fine as long as we're not talking audit log - we don't want to drop any actions that will appear in the security audit log.

## Test plan

Automated tests.
