### PR TITLE
CodeMirror blob: Show pointer cursor when "click to go to def/ref" is available

### DIFF
--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -78,7 +78,12 @@ import { addLineRangeQueryParameter, isErrorLike, toPositionOrRangeQueryParamete
 import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { UIPositionSpec, UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 
-import { WebHoverOverlay, WebHoverOverlayProps } from '../../../components/WebHoverOverlay'
+import {
+    getClickToGoToDefinition,
+    getGoToURL,
+    WebHoverOverlay,
+    WebHoverOverlayProps,
+} from '../../../components/WebHoverOverlay'
 import { BlobProps, updateBrowserHistoryIfChanged } from '../Blob'
 
 import { Container } from './react-interop'
@@ -88,6 +93,8 @@ import {
     preciseOffsetAtCoords,
     rangesContain,
     uiPositionToOffset,
+    zeroToOneBasedPosition,
+    zeroToOneBasedRange,
 } from './utils'
 
 import { blobPropsFacet } from '.'
@@ -111,7 +118,8 @@ interface HovercardRange {
     // click-to-go-to-definition should use this range if available.
     providerRange?: UIRange
 
-    // Used to provide "click to go to definition"
+    // Used to provide "click to go to definition". The presence of this value
+    // also indicates that the range should be decorated with a pointer cursor.
     onClick?: () => void
 
     // Whether or not this hovercard is considered "pinned". We only show a
@@ -143,6 +151,9 @@ const hovercardTheme = EditorView.theme({
         // panel header.
         zIndex: 1024,
     },
+    '.hover-gtd': {
+        cursor: 'pointer',
+    },
 })
 
 /**
@@ -156,6 +167,7 @@ const hovercardTheme = EditorView.theme({
 const addRange = StateEffect.define<HovercardRange>()
 const removeRange = StateEffect.define<HovercardRange>()
 const selectionHighlightDecoration = Decoration.mark({ class: 'selection-highlight' })
+const selectionGoToDefinitionDecoration = Decoration.mark({ class: 'selection-highlight hover-gtd' })
 
 const activeRanges = StateField.define<Map<number, HovercardRange>>({
     create() {
@@ -206,7 +218,9 @@ const activeRanges = StateField.define<Map<number, HovercardRange>>({
                 RangeSet.of(
                     Array.from(ranges.values(), range => {
                         const { from, to } = getHoverOffsets(range, view.state.doc)
-                        return selectionHighlightDecoration.range(from, to)
+                        return range.onClick
+                            ? selectionGoToDefinitionDecoration.range(from, to)
+                            : selectionHighlightDecoration.range(from, to)
                     }),
                     true
                 )
@@ -219,8 +233,13 @@ const activeRanges = StateField.define<Map<number, HovercardRange>>({
                         return false
                     }
 
-                    const offset = preciseOffsetAtCoords(view, event)
+                    // Ignore event when the click event is the result of the
+                    // user selecting text
+                    if (view.state.selection.main.from !== view.state.selection.main.to) {
+                        return false
+                    }
 
+                    const offset = preciseOffsetAtCoords(view, event)
                     if (offset === null) {
                         return false
                     }
@@ -519,6 +538,26 @@ class Hovercard implements TooltipView {
             return
         }
 
+        // Used to implement "click to go to definition"
+        let onClick: (() => void) | undefined
+
+        // Adaption of the "click to go to definition" code inside
+        // WebHoverOverlay
+        if (getClickToGoToDefinition(props.settingsCascade)) {
+            const urlAndType = getGoToURL(actionsOrError, props.location)
+            if (urlAndType) {
+                const { url, actionType } = urlAndType
+                onClick = () => {
+                    props.telemetryService.log(`${actionType}HoverOverlay.click`)
+                    if (props.nav) {
+                        props.nav(url)
+                    } else {
+                        props.history.push(url)
+                    }
+                }
+            }
+        }
+
         const hoverContext = {
             commitID: props.blobInfo.commitID,
             filePath: props.blobInfo.filePath,
@@ -531,27 +570,13 @@ class Hovercard implements TooltipView {
             ...this.range.range.start,
         }
 
-        // Used to implement "click to go to definition"
-        const clicks = new Subject<void>()
-        const onClick = (): void => clicks.next()
-
         if (hoverOrError && hoverOrError !== 'loading' && !isErrorLike(hoverOrError) && hoverOrError.range) {
             hoveredToken = {
                 ...hoveredToken,
-                line: hoverOrError.range.start.line + 1,
-                character: hoverOrError.range.start.character + 1,
+                ...zeroToOneBasedPosition(hoverOrError.range.start),
             }
             this.addRange({
-                providerRange: {
-                    start: {
-                        line: hoverOrError.range.start.line + 1,
-                        character: hoverOrError.range.start.character + 1,
-                    },
-                    end: {
-                        line: hoverOrError.range.end.line + 1,
-                        character: hoverOrError.range.end.character + 1,
-                    },
-                },
+                providerRange: zeroToOneBasedRange(hoverOrError.range),
                 onClick,
             })
         } else {
@@ -570,7 +595,6 @@ class Hovercard implements TooltipView {
                         settingsCascade={props.settingsCascade}
                         telemetryService={props.telemetryService}
                         extensionsController={props.extensionsController}
-                        nav={props.nav ?? (url => props.history.push(url))}
                         // Hover props
                         actionsOrError={actionsOrError}
                         hoverOrError={hoverOrError}
@@ -579,7 +603,6 @@ class Hovercard implements TooltipView {
                         // hovercard to render
                         overlayPosition={dummyOverlayPosition}
                         hoveredToken={hoveredToken}
-                        hoveredTokenClick={clicks.asObservable()}
                         onAlertDismissed={() => repositionTooltips(this.view)}
                         pinOptions={{
                             showCloseButton: pinned,

--- a/client/web/src/repo/blob/codemirror/utils.test.ts
+++ b/client/web/src/repo/blob/codemirror/utils.test.ts
@@ -7,9 +7,32 @@ import {
     rangesContain,
     sortRangeValuesByStart,
     uiPositionToOffset,
+    zeroToOneBasedPosition,
+    zeroToOneBasedRange,
 } from './utils'
 
 describe('blob/codemirror/utils', () => {
+    describe('zeroToOneBased...', () => {
+        it('converts zero-based to one-based positions', () => {
+            expect(zeroToOneBasedPosition({ line: 5, character: 10 })).toEqual({
+                line: 6,
+                character: 11,
+            })
+        })
+        it('converts zero-based to one-based ranges', () => {
+            expect(zeroToOneBasedRange({ start: { line: 5, character: 10 }, end: { line: 7, character: 3 } })).toEqual({
+                start: {
+                    line: 6,
+                    character: 11,
+                },
+                end: {
+                    line: 8,
+                    character: 4,
+                },
+            })
+        })
+    })
+
     describe('rangeContains', () => {
         const ranges = [
             { from: 10, to: 20 },

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -6,6 +6,23 @@ import { scan, distinctUntilChanged } from 'rxjs/operators'
 import { Position } from '@sourcegraph/extension-api-types'
 import { UIPositionSpec, UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 
+export function zeroToOneBasedPosition(position: Position): { line: number; character: number } {
+    return {
+        line: position.line + 1,
+        character: position.character + 1,
+    }
+}
+
+export function zeroToOneBasedRange(range: {
+    start: Position
+    end: Position
+}): { start: { line: number; character: number }; end: { line: number; character: number } } {
+    return {
+        start: zeroToOneBasedPosition(range.start),
+        end: zeroToOneBasedPosition(range.end),
+    }
+}
+
 /**
  * Returns true of any of the document offset ranges contains the provided
  * point.


### PR DESCRIPTION
Closes #40901 

The logic for showing a pointer cursor in the old blob view resides in the "click to go to definition" logic inside `WebHoverOverlay`. It operates directly on the DOM node representing the hovered token, but that wouldn't work for CodeMirror.

I briefly considered extending the component with an additional prop to notifier the parent/caller when the component determined that "click to go to definition was available". But that would only make the component more "messy".

Instead I noticed that the whole "click to go to definition" logic inside `WebHoverOverlay` actually operates on data passed into this component and strictily speaking didn't have to reside inside that component at all. But since I don't want to refactor the existing blob view either, I moved as much logic as possible into a reusable function and now use that function inside the CodeMirror hovercard class.

I made sure that `WebHoverOverlays` same internal logic isn't triggered by omitting the props that are necessary to trigger it.

**How does that solve the problem of showing the pointer cursor?**

Until now the hovercard class would always register a click event handler and whether or not this handler had any effect dependent on what `WebHoverOverlay` did.
But now we can determine whether or not "click to go to ..." is available or not *before* we register the click handler. So now the mere presence of the handler indicates that "click to go to ..." is indeed available and we can use that add an additional CSS class to the token decoration to show a pointer.

> **Note**
> I wanted to take a screenshot but I noticed that it doesn't capture the mouse cursor so you have to believe that it works or try it out yourself.

## Test plan

- Enable CodeMirror blob view
  - Hover over a reference token -> cursor changes to pointer and clicking it goes to the definition
  - Hover over a definition token -> cursor changes to pointer and clicking it opens the reference panel
- Enable old blob view and perform the same steps

## App preview:

- [Web](https://sg-web-fkling-40901-hover-pointer.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-syvogxaunk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
