### PR TITLE
dev/sg: add --describe to sg run and sg start

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/cliutil"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
@@ -53,9 +54,17 @@ sg start batches
 
 # Override the logger levels for specific services
 sg start --debug=gitserver --error=enterprise-worker,enterprise-frontend enterprise
-		`,
+
+# View configuration for a commandset
+sg start -describe oss
+`,
 		Category: CategoryDev,
 		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "describe",
+				Usage: "Print details about the selected commandset",
+			},
+
 			&cli.StringSliceFlag{
 				Name:        "debug",
 				Aliases:     []string{"d"},
@@ -154,10 +163,20 @@ func startExec(ctx *cli.Context) error {
 		}
 	}
 
-	set, ok := config.Commandsets[args[0]]
+	commandset := args[0]
+	set, ok := config.Commandsets[commandset]
 	if !ok {
-		std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: commandset %q not found :(", args[0]))
+		std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: commandset %q not found :(", commandset))
 		return flag.ErrHelp
+	}
+
+	if ctx.Bool("describe") {
+		out, err := yaml.Marshal(set)
+		if err != nil {
+			return err
+		}
+
+		return std.Out.WriteMarkdown(fmt.Sprintf("# %s\n\n```yaml\n%s\n```\n\n", commandset, string(out)))
 	}
 
 	// If the commandset requires the dev-private repository to be cloned, we

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -62,12 +62,16 @@ $ sg start batches
 
 # Override the logger levels for specific services
 $ sg start --debug=gitserver --error=enterprise-worker,enterprise-frontend enterprise
+
+# View configuration for a commandset
+$ sg start -describe oss
 ```
 
 Flags:
 
 * `--crit, -c="<value>"`: Services to set at info crit level.
 * `--debug, -d="<value>"`: Services to set at debug log level.
+* `--describe`: Print details about the selected commandset
 * `--error, -e="<value>"`: Services to set at info error level.
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--info, -i="<value>"`: Services to set at info log level.
@@ -127,19 +131,23 @@ Available commands in `sg.config.yaml`:
 * zoekt-web-template
 
 ```sh
-# Run specific commands:
+# Run specific commands
 $ sg run gitserver
 $ sg run frontend
 
-# List available commands (defined under 'commands:' in 'sg.config.yaml'):
+# List available commands (defined under 'commands:' in 'sg.config.yaml')
 $ sg run -help
 
-# Run multiple commands:
+# Run multiple commands
 $ sg run gitserver frontend repo-updater
+
+# View configuration for a command
+$ sg run -describe jaeger
 ```
 
 Flags:
 
+* `--describe`: Print details about selected run target
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 
 ## sg ci


### PR DESCRIPTION
Easily view config to figure out what something does without scrolling a thousand lines of `sg.config.yaml`

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/23356519/192885217-ccf7adc9-77d1-4b1f-b64b-35d08b6644f9.png">
