### PR TITLE
Remove log statement for unconfigured OTLP endpoint

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -303,7 +303,7 @@ func addOpenTelemetryProtocolAdapter(r *mux.Router) {
 
 	// If no endpoint is configured, we export a no-op handler
 	if endpoint == "" {
-		logger.Info("No OTLP endpoint configured, telemetry data will not be exported")
+		logger.Info("no OTLP endpoint configured, data received at /-/debug/otlp will not be exported")
 
 		r.PathPrefix("/otlp").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, `OpenTelemetry protocol tunnel: please configure an exporter endpoint with OTEL_EXPORTER_OTLP_ENDPOINT`)

--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -303,8 +303,6 @@ func addOpenTelemetryProtocolAdapter(r *mux.Router) {
 
 	// If no endpoint is configured, we export a no-op handler
 	if endpoint == "" {
-		logger.Error("unable to parse OTLP export target")
-
 		r.PathPrefix("/otlp").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, `OpenTelemetry protocol tunnel: please configure an exporter endpoint with OTEL_EXPORTER_OTLP_ENDPOINT`)
 			w.WriteHeader(http.StatusNotFound)

--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -303,6 +303,8 @@ func addOpenTelemetryProtocolAdapter(r *mux.Router) {
 
 	// If no endpoint is configured, we export a no-op handler
 	if endpoint == "" {
+		logger.Info("No OTLP endpoint configured, telemetry data will not be exported")
+
 		r.PathPrefix("/otlp").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, `OpenTelemetry protocol tunnel: please configure an exporter endpoint with OTEL_EXPORTER_OTLP_ENDPOINT`)
 			w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
Flagged in #42136 

Not configuring OTLP is definitely not an illegal state to be in, so an error-level log seems too alarming. Furthermore, the [doc comment](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/otlpenv/otlpenv.go?L21-35) of `GetEndpoint()` explains that an empty string equates disabled OpenTelemetry. Finally, the log statement mentions a parsing error, while no parsing is taking place.

Considering that the `/otlp` endpoint returns a message informing the user to configure the environment variable, I think it is safe to just remove the log statement altogether. 

## Test plan
None
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
