### PR TITLE
[DO NOT MERGE][feat] Add access token scopes authorization based on graphql directives

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1141,6 +1141,8 @@ input SurveySubmissionInput {
     better: String
 }
 
+directive @authz(scopes: [String]!) on QUERY | FIELD_DEFINITION | OBJECT
+
 """
 Input for a happiness feedback submission.
 """
@@ -1217,7 +1219,7 @@ type Query {
     ): RepositoryRedirect
     """
     Lists external services under given namespace.
-    If no namespace is given, it returns all external services.
+    If no namespace is given, it returns all external services
     """
     externalServices(
         """
@@ -1233,7 +1235,8 @@ type Query {
         Opaque pagination cursor.
         """
         after: String
-    ): ExternalServiceConnection!
+    ): ExternalServiceConnection! @authz(scopes: ["external_services:read"])
+
     """
     List all repositories.
     """
@@ -1501,7 +1504,7 @@ type Query {
     """
     Retrieve the list of defined feature flags
     """
-    featureFlags: [FeatureFlag!]!
+    featureFlags: [FeatureFlag!]! @authz(scopes: ["feature_flags:read"])
 
     """
     Retrieve a feature flag
@@ -2330,7 +2333,7 @@ type Highlight {
 """
 A list of external services.
 """
-type ExternalServiceConnection {
+type ExternalServiceConnection @authz(scopes: ["external_services:read"]) {
     """
     A list of external services.
     """
@@ -2391,7 +2394,7 @@ type ExternalService implements Node {
     """
     The JSON configuration of the external service.
     """
-    config: JSONCString!
+    config: JSONCString! @authz(scopes: ["external_services:admin"])
 
     """
     When the external service was created.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/sourcegraph/sourcegraph
 
 go 1.18
 
+// TODO: do not merge this local hack
+// source is from this PR: https://github.com/graph-gophers/graphql-go/pull/446
+replace github.com/graph-gophers/graphql-go => /Users/milan/work/graphql-go
+
 require (
 	cloud.google.com/go/kms v1.4.0
 	cloud.google.com/go/monitoring v1.2.0

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -48,6 +48,11 @@ type Actor struct {
 
 	// mockUser indicates this user was created in the context of a test.
 	mockUser bool
+
+	// true if actor was created from a token
+	FromToken bool
+	// list of scopes of a token in case token auth is used
+	Scopes map[string]bool
 }
 
 // FromUser returns an actor corresponding to the user with the given ID

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -130,7 +130,7 @@ func NewMockAccessTokenStore() *MockAccessTokenStore {
 			},
 		},
 		LookupFunc: &AccessTokenStoreLookupFunc{
-			defaultHook: func(context.Context, string, string) (r0 int32, r1 error) {
+			defaultHook: func(context.Context, string) (r0 *AccessToken, r1 error) {
 				return
 			},
 		},
@@ -202,7 +202,7 @@ func NewStrictMockAccessTokenStore() *MockAccessTokenStore {
 			},
 		},
 		LookupFunc: &AccessTokenStoreLookupFunc{
-			defaultHook: func(context.Context, string, string) (int32, error) {
+			defaultHook: func(context.Context, string) (*AccessToken, error) {
 				panic("unexpected invocation of MockAccessTokenStore.Lookup")
 			},
 		},
@@ -1361,24 +1361,24 @@ func (c AccessTokenStoreListFuncCall) Results() []interface{} {
 // AccessTokenStoreLookupFunc describes the behavior when the Lookup method
 // of the parent MockAccessTokenStore instance is invoked.
 type AccessTokenStoreLookupFunc struct {
-	defaultHook func(context.Context, string, string) (int32, error)
-	hooks       []func(context.Context, string, string) (int32, error)
+	defaultHook func(context.Context, string) (*AccessToken, error)
+	hooks       []func(context.Context, string) (*AccessToken, error)
 	history     []AccessTokenStoreLookupFuncCall
 	mutex       sync.Mutex
 }
 
 // Lookup delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockAccessTokenStore) Lookup(v0 context.Context, v1 string, v2 string) (int32, error) {
-	r0, r1 := m.LookupFunc.nextHook()(v0, v1, v2)
-	m.LookupFunc.appendCall(AccessTokenStoreLookupFuncCall{v0, v1, v2, r0, r1})
+func (m *MockAccessTokenStore) Lookup(v0 context.Context, v1 string) (*AccessToken, error) {
+	r0, r1 := m.LookupFunc.nextHook()(v0, v1)
+	m.LookupFunc.appendCall(AccessTokenStoreLookupFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Lookup method of the
 // parent MockAccessTokenStore instance is invoked and the hook queue is
 // empty.
-func (f *AccessTokenStoreLookupFunc) SetDefaultHook(hook func(context.Context, string, string) (int32, error)) {
+func (f *AccessTokenStoreLookupFunc) SetDefaultHook(hook func(context.Context, string) (*AccessToken, error)) {
 	f.defaultHook = hook
 }
 
@@ -1386,7 +1386,7 @@ func (f *AccessTokenStoreLookupFunc) SetDefaultHook(hook func(context.Context, s
 // Lookup method of the parent MockAccessTokenStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *AccessTokenStoreLookupFunc) PushHook(hook func(context.Context, string, string) (int32, error)) {
+func (f *AccessTokenStoreLookupFunc) PushHook(hook func(context.Context, string) (*AccessToken, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1394,20 +1394,20 @@ func (f *AccessTokenStoreLookupFunc) PushHook(hook func(context.Context, string,
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *AccessTokenStoreLookupFunc) SetDefaultReturn(r0 int32, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, string) (int32, error) {
+func (f *AccessTokenStoreLookupFunc) SetDefaultReturn(r0 *AccessToken, r1 error) {
+	f.SetDefaultHook(func(context.Context, string) (*AccessToken, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *AccessTokenStoreLookupFunc) PushReturn(r0 int32, r1 error) {
-	f.PushHook(func(context.Context, string, string) (int32, error) {
+func (f *AccessTokenStoreLookupFunc) PushReturn(r0 *AccessToken, r1 error) {
+	f.PushHook(func(context.Context, string) (*AccessToken, error) {
 		return r0, r1
 	})
 }
 
-func (f *AccessTokenStoreLookupFunc) nextHook() func(context.Context, string, string) (int32, error) {
+func (f *AccessTokenStoreLookupFunc) nextHook() func(context.Context, string) (*AccessToken, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1446,12 +1446,9 @@ type AccessTokenStoreLookupFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 string
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 int32
+	Result0 *AccessToken
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -1460,7 +1457,7 @@ type AccessTokenStoreLookupFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c AccessTokenStoreLookupFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this


### PR DESCRIPTION
# Description

This only works on token based authorization, when using non-internal tokens. Existing functionality was kept backwards compatible on this POC, so if you have a token with "user:all" or "site-admin:sudo" everything works like before. Similarly session based auth still works the same.

Added a directive `@authz(scopes: ["some_scope"])` which controls scopes that are required when calling the graphql API with a token based authentication. When this directive is present on a field, query, mutation or type, it is required that the token has scopes that are listed. The beauty of this approach is, that we can add different scopes to different queries/fields/mutations and single source of truth is our graphql schema.

# Video


https://user-images.githubusercontent.com/9974711/193034083-5806c766-896a-42f1-bc70-d13bc1ca4776.mp4



## Out of scope for POC
- making anything here nice or production ready
- unit tests
- failing authorization on queries/mutations/fields without the directive
- adding scopes to all needed graphql entities
- UI changes to create tokens with more scopes
- making backwards incompatible changes
- authorizing internal API access

## Test plan
Tested locally.

To test locally, you need to modify `go.mod` to point to your own local fork of graph-gophers/graphql-go#446 It is also needed to apply the patch suggested in this comment: https://github.com/graph-gophers/graphql-go/pull/446/files#r914374506

To create a token with different scopes, create a normal token as you would usually by going to Settings -> Access tokens. You need to modify the scopes directly in the database (yikes!). Search the `schema.graphql` file for `@authz` directive scope definitions that are required with these changes.

You then need to use the token directly with curl or similar.

When using the token without proper scopes, you should see graphql errors instead of data.
