### PR TITLE
Update default value of deletedAt filter in user management

### DIFF
--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
@@ -88,7 +88,7 @@ const DEFAULT_FILTERS = {
     maxEventsCount: '',
     lastActiveAt: '',
     createdAt: '',
-    deletedAt: '',
+    deletedAt: '{"isNegated":true}',
 }
 
 const dateRangeQueryParameterToVariable = (


### PR DESCRIPTION
## Test plan

Following the request in the [Slack thread](https://sourcegraph.slack.com/archives/C03D4H7UBEV/p1663937611179289), changing the default value of deleted At filter in the users' list table to exclude deleted users. 

<img width="982" alt="image" src="https://user-images.githubusercontent.com/22571395/192607258-f806178f-ccbb-4b45-9883-651ea5016eb2.png">
 

## App preview:

- [Web](https://sg-web-naman-update-user-management.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-weqbbmwhmm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
