### PR TITLE
codeintel: reduce search based definition query count to 50

### DIFF
--- a/client/web/src/codeintel/searchBased.ts
+++ b/client/web/src/codeintel/searchBased.ts
@@ -26,7 +26,7 @@ export function definitionQuery({
         `^${searchToken}$`,
         'type:symbol',
         'patternType:regexp',
-        'count:500',
+        'count:50',
         'case:yes',
         fileExtensionTerm(path, fileExts),
     ]


### PR DESCRIPTION
When we disabled legacy extensions on Sourcegraph.com (around 13:40 20th Sep UTC), Zoekt's CPU usage and contention went up significantly. In code-intel-extensions repository, the definition query uses count:50. However, in the Sourcegraph repo we use count:500. We believe this is the root cause for the regression.

Using the bubble up feature on [honeycomb](https://ui.honeycomb.io/sourcegraph/datasets/search-zoekt/result/th9oLQAzgsg?tab=bubbleup), it shows that the difference between our bad queries and good is a max shard match count of 500.

![image](https://user-images.githubusercontent.com/187831/192735566-f0efa617-12c9-4f78-b374-1cd41be9358a.png)

Test Plan: CI and then monitoring CPU usage in production.

Co-authored-by: @stefanhengl 

## App preview:

- [Web](https://sg-web-k-count-50.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jjonifpejp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
