### PR TITLE
References Panel: add syntax highlighting to references items

### DIFF
--- a/client/search-ui/src/components/CodeExcerpt.tsx
+++ b/client/search-ui/src/components/CodeExcerpt.tsx
@@ -20,6 +20,13 @@ import { Icon, Code } from '@sourcegraph/wildcard'
 
 import styles from './CodeExcerpt.module.scss'
 
+export interface Shape {
+    top?: number
+    left?: number
+    bottom?: number
+    right?: number
+}
+
 export interface FetchFileParameters {
     repoName: string
     commitID: string
@@ -48,6 +55,7 @@ interface Props extends Repo {
 
     viewerUpdates?: Observable<{ viewerId: ViewerId } & HoverContext>
     hoverifier?: Hoverifier<HoverContext, HoverMerged, ActionItemAction>
+    visibilityOffset?: Shape
     onCopy?: () => void
 }
 
@@ -99,7 +107,7 @@ const domFunctions: DOMFunctions = {
 }
 
 const makeTableHTML = (blobLines: string[]): string => '<table>' + blobLines.join('') + '</table>'
-const visibilitySensorOffset = { bottom: -500 }
+const DEFAULT_VISIBILITY_OFFSET: Shape = { bottom: -500 }
 
 /**
  * A code excerpt that displays syntax highlighting and match range highlighting.
@@ -113,6 +121,7 @@ export const CodeExcerpt: React.FunctionComponent<Props> = ({
     highlightRanges,
     viewerUpdates,
     hoverifier,
+    visibilityOffset = DEFAULT_VISIBILITY_OFFSET,
     className,
     onCopy,
 }) => {
@@ -207,7 +216,7 @@ export const CodeExcerpt: React.FunctionComponent<Props> = ({
     }, [hoverifier, tableContainerElements, viewerUpdates])
 
     return (
-        <VisibilitySensor onChange={setIsVisible} partialVisibility={true} offset={visibilitySensorOffset}>
+        <VisibilitySensor onChange={setIsVisible} partialVisibility={true} offset={visibilityOffset}>
             <Code
                 data-testid="code-excerpt"
                 onCopy={onCopy}

--- a/client/search-ui/src/components/CodeExcerpt.tsx
+++ b/client/search-ui/src/components/CodeExcerpt.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import React, { KeyboardEvent, MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
 import { mdiAlertCircle } from '@mdi/js'
 import classNames from 'classnames'
@@ -108,6 +108,89 @@ const domFunctions: DOMFunctions = {
 
 const makeTableHTML = (blobLines: string[]): string => '<table>' + blobLines.join('') + '</table>'
 const DEFAULT_VISIBILITY_OFFSET: Shape = { bottom: -500 }
+
+/**
+ * This helper function determines whether a mouse/click event was triggered as
+ * a result of selecting text in search results.
+ * There are at least to ways to do this:
+ *
+ * - Tracking `mouseup`, `mousemove` and `mousedown` events. The occurrence of
+ * a `mousemove` event would indicate a text selection. However, users
+ * might slightly move the mouse while clicking, and solutions that would
+ * take this into account seem fragile.
+ * - (implemented here) Inspect the Selection object returned by
+ * `window.getSelection()`.
+ *
+ * CAVEAT: Chromium and Firefox (and maybe other browsers) behave
+ * differently when a search result is clicked *after* text selection was
+ * made:
+ *
+ * - Firefox will clear the selection before executing the click event
+ * handler, i.e. the search result will be opened.
+ * - Chrome will only clear the selection if the click happens *outside*
+ * of the selected text (in which case the search result will be
+ * opened). If the click happens inside the selected text the selection
+ * will be cleared only *after* executing the click event handler.
+ */
+function isTextSelectionEvent(event: MouseEvent<HTMLElement>): boolean {
+    const selection = window.getSelection()
+
+    // Text selections are always ranges. Should the type not be set, verify
+    // that the selection is not empty.
+    if (selection && (selection.type === 'Range' || selection.toString() !== '')) {
+        // Firefox specific: Because our code excerpts are implemented as tables,
+        // CTRL+click would select the table cell. Since users don't know that we
+        // use tables, the most likely wanted to open the search results in a new
+        // tab instead though.
+        if ((event.ctrlKey || event.metaKey) && selection.anchorNode?.nodeName === 'TR') {
+            // Ugly side effect: We don't want the table cell to be highlighted.
+            // The focus style that Firefox uses doesn't seem to be affected by
+            // CSS so instead we clear the selection.
+            selection.empty()
+            return false
+        }
+
+        return true
+    }
+
+    return false
+}
+
+/**
+ * This handler implements the logic to simulate the click/keyboard
+ * activation behavior of links, while also allowing the selection of text
+ * inside the element.
+ * Because a click event is dispatched in both cases (clicking the search
+ * result to open it as well as selecting text within it), we have to be
+ * able to distinguish between those two actions.
+ * If we detect a text selection action, we don't have to do anything.
+ *
+ * CAVEATS:
+ * - In Firefox, Shift+click will open the URL in a new tab instead of
+ * a window (unlike Chromium which seems to show the same behavior as with
+ * native links).
+ * - Firefox will insert \t\n in between table rows, causing the copied
+ * text to be different from what is in the file/search result.
+ */
+export function onClickCodeExcerptHref(
+    event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>,
+    onClickHref: (href: string) => void
+): void {
+    // Testing for text selection is only necessary for mouse/click
+    // events. Middle-click (event.button === 1) is already handled in the `onMouseUp` callback.
+    if (
+        (event.type === 'click' &&
+            !isTextSelectionEvent(event as MouseEvent<HTMLElement>) &&
+            (event as MouseEvent<HTMLElement>).button !== 1) ||
+        (event as KeyboardEvent<HTMLElement>).key === 'Enter'
+    ) {
+        const href = event.currentTarget.getAttribute('data-href')
+        if (!event.defaultPrevented && href) {
+            event.preventDefault()
+            onClickHref(href)
+        }
+    }
+}
 
 /**
  * A code excerpt that displays syntax highlighting and match range highlighting.

--- a/client/search-ui/src/components/FileMatchChildren.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.tsx
@@ -26,7 +26,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 import { useCodeIntelViewerUpdates } from '@sourcegraph/shared/src/util/useCodeIntelViewerUpdates'
 
-import { CodeExcerpt, FetchFileParameters } from './CodeExcerpt'
+import { CodeExcerpt, FetchFileParameters, onClickCodeExcerptHref } from './CodeExcerpt'
 import { LastSyncedIcon } from './LastSyncedIcon'
 
 import styles from './FileMatchChildren.module.scss'
@@ -40,53 +40,6 @@ interface FileMatchProps extends SettingsCascadeProps, TelemetryProps {
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
     extensionsController?: Pick<ExtensionsController, 'extHostAPI'> | null
     hoverifier?: Hoverifier<HoverContext, HoverMerged, ActionItemAction>
-}
-
-/**
- * This helper function determines whether a mouse/click event was triggered as
- * a result of selecting text in search results.
- * There are at least to ways to do this:
- *
- * - Tracking `mouseup`, `mousemove` and `mousedown` events. The occurrence of
- * a `mousemove` event would indicate a text selection. However, users
- * might slightly move the mouse while clicking, and solutions that would
- * take this into account seem fragile.
- * - (implemented here) Inspect the Selection object returned by
- * `window.getSelection()`.
- *
- * CAVEAT: Chromium and Firefox (and maybe other browsers) behave
- * differently when a search result is clicked *after* text selection was
- * made:
- *
- * - Firefox will clear the selection before executing the click event
- * handler, i.e. the search result will be opened.
- * - Chrome will only clear the selection if the click happens *outside*
- * of the selected text (in which case the search result will be
- * opened). If the click happens inside the selected text the selection
- * will be cleared only *after* executing the click event handler.
- */
-function isTextSelectionEvent(event: MouseEvent<HTMLElement>): boolean {
-    const selection = window.getSelection()
-
-    // Text selections are always ranges. Should the type not be set, verify
-    // that the selection is not empty.
-    if (selection && (selection.type === 'Range' || selection.toString() !== '')) {
-        // Firefox specific: Because our code excerpts are implemented as tables,
-        // CTRL+click would select the table cell. Since users don't know that we
-        // use tables, the most likely wanted to open the search results in a new
-        // tab instead though.
-        if ((event.ctrlKey || event.metaKey) && selection.anchorNode?.nodeName === 'TR') {
-            // Ugly side effect: We don't want the table cell to be highlighted.
-            // The focus style that Firefox uses doesn't seem to be affected by
-            // CSS so instead we clear the selection.
-            selection.empty()
-            return false
-        }
-
-        return true
-    }
-
-    return false
 }
 
 /**
@@ -298,42 +251,15 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
     const viewerUpdates = useCodeIntelViewerUpdates(codeIntelViewerUpdatesProps)
 
     const history = useHistory()
-    /**
-     * This handler implements the logic to simulate the click/keyboard
-     * activation behavior of links, while also allowing the selection of text
-     * inside the element.
-     * Because a click event is dispatched in both cases (clicking the search
-     * result to open it as well as selecting text within it), we have to be
-     * able to distinguish between those two actions.
-     * If we detect a text selection action, we don't have to do anything.
-     *
-     * CAVEATS:
-     * - In Firefox, Shift+click will open the URL in a new tab instead of
-     * a window (unlike Chromium which seems to show the same behavior as with
-     * native links).
-     * - Firefox will insert \t\n in between table rows, causing the copied
-     * text to be different from what is in the file/search result.
-     */
     const navigateToFile = useCallback(
         (event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>): void => {
-            // Testing for text selection is only necessary for mouse/click
-            // events. Middle-click (event.button === 1) is already handled in the `onMouseUp` callback.
-            if (
-                (event.type === 'click' &&
-                    !isTextSelectionEvent(event as MouseEvent<HTMLElement>) &&
-                    (event as MouseEvent<HTMLElement>).button !== 1) ||
-                (event as KeyboardEvent<HTMLElement>).key === 'Enter'
-            ) {
-                const href = event.currentTarget.getAttribute('data-href')
-                if (!event.defaultPrevented && href) {
-                    event.preventDefault()
-                    if (props.openInNewTab || event.ctrlKey || event.metaKey || event.shiftKey) {
-                        openLinkInNewTab(href, event, 'primary')
-                    } else {
-                        history.push(href)
-                    }
+            onClickCodeExcerptHref(event, href => {
+                if (props.openInNewTab || event.ctrlKey || event.metaKey || event.shiftKey) {
+                    openLinkInNewTab(href, event, 'primary')
+                } else {
+                    history.push(href)
                 }
-            }
+            })
         },
         [props.openInNewTab, history]
     )

--- a/client/web/src/codeintel/ReferencesPanel.mocks.ts
+++ b/client/web/src/codeintel/ReferencesPanel.mocks.ts
@@ -170,6 +170,17 @@ function buildMockLocation({
     }
 }
 
+// Fake highlighting for lines 16 and 52 in diff/diff.go
+export const highlightedLinesDiffGo = [
+    ['<tr><td class="line" data-line="16"></td><td class="code">line 16</td></tr>'],
+    ['<tr><td class="line" data-line="52"></td><td class="code">line 52</td></tr>'],
+]
+
+// Fake highlighting for line 46 in cmd/go-diff/go-diff.go
+export const highlightedLinesGoDiffGo = [
+    ['<tr><td class="line" data-line="46"></td><td class="code">line 46</td></tr>'],
+]
+
 const MOCK_DEFINITIONS: LocationFields[] = [
     buildMockLocation({
         repo: 'github.com/sourcegraph/go-diff',
@@ -283,6 +294,7 @@ const HIGHLIGHTED_FILE_MOCK = {
                     highlight: {
                         aborted: false,
                         html: highlightedDiffFileContent,
+                        lsif: false,
                         __typename: 'HighlightedFile',
                     },
                     __typename: 'GitBlob',

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -100,11 +100,29 @@
     flex-direction: column;
     min-height: 18px;
 
-    &:not(:last-child) > button {
+    &:not(:last-child) > &--link {
         border-bottom: 1px solid var(--body-bg);
     }
 
-    button {
+    &--active {
+        background-color: var(--color-bg-3);
+    }
+
+    &--link:hover {
+        background-color: var(--color-bg-2);
+    }
+
+    &--active:hover {
+        // Needed to override `&--link:hover`
+        background-color: var(--color-bg-3);
+    }
+
+    &--link {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        color: inherit;
+
         padding-top: 0;
         padding-bottom: 0;
         width: 100%;
@@ -118,10 +136,15 @@
         font-family: 'SF Mono', monospace;
 
         border: none;
-    }
 
-    button:hover {
-        background-color: var(--color-bg-2);
+        &--code-excerpt {
+            flex: 1;
+            width: 100%;
+
+            :global(.line) {
+                min-width: 2.5rem;
+            }
+        }
     }
 
     code {
@@ -138,28 +161,8 @@
         font-size: 0.75rem;
     }
 
-    &--active {
-        background-color: var(--color-bg-2);
-    }
-
     &--link:hover {
         cursor: pointer;
-    }
-
-    &--link {
-        display: flex;
-        flex-direction: column;
-        flex: 1;
-        color: inherit;
-
-        &--code-excerpt {
-            flex: 1;
-            width: 100%;
-
-            :global(.line) {
-                min-width: 2.5rem;
-            }
-        }
     }
 }
 

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -96,6 +96,14 @@
 }
 
 .location {
+    display: flex;
+    flex-direction: column;
+    min-height: 18px;
+
+    &:not(:last-child) > button {
+        border-bottom: 1px solid var(--body-bg);
+    }
+
     button {
         padding-top: 0;
         padding-bottom: 0;
@@ -107,8 +115,9 @@
         // Avoid line number and filename getting put on different lines
         white-space: nowrap;
         padding-left: 0;
-        border: none;
         font-family: 'SF Mono', monospace;
+
+        border: none;
     }
 
     button:hover {
@@ -134,20 +143,18 @@
     }
 
     &--link {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
         color: inherit;
 
-        &--line-number {
-            font-family: 'SF Mono', monospace;
-            font-weight: 400;
-            color: var(--line-number-color);
-            min-width: 2.5rem;
-            text-align: right;
-            display: inline-block;
-            margin-right: 0.5rem;
+        &--code-excerpt {
+            flex: 1;
+            width: 100%;
 
-            font-style: normal;
-            font-size: 0.75rem;
-            line-height: 136%;
+            :global(.line) {
+                min-width: 2.5rem;
+            }
         }
     }
 }

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -142,6 +142,10 @@
         background-color: var(--color-bg-2);
     }
 
+    &--link:hover {
+        cursor: pointer;
+    }
+
     &--link {
         display: flex;
         flex-direction: column;

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -110,6 +110,7 @@
 
     &--link:hover {
         background-color: var(--color-bg-2);
+        cursor: pointer;
     }
 
     &--active:hover {
@@ -159,10 +160,6 @@
         font-family: 'SF Mono', monospace;
         font-weight: 400;
         font-size: 0.75rem;
-    }
-
-    &--link:hover {
-        cursor: pointer;
     }
 }
 

--- a/client/web/src/codeintel/ReferencesPanel.test.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.test.tsx
@@ -1,21 +1,18 @@
 import { render, RenderResult, within, fireEvent } from '@testing-library/react'
 import * as H from 'history'
 import { EMPTY, NEVER, noop, of, Subscription } from 'rxjs'
-import { HoverThresholdProps } from 'src/repo/RepoContainer'
 
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
 import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src/api/util'
 import { ViewerId } from '@sourcegraph/shared/src/api/viewerTypes'
-import { Controller, ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { PlatformContext, PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { NOOP_TELEMETRY_SERVICE, TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Controller } from '@sourcegraph/shared/src/extensions/controller'
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider, waitForNextApolloResponse } from '@sourcegraph/shared/src/testing/apollo'
-import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import '@sourcegraph/shared/dev/mockReactVisibilitySensor'
 
-import { Location } from './location'
-import { getLineContent, ReferencesPanelWithMemoryRouter } from './ReferencesPanel'
-import { buildReferencePanelMocks } from './ReferencesPanel.mocks'
+import { ReferencesPanelProps, ReferencesPanelWithMemoryRouter } from './ReferencesPanel'
+import { buildReferencePanelMocks, highlightedLinesDiffGo, highlightedLinesGoDiffGo } from './ReferencesPanel.mocks'
 
 const NOOP_SETTINGS_CASCADE = {
     subjects: null,
@@ -46,12 +43,7 @@ const NOOP_EXTENSIONS_CONTROLLER: Controller = {
     unsubscribe: noop,
 }
 
-const defaultProps: SettingsCascadeProps &
-    PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'> &
-    TelemetryProps &
-    HoverThresholdProps &
-    ExtensionsControllerProps &
-    ThemeProps = {
+const defaultProps: Omit<ReferencesPanelProps, 'externalHistory' | 'externalLocation'> = {
     extensionsController: NOOP_EXTENSIONS_CONTROLLER,
     telemetryService: NOOP_TELEMETRY_SERVICE,
     settingsCascade: {
@@ -60,6 +52,16 @@ const defaultProps: SettingsCascadeProps &
     },
     platformContext: NOOP_PLATFORM_CONTEXT,
     isLightTheme: false,
+    fetchHighlightedFileLineRanges: args => {
+        if (args.filePath === 'cmd/go-diff/go-diff.go') {
+            return of(highlightedLinesGoDiffGo)
+        }
+        if (args.filePath === 'diff/diff.go') {
+            return of(highlightedLinesDiffGo)
+        }
+        console.error('attempt to fetch highlighted lines for file without mocks', args.filePath)
+        return of([])
+    },
 }
 
 describe('ReferencesPanel', () => {
@@ -88,16 +90,12 @@ describe('ReferencesPanel', () => {
 
         expect(result.getByText('Definitions')).toBeVisible()
 
-        const definitions = [['', 'string']]
+        // See MOCK_DEFINITIONS and highlightedLinesDiffGo/highlightedLinesGoDiffGo to see how these expectations here came to be
+        const definitions = ['line 16']
 
         const definitionsList = result.getByTestId('definitions')
         for (const line of definitions) {
-            for (const surrounding of line) {
-                if (surrounding === '') {
-                    continue
-                }
-                expect(within(definitionsList).getByText(surrounding)).toBeVisible()
-            }
+            expect(within(definitionsList).getByText(line)).toBeVisible()
         }
     })
 
@@ -106,20 +104,12 @@ describe('ReferencesPanel', () => {
 
         expect(result.getByText('References')).toBeVisible()
 
-        const references = [
-            ['', 'string'],
-            ['label = fmt.Sprintf("orig(%s) new(%s)", fdiff.', ', fdiff.NewName)'],
-            ['if err := printFileHeader(&buf, "--- ", d.', ', d.OrigTime); err != nil {'],
-        ]
+        // See MOCK_REFERENCES and highlightedLinesDiffGo/highlightedLinesGoDiffGo to see how these expectations here came to be
+        const references = ['line 46', 'line 16', 'line 52']
 
         const referencesList = result.getByTestId('references')
         for (const line of references) {
-            for (const surrounding of line) {
-                if (surrounding === '') {
-                    continue
-                }
-                expect(within(referencesList).getByText(surrounding)).toBeVisible()
-            }
+            expect(within(referencesList).getByText(line)).toBeVisible()
         }
     })
 
@@ -129,7 +119,7 @@ describe('ReferencesPanel', () => {
         const definitionsList = result.getByTestId('definitions')
         const referencesList = result.getByTestId('references')
 
-        const referenceButton = within(referencesList).getByRole('button', { name: '16: OrigName string' })
+        const referenceButton = within(referencesList).getByRole('button', { name: 'line 16' })
         const fullReferenceURL =
             '/github.com/sourcegraph/go-diff@9d1f353a285b3094bc33bdae277a19aedabe8b71/-/blob/diff/diff.go?L16:2-16:10'
         expect(referenceButton).toHaveAttribute('data-test-reference-url', fullReferenceURL)
@@ -141,7 +131,7 @@ describe('ReferencesPanel', () => {
         // Reference is marked as active
         expect(referenceButton.parentNode).toHaveClass('locationActive')
         // But we have the same in Definitions too, and that should be marked active too
-        const definitionButton = within(definitionsList).getByRole('button', { name: '16: OrigName string' })
+        const definitionButton = within(definitionsList).getByRole('button', { name: 'line 16' })
         expect(definitionButton.parentNode).toHaveClass('locationActive')
 
         // Expect "Loading" message
@@ -164,83 +154,5 @@ describe('ReferencesPanel', () => {
         // Assert the code view is rendered, by doing a partial match against its content
         const codeView = within(rightPane).getByRole('table')
         expect(codeView).toHaveTextContent('package diff import')
-    })
-})
-
-describe('getLineContent', () => {
-    const testFileLines = [
-        'package main',
-        '',
-        'import "fmt"',
-        '',
-        'type Animal interface {',
-        '\tSound() string',
-        '}',
-        '',
-        'var _ Animal = Cat{}',
-        '',
-        'type Cat struct{}',
-        '',
-        'func (c Cat) Sound() string { return "i am a cat" }',
-        '',
-        'type Dog struct{}',
-        '',
-        'func (d Dog) Sound() string { return "it is i, the dog" }',
-        '',
-        'func animalFarm() {',
-        '\tmakeSound(Cat{})',
-        '\tmakeSound(Dog{})',
-        '}',
-        '',
-        'func makeSound(a Animal) {',
-        '\tfmt.Printf("animal made a sound: %s", a.Sound())',
-        '',
-        '\tfoo := a',
-        '',
-        '\tfmt.Printf("another animal: %s", foo.Sound())',
-        '}',
-        '',
-    ]
-
-    it('returns pre/post and token of line', () => {
-        const location: Location = {
-            repo: 'a',
-            file: 'file',
-            commitID: 'f00b4r',
-            url: 'url',
-            precise: true,
-            content: '',
-            lines: testFileLines,
-            range: {
-                start: { line: 23, character: 5 },
-                end: { line: 23, character: 14 },
-            },
-        }
-
-        const content = getLineContent(location)
-        expect(content.prePostToken?.pre).toEqual('func ')
-        expect(content.prePostToken?.token).toEqual('makeSound')
-        expect(content.prePostToken?.post).toEqual('(a Animal) {')
-    })
-
-    it('handles token on multiple lines', () => {
-        const location: Location = {
-            repo: 'a',
-            file: 'file',
-            commitID: 'f00b4r',
-            url: 'url',
-            precise: true,
-            content: '',
-            lines: ['line0 start-of-tok', 'en-ends-here line1'],
-            range: {
-                start: { line: 0, character: 6 },
-                end: { line: 1, character: 12 },
-            },
-        }
-
-        const content = getLineContent(location)
-        expect(content.prePostToken?.pre).toEqual('line0 ')
-        expect(content.prePostToken?.token).toEqual('start-of-tok')
-        expect(content.prePostToken?.post).toEqual('')
     })
 })

--- a/client/web/src/codeintel/ReferencesPanel.test.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.test.tsx
@@ -119,7 +119,7 @@ describe('ReferencesPanel', () => {
         const definitionsList = result.getByTestId('definitions')
         const referencesList = result.getByTestId('references')
 
-        const referenceButton = within(referencesList).getByRole('button', { name: 'line 16' })
+        const referenceButton = within(referencesList).getByTestId('reference-item', { name: 'line 16' })
         const fullReferenceURL =
             '/github.com/sourcegraph/go-diff@9d1f353a285b3094bc33bdae277a19aedabe8b71/-/blob/diff/diff.go?L16:2-16:10'
         expect(referenceButton).toHaveAttribute('data-test-reference-url', fullReferenceURL)
@@ -131,7 +131,7 @@ describe('ReferencesPanel', () => {
         // Reference is marked as active
         expect(referenceButton.parentNode).toHaveClass('locationActive')
         // But we have the same in Definitions too, and that should be marked active too
-        const definitionButton = within(definitionsList).getByRole('button', { name: 'line 16' })
+        const definitionButton = within(definitionsList).getByTestId('reference-item', { name: 'line 16' })
         expect(definitionButton.parentNode).toHaveClass('locationActive')
 
         // Expect "Loading" message

--- a/client/web/src/codeintel/ReferencesPanel.test.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.test.tsx
@@ -119,20 +119,21 @@ describe('ReferencesPanel', () => {
         const definitionsList = result.getByTestId('definitions')
         const referencesList = result.getByTestId('references')
 
-        const referenceButton = within(referencesList).getByTestId('reference-item', { name: 'line 16' })
+        console.log({ referencesList })
+        const referenceButton = within(referencesList).getByTestId('reference-item-diff/diff.go-0')
         const fullReferenceURL =
             '/github.com/sourcegraph/go-diff@9d1f353a285b3094bc33bdae277a19aedabe8b71/-/blob/diff/diff.go?L16:2-16:10'
-        expect(referenceButton).toHaveAttribute('data-test-reference-url', fullReferenceURL)
-        expect(referenceButton.parentNode).not.toHaveClass('locationActive')
+        expect(referenceButton).toHaveAttribute('data-href', fullReferenceURL)
+        expect(referenceButton).not.toHaveClass('locationActive')
 
         // Click on reference
         fireEvent.click(referenceButton)
 
         // Reference is marked as active
-        expect(referenceButton.parentNode).toHaveClass('locationActive')
+        expect(referenceButton).toHaveClass('locationActive')
         // But we have the same in Definitions too, and that should be marked active too
-        const definitionButton = within(definitionsList).getByTestId('reference-item', { name: 'line 16' })
-        expect(definitionButton.parentNode).toHaveClass('locationActive')
+        const definitionButton = within(definitionsList).getByTestId('reference-item-diff/diff.go-0')
+        expect(definitionButton).toHaveClass('locationActive')
 
         // Expect "Loading" message
         const loadingText = result.getByText('Loading ...')

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -5,6 +5,8 @@ import classNames from 'classnames'
 import * as H from 'history'
 import { capitalize } from 'lodash'
 import { MemoryRouter, useLocation } from 'react-router'
+import { Observable, of } from 'rxjs'
+import { map } from 'rxjs/operators'
 
 import { HoveredToken } from '@sourcegraph/codeintellify'
 import {
@@ -17,6 +19,7 @@ import {
 } from '@sourcegraph/common'
 import { Position } from '@sourcegraph/extension-api-classes'
 import { useQuery } from '@sourcegraph/http-client'
+import { CodeExcerpt, FetchFileParameters } from '@sourcegraph/search-ui'
 import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
 import { findLanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/languages'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
@@ -73,13 +76,18 @@ import styles from './ReferencesPanel.module.scss'
 
 type Token = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
 
-interface ReferencesPanelProps
+interface HighlightedFileLineRangesProps {
+    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
+}
+
+export interface ReferencesPanelProps
     extends SettingsCascadeProps,
         PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'>,
         TelemetryProps,
         HoverThresholdProps,
         ExtensionsControllerProps,
-        ThemeProps {
+        ThemeProps,
+        HighlightedFileLineRangesProps {
     /** Whether to show the first loaded reference in mini code view */
     jumpToFirst?: boolean
 
@@ -511,7 +519,11 @@ interface ActiveLocationProps {
     setActiveLocation: (reference: Location | undefined) => void
 }
 
-interface CollapsibleLocationListProps extends ActiveLocationProps, CollapseProps, SearchTokenProps {
+interface CollapsibleLocationListProps
+    extends ActiveLocationProps,
+        CollapseProps,
+        SearchTokenProps,
+        HighlightedFileLineRangesProps {
     name: string
     locations: Location[]
     filter: string | undefined
@@ -559,6 +571,7 @@ const CollapsibleLocationList: React.FunctionComponent<
                             navigateToUrl={props.navigateToUrl}
                             handleOpenChange={(id, isOpen) => props.handleOpenChange(props.name + id, isOpen)}
                             isOpen={id => props.isOpen(props.name + id)}
+                            fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
                         />
                     ) : (
                         <Text className="text-muted pl-2">
@@ -711,7 +724,11 @@ const SideBlob: React.FunctionComponent<React.PropsWithChildren<SideBlobProps>> 
     )
 }
 
-interface LocationsListProps extends ActiveLocationProps, CollapseProps, SearchTokenProps {
+interface LocationsListProps
+    extends ActiveLocationProps,
+        CollapseProps,
+        SearchTokenProps,
+        HighlightedFileLineRangesProps {
     locations: Location[]
     filter: string | undefined
     navigateToUrl: (url: string) => void
@@ -726,6 +743,7 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
     handleOpenChange,
     isOpen,
     searchToken,
+    fetchHighlightedFileLineRanges,
 }) => {
     const repoLocationGroups = useMemo(() => buildRepoLocationGroups(locations), [locations])
     const openByDefault = repoLocationGroups.length === 1
@@ -744,6 +762,7 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
                     navigateToUrl={navigateToUrl}
                     handleOpenChange={handleOpenChange}
                     isOpen={isOpen}
+                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                 />
             ))}
         </>
@@ -754,7 +773,8 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     React.PropsWithChildren<
         ActiveLocationProps &
             CollapseProps &
-            SearchTokenProps & {
+            SearchTokenProps &
+            HighlightedFileLineRangesProps & {
                 filter: string | undefined
                 navigateToUrl: (url: string) => void
                 repoLocationGroup: RepoLocationGroup
@@ -771,6 +791,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     isOpen,
     handleOpenChange,
     searchToken,
+    fetchHighlightedFileLineRanges,
 }) => {
     const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
 
@@ -804,6 +825,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                             handleOpenChange={(id, isOpen) => handleOpenChange(repoLocationGroup.repoName + id, isOpen)}
                             isOpen={id => isOpen(repoLocationGroup.repoName + id)}
                             navigateToUrl={navigateToUrl}
+                            fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                         />
                     ))}
                 </CollapsePanel>
@@ -816,13 +838,22 @@ const CollapsibleLocationGroup: React.FunctionComponent<
     React.PropsWithChildren<
         ActiveLocationProps &
             CollapseProps &
-            SearchTokenProps & {
+            SearchTokenProps &
+            HighlightedFileLineRangesProps & {
                 group: LocationGroup
                 filter: string | undefined
                 navigateToUrl: (url: string) => void
             }
     >
-> = ({ group, setActiveLocation, isActiveLocation, filter, isOpen, handleOpenChange }) => {
+> = ({
+    group,
+    setActiveLocation,
+    isActiveLocation,
+    filter,
+    isOpen,
+    handleOpenChange,
+    fetchHighlightedFileLineRanges,
+}) => {
     // On the first load, update the scroll position towards the active
     // location.  Without this behavior, the scroll position points at the top
     // of the reference panel when reloading the page or going back/forward in
@@ -833,10 +864,52 @@ const CollapsibleLocationGroup: React.FunctionComponent<
             activeLocationElement.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'center' })
         }
     }, [])
-
     let highlighted = [group.path]
     if (filter !== undefined) {
         highlighted = group.path.split(filter)
+    }
+
+    const { repo, commitID, file } = useMemo(() => group.locations[0], [group])
+    const ranges = useMemo(
+        () =>
+            group.locations.map(location => ({
+                startLine: location.range?.start.line ?? 0,
+                // TODO: off-by-one danger?
+                endLine: (location.range?.end.line ?? 0) + 1,
+            })),
+        [group.locations]
+    )
+
+    const fetchHighlightedFileRangeLines = useCallback(
+        (startLine: number, endLine: number): Observable<string[]> =>
+            fetchHighlightedFileLineRanges(
+                {
+                    repoName: repo,
+                    commitID,
+                    filePath: file,
+                    disableTimeout: false,
+                    format: HighlightResponseFormat.HTML_HIGHLIGHT,
+                    ranges,
+                },
+                false
+            ).pipe(
+                map(
+                    lines =>
+                        lines[ranges.findIndex(group => group.startLine === startLine && group.endLine === endLine + 1)]
+                )
+            ),
+        [fetchHighlightedFileLineRanges, repo, commitID, file, ranges]
+    )
+
+    const fetchPlainTextFileRangeLines = (location: Location): Observable<string[]> => {
+        const range = location.range
+        if (range !== undefined) {
+            const lineNumber = range.start.line + 1
+            const lineContent = location.lines[range.start.line]
+            const tableLine = `<tr><td class="line" data-line="${lineNumber}"></td><td class="code">${lineContent}</td></tr>`
+            return of([tableLine])
+        }
+        return of([])
     }
 
     const open = isOpen(group.path) ?? true
@@ -891,29 +964,6 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                             {group.locations.map(reference => {
                                 const className = isActiveLocation(reference) ? styles.locationActive : ''
 
-                                const locationLine = getLineContent(reference)
-                                const lineWithHighlightedToken = locationLine.prePostToken ? (
-                                    <>
-                                        {locationLine.prePostToken.pre === '' ? (
-                                            <></>
-                                        ) : (
-                                            <Code>{locationLine.prePostToken.pre}</Code>
-                                        )}
-                                        <mark className="p-0 selection-highlight sourcegraph-document-highlight">
-                                            <Code>{locationLine.prePostToken.token}</Code>
-                                        </mark>
-                                        {locationLine.prePostToken.post === '' ? (
-                                            <></>
-                                        ) : (
-                                            <Code>{locationLine.prePostToken.post}</Code>
-                                        )}
-                                    </>
-                                ) : locationLine.line ? (
-                                    <Code>{locationLine.line}</Code>
-                                ) : (
-                                    ''
-                                )
-
                                 return (
                                     <li
                                         key={reference.url}
@@ -927,11 +977,28 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                             data-test-reference-url={reference.url}
                                             className={styles.locationLink}
                                         >
-                                            <span className={styles.locationLinkLineNumber}>
-                                                {(reference.range?.start?.line ?? 0) + 1}
-                                                {': '}
-                                            </span>
-                                            {lineWithHighlightedToken}
+                                            <CodeExcerpt
+                                                className={styles.locationLinkCodeExcerpt}
+                                                commitID={reference.commitID}
+                                                filePath={reference.file}
+                                                repoName={reference.repo}
+                                                highlightRanges={[
+                                                    {
+                                                        line: reference.range?.start.line ?? 0,
+                                                        character: reference.range?.start.character ?? 0,
+                                                        highlightLength:
+                                                            (reference.range?.end.character ?? 0) -
+                                                            (reference.range?.start.character ?? 0),
+                                                    },
+                                                ]}
+                                                startLine={reference.range?.start.line ?? 0}
+                                                endLine={reference.range?.end.line ?? 0}
+                                                fetchHighlightedFileRangeLines={fetchHighlightedFileRangeLines}
+                                                visibilityOffset={{ bottom: 0 }}
+                                                fetchPlainTextFileRangeLines={(): Observable<string[]> =>
+                                                    fetchPlainTextFileRangeLines(reference)
+                                                }
+                                            />
                                         </Button>
                                     </li>
                                 )
@@ -942,38 +1009,6 @@ const CollapsibleLocationGroup: React.FunctionComponent<
             </div>
         </Collapse>
     )
-}
-
-interface LocationLine {
-    prePostToken?: { pre: string; token: string; post: string }
-    line?: string
-}
-
-export const getLineContent = (location: Location): LocationLine => {
-    const range = location.range
-    if (range !== undefined) {
-        const line = location.lines[range.start.line]
-
-        if (range.end.line === range.start.line) {
-            return {
-                prePostToken: {
-                    pre: line.slice(0, range.start.character).trimStart(),
-                    token: line.slice(range.start.character, range.end.character),
-                    post: line.slice(range.end.character),
-                },
-                line: line.trimStart(),
-            }
-        }
-        return {
-            prePostToken: {
-                pre: line.slice(0, range.start.character).trimStart(),
-                token: line.slice(range.start.character),
-                post: '',
-            },
-            line: line.trimStart(),
-        }
-    }
-    return {}
 }
 
 const LoadingCodeIntel: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -960,7 +960,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                 <CollapsePanel id={group.repoName + group.path} className="ml-0">
                     <div className={styles.locationContainer}>
                         <ul className="list-unstyled mb-0">
-                            {group.locations.map(reference => {
+                            {group.locations.map((reference, index) => {
                                 const locationActive = isActiveLocation(reference) ? styles.locationActive : ''
                                 const selectReference = (
                                     event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>
@@ -976,7 +976,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                     >
                                         <div
                                             role="link"
-                                            data-testid="reference-item"
+                                            data-testid={`reference-item-${group.path}-${index}`}
                                             tabIndex={0}
                                             onClick={selectReference}
                                             onKeyDown={selectReference}

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import React, { KeyboardEvent, MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
 import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronRight, mdiFilterOutline } from '@mdi/js'
 import classNames from 'classnames'
@@ -19,7 +19,7 @@ import {
 } from '@sourcegraph/common'
 import { Position } from '@sourcegraph/extension-api-classes'
 import { useQuery } from '@sourcegraph/http-client'
-import { CodeExcerpt, FetchFileParameters } from '@sourcegraph/search-ui'
+import { CodeExcerpt, FetchFileParameters, onClickCodeExcerptHref } from '@sourcegraph/search-ui'
 import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
 import { findLanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/languages'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
@@ -963,18 +963,24 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                         <ul className="list-unstyled mb-0">
                             {group.locations.map(reference => {
                                 const className = isActiveLocation(reference) ? styles.locationActive : ''
+                                const selectReference = (
+                                    event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>
+                                ): void =>
+                                    onClickCodeExcerptHref(event, () => {
+                                        setActiveLocation(reference)
+                                    })
 
                                 return (
                                     <li
                                         key={reference.url}
                                         className={classNames('border-0 rounded-0 mb-0', styles.location, className)}
                                     >
-                                        <Button
-                                            onClick={event => {
-                                                event.preventDefault()
-                                                setActiveLocation(reference)
-                                            }}
-                                            data-test-reference-url={reference.url}
+                                        <div
+                                            role="link"
+                                            tabIndex={0}
+                                            onClick={selectReference}
+                                            onKeyDown={selectReference}
+                                            data-href={reference.url}
                                             className={styles.locationLink}
                                         >
                                             <CodeExcerpt
@@ -999,7 +1005,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                                     fetchPlainTextFileRangeLines(reference)
                                                 }
                                             />
-                                        </Button>
+                                        </div>
                                     </li>
                                 )
                             })}

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -874,7 +874,6 @@ const CollapsibleLocationGroup: React.FunctionComponent<
         () =>
             group.locations.map(location => ({
                 startLine: location.range?.start.line ?? 0,
-                // TODO: off-by-one danger?
                 endLine: (location.range?.end.line ?? 0) + 1,
             })),
         [group.locations]
@@ -962,7 +961,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                     <div className={styles.locationContainer}>
                         <ul className="list-unstyled mb-0">
                             {group.locations.map(reference => {
-                                const className = isActiveLocation(reference) ? styles.locationActive : ''
+                                const locationActive = isActiveLocation(reference) ? styles.locationActive : ''
                                 const selectReference = (
                                     event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>
                                 ): void =>
@@ -973,15 +972,16 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                 return (
                                     <li
                                         key={reference.url}
-                                        className={classNames('border-0 rounded-0 mb-0', styles.location, className)}
+                                        className={classNames('border-0 rounded-0 mb-0', styles.location)}
                                     >
                                         <div
                                             role="link"
+                                            data-testid="reference-item"
                                             tabIndex={0}
                                             onClick={selectReference}
                                             onKeyDown={selectReference}
                                             data-href={reference.url}
-                                            className={styles.locationLink}
+                                            className={classNames(styles.locationLink, locationActive)}
                                         >
                                             <CodeExcerpt
                                                 className={styles.locationLinkCodeExcerpt}

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -111,6 +111,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                                     repoHeaderContributionsLifecycleProps={
                                         context.repoHeaderContributionsLifecycleProps
                                     }
+                                    fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
                                 />
                             </TraceSpanProvider>
                         ) : resolvedRevision ? (

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -18,7 +18,7 @@ import {
     reactManualTracer,
 } from '@sourcegraph/observability-client'
 import { SearchContextProps } from '@sourcegraph/search'
-import { StreamingSearchResultsListProps } from '@sourcegraph/search-ui'
+import { FetchFileParameters, StreamingSearchResultsListProps } from '@sourcegraph/search-ui'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { HighlightResponseFormat, Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -84,6 +84,8 @@ interface BlobPageProps
     isSourcegraphDotCom: boolean
     repoID?: Scalars['ID']
     repoUrl?: string
+
+    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
 
 /**

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -14,6 +14,7 @@ import { ReferenceParameters, TextDocumentPositionParameters } from '@sourcegrap
 import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import { isErrorLike } from '@sourcegraph/common'
 import * as clientType from '@sourcegraph/extension-api-types'
+import { FetchFileParameters } from '@sourcegraph/search-ui'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { Activation, ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
@@ -42,6 +43,8 @@ interface Props
     repoID: Scalars['ID']
     repoName: string
     commitID: string
+
+    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
 
 export type BlobPanelTabID = 'info' | 'def' | 'references' | 'impl' | 'typedef' | 'history'
@@ -78,6 +81,7 @@ function useBlobPanelViews({
     isLightTheme,
     platformContext,
     telemetryService,
+    fetchHighlightedFileLineRanges,
 }: Props): void {
     const subscriptions = useMemo(() => new Subscription(), [])
 
@@ -264,6 +268,7 @@ function useBlobPanelViews({
                                     key="references"
                                     externalHistory={history}
                                     externalLocation={location}
+                                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                 />
                             ) : (
                                 <></>
@@ -284,6 +289,7 @@ function useBlobPanelViews({
             telemetryService,
             platformContext,
             extensionsController,
+            fetchHighlightedFileLineRanges,
         ])
     )
 


### PR DESCRIPTION
Followup on https://github.com/sourcegraph/sourcegraph/pull/41569

Fixes #38665

## Test plan

WIP
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-ref-panel-highlight.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-emdpkzabpg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
