### PR TITLE
References Panel: promote on second click/enter

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.test.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.test.tsx
@@ -82,11 +82,11 @@ describe('ReferencesPanel', () => {
         )
         await waitForNextApolloResponse()
         await waitForNextApolloResponse()
-        return result
+        return { result, externalHistory: fakeExternalHistory }
     }
 
     it('renders definitions correctly', async () => {
-        const result = await renderReferencesPanel()
+        const { result } = await renderReferencesPanel()
 
         expect(result.getByText('Definitions')).toBeVisible()
 
@@ -100,7 +100,7 @@ describe('ReferencesPanel', () => {
     })
 
     it('renders references correctly', async () => {
-        const result = await renderReferencesPanel()
+        const { result } = await renderReferencesPanel()
 
         expect(result.getByText('References')).toBeVisible()
 
@@ -114,12 +114,11 @@ describe('ReferencesPanel', () => {
     })
 
     it('renders a code view when clicking on a location', async () => {
-        const result = await renderReferencesPanel()
+        const { result, externalHistory } = await renderReferencesPanel()
 
         const definitionsList = result.getByTestId('definitions')
         const referencesList = result.getByTestId('references')
 
-        console.log({ referencesList })
         const referenceButton = within(referencesList).getByTestId('reference-item-diff/diff.go-0')
         const fullReferenceURL =
             '/github.com/sourcegraph/go-diff@9d1f353a285b3094bc33bdae277a19aedabe8b71/-/blob/diff/diff.go?L16:2-16:10'
@@ -155,5 +154,13 @@ describe('ReferencesPanel', () => {
         // Assert the code view is rendered, by doing a partial match against its content
         const codeView = within(rightPane).getByRole('table')
         expect(codeView).toHaveTextContent('package diff import')
+
+        // Assert the current URL points at the reference panel
+        expect(externalHistory.createHref(externalHistory.location)).toBe(
+            '/github.com/sourcegraph/go-diff/-/blob/diff/diff.go?L16:2&subtree=true#tab=references'
+        )
+        // Click on reference the second time promotes the active location to the URL (and main blob view)
+        fireEvent.click(referenceButton)
+        expect(externalHistory.createHref(externalHistory.location)).toBe(fullReferenceURL)
     })
 })


### PR DESCRIPTION
Previously, it was necessary to move the mouse to the preview pane to promote a line. This PR adds the ability to promote the "active" item by clicking on it a second time (or pressing enter).

Demo https://www.loom.com/share/1d7aa783fcc84387b82a5c6443c0bf11

## Test plan

See updated test case that asserts the updated URL after a second click.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-ref-panel-doubleclick.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ryfdbuurwg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
