### PR TITLE
Align tooltips on action sidebar to the left

### DIFF
--- a/client/shared/src/actions/SimpleActionItem.module.scss
+++ b/client/shared/src/actions/SimpleActionItem.module.scss
@@ -2,7 +2,6 @@
     width: 2rem;
     height: 2rem;
 
-    margin: 0.375rem 0.25rem;
     padding: 0.4375rem 0;
 
     &:hover:not(&--active) {
@@ -12,4 +11,8 @@
     &--active {
         background-color: var(--color-bg-3);
     }
+}
+
+.margin {
+    margin: 0.375rem 0.25rem;
 }

--- a/client/shared/src/actions/SimpleActionItem.module.scss
+++ b/client/shared/src/actions/SimpleActionItem.module.scss
@@ -1,8 +1,10 @@
 .simple-action-item {
     width: 2rem;
     height: 2rem;
-
-    padding: 0.4375rem 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     &:hover:not(&--active) {
         background-color: var(--color-bg-2);

--- a/client/shared/src/actions/SimpleActionItem.tsx
+++ b/client/shared/src/actions/SimpleActionItem.tsx
@@ -15,7 +15,7 @@ export const SimpleActionItem: React.FunctionComponent<SimpleActionItemProps> = 
     const { isActive, tooltip, children, className, ...buttonLinkProps } = props
 
     return (
-        <Tooltip content={props.tooltip}>
+        <Tooltip content={props.tooltip} placement="left">
             <span>
                 {/**
                  * This <ButtonLink> must be wrapped with an additional span, since the tooltip currently has an issue that will

--- a/client/shared/src/actions/SimpleActionItem.tsx
+++ b/client/shared/src/actions/SimpleActionItem.tsx
@@ -15,24 +15,26 @@ export const SimpleActionItem: React.FunctionComponent<SimpleActionItemProps> = 
     const { isActive, tooltip, children, className, ...buttonLinkProps } = props
 
     return (
-        <Tooltip content={props.tooltip} placement="left">
-            <span>
-                {/**
-                 * This <ButtonLink> must be wrapped with an additional span, since the tooltip currently has an issue that will
-                 * break its onClick handler, and it will no longer prevent the default page reload (with no href).
-                 */}
-                <ButtonLink
-                    className={classNames(
-                        styles.simpleActionItem,
-                        isActive && styles.simpleActionItemActive,
-                        className
-                    )}
-                    aria-label={props.tooltip}
-                    {...buttonLinkProps}
-                >
-                    {children}
-                </ButtonLink>
-            </span>
-        </Tooltip>
+        <div className={styles.margin}>
+            <Tooltip content={props.tooltip} placement="left">
+                <span>
+                    {/**
+                     * This <ButtonLink> must be wrapped with an additional span, since the tooltip currently has an issue that will
+                     * break its onClick handler, and it will no longer prevent the default page reload (with no href).
+                     */}
+                    <ButtonLink
+                        className={classNames(
+                            styles.simpleActionItem,
+                            isActive && styles.simpleActionItemActive,
+                            className
+                        )}
+                        aria-label={props.tooltip}
+                        {...buttonLinkProps}
+                    >
+                        {children}
+                    </ButtonLink>
+                </span>
+            </Tooltip>
+        </div>
     )
 }


### PR DESCRIPTION
This PR fixes a small annoyance (thanks @vovakulikov for [reporting it](https://sourcegraph.slack.com/archives/C0HMGV90V/p1664454390437249)):

<img width="141" alt="screenshot_2022-09-29_at_18 24 59" src="https://user-images.githubusercontent.com/458591/193037662-ad44338d-a761-47a8-959d-5111568b19b8.png">

Unfortunately the root issue for this seems to be deeper in the tooltip library (as I can reproduce it in the wildcard storybook) so this is a quick workaround until we have a proper fix. 

## Test plan

![Screenshot 2022-09-29 at 15 21 13](https://user-images.githubusercontent.com/458591/193042848-cbe3cc87-ab9f-47f6-9b07-13bdcb044e0e.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-tooltip-position.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ajuithmgjt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
