### PR TITLE
Single File Diff View: Add `filePath` search param to "Compare" page

### DIFF
--- a/client/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -180,6 +180,10 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
             spec = parseComparisonSpec(decodeURIComponent(this.props.match.params.spec))
         }
 
+        // Parse out the optional filePath search param, which is used to show only a single file in the compare view
+        const searchParams = new URLSearchParams(this.props.location.search)
+        const path = searchParams.get('filePath')
+
         if (!this.props.repo) {
             return <LoadingSpinner />
         }
@@ -209,6 +213,7 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
                                 <RepositoryCompareOverviewPage
                                     {...routeComponentProps}
                                     {...commonProps}
+                                    path={path}
                                     hoverifier={this.hoverifier}
                                     isLightTheme={this.props.isLightTheme}
                                     extensionsController={this.props.extensionsController}

--- a/client/web/src/repo/compare/RepositoryCompareDiffPage.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareDiffPage.tsx
@@ -29,14 +29,22 @@ export function queryRepositoryComparisonFileDiffs(args: {
     head: string | null
     first?: number
     after?: string | null
+    paths?: string[]
 }): Observable<GQL.IFileDiffConnection> {
     return queryGraphQL(
         gql`
-            query RepositoryComparisonDiff($repo: ID!, $base: String, $head: String, $first: Int, $after: String) {
+            query RepositoryComparisonDiff(
+                $repo: ID!
+                $base: String
+                $head: String
+                $first: Int
+                $after: String
+                $paths: [String!]
+            ) {
                 node(id: $repo) {
                     ... on Repository {
                         comparison(base: $base, head: $head) {
-                            fileDiffs(first: $first, after: $after) {
+                            fileDiffs(first: $first, after: $after, paths: $paths) {
                                 nodes {
                                     ...FileDiffFields
                                 }
@@ -84,6 +92,10 @@ interface RepositoryCompareDiffPageProps
 
     /** The head of the comparison. */
     head: { repoName: string; repoID: Scalars['ID']; revision: string | null; commitID: string }
+
+    /** An optional path of a specific file to compare */
+    path: string | null
+
     hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
 }
 
@@ -130,5 +142,8 @@ export class RepositoryCompareDiffPage extends React.PureComponent<RepositoryCom
             repo: this.props.repo.id,
             base: this.props.base.commitID,
             head: this.props.head.commitID,
+            // All of our user journeys are designed for just a single file path, so the component APIs are set up to
+            // enforce that, even though the GraphQL query is able to support any number of paths
+            paths: this.props.path ? [this.props.path] : [],
         })
 }

--- a/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -167,8 +167,8 @@ export class RepositoryCompareOverviewPage extends React.PureComponent<Props, St
                 ) : (
                     <>
                         {/* The query to load the list of commits does not currently support filtering them for just a single file, so only render the commits
-                         * when all files will be shown (i.e. no single file path was specified) to avoid innacurate results. */}
-                        {this.props.path === null && <RepositoryCompareCommitsPage {...this.props} />}
+                         * when all files will be shown (i.e. no `path` to a single file was provided) to avoid innacurate results. */}
+                        {this.props.path ? null : <RepositoryCompareCommitsPage {...this.props} />}
                         <div className="mb-3" />
                         <RepositoryCompareDiffPage
                             {...this.props}

--- a/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -90,6 +90,10 @@ interface Props
 
     /** The head of the comparison. */
     head: { repoName: string; repoID: Scalars['ID']; revision?: string | null }
+
+    /** An optional path of a specific file to compare */
+    path: string | null
+
     hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
 }
 
@@ -162,7 +166,9 @@ export class RepositoryCompareOverviewPage extends React.PureComponent<Props, St
                     <ErrorAlert className="mt-2" error={this.state.rangeOrError} />
                 ) : (
                     <>
-                        <RepositoryCompareCommitsPage {...this.props} />
+                        {/* The query to load the list of commits does not currently support filtering them for just a single file, so only render the commits
+                         * when all files will be shown (i.e. no single file path was specified) to avoid innacurate results. */}
+                        {this.props.path === null && <RepositoryCompareCommitsPage {...this.props} />}
                         <div className="mb-3" />
                         <RepositoryCompareDiffPage
                             {...this.props}


### PR DESCRIPTION
Closes #41891.

Updates the "compare" page to look for an option `filePath` URL search parameter. If the `filePath` is provided, the compare page will render the diff for _just_ that single file and hide the "Commits" list (as we currently do not have support for filtering this commit list for just a single file).

Note that this does not display the file path in the breadcrumbs yet - that will be addressed separately with #42308.

## Test plan

1. Visit the "compare" page for a set of revisions (e.g. [local dev link](https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/compare/1acc14aa359bdd78cfcc972b2fb7e23383cf06b8...4c7f370d4d42467ab3a012315bdef4633f8eee50)).
2. To check that `filePath` is utilized when provided, add that search param to the URL using one of the file paths in the diff set (e.g. `schema/site.schema.json`, [local dev link](https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/compare/1acc14aa359bdd78cfcc972b2fb7e23383cf06b8...4c7f370d4d42467ab3a012315bdef4633f8eee50?visible=1&filePath=schema%2Fsite.schema.json)).
    - Note: Chrome will automatically encode this value when typing it into the search bar manually; within the app, we will make sure the upcoming entry points use proper encoding when generating links.
4. Entering a file path that does not exist with in the diff set (e.g. `foo`, [local dev link](https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/compare/1acc14aa359bdd78cfcc972b2fb7e23383cf06b8...4c7f370d4d42467ab3a012315bdef4633f8eee50?visible=1&filePath=foo)) should display a "No changed files" message.
5. Providing an empty `filePath` parameter should not attempt to filter to a single file at all and will show the commit list and full diff set (watch out for the `visible` param getting set to `1` after filtering to a single file, which can make this appear to not work).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lrh-single-file-diff-view-compare.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-elihvhhzkq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
