### PR TITLE
migrator: Fix drift patch version in upgrade

### DIFF
--- a/internal/database/migration/cliutil/multiversion.go
+++ b/internal/database/migration/cliutil/multiversion.go
@@ -154,7 +154,7 @@ func runMigration(
 	}
 
 	if !skipDriftCheck {
-		if err := checkDrift(ctx, r, plan, out, expectedSchemaFactories); err != nil {
+		if err := checkDrift(ctx, r, plan.from.GitTag(), out, expectedSchemaFactories); err != nil {
 			return err
 		}
 	}
@@ -301,7 +301,7 @@ func setServiceVersion(ctx context.Context, r Runner, version oobmigration.Versi
 	)
 }
 
-func checkDrift(ctx context.Context, r Runner, plan migrationPlan, out *output.Output, expectedSchemaFactories []ExpectedSchemaFactory) error {
+func checkDrift(ctx context.Context, r Runner, version string, out *output.Output, expectedSchemaFactories []ExpectedSchemaFactory) error {
 	schemasWithDrift := make([]string, 0, len(schemas.SchemaNames))
 	for _, schemaName := range schemas.SchemaNames {
 		store, err := r.Store(ctx, schemaName)
@@ -317,7 +317,7 @@ func checkDrift(ctx context.Context, r Runner, plan migrationPlan, out *output.O
 		var buf bytes.Buffer
 		noopOutput := output.NewOutput(&buf, output.OutputOpts{})
 
-		if err := compareByFactories(schemaName, plan.from.GitTag(), schema, noopOutput, expectedSchemaFactories); err != nil {
+		if err := compareByFactories(schemaName, version, schema, noopOutput, expectedSchemaFactories); err != nil {
 			schemasWithDrift = append(schemasWithDrift, schemaName)
 		}
 	}

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -55,7 +55,7 @@ func (v Version) String() string {
 }
 
 func (v Version) GitTag() string {
-	v.GitTagWithPatch(0)
+	return v.GitTagWithPatch(0)
 }
 
 func (v Version) GitTagWithPatch(patch int) string {

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -20,19 +20,34 @@ func NewVersion(major, minor int) Version {
 	}
 }
 
-var versionPattern = lazyregexp.New(`^v?(\d+)\.(\d+)(?:\.\d+)?$`)
+var versionPattern = lazyregexp.New(`^v?(\d+)\.(\d+)(?:\.(\d+))?$`)
 
 // NewVersionFromString parses the major and minor version from the given string. If
 // the string does not look like a parseable version, a false-valued flag is returned.
 func NewVersionFromString(v string) (Version, bool) {
-	if matches := versionPattern.FindStringSubmatch(v); len(matches) >= 3 {
-		major, _ := strconv.Atoi(matches[1])
-		minor, _ := strconv.Atoi(matches[2])
+	version, _, ok := NewVersionAndPatchFromString(v)
+	return version, ok
+}
 
-		return NewVersion(major, minor), true
+// NewVersionFromString parses the major and minor version from the given string. If
+// the string does not look like a parseable version, a false-valued flag is returned.
+// If the input string also supplies a patch version, it is returned. If a patch is
+// not supplied this value is zero.
+func NewVersionAndPatchFromString(v string) (Version, int, bool) {
+	matches := versionPattern.FindStringSubmatch(v)
+	if len(matches) < 3 {
+		return Version{}, 0, false
 	}
 
-	return Version{}, false
+	major, _ := strconv.Atoi(matches[1])
+	minor, _ := strconv.Atoi(matches[2])
+
+	if len(matches) == 3 {
+		return NewVersion(major, minor), 0, true
+	}
+
+	patch, _ := strconv.Atoi(matches[3])
+	return NewVersion(major, minor), patch, true
 }
 
 func (v Version) String() string {

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -55,7 +55,11 @@ func (v Version) String() string {
 }
 
 func (v Version) GitTag() string {
-	return fmt.Sprintf("v%d.%d.0", v.Major, v.Minor)
+	v.GitTagWithPatch(0)
+}
+
+func (v Version) GitTagWithPatch(patch int) string {
+	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, patch)
 }
 
 var lastMinorVersionInMajorRelease = map[int]int{

--- a/internal/oobmigration/version_test.go
+++ b/internal/oobmigration/version_test.go
@@ -6,6 +6,37 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestNewVersionFromString(t *testing.T) {
+	testCases := []struct {
+		v       string
+		version Version
+		patch   int
+		ok      bool
+	}{
+		{"3.50", NewVersion(3, 50), 0, true},
+		{"v3.50.3", NewVersion(3, 50), 3, true},
+		{"v3.50", NewVersion(3, 50), 0, true},
+		{"3.50.3", NewVersion(3, 50), 3, true},
+		{"350", Version{}, 0, false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.v, func(t *testing.T) {
+			version, patch, ok := NewVersionAndPatchFromString(testCase.v)
+			if ok != testCase.ok {
+				t.Errorf("unexpected ok. want=%v have=%v", testCase.ok, ok)
+			} else {
+				if version != testCase.version {
+					t.Errorf("unexpected version. want=%s have=%s", testCase.version, version)
+				}
+				if patch != testCase.patch {
+					t.Errorf("unexpected patch. want=%d have=%d", testCase.patch, patch)
+				}
+			}
+		})
+	}
+}
+
 func TestCompareVersions(t *testing.T) {
 	testCases := []struct {
 		left     Version


### PR DESCRIPTION
If you're running `upgrade --from=3.36 --to=4.0` and you're on `3.36.3`, we'll check your drift against `3.36.0`, which can have some differences. We should check the actual reported instance version when available instead.

## Test plan

Tested locally.