### PR TITLE
web: add option to disable autolink in markdown renderer and use with search alerts

### DIFF
--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -6,6 +6,17 @@ import { marked } from 'marked'
 import sanitize from 'sanitize-html'
 import { Overwrite } from 'utility-types'
 
+// Disable autolinks in Marked
+// Returning undefined is not allowed by the type definition
+// but is the only think that worked for me to easily disable autolinks.
+// Explicit links using `[text](url)` are still allowed.
+// More context here: https://github.com/markedjs/marked/issues/882
+marked.use({
+    tokenizer: {
+        url: () => (undefined as unknown) as false,
+    },
+})
+
 /**
  * Escapes HTML by replacing characters like `<` with their HTML escape sequences like `&lt;`
  */

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -7,8 +7,9 @@ import sanitize from 'sanitize-html'
 import { Overwrite } from 'utility-types'
 
 // Disable autolinks in Marked
-// Returning undefined is not allowed by the type definition
-// but is the only think that worked for me to easily disable autolinks.
+// Returning `undefined` is not allowed by TypeScript so we
+// need to do a bit of hacky type casting.
+// Returning `false` did NOT disable the autolinking when testing.
 // Explicit links using `[text](url)` are still allowed.
 // More context here: https://github.com/markedjs/marked/issues/882
 marked.use({

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -58,7 +58,7 @@ export const renderMarkdown = (
         /** Whether to render line breaks as HTML `<br>`s */
         breaks?: boolean
         /** Whether to disable autolinks. Explicit links using `[text](url)` are still allowed. */
-        disableAutolink?: boolean
+        disableAutolinks?: boolean
         renderer?: marked.Renderer
         headerPrefix?: string
     } & (
@@ -76,9 +76,10 @@ export const renderMarkdown = (
     ) = {}
 ): string => {
     const tokenizer = new marked.Tokenizer()
-    if (options.disableAutolink) {
-        // Returning undefined is not allowed by the type definition
-        // but is the recommended way to easily disable autolinks.
+    if (options.disableAutolinks) {
+        // Why the odd double-casting below?
+        // Because returning undefined is the recommended way to easily disable autolinks
+        // but the type definition does not allow it.
         // More context here: https://github.com/markedjs/marked/issues/882
         tokenizer.url = () => (undefined as unknown) as marked.Tokens.Link
     }

--- a/client/web/src/search/results/SearchAlert.tsx
+++ b/client/web/src/search/results/SearchAlert.tsx
@@ -26,7 +26,16 @@ export const SearchAlert: React.FunctionComponent<React.PropsWithChildren<Search
     <Alert className="my-2" data-testid="alert-container" variant="info">
         <H3>{alert.title}</H3>
 
-        {alert.description && <Markdown className="mb-3" dangerousInnerHTML={renderMarkdown(alert.description)} />}
+        {alert.description && (
+            <Markdown
+                className="mb-3"
+                dangerousInnerHTML={renderMarkdown(alert.description, {
+                    // Disable autolinks to rev specs are not rendered as email links
+                    // (e.g. sourcegraph@4.0.1)
+                    disableAutolink: true,
+                })}
+            />
+        )}
 
         {alert.proposedQueries && (
             <>

--- a/client/web/src/search/results/SearchAlert.tsx
+++ b/client/web/src/search/results/SearchAlert.tsx
@@ -30,9 +30,9 @@ export const SearchAlert: React.FunctionComponent<React.PropsWithChildren<Search
             <Markdown
                 className="mb-3"
                 dangerousInnerHTML={renderMarkdown(alert.description, {
-                    // Disable autolinks to rev specs are not rendered as email links
-                    // (e.g. sourcegraph@4.0.1)
-                    disableAutolink: true,
+                    // Disable autolinks so revision specifications are not rendered as email links
+                    // (for exaple, "sourcegraph@4.0.1")
+                    disableAutolinks: true,
                 })}
             />
         )}

--- a/client/web/src/search/results/SearchAlert.tsx
+++ b/client/web/src/search/results/SearchAlert.tsx
@@ -31,7 +31,7 @@ export const SearchAlert: React.FunctionComponent<React.PropsWithChildren<Search
                 className="mb-3"
                 dangerousInnerHTML={renderMarkdown(alert.description, {
                     // Disable autolinks so revision specifications are not rendered as email links
-                    // (for exaple, "sourcegraph@4.0.1")
+                    // (for example, "sourcegraph@4.0.1")
                     disableAutolinks: true,
                 })}
             />


### PR DESCRIPTION
Some search alerts are rendering rev strings as emails due to the Markdown renderer's autolink feature.
[Context on Slack](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1664310266331089)
![image](https://user-images.githubusercontent.com/206864/192640249-496a8675-1b64-4605-8610-809bcad8a54f.png)


## Test plan

Verify the search alerts render rev strings correctly:
![image](https://user-images.githubusercontent.com/206864/192640208-f14cd353-3832-42a5-bd99-c40afe230a16.png)

## App preview:

- [Web](https://sg-web-jp-disableautolink.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ckltralrhy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
