### PR TITLE
chore: remove dead reference to lucky search

### DIFF
--- a/enterprise/internal/insights/query/streaming/search_client.go
+++ b/enterprise/internal/insights/query/streaming/search_client.go
@@ -15,7 +15,6 @@ import (
 )
 
 const ShardTimeoutSkippedReason = streamapi.ShardTimeout
-const LuckySearchAlertKind = "lucky-search-queries"
 
 type SearchClient interface {
 	Search(ctx context.Context, query string, patternType *string, sender streaming.Sender) (*search.Alert, error)


### PR DESCRIPTION
Found this reference while renaming things and it's unused as far as I can tell


## Test plan
existing tests, dead code
