### PR TITLE
Format main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- Git server access logs are now compliant with the audit logging format. Breaking change: The 'actor' field is now nested under 'audit' field.  [#41865](https://github.com/sourcegraph/sourcegraph/pull/41865)
+- Git server access logs are now compliant with the audit logging format. Breaking change: The 'actor' field is now nested under 'audit' field. [#41865](https://github.com/sourcegraph/sourcegraph/pull/41865)
 
 ### Fixed
 

--- a/client/web/src/user/settings/profile/UserProfileFormFields.tsx
+++ b/client/web/src/user/settings/profile/UserProfileFormFields.tsx
@@ -53,8 +53,8 @@ export const UserProfileFormFields: React.FunctionComponent<React.PropsWithChild
                     aria-describedby="UserProfileFormFields__username-help"
                 />
                 <small id="UserProfileFormFields__username-help" className="form-text text-muted">
-                    A username consists of letters, numbers, hyphens (-), dots (.), underscore (_) and may not begin or end with a dot,
-                    nor begin with a hyphen.
+                    A username consists of letters, numbers, hyphens (-), dots (.), underscore (_) and may not begin or
+                    end with a dot, nor begin with a hyphen.
                 </small>
             </div>
             <Input


### PR DESCRIPTION
It seems like we've missed format checks on the main branch and currently have two places that we should format with `yarn format`

## Test plan
- Make sure that `yarn format` on the main doesn't do anything 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-format-main.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-iloxsuasyf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
