### PR TITLE
docker-images: update alpine image's bind-tools for many CVEs

### DIFF
--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -24,7 +24,7 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 # See https://github.com/sourcegraph/deploy-sourcegraph-docker/issues/1
 # Install other packages that are desirable in ALL Sourcegraph Docker images.
 RUN apk update && apk add --no-cache \
-    bind-tools \
+    'bind-tools>=9.16.33-r0' \
     busybox \
     ca-certificates \
     'curl>=7.79.1-r2' \


### PR DESCRIPTION
There is a whole slew of CVEs currently which is affecting all our images:

- CVE-2022-2795
- CVE-2022-2881
- CVE-2022-2906
- CVE-2022-3080
- CVE-2022-38177
- CVE-2022-38178

Note: This only updates the base image, another commit will need to update all images to use this.

Test Plan: `docker build docker-images/alpine-3.14` and output indicates a version greater than or equal to 9.16.33-r0