### PR TITLE
gitoltite: Check for header before executing gitolite list

### DIFF
--- a/cmd/gitserver/server/list_gitolite.go
+++ b/cmd/gitserver/server/list_gitolite.go
@@ -21,10 +21,10 @@ func (s *Server) handleListGitolite(w http.ResponseWriter, r *http.Request) {
 var defaultGitolite = gitoliteFetcher{client: gitoliteClient{}}
 
 type gitoliteFetcher struct {
-	client iGitoliteClient
+	client gitoliteRepoLister
 }
 
-type iGitoliteClient interface {
+type gitoliteRepoLister interface {
 	ListRepos(ctx context.Context, host string) ([]*gitolite.Repo, error)
 }
 

--- a/cmd/gitserver/server/list_gitolite.go
+++ b/cmd/gitserver/server/list_gitolite.go
@@ -9,6 +9,12 @@ import (
 )
 
 func (s *Server) handleListGitolite(w http.ResponseWriter, r *http.Request) {
+	// Ensure the request came from us
+	if h := r.Header.Get("X-Requested-With"); h != "Sourcegraph" {
+		http.Error(w, "incorrect headers", http.StatusBadRequest)
+		return
+	}
+
 	defaultGitolite.listRepos(r.Context(), r.URL.Query().Get("gitolite"), w)
 }
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -49,7 +49,7 @@ type Test struct {
 	ExpectedTrailers http.Header
 }
 
-func TestRequest(t *testing.T) {
+func TestExecRequest(t *testing.T) {
 	tests := []Test{
 		{
 			Name:         "HTTP GET",
@@ -57,7 +57,6 @@ func TestRequest(t *testing.T) {
 			ExpectedCode: http.StatusMethodNotAllowed,
 			ExpectedBody: "",
 		},
-
 		{
 			Name:         "Command",
 			Request:      httptest.NewRequest("POST", "/exec", strings.NewReader(`{"repo": "github.com/gorilla/mux", "args": ["testcommand"]}`)),

--- a/internal/gitserver/gitolite.go
+++ b/internal/gitserver/gitolite.go
@@ -38,6 +38,8 @@ func (c *GitoliteLister) ListRepos(ctx context.Context, gitoliteHost string) (li
 	if err != nil {
 		return nil, err
 	}
+	// Set header so that the handler knows the request is from us
+	req.Header.Set("X-Requested-With", "Sourcegraph")
 
 	resp, err := c.httpClient.Do(req.WithContext(ctx))
 	if err != nil {


### PR DESCRIPTION
This ensures that the request came from use and we can assume some level
of scrutiny was given to the parameters being passed.

## Test plan

HTTP integration tests added
