### PR TITLE
codeintel: Offload reference counts to cold table

### DIFF
--- a/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -577,7 +577,11 @@ const softDeleteExpiredUploadsQuery = `
 WITH candidates AS (
 	SELECT u.id
 	FROM lsif_uploads u
-	WHERE u.state = 'completed' AND u.expired AND u.reference_count = 0
+	JOIN lsif_uploads_reference_counts urc ON urc.upload_id = u.id
+	WHERE
+		u.state = 'completed' AND
+		u.expired AND
+		urc.reference_count = 0
 	-- Lock these rows in a deterministic order so that we don't
 	-- deadlock with other processes updating the lsif_uploads table.
 	ORDER BY u.id FOR UPDATE
@@ -758,7 +762,13 @@ const backfillReferenceCountBatchQuery = `
 -- source: internal/codeintel/uploads/internal/store/store_uploads.go:BackfillReferenceCountBatch
 SELECT u.id
 FROM lsif_uploads u
-WHERE u.state = 'completed' AND u.reference_count IS NULL
+WHERE
+	u.state = 'completed' AND
+	NOT EXISTS (
+		SELECT 1
+		FROM lsif_uploads_reference_counts urc
+		WHERE urc.upload_id = u.id
+	)
 ORDER BY u.id
 FOR UPDATE SKIP LOCKED
 LIMIT %s
@@ -947,7 +957,7 @@ canonical_package_reference_counts AS (
 	WHERE ru.rank = 1
 ),
 
--- Count (and ranks) the set of edges that cross over from the target list of uploads
+-- Count (and rank) the set of edges that cross over from the target list of uploads
 -- to existing uploads that provide a dependent package. This is the modifier by which
 -- dependency reference counts must be altered in order for existing package reference
 -- counts to remain up-to-date.
@@ -981,11 +991,10 @@ canonical_dependency_reference_counts AS (
 	GROUP BY rc.id
 ),
 
--- Determine the set of reference count values to write to the lsif_uploads table, then
--- lock all of the affected rows in a deterministic order. This should prevent hitting
--- deadlock conditions when multiple bulk operations are happening over intersecting
--- rows of the same table.
-locked_uploads AS (
+-- Determine the set of reference count values to write to the lsif_uploads_reference_counts
+-- table. We will actually persist these values in two steps: a distinct insert and a distinct
+-- update to minimize lock contention on existing rows.
+calculated_reference_counts AS (
 	SELECT
 		u.id,
 
@@ -994,7 +1003,7 @@ locked_uploads AS (
 		-- this row is a dependency of the target upload list and we only be incrementally
 		-- modifying the row's reference count.
 		--
-		CASE WHEN ru.id IS NOT NULL THEN COALESCE(pkg_refcount.count, 0) ELSE u.reference_count END +
+		CASE WHEN ru.id IS NOT NULL THEN COALESCE(pkg_refcount.count, 0) ELSE urc.reference_count END +
 
 		-- If ru.id IN canonical_dependency_reference_counts, then we incrementally modify
 		-- the row's reference count proportional the number of additional dependent edges
@@ -1002,18 +1011,41 @@ locked_uploads AS (
 		-- to specify if we are adding or removing a set of upload records.
 		COALESCE(dep_refcount.count, 0) * %s AS reference_count
 	FROM lsif_uploads u
+	LEFT JOIN lsif_uploads_reference_counts urc ON urc.upload_id = u.id
 	LEFT JOIN ranked_uploads_providing_packages ru ON ru.id = u.id
 	LEFT JOIN canonical_package_reference_counts pkg_refcount ON pkg_refcount.id = u.id
 	LEFT JOIN canonical_dependency_reference_counts dep_refcount ON dep_refcount.id = u.id
 	-- Prevent creating no-op updates for every row in the table
 	WHERE ru.id IS NOT NULL OR dep_refcount.id IS NOT NULL
-	ORDER BY u.id FOR UPDATE
+),
+
+-- Insert reference counts for uploads that don't already exist
+new_reference_counts AS (
+	INSERT INTO lsif_uploads_reference_counts (upload_id, reference_count)
+	SELECT crc.id, crc.reference_count FROM calculated_reference_counts crc
+	ON CONFLICT DO NOTHING
+	RETURNING upload_id AS id
+),
+
+-- Deterministically order the reference counts that already exist but need to be
+-- updated. This ordering/locking sequence should prevent hitting deadlock conditions
+-- when multiple bulk operations are happening over intersecting rows of the same table.
+
+locked_updates AS (
+	SELECT
+		urc.upload_id,
+		crc.reference_count
+	FROM lsif_uploads_reference_counts urc
+	JOIN calculated_reference_counts crc ON crc.id = urc.upload_id
+	WHERE urc.upload_id NOT IN (SELECT id FROM new_reference_counts)
+	ORDER BY urc.upload_id
+	FOR UPDATE
 )
 
--- Perform deterministically ordered update
-UPDATE lsif_uploads u
+-- Perform the update actual
+UPDATE lsif_uploads_reference_counts urc
 SET reference_count = lu.reference_count
-FROM locked_uploads lu WHERE lu.id = u.id
+FROM locked_updates lu WHERE lu.upload_id = urc.upload_id
 `
 
 // UpdateUploadsVisibleToCommits uses the given commit graph and the tip of non-stale branches and tags to determine the

--- a/internal/codeintel/uploads/internal/store/store_uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads_test.go
@@ -731,7 +731,7 @@ func TestBackfillReferenceCountBatch(t *testing.T) {
 	if err := store.BackfillReferenceCountBatch(context.Background(), n/2); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	referenceCountQuery := sqlf.Sprintf("SELECT u.reference_count FROM lsif_uploads u WHERE u.reference_count IS NOT NULL ORDER BY u.id")
+	referenceCountQuery := sqlf.Sprintf("SELECT urc.reference_count FROM lsif_uploads_reference_counts urc ORDER BY urc.upload_id")
 	if referenceCounts, err := basestore.ScanInts(db.QueryContext(context.Background(), referenceCountQuery.Query(sqlf.PostgresBindVar), referenceCountQuery.Args()...)); err != nil {
 		t.Fatalf("unexpected error querying uploads: %s", err)
 	} else if diff := cmp.Diff(expectedReferenceCounts[:n/2], referenceCounts); diff != "" {
@@ -2010,7 +2010,7 @@ func getProtectedUploads(t testing.TB, db database.DB, repositoryID int) []int {
 func assertReferenceCounts(t *testing.T, store database.DB, expectedReferenceCountsByID map[int]int) {
 	db := basestore.NewWithHandle(store.Handle())
 
-	referenceCountsByID, err := scanIntPairs(db.Query(context.Background(), sqlf.Sprintf(`SELECT id, reference_count FROM lsif_uploads`)))
+	referenceCountsByID, err := scanIntPairs(db.Query(context.Background(), sqlf.Sprintf(`SELECT upload_id, reference_count FROM lsif_uploads_reference_counts ORDER BY upload_id`)))
 	if err != nil {
 		t.Fatalf("unexpected error querying reference counts: %s", err)
 	}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -13278,6 +13278,60 @@
       "Triggers": []
     },
     {
+      "Name": "lsif_uploads_reference_counts",
+      "Comment": "A less hot-path reference count for upload records.",
+      "Columns": [
+        {
+          "Name": "reference_count",
+          "Index": 2,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The number of references to the associated upload from other records (via lsif_references)."
+        },
+        {
+          "Name": "upload_id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The identifier of the referenced upload."
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "lsif_uploads_reference_counts_upload_id_key",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX lsif_uploads_reference_counts_upload_id_key ON lsif_uploads_reference_counts USING btree (upload_id)",
+          "ConstraintType": "u",
+          "ConstraintDefinition": "UNIQUE (upload_id)"
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "lsif_data_docs_search_private_repo_name_id_fk",
+          "ConstraintType": "f",
+          "RefTableName": "lsif_uploads",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE"
+        }
+      ],
+      "Triggers": []
+    },
+    {
       "Name": "lsif_uploads_visible_at_tip",
       "Comment": "Associates a repository with the set of LSIF upload identifiers that can serve intelligence for the tip of the default branch.",
       "Columns": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1909,6 +1909,7 @@ Indexes:
 Check constraints:
     "lsif_uploads_commit_valid_chars" CHECK (commit ~ '^[a-z0-9]{40}$'::text)
 Referenced by:
+    TABLE "lsif_uploads_reference_counts" CONSTRAINT "lsif_data_docs_search_private_repo_name_id_fk" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
     TABLE "lsif_dependency_syncing_jobs" CONSTRAINT "lsif_dependency_indexing_jobs_upload_id_fkey" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
     TABLE "lsif_dependency_indexing_jobs" CONSTRAINT "lsif_dependency_indexing_jobs_upload_id_fkey1" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
     TABLE "lsif_packages" CONSTRAINT "lsif_packages_dump_id_fkey" FOREIGN KEY (dump_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
@@ -1978,6 +1979,25 @@ Indexes:
 **record_deleted_at**: Set once the upload this entry is associated with is deleted. Once NOW() - record_deleted_at is above a certain threshold, this log entry will be deleted.
 
 **transition_columns**: Array of changes that occurred to the upload for this entry, in the form of {&#34;column&#34;=&gt;&#34;&lt;column name&gt;&#34;, &#34;old&#34;=&gt;&#34;&lt;previous value&gt;&#34;, &#34;new&#34;=&gt;&#34;&lt;new value&gt;&#34;}.
+
+# Table "public.lsif_uploads_reference_counts"
+```
+     Column      |  Type   | Collation | Nullable | Default 
+-----------------+---------+-----------+----------+---------
+ upload_id       | integer |           | not null | 
+ reference_count | integer |           | not null | 
+Indexes:
+    "lsif_uploads_reference_counts_upload_id_key" UNIQUE CONSTRAINT, btree (upload_id)
+Foreign-key constraints:
+    "lsif_data_docs_search_private_repo_name_id_fk" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
+
+```
+
+A less hot-path reference count for upload records.
+
+**reference_count**: The number of references to the associated upload from other records (via lsif_references).
+
+**upload_id**: The identifier of the referenced upload.
 
 # Table "public.lsif_uploads_visible_at_tip"
 ```

--- a/migrations/frontend/1664300936_move_lsif_upload_reference_count_to_different_table/down.sql
+++ b/migrations/frontend/1664300936_move_lsif_upload_reference_count_to_different_table/down.sql
@@ -1,0 +1,8 @@
+-- Force recalculation of reference counts
+UPDATE
+    lsif_uploads
+SET
+    reference_count = NULL;
+
+-- Remove new table
+DROP TABLE IF EXISTS lsif_uploads_reference_counts;

--- a/migrations/frontend/1664300936_move_lsif_upload_reference_count_to_different_table/metadata.yaml
+++ b/migrations/frontend/1664300936_move_lsif_upload_reference_count_to_different_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: Move lsif_upload reference count to different table
+parents: [1660711451, 1661441160, 1663569995]

--- a/migrations/frontend/1664300936_move_lsif_upload_reference_count_to_different_table/up.sql
+++ b/migrations/frontend/1664300936_move_lsif_upload_reference_count_to_different_table/up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS lsif_uploads_reference_counts (
+    upload_id INTEGER UNIQUE NOT NULL,
+    reference_count INTEGER NOT NULL
+);
+
+COMMENT ON TABLE lsif_uploads_reference_counts IS 'A less hot-path reference count for upload records.';
+
+COMMENT ON COLUMN lsif_uploads_reference_counts.upload_id IS 'The identifier of the referenced upload.';
+
+COMMENT ON COLUMN lsif_uploads_reference_counts.reference_count IS 'The number of references to the associated upload from other records (via lsif_references).';
+
+ALTER TABLE
+    lsif_uploads_reference_counts DROP CONSTRAINT IF EXISTS lsif_data_docs_search_private_repo_name_id_fk;
+
+ALTER TABLE
+    lsif_uploads_reference_counts
+ADD
+    CONSTRAINT lsif_data_docs_search_private_repo_name_id_fk FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2682,6 +2682,17 @@ CREATE SEQUENCE lsif_uploads_audit_logs_seq
 
 ALTER SEQUENCE lsif_uploads_audit_logs_seq OWNED BY lsif_uploads_audit_logs.sequence;
 
+CREATE TABLE lsif_uploads_reference_counts (
+    upload_id integer NOT NULL,
+    reference_count integer NOT NULL
+);
+
+COMMENT ON TABLE lsif_uploads_reference_counts IS 'A less hot-path reference count for upload records.';
+
+COMMENT ON COLUMN lsif_uploads_reference_counts.upload_id IS 'The identifier of the referenced upload.';
+
+COMMENT ON COLUMN lsif_uploads_reference_counts.reference_count IS 'The number of references to the associated upload from other records (via lsif_references).';
+
 CREATE TABLE lsif_uploads_visible_at_tip (
     repository_id integer NOT NULL,
     upload_id integer NOT NULL,
@@ -3865,6 +3876,9 @@ ALTER TABLE ONLY lsif_retention_configuration
 ALTER TABLE ONLY lsif_uploads
     ADD CONSTRAINT lsif_uploads_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY lsif_uploads_reference_counts
+    ADD CONSTRAINT lsif_uploads_reference_counts_upload_id_key UNIQUE (upload_id);
+
 ALTER TABLE ONLY names
     ADD CONSTRAINT names_pkey PRIMARY KEY (name);
 
@@ -4586,6 +4600,9 @@ ALTER TABLE ONLY gitserver_repos
 
 ALTER TABLE ONLY insights_query_runner_jobs_dependencies
     ADD CONSTRAINT insights_query_runner_jobs_dependencies_fk_job_id FOREIGN KEY (job_id) REFERENCES insights_query_runner_jobs(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY lsif_uploads_reference_counts
+    ADD CONSTRAINT lsif_data_docs_search_private_repo_name_id_fk FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY lsif_dependency_syncing_jobs
     ADD CONSTRAINT lsif_dependency_indexing_jobs_upload_id_fkey FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE;


### PR DESCRIPTION
Basic idea: Make a new table to store `lsif_uploads.reference_count` so that it can be updated without locking the `lsif_uploads` table, which contends heavily with heartbeats.

## Test plan

Will test locally and in a clone of a production database to gain confidence that there's no semantic difference in the query. Will then roll it out to a live environment and monitor lock contention to see if this helped.

🙏 