### PR TITLE
CodeMirror blob: Override browser search to trigger file search

### DIFF
--- a/client/shared/src/keyboardShortcuts.ts
+++ b/client/shared/src/keyboardShortcuts.ts
@@ -17,7 +17,7 @@ export interface KeyboardShortcut {
 /** A key sequence (that triggers a keyboard shortcut). */
 export interface Keybinding {
     /** Keys that must be held down. */
-    held?: ModifierKey[]
+    held?: (ModifierKey | 'Mod')[]
 
     /** Keys that must be pressed in order (when holding the `held` keys). */
     ordered: Key[]

--- a/client/shared/src/keyboardShortcuts/keyboardShortcuts.ts
+++ b/client/shared/src/keyboardShortcuts/keyboardShortcuts.ts
@@ -33,10 +33,10 @@ export const KEYBOARD_SHORTCUTS: KEYBOARD_SHORTCUT_MAPPING = {
     },
     fuzzyFinder: {
         title: 'Fuzzy search files',
-        keybindings: [{ held: [isMacPlatform() ? 'Meta' : 'Control'], ordered: ['k'] }],
+        keybindings: [{ held: ['Mod'], ordered: ['k'] }],
     },
     copyFullQuery: {
         title: 'Copy full query',
-        keybindings: [{ held: [isMacPlatform() ? 'Meta' : 'Control', 'Shift'], ordered: ['c'] }],
+        keybindings: [{ held: ['Mod', 'Shift'], ordered: ['c'] }],
     },
 }

--- a/client/shared/src/keyboardShortcuts/useKeyboardShortcut.test.tsx
+++ b/client/shared/src/keyboardShortcuts/useKeyboardShortcut.test.tsx
@@ -57,7 +57,7 @@ describe('useKeyboardShortcut', () => {
                   "keybindings": [
                     {
                       "held": [
-                        "Control"
+                        "Mod"
                       ],
                       "ordered": [
                         "k"
@@ -103,7 +103,7 @@ describe('useKeyboardShortcut', () => {
                   "keybindings": [
                     {
                       "held": [
-                        "Control"
+                        "Mod"
                       ],
                       "ordered": [
                         "k"

--- a/client/shared/src/react-shortcuts/Shortcut.tsx
+++ b/client/shared/src/react-shortcuts/Shortcut.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { Key, ModifierKey } from './keys'
+import { Data } from './ShortcutManager'
 import { Consumer, Context } from './ShortcutProvider'
 
 export interface Props {
@@ -16,11 +17,6 @@ export interface Props {
      * 'Ctrl' on other platforms.
      */
     held?: (ModifierKey | 'Mod')[]
-    /**
-     * DO NOT USE! Scoping the keybinding to a specific element doesn't actually
-     * work.
-     */
-    node?: HTMLElement | null
     /**
      * Be default keybindings are not triggered when the keyboard events
      * originate from an input element. Set this to `true` to also react to
@@ -50,8 +46,8 @@ export const Shortcut: React.FunctionComponent<Props> = props => (
 )
 
 class ShortcutConsumer extends React.Component<Props & Context, never> {
-    public data = {
-        node: this.props.node,
+    public data: Data = {
+        node: null,
         ordered: this.props.ordered,
         held: this.props.held,
         ignoreInput: this.props.ignoreInput || false,

--- a/client/shared/src/react-shortcuts/Shortcut.tsx
+++ b/client/shared/src/react-shortcuts/Shortcut.tsx
@@ -4,11 +4,37 @@ import { Key, ModifierKey } from './keys'
 import { Consumer, Context } from './ShortcutProvider'
 
 export interface Props {
+    /**
+     * Order in which they keys should be pressed. At the moment the values used
+     * need to take into account any modifier key (e.g. to register a keyboard
+     * shortcut for 'Alt+t', you'd have to specify the character '†').
+     */
     ordered: Key[]
-    held?: ModifierKey[]
+    /**
+     * Which modifiers keys need to be pressed for the handler to be triggered.
+     * 'Mod' is a special value that translates to 'Meta' (Cmd) on macOS and
+     * 'Ctrl' on other platforms.
+     */
+    held?: (ModifierKey | 'Mod')[]
+    /**
+     * DO NOT USE! Scoping the keybinding to a specific element doesn't actually
+     * work.
+     */
     node?: HTMLElement | null
+    /**
+     * Be default keybindings are not triggered when the keyboard events
+     * originate from an input element. Set this to `true` to also react to
+     * keyboard events originaing from input elements.
+     */
     ignoreInput?: boolean
+    /**
+     * The function to be called when the keybinding is triggered.
+     */
     onMatch(matched: { ordered: Key[]; held?: ModifierKey[] }): void
+    /**
+     * By default the browser's default action for the event is prevented. Set
+     * to `true` to allow the default action.
+     */
     allowDefault?: boolean
 }
 
@@ -16,6 +42,9 @@ export interface Subscription {
     unsubscribe(): void
 }
 
+/**
+ * Registers a global keyboard shortcut.
+ */
 export const Shortcut: React.FunctionComponent<Props> = props => (
     <Consumer>{(context: Context) => <ShortcutConsumer {...props} {...context} />}</Consumer>
 )

--- a/client/shared/src/react-shortcuts/ShortcutManager.test.tsx
+++ b/client/shared/src/react-shortcuts/ShortcutManager.test.tsx
@@ -4,6 +4,8 @@ import { act, createEvent, fireEvent, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as sinon from 'sinon'
 
+import { platform } from '../testing/dom-utils'
+
 import { ModifierKey } from './keys'
 
 import { Shortcut, ShortcutProvider } from '.'
@@ -258,6 +260,38 @@ describe('ShortcutManager', () => {
             userEvent.keyboard('{Control>}{Shift>}/{/Shift}{/Control}')
 
             sinon.assert.notCalled(fooSpy)
+        })
+
+        it('maps the special value "Mod" to "Control"', () => {
+            const fooSpy = sinon.spy()
+
+            render(
+                <ShortcutProvider>
+                    <Shortcut held={['Mod']} ordered={['/']} onMatch={fooSpy} />
+                </ShortcutProvider>
+            )
+
+            userEvent.keyboard('{Control>}/{/Control}')
+
+            sinon.assert.called(fooSpy)
+        })
+
+        it('maps the special value "Mod" to "Meta" (Cmd) on macOS', () => {
+            platform.set('mac')
+
+            const fooSpy = sinon.spy()
+
+            render(
+                <ShortcutProvider>
+                    <Shortcut held={['Mod']} ordered={['/']} onMatch={fooSpy} />
+                </ShortcutProvider>
+            )
+
+            userEvent.keyboard('{Meta>}/{/Meta}')
+
+            sinon.assert.called(fooSpy)
+
+            platform.reset()
         })
     })
 })

--- a/client/shared/src/react-shortcuts/ShortcutManager.test.tsx
+++ b/client/shared/src/react-shortcuts/ShortcutManager.test.tsx
@@ -132,24 +132,6 @@ describe('ShortcutManager', () => {
         sinon.assert.notCalled(spy)
     })
 
-    it.skip('calls shortcuts that are scoped to a specific node only when that node is focused', () => {
-        // This test is meaningless atm because the current implementation of
-        // Shortcut doesn't actually work for scoped events.
-
-        const spy = sinon.spy()
-
-        act(() => {
-            render(
-                <ShortcutProvider>
-                    <ShortcutWithFocus spy={spy} />
-                </ShortcutProvider>
-            )
-        })
-
-        userEvent.keyboard('z')
-        sinon.assert.called(spy)
-    })
-
     it('only registers a unique shortcut once', () => {
         const spy = sinon.spy()
 
@@ -295,47 +277,3 @@ describe('ShortcutManager', () => {
         })
     })
 })
-
-interface Props {
-    spy: sinon.SinonSpy
-}
-
-interface State {
-    node: HTMLElement | null
-}
-
-// This component isn't used currently. It and the corresponding test need
-// to be updated.
-// eslint-disable-next-line react/no-unsafe
-class ShortcutWithFocus extends React.Component<Props, State> {
-    public state: State = {
-        node: null,
-    }
-
-    public UNSAFE_componentWillUpdate(): void {
-        const { node } = this.state
-
-        if (!node) {
-            return
-        }
-
-        node.focus()
-    }
-
-    public render(): React.ReactNode {
-        const { spy } = this.props
-        const { node } = this.state
-        return (
-            <div className="app">
-                <button type="button" ref={this.setRef} />
-                <Shortcut ordered={['z']} onMatch={spy} node={node} />
-            </div>
-        )
-    }
-
-    private setRef = (node: HTMLElement | null) => {
-        this.setState({
-            node,
-        })
-    }
-}

--- a/client/shared/src/react-shortcuts/ShortcutManager.test.tsx
+++ b/client/shared/src/react-shortcuts/ShortcutManager.test.tsx
@@ -1,6 +1,4 @@
-import * as React from 'react'
-
-import { act, createEvent, fireEvent, render } from '@testing-library/react'
+import { createEvent, fireEvent, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as sinon from 'sinon'
 

--- a/client/shared/src/react-shortcuts/ShortcutManager.tsx
+++ b/client/shared/src/react-shortcuts/ShortcutManager.tsx
@@ -116,7 +116,10 @@ function isModifierHeld(held: Exclude<Data['held'], undefined>, event: KeyboardE
     return held.every(key => event.getModifierState(key === 'Mod' ? modKey : key))
 }
 
-function getModKey(): 'Control' | 'Meta' {
+/**
+ * Returns the physicial key for the virtual 'Mod' key for the current platform.
+ */
+export function getModKey(): 'Control' | 'Meta' {
     return isMacPlatform() ? 'Meta' : 'Control'
 }
 

--- a/client/shared/src/react-shortcuts/ShortcutManager.tsx
+++ b/client/shared/src/react-shortcuts/ShortcutManager.tsx
@@ -1,3 +1,5 @@
+import { isMacPlatform } from '@sourcegraph/common'
+
 import { Key, ModifierKey } from './keys'
 
 const ON_MATCH_DELAY = 500
@@ -5,7 +7,7 @@ const ON_MATCH_DELAY = 500
 export interface Data {
     node: HTMLElement | null | undefined
     ordered: Key[]
-    held?: ModifierKey[]
+    held?: (ModifierKey | 'Mod')[]
     ignoreInput: boolean
     onMatch(matched: { ordered: Key[]; held?: ModifierKey[] }): void
     allowDefault: boolean
@@ -67,7 +69,7 @@ export class ShortcutManager {
                 return false
             }
 
-            if (held && !held.every(key => event.getModifierState(key))) {
+            if (held && !isModifierHeld(held, event)) {
                 return false
             }
 
@@ -95,15 +97,27 @@ export class ShortcutManager {
             event.preventDefault()
         }
 
+        const modKey = getModKey()
         longestMatchingShortcut.onMatch({
             ordered: longestMatchingShortcut.ordered,
-            held: longestMatchingShortcut.held,
+            held: longestMatchingShortcut.held?.map(key => (key === 'Mod' ? modKey : key)),
         })
 
         clearTimeout(this.timer)
 
         this.resetKeys()
     }
+}
+
+function isModifierHeld(held: Exclude<Data['held'], undefined>, event: KeyboardEvent): boolean {
+    // It would be better to only call this once when the module loads but
+    // calling it here makes the code easier to test
+    const modKey = getModKey()
+    return held.every(key => event.getModifierState(key === 'Mod' ? modKey : key))
+}
+
+function getModKey(): 'Control' | 'Meta' {
+    return isMacPlatform() ? 'Meta' : 'Control'
 }
 
 function isFocusedInput(): boolean {

--- a/client/shared/src/testing/dom-utils.ts
+++ b/client/shared/src/testing/dom-utils.ts
@@ -1,0 +1,27 @@
+// Inspired by React's packages/dom-event-testing-library/domEnvironment.js
+const originalPlatform = window.navigator.platform
+const platformGetter = jest.spyOn(window.navigator, 'platform', 'get')
+
+/**
+ * Change environment host platform.
+ */
+export const platform = {
+    reset() {
+        platformGetter.mockReturnValue(originalPlatform)
+    },
+    set(name: 'mac' | 'windows') {
+        switch (name) {
+            case 'mac': {
+                platformGetter.mockReturnValue('MacIntel')
+                break
+            }
+            case 'windows': {
+                platformGetter.mockReturnValue('Win32')
+                break
+            }
+            default: {
+                break
+            }
+        }
+    },
+}

--- a/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
+++ b/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
@@ -29,7 +29,7 @@ const LEGACY_KEYBOARD_SHORTCUTS: Record<string, KeyboardShortcut> = {
 }
 
 const KEY_TO_NAMES: { [P in Key | ModifierKey | string]?: string } = {
-    Mod: ((modKey: string) => (modKey === 'Meta' ? 'Cmd' : modKey))(getModKey()),
+    Mod: ((modKey: string) => (modKey === 'Meta' ? 'Cmd' : 'Ctrl'))(getModKey()),
     Meta: 'Cmd',
     Control: 'Ctrl',
     '†': 't',

--- a/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
+++ b/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
@@ -6,6 +6,7 @@ import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { KEYBOARD_SHORTCUTS } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
 import { ModifierKey, Key } from '@sourcegraph/shared/src/react-shortcuts'
+import { getModKey } from '@sourcegraph/shared/src/react-shortcuts/ShortcutManager'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { Button, Modal, Icon, H4, Label } from '@sourcegraph/wildcard'
 
@@ -28,6 +29,7 @@ const LEGACY_KEYBOARD_SHORTCUTS: Record<string, KeyboardShortcut> = {
 }
 
 const KEY_TO_NAMES: { [P in Key | ModifierKey | string]?: string } = {
+    Mod: ((modKey: string) => (modKey === 'Meta' ? 'Cmd' : modKey))(getModKey()),
     Meta: 'Cmd',
     Control: 'Ctrl',
     '†': 't',

--- a/client/web/src/integration/codemirror-blob-view.test.ts
+++ b/client/web/src/integration/codemirror-blob-view.test.ts
@@ -128,6 +128,18 @@ describe('CodeMirror blob view', () => {
                 'search form is not presetn'
             )
         })
+
+        it('opens in-document when pressing ctrl-f anywhere on the page', async () => {
+            await driver.page.goto(`${driver.sourcegraphBaseUrl}${filePaths['test.ts']}`)
+            await driver.page.waitForSelector(blobSelector)
+            // Wait for page to "settle" so that focus management works better
+            await driver.page.waitForTimeout(1000)
+
+            // Focus file view and trigger in-document search
+            await driver.page.click('body')
+            await pressCtrlF()
+            await driver.page.waitForSelector('.search-container')
+        })
     })
 })
 

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -99,13 +99,20 @@ import styles from './Blob.module.scss'
  */
 const toPortalID = (line: number): string => `line-decoration-attachment-${line}`
 
+// Logical grouping of props that are only used by the CodeMirror blob view
+// implementation.
+interface CodeMirrorBlobProps {
+    overrideBrowserSearchKeybinding?: boolean
+}
+
 export interface BlobProps
     extends SettingsCascadeProps,
         PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'>,
         TelemetryProps,
         HoverThresholdProps,
         ExtensionsControllerProps,
-        ThemeProps {
+        ThemeProps,
+        CodeMirrorBlobProps {
     location: H.Location
     history: H.History
     className: string

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -483,6 +483,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                         ariaLabel="File blob"
                         isBlameVisible={isBlameVisible}
                         blameHunks={blameDecorations}
+                        overrideBrowserSearchKeybinding={true}
                     />
                 </TraceSpanProvider>
             )}


### PR DESCRIPTION
Closes #40724 

Revival of #40739 with some additional changes.

File pages now override the browser's built-in search trigger. CTRL/CMD + f will trigger CodeMirror's document search instead of the browser's built-in search. Because CodeMirror doesn't necessarily render all lines of a document it's not possible to user the browser's built-int search to search inside the file.

Additional changes in this PR (which I can move in a separate PR if desired):

- Introduced a special `'Mod'` modifier that represents Command/Meta on macOS and `Ctrl` elsewhere.
- Added a utility function to set the platform value in unit tests.

## Test plan

Manual testing and unit/integration tests.

## App preview:

- [Web](https://sg-web-fkling-40724-override-cmd-f.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fkuhmqqhoa.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
