### PR TITLE
dev/release: remove mi upgrade tracking issue

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -122,13 +122,6 @@ const getTemplates = () => {
         titleSuffix: IssueTitleSuffix.PATCH_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.PATCH],
     }
-    const upgradeManagedInstanceIssue: IssueTemplate = {
-        owner: 'sourcegraph',
-        repo: 'handbook',
-        path: 'content/departments/engineering/dev/process/releases/upgrade_managed_issue_template.md',
-        titleSuffix: IssueTitleSuffix.MANAGED_TRACKING,
-        labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.MANAGED, IssueLabel.DEVOPS_TEAM],
-    }
     const securityAssessmentIssue: IssueTemplate = {
         owner: 'sourcegraph',
         repo: 'handbook',
@@ -136,7 +129,7 @@ const getTemplates = () => {
         titleSuffix: IssueTitleSuffix.SECURITY_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.SECURITY_TEAM, IssueLabel.RELEASE_BLOCKER],
     }
-    return { releaseIssue, patchReleaseIssue, upgradeManagedInstanceIssue, securityAssessmentIssue }
+    return { releaseIssue, patchReleaseIssue, securityAssessmentIssue }
 }
 
 function dateMarkdown(date: Date, name: string): string {
@@ -201,9 +194,9 @@ export async function ensureTrackingIssues({
     // tracking issue, and subsequent issues will contain references to it.
     let issueTemplates: IssueTemplate[]
     if (version.patch === 0) {
-        issueTemplates = [templates.releaseIssue, templates.upgradeManagedInstanceIssue]
+        issueTemplates = [templates.releaseIssue]
     } else {
-        issueTemplates = [templates.patchReleaseIssue, templates.upgradeManagedInstanceIssue]
+        issueTemplates = [templates.patchReleaseIssue]
     }
 
     // Release milestones are not as emphasised now as they used to be, since most teams


### PR DESCRIPTION
in the updated upgrade process https://handbook.sourcegraph.com/departments/cloud/technical-docs/v1.1/mi1-1_upgrade_process/#upgrade

#cloud is responsible for maintaining our own tracking issue (we have a new `mi` command to auto-gen the tracking issue)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a

## App preview:

- [Web](https://sg-web-09-27-dev-release-remove-mi.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-utpswabasd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
