### PR TITLE
codeintel: Lower backfillter task interval from 1m to 10s

### DIFF
--- a/internal/codeintel/uploads/background/backfill/config.go
+++ b/internal/codeintel/uploads/background/backfill/config.go
@@ -16,6 +16,6 @@ type config struct {
 var ConfigInst = &config{}
 
 func (c *config) Load() {
-	c.Interval = c.GetInterval("CODEINTEL_UPLOAD_BACKFILLER_INTERVAL", "1m", "The frequency with which to run periodic codeintel backfiller tasks.")
+	c.Interval = c.GetInterval("CODEINTEL_UPLOAD_BACKFILLER_INTERVAL", "10s", "The frequency with which to run periodic codeintel backfiller tasks.")
 	c.BatchSize = c.GetInt("CODEINTEL_UPLOAD_BACKFILLER_BATCH_SIZE", "100", "The number of upload to populate an unset `commited_at` field per batch.")
 }


### PR DESCRIPTION
This can add 1m of processing to uploads before they are available. Backfilling these values more frequently will make the commit graph resolvable sooner.

## Test plan

N/A.