### PR TITLE
Code insights: Add dashboard cards integration test

### DIFF
--- a/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.tsx
@@ -78,7 +78,7 @@ export function SeriesChart<Datum>(props: SeriesChartProps<Datum>): React.ReactE
 
     return (
         <LineChart
-            aria-label='Line chart'
+            aria-label="Line chart"
             series={series}
             getLineGroupStyle={getHoverStyle}
             getActiveSeries={getActiveSeries}

--- a/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.tsx
@@ -78,6 +78,7 @@ export function SeriesChart<Datum>(props: SeriesChartProps<Datum>): React.ReactE
 
     return (
         <LineChart
+            aria-label='Line chart'
             series={series}
             getLineGroupStyle={getHoverStyle}
             getActiveSeries={getActiveSeries}

--- a/client/web/src/integration/insights/insight/dashboard-cards.test.ts
+++ b/client/web/src/integration/insights/insight/dashboard-cards.test.ts
@@ -1,0 +1,214 @@
+import assert from 'assert';
+
+import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
+import { testUserID } from '@sourcegraph/shared/src/testing/integration/graphQlResults'
+import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
+
+import {
+    GetDashboardInsightsResult,
+    InsightsDashboardNode,
+    InsightViewNode
+} from '../../../graphql-operations'
+import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../../context'
+import {
+    LANG_STATS_INSIGHT,
+    LANG_STAT_INSIGHT_CONTENT, CAPTURE_GROUP_INSIGHT, GET_INSIGHT_VIEW_CAPTURE_GROUP_INSIGHT,
+} from '../fixtures/dashboards'
+import { overrideInsightsGraphQLApi } from '../utils/override-insights-graphql-api'
+
+interface DashboardMockOptions {
+    id?: string,
+    title?: string
+    insightIds?: string[]
+}
+
+/**
+ * Creates dashboard mock entity in order to mock insight dashboard configurations.
+ * It's used for easier mocking dashboards list gql handler see InsightsDashboards entry point.
+ */
+function createDashboard(options: DashboardMockOptions): InsightsDashboardNode  {
+    const {
+        id = '001_dashboard',
+        title = 'Default dashboard',
+        insightIds = []
+    } = options
+
+    return {
+        __typename: 'InsightsDashboard',
+        id,
+        title,
+        views: {
+            __typename: 'InsightViewConnection',
+            nodes: insightIds.map(id => ({ __typename: 'InsightView', id })),
+        },
+        grants: {
+            __typename: 'InsightsPermissionGrants',
+            users: [testUserID],
+            organizations: [],
+            global: false,
+        },
+    }
+}
+
+interface DashboardViewMockOptions {
+    id?: string,
+    insightsMocks?: InsightViewNode[]
+}
+
+/**
+ * Creates mocks for the dashboard view entity, you may ask what difference between createDashboard
+ * and this mock helper. Dashboard view mock contains insight configurations, dashboard mocks contain
+ * only insight ids. (we should mock dashboard view only when this dashboard is opened on the page)
+ */
+function createDashboardViewMock(options: DashboardViewMockOptions): GetDashboardInsightsResult {
+    const { id = '001_dashboard', insightsMocks = [] } = options
+
+    return {
+        insightsDashboards: {
+            __typename: 'InsightsDashboardConnection',
+                nodes: [
+                {
+                    __typename: 'InsightsDashboard',
+                    id,
+                    views: { __typename: 'InsightViewConnection', nodes: insightsMocks.map(mock => ({ ... mock, __typename: 'InsightView' })) },
+                }
+            ]
+        }
+    }
+}
+
+describe('Code insights [Dashboard card]', () => {
+    let driver: Driver
+    let testContext: WebIntegrationTestContext
+
+    before(async () => {
+        driver = await createDriverForTest()
+    })
+
+    beforeEach(async function () {
+        testContext = await createWebIntegrationTestContext({
+            driver,
+            currentTest: this.currentTest!,
+            directory: __dirname,
+        })
+    })
+
+    after(() => driver?.close())
+    afterEachSaveScreenshotIfFailed(() => driver.page)
+
+    it('renders lang stats insight card with proper options context', async () => {
+        overrideInsightsGraphQLApi({
+            testContext,
+            overrides: {
+                // Mock list of possible code insights dashboards on the dashboard page
+                InsightsDashboards: () => ({
+                    currentUser: {
+                        __typename: 'User',
+                        id: testUserID,
+                        organizations: { nodes: [] },
+                    },
+                    insightsDashboards: {
+                        __typename: 'InsightsDashboardConnection',
+                        nodes: [
+                            createDashboard({ id: 'DASHBOARD_WITH_LANG_INSIGHT', insightIds: [LANG_STATS_INSIGHT.id] }),
+                        ]
+                    }
+                }),
+
+                // Mock dashboard configuration (dashboard content)
+                GetDashboardInsights: () => createDashboardViewMock({ id: 'DASHBOARD_WITH_LANG_INSIGHT', insightsMocks: [LANG_STATS_INSIGHT] }),
+
+                // Mock lang stats insight content
+                LangStatsInsightContent: () => LANG_STAT_INSIGHT_CONTENT,
+            }
+        })
+
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/DASHBOARD_WITH_LANG_INSIGHT')
+        await driver.page.waitForSelector('[aria-label="Pie chart"]')
+
+        const numberOfArcs = await driver.page.$$eval('[aria-label="Pie chart"] path', elements => elements.length)
+        const numberHeadings = await driver.page.$$eval('[aria-label="Pie chart"] h3', elements => elements.length)
+
+        // Why 12?, because LANG_STAT_INSIGHT_CONTENT mock has 14 entries and only five of them
+        // are rendered because all other (7 groups) are too small, and they are grouped and presented
+        // by special "Other" category (5 original rendered groups + one special Other group = 6)
+        // 12 paths because we render 2 paths per pie part (one for the pie arc itself and one for the annotation line)
+        assert.strictEqual(numberOfArcs, 12)
+
+        // Why 6?, because LANG_STAT_INSIGHT_CONTENT mock has 14 entries and only five of them
+        // are rendered because all other (7 groups) are too small, and they are grouped and presented
+        // by special "Other" category (5 original rendered groups + one special Other group = 6)
+        assert.strictEqual(numberHeadings, 6)
+
+        const filtersButton = await driver.page.$('[aria-label="Active filters"], [aria-label="Filters"]')
+
+        // Lang's stats insight doesn't support filters functionality, so we shouldn't have any filter UI
+        assert.strictEqual(filtersButton, null)
+
+        await driver.page.click('[aria-label="Insight options"]')
+
+        const menuOptions = await driver.page.$$eval(
+            '[role="dialog"][aria-modal="true"] [role="menuitem"]',
+                elements => elements.map(element => element.textContent)
+        )
+
+        // Check that Pie chart doesn't have anything non pie chart specific menu options
+        assert.deepStrictEqual(menuOptions, ['Edit', 'Get shareable link', 'Remove from this dashboard', 'Delete'])
+    })
+
+    it('renders lang stats insight card with proper options context', async () => {
+        overrideInsightsGraphQLApi({
+            testContext,
+            overrides: {
+                // Mock list of possible code insights dashboards on the dashboard page
+                InsightsDashboards: () => ({
+                    currentUser: {
+                        __typename: 'User',
+                        id: testUserID,
+                        organizations: { nodes: [] },
+                    },
+                    insightsDashboards: {
+                        __typename: 'InsightsDashboardConnection',
+                        nodes: [
+                            createDashboard({ id: 'DASHBOARD_WITH_CAPTURE_GROUP', insightIds: [CAPTURE_GROUP_INSIGHT.id] }),
+                        ]
+                    }
+                }),
+                // Mock dashboard configuration (dashboard content) with one capture group insight configuration
+                GetDashboardInsights: () => createDashboardViewMock({ id: 'DASHBOARD_WITH_CAPTURE_GROUP', insightsMocks: [CAPTURE_GROUP_INSIGHT] }),
+
+                // Mock capture group insight content
+                GetInsightView: () => GET_INSIGHT_VIEW_CAPTURE_GROUP_INSIGHT
+            }
+        })
+
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/DASHBOARD_WITH_CAPTURE_GROUP')
+        await driver.page.waitForSelector('[aria-label="Line chart"]')
+
+        const numberOfLines = await driver.page.$$eval('[aria-label="Line chart"] path', elements => elements.length)
+        const numberOfPointLinks = await driver.page.$$eval('[aria-label="Line chart"] a', elements => elements.length)
+
+        // Why 20 and 189? See GET_INSIGHT_VIEW_CAPTURE_GROUP_INSIGHT dataset mock, it has 20 lines and 189 points
+        assert.strictEqual(numberOfLines, 20)
+        assert.strictEqual(numberOfPointLinks, 189)
+
+        await driver.page.click('[aria-label="Filters"]')
+        const filterPanel = await driver.page.$('[aria-label="Drill-down filters panel"]')
+
+        // Should open filter panel on filter panel icon click
+        assert.strictEqual(filterPanel !== null, true)
+
+        // // Toggle insight filters (close filters panel)
+        await driver.page.click('[aria-label="Filters"]')
+
+        await driver.page.click('[aria-label="Insight options"]')
+
+        const menuOptions = await driver.page.$$eval(
+            '[role="dialog"][aria-modal="true"] [role="menuitem"]',
+            elements => elements.map(element => element.textContent)
+        )
+
+        // Check that Line chart doesn't have anything non-related to capture group menu options
+        assert.deepStrictEqual(menuOptions, ['Edit', 'Get shareable link', 'Remove from this dashboard', 'Delete'])
+    })
+})

--- a/client/web/src/integration/insights/insight/dashboard-cards.test.ts
+++ b/client/web/src/integration/insights/insight/dashboard-cards.test.ts
@@ -153,7 +153,7 @@ describe('Code insights [Dashboard card]', () => {
         assert.deepStrictEqual(menuOptions, ['Edit', 'Get shareable link', 'Remove from this dashboard', 'Delete'])
     })
 
-    it('renders lang stats insight card with proper options context', async () => {
+    it('renders capture group insight card with proper options context', async () => {
         overrideInsightsGraphQLApi({
             testContext,
             overrides: {

--- a/client/web/src/integration/insights/insight/dashboard-cards.test.ts
+++ b/client/web/src/integration/insights/insight/dashboard-cards.test.ts
@@ -1,23 +1,21 @@
-import assert from 'assert';
+import assert from 'assert'
 
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
 import { testUserID } from '@sourcegraph/shared/src/testing/integration/graphQlResults'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
-import {
-    GetDashboardInsightsResult,
-    InsightsDashboardNode,
-    InsightViewNode
-} from '../../../graphql-operations'
+import { GetDashboardInsightsResult, InsightsDashboardNode, InsightViewNode } from '../../../graphql-operations'
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../../context'
 import {
     LANG_STATS_INSIGHT,
-    LANG_STAT_INSIGHT_CONTENT, CAPTURE_GROUP_INSIGHT, GET_INSIGHT_VIEW_CAPTURE_GROUP_INSIGHT,
+    LANG_STAT_INSIGHT_CONTENT,
+    CAPTURE_GROUP_INSIGHT,
+    GET_INSIGHT_VIEW_CAPTURE_GROUP_INSIGHT,
 } from '../fixtures/dashboards'
 import { overrideInsightsGraphQLApi } from '../utils/override-insights-graphql-api'
 
 interface DashboardMockOptions {
-    id?: string,
+    id?: string
     title?: string
     insightIds?: string[]
 }
@@ -26,12 +24,8 @@ interface DashboardMockOptions {
  * Creates dashboard mock entity in order to mock insight dashboard configurations.
  * It's used for easier mocking dashboards list gql handler see InsightsDashboards entry point.
  */
-function createDashboard(options: DashboardMockOptions): InsightsDashboardNode  {
-    const {
-        id = '001_dashboard',
-        title = 'Default dashboard',
-        insightIds = []
-    } = options
+function createDashboard(options: DashboardMockOptions): InsightsDashboardNode {
+    const { id = '001_dashboard', title = 'Default dashboard', insightIds = [] } = options
 
     return {
         __typename: 'InsightsDashboard',
@@ -51,7 +45,7 @@ function createDashboard(options: DashboardMockOptions): InsightsDashboardNode  
 }
 
 interface DashboardViewMockOptions {
-    id?: string,
+    id?: string
     insightsMocks?: InsightViewNode[]
 }
 
@@ -66,14 +60,17 @@ function createDashboardViewMock(options: DashboardViewMockOptions): GetDashboar
     return {
         insightsDashboards: {
             __typename: 'InsightsDashboardConnection',
-                nodes: [
+            nodes: [
                 {
                     __typename: 'InsightsDashboard',
                     id,
-                    views: { __typename: 'InsightViewConnection', nodes: insightsMocks.map(mock => ({ ... mock, __typename: 'InsightView' })) },
-                }
-            ]
-        }
+                    views: {
+                        __typename: 'InsightViewConnection',
+                        nodes: insightsMocks.map(mock => ({ ...mock, __typename: 'InsightView' })),
+                    },
+                },
+            ],
+        },
     }
 }
 
@@ -111,16 +108,17 @@ describe('Code insights [Dashboard card]', () => {
                         __typename: 'InsightsDashboardConnection',
                         nodes: [
                             createDashboard({ id: 'DASHBOARD_WITH_LANG_INSIGHT', insightIds: [LANG_STATS_INSIGHT.id] }),
-                        ]
-                    }
+                        ],
+                    },
                 }),
 
                 // Mock dashboard configuration (dashboard content)
-                GetDashboardInsights: () => createDashboardViewMock({ id: 'DASHBOARD_WITH_LANG_INSIGHT', insightsMocks: [LANG_STATS_INSIGHT] }),
+                GetDashboardInsights: () =>
+                    createDashboardViewMock({ id: 'DASHBOARD_WITH_LANG_INSIGHT', insightsMocks: [LANG_STATS_INSIGHT] }),
 
                 // Mock lang stats insight content
                 LangStatsInsightContent: () => LANG_STAT_INSIGHT_CONTENT,
-            }
+            },
         })
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/DASHBOARD_WITH_LANG_INSIGHT')
@@ -147,9 +145,8 @@ describe('Code insights [Dashboard card]', () => {
 
         await driver.page.click('[aria-label="Insight options"]')
 
-        const menuOptions = await driver.page.$$eval(
-            '[role="dialog"][aria-modal="true"] [role="menuitem"]',
-                elements => elements.map(element => element.textContent)
+        const menuOptions = await driver.page.$$eval('[role="dialog"][aria-modal="true"] [role="menuitem"]', elements =>
+            elements.map(element => element.textContent)
         )
 
         // Check that Pie chart doesn't have anything non pie chart specific menu options
@@ -170,16 +167,23 @@ describe('Code insights [Dashboard card]', () => {
                     insightsDashboards: {
                         __typename: 'InsightsDashboardConnection',
                         nodes: [
-                            createDashboard({ id: 'DASHBOARD_WITH_CAPTURE_GROUP', insightIds: [CAPTURE_GROUP_INSIGHT.id] }),
-                        ]
-                    }
+                            createDashboard({
+                                id: 'DASHBOARD_WITH_CAPTURE_GROUP',
+                                insightIds: [CAPTURE_GROUP_INSIGHT.id],
+                            }),
+                        ],
+                    },
                 }),
                 // Mock dashboard configuration (dashboard content) with one capture group insight configuration
-                GetDashboardInsights: () => createDashboardViewMock({ id: 'DASHBOARD_WITH_CAPTURE_GROUP', insightsMocks: [CAPTURE_GROUP_INSIGHT] }),
+                GetDashboardInsights: () =>
+                    createDashboardViewMock({
+                        id: 'DASHBOARD_WITH_CAPTURE_GROUP',
+                        insightsMocks: [CAPTURE_GROUP_INSIGHT],
+                    }),
 
                 // Mock capture group insight content
-                GetInsightView: () => GET_INSIGHT_VIEW_CAPTURE_GROUP_INSIGHT
-            }
+                GetInsightView: () => GET_INSIGHT_VIEW_CAPTURE_GROUP_INSIGHT,
+            },
         })
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/DASHBOARD_WITH_CAPTURE_GROUP')
@@ -203,9 +207,8 @@ describe('Code insights [Dashboard card]', () => {
 
         await driver.page.click('[aria-label="Insight options"]')
 
-        const menuOptions = await driver.page.$$eval(
-            '[role="dialog"][aria-modal="true"] [role="menuitem"]',
-            elements => elements.map(element => element.textContent)
+        const menuOptions = await driver.page.$$eval('[role="dialog"][aria-modal="true"] [role="menuitem"]', elements =>
+            elements.map(element => element.textContent)
         )
 
         // Check that Line chart doesn't have anything non-related to capture group menu options


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41811
Closes https://github.com/sourcegraph/sourcegraph/issues/41813

## Background
And new integration checks for insight cards 
- Capture group 
   - Renders with a line chart
   - Filter panel opens on click
   - Options menu opens on click and contains correct items 
- Lang stats 
  - Renders with a pie chart
  - Does not contain a filter button
  - Options menu opens on click and contains correct items 

## Test plan
- Make sure that the new integration test covers all checks for lang stats and capture group insight cards

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-dashboard-cards-test.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ijcecawlvj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
