### PR TITLE
flake: Rewrite flaky periodic goroutine test

### DIFF
--- a/internal/goroutine/periodic_test.go
+++ b/internal/goroutine/periodic_test.go
@@ -36,8 +36,6 @@ func TestPeriodicGoroutine(t *testing.T) {
 }
 
 func TestPeriodicGoroutineError(t *testing.T) {
-	t.Skip("flaky") // See https://github.com/sourcegraph/sourcegraph/issues/42062
-
 	clock := glock.NewMockClock()
 	handler := NewMockHandlerWithErrorHandler()
 


### PR DESCRIPTION
Fixes #42062.

This PR re-enables a flaky test would hit a very uncommon race condition:

In the test, we perform `clock.BlockingAdvance(...)` followed by `routine.Stop()`. These in sequence will make it so that _either_ of the select branches within the actual goroutine runner can fire, and if it hits the context one we're off by a count of one. The fix is to ensure that we make only one of the select branches capable of making progress. We put a channel in the handler to ensure that the Go scheduler will not call `BlockingAdvance` and `Stop` without a scheduling the runner routine sometime inbetween.

## Test plan

Existing unit tests.