### PR TITLE
dev/sg: properly name usage linters

### DIFF
--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -68,7 +68,7 @@ func lintSGExit() *linter {
 
 // lintLoggingLibraries enforces that only usages of github.com/sourcegraph/log are added
 func lintLoggingLibraries() *linter {
-	return newUsageLinter(usageLinterOptions{
+	return newUsageLinter("Logging libraries linter", usageLinterOptions{
 		Target: "**/*.go",
 		BannedUsages: []string{
 			// No standard log library
@@ -101,7 +101,7 @@ func lintLoggingLibraries() *linter {
 }
 
 func lintTracingLibraries() *linter {
-	return newUsageLinter(usageLinterOptions{
+	return newUsageLinter("Tracing libraries linter", usageLinterOptions{
 		Target: "**/*.go",
 		BannedUsages: []string{
 			// No OpenTracing

--- a/dev/sg/linters/usage_linter.go
+++ b/dev/sg/linters/usage_linter.go
@@ -31,7 +31,7 @@ type usageLinterOptions struct {
 
 // newUsageLinter is a helper that creates a linter that guards against *additions* that
 // introduce usages banned strings.
-func newUsageLinter(opts usageLinterOptions) *linter {
+func newUsageLinter(name string, opts usageLinterOptions) *linter {
 	// checkHunk returns an error if a banned library is used
 	checkHunk := func(file string, hunk repo.DiffHunk) error {
 		for _, allowed := range opts.AllowedFiles {
@@ -50,7 +50,7 @@ func newUsageLinter(opts usageLinterOptions) *linter {
 		return nil
 	}
 
-	return runCheck("Logging library linter", func(ctx context.Context, out *std.Output, state *repo.State) error {
+	return runCheck(name, func(ctx context.Context, out *std.Output, state *repo.State) error {
 		diffs, err := state.GetDiff(opts.Target)
 		if err != nil {
 			return err


### PR DESCRIPTION
Spotted this in a CI build

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a