### PR TITLE
remove references to codeInsightsGqlApiEnabled

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -31,7 +31,6 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         executorsEnabled: false,
         codeIntelAutoIndexingEnabled: false,
         codeIntelAutoIndexingAllowGlobalPolicies: false,
-        codeInsightsGqlApiEnabled: true,
         externalServicesUserMode: 'public',
         productResearchPageEnabled: true,
         assetsRoot: '/.assets',

--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -26,10 +26,6 @@ describe('Code insight create insight page', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforce using a new gql API for code insights pages
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/insights/dashboards/add-remove-insights.test.ts
+++ b/client/web/src/integration/insights/dashboards/add-remove-insights.test.ts
@@ -54,10 +54,6 @@ describe('Code insights empty dashboard', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforce using a new gql API for code insights pages
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/insights/dashboards/create-dashboard.test.ts
+++ b/client/web/src/integration/insights/dashboards/create-dashboard.test.ts
@@ -19,10 +19,6 @@ describe('[Code Insight] Dashboard', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforce using a new gql API for code insights pages
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/insights/dashboards/delete-dashboard.test.ts
+++ b/client/web/src/integration/insights/dashboards/delete-dashboard.test.ts
@@ -20,10 +20,6 @@ describe('Code insights dashboard', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforce using a new gql API for code insights pages
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/insights/dashboards/render-empty-dashboard.test.ts
+++ b/client/web/src/integration/insights/dashboards/render-empty-dashboard.test.ts
@@ -20,10 +20,6 @@ describe('Code insights empty dashboard', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforce using a new gql API for code insights pages
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/insights/dashboards/update-dashboard.test.ts
+++ b/client/web/src/integration/insights/dashboards/update-dashboard.test.ts
@@ -69,10 +69,6 @@ describe('Code insights dashboard', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforce using a new gql API for code insights pages
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/insights/delete-insights.test.ts
+++ b/client/web/src/integration/insights/delete-insights.test.ts
@@ -22,10 +22,6 @@ describe('Code insights page', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforce using a new gql API for code insights pages
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -26,10 +26,6 @@ describe('Backend insight drill down filters', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforce using a new gql API for code insights pages
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/insights/edit-search-insights.test.ts
+++ b/client/web/src/integration/insights/edit-search-insights.test.ts
@@ -65,10 +65,6 @@ describe('Code insight edit insight page', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforces a new GQL backend for the creation UI
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/insights/single-insight-page.test.ts
+++ b/client/web/src/integration/insights/single-insight-page.test.ts
@@ -25,10 +25,6 @@ describe('Code insights single insight page', () => {
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
-            customContext: {
-                // Enforce using a new gql API for code insights pages
-                codeInsightsGqlApiEnabled: true,
-            },
         })
     })
 

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -22,7 +22,6 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     executorsEnabled: true,
     codeIntelAutoIndexingEnabled: true,
     codeIntelAutoIndexingAllowGlobalPolicies: true,
-    codeInsightsGqlApiEnabled: false,
     externalServicesUserMode: 'disabled',
     productResearchPageEnabled: true,
     assetsRoot: new URL('/.assets', sourcegraphBaseUrl).href,

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -112,9 +112,6 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether global policies are enabled for auto-indexing. */
     codeIntelAutoIndexingAllowGlobalPolicies: boolean
 
-    /** Whether the new gql api for code insights is enabled. */
-    codeInsightsGqlApiEnabled: boolean
-
     /** Whether users are allowed to add their own code and at what permission level. */
     externalServicesUserMode: 'disabled' | 'public' | 'all' | 'unknown'
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -106,8 +106,6 @@ type JSContext struct {
 	CodeIntelAutoIndexingEnabled             bool `json:"codeIntelAutoIndexingEnabled"`
 	CodeIntelAutoIndexingAllowGlobalPolicies bool `json:"codeIntelAutoIndexingAllowGlobalPolicies"`
 
-	CodeInsightsGQLApiEnabled bool `json:"codeInsightsGqlApiEnabled"`
-
 	RedirectUnsupportedBrowser bool `json:"RedirectUnsupportedBrowser"`
 
 	ProductResearchPageEnabled bool `json:"productResearchPageEnabled"`
@@ -242,8 +240,6 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		ExecutorsEnabled:                         conf.ExecutorsEnabled(),
 		CodeIntelAutoIndexingEnabled:             conf.CodeIntelAutoIndexingEnabled(),
 		CodeIntelAutoIndexingAllowGlobalPolicies: conf.CodeIntelAutoIndexingAllowGlobalPolicies(),
-
-		CodeInsightsGQLApiEnabled: conf.CodeInsightsGQLApiEnabled(),
 
 		ProductResearchPageEnabled: conf.ProductResearchPageEnabled(),
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -3,8 +3,6 @@ package conf
 import (
 	"context"
 	"log"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -185,11 +183,6 @@ func CodeIntelAutoIndexingPolicyRepositoryMatchLimit() int {
 	}
 
 	return *val
-}
-
-func CodeInsightsGQLApiEnabled() bool {
-	enabled, _ := strconv.ParseBool(os.Getenv("ENABLE_CODE_INSIGHTS_SETTINGS_STORAGE"))
-	return !enabled
 }
 
 func ProductResearchPageEnabled() bool {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41890

Removes references to the codeInsightsGqlApiEnabled flat
since the settings api is no longer used.

## Test plan

All automated tests should pass