### PR TITLE
authz/perforce: add additional unit test cases

### DIFF
--- a/enterprise/internal/authz/perforce/perforce_test.go
+++ b/enterprise/internal/authz/perforce/perforce_test.go
@@ -227,6 +227,43 @@ open user alice * -//Sourcegraph/*/Handbook/...                      ## sub-matc
 				},
 			},
 		},
+		{
+			name: "include and exclude, then include again",
+			response: `
+read user alice * //Sourcegraph/Security/...
+read user alice * //Sourcegraph/Engineering/...
+owner user alice * //Sourcegraph/Engineering/Backend/...
+open user alice * //Sourcegraph/Engineering/Frontend/...
+review user alice * //Sourcegraph/Handbook/...
+open user alice * //Sourcegraph/Engineering/.../Frontend/...
+open user alice * //Sourcegraph/.../Handbook/...  ## wildcard A
+
+list user alice * -//Sourcegraph/Security/...                        ## "list" can revoke read access
+=read user alice * -//Sourcegraph/Engineering/Frontend/...           ## exact match of a previous include
+open user alice * -//Sourcegraph/Engineering/Backend/Credentials/... ## sub-match of a previous include
+open user alice * -//Sourcegraph/Engineering/*/Frontend/Folder/...   ## sub-match of a previous include
+open user alice * -//Sourcegraph/*/Handbook/...                      ## sub-match of wildcard A include
+
+read user alice * //Sourcegraph/Security/... 						 ## give access to alice again after revoking
+`,
+			wantPerms: &authz.ExternalUserPermissions{
+				IncludeContains: []extsvc.RepoID{
+					"//Sourcegraph/Engineering/%",
+					"//Sourcegraph/Engineering/Backend/%",
+					"//Sourcegraph/Engineering/Frontend/%",
+					"//Sourcegraph/Handbook/%",
+					"//Sourcegraph/Engineering/%/Frontend/%",
+					"//Sourcegraph/%/Handbook/%",
+					"//Sourcegraph/Security/%",
+				},
+				ExcludeContains: []extsvc.RepoID{
+					"//Sourcegraph/Engineering/Frontend/%",
+					"//Sourcegraph/Engineering/Backend/Credentials/%",
+					"//Sourcegraph/Engineering/[^/]+/Frontend/Folder/%",
+					"//Sourcegraph/[^/]+/Handbook/%",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/enterprise/internal/authz/perforce/protects_test.go
+++ b/enterprise/internal/authz/perforce/protects_test.go
@@ -517,12 +517,6 @@ read    group   Dev1    *   -//-depot/-main/.../dev/foo.java
 			canReadAll:    []string{"dev/bar.java", "/-minus/dev/bar.java"},
 			cannotReadAny: []string{"dev/foo.java"},
 		},
-		{
-			name:          "Test protects from manual testing doc",
-			depot:         "//depot/foo/bar/",
-			protectsFile:  "testdata/sample-protects-manual.txt",
-			cannotReadAny: []string{"depot/foo/bar"},
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := logtest.Scoped(t)

--- a/enterprise/internal/authz/perforce/protects_test.go
+++ b/enterprise/internal/authz/perforce/protects_test.go
@@ -488,12 +488,40 @@ read   group   Rome    *   -//depot/dev/prodA/...   ## Except files in this dire
 			name:  "Deny all, grant some",
 			depot: "//depot/main/",
 			protects: `
-read    group   Dev1    *   //depot/main/...
+read    group   Dev1    *   -//depot/main/...
 read    group   Dev1    *   -//depot/main/.../*.java
 read    group   Dev1    *   //depot/main/.../dev/foo.java
 `,
 			canReadAll:    []string{"dev/foo.java"},
 			cannotReadAny: []string{"dev/bar.java"},
+		},
+		{
+			name:  "Grant all, deny some",
+			depot: "//depot/main/",
+			protects: `
+read    group   Dev1    *   //depot/main/...
+read    group   Dev1    *   //depot/main/.../*.java
+read    group   Dev1    *   -//depot/main/.../dev/foo.java
+`,
+			canReadAll:    []string{"dev/bar.java"},
+			cannotReadAny: []string{"dev/foo.java"},
+		},
+		{
+			name:  "Tricky minus names",
+			depot: "//-depot/-main/",
+			protects: `
+read    group   Dev1    *   //-depot/-main/...
+read    group   Dev1    *   //-depot/-main/.../*.java
+read    group   Dev1    *   -//-depot/-main/.../dev/foo.java
+`,
+			canReadAll:    []string{"dev/bar.java", "/-minus/dev/bar.java"},
+			cannotReadAny: []string{"dev/foo.java"},
+		},
+		{
+			name:          "Test protects from manual testing doc",
+			depot:         "//depot/foo/bar/",
+			protectsFile:  "testdata/sample-protects-manual.txt",
+			cannotReadAny: []string{"depot/foo/bar"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Adding some test cases.

Initial intention was to also add tests from [manual testing doc](https://docs.google.com/document/d/1HHY5Q3TaPkAwAW0JXTMfmU8qTt0QOPYQp0Q2aFynmX4/edit), but our current unit test setup cannot support such e2e tests.

Closes https://github.com/sourcegraph/sourcegraph/issues/42156
## Test plan
New tests added
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
