### PR TITLE
add detail around admin perms

### DIFF
--- a/doc/admin/privileges.md
+++ b/doc/admin/privileges.md
@@ -1,5 +1,7 @@
 # Site administrator privileges
 
+this is a pro gamer move
+
 Site administrators have full administrative access to the Sourcegraph instance. In many cases, they also control the deployment environment. Special privileges are granted to site-admin users.
 
 ## Access to all repositories

--- a/doc/admin/privileges.md
+++ b/doc/admin/privileges.md
@@ -4,7 +4,7 @@ Site administrators have full administrative access to the Sourcegraph instance.
 
 ## Access to all repositories
 
-Site administrators are able to access all repositories on the Sourcegraph instance and manage the settings of individual repositories.
+Site administrators are able to access all repositories on the Sourcegraph instance and manage the settings of individual repositories. However, this setting can be changed in `admin/config/site.schema.json` as seen [here](https://docs.sourcegraph.com/admin/config/site_config#authz-enforceForSiteAdmins) so admins can only see private code they have access to in the code host. 
 
 ## Access to all GraphQL APIs
 

--- a/doc/admin/privileges.md
+++ b/doc/admin/privileges.md
@@ -1,7 +1,5 @@
 # Site administrator privileges
 
-this is a pro gamer move
-
 Site administrators have full administrative access to the Sourcegraph instance. In many cases, they also control the deployment environment. Special privileges are granted to site-admin users.
 
 ## Access to all repositories


### PR DESCRIPTION
I have heard the question multiple times from customers about site admin permissions and whether or not they can force the site admin to respect the permissions of the code host instead of having access to every repo. I just wanted to add the link in there to show it is possible

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
small docs change, not test needed