### PR TITLE
Revert "validate settings and site config in DB layer, not elsewhere (#42039)"

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -168,6 +168,12 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 		return false, errors.Errorf("blank site configuration is invalid (you can clear the site configuration by entering an empty JSON object: {})")
 	}
 
+	if problems, err := conf.ValidateSite(args.Input); err != nil {
+		return false, errors.Errorf("failed to validate site configuration: %w", err)
+	} else if len(problems) > 0 {
+		return false, errors.Errorf("site configuration is invalid: %s", strings.Join(problems, ","))
+	}
+
 	prev := conf.Raw()
 	unredacted, err := conf.UnredactSecrets(args.Input, prev)
 	if err != nil {

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/lib/errors"
-
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -45,7 +43,7 @@ func TestSiteCreate_RejectInvalidJSON(t *testing.T) {
 
 	_, err := db.Conf().SiteCreateIfUpToDate(ctx, nil, malformedJSON)
 
-	if err == nil || !strings.Contains(err.Error(), "failed to parse JSON") {
+	if err == nil || !strings.Contains(err.Error(), "invalid settings JSON") {
 		t.Fatalf("expected parse error after creating configuration with malformed JSON, got: %+v", err)
 	}
 }
@@ -82,11 +80,11 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 				{
 					input{
 						lastID:   0,
-						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
+						contents: `"This is a test."`,
 					},
 					output{
 						ID:       2,
-						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
+						contents: `"This is a test."`,
 					},
 				},
 			},
@@ -97,21 +95,21 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 				{
 					input{
 						lastID:   0,
-						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
+						contents: `"This is the first one."`,
 					},
 					output{
 						ID:       2,
-						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
+						contents: `"This is the first one."`,
 					},
 				},
 				{
 					input{
 						lastID:   2,
-						contents: `{"defaultRateLimit": 1,"auth.providers": []}`,
+						contents: `"This is the second one."`,
 					},
 					output{
 						ID:       3,
-						contents: `{"defaultRateLimit": 1,"auth.providers": []}`,
+						contents: `"This is the second one."`,
 					},
 				},
 			},
@@ -122,23 +120,22 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 				{
 					input{
 						lastID:   0,
-						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
+						contents: `"This is the first one."`,
 					},
 					output{
 						ID:       2,
-						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
+						contents: `"This is the first one."`,
 					},
 				},
 				{
 					input{
-						lastID: 0,
-						// This configuration is now behind the first one, so it shouldn't be saved
-						contents: `{"defaultRateLimit": 1,"auth.providers": []}`,
+						lastID:   0,
+						contents: `"This configuration is now behind the first one, so it shouldn't be saved."`,
 					},
 					output{
 						ID:       2,
-						contents: `{"defaultRateLimit": 1,"auth.providers": []}`,
-						err:      errors.Append(ErrNewerEdit),
+						contents: `"This is the first one."`,
+						err:      ErrNewerEdit,
 					},
 				},
 			},
@@ -149,29 +146,24 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 				{
 					input{
 						lastID: 0,
-						contents: `{"disableBuiltInSearches": true,
+						contents: `{"fieldA": "valueA",
 
 // This is a comment.
-             "defaultRateLimit": 42,
-             "auth.providers": [],
+             "fieldB": "valueB",
 						}`,
 					},
 					output{
 						ID: 2,
-						contents: `{"disableBuiltInSearches": true,
+						contents: `{"fieldA": "valueA",
 
 // This is a comment.
-             "defaultRateLimit": 42,
-             "auth.providers": [],
+             "fieldB": "valueB",
 						}`,
 					},
 				},
 			},
 		},
 	} {
-		// we were running the same test all the time, see this gist for more information
-		// https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			db := NewDB(logger, dbtest.NewDB(logger, t))
@@ -179,7 +171,7 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 			for _, p := range test.sequence {
 				output, err := db.Conf().SiteCreateIfUpToDate(ctx, &p.input.lastID, p.input.contents)
 				if err != nil {
-					if errors.Is(err, p.expected.err) {
+					if err == p.expected.err {
 						continue
 					}
 					t.Fatal(err)

--- a/internal/database/settings_test.go
+++ b/internal/database/settings_test.go
@@ -115,7 +115,7 @@ func TestCreateIfUpToDate(t *testing.T) {
 
 	t.Run("syntactically invalid settings", func(t *testing.T) {
 		contents := `{`
-		wantErr := "invalid settings: failed to parse JSON: [CloseBraceExpected]"
+		wantErr := "invalid settings JSON: [CloseBraceExpected]"
 		_, err := db.Settings().CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, contents)
 		if err == nil || err.Error() != wantErr {
 			t.Errorf("got err %q, want %q", err, wantErr)


### PR DESCRIPTION
This commit caused main to break.
```
$ sg start enterprise-e2e
`[       searcher] ERROR conf.client conf/client.go:290 received error during background config update {"triggered_by": "waitForSleep", "error": "unable to fetch new configuration: Post \"http://localhost:3090/.internal/configuration\": dial tcp [::1]:3090: connect: connection refused"}
```
This reverts commit c93fdbbd48f24acf36e3f5ba75155ab91a98267d.

cc @sqs 
## Test plan
`sg start enterprise-e2e`
```
[      gitserver] WARN server.http trace/httptrace.go:282 slow http request {"route_name": "repo-update", "method": "POST", "url": "/repo-update", "code": 200, "duration": "10.14469475s", "shouldTrace": false}
[            web] ℹ  info      Webpack server is ready after 12120ms
[            web] ===================================================
[            web]
[            web]         ✱ Sourcegraph is really ready now!
[            web]
[            web]      Click here: https://sourcegraph.test:3443
[            web]
[            web] ===================================================

```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
